### PR TITLE
Fix stale bench harness runs

### DIFF
--- a/packages/remnic-cli/src/bench-build-freshness.test.ts
+++ b/packages/remnic-cli/src/bench-build-freshness.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { checkBenchBuildFreshness } from "./bench-build-freshness.js";
+
+test("checkBenchBuildFreshness flags local bench source newer than dist", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-freshness-"));
+  const benchDir = path.join(root, "bench");
+  const srcDir = path.join(benchDir, "src");
+  const distDir = path.join(benchDir, "dist");
+  await mkdir(srcDir, { recursive: true });
+  await mkdir(distDir, { recursive: true });
+  await writeFile(
+    path.join(benchDir, "package.json"),
+    JSON.stringify({ name: "@remnic/bench" }),
+  );
+  await writeFile(path.join(srcDir, "index.ts"), "export const value = 1;\n");
+  await writeFile(path.join(distDir, "index.js"), "export const value = 0;\n");
+
+  const oldTime = new Date("2026-01-01T00:00:00.000Z");
+  const newTime = new Date("2026-01-01T00:00:05.000Z");
+  await touch(path.join(distDir, "index.js"), oldTime);
+  await touch(path.join(srcDir, "index.ts"), newTime);
+
+  const freshness = checkBenchBuildFreshness(benchDir);
+  assert.equal(freshness.stale, true);
+  assert.match(freshness.reason ?? "", /Source files are newer/);
+  assert.ok(
+    freshness.sourcePath === path.join(srcDir, "index.ts") ||
+      freshness.sourcePath === path.join(benchDir, "package.json"),
+  );
+});
+
+test("checkBenchBuildFreshness ignores non-local bench package paths", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-freshness-"));
+  const benchDir = path.join(root, "bench");
+  await mkdir(benchDir, { recursive: true });
+  await writeFile(
+    path.join(benchDir, "package.json"),
+    JSON.stringify({ name: "not-remnic-bench" }),
+  );
+
+  assert.equal(checkBenchBuildFreshness(benchDir).stale, false);
+});
+
+async function touch(filePath: string, date: Date): Promise<void> {
+  const { utimes } = await import("node:fs/promises");
+  await utimes(filePath, date, date);
+}

--- a/packages/remnic-cli/src/bench-build-freshness.ts
+++ b/packages/remnic-cli/src/bench-build-freshness.ts
@@ -1,0 +1,147 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STALE_BUILD_TOLERANCE_MS = 1_000;
+
+export interface BenchBuildFreshness {
+  stale: boolean;
+  reason?: string;
+  sourcePath?: string;
+  sourceMtimeMs?: number;
+  distPath?: string;
+  distMtimeMs?: number;
+}
+
+export function assertLocalBenchBuildFreshForDevelopment(
+  currentModuleUrl: string,
+): void {
+  if (isTruthyEnv(process.env.REMNIC_BENCH_ALLOW_STALE_DIST)) {
+    return;
+  }
+
+  const currentDir = path.dirname(fileURLToPath(currentModuleUrl));
+  const benchPackageDir = path.resolve(currentDir, "../../bench");
+  const freshness = checkBenchBuildFreshness(benchPackageDir);
+  if (!freshness.stale) {
+    return;
+  }
+
+  throw new Error(
+    [
+      "Local @remnic/bench build is stale; refusing to run benchmarks with outdated harness code.",
+      freshness.reason,
+      freshness.sourcePath && freshness.sourceMtimeMs !== undefined
+        ? `Newest source: ${freshness.sourcePath} (${new Date(freshness.sourceMtimeMs).toISOString()})`
+        : undefined,
+      freshness.distPath && freshness.distMtimeMs !== undefined
+        ? `Current build: ${freshness.distPath} (${new Date(freshness.distMtimeMs).toISOString()})`
+        : undefined,
+      "Run `pnpm --filter @remnic/bench build` before launching the benchmark.",
+      "For diagnostics only, set REMNIC_BENCH_ALLOW_STALE_DIST=1 to bypass this guard.",
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n"),
+  );
+}
+
+export function checkBenchBuildFreshness(
+  benchPackageDir: string,
+): BenchBuildFreshness {
+  const packageJsonPath = path.join(benchPackageDir, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    return { stale: false };
+  }
+
+  let packageName: unknown;
+  try {
+    packageName = JSON.parse(readFileSync(packageJsonPath, "utf8")).name;
+  } catch {
+    return { stale: false };
+  }
+  if (packageName !== "@remnic/bench") {
+    return { stale: false };
+  }
+
+  const sourceRoots = [
+    path.join(benchPackageDir, "src"),
+    packageJsonPath,
+    path.join(benchPackageDir, "tsup.config.ts"),
+    path.join(benchPackageDir, "tsconfig.json"),
+  ];
+  const distPath = path.join(benchPackageDir, "dist", "index.js");
+  if (!existsSync(distPath)) {
+    return {
+      stale: true,
+      reason: `Missing build output: ${distPath}`,
+      distPath,
+    };
+  }
+
+  const newestSource = newestMtime(sourceRoots);
+  if (!newestSource) {
+    return { stale: false };
+  }
+
+  const distMtimeMs = statSync(distPath).mtimeMs;
+  if (newestSource.mtimeMs > distMtimeMs + STALE_BUILD_TOLERANCE_MS) {
+    return {
+      stale: true,
+      reason: "Source files are newer than packages/bench/dist/index.js.",
+      sourcePath: newestSource.path,
+      sourceMtimeMs: newestSource.mtimeMs,
+      distPath,
+      distMtimeMs,
+    };
+  }
+
+  return {
+    stale: false,
+    sourcePath: newestSource.path,
+    sourceMtimeMs: newestSource.mtimeMs,
+    distPath,
+    distMtimeMs,
+  };
+}
+
+function newestMtime(
+  roots: string[],
+): { path: string; mtimeMs: number } | undefined {
+  let newest: { path: string; mtimeMs: number } | undefined;
+  const visit = (entryPath: string): void => {
+    if (!existsSync(entryPath)) {
+      return;
+    }
+    const stat = statSync(entryPath);
+    if (stat.isDirectory()) {
+      for (const child of readdirSync(entryPath)) {
+        visit(path.join(entryPath, child));
+      }
+      return;
+    }
+    if (!stat.isFile()) {
+      return;
+    }
+    if (!newest || stat.mtimeMs > newest.mtimeMs) {
+      newest = { path: entryPath, mtimeMs: stat.mtimeMs };
+    }
+  };
+
+  for (const root of roots) {
+    visit(root);
+  }
+  return newest;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "" && normalized !== "0" && normalized !== "false" && normalized !== "no" && normalized !== "off";
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -139,7 +139,11 @@ import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 // top level (erased at compile time); runtime access goes through
 // loadBenchModule() / tryLoadBenchModule() so the CLI stays functional for
 // users who never run `remnic bench *`.
-import { loadBenchModule, tryLoadBenchModule } from "./optional-bench.js";
+import {
+  assertBenchModuleFreshForDevelopment,
+  loadBenchModule,
+  tryLoadBenchModule,
+} from "./optional-bench.js";
 import type {
   BenchConfig,
   BenchmarkDefinition,
@@ -2012,6 +2016,7 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
       );
       process.exit(1);
     }
+    assertBenchModuleFreshForDevelopment();
     const benchModule = loaded as unknown as PackageBenchModule;
     const benchmarkId = parsed.publishedName;
     const mode = parsed.quick ? "quick" : "full";
@@ -2197,6 +2202,7 @@ async function runBenchViaPackage(
 ): Promise<{ ok: boolean; writtenPath?: string }> {
   const loaded = await tryLoadBenchModule();
   if (!loaded) return { ok: false };
+  assertBenchModuleFreshForDevelopment();
   const benchModule = loaded as unknown as PackageBenchModule;
 
   const definition = benchModule.getBenchmark?.(benchmarkId);
@@ -2475,6 +2481,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
   const runtimeProfiles = resolveBenchRunProfiles(parsed);
   const loaded = await tryLoadBenchModule();
   if (!loaded) return false;
+  assertBenchModuleFreshForDevelopment();
   const benchModule = loaded as unknown as PackageBenchModule;
 
   if (!benchModule.runCustomBenchmarkFile || !benchModule.writeBenchmarkResult) {
@@ -2560,9 +2567,24 @@ function resolveBenchReproDatasetDirs(
   return Object.fromEntries(
     benchmarkIds.map((benchmarkId) => [
       benchmarkId,
-      resolveBenchDatasetDir(benchmarkId, parsed.quick, parsed.datasetDir),
+      resolveBenchReproDatasetDir(
+        resolveBenchDatasetDir(benchmarkId, parsed.quick, parsed.datasetDir),
+      ),
     ]),
   );
+}
+
+function resolveBenchReproDatasetDir(
+  datasetDir: string | undefined,
+): string | undefined {
+  if (!datasetDir) {
+    return undefined;
+  }
+  try {
+    return fs.realpathSync(datasetDir);
+  } catch {
+    return datasetDir;
+  }
 }
 
 async function writeBenchReproManifestForPackageRun(args: {

--- a/packages/remnic-cli/src/optional-bench.ts
+++ b/packages/remnic-cli/src/optional-bench.ts
@@ -12,6 +12,7 @@
 // optional workspace packages via computed-specifier dynamic imports."
 
 import { isSpecifierNotFoundError } from "./optional-module-loader.js";
+import { assertLocalBenchBuildFreshForDevelopment } from "./bench-build-freshness.js";
 
 type BenchModule = typeof import("@remnic/bench");
 
@@ -51,9 +52,10 @@ export async function loadBenchModule(): Promise<BenchModule> {
         "  npm install -g @remnic/bench\n" +
         "\n" +
         "Or add it to a project:\n" +
-        "  pnpm add @remnic/bench\n",
+      "  pnpm add @remnic/bench\n",
     );
   }
+  assertBenchModuleFreshForDevelopment();
   return cached;
 }
 
@@ -67,4 +69,8 @@ export async function tryLoadBenchModule(): Promise<BenchModule | undefined> {
     cached = await tryImportBench();
   }
   return cached ?? undefined;
+}
+
+export function assertBenchModuleFreshForDevelopment(): void {
+  assertLocalBenchBuildFreshForDevelopment(import.meta.url);
 }

--- a/scripts/run-bench-cli.mjs
+++ b/scripts/run-bench-cli.mjs
@@ -24,13 +24,48 @@ function run(args) {
 
 const coreDistPath = path.join(repoRoot, "packages", "remnic-core", "dist", "index.js");
 const benchDistPath = path.join(repoRoot, "packages", "bench", "dist", "index.js");
+const benchSourcePaths = [
+  path.join(repoRoot, "packages", "bench", "src"),
+  path.join(repoRoot, "packages", "bench", "package.json"),
+  path.join(repoRoot, "packages", "bench", "tsup.config.ts"),
+  path.join(repoRoot, "packages", "bench", "tsconfig.json"),
+];
 
 if (!fs.existsSync(coreDistPath)) {
   run(["--filter", "@remnic/core", "build"]);
 }
 
-if (!fs.existsSync(benchDistPath)) {
+if (!fs.existsSync(benchDistPath) || isAnySourceNewerThan(benchSourcePaths, benchDistPath)) {
   run(["--filter", "@remnic/bench", "build"]);
 }
 
 run(["exec", "tsx", "packages/remnic-cli/src/index.ts", "bench", ...process.argv.slice(2)]);
+
+function isAnySourceNewerThan(sourcePaths, distPath) {
+  const distMtimeMs = fs.statSync(distPath).mtimeMs;
+  const newestSource = newestMtime(sourcePaths);
+  return newestSource !== undefined && newestSource > distMtimeMs + 1000;
+}
+
+function newestMtime(paths) {
+  let newest;
+  const visit = (entryPath) => {
+    if (!fs.existsSync(entryPath)) {
+      return;
+    }
+    const stat = fs.statSync(entryPath);
+    if (stat.isDirectory()) {
+      for (const child of fs.readdirSync(entryPath)) {
+        visit(path.join(entryPath, child));
+      }
+      return;
+    }
+    if (stat.isFile()) {
+      newest = newest === undefined ? stat.mtimeMs : Math.max(newest, stat.mtimeMs);
+    }
+  };
+  for (const sourcePath of paths) {
+    visit(sourcePath);
+  }
+  return newest;
+}


### PR DESCRIPTION
## Summary
- fail fast when local @remnic/bench source is newer than its dist bundle, so direct source CLI benchmark runs cannot silently use stale harness code
- make scripts/run-bench-cli.mjs rebuild @remnic/bench when source/config files are newer than dist
- resolve benchmark dataset paths to real paths for reproducibility manifests so symlinked monorepo datasets hash correctly

## Validation
- npx tsx --test packages/remnic-cli/src/bench-build-freshness.test.ts packages/remnic-cli/src/bench-args.test.ts packages/bench/src/benchmarks/published/ama-bench/runner.test.ts packages/bench/src/leaderboard-export.test.ts packages/bench/src/reporter.test.ts
- pnpm --filter @remnic/bench build
- quick AMA-Bench against Ollama Cloud gemma4:31b: 2/2, ama_bench_recommended_accuracy=1.0000, leaderboard JSONL written
- full-mode AMA-Bench --limit 1 against Ollama Cloud gemma4:31b: 12/12, ama_bench_recommended_accuracy=0.6667, leaderboard JSONL written, dataset manifest hashed

## Known issue
- npm run check-types and npm run preflight:quick currently fail before this patch on missing @node-rs/argon2 types in packages/remnic-core/src/secure-store/kdf.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new fail-fast behavior that can block local benchmark runs if timestamps/config are misdetected, and changes repro manifest dataset path normalization which may alter downstream hashing/outputs.
> 
> **Overview**
> Prevents silent benchmark runs with an outdated local `@remnic/bench` harness by adding a build-freshness guard that detects when `packages/bench/src` (or key config files) is newer than `packages/bench/dist/index.js` and throws unless `REMNIC_BENCH_ALLOW_STALE_DIST` is set.
> 
> Updates `scripts/run-bench-cli.mjs` to automatically rebuild `@remnic/bench` when sources/config are newer than `dist`, and resolves benchmark dataset directories via `realpath` when writing repro manifests so symlinked dataset roots hash consistently. Includes new unit tests for the freshness checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267112f5072cb0c4a09d8fb2a5f8214b618de62b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->