### PR TITLE
docs(readme): refresh Remnic package surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,24 +179,24 @@ After installation, add the Remnic bridge plugin to your `openclaw.json`:
 ```jsonc
 {
   "plugins": {
-    "allow": ["openclaw-engram"],
-    "slots": { "memory": "openclaw-engram" },
+    "allow": ["openclaw-remnic"],
+    "slots": { "memory": "openclaw-remnic" },
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "enabled": true,
         "config": {
           // Option 1: Use OpenAI for extraction:
           "openaiApiKey": "${OPENAI_API_KEY}"
 
-          // Option 2: Use Engram's local LLM path (plugin mode only; no API key needed):
+          // Option 2: Use Remnic's local LLM path (plugin mode only; no API key needed):
           // "localLlmEnabled": true,
           // "localLlmUrl": "http://localhost:1234/v1",
           // "localLlmModel": "qwen2.5-32b-instruct"
 
           // Option 3: Use the gateway model chain (primary path in gateway mode):
           // "modelSource": "gateway",
-          // "gatewayAgentId": "engram-llm",
-          // "fastGatewayAgentId": "engram-llm-fast"
+          // "gatewayAgentId": "remnic-llm",
+          // "fastGatewayAgentId": "remnic-llm-fast"
         }
       }
     }
@@ -227,7 +227,7 @@ Default: `"low"` — only `"trivial"` content is dropped. Raise to `"normal"` or
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           // Allowed values: "trivial" | "low" | "normal" | "high" | "critical"
           "extractionMinImportanceLevel": "normal"
@@ -256,7 +256,7 @@ Enable it per plugin:
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           "inlineSourceAttributionEnabled": true,
           // Optional: customize the tag format.
@@ -282,9 +282,9 @@ See `packages/remnic-core/src/source-attribution.ts` for the helpers and `packag
 ### Verify installation
 
 ```bash
-openclaw engram setup --json         # Validates config, scaffolds directories
-openclaw engram doctor --json        # Health diagnostics with remediation hints
-openclaw engram config-review --json # Opinionated config tuning recommendations
+remnic doctor              # Health diagnostics with remediation hints
+remnic connectors doctor   # Connector-specific health checks
+remnic status              # Daemon status and local endpoint summary
 ```
 
 ## Bring your memory
@@ -347,7 +347,7 @@ Restart the gateway after running this command.
 After restarting, check the gateway log for this line:
 
 ```
-[remnic] gateway_start fired — Remnic memory plugin is active (id=openclaw-engram, memoryDir=~/.openclaw/workspace/memory/local)
+[remnic] gateway_start fired — Remnic memory plugin is active (id=openclaw-remnic, memoryDir=~/.openclaw/workspace/memory/local)
 ```
 
 On macOS:
@@ -483,7 +483,7 @@ OpenClaw remains the recommended path for most users. The standalone CLI is usef
 
 ## How It Works
 
-Engram operates in three phases:
+Remnic operates in three phases:
 
 ```
  Recall    → Before each conversation, inject relevant memories into context
@@ -508,7 +508,7 @@ Memory categories include: `fact`, `decision`, `preference`, `correction`, `rela
 
 ## Architecture
 
-Engram is organized as a monorepo with a core engine, standalone server/CLI, and native plugins for multiple AI platforms:
+Remnic is organized as a monorepo with a core engine, standalone server/CLI, and native plugins for multiple AI platforms:
 
 ```
                          ┌─────────────────┐
@@ -540,13 +540,17 @@ Engram is organized as a monorepo with a core engine, standalone server/CLI, and
 | `@remnic/export-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/export-weclone)](https://www.npmjs.com/package/@remnic/export-weclone) | WeClone fine-tuning dataset exporter — optional `remnic training:export` surface |
 | `@remnic/import-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/import-weclone)](https://www.npmjs.com/package/@remnic/import-weclone) | WeClone chat-history importer — optional `remnic bulk-import` source |
 | `@remnic/connector-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/connector-weclone)](https://www.npmjs.com/package/@remnic/connector-weclone) | OpenAI-compatible proxy layering Remnic memory onto WeClone avatars |
+| `@remnic/import-chatgpt` | [![npm](https://img.shields.io/npm/v/@remnic/import-chatgpt)](https://www.npmjs.com/package/@remnic/import-chatgpt) | ChatGPT saved-memory and conversation-summary importer — optional `remnic import --adapter chatgpt` surface |
+| `@remnic/import-claude` | [![npm](https://img.shields.io/npm/v/@remnic/import-claude)](https://www.npmjs.com/package/@remnic/import-claude) | Claude project docs and prompt-template importer — optional `remnic import --adapter claude` surface |
+| `@remnic/import-gemini` | [![npm](https://img.shields.io/npm/v/@remnic/import-gemini)](https://www.npmjs.com/package/@remnic/import-gemini) | Google Takeout Gemini Apps Activity importer — optional `remnic import --adapter gemini` surface |
+| `@remnic/import-mem0` | [![npm](https://img.shields.io/npm/v/@remnic/import-mem0)](https://www.npmjs.com/package/@remnic/import-mem0) | mem0 REST and JSON importer — optional `remnic import --adapter mem0` surface |
 | `@remnic/plugin-openclaw` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-openclaw)](https://www.npmjs.com/package/@remnic/plugin-openclaw) | OpenClaw adapter — thin bridge (embedded or delegate mode) |
 | `@remnic/plugin-claude-code` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-claude-code)](https://www.npmjs.com/package/@remnic/plugin-claude-code) | Native Claude Code plugin — hooks, skills, MCP |
 | `@remnic/plugin-codex` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-codex)](https://www.npmjs.com/package/@remnic/plugin-codex) | Native Codex CLI plugin — hooks, skills, MCP |
 | `@remnic/replit` | [![npm](https://img.shields.io/npm/v/@remnic/replit)](https://www.npmjs.com/package/@remnic/replit) | Replit Agent MCP connector — setup snippet + token helper |
 | `remnic-hermes` | [![PyPI](https://img.shields.io/pypi/v/remnic-hermes)](https://pypi.org/project/remnic-hermes/) | Python MemoryProvider for Hermes Agent |
 
-Remnic is installed à la carte: `@remnic/core` is the only package most users need, and optional surfaces (bench, weclone, plugins) are installed separately when you need them. Commands like `remnic bench *` and `remnic training:export` lazy-load their companion package and print an install hint if it's missing.
+Remnic is installed à la carte: most users start with `@remnic/cli`, while `@remnic/core` stays available for framework-agnostic embedding. Optional surfaces (bench, WeClone, plugins, and importers) are installed separately when you need them. Commands like `remnic bench *`, `remnic training:export`, and `remnic import --adapter <source>` lazy-load their companion package and print an install hint if it's missing.
 
 The old `@joshuaswarren/openclaw-engram` package is **deprecated**. Use `@remnic/plugin-openclaw` for OpenClaw installs and `@remnic/*` for standalone or multi-platform use.
 
@@ -558,7 +562,7 @@ All memory lives on your filesystem as plain markdown files. No cloud dependency
 
 ### A real upgrade from default OpenClaw memory
 
-OpenClaw's built-in memory is basic — it works for getting started, but lacks semantic search, entity tracking, lifecycle management, governance, and multi-agent isolation. Engram is a drop-in replacement that brings all of those capabilities while keeping the same local-first philosophy.
+OpenClaw's built-in memory is basic — it works for getting started, but lacks semantic search, entity tracking, lifecycle management, governance, and multi-agent isolation. Remnic is a drop-in replacement that brings all of those capabilities while keeping the same local-first philosophy.
 
 ### Smart recall, not keyword search
 
@@ -595,7 +599,7 @@ Use a preset to jump to a recommended level: `conservative`, `balanced`, `resear
 
 ### Standalone Multi-Tenant Server
 
-Run Engram as a standalone HTTP server that multiple agent harnesses share. Isolate tenants with namespace policies, feed conversations from any client via the observe endpoint, and search archived history with LCM full-text search. Works with OpenClaw, Codex CLI, Claude Code, and custom HTTP agents. See the [Standalone Server Guide](docs/guides/standalone-server.md).
+Run Remnic as a standalone HTTP server that multiple agent harnesses share. Isolate tenants with namespace policies, feed conversations from any client via the observe endpoint, and search archived history with LCM full-text search. Works with OpenClaw, Codex CLI, Claude Code, and custom HTTP agents. See the [Standalone Server Guide](docs/guides/standalone-server.md).
 
 ### Built for production
 
@@ -690,7 +694,7 @@ Enable it in your `openclaw.json`:
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           "lcmEnabled": true
           // All other LCM settings have sensible defaults
@@ -705,7 +709,7 @@ See the [LCM Guide](docs/guides/lossless-context-management.md) for architecture
 
 ### Parallel Specialized Retrieval (opt-in)
 
-Engram's default retrieval runs a single hybrid search pass. Parallel Specialized Retrieval (inspired by [Supermemory's ASMR technique](https://blog.supermemory.ai/we-broke-the-frontier-in-agent-memory-introducing-99-sota-memory-system/)) runs three specialized agents in parallel so total latency equals `max(agents)` not `sum(agents)`.
+Remnic's default retrieval runs a single hybrid search pass. Parallel Specialized Retrieval (inspired by [Supermemory's ASMR technique](https://blog.supermemory.ai/we-broke-the-frontier-in-agent-memory-introducing-99-sota-memory-system/)) runs three specialized agents in parallel so total latency equals `max(agents)` not `sum(agents)`.
 
 | Agent | What It Does | Cost |
 |-------|-------------|------|
@@ -723,7 +727,7 @@ Enable it in your `openclaw.json`:
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           "parallelRetrievalEnabled": true
           // Optional tuning:
@@ -754,7 +758,7 @@ Enable it in your `openclaw.json`:
 {
   "plugins": {
     "entries": {
-      "openclaw-engram": {
+      "openclaw-remnic": {
         "config": {
           "semanticConsolidationEnabled": true
           // Optional tuning:
@@ -842,6 +846,9 @@ For namespace-enabled deployments, configure `server.principal` in `remnic.confi
 ## CLI Reference
 
 ```bash
+# OpenClaw-hosted compatibility commands still use the `openclaw engram`
+# namespace during the v1.x rename window. Standalone commands use `remnic`.
+#
 # Setup & diagnostics
 openclaw engram setup              # Guided first-run setup
 openclaw engram doctor             # Health diagnostics with remediation hints
@@ -923,12 +930,12 @@ See the [full CLI reference](docs/api.md#cli-commands) for all commands.
 
 ## Configuration
 
-All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.config`. The table below shows the most commonly changed settings — Engram has **60+ configuration options** covering search backends, capture modes, memory OS features, namespaces, governance, benchmarking, and more.
+OpenClaw plugin settings live in `openclaw.json` under `plugins.entries.openclaw-remnic.config` (with a legacy `openclaw-engram` fallback during the rename window). Standalone settings live in `remnic.config.json` or `~/.config/remnic/config.json`. The table below shows the most commonly changed settings — Remnic has **60+ configuration options** covering search backends, capture modes, memory OS features, namespaces, governance, benchmarking, and more.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `openaiApiKey` | `(env)` | OpenAI API key (optional when using a local LLM) |
-| `localLlmEnabled` | `false` | Enable Engram's local LLM path when `modelSource` is `plugin` |
+| `localLlmEnabled` | `false` | Enable Remnic's local LLM path when `modelSource` is `plugin` |
 | `localLlmUrl` | unset | Local LLM endpoint (e.g., `http://localhost:1234/v1`) |
 | `localLlmModel` | unset | Local model name (e.g., `qwen2.5-32b-instruct`) |
 | `model` | `gpt-5.2` | OpenAI model for extraction when `modelSource` is `plugin` and local LLM is disabled |
@@ -981,7 +988,7 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 - [Search Backends](docs/search-backends.md) — Choosing and configuring search engines
 - [Writing a Search Backend](docs/writing-a-search-backend.md) — Build your own adapter
 - [API Reference](docs/api.md) — HTTP, MCP, and CLI documentation
-- [Codex CLI Integration](docs/guides/codex-cli.md) — Setup Engram with OpenAI's Codex
+- [Codex CLI Integration](docs/guides/codex-cli.md) — Set up Remnic with OpenAI's Codex
 - [Standalone Server Guide](docs/guides/standalone-server.md) — Multi-tenant HTTP server for multiple agent harnesses
 - [Local LLM Guide](docs/guides/local-llm.md) — Local-first extraction and reranking
 - [Cost Control Guide](docs/guides/cost-control.md) — Budget mappings and presets

--- a/docs/integration/connector-setup.md
+++ b/docs/integration/connector-setup.md
@@ -31,7 +31,7 @@ Add to `~/.claude.json` (or project `.mcp.json`):
 ```jsonc
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "type": "http",
       "url": "http://localhost:4318/mcp",
       "headers": {
@@ -47,7 +47,7 @@ Add to `~/.claude.json` (or project `.mcp.json`):
 
 Restart Claude Code. Verify with: `What MCP tools do you have?`
 
-**Auto-detection:** Claude Code sends `clientInfo.name = "claude-code"` and `User-Agent: claude-code/<version>` — Engram identifies it automatically.
+**Auto-detection:** Claude Code sends `clientInfo.name = "claude-code"` and `User-Agent: claude-code/<version>` — Remnic identifies it automatically.
 
 **Capabilities:** observe, recall, store, search, entities, real-time sync
 
@@ -58,7 +58,7 @@ Restart Claude Code. Verify with: `What MCP tools do you have?`
 Add to `~/.codex/config.toml`:
 
 ```toml
-[mcp_servers.engram]
+[mcp_servers.remnic]
 url = "http://127.0.0.1:4318/mcp"
 bearer_token_env_var = "REMNIC_AUTH_TOKEN"
 # Optional: scope memory to a project/team namespace
@@ -67,7 +67,7 @@ http_headers = { "X-Engram-Namespace" = "my-project", "X-Engram-Principal" = "co
 
 See the [full Codex CLI guide](../guides/codex-cli.md) for session-start hooks and automatic recall.
 
-**Auto-detection:** Codex sends `clientInfo.name = "codex-mcp-client"` — Engram identifies it automatically.
+**Auto-detection:** Codex sends `clientInfo.name = "codex-mcp-client"` — Remnic identifies it automatically.
 
 **Capabilities:** observe, recall, store, batch
 
@@ -80,7 +80,7 @@ Add to `.cursor/mcp.json` in your project root (or `~/.cursor/mcp.json` globally
 ```jsonc
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "url": "http://localhost:4318/mcp",
       "headers": {
         "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
@@ -103,7 +103,7 @@ GitHub Copilot supports MCP servers in VS Code. Add to your VS Code `settings.js
 ```jsonc
 {
   "github.copilot.chat.experimental.mcpServers": {
-    "engram": {
+    "remnic": {
       "url": "http://localhost:4318/mcp",
       "headers": {
         "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
@@ -123,7 +123,7 @@ Add to your Cline MCP settings (VS Code Settings > Cline > MCP Servers):
 
 ```jsonc
 {
-  "engram": {
+  "remnic": {
     "url": "http://localhost:4318/mcp",
     "headers": {
       "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
@@ -143,7 +143,7 @@ Add to your Roo Code MCP settings:
 ```jsonc
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "url": "http://localhost:4318/mcp",
       "headers": {
         "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
@@ -164,7 +164,7 @@ Add to your Windsurf MCP settings (Settings > MCP):
 ```jsonc
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "url": "http://localhost:4318/mcp",
       "headers": {
         "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
@@ -185,7 +185,7 @@ Add to your Amp configuration:
 ```jsonc
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "url": "http://localhost:4318/mcp",
       "headers": {
         "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
@@ -201,19 +201,19 @@ Add to your Amp configuration:
 
 ## Replit Agent
 
-Replit Agent supports MCP natively via the **Integrations pane** (HTTP transport only — the Engram server must be publicly reachable).
+Replit Agent supports MCP natively via the **Integrations pane** (HTTP transport only — the Remnic server must be publicly reachable).
 
 ### Option A: MCP (recommended)
 
 1. In your Replit workspace, open **Integrations** > **Add MCP server**
-2. Enter the Remnic server URL: `https://your-engram-server.com/mcp`
+2. Enter the Remnic server URL: `https://your-remnic-server.com/mcp`
 3. Add custom headers:
-   - `Authorization`: `Bearer <your-engram-token>`
+   - `Authorization`: `Bearer <your-remnic-token>`
    - `X-Engram-Client-Id`: `replit` (enables auto-detection)
    - `X-Engram-Namespace`: `<your-project-name>` (optional)
 4. Click **Test & Save**
 
-Replit Agent will auto-discover all Engram MCP tools and use them contextually.
+Replit Agent will auto-discover all Remnic MCP tools and use them contextually.
 
 ### Option B: HTTP API (for custom agent code)
 
@@ -234,7 +234,7 @@ const response = await fetch(`${REMNIC_API_URL}/recall`, {
 });
 ```
 
-**Note:** Replit does not send identifying headers automatically. The `X-Engram-Client-Id: replit` header enables Engram's adapter auto-detection.
+**Note:** Replit does not send identifying headers automatically. The `X-Engram-Client-Id: replit` header enables Remnic's adapter auto-detection. The header name remains `X-Engram-*` during the v1.x compatibility window.
 
 **Capabilities:** observe, recall, store, search (via MCP or HTTP)
 
@@ -250,7 +250,7 @@ Add to your Hermes `config.yaml`:
 
 ```yaml
 mcp_servers:
-  engram:
+  remnic:
     url: "http://localhost:4318/mcp"
     headers:
       Authorization: "Bearer ${REMNIC_AUTH_TOKEN}"
@@ -259,7 +259,7 @@ mcp_servers:
       X-Engram-Namespace: "my-profile"
 ```
 
-**Auto-detection:** Hermes sends `X-Hermes-Session-Id` on API requests — Engram identifies it automatically. The `X-Engram-Client-Id: hermes` header provides a fallback for MCP-only connections.
+**Auto-detection:** Hermes sends `X-Hermes-Session-Id` on API requests — Remnic identifies it automatically. The `X-Engram-Client-Id: hermes` header provides a fallback for MCP-only connections. The `X-Engram-*` header names remain accepted during the v1.x compatibility window.
 
 ### Option B: MemoryProvider Plugin (recommended for production)
 
@@ -288,8 +288,8 @@ remnic connectors install weclone \
 
 This writes two files:
 
-- `~/.config/engram/.engram-connectors/connectors/weclone.json` — registry entry
-  used by `remnic connectors list / remove / doctor`.
+- `~/.config/engram/.engram-connectors/connectors/weclone.json` — legacy registry path
+  used by `remnic connectors list / remove / doctor` during the v1.x compatibility window.
 - `~/.remnic/connectors/weclone.json` — proxy config read by
   `remnic-weclone-proxy` at startup. A Remnic daemon auth token is minted and
   stored here so the proxy can authenticate without additional setup.
@@ -327,13 +327,16 @@ for the full config reference and architecture diagram.
 
 ## Generic MCP Client
 
-Any tool that supports the [Model Context Protocol](https://modelcontextprotocol.io/) can connect to Engram. Point your client at:
+Any tool that supports the [Model Context Protocol](https://modelcontextprotocol.io/) can connect to Remnic. Point your client at:
 
 - **MCP endpoint:** `http://localhost:4318/mcp`
 - **Auth:** `Authorization: Bearer <token>` header
 - **Transport:** HTTP (SSE for streaming)
 
 ### Available MCP Tools
+
+Most tools are currently exposed with `engram.*` names for v1.x compatibility;
+canonical `remnic.*` aliases are being added on the same MCP surface.
 
 | Tool | Description |
 |------|-------------|
@@ -413,7 +416,7 @@ The Remnic server isn't running. Start it:
 ```bash
 remnic daemon start    # standalone
 # or
-openclaw engram access http-serve --port 4318 --token "$REMNIC_AUTH_TOKEN"  # OpenClaw
+openclaw engram access http-serve --port 4318 --token "$REMNIC_AUTH_TOKEN"  # OpenClaw-hosted compatibility path
 ```
 
 ### 401 Unauthorized
@@ -431,7 +434,7 @@ Token mismatch. Verify `REMNIC_AUTH_TOKEN` matches between server and client con
 If queries are slow, enable QMD for hybrid search:
 
 ```bash
-engram doctor    # checks search backend status
+remnic doctor    # checks search backend status
 ```
 
 See [Getting Started](../getting-started.md) for QMD setup.


### PR DESCRIPTION
## Summary
- refresh README examples for canonical openclaw-remnic config while preserving legacy openclaw-engram fallback notes
- document the current published Remnic package/importer surface
- clarify connector setup around Remnic MCP naming and v1.x Engram compatibility commands/headers

## Verification
- git diff --check
- PATH=/Users/joshuawarren/.nvm/versions/node/v22.20.0/bin:$PATH npm run preflight:quick (pass: 6,383 tests, 0 failures; rebuilt native better-sqlite3 binding before rerun)
- Remnic.ai live check: https://remnic.ai/ shows v1.1.3 and new importer packages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update configuration examples and naming; no runtime or API behavior is modified.
> 
> **Overview**
> Refreshes documentation to use the canonical `openclaw-remnic` plugin ID in `openclaw.json` examples, verification output, and feature enablement snippets, while explicitly calling out the v1.x compatibility window.
> 
> Expands the README’s published package surface to include the current `@remnic/import-*` importers and clarifies install guidance (start with `@remnic/cli`, optional surfaces lazy-load).
> 
> Updates the Connector Setup Guide to use `remnic` as the MCP server name across tools and clarifies where legacy `engram` naming remains (e.g., `openclaw engram` compatibility commands, `X-Engram-*` headers, and `engram.*` MCP tool aliases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0673edce7f71ca13543bfb77f60a481328c9af31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->