### PR TITLE
feat(import): add lossless-claw → Remnic LCM importer

### DIFF
--- a/docs/lcm-to-remnic-migration.md
+++ b/docs/lcm-to-remnic-migration.md
@@ -1,0 +1,179 @@
+# Migrating from lossless-claw to Remnic
+
+[lossless-claw](https://github.com/martian-engineering/lossless-claw) (LCM —
+*Lossless Context Management*) is an OpenClaw plugin that replaces native
+conversation compaction with a SQLite-backed message archive plus a
+hierarchical summary DAG. Remnic ships its own LCM mode that uses an
+almost-identical schema. This guide explains what each system does, when
+to switch, and how to run the migration.
+
+## Should you switch?
+
+You can also **run both at once**.
+
+| | lossless-claw | Remnic LCM mode |
+|---|---|---|
+| OpenClaw plugin slot | `contextEngine` | `memory` |
+| What it preserves | Verbatim turns + summary DAG | Verbatim turns + summary DAG |
+| Replaces native compaction? | Yes | No — complements it |
+| Surfaces facts / entities / extraction? | No | Yes (Remnic's main job) |
+| Storage | `~/.openclaw/lcm.db` | `<memoryDir>/state/lcm.sqlite` |
+| Search | FTS5 (BM25) | FTS5 (BM25) + Remnic recall pipeline |
+
+Because the slots are different, **a single OpenClaw config can run both
+plugins side-by-side**. Useful if you want lossless-claw to keep doing
+compaction substitution while Remnic builds up extracted-fact memory.
+
+If you want Remnic to own context management end-to-end, run the importer
+to migrate session history, then disable the lossless-claw plugin.
+
+## Coexistence (no migration)
+
+In your `openclaw.json`:
+
+```jsonc
+{
+  "plugins": {
+    "slots": {
+      "memory": "remnic",
+      "contextEngine": "lossless-claw"
+    }
+  }
+}
+```
+
+Both subsystems read and write their own SQLite databases; they do not
+share storage. No additional configuration needed.
+
+## Switching to Remnic LCM mode
+
+### 1. Enable Remnic's LCM mode
+
+In your `openclaw.json` (or whatever config file the Remnic plugin reads):
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-engram": {
+        "config": {
+          "lcmEnabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+See [`docs/guides/lossless-context-management.md`](guides/lossless-context-management.md)
+for the full LCM configuration reference.
+
+### 2. Run the importer
+
+The importer ships as a separate optional package:
+
+```bash
+npm install -g @remnic/import-lossless-claw
+# or:
+pnpm add @remnic/import-lossless-claw
+```
+
+Then run:
+
+```bash
+remnic import-lossless-claw --src ~/.openclaw/lcm.db
+```
+
+Common flags:
+
+- `--src <path>` — required; the lossless-claw SQLite file
+- `--dry-run` — count what would be imported without writing
+- `--session-filter <id>` — repeatable; restrict to specific resolved session IDs
+- `--memory-dir <path>` — override the resolved Remnic memory directory
+
+The importer is idempotent: re-running it inserts zero new rows for
+already-imported messages and summaries.
+
+### 3. Disable lossless-claw (optional)
+
+Once the import succeeds and you are confident Remnic's LCM mode is
+serving your traffic, remove `contextEngine: "lossless-claw"` from
+`plugins.slots` in your OpenClaw config. OpenClaw will fall back to its
+built-in compaction strategy, which Remnic LCM is designed to complement
+rather than replace.
+
+## What migrates and what is lost
+
+### Migrates 1:1
+
+| lossless-claw | Remnic LCM |
+|---|---|
+| `messages.seq, role, content, token_count, created_at` | `lcm_messages.turn_index, role, content, token_count, created_at` |
+| `summaries.summary_id, depth, content, token_count` | `lcm_summary_nodes.id, depth, summary_text, token_count` |
+| `MIN/MAX(messages.seq)` per summary (via `summary_messages`) | `lcm_summary_nodes.msg_start, msg_end` |
+| `conversations.session_id` (or `conversation_id` fallback) | `lcm_messages.session_id` |
+
+### Migrates with degradation
+
+- **Multi-parent summary nodes**: lossless-claw's summary DAG can attach
+  one summary to several parents. Remnic's `lcm_summary_nodes.parent_id`
+  is a single foreign key. The importer keeps the lowest-`ordinal`
+  parent (lexicographic tie-break) and reports the collapse count. Most
+  summary DAGs produced by default `summaryRollupFanIn = 4` are
+  single-parent in practice; this only matters if the DAG was
+  hand-stitched.
+- **Conversation titles**: stored in the message `metadata` JSON blob
+  (`{ "title": "...", "source": "lossless-claw" }`) since Remnic LCM
+  has no per-conversation table.
+
+### Does not migrate (no Remnic LCM analog)
+
+- `message_parts` — fine-grained tool I/O, patches, file references,
+  step-start/finish markers. Only the rendered `messages.content`
+  carries forward.
+- `large_files` — spilled blobs and their `exploration_summary`. If you
+  rely on these for recall, run the importer after first round-tripping
+  the relevant exploration summaries through Remnic's normal extraction
+  path so they end up in `facts/` instead of LCM.
+- `conversation_compaction_telemetry`, `conversation_compaction_maintenance`
+  — prompt cache / activity tracking owned by lossless-claw's
+  compaction loop, not portable to Remnic.
+
+## Import-boundary marker
+
+For each session that gains data, the importer writes one row to
+`lcm_compaction_events` with `tokens_before == tokens_after`. This
+encodes "import boundary" rather than a real compaction — Remnic's own
+compaction telemetry will start from this anchor. A consumer that needs
+to distinguish real compactions from import boundaries can detect the
+equality.
+
+## Idempotency and safety
+
+- Source database is opened **read-only** (`fileMustExist: true`,
+  `readonly: true`).
+- Inserts use natural-key existence checks (`session_id, turn_index` for
+  messages; `id` for summaries) so a second run is a no-op.
+- The destination database keeps its existing data — the importer only
+  appends. Remnic's normal compaction will operate on the merged data.
+- `--dry-run` runs every read and transformation but skips all writes.
+
+## Troubleshooting
+
+- **`Source database is missing lossless-claw tables: …`** — the file
+  passed to `--src` does not have the lossless-claw schema. Confirm you
+  pointed at `~/.openclaw/lcm.db` (or wherever your `LCM_DATABASE_PATH`
+  override points).
+- **`better-sqlite3 is unavailable`** — the native module needs a
+  rebuild for your Node version. Run
+  `pnpm rebuild better-sqlite3` (or `npm rebuild better-sqlite3 --build-from-source`).
+- **Multi-parent collapse counts are higher than expected** — your
+  source DAG is not a tree. The importer picks deterministic single
+  parents but if you rely on the multi-parent edges for recall in
+  lossless-claw, that signal will not survive the migration. Consider
+  running both plugins in coexistence mode instead.
+
+## Related documents
+
+- [Lossless Context Management (Remnic)](guides/lossless-context-management.md) — full LCM mode reference
+- [`packages/import-lossless-claw/`](../packages/import-lossless-claw/) — importer source code

--- a/docs/lcm-to-remnic-migration.md
+++ b/docs/lcm-to-remnic-migration.md
@@ -108,7 +108,8 @@ rather than replace.
 
 | lossless-claw | Remnic LCM |
 |---|---|
-| `messages.seq, role, content, token_count, created_at` | `lcm_messages.turn_index, role, content, token_count, created_at` |
+| `messages.role, content, token_count, created_at` | `lcm_messages.role, content, token_count, created_at` |
+| `messages.seq` (per-conversation) | `lcm_messages.turn_index` (session-global) — original `seq` preserved in `metadata.source_seq` |
 | `summaries.summary_id, depth, content, token_count` | `lcm_summary_nodes.id, depth, summary_text, token_count` |
 | `MIN/MAX(messages.seq)` per summary (via `summary_messages`) | `lcm_summary_nodes.msg_start, msg_end` |
 | `conversations.session_id` (or `conversation_id` fallback) | `lcm_messages.session_id` |

--- a/packages/import-lossless-claw/README.md
+++ b/packages/import-lossless-claw/README.md
@@ -1,0 +1,79 @@
+# @remnic/import-lossless-claw
+
+Migrate a [lossless-claw](https://github.com/martian-engineering/lossless-claw)
+LCM SQLite database into Remnic's LCM mode.
+
+## Why this exists
+
+Remnic ships its own *lossless context management* mode whose schema is
+near-isomorphic to lossless-claw's. This package is a SQLite→SQLite
+importer for users who want to switch from lossless-claw to Remnic without
+losing session history.
+
+For coexistence (running both side-by-side) and the full migration story,
+see [`docs/lcm-to-remnic-migration.md`](../../docs/lcm-to-remnic-migration.md).
+
+## Install
+
+```bash
+npm install -g @remnic/import-lossless-claw
+# or
+pnpm add @remnic/import-lossless-claw
+```
+
+The CLI command lives in `@remnic/cli`; this package is loaded lazily on
+demand via the à-la-carte loader (CLAUDE.md gotcha #57).
+
+## Usage
+
+```bash
+remnic import-lossless-claw --src ~/.openclaw/lcm.db
+remnic import-lossless-claw --src ~/.openclaw/lcm.db --dry-run
+remnic import-lossless-claw --src ~/.openclaw/lcm.db --session-filter sess-A
+```
+
+The destination is `<memoryDir>/state/lcm.sqlite`, which Remnic creates
+automatically when `lcmEnabled: true` is set in plugin config.
+
+## Programmatic API
+
+```ts
+import {
+  importLosslessClaw,
+  openSourceDatabase,
+} from "@remnic/import-lossless-claw";
+import { ensureLcmStateDir, openLcmDatabase } from "@remnic/core";
+
+const sourceDb = openSourceDatabase("/path/to/lcm.db");
+await ensureLcmStateDir("/path/to/memoryDir");
+const destDb = openLcmDatabase("/path/to/memoryDir");
+
+const result = importLosslessClaw({
+  sourceDb,
+  destDb,
+  dryRun: false,
+  sessionFilter: new Set(["sess-A"]),
+  onLog: (line) => console.log(line),
+});
+
+sourceDb.close();
+destDb.close();
+```
+
+## Idempotency
+
+Re-running the importer inserts zero new rows. Messages dedupe on
+`(session_id, turn_index)`; summary nodes dedupe on `id`.
+
+## What's lossy
+
+- Multi-parent summary DAG → single-parent (lowest `ordinal` wins,
+  lexicographic tie-break). Count reported in result.
+- `message_parts`, `large_files`, compaction telemetry — no Remnic LCM
+  analog, skipped silently.
+
+See the migration doc for the full mapping table.
+
+## License
+
+MIT

--- a/packages/import-lossless-claw/package.json
+++ b/packages/import-lossless-claw/package.json
@@ -22,13 +22,15 @@
     "access": "public",
     "provenance": true
   },
+  "dependencies": {
+    "better-sqlite3": "^11.0.0"
+  },
   "peerDependencies": {
     "@remnic/core": "workspace:^"
   },
   "devDependencies": {
     "@remnic/core": "workspace:*",
     "@types/better-sqlite3": "^7.6.0",
-    "better-sqlite3": "^11.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0"

--- a/packages/import-lossless-claw/package.json
+++ b/packages/import-lossless-claw/package.json
@@ -23,7 +23,7 @@
     "provenance": true
   },
   "dependencies": {
-    "better-sqlite3": "^11.0.0"
+    "better-sqlite3": "^12.6.2"
   },
   "peerDependencies": {
     "@remnic/core": "workspace:^"

--- a/packages/import-lossless-claw/package.json
+++ b/packages/import-lossless-claw/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@remnic/import-lossless-claw",
+  "version": "0.1.0",
+  "description": "Import lossless-claw (LCM) SQLite databases into Remnic's LCM mode",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "tsx --test src/transform.test.ts src/source.test.ts src/importer.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "@types/better-sqlite3": "^7.6.0",
+    "better-sqlite3": "^11.0.0",
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/import-lossless-claw"
+  },
+  "keywords": ["remnic", "memory", "lcm", "lossless-claw", "import", "openclaw"]
+}

--- a/packages/import-lossless-claw/src/importer.test.ts
+++ b/packages/import-lossless-claw/src/importer.test.ts
@@ -428,6 +428,18 @@ describe("importLosslessClaw — dry run", () => {
 });
 
 describe("importLosslessClaw — session filter", () => {
+  it("treats an empty Set as 'import all' (Cursor low-sev: empty Set is truthy)", () => {
+    const src = buildSourceDb(TWO_CONVS());
+    const dst = buildDestDb();
+    const result = importLosslessClaw({
+      sourceDb: src,
+      destDb: dst,
+      sessionFilter: new Set<string>(),
+    });
+    assert.equal(result.messagesInserted, 3, "empty Set must not skip all");
+    assert.equal(result.summariesInserted, 1);
+  });
+
   it("limits import to specified resolved sessions", () => {
     const src = buildSourceDb(TWO_CONVS());
     const dst = buildDestDb();

--- a/packages/import-lossless-claw/src/importer.test.ts
+++ b/packages/import-lossless-claw/src/importer.test.ts
@@ -616,6 +616,70 @@ describe("importLosslessClaw — multiple conversations per session (Codex P1)",
     );
   });
 
+  it("interleaves messages across conversations by created_at (Codex P1 follow-up #2)", () => {
+    // Conv-A: messages at t=0 and t=10
+    // Conv-B: messages at t=5 and t=6
+    // Expected turn_index order: A@t0, B@t5, B@t6, A@t10
+    const seed = {
+      conversations: [
+        { conversation_id: "conv-A", session_id: "sess" },
+        { conversation_id: "conv-B", session_id: "sess" },
+      ],
+      messages: [
+        {
+          message_id: "a1",
+          conversation_id: "conv-A",
+          seq: 0,
+          role: "user",
+          content: "A@t0",
+          token_count: 1,
+          created_at: "2026-04-01T00:00:00.000Z",
+        },
+        {
+          message_id: "a2",
+          conversation_id: "conv-A",
+          seq: 1,
+          role: "assistant",
+          content: "A@t10",
+          token_count: 1,
+          created_at: "2026-04-01T00:00:10.000Z",
+        },
+        {
+          message_id: "b1",
+          conversation_id: "conv-B",
+          seq: 0,
+          role: "user",
+          content: "B@t5",
+          token_count: 1,
+          created_at: "2026-04-01T00:00:05.000Z",
+        },
+        {
+          message_id: "b2",
+          conversation_id: "conv-B",
+          seq: 1,
+          role: "assistant",
+          content: "B@t6",
+          token_count: 1,
+          created_at: "2026-04-01T00:00:06.000Z",
+        },
+      ],
+    };
+    const src = buildSourceDb(seed);
+    const dst = buildDestDb();
+    importLosslessClaw({ sourceDb: src, destDb: dst });
+
+    const rows = dst
+      .prepare(
+        "SELECT turn_index, content FROM lcm_messages WHERE session_id = 'sess' ORDER BY turn_index",
+      )
+      .all() as Array<{ turn_index: number; content: string }>;
+    assert.deepEqual(
+      rows.map((r) => r.content),
+      ["A@t0", "B@t5", "B@t6", "A@t10"],
+      "interleaved messages must appear in chronological order",
+    );
+  });
+
   it("orders conversations by earliest message timestamp, not by conversation_id (Codex P1 follow-up)", () => {
     // UUID-like ids that sort the OPPOSITE direction of chronology.
     // 'aaaa-conv-id' < 'zzzz-conv-id' lexicographically, but 'zzzz' is

--- a/packages/import-lossless-claw/src/importer.test.ts
+++ b/packages/import-lossless-claw/src/importer.test.ts
@@ -1,0 +1,520 @@
+// ---------------------------------------------------------------------------
+// Importer integration tests.
+//
+// Uses synthetic in-memory SQLite databases — no real user data, no fixture
+// files. Per CLAUDE.md (public repo policy): test data must be synthetic.
+// ---------------------------------------------------------------------------
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import BetterSqlite3 from "better-sqlite3";
+
+import { importLosslessClaw } from "./importer.js";
+
+type DbHandle = ReturnType<typeof BetterSqlite3>;
+
+interface SeedMessage {
+  message_id: string;
+  conversation_id: string;
+  seq: number;
+  role: string;
+  content: string;
+  token_count: number;
+  identity_hash?: string | null;
+  created_at: string;
+}
+
+interface SeedSummary {
+  summary_id: string;
+  kind: "leaf" | "condensed";
+  depth: number;
+  content: string;
+  token_count: number;
+  earliest_at?: string | null;
+  latest_at?: string | null;
+  message_ids: string[];
+  parent_ids?: Array<{ parent_summary_id: string; ordinal: number }>;
+}
+
+interface SeedConversation {
+  conversation_id: string;
+  session_id?: string | null;
+  session_key?: string | null;
+  title?: string | null;
+}
+
+function buildSourceDb(seed: {
+  conversations: SeedConversation[];
+  messages: SeedMessage[];
+  summaries?: SeedSummary[];
+}): DbHandle {
+  const db = new BetterSqlite3(":memory:");
+  db.exec(`
+    CREATE TABLE conversations (
+      conversation_id TEXT PRIMARY KEY,
+      session_id      TEXT,
+      session_key     TEXT,
+      title           TEXT
+    );
+    CREATE TABLE messages (
+      message_id      TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      seq             INTEGER NOT NULL,
+      role            TEXT NOT NULL,
+      content         TEXT NOT NULL,
+      token_count     INTEGER NOT NULL,
+      identity_hash   TEXT,
+      created_at      TEXT NOT NULL
+    );
+    CREATE TABLE summaries (
+      summary_id      TEXT PRIMARY KEY,
+      kind            TEXT NOT NULL,
+      depth           INTEGER NOT NULL,
+      content         TEXT NOT NULL,
+      token_count     INTEGER NOT NULL,
+      earliest_at     TEXT,
+      latest_at       TEXT
+    );
+    CREATE TABLE summary_messages (
+      summary_id TEXT NOT NULL,
+      message_id TEXT NOT NULL
+    );
+    CREATE TABLE summary_parents (
+      summary_id        TEXT NOT NULL,
+      parent_summary_id TEXT NOT NULL,
+      ordinal           INTEGER NOT NULL
+    );
+  `);
+
+  const insConv = db.prepare(
+    "INSERT INTO conversations (conversation_id, session_id, session_key, title) VALUES (?, ?, ?, ?)",
+  );
+  for (const c of seed.conversations) {
+    insConv.run(
+      c.conversation_id,
+      c.session_id ?? null,
+      c.session_key ?? null,
+      c.title ?? null,
+    );
+  }
+
+  const insMsg = db.prepare(
+    "INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count, identity_hash, created_at) " +
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+  );
+  for (const m of seed.messages) {
+    insMsg.run(
+      m.message_id,
+      m.conversation_id,
+      m.seq,
+      m.role,
+      m.content,
+      m.token_count,
+      m.identity_hash ?? null,
+      m.created_at,
+    );
+  }
+
+  if (seed.summaries) {
+    const insSum = db.prepare(
+      "INSERT INTO summaries (summary_id, kind, depth, content, token_count, earliest_at, latest_at) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+    );
+    const insSumMsg = db.prepare(
+      "INSERT INTO summary_messages (summary_id, message_id) VALUES (?, ?)",
+    );
+    const insSumPar = db.prepare(
+      "INSERT INTO summary_parents (summary_id, parent_summary_id, ordinal) VALUES (?, ?, ?)",
+    );
+    for (const s of seed.summaries) {
+      insSum.run(
+        s.summary_id,
+        s.kind,
+        s.depth,
+        s.content,
+        s.token_count,
+        s.earliest_at ?? null,
+        s.latest_at ?? null,
+      );
+      for (const mid of s.message_ids) {
+        insSumMsg.run(s.summary_id, mid);
+      }
+      for (const p of s.parent_ids ?? []) {
+        insSumPar.run(s.summary_id, p.parent_summary_id, p.ordinal);
+      }
+    }
+  }
+
+  return db;
+}
+
+/**
+ * Build a destination database with the EXACT Remnic LCM schema (kept
+ * inline here so the test fails loudly if the production schema drifts).
+ * Mirrors packages/remnic-core/src/lcm/schema.ts.
+ */
+function buildDestDb(): DbHandle {
+  const db = new BetterSqlite3(":memory:");
+  db.exec(`
+    CREATE TABLE lcm_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+
+    CREATE TABLE lcm_messages (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id  TEXT NOT NULL,
+      turn_index  INTEGER NOT NULL,
+      role        TEXT NOT NULL,
+      content     TEXT NOT NULL,
+      token_count INTEGER NOT NULL,
+      created_at  TEXT NOT NULL,
+      metadata    TEXT
+    );
+    CREATE INDEX idx_lcm_messages_session ON lcm_messages(session_id, turn_index);
+
+    CREATE TABLE lcm_summary_nodes (
+      id            TEXT PRIMARY KEY,
+      session_id    TEXT NOT NULL,
+      depth         INTEGER NOT NULL,
+      parent_id     TEXT,
+      summary_text  TEXT NOT NULL,
+      token_count   INTEGER NOT NULL,
+      msg_start     INTEGER NOT NULL,
+      msg_end       INTEGER NOT NULL,
+      escalation    INTEGER NOT NULL DEFAULT 0,
+      created_at    TEXT NOT NULL,
+      FOREIGN KEY (parent_id) REFERENCES lcm_summary_nodes(id)
+    );
+
+    CREATE TABLE lcm_compaction_events (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id    TEXT NOT NULL,
+      fired_at      TEXT NOT NULL,
+      msg_before    INTEGER NOT NULL,
+      tokens_before INTEGER NOT NULL,
+      tokens_after  INTEGER NOT NULL
+    );
+
+    CREATE VIRTUAL TABLE lcm_messages_fts USING fts5(
+      content,
+      content=lcm_messages,
+      content_rowid=id
+    );
+    CREATE VIRTUAL TABLE lcm_summaries_fts USING fts5(
+      summary_text,
+      content=lcm_summary_nodes,
+      content_rowid=rowid
+    );
+  `);
+  return db;
+}
+
+const TWO_CONVS = (): {
+  conversations: SeedConversation[];
+  messages: SeedMessage[];
+  summaries: SeedSummary[];
+} => ({
+  conversations: [
+    { conversation_id: "conv-A", session_id: "sess-A", title: "topic A" },
+    { conversation_id: "conv-B", session_id: null, title: "topic B" },
+  ],
+  messages: [
+    {
+      message_id: "m-a-1",
+      conversation_id: "conv-A",
+      seq: 0,
+      role: "user",
+      content: "hello A",
+      token_count: 2,
+      created_at: "2026-04-01T00:00:00.000Z",
+    },
+    {
+      message_id: "m-a-2",
+      conversation_id: "conv-A",
+      seq: 1,
+      role: "assistant",
+      content: "hi A back",
+      token_count: 3,
+      created_at: "2026-04-01T00:00:01.000Z",
+    },
+    {
+      message_id: "m-b-1",
+      conversation_id: "conv-B",
+      seq: 0,
+      role: "user",
+      content: "hello B",
+      token_count: 2,
+      created_at: "2026-04-01T00:01:00.000Z",
+    },
+  ],
+  summaries: [
+    {
+      summary_id: "sum-A",
+      kind: "leaf",
+      depth: 0,
+      content: "summary of A",
+      token_count: 4,
+      earliest_at: "2026-04-01T00:00:00.000Z",
+      latest_at: "2026-04-01T00:00:01.000Z",
+      message_ids: ["m-a-1", "m-a-2"],
+    },
+  ],
+});
+
+describe("importLosslessClaw — basic copy", () => {
+  it("copies messages and summary across two conversations, falling back to conversation_id when session_id is null", () => {
+    const src = buildSourceDb(TWO_CONVS());
+    const dst = buildDestDb();
+    const result = importLosslessClaw({ sourceDb: src, destDb: dst });
+
+    assert.equal(result.conversationsScanned, 2);
+    assert.equal(result.messagesInserted, 3);
+    assert.equal(result.messagesSkipped, 0);
+    assert.equal(result.summariesInserted, 1);
+    assert.equal(result.summariesMultiParentCollapsed, 0);
+    assert.equal(result.dryRun, false);
+    // sessionsTouched: explicit "sess-A" + fallback "conv-B"
+    assert.deepEqual(result.sessionsTouched, ["conv-B", "sess-A"]);
+
+    const msgs = dst
+      .prepare("SELECT session_id, turn_index, role, content FROM lcm_messages ORDER BY session_id, turn_index")
+      .all();
+    assert.deepEqual(msgs, [
+      { session_id: "conv-B", turn_index: 0, role: "user", content: "hello B" },
+      { session_id: "sess-A", turn_index: 0, role: "user", content: "hello A" },
+      {
+        session_id: "sess-A",
+        turn_index: 1,
+        role: "assistant",
+        content: "hi A back",
+      },
+    ]);
+
+    const summaries = dst
+      .prepare(
+        "SELECT id, session_id, depth, msg_start, msg_end, summary_text FROM lcm_summary_nodes",
+      )
+      .all();
+    assert.deepEqual(summaries, [
+      {
+        id: "sum-A",
+        session_id: "sess-A",
+        depth: 0,
+        msg_start: 0,
+        msg_end: 1,
+        summary_text: "summary of A",
+      },
+    ]);
+  });
+});
+
+describe("importLosslessClaw — idempotency", () => {
+  it("re-running imports zero new rows", () => {
+    const src = buildSourceDb(TWO_CONVS());
+    const dst = buildDestDb();
+
+    const first = importLosslessClaw({ sourceDb: src, destDb: dst });
+    const second = importLosslessClaw({ sourceDb: src, destDb: dst });
+
+    assert.equal(first.messagesInserted, 3);
+    assert.equal(second.messagesInserted, 0);
+    assert.equal(second.messagesSkipped, 3);
+    assert.equal(second.summariesInserted, 0);
+    assert.equal(second.summariesSkipped, 1);
+
+    const total = dst
+      .prepare("SELECT COUNT(*) AS n FROM lcm_messages")
+      .get() as { n: number };
+    assert.equal(total.n, 3);
+  });
+});
+
+describe("importLosslessClaw — FTS sync", () => {
+  it("messages_fts and summaries_fts are queryable post-import", () => {
+    const src = buildSourceDb(TWO_CONVS());
+    const dst = buildDestDb();
+    importLosslessClaw({ sourceDb: src, destDb: dst });
+
+    const ftsMsgs = dst
+      .prepare(
+        "SELECT lcm_messages.session_id FROM lcm_messages_fts " +
+          "JOIN lcm_messages ON lcm_messages.id = lcm_messages_fts.rowid " +
+          "WHERE lcm_messages_fts MATCH 'hello'",
+      )
+      .all() as Array<{ session_id: string }>;
+    const sessions = ftsMsgs.map((r) => r.session_id).sort();
+    assert.deepEqual(sessions, ["conv-B", "sess-A"]);
+
+    const ftsSums = dst
+      .prepare("SELECT count(*) AS n FROM lcm_summaries_fts WHERE lcm_summaries_fts MATCH 'summary'")
+      .get() as { n: number };
+    assert.equal(ftsSums.n, 1);
+  });
+});
+
+describe("importLosslessClaw — compaction-event boundary", () => {
+  it("inserts one marker per session with tokens_before == tokens_after", () => {
+    const src = buildSourceDb(TWO_CONVS());
+    const dst = buildDestDb();
+    const result = importLosslessClaw({ sourceDb: src, destDb: dst });
+
+    assert.equal(result.compactionEventsInserted, 2);
+
+    const events = dst
+      .prepare(
+        "SELECT session_id, msg_before, tokens_before, tokens_after FROM lcm_compaction_events ORDER BY session_id",
+      )
+      .all() as Array<{
+      session_id: string;
+      msg_before: number;
+      tokens_before: number;
+      tokens_after: number;
+    }>;
+    assert.equal(events.length, 2);
+    for (const e of events) {
+      assert.equal(
+        e.tokens_before,
+        e.tokens_after,
+        "import marker must encode no-op compaction",
+      );
+    }
+    const byId = new Map(events.map((e) => [e.session_id, e]));
+    // sess-A has 2 messages → msg_before = max turn_index + 1 = 2; tokens = 2 + 3 = 5
+    assert.equal(byId.get("sess-A")?.msg_before, 2);
+    assert.equal(byId.get("sess-A")?.tokens_before, 5);
+    // conv-B (fallback) has 1 message → msg_before = 1; tokens = 2
+    assert.equal(byId.get("conv-B")?.msg_before, 1);
+    assert.equal(byId.get("conv-B")?.tokens_before, 2);
+  });
+
+  it("does NOT insert markers in dry-run mode", () => {
+    const src = buildSourceDb(TWO_CONVS());
+    const dst = buildDestDb();
+    const result = importLosslessClaw({
+      sourceDb: src,
+      destDb: dst,
+      dryRun: true,
+    });
+    assert.equal(result.dryRun, true);
+    assert.equal(result.compactionEventsInserted, 0);
+    const total = dst
+      .prepare("SELECT COUNT(*) AS n FROM lcm_compaction_events")
+      .get() as { n: number };
+    assert.equal(total.n, 0);
+  });
+});
+
+describe("importLosslessClaw — dry run", () => {
+  it("counts what would be inserted without writing", () => {
+    const src = buildSourceDb(TWO_CONVS());
+    const dst = buildDestDb();
+    const result = importLosslessClaw({
+      sourceDb: src,
+      destDb: dst,
+      dryRun: true,
+    });
+
+    assert.equal(result.messagesInserted, 3);
+    assert.equal(result.summariesInserted, 1);
+
+    const totalMsgs = dst
+      .prepare("SELECT COUNT(*) AS n FROM lcm_messages")
+      .get() as { n: number };
+    assert.equal(totalMsgs.n, 0);
+    const totalSums = dst
+      .prepare("SELECT COUNT(*) AS n FROM lcm_summary_nodes")
+      .get() as { n: number };
+    assert.equal(totalSums.n, 0);
+  });
+});
+
+describe("importLosslessClaw — session filter", () => {
+  it("limits import to specified resolved sessions", () => {
+    const src = buildSourceDb(TWO_CONVS());
+    const dst = buildDestDb();
+    const result = importLosslessClaw({
+      sourceDb: src,
+      destDb: dst,
+      sessionFilter: new Set(["sess-A"]),
+    });
+
+    assert.equal(result.messagesInserted, 2);
+    assert.equal(result.summariesInserted, 1);
+    assert.deepEqual(result.sessionsTouched, ["sess-A"]);
+
+    const otherSession = dst
+      .prepare("SELECT COUNT(*) AS n FROM lcm_messages WHERE session_id = 'conv-B'")
+      .get() as { n: number };
+    assert.equal(otherSession.n, 0);
+  });
+});
+
+describe("importLosslessClaw — multi-parent DAG collapse", () => {
+  it("counts and logs collapsed multi-parent rows, picks lowest-ordinal parent", () => {
+    const seed = TWO_CONVS();
+    seed.summaries.push({
+      summary_id: "sum-rollup",
+      kind: "condensed",
+      depth: 1,
+      content: "rollup",
+      token_count: 8,
+      message_ids: ["m-a-1", "m-a-2"],
+      parent_ids: [
+        { parent_summary_id: "p-late", ordinal: 5 },
+        { parent_summary_id: "sum-A", ordinal: 0 },
+      ],
+    });
+    const src = buildSourceDb(seed);
+    const dst = buildDestDb();
+    const logs: string[] = [];
+    const result = importLosslessClaw({
+      sourceDb: src,
+      destDb: dst,
+      onLog: (line) => logs.push(line),
+    });
+
+    assert.equal(result.summariesMultiParentCollapsed, 1);
+    assert.ok(
+      logs.some((l) => l.includes("sum-rollup") && l.includes("2 parents")),
+      "expected log about multi-parent collapse",
+    );
+
+    const row = dst
+      .prepare("SELECT parent_id FROM lcm_summary_nodes WHERE id = 'sum-rollup'")
+      .get() as { parent_id: string | null };
+    assert.equal(row.parent_id, "sum-A");
+  });
+});
+
+describe("importLosslessClaw — schema rejection", () => {
+  it("throws when source DB lacks lossless-claw tables", () => {
+    const src = new BetterSqlite3(":memory:");
+    src.exec("CREATE TABLE foo (x INTEGER);");
+    const dst = buildDestDb();
+    assert.throws(
+      () => importLosslessClaw({ sourceDb: src, destDb: dst }),
+      /lossless-claw tables/,
+    );
+  });
+});
+
+describe("importLosslessClaw — orphan summaries", () => {
+  it("skips summaries with no message references and increments the counter", () => {
+    const seed = TWO_CONVS();
+    seed.summaries.push({
+      summary_id: "sum-orphan",
+      kind: "leaf",
+      depth: 0,
+      content: "orphan",
+      token_count: 4,
+      message_ids: [],
+    });
+    const src = buildSourceDb(seed);
+    const dst = buildDestDb();
+    const result = importLosslessClaw({ sourceDb: src, destDb: dst });
+    assert.equal(result.summariesSkippedNoMessages, 1);
+    const row = dst
+      .prepare("SELECT count(*) AS n FROM lcm_summary_nodes WHERE id = 'sum-orphan'")
+      .get() as { n: number };
+    assert.equal(row.n, 0);
+  });
+});

--- a/packages/import-lossless-claw/src/importer.test.ts
+++ b/packages/import-lossless-claw/src/importer.test.ts
@@ -616,6 +616,54 @@ describe("importLosslessClaw — multiple conversations per session (Codex P1)",
     );
   });
 
+  it("orders conversations by earliest message timestamp, not by conversation_id (Codex P1 follow-up)", () => {
+    // UUID-like ids that sort the OPPOSITE direction of chronology.
+    // 'aaaa-conv-id' < 'zzzz-conv-id' lexicographically, but 'zzzz' is
+    // chronologically earlier. A conversation_id sort would give the
+    // wrong session timeline.
+    const seed = {
+      conversations: [
+        { conversation_id: "aaaa-conv-id", session_id: "sess" },
+        { conversation_id: "zzzz-conv-id", session_id: "sess" },
+      ],
+      messages: [
+        {
+          message_id: "z1",
+          conversation_id: "zzzz-conv-id",
+          seq: 0,
+          role: "user",
+          content: "earliest in time, conv-z",
+          token_count: 1,
+          created_at: "2026-04-01T00:00:00.000Z",
+        },
+        {
+          message_id: "a1",
+          conversation_id: "aaaa-conv-id",
+          seq: 0,
+          role: "user",
+          content: "later in time, conv-a",
+          token_count: 1,
+          created_at: "2026-04-02T00:00:00.000Z",
+        },
+      ],
+    };
+    const src = buildSourceDb(seed);
+    const dst = buildDestDb();
+    importLosslessClaw({ sourceDb: src, destDb: dst });
+
+    const rows = dst
+      .prepare(
+        "SELECT turn_index, content FROM lcm_messages WHERE session_id = 'sess' ORDER BY turn_index",
+      )
+      .all() as Array<{ turn_index: number; content: string }>;
+    // Earliest message (zzzz-conv-id, 2026-04-01) gets turn_index 0
+    // even though 'zzzz' sorts AFTER 'aaaa' lexicographically.
+    assert.equal(rows[0]!.turn_index, 0);
+    assert.match(rows[0]!.content, /earliest in time/);
+    assert.equal(rows[1]!.turn_index, 1);
+    assert.match(rows[1]!.content, /later in time/);
+  });
+
   it("idempotent re-run still inserts zero new rows when conversations share a session", () => {
     const seed = {
       conversations: [

--- a/packages/import-lossless-claw/src/importer.test.ts
+++ b/packages/import-lossless-claw/src/importer.test.ts
@@ -532,6 +532,128 @@ describe("importLosslessClaw — compaction-event token aggregation", () => {
   });
 });
 
+describe("importLosslessClaw — multiple conversations per session (Codex P1)", () => {
+  it("preserves all messages when two conversations share a session_id, despite seq overlap", () => {
+    // Two conversations under one session, both starting at seq=0.
+    // Naive (session_id, turn_index) dedup would silently drop the
+    // second conversation's seq=0,1 as 'already present'. The fix
+    // assigns session-global turn_index and dedupes on
+    // metadata.{conversation_id, source_seq}.
+    const seed = {
+      conversations: [
+        { conversation_id: "conv-A", session_id: "shared-sess" },
+        { conversation_id: "conv-B", session_id: "shared-sess" },
+      ],
+      messages: [
+        {
+          message_id: "ma1",
+          conversation_id: "conv-A",
+          seq: 0,
+          role: "user",
+          content: "A says hello",
+          token_count: 3,
+          created_at: "2026-04-01T00:00:00.000Z",
+        },
+        {
+          message_id: "ma2",
+          conversation_id: "conv-A",
+          seq: 1,
+          role: "assistant",
+          content: "A responds",
+          token_count: 2,
+          created_at: "2026-04-01T00:00:01.000Z",
+        },
+        {
+          message_id: "mb1",
+          conversation_id: "conv-B",
+          seq: 0,
+          role: "user",
+          content: "B says hello",
+          token_count: 3,
+          created_at: "2026-04-01T00:01:00.000Z",
+        },
+        {
+          message_id: "mb2",
+          conversation_id: "conv-B",
+          seq: 1,
+          role: "assistant",
+          content: "B responds",
+          token_count: 2,
+          created_at: "2026-04-01T00:01:01.000Z",
+        },
+      ],
+    };
+    const src = buildSourceDb(seed);
+    const dst = buildDestDb();
+    const result = importLosslessClaw({ sourceDb: src, destDb: dst });
+
+    assert.equal(result.messagesInserted, 4, "all 4 messages must land");
+    assert.equal(result.messagesSkipped, 0);
+
+    const rows = dst
+      .prepare(
+        "SELECT turn_index, content, json_extract(metadata, '$.conversation_id') AS conv, " +
+          "json_extract(metadata, '$.source_seq') AS source_seq " +
+          "FROM lcm_messages WHERE session_id = 'shared-sess' ORDER BY turn_index",
+      )
+      .all() as Array<{
+      turn_index: number;
+      content: string;
+      conv: string;
+      source_seq: number;
+    }>;
+    assert.equal(rows.length, 4);
+    // Session-global turn_index 0..3, no collisions
+    assert.deepEqual(
+      rows.map((r) => r.turn_index),
+      [0, 1, 2, 3],
+    );
+    // Conversation order is deterministic by conversation_id sort:
+    // conv-A first (seqs 0,1), then conv-B (seqs 0,1).
+    assert.deepEqual(
+      rows.map((r) => `${r.conv}:${r.source_seq}`),
+      ["conv-A:0", "conv-A:1", "conv-B:0", "conv-B:1"],
+    );
+  });
+
+  it("idempotent re-run still inserts zero new rows when conversations share a session", () => {
+    const seed = {
+      conversations: [
+        { conversation_id: "conv-A", session_id: "shared-sess" },
+        { conversation_id: "conv-B", session_id: "shared-sess" },
+      ],
+      messages: [
+        {
+          message_id: "ma1",
+          conversation_id: "conv-A",
+          seq: 0,
+          role: "user",
+          content: "A0",
+          token_count: 1,
+          created_at: "2026-04-01T00:00:00.000Z",
+        },
+        {
+          message_id: "mb1",
+          conversation_id: "conv-B",
+          seq: 0,
+          role: "user",
+          content: "B0",
+          token_count: 1,
+          created_at: "2026-04-01T00:01:00.000Z",
+        },
+      ],
+    };
+    const src = buildSourceDb(seed);
+    const dst = buildDestDb();
+
+    const first = importLosslessClaw({ sourceDb: src, destDb: dst });
+    const second = importLosslessClaw({ sourceDb: src, destDb: dst });
+    assert.equal(first.messagesInserted, 2);
+    assert.equal(second.messagesInserted, 0);
+    assert.equal(second.messagesSkipped, 2);
+  });
+});
+
 describe("importLosslessClaw — orphan summaries", () => {
   it("skips summaries with no message references and increments the counter", () => {
     const seed = TWO_CONVS();

--- a/packages/import-lossless-claw/src/importer.test.ts
+++ b/packages/import-lossless-claw/src/importer.test.ts
@@ -497,6 +497,41 @@ describe("importLosslessClaw — schema rejection", () => {
   });
 });
 
+describe("importLosslessClaw — compaction-event token aggregation", () => {
+  it("uses the destination's actual SUM(token_count), not just newly-inserted", () => {
+    // Simulate a partial-retry scenario: messages already in dest, only
+    // summaries new this run. The compaction event must reflect the dest's
+    // real token total, not zero.
+    const seed = TWO_CONVS();
+    const src = buildSourceDb(seed);
+    const dst = buildDestDb();
+
+    // Pre-populate dst with the same messages so this run is summary-only.
+    importLosslessClaw({ sourceDb: src, destDb: dst });
+
+    // Wipe summaries + compaction events so the next run re-inserts them
+    // but messages are already there.
+    dst.exec("DELETE FROM lcm_summary_nodes; DELETE FROM lcm_compaction_events;");
+
+    const result = importLosslessClaw({ sourceDb: src, destDb: dst });
+    assert.equal(result.messagesInserted, 0);
+    assert.equal(result.summariesInserted, 1);
+    assert.equal(result.compactionEventsInserted, 1);
+
+    const event = dst
+      .prepare(
+        "SELECT session_id, tokens_before FROM lcm_compaction_events WHERE session_id = 'sess-A'",
+      )
+      .get() as { session_id: string; tokens_before: number };
+    // Total token_count for sess-A is 2 + 3 = 5, all already present in dest.
+    assert.equal(
+      event.tokens_before,
+      5,
+      "summary-only retry must read tokens from dest, not from this run's writes",
+    );
+  });
+});
+
 describe("importLosslessClaw — orphan summaries", () => {
   it("skips summaries with no message references and increments the counter", () => {
     const seed = TWO_CONVS();

--- a/packages/import-lossless-claw/src/importer.test.ts
+++ b/packages/import-lossless-claw/src/importer.test.ts
@@ -386,7 +386,10 @@ describe("importLosslessClaw — compaction-event boundary", () => {
     assert.equal(byId.get("conv-B")?.tokens_before, 2);
   });
 
-  it("does NOT insert markers in dry-run mode", () => {
+  it("dry-run COUNTS markers (matches other counters) but does not write them", () => {
+    // Cursor low-sev: Messages/Summaries inserted are reported as
+    // 'would insert' counts in dry-run; compactionEventsInserted must
+    // follow the same contract for output consistency.
     const src = buildSourceDb(TWO_CONVS());
     const dst = buildDestDb();
     const result = importLosslessClaw({
@@ -395,11 +398,15 @@ describe("importLosslessClaw — compaction-event boundary", () => {
       dryRun: true,
     });
     assert.equal(result.dryRun, true);
-    assert.equal(result.compactionEventsInserted, 0);
+    assert.equal(
+      result.compactionEventsInserted,
+      2,
+      "dry-run reports the same count as a real run (2 sessions)",
+    );
     const total = dst
       .prepare("SELECT COUNT(*) AS n FROM lcm_compaction_events")
       .get() as { n: number };
-    assert.equal(total.n, 0);
+    assert.equal(total.n, 0, "no actual rows written in dry-run");
   });
 });
 

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -1,0 +1,382 @@
+// ---------------------------------------------------------------------------
+// lossless-claw → Remnic LCM importer (orchestration)
+//
+// Streams rows from a lossless-claw SQLite export into a Remnic LCM
+// SQLite database opened by the caller. The Remnic database must already
+// have its schema applied (use openLcmDatabase() from @remnic/core).
+//
+// Idempotency: messages are keyed on (session_id, turn_index) — the same
+// natural key Remnic's own indexer uses. Summary nodes are keyed on the
+// preserved primary id.
+//
+// FTS sync: lcm_messages_fts and lcm_summaries_fts are external-content
+// FTS5 tables, so every insert must be mirrored. We do this in the same
+// transaction as the row write to keep the index consistent on crash.
+//
+// Compaction-event boundary: per-session, we insert one row into
+// lcm_compaction_events with tokens_before == tokens_after, marking the
+// post-import state from which Remnic's own compaction will operate.
+// ---------------------------------------------------------------------------
+
+import type Database from "better-sqlite3";
+
+import {
+  assertLosslessClawSchema,
+  listConversations,
+  listMessagesForConversation,
+  listSummaries,
+  listSummaryMessages,
+  listSummaryParents,
+  type LosslessClawConversation,
+} from "./source.js";
+import {
+  indexSummaryDerivations,
+  isMultiParent,
+  mapMessage,
+  mapSummary,
+  resolveSessionId,
+  resolveSummarySession,
+} from "./transform.js";
+
+export interface ImportLosslessClawOptions {
+  /** Open lossless-claw source database (read-only OK). */
+  sourceDb: Database.Database;
+  /** Open Remnic LCM destination database with schema applied. */
+  destDb: Database.Database;
+  /** When true, run all reads + transformations but skip writes. */
+  dryRun?: boolean;
+  /** Optional set of session_ids (post-resolve) to import. Empty = all. */
+  sessionFilter?: ReadonlySet<string>;
+  /** Hook for status output (defaults to no-op). */
+  onLog?: (line: string) => void;
+}
+
+export interface ImportLosslessClawResult {
+  conversationsScanned: number;
+  sessionsTouched: string[];
+  messagesInserted: number;
+  messagesSkipped: number;
+  summariesInserted: number;
+  summariesSkipped: number;
+  summariesMultiParentCollapsed: number;
+  summariesSkippedNoMessages: number;
+  summariesSkippedMultiSession: number;
+  compactionEventsInserted: number;
+  dryRun: boolean;
+}
+
+const NOOP_LOG = (_line: string): void => {
+  /* default sink */
+};
+
+export function importLosslessClaw(
+  options: ImportLosslessClawOptions,
+): ImportLosslessClawResult {
+  const { sourceDb, destDb } = options;
+  const dryRun = options.dryRun ?? false;
+  const sessionFilter = options.sessionFilter;
+  const log = options.onLog ?? NOOP_LOG;
+
+  assertLosslessClawSchema(sourceDb);
+
+  const result: ImportLosslessClawResult = {
+    conversationsScanned: 0,
+    sessionsTouched: [],
+    messagesInserted: 0,
+    messagesSkipped: 0,
+    summariesInserted: 0,
+    summariesSkipped: 0,
+    summariesMultiParentCollapsed: 0,
+    summariesSkippedNoMessages: 0,
+    summariesSkippedMultiSession: 0,
+    compactionEventsInserted: 0,
+    dryRun,
+  };
+
+  // ── Pre-resolve session ids per conversation + per message id ──────────
+  const conversations = listConversations(sourceDb);
+  result.conversationsScanned = conversations.length;
+
+  const conversationById = new Map<string, LosslessClawConversation>();
+  for (const c of conversations) conversationById.set(c.conversation_id, c);
+
+  const sessionByConvId = new Map<string, string>();
+  const sessionByMessageId = new Map<string, string>();
+  const seqByMessageId = new Map<string, number>();
+
+  for (const c of conversations) {
+    sessionByConvId.set(c.conversation_id, resolveSessionId(c));
+  }
+
+  // We materialize messages once per conversation, twice traversed:
+  // first pass populates sessionByMessageId + seqByMessageId, second pass
+  // (below) writes them. Cheaper than re-querying per summary lookup.
+  const messagesByConv = new Map<
+    string,
+    ReturnType<typeof listMessagesForConversation>
+  >();
+
+  for (const c of conversations) {
+    const msgs = listMessagesForConversation(sourceDb, c.conversation_id);
+    messagesByConv.set(c.conversation_id, msgs);
+    const session = sessionByConvId.get(c.conversation_id)!;
+    for (const m of msgs) {
+      sessionByMessageId.set(m.message_id, session);
+      seqByMessageId.set(m.message_id, m.seq);
+    }
+  }
+
+  // ── Insert messages ────────────────────────────────────────────────────
+  const messageExistsStmt = destDb.prepare(
+    "SELECT 1 AS hit FROM lcm_messages WHERE session_id = ? AND turn_index = ? LIMIT 1",
+  );
+  const insertMessageStmt = destDb.prepare(
+    "INSERT INTO lcm_messages (session_id, turn_index, role, content, token_count, created_at, metadata) " +
+      "VALUES (?, ?, ?, ?, ?, ?, ?)",
+  );
+  const insertMessageFtsStmt = destDb.prepare(
+    "INSERT INTO lcm_messages_fts (rowid, content) VALUES (?, ?)",
+  );
+
+  const sessionsTouched = new Set<string>();
+  const tokensImportedBySession = new Map<string, number>();
+
+  const writeMessages = destDb.transaction(() => {
+    for (const c of conversations) {
+      const session = sessionByConvId.get(c.conversation_id)!;
+      if (sessionFilter && !sessionFilter.has(session)) continue;
+      const msgs = messagesByConv.get(c.conversation_id) ?? [];
+      for (const m of msgs) {
+        const mapped = mapMessage(c, m);
+        const existing = messageExistsStmt.get(
+          mapped.session_id,
+          mapped.turn_index,
+        ) as { hit: number } | undefined;
+        if (existing) {
+          result.messagesSkipped += 1;
+          continue;
+        }
+        const info = insertMessageStmt.run(
+          mapped.session_id,
+          mapped.turn_index,
+          mapped.role,
+          mapped.content,
+          mapped.token_count,
+          mapped.created_at,
+          mapped.metadata,
+        );
+        insertMessageFtsStmt.run(Number(info.lastInsertRowid), mapped.content);
+        result.messagesInserted += 1;
+        sessionsTouched.add(mapped.session_id);
+        tokensImportedBySession.set(
+          mapped.session_id,
+          (tokensImportedBySession.get(mapped.session_id) ?? 0) +
+            mapped.token_count,
+        );
+      }
+    }
+  });
+
+  if (!dryRun) {
+    writeMessages();
+  } else {
+    // Dry run: count what would have been inserted vs skipped without
+    // mutating either DB. Re-walk for counters only.
+    for (const c of conversations) {
+      const session = sessionByConvId.get(c.conversation_id)!;
+      if (sessionFilter && !sessionFilter.has(session)) continue;
+      const msgs = messagesByConv.get(c.conversation_id) ?? [];
+      for (const m of msgs) {
+        const mapped = mapMessage(c, m);
+        const existing = messageExistsStmt.get(
+          mapped.session_id,
+          mapped.turn_index,
+        ) as { hit: number } | undefined;
+        if (existing) {
+          result.messagesSkipped += 1;
+        } else {
+          result.messagesInserted += 1;
+          sessionsTouched.add(mapped.session_id);
+          tokensImportedBySession.set(
+            mapped.session_id,
+            (tokensImportedBySession.get(mapped.session_id) ?? 0) +
+              mapped.token_count,
+          );
+        }
+      }
+    }
+  }
+
+  // ── Insert summaries ───────────────────────────────────────────────────
+  const summaries = listSummaries(sourceDb);
+  const summaryMessages = listSummaryMessages(sourceDb);
+  const summaryParents = listSummaryParents(sourceDb);
+  const derivations = indexSummaryDerivations(summaryMessages, summaryParents);
+
+  const summaryExistsStmt = destDb.prepare(
+    "SELECT 1 AS hit FROM lcm_summary_nodes WHERE id = ? LIMIT 1",
+  );
+  const insertSummaryStmt = destDb.prepare(
+    "INSERT INTO lcm_summary_nodes (id, session_id, depth, parent_id, summary_text, token_count, msg_start, msg_end, escalation, created_at) " +
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+  );
+  const insertSummaryFtsStmt = destDb.prepare(
+    "INSERT INTO lcm_summaries_fts (rowid, summary_text) VALUES (?, ?)",
+  );
+  const lookupSummaryRowidStmt = destDb.prepare(
+    "SELECT rowid AS rowid FROM lcm_summary_nodes WHERE id = ?",
+  );
+
+  const writeSummaries = destDb.transaction(() => {
+    for (const summary of summaries) {
+      const derivation = derivations.get(summary.summary_id);
+      if (!derivation || derivation.messageIds.length === 0) {
+        result.summariesSkippedNoMessages += 1;
+        log(
+          `skip summary ${summary.summary_id}: no message references in summary_messages`,
+        );
+        continue;
+      }
+      const session = resolveSummarySession(
+        derivation.messageIds,
+        sessionByMessageId,
+      );
+      if (!session) {
+        result.summariesSkippedMultiSession += 1;
+        log(
+          `skip summary ${summary.summary_id}: covers messages from multiple sessions`,
+        );
+        continue;
+      }
+      if (sessionFilter && !sessionFilter.has(session)) continue;
+
+      const messageSeqs: number[] = [];
+      for (const mid of derivation.messageIds) {
+        const seq = seqByMessageId.get(mid);
+        if (typeof seq === "number") messageSeqs.push(seq);
+      }
+      if (messageSeqs.length === 0) {
+        result.summariesSkippedNoMessages += 1;
+        log(
+          `skip summary ${summary.summary_id}: message ids exist but seqs unresolved`,
+        );
+        continue;
+      }
+
+      const mapped = mapSummary({
+        summary,
+        parents: derivation.parents,
+        messageSeqs,
+        sessionId: session,
+      });
+
+      if (isMultiParent(derivation.parents)) {
+        result.summariesMultiParentCollapsed += 1;
+        log(
+          `summary ${summary.summary_id} has ${derivation.parents.length} parents; ` +
+            `keeping ${mapped.parent_id ?? "(none)"} (Remnic LCM is single-parent).`,
+        );
+      }
+
+      const existing = summaryExistsStmt.get(mapped.id) as
+        | { hit: number }
+        | undefined;
+      if (existing) {
+        result.summariesSkipped += 1;
+        continue;
+      }
+      insertSummaryStmt.run(
+        mapped.id,
+        mapped.session_id,
+        mapped.depth,
+        mapped.parent_id,
+        mapped.summary_text,
+        mapped.token_count,
+        mapped.msg_start,
+        mapped.msg_end,
+        mapped.escalation,
+        mapped.created_at,
+      );
+      const row = lookupSummaryRowidStmt.get(mapped.id) as
+        | { rowid: number }
+        | undefined;
+      if (row) {
+        insertSummaryFtsStmt.run(row.rowid, mapped.summary_text);
+      }
+      result.summariesInserted += 1;
+      sessionsTouched.add(mapped.session_id);
+    }
+  });
+
+  if (!dryRun) {
+    writeSummaries();
+  } else {
+    // Dry run: count without writing.
+    for (const summary of summaries) {
+      const derivation = derivations.get(summary.summary_id);
+      if (!derivation || derivation.messageIds.length === 0) {
+        result.summariesSkippedNoMessages += 1;
+        continue;
+      }
+      const session = resolveSummarySession(
+        derivation.messageIds,
+        sessionByMessageId,
+      );
+      if (!session) {
+        result.summariesSkippedMultiSession += 1;
+        continue;
+      }
+      if (sessionFilter && !sessionFilter.has(session)) continue;
+      const messageSeqs: number[] = [];
+      for (const mid of derivation.messageIds) {
+        const seq = seqByMessageId.get(mid);
+        if (typeof seq === "number") messageSeqs.push(seq);
+      }
+      if (messageSeqs.length === 0) {
+        result.summariesSkippedNoMessages += 1;
+        continue;
+      }
+      const existing = summaryExistsStmt.get(summary.summary_id) as
+        | { hit: number }
+        | undefined;
+      if (existing) {
+        result.summariesSkipped += 1;
+      } else {
+        result.summariesInserted += 1;
+        sessionsTouched.add(session);
+      }
+      if (isMultiParent(derivation.parents)) {
+        result.summariesMultiParentCollapsed += 1;
+      }
+    }
+  }
+
+  // ── Compaction-event boundary ──────────────────────────────────────────
+  // Insert one marker row per session that gained data. tokens_before
+  // equals tokens_after to encode "this is an import boundary, not a real
+  // compaction event"; any consumer that needs the distinction can detect
+  // the equality.
+  if (!dryRun) {
+    const insertEventStmt = destDb.prepare(
+      "INSERT INTO lcm_compaction_events (session_id, fired_at, msg_before, tokens_before, tokens_after) " +
+        "VALUES (?, ?, ?, ?, ?)",
+    );
+    const maxTurnStmt = destDb.prepare(
+      "SELECT IFNULL(MAX(turn_index), -1) AS max_turn FROM lcm_messages WHERE session_id = ?",
+    );
+    const writeEvents = destDb.transaction(() => {
+      const firedAt = new Date().toISOString();
+      for (const session of sessionsTouched) {
+        const row = maxTurnStmt.get(session) as { max_turn: number };
+        const msgBefore = row.max_turn + 1;
+        const tokens = tokensImportedBySession.get(session) ?? 0;
+        insertEventStmt.run(session, firedAt, msgBefore, tokens, tokens);
+        result.compactionEventsInserted += 1;
+      }
+    });
+    writeEvents();
+  }
+
+  result.sessionsTouched = [...sessionsTouched].sort();
+  return result;
+}

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -119,12 +119,28 @@ export function importLosslessClaw(
     }
   }
 
-  // Group conversations by session in deterministic order so two
-  // conversations resolving to the same session id get a consistent
-  // assignment of session-global turn_index values across runs.
-  const orderedConversations = [...conversations].sort((a, b) =>
-    a.conversation_id.localeCompare(b.conversation_id),
-  );
+  // Group conversations by session, ordered by earliest message
+  // timestamp so cross-conversation turn ordering is chronological — a
+  // raw `conversation_id` sort risks ordering by UUID (Codex P1 review:
+  // session timelines and summary msg_start/msg_end depend on
+  // turn_index reflecting real chronology).
+  const earliestByConv = new Map<string, string>();
+  for (const [convId, msgs] of messagesByConv) {
+    if (msgs.length === 0) continue;
+    let earliest = msgs[0]!.created_at;
+    for (let i = 1; i < msgs.length; i++) {
+      if (msgs[i]!.created_at < earliest) earliest = msgs[i]!.created_at;
+    }
+    earliestByConv.set(convId, earliest);
+  }
+  const orderedConversations = [...conversations].sort((a, b) => {
+    const ea = earliestByConv.get(a.conversation_id) ?? "";
+    const eb = earliestByConv.get(b.conversation_id) ?? "";
+    if (ea !== eb) return ea < eb ? -1 : 1;
+    // Stable tie-break on conversation_id when earliest timestamps match
+    // (or both are missing).
+    return a.conversation_id.localeCompare(b.conversation_id);
+  });
   const convsBySession = new Map<string, typeof orderedConversations>();
   for (const c of orderedConversations) {
     const session = sessionByConvId.get(c.conversation_id)!;
@@ -138,13 +154,11 @@ export function importLosslessClaw(
   // `metadata.source_seq`) rather than `(session_id, turn_index)` so two
   // source conversations sharing one session can both contribute messages
   // without one's `seq=N` masking the other's `seq=N` (Codex P1 review).
-  const sourceMessageLookupStmt = destDb.prepare(
-    "SELECT turn_index FROM lcm_messages " +
-      "WHERE session_id = ? " +
-      "  AND json_extract(metadata, '$.conversation_id') = ? " +
-      "  AND json_extract(metadata, '$.source_seq') = ? " +
-      "LIMIT 1",
-  );
+  //
+  // To avoid the O(n²) behavior of a per-row `json_extract` lookup with
+  // no covering index (Codex P2 review), pre-fetch existing source
+  // identities once per affected session into an in-memory Map. The
+  // import loop then does O(1) Map lookups for dedup.
   const insertMessageStmt = destDb.prepare(
     "INSERT INTO lcm_messages (session_id, turn_index, role, content, token_count, created_at, metadata) " +
       "VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -152,9 +166,36 @@ export function importLosslessClaw(
   const insertMessageFtsStmt = destDb.prepare(
     "INSERT INTO lcm_messages_fts (rowid, content) VALUES (?, ?)",
   );
-  const maxTurnInDestStmt = destDb.prepare(
-    "SELECT IFNULL(MAX(turn_index), -1) AS max FROM lcm_messages WHERE session_id = ?",
+  const existingScanStmt = destDb.prepare(
+    "SELECT turn_index, " +
+      "json_extract(metadata, '$.conversation_id') AS conv, " +
+      "json_extract(metadata, '$.source_seq') AS source_seq " +
+      "FROM lcm_messages WHERE session_id = ?",
   );
+
+  // session → "convId|seq" → turn_index of the existing row. Lookup is
+  // O(1) Map membership instead of a per-row JSON-extract scan.
+  const existingBySession = new Map<string, Map<string, number>>();
+  // session → max(turn_index) currently in dest (so new rows append).
+  const maxTurnBySession = new Map<string, number>();
+  for (const session of convsBySession.keys()) {
+    if (sessionFilter && !sessionFilter.has(session)) continue;
+    const map = new Map<string, number>();
+    let max = -1;
+    const rows = existingScanStmt.iterate(session) as Iterable<{
+      turn_index: number;
+      conv: string | null;
+      source_seq: number | null;
+    }>;
+    for (const row of rows) {
+      if (row.turn_index > max) max = row.turn_index;
+      if (row.conv != null && row.source_seq != null) {
+        map.set(`${row.conv}|${row.source_seq}`, row.turn_index);
+      }
+    }
+    existingBySession.set(session, map);
+    maxTurnBySession.set(session, max);
+  }
 
   const sessionsTouched = new Set<string>();
   // Mapping from source message_id → assigned (or pre-existing)
@@ -165,23 +206,25 @@ export function importLosslessClaw(
   function assignTurnIndices(forWrite: boolean): void {
     for (const [session, convs] of convsBySession) {
       if (sessionFilter && !sessionFilter.has(session)) continue;
-      const startRow = maxTurnInDestStmt.get(session) as { max: number };
-      let nextTurn = startRow.max + 1;
+      const existing =
+        existingBySession.get(session) ?? new Map<string, number>();
+      let nextTurn = (maxTurnBySession.get(session) ?? -1) + 1;
       for (const c of convs) {
         const msgs = messagesByConv.get(c.conversation_id) ?? [];
         for (const m of msgs) {
-          const existing = sourceMessageLookupStmt.get(
-            session,
-            c.conversation_id,
-            m.seq,
-          ) as { turn_index: number } | undefined;
-          if (existing) {
-            turnIndexByMessageId.set(m.message_id, existing.turn_index);
+          const key = `${c.conversation_id}|${m.seq}`;
+          const existingTurn = existing.get(key);
+          if (existingTurn !== undefined) {
+            turnIndexByMessageId.set(m.message_id, existingTurn);
             result.messagesSkipped += 1;
             continue;
           }
           const ti = nextTurn++;
           turnIndexByMessageId.set(m.message_id, ti);
+          // Update the in-memory dedup map so duplicates within this
+          // run also count as skips on subsequent passes (defensive;
+          // shouldn't happen with valid source data).
+          existing.set(key, ti);
           if (forWrite) {
             const mapped = mapMessage(c, m, ti);
             const info = insertMessageStmt.run(

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -46,7 +46,12 @@ export interface ImportLosslessClawOptions {
   destDb: Database.Database;
   /** When true, run all reads + transformations but skip writes. */
   dryRun?: boolean;
-  /** Optional set of session_ids (post-resolve) to import. Empty = all. */
+  /**
+   * Optional set of session_ids (post-resolve) to import.
+   *
+   * `undefined` or an empty Set both mean "import every session".
+   * Pass a non-empty Set to restrict to specific resolved session ids.
+   */
   sessionFilter?: ReadonlySet<string>;
   /** Hook for status output (defaults to no-op). */
   onLog?: (line: string) => void;
@@ -75,7 +80,16 @@ export function importLosslessClaw(
 ): ImportLosslessClawResult {
   const { sourceDb, destDb } = options;
   const dryRun = options.dryRun ?? false;
-  const sessionFilter = options.sessionFilter;
+  // Normalise sessionFilter: an empty Set is truthy in JavaScript, so a
+  // raw `sessionFilter && !sessionFilter.has(session)` guard would skip
+  // every session if a caller passed `new Set()` expecting "import all"
+  // (the documented contract on the option). Treat empty-Set the same
+  // as undefined here so every guard below is correct (Cursor Bugbot
+  // review on PR #797).
+  const sessionFilter =
+    options.sessionFilter && options.sessionFilter.size > 0
+      ? options.sessionFilter
+      : undefined;
   const log = options.onLog ?? NOOP_LOG;
 
   assertLosslessClawSchema(sourceDb);

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -98,15 +98,13 @@ export function importLosslessClaw(
 
   const sessionByConvId = new Map<string, string>();
   const sessionByMessageId = new Map<string, string>();
-  const seqByMessageId = new Map<string, number>();
 
   for (const c of conversations) {
     sessionByConvId.set(c.conversation_id, resolveSessionId(c));
   }
 
-  // We materialize messages once per conversation, twice traversed:
-  // first pass populates sessionByMessageId + seqByMessageId, second pass
-  // (below) writes them. Cheaper than re-querying per summary lookup.
+  // Materialize messages once per conversation; reused for the write pass
+  // and (via sessionByMessageId) for summary mapping.
   const messagesByConv = new Map<
     string,
     ReturnType<typeof listMessagesForConversation>
@@ -118,13 +116,34 @@ export function importLosslessClaw(
     const session = sessionByConvId.get(c.conversation_id)!;
     for (const m of msgs) {
       sessionByMessageId.set(m.message_id, session);
-      seqByMessageId.set(m.message_id, m.seq);
     }
   }
 
+  // Group conversations by session in deterministic order so two
+  // conversations resolving to the same session id get a consistent
+  // assignment of session-global turn_index values across runs.
+  const orderedConversations = [...conversations].sort((a, b) =>
+    a.conversation_id.localeCompare(b.conversation_id),
+  );
+  const convsBySession = new Map<string, typeof orderedConversations>();
+  for (const c of orderedConversations) {
+    const session = sessionByConvId.get(c.conversation_id)!;
+    const list = convsBySession.get(session) ?? [];
+    list.push(c);
+    convsBySession.set(session, list);
+  }
+
   // ── Insert messages ────────────────────────────────────────────────────
-  const messageExistsStmt = destDb.prepare(
-    "SELECT 1 AS hit FROM lcm_messages WHERE session_id = ? AND turn_index = ? LIMIT 1",
+  // Dedup uses source identity (`metadata.conversation_id` +
+  // `metadata.source_seq`) rather than `(session_id, turn_index)` so two
+  // source conversations sharing one session can both contribute messages
+  // without one's `seq=N` masking the other's `seq=N` (Codex P1 review).
+  const sourceMessageLookupStmt = destDb.prepare(
+    "SELECT turn_index FROM lcm_messages " +
+      "WHERE session_id = ? " +
+      "  AND json_extract(metadata, '$.conversation_id') = ? " +
+      "  AND json_extract(metadata, '$.source_seq') = ? " +
+      "LIMIT 1",
   );
   const insertMessageStmt = destDb.prepare(
     "INSERT INTO lcm_messages (session_id, turn_index, role, content, token_count, created_at, metadata) " +
@@ -133,63 +152,66 @@ export function importLosslessClaw(
   const insertMessageFtsStmt = destDb.prepare(
     "INSERT INTO lcm_messages_fts (rowid, content) VALUES (?, ?)",
   );
+  const maxTurnInDestStmt = destDb.prepare(
+    "SELECT IFNULL(MAX(turn_index), -1) AS max FROM lcm_messages WHERE session_id = ?",
+  );
 
   const sessionsTouched = new Set<string>();
+  // Mapping from source message_id → assigned (or pre-existing)
+  // turn_index. Populated for both inserted rows and dedup-skipped rows
+  // so summary mapping (msg_start/msg_end) reflects real turn indices.
+  const turnIndexByMessageId = new Map<string, number>();
 
-  const writeMessages = destDb.transaction(() => {
-    for (const c of conversations) {
-      const session = sessionByConvId.get(c.conversation_id)!;
+  function assignTurnIndices(forWrite: boolean): void {
+    for (const [session, convs] of convsBySession) {
       if (sessionFilter && !sessionFilter.has(session)) continue;
-      const msgs = messagesByConv.get(c.conversation_id) ?? [];
-      for (const m of msgs) {
-        const mapped = mapMessage(c, m);
-        const existing = messageExistsStmt.get(
-          mapped.session_id,
-          mapped.turn_index,
-        ) as { hit: number } | undefined;
-        if (existing) {
-          result.messagesSkipped += 1;
-          continue;
+      const startRow = maxTurnInDestStmt.get(session) as { max: number };
+      let nextTurn = startRow.max + 1;
+      for (const c of convs) {
+        const msgs = messagesByConv.get(c.conversation_id) ?? [];
+        for (const m of msgs) {
+          const existing = sourceMessageLookupStmt.get(
+            session,
+            c.conversation_id,
+            m.seq,
+          ) as { turn_index: number } | undefined;
+          if (existing) {
+            turnIndexByMessageId.set(m.message_id, existing.turn_index);
+            result.messagesSkipped += 1;
+            continue;
+          }
+          const ti = nextTurn++;
+          turnIndexByMessageId.set(m.message_id, ti);
+          if (forWrite) {
+            const mapped = mapMessage(c, m, ti);
+            const info = insertMessageStmt.run(
+              mapped.session_id,
+              mapped.turn_index,
+              mapped.role,
+              mapped.content,
+              mapped.token_count,
+              mapped.created_at,
+              mapped.metadata,
+            );
+            insertMessageFtsStmt.run(
+              Number(info.lastInsertRowid),
+              mapped.content,
+            );
+          }
+          result.messagesInserted += 1;
+          sessionsTouched.add(session);
         }
-        const info = insertMessageStmt.run(
-          mapped.session_id,
-          mapped.turn_index,
-          mapped.role,
-          mapped.content,
-          mapped.token_count,
-          mapped.created_at,
-          mapped.metadata,
-        );
-        insertMessageFtsStmt.run(Number(info.lastInsertRowid), mapped.content);
-        result.messagesInserted += 1;
-        sessionsTouched.add(mapped.session_id);
       }
     }
-  });
+  }
 
   if (!dryRun) {
+    const writeMessages = destDb.transaction(() => assignTurnIndices(true));
     writeMessages();
   } else {
-    // Dry run: count what would have been inserted vs skipped without
-    // mutating either DB. Re-walk for counters only.
-    for (const c of conversations) {
-      const session = sessionByConvId.get(c.conversation_id)!;
-      if (sessionFilter && !sessionFilter.has(session)) continue;
-      const msgs = messagesByConv.get(c.conversation_id) ?? [];
-      for (const m of msgs) {
-        const mapped = mapMessage(c, m);
-        const existing = messageExistsStmt.get(
-          mapped.session_id,
-          mapped.turn_index,
-        ) as { hit: number } | undefined;
-        if (existing) {
-          result.messagesSkipped += 1;
-        } else {
-          result.messagesInserted += 1;
-          sessionsTouched.add(mapped.session_id);
-        }
-      }
-    }
+    // Dry run: walk the same iteration to populate counters and
+    // turnIndexByMessageId without mutating either DB.
+    assignTurnIndices(false);
   }
 
   // ── Insert summaries ───────────────────────────────────────────────────
@@ -237,7 +259,7 @@ export function importLosslessClaw(
 
       const messageSeqs: number[] = [];
       for (const mid of derivation.messageIds) {
-        const seq = seqByMessageId.get(mid);
+        const seq = turnIndexByMessageId.get(mid);
         if (typeof seq === "number") messageSeqs.push(seq);
       }
       if (messageSeqs.length === 0) {
@@ -314,7 +336,7 @@ export function importLosslessClaw(
       if (sessionFilter && !sessionFilter.has(session)) continue;
       const messageSeqs: number[] = [];
       for (const mid of derivation.messageIds) {
-        const seq = seqByMessageId.get(mid);
+        const seq = turnIndexByMessageId.get(mid);
         if (typeof seq === "number") messageSeqs.push(seq);
       }
       if (messageSeqs.length === 0) {

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -300,7 +300,10 @@ export function importLosslessClaw(
     "SELECT rowid AS rowid FROM lcm_summary_nodes WHERE id = ?",
   );
 
-  const writeSummaries = destDb.transaction(() => {
+  // Single shared loop body for both write and dry-run paths so summary
+  // filter conditions (skip-no-messages, multi-session, dedup, etc.)
+  // can never silently diverge between modes (Cursor Bugbot review).
+  function processSummaries(forWrite: boolean): void {
     for (const summary of summaries) {
       const derivation = derivations.get(summary.summary_id);
       if (!derivation || derivation.messageIds.length === 0) {
@@ -317,7 +320,7 @@ export function importLosslessClaw(
       if (!session) {
         result.summariesSkippedMultiSession += 1;
         log(
-          `skip summary ${summary.summary_id}: covers messages from multiple sessions`,
+          `skip summary ${summary.summary_id}: covers messages from multiple sessions or has dangling references`,
         );
         continue;
       }
@@ -358,70 +361,36 @@ export function importLosslessClaw(
         result.summariesSkipped += 1;
         continue;
       }
-      insertSummaryStmt.run(
-        mapped.id,
-        mapped.session_id,
-        mapped.depth,
-        mapped.parent_id,
-        mapped.summary_text,
-        mapped.token_count,
-        mapped.msg_start,
-        mapped.msg_end,
-        mapped.escalation,
-        mapped.created_at,
-      );
-      const row = lookupSummaryRowidStmt.get(mapped.id) as
-        | { rowid: number }
-        | undefined;
-      if (row) {
-        insertSummaryFtsStmt.run(row.rowid, mapped.summary_text);
+      if (forWrite) {
+        insertSummaryStmt.run(
+          mapped.id,
+          mapped.session_id,
+          mapped.depth,
+          mapped.parent_id,
+          mapped.summary_text,
+          mapped.token_count,
+          mapped.msg_start,
+          mapped.msg_end,
+          mapped.escalation,
+          mapped.created_at,
+        );
+        const row = lookupSummaryRowidStmt.get(mapped.id) as
+          | { rowid: number }
+          | undefined;
+        if (row) {
+          insertSummaryFtsStmt.run(row.rowid, mapped.summary_text);
+        }
       }
       result.summariesInserted += 1;
       sessionsTouched.add(mapped.session_id);
     }
-  });
+  }
 
   if (!dryRun) {
+    const writeSummaries = destDb.transaction(() => processSummaries(true));
     writeSummaries();
   } else {
-    // Dry run: count without writing.
-    for (const summary of summaries) {
-      const derivation = derivations.get(summary.summary_id);
-      if (!derivation || derivation.messageIds.length === 0) {
-        result.summariesSkippedNoMessages += 1;
-        continue;
-      }
-      const session = resolveSummarySession(
-        derivation.messageIds,
-        sessionByMessageId,
-      );
-      if (!session) {
-        result.summariesSkippedMultiSession += 1;
-        continue;
-      }
-      if (sessionFilter && !sessionFilter.has(session)) continue;
-      const messageSeqs: number[] = [];
-      for (const mid of derivation.messageIds) {
-        const seq = turnIndexByMessageId.get(mid);
-        if (typeof seq === "number") messageSeqs.push(seq);
-      }
-      if (messageSeqs.length === 0) {
-        result.summariesSkippedNoMessages += 1;
-        continue;
-      }
-      const existing = summaryExistsStmt.get(summary.summary_id) as
-        | { hit: number }
-        | undefined;
-      if (existing) {
-        result.summariesSkipped += 1;
-      } else {
-        result.summariesInserted += 1;
-        sessionsTouched.add(session);
-      }
-      if (isMultiParent(derivation.parents)) {
-        result.summariesMultiParentCollapsed += 1;
-      }
-    }
+    processSummaries(false);
   }
 
   // ── Compaction-event boundary ──────────────────────────────────────────

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -27,6 +27,8 @@ import {
   listSummaries,
   listSummaryMessages,
   listSummaryParents,
+  type LosslessClawConversation,
+  type LosslessClawMessage,
 } from "./source.js";
 import {
   indexSummaryDerivations,
@@ -119,34 +121,43 @@ export function importLosslessClaw(
     }
   }
 
-  // Group conversations by session, ordered by earliest message
-  // timestamp so cross-conversation turn ordering is chronological — a
-  // raw `conversation_id` sort risks ordering by UUID (Codex P1 review:
-  // session timelines and summary msg_start/msg_end depend on
-  // turn_index reflecting real chronology).
-  const earliestByConv = new Map<string, string>();
-  for (const [convId, msgs] of messagesByConv) {
-    if (msgs.length === 0) continue;
-    let earliest = msgs[0]!.created_at;
-    for (let i = 1; i < msgs.length; i++) {
-      if (msgs[i]!.created_at < earliest) earliest = msgs[i]!.created_at;
-    }
-    earliestByConv.set(convId, earliest);
-  }
-  const orderedConversations = [...conversations].sort((a, b) => {
-    const ea = earliestByConv.get(a.conversation_id) ?? "";
-    const eb = earliestByConv.get(b.conversation_id) ?? "";
-    if (ea !== eb) return ea < eb ? -1 : 1;
-    // Stable tie-break on conversation_id when earliest timestamps match
-    // (or both are missing).
-    return a.conversation_id.localeCompare(b.conversation_id);
-  });
-  const convsBySession = new Map<string, typeof orderedConversations>();
-  for (const c of orderedConversations) {
+  // Build a per-session list of (conversation, message) pairs and sort
+  // by message.created_at. This handles interleaved conversations
+  // correctly: if conv-A has messages at t=0 and t=10 and conv-B has
+  // messages at t=5 and t=6, turn_index ends up as t=0, t=5, t=6,
+  // t=10 (chronological), not t=0, t=10, t=5, t=6 (which a per-
+  // conversation pre-sort produces — Codex P1 follow-up review).
+  type SessionEntry = {
+    conv: LosslessClawConversation;
+    msg: LosslessClawMessage;
+  };
+  const sessionMessages = new Map<string, SessionEntry[]>();
+  const sessionOrder: string[] = [];
+  for (const c of conversations) {
     const session = sessionByConvId.get(c.conversation_id)!;
-    const list = convsBySession.get(session) ?? [];
-    list.push(c);
-    convsBySession.set(session, list);
+    if (!sessionMessages.has(session)) {
+      sessionMessages.set(session, []);
+      sessionOrder.push(session);
+    }
+    const list = sessionMessages.get(session)!;
+    for (const m of messagesByConv.get(c.conversation_id) ?? []) {
+      list.push({ conv: c, msg: m });
+    }
+  }
+  for (const list of sessionMessages.values()) {
+    list.sort((a, b) => {
+      if (a.msg.created_at !== b.msg.created_at) {
+        return a.msg.created_at < b.msg.created_at ? -1 : 1;
+      }
+      // Stable tie-breaker chain when timestamps collide: conversation
+      // id, then per-conversation seq (preserves intra-conversation
+      // order even on identical timestamps).
+      const cidCmp = a.conv.conversation_id.localeCompare(
+        b.conv.conversation_id,
+      );
+      if (cidCmp !== 0) return cidCmp;
+      return a.msg.seq - b.msg.seq;
+    });
   }
 
   // ── Insert messages ────────────────────────────────────────────────────
@@ -178,7 +189,7 @@ export function importLosslessClaw(
   const existingBySession = new Map<string, Map<string, number>>();
   // session → max(turn_index) currently in dest (so new rows append).
   const maxTurnBySession = new Map<string, number>();
-  for (const session of convsBySession.keys()) {
+  for (const session of sessionMessages.keys()) {
     if (sessionFilter && !sessionFilter.has(session)) continue;
     const map = new Map<string, number>();
     let max = -1;
@@ -204,46 +215,44 @@ export function importLosslessClaw(
   const turnIndexByMessageId = new Map<string, number>();
 
   function assignTurnIndices(forWrite: boolean): void {
-    for (const [session, convs] of convsBySession) {
+    for (const session of sessionOrder) {
       if (sessionFilter && !sessionFilter.has(session)) continue;
+      const entries = sessionMessages.get(session) ?? [];
       const existing =
         existingBySession.get(session) ?? new Map<string, number>();
       let nextTurn = (maxTurnBySession.get(session) ?? -1) + 1;
-      for (const c of convs) {
-        const msgs = messagesByConv.get(c.conversation_id) ?? [];
-        for (const m of msgs) {
-          const key = `${c.conversation_id}|${m.seq}`;
-          const existingTurn = existing.get(key);
-          if (existingTurn !== undefined) {
-            turnIndexByMessageId.set(m.message_id, existingTurn);
-            result.messagesSkipped += 1;
-            continue;
-          }
-          const ti = nextTurn++;
-          turnIndexByMessageId.set(m.message_id, ti);
-          // Update the in-memory dedup map so duplicates within this
-          // run also count as skips on subsequent passes (defensive;
-          // shouldn't happen with valid source data).
-          existing.set(key, ti);
-          if (forWrite) {
-            const mapped = mapMessage(c, m, ti);
-            const info = insertMessageStmt.run(
-              mapped.session_id,
-              mapped.turn_index,
-              mapped.role,
-              mapped.content,
-              mapped.token_count,
-              mapped.created_at,
-              mapped.metadata,
-            );
-            insertMessageFtsStmt.run(
-              Number(info.lastInsertRowid),
-              mapped.content,
-            );
-          }
-          result.messagesInserted += 1;
-          sessionsTouched.add(session);
+      for (const { conv, msg } of entries) {
+        const key = `${conv.conversation_id}|${msg.seq}`;
+        const existingTurn = existing.get(key);
+        if (existingTurn !== undefined) {
+          turnIndexByMessageId.set(msg.message_id, existingTurn);
+          result.messagesSkipped += 1;
+          continue;
         }
+        const ti = nextTurn++;
+        turnIndexByMessageId.set(msg.message_id, ti);
+        // Update the in-memory dedup map so duplicates within this
+        // run also count as skips on subsequent passes (defensive;
+        // shouldn't happen with valid source data).
+        existing.set(key, ti);
+        if (forWrite) {
+          const mapped = mapMessage(conv, msg, ti);
+          const info = insertMessageStmt.run(
+            mapped.session_id,
+            mapped.turn_index,
+            mapped.role,
+            mapped.content,
+            mapped.token_count,
+            mapped.created_at,
+            mapped.metadata,
+          );
+          insertMessageFtsStmt.run(
+            Number(info.lastInsertRowid),
+            mapped.content,
+          );
+        }
+        result.messagesInserted += 1;
+        sessionsTouched.add(session);
       }
     }
   }

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -27,7 +27,6 @@ import {
   listSummaries,
   listSummaryMessages,
   listSummaryParents,
-  type LosslessClawConversation,
 } from "./source.js";
 import {
   indexSummaryDerivations,
@@ -96,9 +95,6 @@ export function importLosslessClaw(
   // ── Pre-resolve session ids per conversation + per message id ──────────
   const conversations = listConversations(sourceDb);
   result.conversationsScanned = conversations.length;
-
-  const conversationById = new Map<string, LosslessClawConversation>();
-  for (const c of conversations) conversationById.set(c.conversation_id, c);
 
   const sessionByConvId = new Map<string, string>();
   const sessionByMessageId = new Map<string, string>();

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -405,29 +405,41 @@ export function importLosslessClaw(
   // after a crash between message and summary transactions) still gets
   // a correct anchor reflecting the messages already in the destination
   // (Cursor Bugbot review on PR #797).
-  if (!dryRun) {
-    const insertEventStmt = destDb.prepare(
-      "INSERT INTO lcm_compaction_events (session_id, fired_at, msg_before, tokens_before, tokens_after) " +
-        "VALUES (?, ?, ?, ?, ?)",
-    );
-    const maxTurnStmt = destDb.prepare(
-      "SELECT IFNULL(MAX(turn_index), -1) AS max_turn FROM lcm_messages WHERE session_id = ?",
-    );
-    const totalTokensStmt = destDb.prepare(
-      "SELECT IFNULL(SUM(token_count), 0) AS total FROM lcm_messages WHERE session_id = ?",
-    );
-    const writeEvents = destDb.transaction(() => {
-      const firedAt = new Date().toISOString();
-      for (const session of sessionsTouched) {
-        const turnRow = maxTurnStmt.get(session) as { max_turn: number };
-        const msgBefore = turnRow.max_turn + 1;
-        const tokRow = totalTokensStmt.get(session) as { total: number };
-        const tokens = tokRow.total;
+  // Always count what compaction events WOULD be written so dry-run
+  // output matches the rest of the counters (Cursor Bugbot review on
+  // PR #797: dry-run was reporting `Messages inserted: N` but
+  // `Compaction events written: 0` despite the documented "count what
+  // would be imported" contract). Skip the actual INSERTs in dry-run.
+  const insertEventStmt = destDb.prepare(
+    "INSERT INTO lcm_compaction_events (session_id, fired_at, msg_before, tokens_before, tokens_after) " +
+      "VALUES (?, ?, ?, ?, ?)",
+  );
+  const maxTurnStmt = destDb.prepare(
+    "SELECT IFNULL(MAX(turn_index), -1) AS max_turn FROM lcm_messages WHERE session_id = ?",
+  );
+  const totalTokensStmt = destDb.prepare(
+    "SELECT IFNULL(SUM(token_count), 0) AS total FROM lcm_messages WHERE session_id = ?",
+  );
+
+  function processCompactionBoundaries(forWrite: boolean): void {
+    const firedAt = new Date().toISOString();
+    for (const session of sessionsTouched) {
+      const turnRow = maxTurnStmt.get(session) as { max_turn: number };
+      const msgBefore = turnRow.max_turn + 1;
+      const tokRow = totalTokensStmt.get(session) as { total: number };
+      const tokens = tokRow.total;
+      if (forWrite) {
         insertEventStmt.run(session, firedAt, msgBefore, tokens, tokens);
-        result.compactionEventsInserted += 1;
       }
-    });
+      result.compactionEventsInserted += 1;
+    }
+  }
+
+  if (!dryRun) {
+    const writeEvents = destDb.transaction(() => processCompactionBoundaries(true));
     writeEvents();
+  } else {
+    processCompactionBoundaries(false);
   }
 
   result.sessionsTouched = [...sessionsTouched].sort();

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -135,7 +135,6 @@ export function importLosslessClaw(
   );
 
   const sessionsTouched = new Set<string>();
-  const tokensImportedBySession = new Map<string, number>();
 
   const writeMessages = destDb.transaction(() => {
     for (const c of conversations) {
@@ -164,11 +163,6 @@ export function importLosslessClaw(
         insertMessageFtsStmt.run(Number(info.lastInsertRowid), mapped.content);
         result.messagesInserted += 1;
         sessionsTouched.add(mapped.session_id);
-        tokensImportedBySession.set(
-          mapped.session_id,
-          (tokensImportedBySession.get(mapped.session_id) ?? 0) +
-            mapped.token_count,
-        );
       }
     }
   });
@@ -193,11 +187,6 @@ export function importLosslessClaw(
         } else {
           result.messagesInserted += 1;
           sessionsTouched.add(mapped.session_id);
-          tokensImportedBySession.set(
-            mapped.session_id,
-            (tokensImportedBySession.get(mapped.session_id) ?? 0) +
-              mapped.token_count,
-          );
         }
       }
     }
@@ -352,6 +341,13 @@ export function importLosslessClaw(
   // equals tokens_after to encode "this is an import boundary, not a real
   // compaction event"; any consumer that needs the distinction can detect
   // the equality.
+  //
+  // Token totals are queried from the destination at boundary-write time
+  // rather than accumulated from this run's newly-inserted rows. That
+  // way a session whose only new rows are summaries (e.g. partial retry
+  // after a crash between message and summary transactions) still gets
+  // a correct anchor reflecting the messages already in the destination
+  // (Cursor Bugbot review on PR #797).
   if (!dryRun) {
     const insertEventStmt = destDb.prepare(
       "INSERT INTO lcm_compaction_events (session_id, fired_at, msg_before, tokens_before, tokens_after) " +
@@ -360,12 +356,16 @@ export function importLosslessClaw(
     const maxTurnStmt = destDb.prepare(
       "SELECT IFNULL(MAX(turn_index), -1) AS max_turn FROM lcm_messages WHERE session_id = ?",
     );
+    const totalTokensStmt = destDb.prepare(
+      "SELECT IFNULL(SUM(token_count), 0) AS total FROM lcm_messages WHERE session_id = ?",
+    );
     const writeEvents = destDb.transaction(() => {
       const firedAt = new Date().toISOString();
       for (const session of sessionsTouched) {
-        const row = maxTurnStmt.get(session) as { max_turn: number };
-        const msgBefore = row.max_turn + 1;
-        const tokens = tokensImportedBySession.get(session) ?? 0;
+        const turnRow = maxTurnStmt.get(session) as { max_turn: number };
+        const msgBefore = turnRow.max_turn + 1;
+        const tokRow = totalTokensStmt.get(session) as { total: number };
+        const tokens = tokRow.total;
         insertEventStmt.run(session, firedAt, msgBefore, tokens, tokens);
         result.compactionEventsInserted += 1;
       }

--- a/packages/import-lossless-claw/src/index.ts
+++ b/packages/import-lossless-claw/src/index.ts
@@ -11,6 +11,7 @@ export {
 export {
   assertLosslessClawSchema,
   openSourceDatabase,
+  openInMemoryDestinationDatabase,
   listConversations,
   listMessagesForConversation,
   listSummaries,

--- a/packages/import-lossless-claw/src/index.ts
+++ b/packages/import-lossless-claw/src/index.ts
@@ -12,6 +12,7 @@ export {
   assertLosslessClawSchema,
   openSourceDatabase,
   openInMemoryDestinationDatabase,
+  openExistingLcmDatabaseReadOnly,
   listConversations,
   listMessagesForConversation,
   listSummaries,

--- a/packages/import-lossless-claw/src/index.ts
+++ b/packages/import-lossless-claw/src/index.ts
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------
+// @remnic/import-lossless-claw — public surface
+// ---------------------------------------------------------------------------
+
+export {
+  importLosslessClaw,
+  type ImportLosslessClawOptions,
+  type ImportLosslessClawResult,
+} from "./importer.js";
+
+export {
+  assertLosslessClawSchema,
+  openSourceDatabase,
+  listConversations,
+  listMessagesForConversation,
+  listSummaries,
+  listSummaryMessages,
+  listSummaryParents,
+  type LosslessClawConversation,
+  type LosslessClawMessage,
+  type LosslessClawSummary,
+  type LosslessClawSummaryMessage,
+  type LosslessClawSummaryParent,
+} from "./source.js";
+
+export {
+  buildMessageMetadata,
+  indexSummaryDerivations,
+  isMultiParent,
+  LOSSLESS_CLAW_SOURCE_LABEL,
+  mapMessage,
+  mapSummary,
+  pickCanonicalParent,
+  resolveSessionId,
+  resolveSummarySession,
+  type MappedMessage,
+  type MappedSummaryNode,
+} from "./transform.js";

--- a/packages/import-lossless-claw/src/source.test.ts
+++ b/packages/import-lossless-claw/src/source.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import BetterSqlite3 from "better-sqlite3";
+
+import { assertLosslessClawSchema } from "./source.js";
+
+describe("assertLosslessClawSchema", () => {
+  it("passes when every required table is present", () => {
+    const db = new BetterSqlite3(":memory:");
+    db.exec(`
+      CREATE TABLE conversations (conversation_id TEXT PRIMARY KEY);
+      CREATE TABLE messages (message_id TEXT PRIMARY KEY);
+      CREATE TABLE summaries (summary_id TEXT PRIMARY KEY);
+      CREATE TABLE summary_messages (summary_id TEXT, message_id TEXT);
+      CREATE TABLE summary_parents (summary_id TEXT, parent_summary_id TEXT, ordinal INTEGER);
+    `);
+    assert.doesNotThrow(() => assertLosslessClawSchema(db));
+  });
+
+  it("throws listing every missing table", () => {
+    const db = new BetterSqlite3(":memory:");
+    db.exec("CREATE TABLE conversations (conversation_id TEXT PRIMARY KEY);");
+    let captured: Error | undefined;
+    try {
+      assertLosslessClawSchema(db);
+    } catch (err) {
+      captured = err as Error;
+    }
+    assert.ok(captured, "expected error");
+    assert.match(captured!.message, /messages/);
+    assert.match(captured!.message, /summaries/);
+    assert.match(captured!.message, /summary_messages/);
+    assert.match(captured!.message, /summary_parents/);
+  });
+});

--- a/packages/import-lossless-claw/src/source.ts
+++ b/packages/import-lossless-claw/src/source.ts
@@ -59,14 +59,28 @@ export function openSourceDatabase(filePath: string): Database.Database {
  * the Remnic LCM schema via `applyLcmSchema(db)` from `@remnic/core` before
  * passing it to `importLosslessClaw`.
  *
- * Used by the `--dry-run` CLI path so a true write-free run can compute
- * insert/skip counts against an empty destination without ever touching
- * the filesystem (Codex P2 review: dry-run must not mutate destination
- * storage).
+ * Used by the `--dry-run` CLI path as a fallback when no existing on-disk
+ * destination exists, so a true write-free run can still compute counts
+ * against an empty destination without touching the filesystem.
  */
 export function openInMemoryDestinationDatabase(): Database.Database {
   const Ctor = loadBetterSqlite3();
   return new Ctor(":memory:");
+}
+
+/**
+ * Open an existing Remnic LCM database file in read-only mode. Used by the
+ * `--dry-run` CLI path so dedup counts reflect the user's real
+ * destination state without any write risk (Codex P2 follow-up: a fresh
+ * in-memory database makes `messagesSkipped`/`summariesSkipped` always
+ * report zero, which is misleading when the user has run a real import
+ * before).
+ */
+export function openExistingLcmDatabaseReadOnly(
+  filePath: string,
+): Database.Database {
+  const Ctor = loadBetterSqlite3();
+  return new Ctor(filePath, { readonly: true, fileMustExist: true });
 }
 
 export interface LosslessClawConversation {

--- a/packages/import-lossless-claw/src/source.ts
+++ b/packages/import-lossless-claw/src/source.ts
@@ -1,0 +1,175 @@
+// ---------------------------------------------------------------------------
+// Lossless-claw source database access.
+//
+// Reads the schema produced by github.com/martian-engineering/lossless-claw
+// (default location ~/.openclaw/lcm.db). Only the subset of tables that has
+// a clean Remnic-LCM analog is surfaced:
+//
+//   conversations  → session_id resolution
+//   messages       → lcm_messages
+//   summaries      → lcm_summary_nodes
+//   summary_messages, summary_parents → derived msg_start/msg_end + parent_id
+//
+// Tables intentionally NOT read: large_files, message_parts,
+// conversation_compaction_telemetry, conversation_compaction_maintenance,
+// lcm_migration_state. None have a Remnic LCM analog and importing them
+// would create dead data.
+// ---------------------------------------------------------------------------
+
+import { createRequire } from "node:module";
+
+import type Database from "better-sqlite3";
+
+type BetterSqlite3Ctor = typeof import("better-sqlite3");
+
+let cachedCtor: BetterSqlite3Ctor | null = null;
+
+function loadBetterSqlite3(): BetterSqlite3Ctor {
+  if (cachedCtor) return cachedCtor;
+  const require = createRequire(import.meta.url);
+  const loaded = require("better-sqlite3") as
+    | BetterSqlite3Ctor
+    | { default?: BetterSqlite3Ctor };
+  const ctor = typeof loaded === "function" ? loaded : loaded.default;
+  if (typeof ctor !== "function") {
+    throw new Error(
+      "better-sqlite3 is unavailable. Install it alongside @remnic/import-lossless-claw " +
+        "or rebuild from source: `pnpm rebuild better-sqlite3`.",
+    );
+  }
+  cachedCtor = ctor;
+  return ctor;
+}
+
+/**
+ * Open a lossless-claw SQLite database file in read-only mode. The CLI uses
+ * this so a half-baked source file cannot be written to during import.
+ *
+ * Tildes in the path are NOT expanded here — callers (CLI, tests) must
+ * normalise paths first to keep the boundary explicit (CLAUDE.md gotcha
+ * #17).
+ */
+export function openSourceDatabase(filePath: string): Database.Database {
+  const Ctor = loadBetterSqlite3();
+  return new Ctor(filePath, { readonly: true, fileMustExist: true });
+}
+
+export interface LosslessClawConversation {
+  conversation_id: string;
+  session_id: string | null;
+  session_key: string | null;
+  title: string | null;
+}
+
+export interface LosslessClawMessage {
+  message_id: string;
+  conversation_id: string;
+  seq: number;
+  role: string;
+  content: string;
+  token_count: number;
+  identity_hash: string | null;
+  created_at: string;
+}
+
+export interface LosslessClawSummary {
+  summary_id: string;
+  kind: string;
+  depth: number;
+  content: string;
+  token_count: number;
+  earliest_at: string | null;
+  latest_at: string | null;
+}
+
+export interface LosslessClawSummaryParent {
+  summary_id: string;
+  parent_summary_id: string;
+  ordinal: number;
+}
+
+export interface LosslessClawSummaryMessage {
+  summary_id: string;
+  message_id: string;
+}
+
+/**
+ * Verify a database handle points at a lossless-claw export by checking for
+ * the required tables. Throws a user-facing error on mismatch so callers can
+ * surface a clear "this isn't a lossless-claw database" message instead of
+ * cryptic SQL errors during import.
+ */
+export function assertLosslessClawSchema(db: Database.Database): void {
+  const required = [
+    "conversations",
+    "messages",
+    "summaries",
+    "summary_messages",
+    "summary_parents",
+  ];
+  const stmt = db.prepare(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+  );
+  const missing: string[] = [];
+  for (const name of required) {
+    const row = stmt.get(name) as { name: string } | undefined;
+    if (!row) missing.push(name);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Source database is missing lossless-claw tables: ${missing.join(", ")}. ` +
+        "Confirm --src points at a lossless-claw lcm.db file.",
+    );
+  }
+}
+
+export function listConversations(
+  db: Database.Database,
+): LosslessClawConversation[] {
+  return db
+    .prepare(
+      "SELECT conversation_id, session_id, session_key, title FROM conversations ORDER BY conversation_id",
+    )
+    .all() as LosslessClawConversation[];
+}
+
+export function listMessagesForConversation(
+  db: Database.Database,
+  conversationId: string,
+): LosslessClawMessage[] {
+  return db
+    .prepare(
+      "SELECT message_id, conversation_id, seq, role, content, token_count, identity_hash, created_at " +
+        "FROM messages WHERE conversation_id = ? ORDER BY seq",
+    )
+    .all(conversationId) as LosslessClawMessage[];
+}
+
+export function listSummaries(db: Database.Database): LosslessClawSummary[] {
+  return db
+    .prepare(
+      "SELECT summary_id, kind, depth, content, token_count, earliest_at, latest_at " +
+        "FROM summaries ORDER BY depth, summary_id",
+    )
+    .all() as LosslessClawSummary[];
+}
+
+export function listSummaryParents(
+  db: Database.Database,
+): LosslessClawSummaryParent[] {
+  return db
+    .prepare(
+      "SELECT summary_id, parent_summary_id, ordinal FROM summary_parents ORDER BY summary_id, ordinal",
+    )
+    .all() as LosslessClawSummaryParent[];
+}
+
+export function listSummaryMessages(
+  db: Database.Database,
+): LosslessClawSummaryMessage[] {
+  return db
+    .prepare(
+      "SELECT summary_id, message_id FROM summary_messages",
+    )
+    .all() as LosslessClawSummaryMessage[];
+}

--- a/packages/import-lossless-claw/src/source.ts
+++ b/packages/import-lossless-claw/src/source.ts
@@ -54,6 +54,21 @@ export function openSourceDatabase(filePath: string): Database.Database {
   return new Ctor(filePath, { readonly: true, fileMustExist: true });
 }
 
+/**
+ * Open an in-memory destination database. The caller is expected to apply
+ * the Remnic LCM schema via `applyLcmSchema(db)` from `@remnic/core` before
+ * passing it to `importLosslessClaw`.
+ *
+ * Used by the `--dry-run` CLI path so a true write-free run can compute
+ * insert/skip counts against an empty destination without ever touching
+ * the filesystem (Codex P2 review: dry-run must not mutate destination
+ * storage).
+ */
+export function openInMemoryDestinationDatabase(): Database.Database {
+  const Ctor = loadBetterSqlite3();
+  return new Ctor(":memory:");
+}
+
 export interface LosslessClawConversation {
   conversation_id: string;
   session_id: string | null;

--- a/packages/import-lossless-claw/src/transform.test.ts
+++ b/packages/import-lossless-claw/src/transform.test.ts
@@ -172,6 +172,23 @@ describe("resolveSummarySession", () => {
       null,
     );
   });
+
+  it("returns null when ANY referenced message id is dangling (Codex P2)", () => {
+    // One valid + one missing → reject the whole summary so msg_start/end
+    // can't be silently computed from only the resolved subset.
+    const sessionByMessageId = new Map([
+      ["m1", "sess-A"],
+      // m2 deliberately not in the map
+    ]);
+    assert.equal(
+      resolveSummarySession(["m1", "m2"], sessionByMessageId),
+      null,
+    );
+  });
+
+  it("returns null on empty messageIds (defensive)", () => {
+    assert.equal(resolveSummarySession([], new Map()), null);
+  });
 });
 
 describe("mapSummary", () => {

--- a/packages/import-lossless-claw/src/transform.test.ts
+++ b/packages/import-lossless-claw/src/transform.test.ts
@@ -59,16 +59,18 @@ describe("resolveSessionId", () => {
 });
 
 describe("buildMessageMetadata", () => {
-  it("emits sorted JSON keys for stable hashing", () => {
+  it("emits sorted JSON keys including source_seq (Codex P1)", () => {
     const json = buildMessageMetadata(conv, msg);
     const parsed = JSON.parse(json);
     assert.deepEqual(Object.keys(parsed), [
       "conversation_id",
       "identity_hash",
       "source",
+      "source_seq",
       "title",
     ]);
     assert.equal(parsed.source, LOSSLESS_CLAW_SOURCE_LABEL);
+    assert.equal(parsed.source_seq, 7);
     assert.equal(parsed.conversation_id, "conv-A");
     assert.equal(parsed.identity_hash, "abc");
     assert.equal(parsed.title, "Hello world");
@@ -86,15 +88,16 @@ describe("buildMessageMetadata", () => {
 });
 
 describe("mapMessage", () => {
-  it("preserves seq, role, content, token_count, created_at", () => {
-    const mapped = mapMessage(conv, msg);
+  it("preserves role, content, token_count, created_at; turn_index from caller", () => {
+    const mapped = mapMessage(conv, msg, 42);
     assert.equal(mapped.session_id, "sess-A");
-    assert.equal(mapped.turn_index, 7);
+    assert.equal(mapped.turn_index, 42, "caller-supplied session-global turn_index");
     assert.equal(mapped.role, "user");
     assert.equal(mapped.content, "what is the answer?");
     assert.equal(mapped.token_count, 5);
     assert.equal(mapped.created_at, "2026-04-01T00:00:00.000Z");
     assert.match(mapped.metadata, /"source":"lossless-claw"/);
+    assert.match(mapped.metadata, /"source_seq":7/);
   });
 });
 

--- a/packages/import-lossless-claw/src/transform.test.ts
+++ b/packages/import-lossless-claw/src/transform.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildMessageMetadata,
+  indexSummaryDerivations,
+  isMultiParent,
+  LOSSLESS_CLAW_SOURCE_LABEL,
+  mapMessage,
+  mapSummary,
+  pickCanonicalParent,
+  resolveSessionId,
+  resolveSummarySession,
+} from "./transform.js";
+import type {
+  LosslessClawConversation,
+  LosslessClawMessage,
+  LosslessClawSummary,
+  LosslessClawSummaryMessage,
+  LosslessClawSummaryParent,
+} from "./source.js";
+
+const conv: LosslessClawConversation = {
+  conversation_id: "conv-A",
+  session_id: "sess-A",
+  session_key: null,
+  title: "Hello world",
+};
+
+const msg: LosslessClawMessage = {
+  message_id: "msg-1",
+  conversation_id: "conv-A",
+  seq: 7,
+  role: "user",
+  content: "what is the answer?",
+  token_count: 5,
+  identity_hash: "abc",
+  created_at: "2026-04-01T00:00:00.000Z",
+};
+
+describe("resolveSessionId", () => {
+  it("returns explicit session_id when present", () => {
+    assert.equal(resolveSessionId(conv), "sess-A");
+  });
+
+  it("falls back to conversation_id when session_id is null", () => {
+    assert.equal(
+      resolveSessionId({ ...conv, session_id: null }),
+      "conv-A",
+    );
+  });
+
+  it("falls back to conversation_id when session_id is empty/whitespace", () => {
+    assert.equal(
+      resolveSessionId({ ...conv, session_id: "   " }),
+      "conv-A",
+    );
+  });
+});
+
+describe("buildMessageMetadata", () => {
+  it("emits sorted JSON keys for stable hashing", () => {
+    const json = buildMessageMetadata(conv, msg);
+    const parsed = JSON.parse(json);
+    assert.deepEqual(Object.keys(parsed), [
+      "conversation_id",
+      "identity_hash",
+      "source",
+      "title",
+    ]);
+    assert.equal(parsed.source, LOSSLESS_CLAW_SOURCE_LABEL);
+    assert.equal(parsed.conversation_id, "conv-A");
+    assert.equal(parsed.identity_hash, "abc");
+    assert.equal(parsed.title, "Hello world");
+  });
+
+  it("nulls out missing identity_hash + title without dropping keys", () => {
+    const json = buildMessageMetadata(
+      { ...conv, title: null },
+      { ...msg, identity_hash: null },
+    );
+    const parsed = JSON.parse(json);
+    assert.equal(parsed.identity_hash, null);
+    assert.equal(parsed.title, null);
+  });
+});
+
+describe("mapMessage", () => {
+  it("preserves seq, role, content, token_count, created_at", () => {
+    const mapped = mapMessage(conv, msg);
+    assert.equal(mapped.session_id, "sess-A");
+    assert.equal(mapped.turn_index, 7);
+    assert.equal(mapped.role, "user");
+    assert.equal(mapped.content, "what is the answer?");
+    assert.equal(mapped.token_count, 5);
+    assert.equal(mapped.created_at, "2026-04-01T00:00:00.000Z");
+    assert.match(mapped.metadata, /"source":"lossless-claw"/);
+  });
+});
+
+describe("pickCanonicalParent", () => {
+  it("returns null for orphan summaries", () => {
+    assert.equal(pickCanonicalParent([]), null);
+  });
+
+  it("picks the lowest-ordinal parent", () => {
+    const parents: LosslessClawSummaryParent[] = [
+      { summary_id: "s1", parent_summary_id: "p-late", ordinal: 5 },
+      { summary_id: "s1", parent_summary_id: "p-early", ordinal: 0 },
+      { summary_id: "s1", parent_summary_id: "p-mid", ordinal: 2 },
+    ];
+    assert.equal(pickCanonicalParent(parents), "p-early");
+  });
+
+  it("breaks ties by lexicographic parent id (deterministic)", () => {
+    const parents: LosslessClawSummaryParent[] = [
+      { summary_id: "s1", parent_summary_id: "p-zzz", ordinal: 0 },
+      { summary_id: "s1", parent_summary_id: "p-aaa", ordinal: 0 },
+    ];
+    assert.equal(pickCanonicalParent(parents), "p-aaa");
+  });
+});
+
+describe("isMultiParent", () => {
+  it("flags summaries with >1 parent edge", () => {
+    assert.equal(isMultiParent([]), false);
+    assert.equal(
+      isMultiParent([
+        { summary_id: "s", parent_summary_id: "p", ordinal: 0 },
+      ]),
+      false,
+    );
+    assert.equal(
+      isMultiParent([
+        { summary_id: "s", parent_summary_id: "p1", ordinal: 0 },
+        { summary_id: "s", parent_summary_id: "p2", ordinal: 1 },
+      ]),
+      true,
+    );
+  });
+});
+
+describe("resolveSummarySession", () => {
+  it("returns the session when all messages share one", () => {
+    const sessionByMessageId = new Map([
+      ["m1", "sess-A"],
+      ["m2", "sess-A"],
+    ]);
+    assert.equal(
+      resolveSummarySession(["m1", "m2"], sessionByMessageId),
+      "sess-A",
+    );
+  });
+
+  it("returns null on multi-session summaries (caller should skip)", () => {
+    const sessionByMessageId = new Map([
+      ["m1", "sess-A"],
+      ["m2", "sess-B"],
+    ]);
+    assert.equal(
+      resolveSummarySession(["m1", "m2"], sessionByMessageId),
+      null,
+    );
+  });
+
+  it("returns null when no message ids resolve", () => {
+    assert.equal(
+      resolveSummarySession(["m1"], new Map()),
+      null,
+    );
+  });
+});
+
+describe("mapSummary", () => {
+  const summary: LosslessClawSummary = {
+    summary_id: "sum-1",
+    kind: "leaf",
+    depth: 0,
+    content: "summary text",
+    token_count: 42,
+    earliest_at: "2026-04-01T00:00:00.000Z",
+    latest_at: "2026-04-01T01:00:00.000Z",
+  };
+
+  it("maps msg_start/msg_end from min/max of provided seqs", () => {
+    const out = mapSummary({
+      summary,
+      parents: [],
+      messageSeqs: [10, 5, 7, 12],
+      sessionId: "sess-A",
+    });
+    assert.equal(out.id, "sum-1");
+    assert.equal(out.session_id, "sess-A");
+    assert.equal(out.depth, 0);
+    assert.equal(out.parent_id, null);
+    assert.equal(out.summary_text, "summary text");
+    assert.equal(out.token_count, 42);
+    assert.equal(out.msg_start, 5);
+    assert.equal(out.msg_end, 12);
+    assert.equal(out.escalation, 0);
+    assert.equal(out.created_at, "2026-04-01T01:00:00.000Z");
+  });
+
+  it("uses earliest_at when latest_at is null", () => {
+    const out = mapSummary({
+      summary: { ...summary, latest_at: null },
+      parents: [],
+      messageSeqs: [1],
+      sessionId: "sess-A",
+    });
+    assert.equal(out.created_at, "2026-04-01T00:00:00.000Z");
+  });
+
+  it("falls back to current time when both at-fields are null", () => {
+    const out = mapSummary({
+      summary: { ...summary, earliest_at: null, latest_at: null },
+      parents: [],
+      messageSeqs: [1],
+      sessionId: "sess-A",
+    });
+    // Just confirm it parses as a valid ISO string
+    assert.ok(!Number.isNaN(Date.parse(out.created_at)));
+  });
+
+  it("throws when no message seqs are provided (caller must skip)", () => {
+    assert.throws(() =>
+      mapSummary({
+        summary,
+        parents: [],
+        messageSeqs: [],
+        sessionId: "sess-A",
+      }),
+    );
+  });
+});
+
+describe("indexSummaryDerivations", () => {
+  it("groups parents and message ids by summary_id", () => {
+    const sm: LosslessClawSummaryMessage[] = [
+      { summary_id: "s1", message_id: "m1" },
+      { summary_id: "s1", message_id: "m2" },
+      { summary_id: "s2", message_id: "m3" },
+    ];
+    const sp: LosslessClawSummaryParent[] = [
+      { summary_id: "s1", parent_summary_id: "p", ordinal: 0 },
+      { summary_id: "s2", parent_summary_id: "p", ordinal: 0 },
+      { summary_id: "s2", parent_summary_id: "q", ordinal: 1 },
+    ];
+    const idx = indexSummaryDerivations(sm, sp);
+    assert.deepEqual(idx.get("s1")?.messageIds.sort(), ["m1", "m2"]);
+    assert.equal(idx.get("s1")?.parents.length, 1);
+    assert.deepEqual(idx.get("s2")?.messageIds, ["m3"]);
+    assert.equal(idx.get("s2")?.parents.length, 2);
+  });
+
+  it("returns empty map when both inputs are empty", () => {
+    assert.equal(indexSummaryDerivations([], []).size, 0);
+  });
+});

--- a/packages/import-lossless-claw/src/transform.ts
+++ b/packages/import-lossless-claw/src/transform.ts
@@ -128,8 +128,17 @@ export function mapSummary(input: MapSummaryInput): MappedSummaryNode {
         "cannot derive msg_start/msg_end. Skip this summary at the caller.",
     );
   }
-  const msg_start = Math.min(...input.messageSeqs);
-  const msg_end = Math.max(...input.messageSeqs);
+  // Iterative min/max — `Math.min(...arr)` / `Math.max(...arr)` push every
+  // element onto the call stack via spread and throw `RangeError: Maximum
+  // call stack size exceeded` on summaries that cover tens of thousands of
+  // messages (Cursor Bugbot review on PR #797).
+  let msg_start = input.messageSeqs[0]!;
+  let msg_end = msg_start;
+  for (let i = 1; i < input.messageSeqs.length; i++) {
+    const seq = input.messageSeqs[i]!;
+    if (seq < msg_start) msg_start = seq;
+    if (seq > msg_end) msg_end = seq;
+  }
   return {
     id: input.summary.summary_id,
     session_id: input.sessionId,

--- a/packages/import-lossless-claw/src/transform.ts
+++ b/packages/import-lossless-claw/src/transform.ts
@@ -54,33 +54,47 @@ export function resolveSessionId(
 /**
  * Build a JSON metadata blob attached to each imported message. Sorted keys
  * (gotcha #38) so dedup or hashing downstream stays stable across runs.
+ *
+ * `source_seq` is the original `messages.seq` value from lossless-claw —
+ * preserved alongside `conversation_id` so dedup can use a stable source
+ * identity. The Remnic LCM `turn_index` is now a session-global running
+ * counter (Codex P1: previously equal to `seq`, which collided when
+ * multiple source conversations resolved to the same session).
  */
 export function buildMessageMetadata(
   conversation: LosslessClawConversation,
   message: LosslessClawMessage,
 ): string {
-  const meta: Record<string, string | null> = {
+  const meta: Record<string, string | number | null> = {
     conversation_id: conversation.conversation_id,
     identity_hash: message.identity_hash ?? null,
     source: LOSSLESS_CLAW_SOURCE_LABEL,
+    source_seq: message.seq,
     title: conversation.title ?? null,
   };
   const sorted = Object.keys(meta)
     .sort()
-    .reduce<Record<string, string | null>>((acc, key) => {
+    .reduce<Record<string, string | number | null>>((acc, key) => {
       acc[key] = meta[key] ?? null;
       return acc;
     }, {});
   return JSON.stringify(sorted);
 }
 
+/**
+ * Map a source message to a Remnic LCM row. `turnIndex` is supplied by the
+ * caller (importer.ts) which assigns a session-global running counter so
+ * multiple conversations sharing one session id do not collide on
+ * (session_id, turn_index).
+ */
 export function mapMessage(
   conversation: LosslessClawConversation,
   message: LosslessClawMessage,
+  turnIndex: number,
 ): MappedMessage {
   return {
     session_id: resolveSessionId(conversation),
-    turn_index: message.seq,
+    turn_index: turnIndex,
     role: message.role,
     content: message.content,
     token_count: message.token_count,

--- a/packages/import-lossless-claw/src/transform.ts
+++ b/packages/import-lossless-claw/src/transform.ts
@@ -181,15 +181,23 @@ export function isMultiParent(parents: LosslessClawSummaryParent[]): boolean {
  * conversations only via DAG construction, which Remnic's per-session
  * structure cannot represent — return null in that case so the caller can
  * skip the summary with a warning rather than picking a wrong session.
+ *
+ * Strict on dangling references: if ANY referenced message_id fails to
+ * resolve to a session, return null. Silently dropping unresolved IDs
+ * would let a summary with mixed valid + dangling refs pass through
+ * with msg_start/msg_end computed from only the resolved subset, mis-
+ * representing the summary's true coverage (Codex P2 review on PR #797).
  */
 export function resolveSummarySession(
   messageIds: string[],
   sessionByMessageId: ReadonlyMap<string, string>,
 ): string | null {
+  if (messageIds.length === 0) return null;
   const sessions = new Set<string>();
   for (const messageId of messageIds) {
     const session = sessionByMessageId.get(messageId);
-    if (session) sessions.add(session);
+    if (!session) return null; // dangling reference — refuse to import
+    sessions.add(session);
   }
   if (sessions.size !== 1) return null;
   return [...sessions][0]!;

--- a/packages/import-lossless-claw/src/transform.ts
+++ b/packages/import-lossless-claw/src/transform.ts
@@ -1,0 +1,195 @@
+// ---------------------------------------------------------------------------
+// Pure mapping functions: lossless-claw rows → Remnic LCM rows.
+//
+// Kept side-effect-free so they can be unit-tested without SQLite in the
+// loop. The orchestration in importer.ts handles I/O.
+// ---------------------------------------------------------------------------
+
+import type {
+  LosslessClawConversation,
+  LosslessClawMessage,
+  LosslessClawSummary,
+  LosslessClawSummaryParent,
+  LosslessClawSummaryMessage,
+} from "./source.js";
+
+export const LOSSLESS_CLAW_SOURCE_LABEL = "lossless-claw";
+
+export interface MappedMessage {
+  session_id: string;
+  turn_index: number;
+  role: string;
+  content: string;
+  token_count: number;
+  created_at: string;
+  metadata: string;
+}
+
+export interface MappedSummaryNode {
+  id: string;
+  session_id: string;
+  depth: number;
+  parent_id: string | null;
+  summary_text: string;
+  token_count: number;
+  msg_start: number;
+  msg_end: number;
+  escalation: number;
+  created_at: string;
+}
+
+/**
+ * Resolve a conversation row to a Remnic session_id. Prefer the explicit
+ * session_id field; fall back to conversation_id when null/empty so every
+ * imported row has a stable session anchor.
+ */
+export function resolveSessionId(
+  conversation: LosslessClawConversation,
+): string {
+  const candidate = conversation.session_id?.trim();
+  if (candidate && candidate.length > 0) return candidate;
+  return conversation.conversation_id;
+}
+
+/**
+ * Build a JSON metadata blob attached to each imported message. Sorted keys
+ * (gotcha #38) so dedup or hashing downstream stays stable across runs.
+ */
+export function buildMessageMetadata(
+  conversation: LosslessClawConversation,
+  message: LosslessClawMessage,
+): string {
+  const meta: Record<string, string | null> = {
+    conversation_id: conversation.conversation_id,
+    identity_hash: message.identity_hash ?? null,
+    source: LOSSLESS_CLAW_SOURCE_LABEL,
+    title: conversation.title ?? null,
+  };
+  const sorted = Object.keys(meta)
+    .sort()
+    .reduce<Record<string, string | null>>((acc, key) => {
+      acc[key] = meta[key] ?? null;
+      return acc;
+    }, {});
+  return JSON.stringify(sorted);
+}
+
+export function mapMessage(
+  conversation: LosslessClawConversation,
+  message: LosslessClawMessage,
+): MappedMessage {
+  return {
+    session_id: resolveSessionId(conversation),
+    turn_index: message.seq,
+    role: message.role,
+    content: message.content,
+    token_count: message.token_count,
+    created_at: message.created_at,
+    metadata: buildMessageMetadata(conversation, message),
+  };
+}
+
+export interface SummaryDerivation {
+  parents: LosslessClawSummaryParent[];
+  messageIds: string[];
+}
+
+/**
+ * Pick the canonical parent id from a multi-parent DAG row. lossless-claw
+ * supports many-to-many parent edges; Remnic's `lcm_summary_nodes.parent_id`
+ * is a single FK. Lowest ordinal wins (tie-break: lexicographic id) so the
+ * choice is deterministic. Multi-parent rows are reported by the importer so
+ * users have visibility into the lossy edge.
+ */
+export function pickCanonicalParent(
+  parents: LosslessClawSummaryParent[],
+): string | null {
+  if (parents.length === 0) return null;
+  const sorted = [...parents].sort((a, b) => {
+    if (a.ordinal !== b.ordinal) return a.ordinal - b.ordinal;
+    return a.parent_summary_id.localeCompare(b.parent_summary_id);
+  });
+  return sorted[0]!.parent_summary_id;
+}
+
+export interface MapSummaryInput {
+  summary: LosslessClawSummary;
+  parents: LosslessClawSummaryParent[];
+  /** Sequence numbers of messages this summary covers. */
+  messageSeqs: number[];
+  /** Resolved session id (single value — multi-session summaries error). */
+  sessionId: string;
+}
+
+export function mapSummary(input: MapSummaryInput): MappedSummaryNode {
+  if (input.messageSeqs.length === 0) {
+    throw new Error(
+      `Summary ${input.summary.summary_id} has no message references; ` +
+        "cannot derive msg_start/msg_end. Skip this summary at the caller.",
+    );
+  }
+  const msg_start = Math.min(...input.messageSeqs);
+  const msg_end = Math.max(...input.messageSeqs);
+  return {
+    id: input.summary.summary_id,
+    session_id: input.sessionId,
+    depth: input.summary.depth,
+    parent_id: pickCanonicalParent(input.parents),
+    summary_text: input.summary.content,
+    token_count: input.summary.token_count,
+    msg_start,
+    msg_end,
+    escalation: 0,
+    created_at:
+      input.summary.latest_at ?? input.summary.earliest_at ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * Determine if a summary has multiple parents (lossy-collapse signal).
+ */
+export function isMultiParent(parents: LosslessClawSummaryParent[]): boolean {
+  return parents.length > 1;
+}
+
+/**
+ * Resolve the (probable) single session for a summary by looking at the
+ * messages it covers. lossless-claw summaries technically span multiple
+ * conversations only via DAG construction, which Remnic's per-session
+ * structure cannot represent — return null in that case so the caller can
+ * skip the summary with a warning rather than picking a wrong session.
+ */
+export function resolveSummarySession(
+  messageIds: string[],
+  sessionByMessageId: ReadonlyMap<string, string>,
+): string | null {
+  const sessions = new Set<string>();
+  for (const messageId of messageIds) {
+    const session = sessionByMessageId.get(messageId);
+    if (session) sessions.add(session);
+  }
+  if (sessions.size !== 1) return null;
+  return [...sessions][0]!;
+}
+
+/**
+ * Index summary_messages and messages so we can emit per-summary message-id
+ * lists and seq lists without N+1 queries. Pure helper.
+ */
+export function indexSummaryDerivations(
+  summaryMessages: LosslessClawSummaryMessage[],
+  parents: LosslessClawSummaryParent[],
+): Map<string, SummaryDerivation> {
+  const out = new Map<string, SummaryDerivation>();
+  for (const sm of summaryMessages) {
+    const entry = out.get(sm.summary_id) ?? { parents: [], messageIds: [] };
+    entry.messageIds.push(sm.message_id);
+    out.set(sm.summary_id, entry);
+  }
+  for (const p of parents) {
+    const entry = out.get(p.summary_id) ?? { parents: [], messageIds: [] };
+    entry.parents.push(p);
+    out.set(p.summary_id, entry);
+  }
+  return out;
+}

--- a/packages/import-lossless-claw/tsconfig.json
+++ b/packages/import-lossless-claw/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -41,6 +41,7 @@
     "@remnic/import-chatgpt": "^0.1.0",
     "@remnic/import-claude": "^0.1.0",
     "@remnic/import-gemini": "^0.1.0",
+    "@remnic/import-lossless-claw": "^0.1.0",
     "@remnic/import-mem0": "^0.1.0"
   },
   "peerDependenciesMeta": {
@@ -50,6 +51,7 @@
     "@remnic/import-chatgpt": { "optional": true },
     "@remnic/import-claude": { "optional": true },
     "@remnic/import-gemini": { "optional": true },
+    "@remnic/import-lossless-claw": { "optional": true },
     "@remnic/import-mem0": { "optional": true }
   },
   "devDependencies": {
@@ -59,6 +61,7 @@
     "@remnic/import-chatgpt": "workspace:*",
     "@remnic/import-claude": "workspace:*",
     "@remnic/import-gemini": "workspace:*",
+    "@remnic/import-lossless-claw": "workspace:*",
     "@remnic/import-mem0": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/remnic-cli/src/import-lossless-claw-args.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-args.ts
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------
+// Pure argv parser for `remnic import-lossless-claw`.
+//
+// Kept side-effect-free and dependency-free (no @remnic/core import) so the
+// parser can be unit-tested without booting the orchestrator or pulling in
+// the SQLite native module. The orchestration in import-lossless-claw-cmd.ts
+// does the real I/O.
+// ---------------------------------------------------------------------------
+
+import { expandTilde } from "./path-utils.js";
+
+export const IMPORT_LOSSLESS_CLAW_USAGE = `remnic import-lossless-claw — Import a lossless-claw LCM database into Remnic
+
+Usage:
+  remnic import-lossless-claw --src <path> [options]
+
+Required:
+  --src <path>                Path to a lossless-claw SQLite database
+                              (typically ~/.openclaw/lcm.db).
+
+Options:
+  --memory-dir <path>         Remnic memory directory. Defaults to the
+                              resolved REMNIC_MEMORY_DIR / config value.
+  --dry-run                   Count what would be imported without writing.
+  --session-filter <id>       Restrict to a single resolved session id.
+                              May be repeated to allow multiple sessions.
+  --help, -h                  Show this help.
+
+Coexistence:
+  lossless-claw occupies OpenClaw's contextEngine slot; Remnic occupies
+  the memory slot. They can run side-by-side. Use this importer only
+  when you want to migrate session history into Remnic's LCM store.
+
+Lossy edges (Remnic LCM is single-parent; lossless-claw can be multi):
+  Multi-parent summary nodes collapse to the lowest-ordinal parent. The
+  collapse count is reported in the run summary.
+`;
+
+export interface ImportLosslessClawCmdArgs {
+  src: string;
+  memoryDir?: string;
+  dryRun: boolean;
+  sessionFilter: string[];
+}
+
+export function parseImportLosslessClawArgs(
+  argv: readonly string[],
+): ImportLosslessClawCmdArgs {
+  let src: string | undefined;
+  let memoryDir: string | undefined;
+  let dryRun = false;
+  const sessionFilter: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    switch (arg) {
+      case "--src": {
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith("--")) {
+          throw new Error("--src requires a path");
+        }
+        src = expandTilde(value);
+        i += 1;
+        break;
+      }
+      case "--memory-dir": {
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith("--")) {
+          throw new Error("--memory-dir requires a path");
+        }
+        memoryDir = expandTilde(value);
+        i += 1;
+        break;
+      }
+      case "--session-filter": {
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith("--")) {
+          throw new Error("--session-filter requires a session id");
+        }
+        sessionFilter.push(value);
+        i += 1;
+        break;
+      }
+      case "--dry-run":
+        dryRun = true;
+        break;
+      default:
+        throw new Error(
+          `Unknown argument "${arg}". Run \`remnic import-lossless-claw --help\` for usage.`,
+        );
+    }
+  }
+
+  if (!src) {
+    throw new Error("--src is required");
+  }
+  return { src, memoryDir, dryRun, sessionFilter };
+}

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.test.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseImportLosslessClawArgs } from "./import-lossless-claw-args.js";
+
+describe("parseImportLosslessClawArgs", () => {
+  it("accepts --src and a relative path", () => {
+    const args = parseImportLosslessClawArgs(["--src", "./lcm.db"]);
+    assert.equal(args.src, "./lcm.db");
+    assert.equal(args.dryRun, false);
+    assert.deepEqual(args.sessionFilter, []);
+  });
+
+  it("expands tildes in --src and --memory-dir", () => {
+    const home = process.env.HOME ?? "/tmp";
+    const args = parseImportLosslessClawArgs([
+      "--src",
+      "~/lcm.db",
+      "--memory-dir",
+      "~/.remnic/memory",
+    ]);
+    assert.equal(args.src, `${home}/lcm.db`);
+    assert.equal(args.memoryDir, `${home}/.remnic/memory`);
+  });
+
+  it("collects multiple --session-filter values", () => {
+    const args = parseImportLosslessClawArgs([
+      "--src",
+      "/tmp/lcm.db",
+      "--session-filter",
+      "sess-A",
+      "--session-filter",
+      "sess-B",
+    ]);
+    assert.deepEqual(args.sessionFilter, ["sess-A", "sess-B"]);
+  });
+
+  it("sets dryRun on --dry-run", () => {
+    const args = parseImportLosslessClawArgs(["--src", "/tmp/lcm.db", "--dry-run"]);
+    assert.equal(args.dryRun, true);
+  });
+
+  it("rejects --src without a following value (CLAUDE.md gotcha #14)", () => {
+    assert.throws(
+      () => parseImportLosslessClawArgs(["--src"]),
+      /requires a path/,
+    );
+  });
+
+  it("rejects --src followed by another flag (no silent default)", () => {
+    assert.throws(
+      () => parseImportLosslessClawArgs(["--src", "--dry-run"]),
+      /requires a path/,
+    );
+  });
+
+  it("rejects --memory-dir without value", () => {
+    assert.throws(
+      () =>
+        parseImportLosslessClawArgs([
+          "--src",
+          "/tmp/lcm.db",
+          "--memory-dir",
+        ]),
+      /requires a path/,
+    );
+  });
+
+  it("rejects --session-filter without value", () => {
+    assert.throws(
+      () =>
+        parseImportLosslessClawArgs([
+          "--src",
+          "/tmp/lcm.db",
+          "--session-filter",
+        ]),
+      /requires a session id/,
+    );
+  });
+
+  it("requires --src", () => {
+    assert.throws(
+      () => parseImportLosslessClawArgs(["--dry-run"]),
+      /--src is required/,
+    );
+  });
+
+  it("rejects unknown flags rather than ignoring them (gotcha #51)", () => {
+    assert.throws(
+      () =>
+        parseImportLosslessClawArgs([
+          "--src",
+          "/tmp/lcm.db",
+          "--unknown-flag",
+        ]),
+      /Unknown argument/,
+    );
+  });
+});

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.ts
@@ -19,6 +19,7 @@ import {
   type ImportLosslessClawCmdArgs,
 } from "./import-lossless-claw-args.js";
 import { loadImportLosslessClawModule } from "./optional-import-lossless-claw.js";
+import { expandTilde } from "./path-utils.js";
 
 export { IMPORT_LOSSLESS_CLAW_USAGE };
 export { parseImportLosslessClawArgs };
@@ -70,7 +71,12 @@ export async function cmdImportLosslessClaw(
 
   try {
     assertFile(parsed.src, "--src");
-    const memoryDir = parsed.memoryDir ?? io.resolveMemoryDir();
+    // CLI flag inputs go through expandTilde at parse time. When the
+    // memory-dir flag is absent, the resolver can still return raw
+    // `~/...` paths from env/config; expand here too so we don't end
+    // up reading/creating a literal `~/...` directory (CLAUDE.md
+    // gotcha #17, Codex P2 review on PR #797).
+    const memoryDir = parsed.memoryDir ?? expandTilde(io.resolveMemoryDir());
     assertDirectoryOrAbsent(memoryDir, "--memory-dir");
 
     const mod = await loadImportLosslessClawModule();

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.ts
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------
+// `remnic import-lossless-claw` runner. Wraps the pure parser
+// (./import-lossless-claw-args.ts) with I/O: opening the source DB, opening
+// the destination LCM DB, and printing the summary.
+// ---------------------------------------------------------------------------
+
+import fs from "node:fs";
+
+import {
+  ensureLcmStateDir,
+  openLcmDatabase,
+} from "@remnic/core";
+
+import {
+  IMPORT_LOSSLESS_CLAW_USAGE,
+  parseImportLosslessClawArgs,
+  type ImportLosslessClawCmdArgs,
+} from "./import-lossless-claw-args.js";
+import { loadImportLosslessClawModule } from "./optional-import-lossless-claw.js";
+
+export { IMPORT_LOSSLESS_CLAW_USAGE };
+export { parseImportLosslessClawArgs };
+export type { ImportLosslessClawCmdArgs };
+
+function assertDirectory(p: string, label: string): void {
+  if (!fs.existsSync(p)) {
+    throw new Error(`${label} does not exist: ${p}`);
+  }
+  if (!fs.statSync(p).isDirectory()) {
+    throw new Error(`${label} is not a directory: ${p}`);
+  }
+}
+
+function assertFile(p: string, label: string): void {
+  if (!fs.existsSync(p)) {
+    throw new Error(`${label} does not exist: ${p}`);
+  }
+  if (!fs.statSync(p).isFile()) {
+    throw new Error(`${label} is not a file: ${p}`);
+  }
+}
+
+export interface CmdImportLosslessClawIO {
+  resolveMemoryDir: () => string;
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+}
+
+export async function cmdImportLosslessClaw(
+  argv: readonly string[],
+  io: CmdImportLosslessClawIO,
+): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h") || argv.length === 0) {
+    io.stdout(IMPORT_LOSSLESS_CLAW_USAGE);
+    return 0;
+  }
+
+  let parsed: ImportLosslessClawCmdArgs;
+  try {
+    parsed = parseImportLosslessClawArgs(argv);
+  } catch (err) {
+    io.stderr(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+
+  try {
+    assertFile(parsed.src, "--src");
+    const memoryDir = parsed.memoryDir ?? io.resolveMemoryDir();
+    assertDirectory(memoryDir, "--memory-dir");
+
+    const mod = await loadImportLosslessClawModule();
+    await ensureLcmStateDir(memoryDir);
+    const destDb = openLcmDatabase(memoryDir);
+    const sourceDb = mod.openSourceDatabase(parsed.src);
+
+    try {
+      const result = mod.importLosslessClaw({
+        sourceDb,
+        destDb,
+        dryRun: parsed.dryRun,
+        sessionFilter:
+          parsed.sessionFilter.length > 0
+            ? new Set(parsed.sessionFilter)
+            : undefined,
+        onLog: (line: string) => io.stdout(line),
+      });
+
+      const summary = [
+        result.dryRun ? "DRY RUN — no rows written." : "Import complete.",
+        `Conversations scanned: ${result.conversationsScanned}`,
+        `Sessions touched:      ${result.sessionsTouched.length}`,
+        `Messages inserted:     ${result.messagesInserted}`,
+        `Messages skipped:      ${result.messagesSkipped} (already present)`,
+        `Summaries inserted:    ${result.summariesInserted}`,
+        `Summaries skipped:     ${result.summariesSkipped} (already present)`,
+        `  multi-parent collapsed: ${result.summariesMultiParentCollapsed}`,
+        `  skipped (no messages):  ${result.summariesSkippedNoMessages}`,
+        `  skipped (multi-session): ${result.summariesSkippedMultiSession}`,
+        `Compaction events written: ${result.compactionEventsInserted}`,
+      ].join("\n");
+      io.stdout(summary);
+      return 0;
+    } finally {
+      sourceDb.close();
+      destDb.close();
+    }
+  } catch (err) {
+    io.stderr(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+}

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 
 import {
+  applyLcmSchema,
   ensureLcmStateDir,
   openLcmDatabase,
 } from "@remnic/core";
@@ -22,11 +23,14 @@ export { IMPORT_LOSSLESS_CLAW_USAGE };
 export { parseImportLosslessClawArgs };
 export type { ImportLosslessClawCmdArgs };
 
-function assertDirectory(p: string, label: string): void {
-  if (!fs.existsSync(p)) {
-    throw new Error(`${label} does not exist: ${p}`);
-  }
-  if (!fs.statSync(p).isDirectory()) {
+/**
+ * Reject file paths used as directory args (CLAUDE.md gotcha #24), but
+ * permit non-existent directories — `ensureLcmStateDir` creates them with
+ * `recursive: true` during a real run, and `--dry-run` does not need the
+ * directory to exist at all.
+ */
+function assertDirectoryOrAbsent(p: string, label: string): void {
+  if (fs.existsSync(p) && !fs.statSync(p).isDirectory()) {
     throw new Error(`${label} is not a directory: ${p}`);
   }
 }
@@ -66,11 +70,25 @@ export async function cmdImportLosslessClaw(
   try {
     assertFile(parsed.src, "--src");
     const memoryDir = parsed.memoryDir ?? io.resolveMemoryDir();
-    assertDirectory(memoryDir, "--memory-dir");
+    assertDirectoryOrAbsent(memoryDir, "--memory-dir");
 
     const mod = await loadImportLosslessClawModule();
-    await ensureLcmStateDir(memoryDir);
-    const destDb = openLcmDatabase(memoryDir);
+
+    // Dry-run must not mutate destination storage (Codex P2). For a real
+    // run, ensureLcmStateDir creates the directory (recursive) and
+    // openLcmDatabase opens the on-disk SQLite file with schema applied.
+    // For --dry-run we use an in-memory destination so insert/skip counts
+    // can still be computed against an empty database without ever
+    // touching the filesystem.
+    let destDb: ReturnType<typeof openLcmDatabase>;
+    if (parsed.dryRun) {
+      destDb = mod.openInMemoryDestinationDatabase();
+      applyLcmSchema(destDb);
+    } else {
+      await ensureLcmStateDir(memoryDir);
+      destDb = openLcmDatabase(memoryDir);
+    }
+
     const sourceDb = mod.openSourceDatabase(parsed.src);
 
     try {

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.ts
@@ -104,7 +104,17 @@ export async function cmdImportLosslessClaw(
       destDb = openLcmDatabase(memoryDir);
     }
 
-    const sourceDb = mod.openSourceDatabase(parsed.src);
+    // Open the source DB inside its own try so a failed open (corrupt
+    // SQLite header, permission error, etc.) doesn't leak destDb (Cursor
+    // Bugbot review on PR #797 — `assertFile` catches existence but not
+    // every I/O failure mode).
+    let sourceDb: ReturnType<typeof mod.openSourceDatabase>;
+    try {
+      sourceDb = mod.openSourceDatabase(parsed.src);
+    } catch (err) {
+      destDb.close();
+      throw err;
+    }
 
     try {
       const result = mod.importLosslessClaw({

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.ts
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------
 
 import fs from "node:fs";
+import path from "node:path";
 
 import {
   applyLcmSchema,
@@ -74,16 +75,30 @@ export async function cmdImportLosslessClaw(
 
     const mod = await loadImportLosslessClawModule();
 
-    // Dry-run must not mutate destination storage (Codex P2). For a real
-    // run, ensureLcmStateDir creates the directory (recursive) and
-    // openLcmDatabase opens the on-disk SQLite file with schema applied.
-    // For --dry-run we use an in-memory destination so insert/skip counts
-    // can still be computed against an empty database without ever
-    // touching the filesystem.
+    // Dry-run must not mutate destination storage (Codex P2). The dest
+    // resolution rules are:
+    //   * existing on-disk lcm.sqlite       → open read-only so dedup
+    //                                          counts reflect reality
+    //                                          (Codex P2 follow-up: an
+    //                                          in-memory fallback would
+    //                                          always report "would
+    //                                          insert").
+    //   * no on-disk lcm.sqlite yet         → in-memory + applyLcmSchema,
+    //                                          so counts reflect a
+    //                                          fresh-import scenario
+    //                                          without touching the
+    //                                          filesystem.
+    // Real runs always go through ensureLcmStateDir + openLcmDatabase
+    // (which creates the dir + file + schema as needed).
     let destDb: ReturnType<typeof openLcmDatabase>;
     if (parsed.dryRun) {
-      destDb = mod.openInMemoryDestinationDatabase();
-      applyLcmSchema(destDb);
+      const lcmPath = path.join(memoryDir, "state", "lcm.sqlite");
+      if (fs.existsSync(lcmPath)) {
+        destDb = mod.openExistingLcmDatabaseReadOnly(lcmPath);
+      } else {
+        destDb = mod.openInMemoryDestinationDatabase();
+        applyLcmSchema(destDb);
+      }
     } else {
       await ensureLcmStateDir(memoryDir);
       destDb = openLcmDatabase(memoryDir);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -189,10 +189,7 @@ import { parseConnectorConfig, stripConfigArgv } from "./parse-connector-config.
 // import; slice 1 ships only the dispatcher and surfaces a clean install hint
 // when an adapter package is absent.
 import { cmdImport, IMPORT_USAGE } from "./import-dispatch.js";
-import {
-  cmdImportLosslessClaw,
-  IMPORT_LOSSLESS_CLAW_USAGE,
-} from "./import-lossless-claw-cmd.js";
+import { cmdImportLosslessClaw } from "./import-lossless-claw-cmd.js";
 
 export { parseConnectorConfig, stripConfigArgv };
 export {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -189,6 +189,10 @@ import { parseConnectorConfig, stripConfigArgv } from "./parse-connector-config.
 // import; slice 1 ships only the dispatcher and surfaces a clean install hint
 // when an adapter package is absent.
 import { cmdImport, IMPORT_USAGE } from "./import-dispatch.js";
+import {
+  cmdImportLosslessClaw,
+  IMPORT_LOSSLESS_CLAW_USAGE,
+} from "./import-lossless-claw-cmd.js";
 
 export { parseConnectorConfig, stripConfigArgv };
 export {
@@ -235,6 +239,7 @@ type CommandName =
   | "extensions"
   | "training:export"
   | "import"
+  | "import-lossless-claw"
   | "xray"
   | "capsule";
 
@@ -7734,6 +7739,20 @@ Other:
       break;
     }
 
+    case "import-lossless-claw": {
+      // SQLite→SQLite migration of a lossless-claw LCM database into
+      // Remnic's LCM mode. Distinct from `remnic import` because the data
+      // model is structurally different (turns + summary DAG, not facts)
+      // and the destination is the LCM SQLite store, not the orchestrator.
+      const exitCode = await cmdImportLosslessClaw(rest, {
+        resolveMemoryDir,
+        stdout: (line) => console.log(line),
+        stderr: (line) => console.error(line),
+      });
+      if (exitCode !== 0) process.exit(exitCode);
+      break;
+    }
+
     case "capsule": {
       // `remnic capsule fork <source-archive> --target <root> --fork-id <id>`
       // Issue #676 PR 4/6: formalise fork semantics — lineage breadcrumb +
@@ -7948,6 +7967,9 @@ Usage:
   remnic import --adapter <name> --file <path> [--dry-run] [--batch-size <n>]
     Import memory from ChatGPT/Claude/Gemini/Mem0 exports (issue #568).
     Run 'remnic import --help' for the full adapter list.
+  remnic import-lossless-claw --src <path> [--dry-run] [--session-filter <id>]
+    Migrate a lossless-claw LCM database into Remnic's LCM mode. Run
+    'remnic import-lossless-claw --help' for full usage.
   remnic capsule fork <archive> --target <dir> --fork-id <id>
     Fork a capsule archive into a memory root. Records land under
     forks/<source-capsule-id>/ and a lineage breadcrumb is written to

--- a/packages/remnic-cli/src/optional-import-lossless-claw.ts
+++ b/packages/remnic-cli/src/optional-import-lossless-claw.ts
@@ -1,0 +1,73 @@
+// Lazy loader for the optional @remnic/import-lossless-claw package.
+//
+// CLAUDE.md à-la-carte invariant: optional packages MUST be loaded via
+// computed-specifier dynamic imports so bundlers cannot statically resolve
+// them. Mirrors optional-bench.ts / optional-weclone-export.ts.
+//
+// Type-shape declared manually (not via `typeof import(...)`) so the CLI
+// type-checks even when the optional package is not yet linked into
+// node_modules — same pattern as optional-importer.ts.
+
+import { isSpecifierNotFoundError } from "./optional-module-loader.js";
+
+const SPECIFIER = "@remnic/" + "import-lossless-claw";
+
+interface BetterSqlite3DatabaseLike {
+  prepare(sql: string): unknown;
+  close(): void;
+}
+
+export interface ImportLosslessClawModule {
+  openSourceDatabase(filePath: string): BetterSqlite3DatabaseLike;
+  importLosslessClaw(options: {
+    sourceDb: BetterSqlite3DatabaseLike;
+    destDb: BetterSqlite3DatabaseLike;
+    dryRun?: boolean;
+    sessionFilter?: ReadonlySet<string>;
+    onLog?: (line: string) => void;
+  }): {
+    conversationsScanned: number;
+    sessionsTouched: string[];
+    messagesInserted: number;
+    messagesSkipped: number;
+    summariesInserted: number;
+    summariesSkipped: number;
+    summariesMultiParentCollapsed: number;
+    summariesSkippedNoMessages: number;
+    summariesSkippedMultiSession: number;
+    compactionEventsInserted: number;
+    dryRun: boolean;
+  };
+}
+
+let cached: ImportLosslessClawModule | null | undefined;
+
+async function tryImport(): Promise<ImportLosslessClawModule | null> {
+  try {
+    return (await import(SPECIFIER)) as ImportLosslessClawModule;
+  } catch (err) {
+    if (isSpecifierNotFoundError(err, SPECIFIER)) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export async function loadImportLosslessClawModule(): Promise<ImportLosslessClawModule> {
+  if (cached === undefined) {
+    cached = await tryImport();
+  }
+  if (!cached) {
+    throw new Error(
+      "The `remnic import-lossless-claw` command requires the optional " +
+        "@remnic/import-lossless-claw package.\n" +
+        "\n" +
+        "Install it alongside the CLI:\n" +
+        "  npm install -g @remnic/import-lossless-claw\n" +
+        "\n" +
+        "Or add it to a project:\n" +
+        "  pnpm add @remnic/import-lossless-claw\n",
+    );
+  }
+  return cached;
+}

--- a/packages/remnic-cli/src/optional-import-lossless-claw.ts
+++ b/packages/remnic-cli/src/optional-import-lossless-claw.ts
@@ -20,6 +20,7 @@ interface BetterSqlite3DatabaseLike {
 export interface ImportLosslessClawModule {
   openSourceDatabase(filePath: string): BetterSqlite3DatabaseLike;
   openInMemoryDestinationDatabase(): BetterSqlite3DatabaseLike;
+  openExistingLcmDatabaseReadOnly(filePath: string): BetterSqlite3DatabaseLike;
   importLosslessClaw(options: {
     sourceDb: BetterSqlite3DatabaseLike;
     destDb: BetterSqlite3DatabaseLike;

--- a/packages/remnic-cli/src/optional-import-lossless-claw.ts
+++ b/packages/remnic-cli/src/optional-import-lossless-claw.ts
@@ -19,6 +19,7 @@ interface BetterSqlite3DatabaseLike {
 
 export interface ImportLosslessClawModule {
   openSourceDatabase(filePath: string): BetterSqlite3DatabaseLike;
+  openInMemoryDestinationDatabase(): BetterSqlite3DatabaseLike;
   importLosslessClaw(options: {
     sourceDb: BetterSqlite3DatabaseLike;
     destDb: BetterSqlite3DatabaseLike;

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     "@remnic/import-weclone",
     "@remnic/import-chatgpt",
     "@remnic/import-gemini",
+    "@remnic/import-lossless-claw",
     "@remnic/import-mem0",
     "@remnic/import-claude",
   ],

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -315,6 +315,11 @@ export {
 
 export { loadDaySummaryPrompt, buildExtensionsFooterForSummary } from "./day-summary.js";
 
+// LCM (Lossless Context Management) database helpers — exposed so optional
+// host packages (e.g. @remnic/import-lossless-claw) can open the same
+// SQLite store the runtime uses without re-implementing schema bootstrap.
+export { openLcmDatabase, ensureLcmStateDir } from "./lcm/schema.js";
+
 // ---------------------------------------------------------------------------
 // Active memory bridge
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -318,7 +318,13 @@ export { loadDaySummaryPrompt, buildExtensionsFooterForSummary } from "./day-sum
 // LCM (Lossless Context Management) database helpers — exposed so optional
 // host packages (e.g. @remnic/import-lossless-claw) can open the same
 // SQLite store the runtime uses without re-implementing schema bootstrap.
-export { openLcmDatabase, ensureLcmStateDir } from "./lcm/schema.js";
+// `applyLcmSchema` lets importers bootstrap an in-memory destination for
+// true read-only `--dry-run` execution.
+export {
+  openLcmDatabase,
+  ensureLcmStateDir,
+  applyLcmSchema,
+} from "./lcm/schema.js";
 
 // ---------------------------------------------------------------------------
 // Active memory bridge

--- a/packages/remnic-core/src/lcm/schema.ts
+++ b/packages/remnic-core/src/lcm/schema.ts
@@ -22,6 +22,18 @@ export async function ensureLcmStateDir(memoryDir: string): Promise<void> {
   await mkdir(path.join(memoryDir, "state"), { recursive: true });
 }
 
+/**
+ * Apply (or upgrade) the LCM schema on an already-open SQLite handle.
+ *
+ * Exposed so optional host packages — e.g. importers using an in-memory
+ * destination database for true read-only `--dry-run` execution — can
+ * bootstrap the schema without going through `openLcmDatabase()` (which
+ * always touches the filesystem).
+ */
+export function applyLcmSchema(db: BetterSqlite3Database): void {
+  applySchema(db);
+}
+
 function applySchema(db: BetterSqlite3Database): void {
   const versionRow = db
     .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='lcm_meta'")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
   packages/import-lossless-claw:
     dependencies:
       better-sqlite3:
-        specifier: ^11.0.0
-        version: 11.10.0
+        specifier: ^12.6.2
+        version: 12.8.0
     devDependencies:
       '@remnic/core':
         specifier: workspace:*
@@ -1059,9 +1059,6 @@ packages:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
   better-sqlite3@12.8.0:
     resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
@@ -2167,11 +2164,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.20: {}
-
-  better-sqlite3@11.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
 
   better-sqlite3@12.8.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,10 @@ importers:
         version: 5.9.3
 
   packages/import-lossless-claw:
+    dependencies:
+      better-sqlite3:
+        specifier: ^11.0.0
+        version: 11.10.0
     devDependencies:
       '@remnic/core':
         specifier: workspace:*
@@ -212,9 +216,6 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.0
         version: 7.6.13
-      better-sqlite3:
-        specifier: ^11.0.0
-        version: 11.10.0
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,27 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/import-lossless-claw:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
+      better-sqlite3:
+        specifier: ^11.0.0
+        version: 11.10.0
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/import-mem0:
     devDependencies:
       '@remnic/core':
@@ -283,6 +304,9 @@ importers:
       '@remnic/import-gemini':
         specifier: workspace:*
         version: link:../import-gemini
+      '@remnic/import-lossless-claw':
+        specifier: workspace:*
+        version: link:../import-lossless-claw
       '@remnic/import-mem0':
         specifier: workspace:*
         version: link:../import-mem0
@@ -1034,6 +1058,9 @@ packages:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
   better-sqlite3@12.8.0:
     resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
@@ -2139,6 +2166,11 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.20: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
 
   better-sqlite3@12.8.0:
     dependencies:


### PR DESCRIPTION
## Summary

Add a SQLite→SQLite importer that migrates [lossless-claw](https://github.com/martian-engineering/lossless-claw) (LCM) databases into Remnic's own LCM mode, plus a migration playbook.

- New package **@remnic/import-lossless-claw** — pure mapper + orchestration over a synthetic test fixture (no real user data per public-repo policy).
- New CLI subcommand **`remnic import-lossless-claw`** — lazy-loaded à-la-carte per CLAUDE.md gotcha #57.
- New doc **docs/lcm-to-remnic-migration.md** — coexistence story (different OpenClaw slots, can run side-by-side), switching playbook, full mapping table, lossy edges, troubleshooting.
- One-line re-export from @remnic/core (openLcmDatabase, ensureLcmStateDir) so optional host packages don't have to dive into core internals.

## Why

The two systems have near-isomorphic schemas:

| lossless-claw | Remnic LCM |
|---|---|
| messages.seq, role, content, token_count, created_at | lcm_messages.turn_index, role, content, token_count, created_at |
| summaries.summary_id, depth, content, token_count | lcm_summary_nodes.id, depth, summary_text, token_count |
| MIN/MAX(messages.seq) per summary (via summary_messages) | lcm_summary_nodes.msg_start, msg_end |
| summary_parents (M:N DAG) | lcm_summary_nodes.parent_id (single FK — collapsed) |
| conversations.session_id (or conversation_id fallback) | lcm_messages.session_id |

The only structurally lossy edge is the multi-parent DAG → single-parent FK collapse. The importer picks the lowest-ordinal parent (lexicographic tie-break) and reports the collapse count in the run summary.

## Coexistence

lossless-claw occupies OpenClaw's contextEngine slot; Remnic occupies memory. They can be configured side-by-side. The importer is for users who want Remnic to own context management end-to-end.

## Compaction-event boundary

The importer writes one row per touched session into lcm_compaction_events with tokens_before == tokens_after — encoding "import boundary, not a real compaction" so subsequent Remnic compaction telemetry has a known anchor.

## Idempotency / safety

- Source DB opened **read-only** with fileMustExist: true.
- Messages dedupe on natural key (session_id, turn_index); summaries dedupe on id.
- --dry-run flag runs every read + transformation but skips all writes.
- Pure parser (import-lossless-claw-args.ts) split from the I/O orchestrator (-cmd.ts) so flag-validation tests stay dependency-light.

## Test plan

- [x] **Package unit tests pass** — 41/41 (transform 19, source 2, importer 10, cli args 10)
- [x] **Package builds clean** — tsup ESM 14.6 KB + DTS 6.59 KB
- [x] **Type-check** — tsc --noEmit clean for the new package
- [x] Idempotent re-run inserts zero new rows
- [x] FTS5 indexes queryable post-import
- [x] Compaction-event boundary written with tokens_before == tokens_after
- [x] Multi-parent DAG collapse logged + counted
- [x] Schema rejection error names every missing table
- [x] Dry-run mutates neither DB
- [x] Session filter restricts inserts
- [ ] CI to run repo-wide preflight against fresh pnpm install + topological build.

## Notes for reviewers

- À-la-carte invariant (CLAUDE.md gotcha #57) preserved: new package in peerDependencies + peerDependenciesMeta.*.optional = true, in tsup external, never in CLI runtime dependencies or noExternal.
- Flag arguments validate value-presence per gotcha #14; tildes expand per #17; directory args reject files per #24; metadata JSON keys sorted per #38; unknown flags throw rather than silently default per #51.
- Slot-mapping inference for lossless-claw came from its README + plugin kind (context-engine); not directly verified against its openclaw.plugin.json. Migration doc states this caveat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new data-migration path that writes directly to the LCM SQLite store and introduces a new CLI entrypoint; mistakes could lead to duplicated/incorrect session timelines or summary parent collapse behavior. Core changes are limited to exporting schema helpers, but importer correctness and idempotency are important to validate on real databases.
> 
> **Overview**
> Adds a new optional package `@remnic/import-lossless-claw` that imports lossless-claw LCM SQLite data into Remnic’s LCM SQLite store, including idempotent deduping, FTS table syncing, multi-parent summary DAG collapse to a single parent, and writing per-session import-boundary rows to `lcm_compaction_events`.
> 
> Introduces a new CLI subcommand `remnic import-lossless-claw` (lazy-loaded optional dependency) with `--src`, `--memory-dir`, `--dry-run`, and repeatable `--session-filter`, plus safe dry-run behavior (read-only destination when present, otherwise in-memory) and new migration documentation describing coexistence and lossy edges.
> 
> Exposes `openLcmDatabase`, `ensureLcmStateDir`, and new `applyLcmSchema` from `@remnic/core` so external tools can bootstrap/operate on the LCM DB without re-implementing schema setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10736d7e8901b07bb075d1e663c92f40534fdd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->