### PR TITLE
feat(secure-store): encrypt entity files

### DIFF
--- a/packages/remnic-core/src/memory-cache.ts
+++ b/packages/remnic-core/src/memory-cache.ts
@@ -80,6 +80,13 @@ export function setCachedEntities(
   });
 }
 
+export function invalidateCachedEntities(baseDir: string): void {
+  const prefix = `${baseDir}\u0000`;
+  for (const key of entityCacheByDir.keys()) {
+    if (key.startsWith(prefix)) entityCacheByDir.delete(key);
+  }
+}
+
 // Derived caches — pre-filtered views invalidated alongside the main cache.
 // These avoid O(146K) filter+map on every verified recall/rules call.
 interface DerivedCacheEntry<T> {
@@ -171,9 +178,7 @@ export function clearMemoryCache(baseDir?: string): void {
   if (baseDir) {
     hotCacheByDir.delete(baseDir);
     archiveCacheByDir.delete(baseDir);
-    const entityPrefix = `${baseDir}\u0000`;
-    const entityKeysToDelete = [...entityCacheByDir.keys()].filter((key) => key.startsWith(entityPrefix));
-    for (const key of entityKeysToDelete) entityCacheByDir.delete(key);
+    invalidateCachedEntities(baseDir);
     episodeMapByDir.delete(baseDir);
     ruleMemoriesByDir.delete(baseDir);
   } else {

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -533,6 +533,7 @@ const ENCRYPTABLE_STORAGE_ROOTS = new Set([
   "reasoning-traces",
   "artifacts",
   "archive",
+  "entities",
 ]);
 
 const DECRYPTABLE_SIDECAR_ROOTS = new Set([

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3,7 +3,7 @@ import { appendFileSync, mkdirSync, statSync } from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { log } from "./logger.js";
-import { getCachedEntities, setCachedEntities } from "./memory-cache.js";
+import { getCachedEntities, invalidateCachedEntities, setCachedEntities } from "./memory-cache.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
 import { createVersion as createPageVersion, type VersioningConfig, type VersionTrigger } from "./page-versioning.js";
@@ -2131,6 +2131,8 @@ export class StorageManager {
   private static readonly ARTIFACT_INDEX_CACHE_TTL_MS = 60_000; // 1 minute
   private static readonly artifactWriteVersionByDir = new Map<string, number>();
   private static readonly memoryStatusVersionByDir = new Map<string, number>();
+  private static readonly secureStoreEntityCacheKeyIds = new WeakMap<Buffer, number>();
+  private static nextSecureStoreEntityCacheKeyId = 1;
   // In-process fallback for the cold-write sentinel (used when the disk file
   // is not accessible).  The canonical source of truth is state/cold-write.log.
   private static readonly coldWriteVersionByDir = new Map<string, number>();
@@ -2242,6 +2244,18 @@ export class StorageManager {
   setSecureStoreKey(key: Buffer | null, encryptOnWrite = true): void {
     this._secureStoreKey = key;
     this._secureStoreEncryptOnWrite = encryptOnWrite;
+    invalidateCachedEntities(this.baseDir);
+    this.invalidateKnowledgeIndexCache();
+  }
+
+  private getEntityCacheSecureStoreKey(): string {
+    if (!this._secureStoreKey) return "secure-store:locked";
+    let id = StorageManager.secureStoreEntityCacheKeyIds.get(this._secureStoreKey);
+    if (id === undefined) {
+      id = StorageManager.nextSecureStoreEntityCacheKeyId++;
+      StorageManager.secureStoreEntityCacheKeyIds.set(this._secureStoreKey, id);
+    }
+    return `secure-store:key:${id}`;
   }
 
   /**
@@ -2427,6 +2441,12 @@ export class StorageManager {
   }
   private get entitiesDir(): string {
     return path.join(this.baseDir, "entities");
+  }
+  private readEntityFileContent(filePath: string): Promise<string> {
+    return readMaybeEncryptedFile(filePath, this._secureStoreKey, this.baseDir);
+  }
+  private writeEntityFileContent(filePath: string, content: string): Promise<void> {
+    return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir);
   }
   private get stateDir(): string {
     return path.join(this.baseDir, "state");
@@ -3103,9 +3123,11 @@ export class StorageManager {
       aliases: [],
     };
     try {
-      const existing = await readFile(filePath, "utf-8");
+      const existing = await this.readEntityFileContent(filePath);
       entity = parseEntityFile(existing, this.entitySchemas);
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       // File doesn't exist yet
     }
 
@@ -3168,7 +3190,7 @@ export class StorageManager {
     entity.updated = new Date().toISOString();
 
     await this.snapshotBeforeWrite(filePath, "write");
-    await writeFile(filePath, serializeEntityFile(entity, this.entitySchemas), "utf-8");
+    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
     this.invalidateKnowledgeIndexCache();
     this.bumpMemoryStatusVersion(); // invalidate entity cache
     log.debug(`wrote entity ${normalized}`);
@@ -3968,8 +3990,10 @@ export class StorageManager {
 
   async readEntity(name: string): Promise<string> {
     try {
-      return await readFile(path.join(this.entitiesDir, `${name}.md`), "utf-8");
-    } catch {
+      return await this.readEntityFileContent(path.join(this.entitiesDir, `${name}.md`));
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return "";
     }
   }
@@ -5272,9 +5296,11 @@ export class StorageManager {
     const filePath = path.join(this.entitiesDir, `${name}.md`);
     let entity: EntityFile;
     try {
-      const content = await readFile(filePath, "utf-8");
+      const content = await this.readEntityFileContent(filePath);
       entity = parseEntityFile(content, this.entitySchemas);
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       log.debug(`addEntityRelationship: entity file ${name}.md not found`);
       return;
     }
@@ -5287,7 +5313,7 @@ export class StorageManager {
 
     entity.relationships.push(rel);
     entity.updated = new Date().toISOString();
-    await writeFile(filePath, serializeEntityFile(entity, this.entitySchemas), "utf-8");
+    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
     this.invalidateKnowledgeIndexCache();
   }
 
@@ -5303,9 +5329,11 @@ export class StorageManager {
     const filePath = path.join(this.entitiesDir, `${name}.md`);
     let entity: EntityFile;
     try {
-      const content = await readFile(filePath, "utf-8");
+      const content = await this.readEntityFileContent(filePath);
       entity = parseEntityFile(content, this.entitySchemas);
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       log.debug(`addEntityActivity: entity file ${name}.md not found`);
       return;
     }
@@ -5315,7 +5343,7 @@ export class StorageManager {
       entity.activity = entity.activity.slice(0, maxEntries);
     }
     entity.updated = new Date().toISOString();
-    await writeFile(filePath, serializeEntityFile(entity, this.entitySchemas), "utf-8");
+    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
     this.invalidateKnowledgeIndexCache();
   }
 
@@ -5326,9 +5354,11 @@ export class StorageManager {
     const filePath = path.join(this.entitiesDir, `${name}.md`);
     let entity: EntityFile;
     try {
-      const content = await readFile(filePath, "utf-8");
+      const content = await this.readEntityFileContent(filePath);
       entity = parseEntityFile(content, this.entitySchemas);
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       log.debug(`addEntityAlias: entity file ${name}.md not found`);
       return;
     }
@@ -5336,7 +5366,7 @@ export class StorageManager {
     if (entity.aliases.includes(alias)) return;
     entity.aliases.push(alias);
     entity.updated = new Date().toISOString();
-    await writeFile(filePath, serializeEntityFile(entity, this.entitySchemas), "utf-8");
+    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
     this.invalidateKnowledgeIndexCache();
   }
 
@@ -5358,9 +5388,11 @@ export class StorageManager {
     const filePath = path.join(this.entitiesDir, `${name}.md`);
     let entity: EntityFile;
     try {
-      const content = await readFile(filePath, "utf-8");
+      const content = await this.readEntityFileContent(filePath);
       entity = parseEntityFile(content, this.entitySchemas);
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       log.debug(`updateEntitySynthesis: entity file ${name}.md not found`);
       return;
     }
@@ -5386,7 +5418,7 @@ export class StorageManager {
     entity.synthesisVersion = Math.max(0, entity.synthesisVersion ?? 0)
       + (options.incrementVersion === false ? 0 : 1);
     entity.updated = entityUpdatedAt;
-    await writeFile(filePath, serializeEntityFile(entity, this.entitySchemas), "utf-8");
+    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
     await this.removeEntitySynthesisQueueEntries([
       ...new Set([name, normalizeEntityName(entity.name, entity.type)]),
     ]);
@@ -5402,9 +5434,11 @@ export class StorageManager {
     let synthesisTimelineCount: number | undefined;
     try {
       const filePath = path.join(this.entitiesDir, `${name}.md`);
-      const content = await readFile(filePath, "utf-8");
+      const content = await this.readEntityFileContent(filePath);
       synthesisTimelineCount = parseEntityFile(content, this.entitySchemas).timeline.length;
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       synthesisTimelineCount = undefined;
     }
     await this.updateEntitySynthesis(name, summary, {
@@ -5496,7 +5530,7 @@ export class StorageManager {
       if (!raw) continue;
       const serialized = serializeEntityFile(parseEntityFile(raw, this.entitySchemas), this.entitySchemas);
       if (raw.trimEnd() === serialized.trimEnd()) continue;
-      await writeFile(path.join(this.entitiesDir, `${entityName}.md`), serialized, "utf-8");
+      await this.writeEntityFileContent(path.join(this.entitiesDir, `${entityName}.md`), serialized);
       migrated += 1;
     }
     if (migrated > 0) {
@@ -5520,7 +5554,8 @@ export class StorageManager {
   async readAllEntityFiles(): Promise<EntityFile[]> {
     const currentVersion = this.getMemoryStatusVersion();
     const schemaCacheKey = buildEntitySchemaCacheKey(this.entitySchemas);
-    const cached = getCachedEntities(this.baseDir, currentVersion, schemaCacheKey);
+    const cacheKey = `${this.getEntityCacheSecureStoreKey()}\u0000${schemaCacheKey}`;
+    const cached = getCachedEntities(this.baseDir, currentVersion, cacheKey);
     if (cached) return cached;
 
     try {
@@ -5536,18 +5571,25 @@ export class StorageManager {
       for (let i = 0; i < mdFiles.length; i += BATCH_SIZE) {
         const batch = mdFiles.slice(i, i + BATCH_SIZE);
         const results = await Promise.all(
-          batch.map((entry) =>
-            readFile(path.join(this.entitiesDir, entry), "utf-8").catch(() => null),
-          ),
+          batch.map(async (entry) => {
+            try {
+              return await this.readEntityFileContent(path.join(this.entitiesDir, entry));
+            } catch (err) {
+              if (err instanceof SecureStoreLockedError) throw err;
+              if (!isErrnoCode(err, "ENOENT")) throw err;
+              return null;
+            }
+          }),
         );
         for (const content of results) {
           if (content !== null) entities.push(parseEntityFile(content, this.entitySchemas));
         }
       }
 
-      setCachedEntities(this.baseDir, entities, currentVersion, schemaCacheKey);
+      setCachedEntities(this.baseDir, entities, currentVersion, cacheKey);
       return entities;
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError || !isErrnoCode(err, "ENOENT")) throw err;
       // Directory doesn't exist yet
       return [];
     }
@@ -5736,7 +5778,7 @@ export class StorageManager {
         for (const file of files) {
           const filePath = path.join(this.entitiesDir, file);
           try {
-            const content = await readFile(filePath, "utf-8");
+            const content = await this.readEntityFileContent(filePath);
             const parsed = parseEntityFile(content, this.entitySchemas);
 
             // Prefer specific types over "other"
@@ -5858,7 +5900,9 @@ export class StorageManager {
               title: section.title,
               lines: [...section.lines],
             })));
-          } catch {
+          } catch (err) {
+            if (err instanceof SecureStoreLockedError) throw err;
+            if (!isErrnoCode(err, "ENOENT")) throw err;
             // Skip unreadable
           }
         }
@@ -5924,7 +5968,7 @@ export class StorageManager {
         mergedEntity.updated = mergedEntity.updated || new Date().toISOString();
 
         const canonicalPath = path.join(this.entitiesDir, `${canonical}.md`);
-        await writeFile(canonicalPath, serializeEntityFile(mergedEntity, this.entitySchemas), "utf-8");
+        await this.writeEntityFileContent(canonicalPath, serializeEntityFile(mergedEntity, this.entitySchemas));
 
         // Remove non-canonical files
         for (const file of files) {
@@ -5940,7 +5984,8 @@ export class StorageManager {
           }
         }
       }
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError || !isErrnoCode(err, "ENOENT")) throw err;
       // Directory doesn't exist yet
     }
 

--- a/tests/secure-store/storage-wrap.test.ts
+++ b/tests/secure-store/storage-wrap.test.ts
@@ -272,11 +272,12 @@ test("migrateMemoryDirToEncrypted — only encrypts storage-secure markdown path
       path.join(dir, "facts", "2024-01-01", "fact.md"),
       path.join(dir, "artifacts", "2024-01-01", "artifact.md"),
       path.join(dir, "archive", "2024-01-01", "archived.md"),
+      path.join(dir, "entities", "person.md"),
       path.join(dir, "namespaces", "team-a", "facts", "2024-01-01", "fact.md"),
+      path.join(dir, "namespaces", "team-a", "entities", "person.md"),
       path.join(dir, "profile.md"),
     ];
     const plainPaths = [
-      path.join(dir, "entities", "person.md"),
       path.join(dir, "identity", "IDENTITY.md"),
     ];
     for (const f of [...encryptedPaths, ...plainPaths]) {
@@ -298,6 +299,14 @@ test("migrateMemoryDirToEncrypted — only encrypts storage-secure markdown path
         path.join(dir, "namespaces", "team-a"),
       ),
       "content for fact.md",
+    );
+    assert.strictEqual(
+      await readMaybeEncryptedFile(
+        path.join(dir, "namespaces", "team-a", "entities", "person.md"),
+        key,
+        path.join(dir, "namespaces", "team-a"),
+      ),
+      "content for person.md",
     );
     for (const f of plainPaths) {
       assert.strictEqual((await readFile(f, "utf8")).startsWith("content for"), true);
@@ -358,10 +367,12 @@ test("decryptMemoryDirToPlaintext — decrypts encrypted files and is idempotent
     const key = makeKey();
     const encryptedFile = path.join(dir, "facts", "2024-01-01", "fact.md");
     const namespacedFile = path.join(dir, "namespaces", "team-a", "facts", "2024-01-01", "fact.md");
+    const entityFile = path.join(dir, "entities", "person.md");
     const plaintextFile = path.join(dir, "facts", "2024-01-01", "plain.md");
     const stateFile = path.join(dir, "state", "fact-hashes.txt");
     await mkdir(path.dirname(encryptedFile), { recursive: true });
     await mkdir(path.dirname(namespacedFile), { recursive: true });
+    await mkdir(path.dirname(entityFile), { recursive: true });
     await mkdir(path.dirname(stateFile), { recursive: true });
     await writeMaybeEncryptedFile(encryptedFile, "encrypted fact", key, {}, dir);
     await writeMaybeEncryptedFile(
@@ -371,21 +382,23 @@ test("decryptMemoryDirToPlaintext — decrypts encrypted files and is idempotent
       {},
       path.join(dir, "namespaces", "team-a"),
     );
+    await writeMaybeEncryptedFile(entityFile, "encrypted entity", key, {}, dir);
     await writeFile(plaintextFile, "already plain", "utf8");
     await writeMaybeEncryptedFile(stateFile, "encrypted state", key, {}, dir);
 
     const first = await decryptMemoryDirToPlaintext(dir, key);
-    assert.strictEqual(first.decrypted, 3);
+    assert.strictEqual(first.decrypted, 4);
     assert.strictEqual(first.skipped, 1);
     assert.strictEqual(first.errors.length, 0);
     assert.strictEqual(await readFile(encryptedFile, "utf8"), "encrypted fact");
     assert.strictEqual(await readFile(namespacedFile, "utf8"), "encrypted namespaced fact");
+    assert.strictEqual(await readFile(entityFile, "utf8"), "encrypted entity");
     assert.strictEqual(await readFile(plaintextFile, "utf8"), "already plain");
     assert.strictEqual(await readFile(stateFile, "utf8"), "encrypted state");
 
     const second = await decryptMemoryDirToPlaintext(dir, key);
     assert.strictEqual(second.decrypted, 0);
-    assert.strictEqual(second.skipped, 4);
+    assert.strictEqual(second.skipped, 5);
     assert.strictEqual(second.errors.length, 0);
   });
 });
@@ -544,5 +557,168 @@ test("StorageManager — locked store throws SecureStoreLockedError on readProfi
       () => storage.readProfile(),
       (err) => err instanceof SecureStoreLockedError,
     );
+  });
+});
+
+test("StorageManager — writeEntity encrypts and entity reads decrypt", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(key, true);
+    await storage.ensureDirectories();
+
+    const entityName = await storage.writeEntity(
+      "Alice Example",
+      "person",
+      ["Alice Example owns the launch checklist."],
+      { timestamp: "2026-04-28T00:00:00.000Z" },
+    );
+    assert.equal(entityName, "person-alice-example");
+
+    const entityPath = path.join(dir, "entities", `${entityName}.md`);
+    const raw = await readFile(entityPath);
+    assert.ok(isEncryptedFile(raw), "entity file should be encrypted on disk");
+
+    const content = await storage.readEntity(entityName);
+    assert.match(content, /Alice Example owns the launch checklist\./);
+
+    const entities = await storage.readAllEntityFiles();
+    assert.equal(entities[0]?.name, "Alice Example");
+    assert.deepEqual(entities[0]?.facts, ["Alice Example owns the launch checklist."]);
+
+    const lockedStorage = new StorageManager(dir, []);
+    await assert.rejects(
+      () => lockedStorage.readAllEntityFiles(),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+
+    storage.setSecureStoreKey(null);
+    await assert.rejects(
+      () => storage.readAllEntityFiles(),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+  });
+});
+
+test("StorageManager — locked store throws SecureStoreLockedError on encrypted entity reads", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const entityDir = path.join(dir, "entities");
+    await mkdir(entityDir, { recursive: true });
+    const entityPath = path.join(entityDir, "person-alice-example.md");
+    await writeMaybeEncryptedFile(
+      entityPath,
+      [
+        "# Alice Example",
+        "",
+        "**Type:** person",
+        "**Created:** 2026-04-28T00:00:00.000Z",
+        "**Updated:** 2026-04-28T00:00:00.000Z",
+        "",
+        "## Facts",
+        "- Alice Example owns the launch checklist.",
+        "",
+      ].join("\n"),
+      key,
+      {},
+      dir,
+    );
+
+    const storage = new StorageManager(dir, []);
+
+    await assert.rejects(
+      () => storage.readEntity("person-alice-example"),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+    await assert.rejects(
+      () => storage.readAllEntityFiles(),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+    await assert.rejects(
+      () => storage.writeEntity(
+        "Alice Example",
+        "person",
+        ["This must not overwrite the encrypted entity while locked."],
+      ),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+  });
+});
+
+test("StorageManager — entity writes reject decrypt failures instead of overwriting", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const wrongKey = makeKey(0x43);
+    const entityDir = path.join(dir, "entities");
+    await mkdir(entityDir, { recursive: true });
+    const entityPath = path.join(entityDir, "person-alice-example.md");
+    await writeMaybeEncryptedFile(
+      entityPath,
+      [
+        "# Alice Example",
+        "",
+        "**Type:** person",
+        "**Created:** 2026-04-28T00:00:00.000Z",
+        "**Updated:** 2026-04-28T00:00:00.000Z",
+        "",
+        "## Facts",
+        "- Alice Example owns the launch checklist.",
+        "",
+      ].join("\n"),
+      key,
+      {},
+      dir,
+    );
+
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(wrongKey, true);
+
+    await assert.rejects(
+      () => storage.readEntity("person-alice-example"),
+      (err) => err instanceof SecureStoreDecryptError,
+    );
+    await assert.rejects(
+      () => storage.readAllEntityFiles(),
+      (err) => err instanceof SecureStoreDecryptError,
+    );
+    await assert.rejects(
+      () => storage.writeEntity(
+        "Alice Example",
+        "person",
+        ["This must not overwrite the encrypted entity with a wrong key."],
+      ),
+      (err) => err instanceof SecureStoreDecryptError,
+    );
+    assert.ok(isEncryptedFile(await readFile(entityPath)), "entity file should remain encrypted");
+  });
+});
+
+test("StorageManager — plaintext entity files remain readable without secure-store key", async () => {
+  await withTempDir(async (dir) => {
+    const entityDir = path.join(dir, "entities");
+    await mkdir(entityDir, { recursive: true });
+    await writeFile(
+      path.join(entityDir, "person-bob-example.md"),
+      [
+        "# Bob Example",
+        "",
+        "**Type:** person",
+        "**Created:** 2026-04-28T00:00:00.000Z",
+        "**Updated:** 2026-04-28T00:00:00.000Z",
+        "",
+        "## Facts",
+        "- Bob Example owns the support queue.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const storage = new StorageManager(dir, []);
+    const content = await storage.readEntity("person-bob-example");
+    assert.match(content, /Bob Example owns the support queue\./);
+
+    const entities = await storage.readAllEntityFiles();
+    assert.equal(entities[0]?.name, "Bob Example");
+    assert.deepEqual(entities[0]?.facts, ["Bob Example owns the support queue."]);
   });
 });


### PR DESCRIPTION
Closes #781.

## Summary
- route entity markdown reads and writes through secure-store file helpers
- keep plaintext entity files backward-compatible
- propagate locked encrypted entity reads instead of silently treating them as missing

## Verification
- npm exec -- tsx --test --test-name-pattern "entity" tests/secure-store/storage-wrap.test.ts
- npm exec -- tsx --test tests/secure-store/storage-wrap.test.ts
- git diff --check

Note: npm run check-types is blocked locally by missing @node-rs/argon2 module/type declarations before it reaches this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends secure-store encryption to `entities/` and changes entity read/write paths to throw on locked/wrong-key states, which can affect availability and error handling for entity operations. Also modifies entity caching keys/invalidation, so regressions could surface as stale reads or unexpected cache misses.
> 
> **Overview**
> Entity markdown files under `entities/` (including namespaced entities) are now treated as secure-store managed: migrations encrypt/decrypt them, and `StorageManager` routes all entity reads/writes through `readMaybeEncryptedFile`/`writeMaybeEncryptedFile`.
> 
> Entity operations (`readEntity`, `writeEntity`, relationship/activity/alias updates, synthesis updates, bulk reads/merges) now **propagate** `SecureStoreLockedError` (and decrypt errors) instead of silently treating encrypted files as missing, and entity caches are updated to invalidate on key changes and to include secure-store key identity in the cache key to avoid cross-key reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216d15483f1c718279832c735ebd361e36faffa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->