### PR TITLE
feat(secure-store): encrypt identity continuity files

### DIFF
--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -7,7 +7,7 @@ import { sanitizeMemoryContent } from "../sanitize.js";
 import { StorageManager } from "../storage.js";
 import type { ContinuityIncidentRecord, PluginConfig } from "../types.js";
 import { SharedFeedbackEntrySchema, type SharedFeedbackEntry } from "../shared-context/manager.js";
-import { parseContinuityIncident, parseContinuityImprovementLoops } from "../identity-continuity.js";
+import { parseContinuityImprovementLoops } from "../identity-continuity.js";
 
 type MistakesFile = {
   version?: number;
@@ -439,14 +439,14 @@ export class CompoundingEngine {
   private readonly rubricsPath: string;
   private readonly mistakesPath: string;
   private readonly feedbackInboxPath: string;
-  private readonly identityAnchorPath: string;
-  private readonly identityIncidentsDir: string;
   private readonly identityAuditWeeklyDir: string;
   private readonly identityAuditMonthlyDir: string;
-  private readonly identityImprovementLoopsPath: string;
   private readonly memoryActionEventsPath: string;
 
-  constructor(private readonly config: PluginConfig) {
+  constructor(
+    private readonly config: PluginConfig,
+    private readonly storage: StorageManager = new StorageManager(config.memoryDir),
+  ) {
     this.weeklyDir = path.join(config.memoryDir, "compounding", "weekly");
     this.rubricsDir = path.join(config.memoryDir, "compounding", "rubrics");
     this.rubricsIndexPath = path.join(this.rubricsDir, "index.json");
@@ -455,11 +455,8 @@ export class CompoundingEngine {
     this.rubricsPath = path.join(config.memoryDir, "compounding", "rubrics.md");
     this.mistakesPath = path.join(config.memoryDir, "compounding", "mistakes.json");
     this.feedbackInboxPath = path.join(sharedContextDir(config), "feedback", "inbox.jsonl");
-    this.identityAnchorPath = path.join(config.memoryDir, "identity", "identity-anchor.md");
-    this.identityIncidentsDir = path.join(config.memoryDir, "identity", "incidents");
     this.identityAuditWeeklyDir = path.join(config.memoryDir, "identity", "audits", "weekly");
     this.identityAuditMonthlyDir = path.join(config.memoryDir, "identity", "audits", "monthly");
-    this.identityImprovementLoopsPath = path.join(config.memoryDir, "identity", "improvement-loops.md");
     this.memoryActionEventsPath = path.join(config.memoryDir, "state", "memory-actions.jsonl");
   }
 
@@ -729,13 +726,14 @@ export class CompoundingEngine {
     const period = opts?.period === "monthly" ? "monthly" : "weekly";
     const key = opts?.key?.trim() || (period === "weekly" ? isoWeekId(new Date()) : isoMonthId(new Date()));
     const nowIso = new Date().toISOString();
-    const [anchorPresent, improvementLoopsRaw, openIncidents, closedIncidents, mistakes] = await Promise.all([
-      this.readNonEmptyFile(this.identityAnchorPath),
-      this.readOptionalFile(this.identityImprovementLoopsPath),
-      this.readContinuityIncidents(200, "open"),
-      this.readContinuityIncidents(200, "closed"),
+    const [identityAnchor, improvementLoopsRaw, openIncidents, closedIncidents, mistakes] = await Promise.all([
+      this.readOptionalIdentityAnchorForAudit(),
+      this.readOptionalImprovementLoopsForAudit(),
+      this.readContinuityIncidentsForAudit(200, "open"),
+      this.readContinuityIncidentsForAudit(200, "closed"),
       this.readMistakes(),
     ]);
+    const anchorPresent = (identityAnchor ?? "").trim().length > 0;
     const improvementLoops = improvementLoopsRaw ? parseContinuityImprovementLoops(improvementLoopsRaw) : [];
     const activeLoops = improvementLoops.filter((loop) => loop.status === "active");
     const staleActiveLoops = activeLoops.filter((loop) => {
@@ -803,10 +801,7 @@ export class CompoundingEngine {
       "",
     ];
 
-    const dir = period === "weekly" ? this.identityAuditWeeklyDir : this.identityAuditMonthlyDir;
-    await mkdir(dir, { recursive: true });
-    const reportPath = path.join(dir, `${key}.md`);
-    await writeFile(reportPath, lines.join("\n"), "utf-8");
+    const reportPath = await this.storage.writeIdentityAudit(period, key, lines.join("\n"));
     return { period, key, reportPath };
   }
 
@@ -1657,52 +1652,42 @@ export class CompoundingEngine {
     entry.provenance = [...new Set((normalized.observationEntries ?? []).flatMap((item) => item.provenance))];
   }
 
-  private async readNonEmptyFile(filePath: string): Promise<boolean> {
+  private async readOptionalIdentityAnchorForAudit(): Promise<string | null> {
     try {
-      const raw = await readFile(filePath, "utf-8");
-      return raw.trim().length > 0;
-    } catch {
-      return false;
-    }
-  }
-
-  private async readOptionalFile(filePath: string): Promise<string | null> {
-    try {
-      const raw = await readFile(filePath, "utf-8");
-      return raw.trim().length > 0 ? raw : null;
+      return await this.storage.readIdentityAnchor();
     } catch {
       return null;
     }
   }
 
-  private async readContinuityIncidents(
-    limit: number = 200,
-    state?: ContinuityIncidentRecord["state"],
-  ): Promise<ContinuityIncidentRecord[]> {
-    const normalizedLimit = Number.isFinite(limit) ? limit : 0;
-    const cappedLimit = Math.max(0, Math.floor(normalizedLimit));
-    if (cappedLimit === 0) return [];
-    const incidents: ContinuityIncidentRecord[] = [];
+  private async readOptionalImprovementLoopsForAudit(): Promise<string | null> {
     try {
-      const names = await readdir(this.identityIncidentsDir);
-      const files = names.filter((n) => n.endsWith(".md")).sort().reverse();
-      for (const file of files) {
-        if (incidents.length >= cappedLimit) break;
-        const filePath = path.join(this.identityIncidentsDir, file);
-        try {
-          const raw = await readFile(filePath, "utf-8");
-          const parsed = parseContinuityIncident(raw);
-          if (!parsed) continue;
-          if (state && parsed.state !== state) continue;
-          incidents.push(parsed);
-        } catch {
-          // fail-open
-        }
-      }
+      return await this.storage.readIdentityImprovementLoops();
     } catch {
-      // fail-open
+      return null;
     }
-    return incidents;
+  }
+
+  private async readContinuityIncidentsForAudit(
+    limit: number,
+    state: "open" | "closed",
+  ): Promise<ContinuityIncidentRecord[]> {
+    try {
+      return await this.storage.readContinuityIncidents(limit, state);
+    } catch {
+      return [];
+    }
+  }
+
+  private async readOptionalIdentityAuditForReference(
+    period: "weekly" | "monthly",
+    key: string,
+  ): Promise<string | null> {
+    try {
+      return await this.storage.readIdentityAudit(period, key);
+    } catch {
+      return null;
+    }
   }
 
   private async readContinuityAuditReferences(weekId: string): Promise<{
@@ -1714,8 +1699,12 @@ export class CompoundingEngine {
     const monthId = monthIdFromIsoWeek(weekId);
     const weeklyPath = path.join(this.identityAuditWeeklyDir, `${weekId}.md`);
     const monthlyPath = path.join(this.identityAuditMonthlyDir, `${monthId}.md`);
-    const weeklyExists = await this.readNonEmptyFile(weeklyPath);
-    const monthlyExists = await this.readNonEmptyFile(monthlyPath);
+    const [weeklyAudit, monthlyAudit] = await Promise.all([
+      this.readOptionalIdentityAuditForReference("weekly", weekId),
+      this.readOptionalIdentityAuditForReference("monthly", monthId),
+    ]);
+    const weeklyExists = (weeklyAudit ?? "").trim().length > 0;
+    const monthlyExists = (monthlyAudit ?? "").trim().length > 0;
     return {
       weekId,
       monthId,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1784,7 +1784,7 @@ export class Orchestrator {
       ? new SharedContextManager(config)
       : undefined;
     this.compounding = config.compoundingEnabled
-      ? new CompoundingEngine(config)
+      ? new CompoundingEngine(config, this.storage)
       : undefined;
     this.buffer = new SmartBuffer(config, this.storage);
     this.transcript = new TranscriptManager(config);

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -534,6 +534,7 @@ const ENCRYPTABLE_STORAGE_ROOTS = new Set([
   "artifacts",
   "archive",
   "entities",
+  "identity",
 ]);
 
 const DECRYPTABLE_SIDECAR_ROOTS = new Set([

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2442,10 +2442,10 @@ export class StorageManager {
   private get entitiesDir(): string {
     return path.join(this.baseDir, "entities");
   }
-  private readEntityFileContent(filePath: string): Promise<string> {
+  private readStorageSecureFile(filePath: string): Promise<string> {
     return readMaybeEncryptedFile(filePath, this._secureStoreKey, this.baseDir);
   }
-  private writeEntityFileContent(filePath: string, content: string): Promise<void> {
+  private writeStorageSecureFile(filePath: string, content: string): Promise<void> {
     return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir);
   }
   private get stateDir(): string {
@@ -3123,7 +3123,7 @@ export class StorageManager {
       aliases: [],
     };
     try {
-      const existing = await this.readEntityFileContent(filePath);
+      const existing = await this.readStorageSecureFile(filePath);
       entity = parseEntityFile(existing, this.entitySchemas);
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
@@ -3190,7 +3190,7 @@ export class StorageManager {
     entity.updated = new Date().toISOString();
 
     await this.snapshotBeforeWrite(filePath, "write");
-    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
+    await this.writeStorageSecureFile(filePath, serializeEntityFile(entity, this.entitySchemas));
     this.invalidateKnowledgeIndexCache();
     this.bumpMemoryStatusVersion(); // invalidate entity cache
     log.debug(`wrote entity ${normalized}`);
@@ -3990,7 +3990,7 @@ export class StorageManager {
 
   async readEntity(name: string): Promise<string> {
     try {
-      return await this.readEntityFileContent(path.join(this.entitiesDir, `${name}.md`));
+      return await this.readStorageSecureFile(path.join(this.entitiesDir, `${name}.md`));
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
       if (!isErrnoCode(err, "ENOENT")) throw err;
@@ -4822,13 +4822,14 @@ export class StorageManager {
 
   async writeIdentityAnchor(content: string): Promise<void> {
     await this.ensureDirectories();
-    await writeFile(this.identityAnchorPath, content, "utf-8");
+    await this.writeStorageSecureFile(this.identityAnchorPath, content);
   }
 
   async readIdentityAnchor(): Promise<string | null> {
     try {
-      return await readFile(this.identityAnchorPath, "utf-8");
-    } catch {
+      return await this.readStorageSecureFile(this.identityAnchorPath);
+    } catch (err) {
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return null;
     }
   }
@@ -4841,7 +4842,7 @@ export class StorageManager {
     const id = this.generateId("incident");
     const incident = createContinuityIncidentRecord(id, input, nowIso);
     const filePath = path.join(this.identityIncidentsDir, `${date}-${id}.md`);
-    await writeFile(filePath, serializeContinuityIncident(incident), "utf-8");
+    await this.writeStorageSecureFile(filePath, serializeContinuityIncident(incident));
     return { ...incident, filePath };
   }
 
@@ -4861,17 +4862,20 @@ export class StorageManager {
         if (incidents.length >= cappedLimit) break;
         const filePath = path.join(this.identityIncidentsDir, file);
         try {
-          const raw = await readFile(filePath, "utf-8");
+          const raw = await this.readStorageSecureFile(filePath);
           const parsed = parseContinuityIncident(raw);
           if (!parsed) continue;
           if (state !== "all" && parsed.state !== state) continue;
           incidents.push({ ...parsed, filePath });
-        } catch {
+        } catch (err) {
+          if (err instanceof SecureStoreLockedError) throw err;
           // Fail-open on malformed/missing files.
         }
       }
       return incidents;
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return [];
     }
   }
@@ -4886,7 +4890,7 @@ export class StorageManager {
     if (target.state === "closed") return target;
 
     const closed = closeContinuityIncidentRecord(target, closure, new Date().toISOString());
-    await writeFile(directFilePath, serializeContinuityIncident(closed), "utf-8");
+    await this.writeStorageSecureFile(directFilePath, serializeContinuityIncident(closed));
     return { ...closed, filePath: directFilePath };
   }
 
@@ -4895,7 +4899,7 @@ export class StorageManager {
     const safeKey = this.sanitizeIdentityAuditKey(key);
     const dir = period === "weekly" ? this.identityAuditsWeeklyDir : this.identityAuditsMonthlyDir;
     const filePath = path.join(dir, `${safeKey}.md`);
-    await writeFile(filePath, content, "utf-8");
+    await this.writeStorageSecureFile(filePath, content);
     return filePath;
   }
 
@@ -4903,21 +4907,24 @@ export class StorageManager {
     try {
       const safeKey = this.sanitizeIdentityAuditKey(key);
       const dir = period === "weekly" ? this.identityAuditsWeeklyDir : this.identityAuditsMonthlyDir;
-      return await readFile(path.join(dir, `${safeKey}.md`), "utf-8");
-    } catch {
+      return await this.readStorageSecureFile(path.join(dir, `${safeKey}.md`));
+    } catch (err) {
+      if (err instanceof Error && err.message === "Invalid identity audit key") return null;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return null;
     }
   }
 
   async writeIdentityImprovementLoops(content: string): Promise<void> {
     await this.ensureDirectories();
-    await writeFile(this.identityImprovementLoopsPath, content, "utf-8");
+    await this.writeStorageSecureFile(this.identityImprovementLoopsPath, content);
   }
 
   async readIdentityImprovementLoops(): Promise<string | null> {
     try {
-      return await readFile(this.identityImprovementLoopsPath, "utf-8");
-    } catch {
+      return await this.readStorageSecureFile(this.identityImprovementLoopsPath);
+    } catch (err) {
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return null;
     }
   }
@@ -4967,10 +4974,11 @@ export class StorageManager {
 
   private async readContinuityIncidentFile(filePath: string): Promise<ContinuityIncidentRecord | null> {
     try {
-      const raw = await readFile(filePath, "utf-8");
+      const raw = await this.readStorageSecureFile(filePath);
       const parsed = parseContinuityIncident(raw);
       return parsed ? { ...parsed, filePath } : null;
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
       return null;
     }
   }
@@ -5239,22 +5247,24 @@ export class StorageManager {
 
   async readIdentityReflections(): Promise<string | null> {
     try {
-      return await readFile(this.identityReflectionsPath, "utf-8");
-    } catch {
+      return await this.readStorageSecureFile(this.identityReflectionsPath);
+    } catch (err) {
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return null;
     }
   }
 
   async writeIdentityReflections(content: string): Promise<void> {
     await mkdir(this.identityDir, { recursive: true });
-    await writeFile(this.identityReflectionsPath, content, "utf-8");
+    await this.writeStorageSecureFile(this.identityReflectionsPath, content);
   }
 
   async appendIdentityReflection(reflection: string): Promise<void> {
     let existing = "";
     try {
-      existing = await readFile(this.identityReflectionsPath, "utf-8");
-    } catch {
+      existing = await this.readStorageSecureFile(this.identityReflectionsPath);
+    } catch (err) {
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       // File doesn't exist yet.
     }
 
@@ -5280,7 +5290,7 @@ export class StorageManager {
     const timestamp = new Date().toISOString();
     const section = `${existing.trimEnd().length > 0 ? "\n\n" : ""}## Reflection — ${timestamp}\n\n${reflection}\n`;
     await mkdir(this.identityDir, { recursive: true });
-    await writeFile(this.identityReflectionsPath, `${existing.trimEnd()}${section}`, "utf-8");
+    await this.writeStorageSecureFile(this.identityReflectionsPath, `${existing.trimEnd()}${section}`);
     log.debug(`appended namespace-local reflection to ${this.identityReflectionsPath}`);
   }
 
@@ -5296,7 +5306,7 @@ export class StorageManager {
     const filePath = path.join(this.entitiesDir, `${name}.md`);
     let entity: EntityFile;
     try {
-      const content = await this.readEntityFileContent(filePath);
+      const content = await this.readStorageSecureFile(filePath);
       entity = parseEntityFile(content, this.entitySchemas);
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
@@ -5313,7 +5323,7 @@ export class StorageManager {
 
     entity.relationships.push(rel);
     entity.updated = new Date().toISOString();
-    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
+    await this.writeStorageSecureFile(filePath, serializeEntityFile(entity, this.entitySchemas));
     this.invalidateKnowledgeIndexCache();
   }
 
@@ -5329,7 +5339,7 @@ export class StorageManager {
     const filePath = path.join(this.entitiesDir, `${name}.md`);
     let entity: EntityFile;
     try {
-      const content = await this.readEntityFileContent(filePath);
+      const content = await this.readStorageSecureFile(filePath);
       entity = parseEntityFile(content, this.entitySchemas);
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
@@ -5343,7 +5353,7 @@ export class StorageManager {
       entity.activity = entity.activity.slice(0, maxEntries);
     }
     entity.updated = new Date().toISOString();
-    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
+    await this.writeStorageSecureFile(filePath, serializeEntityFile(entity, this.entitySchemas));
     this.invalidateKnowledgeIndexCache();
   }
 
@@ -5354,7 +5364,7 @@ export class StorageManager {
     const filePath = path.join(this.entitiesDir, `${name}.md`);
     let entity: EntityFile;
     try {
-      const content = await this.readEntityFileContent(filePath);
+      const content = await this.readStorageSecureFile(filePath);
       entity = parseEntityFile(content, this.entitySchemas);
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
@@ -5366,7 +5376,7 @@ export class StorageManager {
     if (entity.aliases.includes(alias)) return;
     entity.aliases.push(alias);
     entity.updated = new Date().toISOString();
-    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
+    await this.writeStorageSecureFile(filePath, serializeEntityFile(entity, this.entitySchemas));
     this.invalidateKnowledgeIndexCache();
   }
 
@@ -5388,7 +5398,7 @@ export class StorageManager {
     const filePath = path.join(this.entitiesDir, `${name}.md`);
     let entity: EntityFile;
     try {
-      const content = await this.readEntityFileContent(filePath);
+      const content = await this.readStorageSecureFile(filePath);
       entity = parseEntityFile(content, this.entitySchemas);
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
@@ -5418,7 +5428,7 @@ export class StorageManager {
     entity.synthesisVersion = Math.max(0, entity.synthesisVersion ?? 0)
       + (options.incrementVersion === false ? 0 : 1);
     entity.updated = entityUpdatedAt;
-    await this.writeEntityFileContent(filePath, serializeEntityFile(entity, this.entitySchemas));
+    await this.writeStorageSecureFile(filePath, serializeEntityFile(entity, this.entitySchemas));
     await this.removeEntitySynthesisQueueEntries([
       ...new Set([name, normalizeEntityName(entity.name, entity.type)]),
     ]);
@@ -5434,7 +5444,7 @@ export class StorageManager {
     let synthesisTimelineCount: number | undefined;
     try {
       const filePath = path.join(this.entitiesDir, `${name}.md`);
-      const content = await this.readEntityFileContent(filePath);
+      const content = await this.readStorageSecureFile(filePath);
       synthesisTimelineCount = parseEntityFile(content, this.entitySchemas).timeline.length;
     } catch (err) {
       if (err instanceof SecureStoreLockedError) throw err;
@@ -5530,7 +5540,7 @@ export class StorageManager {
       if (!raw) continue;
       const serialized = serializeEntityFile(parseEntityFile(raw, this.entitySchemas), this.entitySchemas);
       if (raw.trimEnd() === serialized.trimEnd()) continue;
-      await this.writeEntityFileContent(path.join(this.entitiesDir, `${entityName}.md`), serialized);
+      await this.writeStorageSecureFile(path.join(this.entitiesDir, `${entityName}.md`), serialized);
       migrated += 1;
     }
     if (migrated > 0) {
@@ -5573,7 +5583,7 @@ export class StorageManager {
         const results = await Promise.all(
           batch.map(async (entry) => {
             try {
-              return await this.readEntityFileContent(path.join(this.entitiesDir, entry));
+              return await this.readStorageSecureFile(path.join(this.entitiesDir, entry));
             } catch (err) {
               if (err instanceof SecureStoreLockedError) throw err;
               if (!isErrnoCode(err, "ENOENT")) throw err;
@@ -5778,7 +5788,7 @@ export class StorageManager {
         for (const file of files) {
           const filePath = path.join(this.entitiesDir, file);
           try {
-            const content = await this.readEntityFileContent(filePath);
+            const content = await this.readStorageSecureFile(filePath);
             const parsed = parseEntityFile(content, this.entitySchemas);
 
             // Prefer specific types over "other"
@@ -5968,7 +5978,7 @@ export class StorageManager {
         mergedEntity.updated = mergedEntity.updated || new Date().toISOString();
 
         const canonicalPath = path.join(this.entitiesDir, `${canonical}.md`);
-        await this.writeEntityFileContent(canonicalPath, serializeEntityFile(mergedEntity, this.entitySchemas));
+        await this.writeStorageSecureFile(canonicalPath, serializeEntityFile(mergedEntity, this.entitySchemas));
 
         // Remove non-canonical files
         for (const file of files) {

--- a/tests/compounding.test.ts
+++ b/tests/compounding.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import os from "node:os";
 import type { PluginConfig } from "../src/types.js";
 import { CompoundingEngine } from "../src/compounding/engine.js";
+import { StorageManager } from "../src/storage.js";
+import { isEncryptedFile } from "../packages/remnic-core/src/secure-store/secure-fs.js";
 
 function tmpDir(prefix: string): string {
   return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
@@ -513,6 +515,21 @@ test("v5 compounding does not read continuity audit references when audits are d
   assert.match(report, /Weekly Compounding/);
 });
 
+test("v5 weekly synthesis ignores unreadable continuity audit references", async () => {
+  const memoryDir = tmpDir("engram-compound-unreadable-audit-ref-");
+  const sharedDir = tmpDir("engram-compound-unreadable-audit-ref-shared-");
+  await mkdir(path.join(memoryDir, "identity", "audits", "weekly", "2026-W11.md"), { recursive: true });
+  await mkdir(sharedDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  cfg.continuityAuditEnabled = true;
+  const eng = new CompoundingEngine(cfg);
+
+  const res = await eng.synthesizeWeekly({ weekId: "2026-W11" });
+  const report = await readFile(res.reportPath, "utf-8");
+  assert.match(report, /Weekly Compounding/);
+});
+
 test("v5 continuity audit filters incidents by state before applying scan cap", async () => {
   const memoryDir = tmpDir("engram-continuity-audit-cap-");
   const sharedDir = tmpDir("engram-continuity-audit-cap-shared-");
@@ -564,4 +581,57 @@ test("v5 continuity audit filters incidents by state before applying scan cap", 
   const report = await readFile(res.reportPath, "utf-8");
   assert.match(report, /Open incidents: 1/);
   assert.match(report, /- continuity-0001/);
+});
+
+test("v5 continuity audit treats unreadable identity anchor as absent", async () => {
+  const memoryDir = tmpDir("engram-continuity-audit-unreadable-anchor-");
+  const sharedDir = tmpDir("engram-continuity-audit-unreadable-anchor-shared-");
+  await mkdir(path.join(memoryDir, "identity", "identity-anchor.md"), { recursive: true });
+  await mkdir(sharedDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  cfg.continuityAuditEnabled = true;
+  const eng = new CompoundingEngine(cfg);
+
+  const res = await eng.synthesizeContinuityAudit({ period: "weekly", key: "2026-W10" });
+  const report = await readFile(res.reportPath, "utf-8");
+  assert.match(report, /Identity anchor drift: needs attention/);
+});
+
+test("v5 continuity audit reads encrypted identity artifacts through storage", async () => {
+  const memoryDir = tmpDir("engram-continuity-audit-encrypted-");
+  const sharedDir = tmpDir("engram-continuity-audit-encrypted-shared-");
+  await mkdir(memoryDir, { recursive: true });
+  await mkdir(sharedDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  cfg.continuityAuditEnabled = true;
+  const storage = new StorageManager(memoryDir);
+  storage.setSecureStoreKey(Buffer.alloc(32, 0x4a), true);
+  await storage.ensureDirectories();
+  await storage.writeIdentityAnchor("# Identity Anchor\n\n- encrypted anchor baseline");
+  await storage.writeIdentityImprovementLoops([
+    "# Continuity Improvement Loops",
+    "",
+    "## weekly-check",
+    "cadence: weekly",
+    "purpose: Keep continuity audit honest.",
+    "status: active",
+    "killCondition: Audit no longer finds stale loops.",
+    "lastReviewed: 2026-04-28T00:00:00.000Z",
+    "",
+  ].join("\n"));
+  await storage.appendContinuityIncident({
+    symptom: "Encrypted open incident remains visible to the continuity audit.",
+  });
+
+  const eng = new CompoundingEngine(cfg, storage);
+  const res = await eng.synthesizeContinuityAudit({ period: "weekly", key: "2026-W09" });
+
+  assert.ok(isEncryptedFile(await readFile(res.reportPath)), "continuity audit report should be encrypted");
+  const report = await storage.readIdentityAudit("weekly", "2026-W09");
+  assert.match(report ?? "", /Identity anchor drift: pass/);
+  assert.match(report ?? "", /Improvement-loop coverage: pass/);
+  assert.match(report ?? "", /Open incidents: 1/);
+  assert.match(report ?? "", /- incident-/);
 });

--- a/tests/identity-continuity-storage.test.ts
+++ b/tests/identity-continuity-storage.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { appendFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createContinuityIncidentRecord, serializeContinuityIncident } from "../src/identity-continuity.ts";
 import { StorageManager } from "../src/storage.ts";
 
@@ -206,6 +206,38 @@ test("identity continuity close verifies frontmatter id for direct filename matc
     const spoofRaw = await readFile(path.join(incidentDir, "2026-02-01-prefix-incident-target.md"), "utf-8");
     assert.match(spoofRaw, /id: \"incident-spoof\"/);
     assert.match(spoofRaw, /state: \"open\"/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("identity continuity close skips unreadable incident entries while scanning", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-identity-close-unreadable-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const incidentDir = path.join(dir, "identity", "incidents");
+    const target = createContinuityIncidentRecord(
+      "incident-target",
+      { symptom: "target should close despite an unreadable neighbor" },
+      "2026-01-01T00:00:00.000Z",
+    );
+    await writeFile(
+      path.join(incidentDir, "2026-01-01-incident-target.md"),
+      serializeContinuityIncident(target),
+      "utf-8",
+    );
+    await mkdir(path.join(incidentDir, "9999-99-99-unreadable.md"));
+
+    const closed = await storage.closeContinuityIncident("incident-target", {
+      fixApplied: "applied fix",
+      verificationResult: "verified",
+    });
+
+    assert.ok(closed);
+    assert.equal(closed?.id, "incident-target");
+    assert.equal(closed?.state, "closed");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/secure-store/storage-wrap.test.ts
+++ b/tests/secure-store/storage-wrap.test.ts
@@ -273,12 +273,18 @@ test("migrateMemoryDirToEncrypted — only encrypts storage-secure markdown path
       path.join(dir, "artifacts", "2024-01-01", "artifact.md"),
       path.join(dir, "archive", "2024-01-01", "archived.md"),
       path.join(dir, "entities", "person.md"),
+      path.join(dir, "identity", "identity-anchor.md"),
+      path.join(dir, "identity", "reflections.md"),
+      path.join(dir, "identity", "improvement-loops.md"),
+      path.join(dir, "identity", "incidents", "2026-04-28-incident-a.md"),
+      path.join(dir, "identity", "audits", "weekly", "2026-W18.md"),
       path.join(dir, "namespaces", "team-a", "facts", "2024-01-01", "fact.md"),
       path.join(dir, "namespaces", "team-a", "entities", "person.md"),
+      path.join(dir, "namespaces", "team-a", "identity", "identity-anchor.md"),
       path.join(dir, "profile.md"),
     ];
     const plainPaths = [
-      path.join(dir, "identity", "IDENTITY.md"),
+      path.join(dir, "workspace", "IDENTITY.md"),
     ];
     for (const f of [...encryptedPaths, ...plainPaths]) {
       await mkdir(path.dirname(f), { recursive: true });
@@ -307,6 +313,14 @@ test("migrateMemoryDirToEncrypted — only encrypts storage-secure markdown path
         path.join(dir, "namespaces", "team-a"),
       ),
       "content for person.md",
+    );
+    assert.strictEqual(
+      await readMaybeEncryptedFile(
+        path.join(dir, "namespaces", "team-a", "identity", "identity-anchor.md"),
+        key,
+        path.join(dir, "namespaces", "team-a"),
+      ),
+      "content for identity-anchor.md",
     );
     for (const f of plainPaths) {
       assert.strictEqual((await readFile(f, "utf8")).startsWith("content for"), true);
@@ -557,6 +571,169 @@ test("StorageManager — locked store throws SecureStoreLockedError on readProfi
       () => storage.readProfile(),
       (err) => err instanceof SecureStoreLockedError,
     );
+  });
+});
+
+test("StorageManager — identity support files encrypt, decrypt, and fail clearly while locked", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(key, true);
+    await storage.ensureDirectories();
+
+    await storage.writeIdentityAnchor("# Identity Anchor\n\n- private anchor");
+    await storage.writeIdentityReflections("## Reflection — 2026-04-28T00:00:00.000Z\n\nprivate reflection\n");
+    await storage.writeIdentityImprovementLoops("## loop-a\n\n- private loop\n");
+    const auditPath = await storage.writeIdentityAudit("weekly", "2026-W18", "private audit");
+
+    const anchorPath = path.join(dir, "identity", "identity-anchor.md");
+    const reflectionsPath = path.join(dir, "identity", "reflections.md");
+    const loopsPath = path.join(dir, "identity", "improvement-loops.md");
+
+    assert.ok(isEncryptedFile(await readFile(anchorPath)), "identity anchor should be encrypted");
+    assert.ok(isEncryptedFile(await readFile(reflectionsPath)), "identity reflections should be encrypted");
+    assert.ok(isEncryptedFile(await readFile(loopsPath)), "improvement loops should be encrypted");
+    assert.ok(isEncryptedFile(await readFile(auditPath)), "identity audit should be encrypted");
+
+    assert.match(await storage.readIdentityAnchor() ?? "", /private anchor/);
+    assert.match(await storage.readIdentityReflections() ?? "", /private reflection/);
+    assert.match(await storage.readIdentityImprovementLoops() ?? "", /private loop/);
+    assert.equal(await storage.readIdentityAudit("weekly", "2026-W18"), "private audit");
+    assert.equal(await storage.readIdentityAudit("weekly", "../escape"), null);
+
+    const lockedStorage = new StorageManager(dir, []);
+    await assert.rejects(
+      () => lockedStorage.readIdentityAnchor(),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+    await assert.rejects(
+      () => lockedStorage.readIdentityReflections(),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+    await assert.rejects(
+      () => lockedStorage.readIdentityImprovementLoops(),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+    await assert.rejects(
+      () => lockedStorage.readIdentityAudit("weekly", "2026-W18"),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+  });
+});
+
+test("StorageManager — plaintext identity support files remain readable without secure-store key", async () => {
+  await withTempDir(async (dir) => {
+    const identityDir = path.join(dir, "identity");
+    await mkdir(path.join(identityDir, "audits", "weekly"), { recursive: true });
+    await writeFile(path.join(identityDir, "identity-anchor.md"), "plain anchor", "utf8");
+    await writeFile(path.join(identityDir, "reflections.md"), "plain reflection", "utf8");
+    await writeFile(path.join(identityDir, "improvement-loops.md"), "plain loop", "utf8");
+    await writeFile(path.join(identityDir, "audits", "weekly", "2026-W18.md"), "plain audit", "utf8");
+
+    const storage = new StorageManager(dir, []);
+
+    assert.equal(await storage.readIdentityAnchor(), "plain anchor");
+    assert.equal(await storage.readIdentityReflections(), "plain reflection");
+    assert.equal(await storage.readIdentityImprovementLoops(), "plain loop");
+    assert.equal(await storage.readIdentityAudit("weekly", "2026-W18"), "plain audit");
+  });
+});
+
+test("StorageManager — continuity incidents encrypt, decrypt, and fail clearly while locked", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(key, true);
+    await storage.ensureDirectories();
+
+    const incident = await storage.appendContinuityIncident({
+      symptom: "Lost continuity across reset.",
+      suspectedCause: "Encrypted support file coverage gap.",
+    });
+
+    assert.ok(isEncryptedFile(await readFile(incident.filePath!)), "continuity incident should be encrypted");
+
+    const incidents = await storage.readContinuityIncidents(10, "all");
+    assert.equal(incidents.length, 1);
+    assert.equal(incidents[0]?.id, incident.id);
+    assert.equal(incidents[0]?.symptom, "Lost continuity across reset.");
+
+    const closed = await storage.closeContinuityIncident(incident.id, {
+      fixApplied: "Routed continuity incident reads and writes through secure-store helpers.",
+      verificationResult: "Encrypted reads round-trip and locked reads fail.",
+    });
+    assert.equal(closed?.state, "closed");
+    assert.ok(isEncryptedFile(await readFile(incident.filePath!)), "closed incident should remain encrypted");
+
+    const lockedStorage = new StorageManager(dir, []);
+    await assert.rejects(
+      () => lockedStorage.readContinuityIncidents(10, "all"),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+    await assert.rejects(
+      () => lockedStorage.closeContinuityIncident(incident.id, {
+        fixApplied: "should not write while locked",
+        verificationResult: "locked",
+      }),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+  });
+});
+
+test("StorageManager — continuity incident list skips corrupted encrypted files", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(key, true);
+    await storage.ensureDirectories();
+
+    const corrupted = await storage.appendContinuityIncident({
+      symptom: "This encrypted incident will be corrupted.",
+    });
+    const healthy = await storage.appendContinuityIncident({
+      symptom: "Healthy encrypted incident remains readable.",
+    });
+
+    const raw = Buffer.from(await readFile(corrupted.filePath!));
+    raw[raw.length - 1] = raw[raw.length - 1] ^ 0xff;
+    await writeFile(corrupted.filePath!, raw);
+
+    const incidents = await storage.readContinuityIncidents(10, "all");
+
+    assert.deepEqual(incidents.map((incident) => incident.id), [healthy.id]);
+    assert.equal(incidents[0]?.symptom, "Healthy encrypted incident remains readable.");
+  });
+});
+
+test("StorageManager — plaintext continuity incidents remain readable without secure-store key", async () => {
+  await withTempDir(async (dir) => {
+    const incidentsDir = path.join(dir, "identity", "incidents");
+    await mkdir(incidentsDir, { recursive: true });
+    await writeFile(
+      path.join(incidentsDir, "2026-04-28-incident-plain.md"),
+      [
+        "---",
+        'id: "incident-plain"',
+        'state: "open"',
+        'openedAt: "2026-04-28T00:00:00.000Z"',
+        'updatedAt: "2026-04-28T00:00:00.000Z"',
+        'triggerWindow: "test"',
+        "---",
+        "",
+        "## Symptom",
+        "",
+        "Plain continuity incident remains readable.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const storage = new StorageManager(dir, []);
+    const incidents = await storage.readContinuityIncidents(10, "all");
+
+    assert.equal(incidents.length, 1);
+    assert.equal(incidents[0]?.id, "incident-plain");
+    assert.equal(incidents[0]?.symptom, "Plain continuity incident remains readable.");
   });
 });
 


### PR DESCRIPTION
Closes #782.

## Summary
- route identity anchor, reflections, audits, improvement loops, and continuity incidents through secure-store read/write helpers
- add `identity` to secure-store migration roots so identity markdown is encrypted/decrypted with the rest of storage
- preserve plaintext backward compatibility while surfacing locked encrypted reads instead of treating them as missing

## Verification
- npm exec -- tsx --test --test-name-pattern "identity support|continuity incidents|migrateMemoryDirToEncrypted" tests/secure-store/storage-wrap.test.ts
- npm exec -- tsx --test tests/secure-store/storage-wrap.test.ts
- npm run test:entity-hardening
- git diff --check

Note: npm run preflight:quick is blocked in this local checkout by missing @node-rs/argon2 type/module resolution; CI should run the full typecheck in its clean environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secure-store encryption boundaries and identity file I/O paths; mistakes could break reads/writes of identity artifacts or cause locked-store errors to surface unexpectedly.
> 
> **Overview**
> **Encrypts identity continuity artifacts.** Identity anchor, reflections, improvement loops, continuity incidents, and identity audits are now read/written via `StorageManager` secure read/write helpers so they can be transparently encrypted and correctly fail with `SecureStoreLockedError` when locked.
> 
> **Compounding continuity audit now uses storage-backed reads/writes.** `CompoundingEngine` accepts an injectable `StorageManager`, reads identity inputs through it (treating unreadable/missing inputs as absent for audit scoring), and writes audit reports via `storage.writeIdentityAudit`.
> 
> **Secure-store migration scope expanded.** Adds `identity` to the encryptable roots so `migrateMemoryDirToEncrypted` encrypts identity markdown (including namespaced identity paths), with extensive new tests covering encrypted/plaintext compatibility, locked-store behavior, and skipping corrupted/unreadable incident entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 302ba5ef66601642533890de14826b6888520009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->