### PR TITLE
feat(secure-store): encrypt memory state sidecars

### DIFF
--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -32,7 +32,6 @@ type ActionOutcomeCounts = {
   applied: number;
   skipped: number;
   failed: number;
-  unknown: number;
 };
 
 type ActionOutcomeSummary = {
@@ -161,7 +160,7 @@ export interface CompoundingPromotionReport {
 type WeeklyActionEvent = {
   line: number;
   action: string;
-  outcome: "applied" | "skipped" | "failed" | "unknown";
+  outcome: "applied" | "skipped" | "failed";
   policyDecision: "deny" | "defer" | null;
   namespace: string;
   reason: string | null;
@@ -996,42 +995,21 @@ export class CompoundingEngine {
 
   private async readActionEventsForWeek(weekId: string): Promise<WeeklyActionEvent[]> {
     const out: WeeklyActionEvent[] = [];
-    try {
-      const raw = await readFile(this.memoryActionEventsPath, "utf-8");
-      const lines = raw.split("\n");
-      for (let idx = 0; idx < lines.length; idx += 1) {
-        const line = lines[idx];
-        if (!line.trim()) continue;
-        try {
-          const parsed = JSON.parse(line) as {
-            timestamp?: string;
-            action?: string;
-            outcome?: string;
-            policyDecision?: string;
-            namespace?: string;
-            reason?: string;
-          };
-          if (typeof parsed.timestamp !== "string" || typeof parsed.action !== "string") continue;
-          const ts = new Date(parsed.timestamp);
-          if (!Number.isFinite(ts.getTime()) || isoWeekId(ts) !== weekId) continue;
-          out.push({
-            line: idx + 1,
-            action: parsed.action,
-            outcome: parsed.outcome === "applied" || parsed.outcome === "skipped" || parsed.outcome === "failed"
-              ? parsed.outcome
-              : "unknown",
-            policyDecision: parsed.policyDecision === "deny" || parsed.policyDecision === "defer"
-              ? parsed.policyDecision
-              : null,
-            namespace: typeof parsed.namespace === "string" && parsed.namespace.length > 0 ? parsed.namespace : "default",
-            reason: typeof parsed.reason === "string" ? parsed.reason : null,
-          });
-        } catch {
-          // Ignore malformed rows (fail-open).
-        }
-      }
-    } catch {
-      // Missing action telemetry is allowed.
+    const rows = await this.storage.readMemoryActionEventRows(Number.MAX_SAFE_INTEGER);
+    for (const row of rows) {
+      const event = row.event;
+      const ts = new Date(event.timestamp);
+      if (!Number.isFinite(ts.getTime()) || isoWeekId(ts) !== weekId) continue;
+      out.push({
+        line: row.line,
+        action: event.action,
+        outcome: event.outcome,
+        policyDecision: event.policyDecision === "deny" || event.policyDecision === "defer"
+          ? event.policyDecision
+          : null,
+        namespace: typeof event.namespace === "string" && event.namespace.length > 0 ? event.namespace : "default",
+        reason: typeof event.reason === "string" ? event.reason : null,
+      });
     }
     return out;
   }
@@ -1041,20 +1019,19 @@ export class CompoundingEngine {
     for (const event of events) {
       const key = event.action;
       const acc = byAction.get(key) ?? {
-        counts: { applied: 0, skipped: 0, failed: 0, unknown: 0 },
+        counts: { applied: 0, skipped: 0, failed: 0 },
         provenance: new Set<string>(),
       };
       if (event.outcome === "applied") acc.counts.applied += 1;
       else if (event.outcome === "skipped") acc.counts.skipped += 1;
-      else if (event.outcome === "failed") acc.counts.failed += 1;
-      else acc.counts.unknown += 1;
+      else acc.counts.failed += 1;
       acc.provenance.add(`${path.basename(this.memoryActionEventsPath)}:L${event.line}`);
       byAction.set(key, acc);
     }
 
     const out: ActionOutcomeSummary[] = [];
     for (const [action, data] of byAction.entries()) {
-      const total = data.counts.applied + data.counts.skipped + data.counts.failed + data.counts.unknown;
+      const total = data.counts.applied + data.counts.skipped + data.counts.failed;
       if (total <= 0) continue;
       // Conservative weighting: reward applied, penalize skipped/failed.
       const weightedScore = Number((((data.counts.applied * 1) - (data.counts.skipped * 0.5) - (data.counts.failed * 1.5)) / total).toFixed(3));
@@ -1098,7 +1075,7 @@ export class CompoundingEngine {
       if (item.total < 3) continue;
       if (item.weightedScore < 0.3) continue;
       const content = normalizePromotedGuidanceContent(
-        `Prefer ${item.action} when the same workflow recurs; this week's outcomes were applied=${item.counts.applied}, skipped=${item.counts.skipped}, failed=${item.counts.failed}, unknown=${item.counts.unknown}.`,
+        `Prefer ${item.action} when the same workflow recurs; this week's outcomes were applied=${item.counts.applied}, skipped=${item.counts.skipped}, failed=${item.counts.failed}.`,
       );
       upsert({
         id: stablePromotionCandidateId("action-outcome", item.action, content),
@@ -1380,7 +1357,7 @@ export class CompoundingEngine {
     } else {
       for (const item of outcomeSummary.slice(0, 20)) {
         lines.push(
-          `- ${item.action}: applied=${item.counts.applied}, skipped=${item.counts.skipped}, failed=${item.counts.failed}, unknown=${item.counts.unknown}, weight=${item.weightedScore} _(source: ${item.provenance.join(", ")})_`,
+          `- ${item.action}: applied=${item.counts.applied}, skipped=${item.counts.skipped}, failed=${item.counts.failed}, weight=${item.weightedScore} _(source: ${item.provenance.join(", ")})_`,
         );
       }
     }
@@ -1393,7 +1370,7 @@ export class CompoundingEngine {
       } else {
         for (const candidate of promotionCandidates) {
           const outcomeSummaryText = candidate.outcome
-            ? ` outcomes[a=${candidate.outcome.applied}, s=${candidate.outcome.skipped}, f=${candidate.outcome.failed}, u=${candidate.outcome.unknown}]`
+            ? ` outcomes[a=${candidate.outcome.applied}, s=${candidate.outcome.skipped}, f=${candidate.outcome.failed}]`
             : "";
           lines.push(
             `- [${candidate.sourceType}] ${candidate.subject} -> ${candidate.content} (category=${candidate.category}, score=${candidate.score}, id=${candidate.id}): ${candidate.rationale}${outcomeSummaryText} _(source: ${candidate.provenance.join(", ")})_`,
@@ -1483,7 +1460,7 @@ export class CompoundingEngine {
       };
       this.addRubricObservation(
         workflowEntry,
-        `Outcome weight=${item.weightedScore} (applied=${item.counts.applied}, skipped=${item.counts.skipped}, failed=${item.counts.failed}, unknown=${item.counts.unknown})`,
+        `Outcome weight=${item.weightedScore} (applied=${item.counts.applied}, skipped=${item.counts.skipped}, failed=${item.counts.failed})`,
         ...item.provenance,
       );
       byWorkflow.set(item.action, workflowEntry);
@@ -1545,7 +1522,7 @@ export class CompoundingEngine {
     } else {
       for (const item of outcomeSummary.slice(0, 20)) {
         lines.push(
-          `- ${item.action}: weight=${item.weightedScore} (applied=${item.counts.applied}, skipped=${item.counts.skipped}, failed=${item.counts.failed}, unknown=${item.counts.unknown})`,
+          `- ${item.action}: weight=${item.weightedScore} (applied=${item.counts.applied}, skipped=${item.counts.skipped}, failed=${item.counts.failed})`,
         );
       }
     }

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -686,7 +686,7 @@ function removeManagedCaptureInstructions(existing: string): { content: string; 
 export async function runOperatorSetup(options: OperatorSetupOptions): Promise<OperatorSetupReport> {
   const now = options.now ?? new Date();
   const configStatus = await loadCliPluginConfig(options.configPath);
-  const storage = new StorageManager(options.orchestrator.config.memoryDir);
+  const storage = options.orchestrator.storage;
   await storage.ensureDirectories();
   await mkdir(options.orchestrator.config.workspaceDir, { recursive: true });
 
@@ -1022,6 +1022,7 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   const configStatus = await loadCliPluginConfig(options.configPath);
   const checks: OperatorDoctorCheck[] = [];
   const config = options.orchestrator.config;
+  const storage = options.orchestrator.storage;
   const configReview = await buildOperatorConfigReviewReport({
     now,
     configStatus,
@@ -1120,7 +1121,7 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
     details: conversationIndex,
   });
 
-  const meta = await new StorageManager(config.memoryDir).loadMeta();
+  const meta = await storage.loadMeta();
   checks.push({
     key: "maintenance",
     status: meta.lastExtractionAt || meta.lastConsolidationAt ? "ok" : "warn",
@@ -1206,14 +1207,14 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // Beta(1,1) prior — but surfacing the count helps operators understand how
   // much history will bootstrap the scoring pipeline landed in later PRs.
   // This is an informational check, never an error.
-  checks.push(await summarizeMemoryWorthLegacyCounters(new StorageManager(config.memoryDir)));
+  checks.push(await summarizeMemoryWorthLegacyCounters(storage));
 
   // Buffer surprise telemetry distribution (issue #563 PR 3).
   // Surfaces recent surprise scores so operators can calibrate the
   // `bufferSurpriseThreshold` from real traffic. Never an error — an empty
   // ledger is the expected state until the flag is turned on.
   checks.push(
-    await summarizeBufferSurpriseDistribution(new StorageManager(config.memoryDir), config),
+    await summarizeBufferSurpriseDistribution(storage, config),
   );
 
   // Consolidation provenance integrity (issue #561 PR 4).
@@ -1227,7 +1228,7 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // `versioningSidecarDir` into the scan so deployments that override
   // the default `.versions` directory get accurate results instead of
   // false-missing warnings.
-  checks.push(await summarizeConsolidationProvenance(new StorageManager(config.memoryDir), config));
+  checks.push(await summarizeConsolidationProvenance(storage, config));
 
   // Graph-edge decay maintenance status (issue #681 PR 2/3).
   // Reports whether the periodic decay job has run and surfaces last-run
@@ -1242,7 +1243,7 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // Dreams phases thresholds and last-run timestamps (issue #678 PR 2/4).
   // Surfaces per-phase: enabled status, cadence, threshold values, and the
   // best-available last-run timestamp for each of the three pipeline phases.
-  checks.push(await summarizeDreamsPhases(config));
+  checks.push(await summarizeDreamsPhases(config, storage));
 
   // Security mitigation status (issue #565).
   // Reports whether the cross-namespace budget and anomaly detection
@@ -1608,9 +1609,9 @@ export async function summarizeTierDistribution(
  */
 export async function summarizeDreamsPhases(
   config: Pick<PluginConfig, "memoryDir" | "dreamsPhases">,
+  storage: StorageManager = new StorageManager(config.memoryDir),
 ): Promise<OperatorDoctorCheck> {
   const phases: DreamsPhasesConfig = config.dreamsPhases;
-  const storage = new StorageManager(config.memoryDir);
 
   // Load meta.json for best-available last-run timestamps.
   const meta = await storage.loadMeta();

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2201,8 +2201,7 @@ export class Orchestrator {
 
       // Initialize content-hash dedup index
       if (this.config.factDeduplicationEnabled) {
-        const stateDir = path.join(this.config.memoryDir, "state");
-        this.contentHashIndex = new ContentHashIndex(stateDir);
+        this.contentHashIndex = this.storage.createContentHashIndex();
         await this.contentHashIndex.load();
         log.info(
           `content-hash dedup: loaded ${this.contentHashIndex.size} hashes`,

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -309,7 +309,7 @@ export interface DecryptResult {
 }
 
 /**
- * Walk `dir` recursively, find encryptable `.md` files that are not
+ * Walk `dir` recursively, find encryptable storage-managed files that are not
  * yet encrypted, and re-write them as encrypted files under `key`.
  *
  * Safety rules per CLAUDE.md gotchas #54 and #25:
@@ -336,8 +336,8 @@ export async function migrateMemoryDirToEncrypted(
 ): Promise<MigrateResult> {
   const result: MigrateResult = { encrypted: 0, skipped: 0, errors: [] };
 
-  const mdFiles = await collectMdFiles(dir);
-  for (const filePath of mdFiles) {
+  const files = await collectEncryptableStorageFiles(dir);
+  for (const filePath of files) {
     try {
       const buf = await readFile(filePath);
       if (isEncryptedFile(buf)) {
@@ -439,13 +439,12 @@ export async function decryptMemoryDirToPlaintext(
 // ---------------------------------------------------------------------------
 
 /**
- * Recursively collect `.md` files under `dir` that are read through
- * the storage-layer secure-store helpers, excluding symlinked entries
- * and `.secure-store/` metadata.
+ * Recursively collect files under `dir` that are read through the
+ * storage-layer secure-store helpers, excluding symlinked entries and
+ * `.secure-store/` metadata.
  */
-async function collectMdFiles(dir: string, rootDir = dir): Promise<string[]> {
-  const files = await collectStorageManagedFiles(dir, isEncryptableStoragePath, rootDir);
-  return files.filter((filePath) => path.basename(filePath).endsWith(".md"));
+async function collectEncryptableStorageFiles(dir: string, rootDir = dir): Promise<string[]> {
+  return collectStorageManagedFiles(dir, isEncryptableStoragePath, rootDir);
 }
 
 /**
@@ -494,8 +493,10 @@ function isEncryptableStoragePath(filePath: string, rootDir: string): boolean {
   if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return false;
   const normalized = normalizeStorageRelativePath(rel);
   if (normalized === "profile.md") return true;
+  if (isEncryptableStateSidecar(normalized)) return true;
+  if (isEncryptableSummarySidecar(normalized)) return true;
   const firstSegment = normalized.split("/", 1)[0];
-  return ENCRYPTABLE_STORAGE_ROOTS.has(firstSegment);
+  return ENCRYPTABLE_MARKDOWN_STORAGE_ROOTS.has(firstSegment) && normalized.endsWith(".md");
 }
 
 function isDecryptableStoragePath(filePath: string, rootDir: string): boolean {
@@ -526,7 +527,7 @@ function storageAadRootForFile(filePath: string, rootDir: string): string {
   return rootDir;
 }
 
-const ENCRYPTABLE_STORAGE_ROOTS = new Set([
+const ENCRYPTABLE_MARKDOWN_STORAGE_ROOTS = new Set([
   "facts",
   "corrections",
   "procedures",
@@ -536,6 +537,31 @@ const ENCRYPTABLE_STORAGE_ROOTS = new Set([
   "entities",
   "identity",
 ]);
+
+const ENCRYPTABLE_STATE_SIDECARS = new Set([
+  "state/behavior-signals.jsonl",
+  "state/buffer-surprise-ledger.jsonl",
+  "state/buffer.json",
+  "state/compression-guideline-draft-state.json",
+  "state/compression-guideline-state.json",
+  "state/compression-guidelines.draft.md",
+  "state/compression-guidelines.md",
+  "state/entity-synthesis-queue.json",
+  "state/fact-hashes.txt",
+  "state/memory-actions.jsonl",
+  "state/memory-lifecycle-ledger.jsonl",
+  "state/meta.json",
+  "state/reextract-jobs.jsonl",
+  "state/topics.json",
+]);
+
+function isEncryptableStateSidecar(normalized: string): boolean {
+  return ENCRYPTABLE_STATE_SIDECARS.has(normalized);
+}
+
+function isEncryptableSummarySidecar(normalized: string): boolean {
+  return normalized.startsWith("summaries/") && normalized.endsWith(".json");
+}
 
 const DECRYPTABLE_SIDECAR_ROOTS = new Set([
   "state",

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -9,6 +9,7 @@ import { sanitizeMemoryContent } from "./sanitize.js";
 import { createVersion as createPageVersion, type VersioningConfig, type VersionTrigger } from "./page-versioning.js";
 import {
   SecureStoreLockedError,
+  isEncryptedFile,
   readMaybeEncryptedFile,
   writeMaybeEncryptedFile,
 } from "./secure-store/secure-fs.js";
@@ -996,15 +997,26 @@ export class ContentHashIndex {
   private hashes: Set<string> = new Set();
   private dirty = false;
   private readonly filePath: string;
+  private readonly secureStoreKeyProvider: () => Buffer | null;
+  private readonly secureStoreWriteKeyProvider: () => Buffer | null;
+  private readonly memoryDir: string;
 
-  constructor(stateDir: string) {
+  constructor(
+    stateDir: string,
+    secureStoreKeyProvider: () => Buffer | null = () => null,
+    secureStoreWriteKeyProvider: () => Buffer | null = secureStoreKeyProvider,
+    memoryDir: string = path.dirname(stateDir),
+  ) {
     this.filePath = path.join(stateDir, "fact-hashes.txt");
+    this.secureStoreKeyProvider = secureStoreKeyProvider;
+    this.secureStoreWriteKeyProvider = secureStoreWriteKeyProvider;
+    this.memoryDir = memoryDir;
   }
 
   /** Load existing hashes from disk. Safe to call multiple times. */
   async load(): Promise<void> {
     try {
-      const raw = await readFile(this.filePath, "utf-8");
+      const raw = await readMaybeEncryptedFile(this.filePath, this.secureStoreKeyProvider(), this.memoryDir);
       for (const line of raw.split("\n")) {
         const trimmed = line.trim();
         if (trimmed.length > 0) {
@@ -1012,7 +1024,9 @@ export class ContentHashIndex {
         }
       }
       log.debug(`content-hash index: loaded ${this.hashes.size} hashes`);
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       log.debug("content-hash index: no existing index — starting fresh");
     }
   }
@@ -1039,7 +1053,13 @@ export class ContentHashIndex {
   async save(): Promise<void> {
     if (!this.dirty) return;
     await mkdir(path.dirname(this.filePath), { recursive: true });
-    await writeFile(this.filePath, [...this.hashes].join("\n") + "\n", "utf-8");
+    await writeMaybeEncryptedFile(
+      this.filePath,
+      [...this.hashes].join("\n") + "\n",
+      this.secureStoreWriteKeyProvider(),
+      {},
+      this.memoryDir,
+    );
     this.dirty = false;
     log.debug(`content-hash index: saved ${this.hashes.size} hashes`);
   }
@@ -2195,6 +2215,7 @@ export class StorageManager {
   private factHashIndexLoadPromise: Promise<ContentHashIndex> | null = null;
   private factHashIndexAuthoritative: boolean | null = null;
   private factHashIndexAuthoritativePromise: Promise<void> | null = null;
+  private readonly secureAppendChains = new Map<string, Promise<void>>();
   /** Optional: set by the orchestrator after construction to enable template-aware citation stripping during legacy hash rebuild. */
   citationTemplate: string = DEFAULT_CITATION_FORMAT;
 
@@ -2448,6 +2469,56 @@ export class StorageManager {
   private writeStorageSecureFile(filePath: string, content: string): Promise<void> {
     return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir);
   }
+  createContentHashIndex(): ContentHashIndex {
+    return new ContentHashIndex(
+      this.stateDir,
+      () => this._secureStoreKey,
+      () => this.resolveWriteKey(),
+      this.baseDir,
+    );
+  }
+
+  private async appendStorageSecureFile(filePath: string, content: string): Promise<void> {
+    const previous = this.secureAppendChains.get(filePath) ?? Promise.resolve();
+    const current = previous
+      .catch(() => undefined)
+      .then(() => this.appendStorageSecureFileUnlocked(filePath, content));
+    const next = current.catch(() => undefined);
+    this.secureAppendChains.set(filePath, next);
+    try {
+      await current;
+    } finally {
+      if (this.secureAppendChains.get(filePath) === next) {
+        this.secureAppendChains.delete(filePath);
+      }
+    }
+  }
+
+  private async appendStorageSecureFileUnlocked(filePath: string, content: string): Promise<void> {
+    const writeKey = this.resolveWriteKey();
+    await mkdir(path.dirname(filePath), { recursive: true });
+    if (writeKey === null) {
+      try {
+        if (isEncryptedFile(await readFile(filePath))) {
+          const existing = await this.readStorageSecureFile(filePath);
+          await writeMaybeEncryptedFile(filePath, `${existing}${content}`, null, {}, this.baseDir);
+          return;
+        }
+      } catch (err) {
+        if (!isErrnoCode(err, "ENOENT")) throw err;
+      }
+      await appendFile(filePath, content, "utf-8");
+      return;
+    }
+
+    let existing = "";
+    try {
+      existing = await this.readStorageSecureFile(filePath);
+    } catch (err) {
+      if (!isErrnoCode(err, "ENOENT")) throw err;
+    }
+    await writeMaybeEncryptedFile(filePath, `${existing}${content}`, writeKey, {}, this.baseDir);
+  }
   private get stateDir(): string {
     return path.join(this.baseDir, "state");
   }
@@ -2463,7 +2534,7 @@ export class StorageManager {
       return this.factHashIndex;
     }
     if (!this.factHashIndexLoadPromise) {
-      const index = new ContentHashIndex(this.stateDir);
+      const index = this.createContentHashIndex();
       this.factHashIndexLoadPromise = index
         .load()
         .then(() => {
@@ -4217,9 +4288,11 @@ export class StorageManager {
   async loadBuffer(): Promise<BufferState> {
     const bufferPath = path.join(this.stateDir, "buffer.json");
     try {
-      const raw = await readFile(bufferPath, "utf-8");
+      const raw = await this.readStorageSecureFile(bufferPath);
       return JSON.parse(raw) as BufferState;
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return { turns: [], lastExtractionAt: null, extractionCount: 0 };
     }
   }
@@ -4227,13 +4300,13 @@ export class StorageManager {
   async saveBuffer(state: BufferState): Promise<void> {
     await this.ensureDirectories();
     const bufferPath = path.join(this.stateDir, "buffer.json");
-    await writeFile(bufferPath, JSON.stringify(state, null, 2), "utf-8");
+    await this.writeStorageSecureFile(bufferPath, JSON.stringify(state, null, 2));
   }
 
   async loadMeta(): Promise<MetaState> {
     const metaPath = path.join(this.stateDir, "meta.json");
     try {
-      const raw = await readFile(metaPath, "utf-8");
+      const raw = await this.readStorageSecureFile(metaPath);
       const parsed = JSON.parse(raw) as MetaState;
       return {
         extractionCount:
@@ -4263,7 +4336,9 @@ export class StorageManager {
               }))
           : [],
       };
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return {
         extractionCount: 0,
         lastExtractionAt: null,
@@ -4278,7 +4353,7 @@ export class StorageManager {
   async saveMeta(state: MetaState): Promise<void> {
     await this.ensureDirectories();
     const metaPath = path.join(this.stateDir, "meta.json");
-    await writeFile(metaPath, JSON.stringify(state, null, 2), "utf-8");
+    await this.writeStorageSecureFile(metaPath, JSON.stringify(state, null, 2));
   }
 
   async appendMemoryActionEvents(events: MemoryActionEvent[]): Promise<number> {
@@ -4294,7 +4369,7 @@ export class StorageManager {
       return `${JSON.stringify(normalized)}\n`;
     }).join("");
 
-    await appendFile(this.memoryActionsPath, payload, "utf-8");
+    await this.appendStorageSecureFile(this.memoryActionsPath, payload);
     return events.length;
   }
 
@@ -4311,7 +4386,7 @@ export class StorageManager {
       return `${JSON.stringify(normalized)}\n`;
     }).join("");
 
-    await appendFile(this.memoryLifecycleLedgerPath, payload, "utf-8");
+    await this.appendStorageSecureFile(this.memoryLifecycleLedgerPath, payload);
     return events.length;
   }
 
@@ -4345,7 +4420,7 @@ export class StorageManager {
       })
       .join("");
 
-    await appendFile(this.bufferSurpriseLedgerPath, payload, "utf-8");
+    await this.appendStorageSecureFile(this.bufferSurpriseLedgerPath, payload);
     return events.length;
   }
 
@@ -4385,8 +4460,9 @@ export class StorageManager {
   ): Promise<BufferSurpriseEvent[]> {
     let raw: string;
     try {
-      raw = await readFile(this.bufferSurpriseLedgerPath, "utf-8");
+      raw = await this.readStorageSecureFile(this.bufferSurpriseLedgerPath);
     } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
       const code = (err as NodeJS.ErrnoException).code;
       if (code === "ENOENT") return [];
       throw err;
@@ -4440,7 +4516,7 @@ export class StorageManager {
 
     let existingKeys = new Set<string>();
     try {
-      const raw = await readFile(this.behaviorSignalsPath, "utf-8");
+      const raw = await this.readStorageSecureFile(this.behaviorSignalsPath);
       const lines = raw.split("\n");
       for (const line of lines) {
         const row = line.trim();
@@ -4454,7 +4530,9 @@ export class StorageManager {
           // Ignore malformed rows (fail-open).
         }
       }
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       existingKeys = new Set<string>();
     }
 
@@ -4472,7 +4550,7 @@ export class StorageManager {
 
     if (deduped.length === 0) return 0;
     const payload = deduped.map((event) => `${JSON.stringify(event)}\n`).join("");
-    await appendFile(this.behaviorSignalsPath, payload, "utf-8");
+    await this.appendStorageSecureFile(this.behaviorSignalsPath, payload);
     return deduped.length;
   }
 
@@ -4482,9 +4560,11 @@ export class StorageManager {
     const filePath = path.join(this.stateDir, "reextract-jobs.jsonl");
     const lines = events.map((event) => JSON.stringify(event)).join("\n") + "\n";
     try {
-      await appendFile(filePath, lines, "utf-8");
+      await this.appendStorageSecureFile(filePath, lines);
       return events.length;
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return 0;
     }
   }
@@ -4493,7 +4573,7 @@ export class StorageManager {
     const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(1000, Math.floor(limit))) : 200;
     const filePath = path.join(this.stateDir, "reextract-jobs.jsonl");
     try {
-      const raw = await readFile(filePath, "utf-8");
+      const raw = await this.readStorageSecureFile(filePath);
       const lines = raw.split("\n").filter((line) => line.trim().length > 0);
       const parsed: ReextractJobRequest[] = [];
       for (const line of lines) {
@@ -4521,7 +4601,9 @@ export class StorageManager {
         }
       }
       return parsed.slice(-safeLimit);
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return [];
     }
   }
@@ -4531,7 +4613,7 @@ export class StorageManager {
     if (cappedLimit === 0) return [];
 
     try {
-      const raw = await readFile(this.behaviorSignalsPath, "utf-8");
+      const raw = await this.readStorageSecureFile(this.behaviorSignalsPath);
       const out: BehaviorSignalEvent[] = [];
       const lines = raw.split("\n");
       for (let i = lines.length - 1; i >= 0 && out.length < cappedLimit; i -= 1) {
@@ -4557,44 +4639,61 @@ export class StorageManager {
         }
       }
       return out.reverse();
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return [];
     }
   }
 
   async readMemoryActionEvents(limit: number = 200): Promise<MemoryActionEvent[]> {
+    return (await this.readMemoryActionEventRows(limit)).map((row) => row.event);
+  }
+
+  async readMemoryActionEventRows(limit: number = 200): Promise<Array<{ line: number; event: MemoryActionEvent }>> {
     const cappedLimit = Math.max(0, Math.floor(limit));
     if (cappedLimit === 0) return [];
 
     try {
-      const raw = await readFile(this.memoryActionsPath, "utf-8");
-      const out: MemoryActionEvent[] = [];
+      const raw = await this.readStorageSecureFile(this.memoryActionsPath);
+      const out: Array<{ line: number; event: MemoryActionEvent }> = [];
       const lines = raw.split("\n");
       for (let i = lines.length - 1; i >= 0 && out.length < cappedLimit; i -= 1) {
         const line = lines[i]?.trim();
         if (!line) continue;
         try {
           const parsed = JSON.parse(line) as Partial<MemoryActionEvent>;
+          const outcome = parsed.outcome === "applied" || parsed.outcome === "skipped" || parsed.outcome === "failed"
+            ? parsed.outcome
+            : null;
           if (
             typeof parsed.timestamp === "string" &&
             typeof parsed.action === "string" &&
-            typeof parsed.outcome === "string"
+            outcome !== null
           ) {
-            out.push(parsed as MemoryActionEvent);
+            out.push({
+              line: i + 1,
+              event: {
+                ...parsed,
+                outcome,
+              } as MemoryActionEvent,
+            });
           }
         } catch {
           // Ignore malformed rows (fail-open).
         }
       }
       return out.reverse();
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return [];
     }
   }
 
   async readAllMemoryLifecycleEvents(): Promise<MemoryLifecycleEvent[]> {
     try {
-      const raw = await readFile(this.memoryLifecycleLedgerPath, "utf-8");
+      const raw = await this.readStorageSecureFile(this.memoryLifecycleLedgerPath);
       const out: MemoryLifecycleEvent[] = [];
       const lines = raw.split("\n");
       for (const line of lines) {
@@ -4617,7 +4716,9 @@ export class StorageManager {
         }
       }
       return sortMemoryLifecycleEvents(out);
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return [];
     }
   }
@@ -4631,26 +4732,30 @@ export class StorageManager {
 
   async writeCompressionGuidelines(content: string): Promise<void> {
     await this.ensureDirectories();
-    await writeFile(this.compressionGuidelinesPath, content, "utf-8");
+    await this.writeStorageSecureFile(this.compressionGuidelinesPath, content);
   }
 
   async readCompressionGuidelines(): Promise<string | null> {
     try {
-      return await readFile(this.compressionGuidelinesPath, "utf-8");
-    } catch {
+      return await this.readStorageSecureFile(this.compressionGuidelinesPath);
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return null;
     }
   }
 
   async writeCompressionGuidelineDraft(content: string): Promise<void> {
     await this.ensureDirectories();
-    await writeFile(this.compressionGuidelineDraftPath, content, "utf-8");
+    await this.writeStorageSecureFile(this.compressionGuidelineDraftPath, content);
   }
 
   async readCompressionGuidelineDraft(): Promise<string | null> {
     try {
-      return await readFile(this.compressionGuidelineDraftPath, "utf-8");
-    } catch {
+      return await this.readStorageSecureFile(this.compressionGuidelineDraftPath);
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return null;
     }
   }
@@ -4659,14 +4764,14 @@ export class StorageManager {
     state: CompressionGuidelineOptimizerState,
   ): Promise<void> {
     await this.ensureDirectories();
-    await writeFile(this.compressionGuidelineStatePath, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+    await this.writeStorageSecureFile(this.compressionGuidelineStatePath, `${JSON.stringify(state, null, 2)}\n`);
   }
 
   async writeCompressionGuidelineDraftState(
     state: CompressionGuidelineOptimizerState,
   ): Promise<void> {
     await this.ensureDirectories();
-    await writeFile(this.compressionGuidelineDraftStatePath, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+    await this.writeStorageSecureFile(this.compressionGuidelineDraftStatePath, `${JSON.stringify(state, null, 2)}\n`);
   }
 
   async readCompressionGuidelineOptimizerState(): Promise<CompressionGuidelineOptimizerState | null> {
@@ -4759,7 +4864,7 @@ export class StorageManager {
     };
 
     try {
-      const raw = await readFile(filePath, "utf-8");
+      const raw = await this.readStorageSecureFile(filePath);
       const parsed = JSON.parse(raw) as Partial<CompressionGuidelineOptimizerState>;
       const sourceWindow = parsed?.sourceWindow as Partial<CompressionGuidelineOptimizerState["sourceWindow"]>;
       const eventCounts = parsed?.eventCounts as Partial<CompressionGuidelineOptimizerState["eventCounts"]>;
@@ -4815,7 +4920,9 @@ export class StorageManager {
         ...(actionSummaries ? { actionSummaries } : {}),
         ...(ruleUpdates ? { ruleUpdates } : {}),
       };
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return null;
     }
   }
@@ -5460,12 +5567,14 @@ export class StorageManager {
 
   async readEntitySynthesisQueue(): Promise<string[]> {
     try {
-      const raw = await readFile(this.entitySynthesisQueuePath, "utf-8");
+      const raw = await this.readStorageSecureFile(this.entitySynthesisQueuePath);
       const parsed = JSON.parse(raw) as { entityNames?: unknown };
       return Array.isArray(parsed.entityNames)
         ? parsed.entityNames.filter((value): value is string => typeof value === "string")
         : [];
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return [];
     }
   }
@@ -5493,7 +5602,7 @@ export class StorageManager {
       .map(({ entityName }) => entityName);
 
     await mkdir(this.stateDir, { recursive: true });
-    await writeFile(
+    await this.writeStorageSecureFile(
       this.entitySynthesisQueuePath,
       JSON.stringify(
         {
@@ -5503,7 +5612,6 @@ export class StorageManager {
         null,
         2,
       ) + "\n",
-      "utf-8",
     );
     return staleEntityNames;
   }
@@ -5515,7 +5623,7 @@ export class StorageManager {
     const removals = new Set(entityNames);
     const nextQueue = queue.filter((name) => !removals.has(name));
     await mkdir(this.stateDir, { recursive: true });
-    await writeFile(
+    await this.writeStorageSecureFile(
       this.entitySynthesisQueuePath,
       JSON.stringify(
         {
@@ -5525,7 +5633,6 @@ export class StorageManager {
         null,
         2,
       ) + "\n",
-      "utf-8",
     );
   }
 
@@ -6063,7 +6170,7 @@ export class StorageManager {
 
       const fileContent = `${serializeFrontmatter(newFm)}\n\n${memory.content}\n`;
       try {
-        await writeFile(memory.path, fileContent, "utf-8");
+        await this.writeStorageSecureFile(memory.path, fileContent);
         updated++;
       } catch (err) {
         log.debug(`failed to update access tracking for ${entry.memoryId}: ${err}`);
@@ -6245,7 +6352,7 @@ export class StorageManager {
       filePath = path.join(this.factsDir, today, `${id}.md`);
     }
 
-    await writeFile(filePath, fileContent, "utf-8");
+    await this.writeStorageSecureFile(filePath, fileContent);
     log.debug(`wrote chunk ${id} (${chunkIndex + 1}/${chunkTotal}) to ${filePath}`);
     return id;
   }
@@ -6333,7 +6440,7 @@ export class StorageManager {
   async writeSummary(summary: MemorySummary): Promise<void> {
     await mkdir(this.summariesDir, { recursive: true });
     const filePath = path.join(this.summariesDir, `${summary.id}.json`);
-    await writeFile(filePath, JSON.stringify(summary, null, 2), "utf-8");
+    await this.writeStorageSecureFile(filePath, JSON.stringify(summary, null, 2));
     log.debug(`wrote summary ${summary.id}`);
   }
 
@@ -6348,12 +6455,14 @@ export class StorageManager {
       for (const file of files) {
         if (!file.endsWith(".json")) continue;
         const filePath = path.join(this.summariesDir, file);
-        const raw = await readFile(filePath, "utf-8");
+        const raw = await this.readStorageSecureFile(filePath);
         summaries.push(JSON.parse(raw) as MemorySummary);
       }
 
       return summaries;
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return [];
     }
   }
@@ -6381,7 +6490,7 @@ export class StorageManager {
       const fileContent = `${serializeFrontmatter(updatedFm)}\n\n${memory.content}\n`;
 
       try {
-        await writeFile(memory.path, fileContent, "utf-8");
+        await this.writeStorageSecureFile(memory.path, fileContent);
         await this.appendGeneratedMemoryLifecycleEventFailOpen("storage.archiveMemories", {
           memoryId: id,
           eventType: "archived",
@@ -6415,7 +6524,7 @@ export class StorageManager {
   async saveTopics(topics: TopicScore[]): Promise<void> {
     const metaPath = path.join(this.stateDir, "topics.json");
     await mkdir(this.stateDir, { recursive: true });
-    await writeFile(metaPath, JSON.stringify({ topics, updatedAt: new Date().toISOString() }, null, 2), "utf-8");
+    await this.writeStorageSecureFile(metaPath, JSON.stringify({ topics, updatedAt: new Date().toISOString() }, null, 2));
     log.debug(`saved ${topics.length} topic scores`);
   }
 
@@ -6425,9 +6534,11 @@ export class StorageManager {
   async loadTopics(): Promise<{ topics: TopicScore[]; updatedAt: string | null }> {
     const metaPath = path.join(this.stateDir, "topics.json");
     try {
-      const raw = await readFile(metaPath, "utf-8");
+      const raw = await this.readStorageSecureFile(metaPath);
       return JSON.parse(raw) as { topics: TopicScore[]; updatedAt: string | null };
-    } catch {
+    } catch (err) {
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (!isErrnoCode(err, "ENOENT")) throw err;
       return { topics: [], updatedAt: null };
     }
   }

--- a/tests/compounding.test.ts
+++ b/tests/compounding.test.ts
@@ -6,7 +6,7 @@ import os from "node:os";
 import type { PluginConfig } from "../src/types.js";
 import { CompoundingEngine } from "../src/compounding/engine.js";
 import { StorageManager } from "../src/storage.js";
-import { isEncryptedFile } from "../packages/remnic-core/src/secure-store/secure-fs.js";
+import { SecureStoreDecryptError, isEncryptedFile } from "../packages/remnic-core/src/secure-store/secure-fs.js";
 
 function tmpDir(prefix: string): string {
   return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
@@ -250,6 +250,74 @@ test("v5 compounding ingests failing memory-action patterns", async () => {
     false,
   );
   assert.ok(mistakes!.registry?.some((entry) => entry.workflow === "memory-actions"));
+});
+
+test("v5 compounding reads encrypted memory-action telemetry through storage", async () => {
+  const memoryDir = tmpDir("engram-compound-encrypted-mem-actions");
+  const sharedDir = tmpDir("engram-compound-encrypted-shared-actions");
+  await mkdir(memoryDir, { recursive: true });
+  await mkdir(path.join(sharedDir, "feedback"), { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  const storage = new StorageManager(memoryDir);
+  storage.setSecureStoreKey(Buffer.alloc(32, 0x5c), true);
+  await storage.ensureDirectories();
+  await storage.appendMemoryActionEvents([
+    {
+      timestamp: new Date().toISOString(),
+      action: "discard",
+      outcome: "skipped",
+      namespace: "team-alpha",
+      policyDecision: "deny",
+      reason: "policy:deny | high_importance_requires_manual_review",
+    },
+  ]);
+
+  const actionPath = path.join(memoryDir, "state", "memory-actions.jsonl");
+  assert.ok(isEncryptedFile(await readFile(actionPath)), "memory-action telemetry should be encrypted");
+
+  const eng = new CompoundingEngine(cfg, storage);
+  await eng.synthesizeWeekly();
+  const mistakes = await eng.readMistakes();
+  assert.ok(mistakes);
+  assert.ok(
+    mistakes!.patterns.some((p) =>
+      p.includes("memory-action/team-alpha: discard skipped/deny"),
+    ),
+  );
+});
+
+test("v5 compounding surfaces encrypted memory-action telemetry decrypt failures", async () => {
+  const memoryDir = tmpDir("engram-compound-encrypted-mem-actions-wrong-key");
+  const sharedDir = tmpDir("engram-compound-encrypted-shared-actions-wrong-key");
+  await mkdir(memoryDir, { recursive: true });
+  await mkdir(path.join(sharedDir, "feedback"), { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  const storage = new StorageManager(memoryDir);
+  storage.setSecureStoreKey(Buffer.alloc(32, 0x5c), true);
+  await storage.ensureDirectories();
+  await storage.appendMemoryActionEvents([
+    {
+      timestamp: new Date().toISOString(),
+      action: "discard",
+      outcome: "skipped",
+      namespace: "team-alpha",
+      policyDecision: "deny",
+      reason: "policy:deny | high_importance_requires_manual_review",
+    },
+  ]);
+
+  const actionPath = path.join(memoryDir, "state", "memory-actions.jsonl");
+  assert.ok(isEncryptedFile(await readFile(actionPath)), "memory-action telemetry should be encrypted");
+
+  const wrongKeyStorage = new StorageManager(memoryDir);
+  wrongKeyStorage.setSecureStoreKey(Buffer.alloc(32, 0xa5), true);
+  const eng = new CompoundingEngine(cfg, wrongKeyStorage);
+  await assert.rejects(
+    () => eng.synthesizeWeekly(),
+    (err) => err instanceof SecureStoreDecryptError,
+  );
 });
 
 test("v5 compounding reads legacy mistake files into stable registry form", async () => {

--- a/tests/dreams-phases-doctor.test.ts
+++ b/tests/dreams-phases-doctor.test.ts
@@ -10,6 +10,7 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
+import { StorageManager } from "../src/storage.js";
 import {
   runOperatorDoctor,
   summarizeDreamsPhases,
@@ -55,6 +56,7 @@ async function makeFixture(overrides: Record<string, unknown> = {}): Promise<{
   );
   const orchestrator: OperatorToolkitOrchestrator = {
     config,
+    storage: new StorageManager(memoryDir),
     qmd: {
       async probe() { return false; },
       isAvailable() { return false; },
@@ -254,6 +256,38 @@ test("runOperatorDoctor: includes dreams_phases check", async () => {
       dreamsCheck.details && typeof dreamsCheck.details === "object",
       "dreams_phases check must have details",
     );
+  } finally {
+    if (savedToken !== undefined) {
+      process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN = savedToken;
+    }
+  }
+});
+
+test("runOperatorDoctor: reads encrypted meta through orchestrator storage", async () => {
+  const savedToken = process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN;
+  delete process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN;
+  try {
+    const fixture = await makeFixture();
+    const key = Buffer.alloc(32, 0x7d);
+    fixture.orchestrator.storage.setSecureStoreKey(key, true);
+    await fixture.orchestrator.storage.saveMeta({
+      extractionCount: 3,
+      lastExtractionAt: "2026-04-28T00:00:00.000Z",
+      lastConsolidationAt: null,
+      totalMemories: 2,
+      totalEntities: 1,
+      processedExtractionFingerprints: [],
+    });
+
+    const report = await runOperatorDoctor({
+      orchestrator: fixture.orchestrator,
+      configPath: fixture.configPath,
+    });
+    const maintenance = report.checks.find((c) => c.key === "maintenance");
+    assert.equal(maintenance?.status, "ok");
+    const dreamsCheck = report.checks.find((c) => c.key === "dreams_phases");
+    const details = dreamsCheck?.details as { lightSleep?: { lastRun?: string | null } } | undefined;
+    assert.equal(details?.lightSleep?.lastRun, "2026-04-28T00:00:00.000Z");
   } finally {
     if (savedToken !== undefined) {
       process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN = savedToken;

--- a/tests/operator-toolkit-cli.test.ts
+++ b/tests/operator-toolkit-cli.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { registerCli } from "../src/cli.js";
+import { StorageManager } from "../src/storage.js";
 import { clearAuthTokenSecretCache } from "../packages/remnic-core/src/resolve-auth-token.js";
 import type { OperatorToolkitOrchestrator } from "../src/operator-toolkit.js";
 
@@ -87,6 +88,7 @@ async function makeFixture(
 
   const orchestrator: OperatorToolkitOrchestrator = {
     config,
+    storage: new StorageManager(memoryDir),
     qmd: {
       async probe() {
         return config.qmdEnabled;

--- a/tests/operator-toolkit.test.ts
+++ b/tests/operator-toolkit.test.ts
@@ -63,6 +63,7 @@ async function makeFixture(overrides: Record<string, unknown> = {}): Promise<{
   await writeFile(configPath, openclawConfigDocument(rawConfig), "utf-8");
   const orchestrator: OperatorToolkitOrchestrator = {
     config,
+    storage: new StorageManager(memoryDir),
     qmd: {
       async probe() {
         return config.qmdEnabled;

--- a/tests/secure-store/storage-wrap.test.ts
+++ b/tests/secure-store/storage-wrap.test.ts
@@ -265,7 +265,7 @@ test("migrateMemoryDirToEncrypted — encrypts all .md files", async () => {
   });
 });
 
-test("migrateMemoryDirToEncrypted — only encrypts storage-secure markdown paths", async () => {
+test("migrateMemoryDirToEncrypted — only encrypts storage-secure paths", async () => {
   await withTempDir(async (dir) => {
     const key = makeKey();
     const encryptedPaths = [
@@ -278,13 +278,32 @@ test("migrateMemoryDirToEncrypted — only encrypts storage-secure markdown path
       path.join(dir, "identity", "improvement-loops.md"),
       path.join(dir, "identity", "incidents", "2026-04-28-incident-a.md"),
       path.join(dir, "identity", "audits", "weekly", "2026-W18.md"),
+      path.join(dir, "state", "buffer.json"),
+      path.join(dir, "state", "meta.json"),
+      path.join(dir, "state", "memory-actions.jsonl"),
+      path.join(dir, "state", "memory-lifecycle-ledger.jsonl"),
+      path.join(dir, "state", "behavior-signals.jsonl"),
+      path.join(dir, "state", "buffer-surprise-ledger.jsonl"),
+      path.join(dir, "state", "reextract-jobs.jsonl"),
+      path.join(dir, "state", "topics.json"),
+      path.join(dir, "state", "entity-synthesis-queue.json"),
+      path.join(dir, "state", "fact-hashes.txt"),
+      path.join(dir, "state", "compression-guidelines.md"),
+      path.join(dir, "state", "compression-guidelines.draft.md"),
+      path.join(dir, "state", "compression-guideline-state.json"),
+      path.join(dir, "state", "compression-guideline-draft-state.json"),
+      path.join(dir, "summaries", "summary-a.json"),
       path.join(dir, "namespaces", "team-a", "facts", "2024-01-01", "fact.md"),
       path.join(dir, "namespaces", "team-a", "entities", "person.md"),
       path.join(dir, "namespaces", "team-a", "identity", "identity-anchor.md"),
+      path.join(dir, "namespaces", "team-a", "state", "buffer.json"),
+      path.join(dir, "namespaces", "team-a", "summaries", "summary-a.json"),
       path.join(dir, "profile.md"),
     ];
     const plainPaths = [
       path.join(dir, "workspace", "IDENTITY.md"),
+      path.join(dir, "state", ".memory-status-version.log"),
+      path.join(dir, "state", "unknown.json"),
     ];
     for (const f of [...encryptedPaths, ...plainPaths]) {
       await mkdir(path.dirname(f), { recursive: true });
@@ -636,6 +655,309 @@ test("StorageManager — plaintext identity support files remain readable withou
     assert.equal(await storage.readIdentityReflections(), "plain reflection");
     assert.equal(await storage.readIdentityImprovementLoops(), "plain loop");
     assert.equal(await storage.readIdentityAudit("weekly", "2026-W18"), "plain audit");
+  });
+});
+
+test("StorageManager — state and index sidecars encrypt, decrypt, and fail clearly while locked", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(key, true);
+    await storage.ensureDirectories();
+
+    await storage.saveBuffer({
+      turns: [{ role: "user", content: "private buffered turn", timestamp: "2026-04-28T00:00:00.000Z" }],
+      lastExtractionAt: "2026-04-28T00:00:00.000Z",
+      extractionCount: 1,
+    });
+    await storage.saveMeta({
+      extractionCount: 2,
+      lastExtractionAt: "2026-04-28T00:00:00.000Z",
+      lastConsolidationAt: null,
+      totalMemories: 1,
+      totalEntities: 0,
+      processedExtractionFingerprints: [
+        { fingerprint: "private-fingerprint", observedAt: "2026-04-28T00:00:00.000Z" },
+      ],
+    });
+    await storage.saveTopics([{ term: "private-topic", score: 1, count: 2 }]);
+    await storage.appendMemoryActionEvents([
+      {
+        timestamp: "2026-04-28T00:00:00.000Z",
+        action: "store_note",
+        outcome: "applied",
+        memoryId: "mem-private-action",
+      },
+    ]);
+    await storage.appendMemoryLifecycleEvents([
+      {
+        eventId: "evt-private-lifecycle",
+        memoryId: "mem-private-action",
+        eventType: "created",
+        timestamp: "2026-04-28T00:00:00.000Z",
+        actor: "test",
+        ruleVersion: "v1",
+      },
+    ]);
+    await storage.writeCompressionGuidelines("private compression guideline");
+    await storage.writeCompressionGuidelineOptimizerState({
+      version: 1,
+      updatedAt: "2026-04-28T00:00:00.000Z",
+      sourceWindow: {
+        from: "2026-04-21T00:00:00.000Z",
+        to: "2026-04-28T00:00:00.000Z",
+      },
+      eventCounts: {
+        total: 1,
+        applied: 1,
+        skipped: 0,
+        failed: 0,
+      },
+      guidelineVersion: 1,
+      activationState: "active",
+    });
+    await storage.writeMemory("fact", "private fact hash sidecar content");
+
+    const encryptedFiles = [
+      path.join(dir, "state", "buffer.json"),
+      path.join(dir, "state", "meta.json"),
+      path.join(dir, "state", "topics.json"),
+      path.join(dir, "state", "memory-actions.jsonl"),
+      path.join(dir, "state", "memory-lifecycle-ledger.jsonl"),
+      path.join(dir, "state", "compression-guidelines.md"),
+      path.join(dir, "state", "compression-guideline-state.json"),
+      path.join(dir, "state", "fact-hashes.txt"),
+    ];
+    for (const filePath of encryptedFiles) {
+      assert.ok(isEncryptedFile(await readFile(filePath)), `${filePath} should be encrypted`);
+    }
+
+    assert.equal((await storage.loadBuffer()).turns[0]?.content, "private buffered turn");
+    assert.equal((await storage.loadMeta()).processedExtractionFingerprints?.[0]?.fingerprint, "private-fingerprint");
+    assert.equal((await storage.loadTopics()).topics[0]?.term, "private-topic");
+    assert.equal((await storage.readMemoryActionEvents(10))[0]?.memoryId, "mem-private-action");
+    assert.ok(
+      (await storage.readAllMemoryLifecycleEvents()).some((event) => event.eventId === "evt-private-lifecycle"),
+      "explicit lifecycle event should decrypt from the encrypted ledger",
+    );
+    assert.equal(await storage.readCompressionGuidelines(), "private compression guideline");
+    assert.equal((await storage.readCompressionGuidelineOptimizerState())?.guidelineVersion, 1);
+    assert.equal(await storage.hasFactContentHash("private fact hash sidecar content"), true);
+
+    const lockedStorage = new StorageManager(dir, []);
+    await assert.rejects(() => lockedStorage.loadBuffer(), (err) => err instanceof SecureStoreLockedError);
+    await assert.rejects(() => lockedStorage.loadMeta(), (err) => err instanceof SecureStoreLockedError);
+    await assert.rejects(() => lockedStorage.loadTopics(), (err) => err instanceof SecureStoreLockedError);
+    await assert.rejects(() => lockedStorage.readMemoryActionEvents(10), (err) => err instanceof SecureStoreLockedError);
+    await assert.rejects(() => lockedStorage.readAllMemoryLifecycleEvents(), (err) => err instanceof SecureStoreLockedError);
+    await assert.rejects(() => lockedStorage.readCompressionGuidelines(), (err) => err instanceof SecureStoreLockedError);
+    await assert.rejects(() => lockedStorage.readCompressionGuidelineOptimizerState(), (err) => err instanceof SecureStoreLockedError);
+    await assert.rejects(
+      () => lockedStorage.hasFactContentHash("private fact hash sidecar content"),
+      (err) => err instanceof SecureStoreLockedError,
+    );
+  });
+});
+
+test("StorageManager — plaintext state sidecars remain readable without secure-store key", async () => {
+  await withTempDir(async (dir) => {
+    const stateDir = path.join(dir, "state");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(
+      path.join(stateDir, "buffer.json"),
+      JSON.stringify({
+        turns: [{ role: "user", content: "plain buffered turn", timestamp: "2026-04-28T00:00:00.000Z" }],
+        lastExtractionAt: null,
+        extractionCount: 1,
+      }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(stateDir, "meta.json"),
+      JSON.stringify({
+        extractionCount: 1,
+        lastExtractionAt: null,
+        lastConsolidationAt: null,
+        totalMemories: 1,
+        totalEntities: 0,
+      }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(stateDir, "topics.json"),
+      JSON.stringify({ topics: [{ term: "plain-topic", score: 1, count: 1 }], updatedAt: "2026-04-28T00:00:00.000Z" }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(stateDir, "memory-actions.jsonl"),
+      `${JSON.stringify({ timestamp: "2026-04-28T00:00:00.000Z", action: "store_note", outcome: "applied", memoryId: "plain-action" })}\n`,
+      "utf8",
+    );
+
+    const storage = new StorageManager(dir, []);
+
+    assert.equal((await storage.loadBuffer()).turns[0]?.content, "plain buffered turn");
+    assert.equal((await storage.loadMeta()).totalMemories, 1);
+    assert.equal((await storage.loadTopics()).topics[0]?.term, "plain-topic");
+    assert.equal((await storage.readMemoryActionEvents(10))[0]?.memoryId, "plain-action");
+  });
+});
+
+test("StorageManager — encrypted state sidecars fail loudly with the wrong key", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey(0x42);
+    const wrongKey = makeKey(0x24);
+    const stateDir = path.join(dir, "state");
+    await mkdir(stateDir, { recursive: true });
+
+    await writeMaybeEncryptedFile(
+      path.join(stateDir, "buffer.json"),
+      JSON.stringify({
+        turns: [{ role: "user", content: "sealed buffered turn", timestamp: "2026-04-28T00:00:00.000Z" }],
+        lastExtractionAt: null,
+        extractionCount: 1,
+      }),
+      key,
+      {},
+      dir,
+    );
+    await writeMaybeEncryptedFile(
+      path.join(stateDir, "meta.json"),
+      JSON.stringify({
+        extractionCount: 7,
+        lastExtractionAt: "2026-04-28T00:00:00.000Z",
+        lastConsolidationAt: null,
+        totalMemories: 3,
+        totalEntities: 2,
+        processedExtractionFingerprints: [{ fingerprint: "sealed-fingerprint", observedAt: "2026-04-28T00:00:00.000Z" }],
+      }),
+      key,
+      {},
+      dir,
+    );
+    await writeMaybeEncryptedFile(
+      path.join(stateDir, "memory-actions.jsonl"),
+      `${JSON.stringify({ timestamp: "2026-04-28T00:00:00.000Z", action: "store_note", outcome: "applied", memoryId: "sealed-action" })}\n`,
+      key,
+      {},
+      dir,
+    );
+    await writeMaybeEncryptedFile(
+      path.join(stateDir, "memory-lifecycle-ledger.jsonl"),
+      `${JSON.stringify({
+        eventId: "sealed-lifecycle",
+        memoryId: "sealed-memory",
+        eventType: "created",
+        timestamp: "2026-04-28T00:00:00.000Z",
+        actor: "test",
+        ruleVersion: "v1",
+      })}\n`,
+      key,
+      {},
+      dir,
+    );
+    await writeMaybeEncryptedFile(
+      path.join(stateDir, "fact-hashes.txt"),
+      "not-important-for-decrypt-failure\n",
+      key,
+      {},
+      dir,
+    );
+    await writeFile(path.join(stateDir, "fact-hashes.ready"), "v1\n", "utf8");
+
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(wrongKey, true);
+
+    await assert.rejects(
+      () => storage.loadBuffer(),
+      (err) => err instanceof SecureStoreDecryptError,
+    );
+    await assert.rejects(
+      () => storage.loadMeta(),
+      (err) => err instanceof SecureStoreDecryptError,
+    );
+    await assert.rejects(
+      () => storage.readMemoryActionEvents(10),
+      (err) => err instanceof SecureStoreDecryptError,
+    );
+    await assert.rejects(
+      () => storage.readAllMemoryLifecycleEvents(),
+      (err) => err instanceof SecureStoreDecryptError,
+    );
+    await assert.rejects(
+      () => storage.hasFactContentHash("not important for decrypt failure"),
+      (err) => err instanceof SecureStoreDecryptError,
+    );
+    assert.ok(isEncryptedFile(await readFile(path.join(stateDir, "buffer.json"))), "buffer should remain encrypted");
+    assert.ok(isEncryptedFile(await readFile(path.join(stateDir, "meta.json"))), "meta should remain encrypted");
+    assert.ok(isEncryptedFile(await readFile(path.join(stateDir, "memory-actions.jsonl"))), "action ledger should remain encrypted");
+    assert.ok(isEncryptedFile(await readFile(path.join(stateDir, "memory-lifecycle-ledger.jsonl"))), "lifecycle ledger should remain encrypted");
+    assert.ok(isEncryptedFile(await readFile(path.join(stateDir, "fact-hashes.txt"))), "fact hash index should remain encrypted");
+  });
+});
+
+test("StorageManager — encrypted ledger appends are serialized", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(key, true);
+    await storage.ensureDirectories();
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        storage.appendMemoryActionEvents([
+          {
+            timestamp: `2026-04-28T00:00:${String(index).padStart(2, "0")}.000Z`,
+            action: "store_note",
+            outcome: "applied",
+            memoryId: `mem-concurrent-${index}`,
+          },
+        ]),
+      ),
+    );
+
+    const ledgerPath = path.join(dir, "state", "memory-actions.jsonl");
+    assert.ok(isEncryptedFile(await readFile(ledgerPath)), "concurrent ledger should remain encrypted");
+    const events = await storage.readMemoryActionEvents(50);
+    assert.equal(events.length, 20);
+    assert.deepEqual(
+      events.map((event) => event.memoryId).sort(),
+      Array.from({ length: 20 }, (_, index) => `mem-concurrent-${index}`).sort(),
+    );
+  });
+});
+
+test("StorageManager — memory-action row reader preserves source lines and skips invalid outcomes", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const storage = new StorageManager(dir, []);
+    storage.setSecureStoreKey(key, true);
+    await storage.ensureDirectories();
+
+    const ledgerPath = path.join(dir, "state", "memory-actions.jsonl");
+    await writeMaybeEncryptedFile(
+      ledgerPath,
+      [
+        JSON.stringify({ timestamp: "2026-04-28T00:00:00.000Z", action: "store_note", outcome: "applied", memoryId: "line-1" }),
+        "",
+        "{not-json",
+        JSON.stringify({ timestamp: "2026-04-28T00:00:01.000Z", action: "store_note", outcome: "pending", memoryId: "bad-outcome" }),
+        JSON.stringify({ timestamp: "2026-04-28T00:00:02.000Z", action: "discard", outcome: "skipped", memoryId: "line-5" }),
+        "",
+      ].join("\n"),
+      key,
+      {},
+      dir,
+    );
+
+    const rows = await storage.readMemoryActionEventRows(10);
+    assert.deepEqual(
+      rows.map((row) => ({ line: row.line, memoryId: row.event.memoryId, outcome: row.event.outcome })),
+      [
+        { line: 1, memoryId: "line-1", outcome: "applied" },
+        { line: 5, memoryId: "line-5", outcome: "skipped" },
+      ],
+    );
   });
 });
 


### PR DESCRIPTION
Closes #783.

## Summary
- route memory-derived state/index/ledger sidecars through secure-store read/write helpers
- add encrypted append handling for JSONL ledgers, including decrypt-and-rewrite when disabling encryption on an encrypted file
- expand secure-store migration to encrypt allow-listed sidecars and summary JSON without touching version logs or unknown state files
- cover encrypted round-trip, locked read failures, and plaintext backward compatibility for representative sidecars

## Verification
- npm exec -- tsx --test tests/secure-store/storage-wrap.test.ts
- npm exec -- tsx --test tests/secure-store/storage-wrap.test.ts tests/storage-fact-hash-index.test.ts
- npm exec -- tsx --test tests/storage-fact-hash-index.test.ts
- npm run test:entity-hardening
- git diff --check

## Local preflight
- npm run preflight:quick currently fails in this local checkout at `packages/remnic-core/src/secure-store/kdf.ts(37,36): error TS2307: Cannot find module @node-rs/argon2 or its corresponding type declarations.` This is the same local dependency/type-resolution blocker observed on the previous secure-store PR; CI quality has been validating in the clean environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persistence paths by routing multiple state/index/ledger files through secure-store encryption (including append semantics), which can affect runtime reads/writes if key handling or migration edge cases are wrong. Adds tests for encrypted/locked/wrong-key behaviors, reducing but not eliminating the risk of data-access regressions.
> 
> **Overview**
> **Encrypts memory-derived state/index/ledger sidecars.** `StorageManager` now reads/writes a broader set of `state/*` and `summaries/*.json` artifacts via secure-store helpers (e.g., `meta.json`, `buffer.json`, topic scores, compression guideline state, fact-hash index), with explicit handling for locked stores and missing files.
> 
> **Adds encrypted-safe append support for ledgers.** JSONL append paths (memory actions/lifecycle, buffer surprise, behavior signals, reextract jobs) now append through a serialized decrypt+rewrite flow when encrypted, and `readMemoryActionEventRows` preserves source line numbers while filtering invalid outcomes.
> 
> **Wires callers to the storage layer and updates reports.** Compounding weekly synthesis reads action telemetry via `storage.readMemoryActionEventRows` (dropping the prior `unknown` outcome bucket), operator toolkit uses the orchestrator’s shared `storage` (including `summarizeDreamsPhases`/maintenance meta), and the orchestrator creates `ContentHashIndex` via `storage.createContentHashIndex()` so the index participates in encryption.
> 
> **Expands migration + tests.** Secure-store migration now encrypts allow-listed state sidecars and summary JSON (without encrypting unknown files/logs), and tests cover encrypted round-trips, wrong-key/locked failures, plaintext backward compatibility, concurrent encrypted appends, and compounding/doctor behavior with encrypted artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed552e444202a119269dc07cb808503e89c968b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->