### PR TITLE
fix(release): add @remnic/import-lossless-claw to PUBLISH_ORDER

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -362,6 +362,7 @@ jobs:
             packages/import-claude
             packages/import-gemini
             packages/import-mem0
+            packages/import-lossless-claw
             packages/connector-weclone
             packages/connector-replit
             packages/hermes-provider

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -17,6 +17,7 @@ const expectedPublishDirs = [
   "packages/import-claude",
   "packages/import-gemini",
   "packages/import-mem0",
+  "packages/import-lossless-claw",
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/hermes-provider",


### PR DESCRIPTION
## Summary

The release-and-publish.yml workflow iterates a hardcoded `PUBLISH_ORDER` array. The new `@remnic/import-lossless-claw` package shipped in #797 but wasn't added to that list, so the post-merge release run iterated past it without ever attempting to publish — the package is not on npmjs.

This adds it next to the other importers.

## Why this happened

Per CLAUDE.md gotcha #57: 'The publish order in `.github/workflows/release-and-publish.yml` is the source of truth; keep it topologically sorted. Publish everything that end users are expected to install.'

I missed that step when adding the package in #797. Picking it up here.

## First-time publish caveat

Even after this fix, the first attempt may not actually publish to npm. The workflow's E404-on-first-publish branch logs:

```
::warning::${pkg_name}@${pkg_version} is not provisioned for first-time
npm publish from this automation yet; skipping so existing package
updates can still ship.
```

That implies new package names need npmjs trusted-publisher / OIDC trust configured before automation can publish them. After this PR merges, options are:

1. Manually `npm publish --access public --provenance` once from a local checkout with appropriate auth, then automation handles every subsequent release.
2. Configure the trusted-publisher entry for `@remnic/import-lossless-claw` on npmjs.com first, then merge — the next release run picks it up.

## Test plan

- [x] Workflow YAML still parses (single-line addition in a known-good Bash heredoc array)
- [ ] Confirmed by next release run on main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow/test list update; the main risk is unintended publish order/coverage changes in the release pipeline, but it only adds a missing package entry.
> 
> **Overview**
> Ensures the `@remnic/import-lossless-claw` workspace is included in automated npm publishing by inserting `packages/import-lossless-claw` into the release workflow’s `PUBLISH_ORDER`.
> 
> Updates the corresponding test (`release-workflow-public-packages.test.ts`) so CI enforces that the workflow’s publish list continues to match the expected set of public install surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cbbb8944786a5f02c35de32983296e2111f7f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->