### PR TITLE
fix(core): isolate shared context under configured workspace

### DIFF
--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -1,12 +1,11 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, readdir, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import { log } from "../logger.js";
 import { sanitizeMemoryContent } from "../sanitize.js";
 import { StorageManager } from "../storage.js";
 import type { ContinuityIncidentRecord, PluginConfig } from "../types.js";
-import { SharedFeedbackEntrySchema, type SharedFeedbackEntry } from "../shared-context/manager.js";
+import { resolveSharedContextDir, SharedFeedbackEntrySchema, type SharedFeedbackEntry } from "../shared-context/manager.js";
 import { parseContinuityImprovementLoops } from "../identity-continuity.js";
 
 type MistakesFile = {
@@ -407,13 +406,6 @@ function monthIdFromIsoWeek(weekId: string): string {
   return isoMonthId(monday);
 }
 
-function sharedContextDir(config: PluginConfig): string {
-  if (typeof config.sharedContextDir === "string" && config.sharedContextDir.length > 0) {
-    return config.sharedContextDir;
-  }
-  return path.join(os.homedir(), ".openclaw", "workspace", "shared-context");
-}
-
 function cadenceStaleWindowMs(cadence: "daily" | "weekly" | "monthly" | "quarterly"): number {
   switch (cadence) {
     case "daily":
@@ -453,7 +445,7 @@ export class CompoundingEngine {
     this.rubricsWorkflowsDir = path.join(this.rubricsDir, "workflows");
     this.rubricsPath = path.join(config.memoryDir, "compounding", "rubrics.md");
     this.mistakesPath = path.join(config.memoryDir, "compounding", "mistakes.json");
-    this.feedbackInboxPath = path.join(sharedContextDir(config), "feedback", "inbox.jsonl");
+    this.feedbackInboxPath = path.join(resolveSharedContextDir(config), "feedback", "inbox.jsonl");
     this.identityAuditWeeklyDir = path.join(config.memoryDir, "identity", "audits", "weekly");
     this.identityAuditMonthlyDir = path.join(config.memoryDir, "identity", "audits", "monthly");
     this.memoryActionEventsPath = path.join(config.memoryDir, "state", "memory-actions.jsonl");

--- a/packages/remnic-core/src/shared-context/manager.ts
+++ b/packages/remnic-core/src/shared-context/manager.ts
@@ -1,9 +1,9 @@
 import { mkdir, readFile, readdir, appendFile, writeFile, stat } from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import { z } from "zod";
 import { log } from "../logger.js";
 import type { PluginConfig } from "../types.js";
+import { expandTildePath } from "../utils/path.js";
 
 export const SharedFeedbackEntrySchema = z.object({
   agent: z.string().min(1),
@@ -335,6 +335,12 @@ function formatOverlapLine(entry: SharedCrossSignalOverlap): string {
   return `- \`${entry.token}\` (${entry.agentCount} agents: ${entry.agents.join(", ")}) [sources: ${entry.sourcePaths.join(", ")}]`;
 }
 
+export function resolveSharedContextDir(config: PluginConfig): string {
+  return typeof config.sharedContextDir === "string" && config.sharedContextDir.length > 0
+    ? expandTildePath(config.sharedContextDir)
+    : path.join(expandTildePath(config.workspaceDir), "shared-context");
+}
+
 export class SharedContextManager {
   readonly dir: string;
   private readonly prioritiesPath: string;
@@ -346,10 +352,7 @@ export class SharedContextManager {
   private readonly crossSignalsDir: string;
 
   constructor(private readonly config: PluginConfig) {
-    const base =
-      typeof config.sharedContextDir === "string" && config.sharedContextDir.length > 0
-        ? config.sharedContextDir
-        : path.join(os.homedir(), ".openclaw", "workspace", "shared-context");
+    const base = resolveSharedContextDir(config);
 
     this.dir = base;
     this.prioritiesPath = path.join(base, "priorities.md");

--- a/tests/compounding.test.ts
+++ b/tests/compounding.test.ts
@@ -12,7 +12,7 @@ function tmpDir(prefix: string): string {
   return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
 }
 
-function minimalConfig(memoryDir: string, sharedContextDir: string): PluginConfig {
+function minimalConfig(memoryDir: string, sharedContextDir?: string): PluginConfig {
   return {
     openaiApiKey: undefined,
     model: "gpt-5.2",
@@ -202,6 +202,40 @@ test("v5 compounding extracts patterns from feedback learning/rejections", async
   assert.ok(mistakes!.patterns.some((p) => p.includes("seo-digest: Always include confidence score")));
   assert.ok(mistakes!.patterns.some((p) => p.includes("client-health: WRONG DATA")));
   assert.ok(mistakes!.registry?.some((entry) => entry.agent === "seo-digest"));
+});
+
+test("v5 compounding defaults shared feedback under configured workspace", async () => {
+  const memoryDir = tmpDir("remnic-compound-workspace-mem");
+  await mkdir(memoryDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir);
+  const feedbackDir = path.join(cfg.workspaceDir, "shared-context", "feedback");
+  await mkdir(feedbackDir, { recursive: true });
+  await writeFile(
+    path.join(feedbackDir, "inbox.jsonl"),
+    [
+      JSON.stringify({
+        agent: "bench-agent",
+        decision: "approved_with_feedback",
+        reason: "Make benchmark isolation explicit",
+        date: new Date().toISOString(),
+        learning: "Always keep benchmark shared context inside the run workspace",
+      }),
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const eng = new CompoundingEngine(cfg);
+  await eng.synthesizeWeekly();
+  const mistakes = await eng.readMistakes();
+
+  assert.ok(mistakes);
+  assert.ok(
+    mistakes!.patterns.some((pattern) =>
+      pattern.includes("bench-agent: Always keep benchmark shared context inside the run workspace"),
+    ),
+  );
 });
 
 test("v5 compounding ingests failing memory-action patterns", async () => {

--- a/tests/shared-context-tools.test.ts
+++ b/tests/shared-context-tools.test.ts
@@ -122,3 +122,74 @@ test("shared_context_cross_signals_run generates markdown and json artifacts on 
     await rm(sharedDir, { recursive: true, force: true });
   }
 });
+
+test("shared context defaults under configured workspace directory", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-workspace-memory-"));
+  try {
+    const workspaceDir = path.join(memoryDir, "workspace");
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      sharedContextEnabled: true,
+    });
+    const manager = new SharedContextManager(config);
+
+    assert.equal(manager.dir, path.join(workspaceDir, "shared-context"));
+    await manager.ensureStructure();
+
+    const priorities = await readFile(path.join(workspaceDir, "shared-context", "priorities.md"), "utf-8");
+    assert.match(priorities, /# Priorities/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("shared context workspace fallback expands leading tilde", async () => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-home-"));
+  const originalHome = process.env.HOME;
+  process.env.HOME = homeDir;
+  try {
+    const memoryDir = path.join(homeDir, "memory");
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: "~/bench-workspace",
+      qmdEnabled: false,
+      sharedContextEnabled: true,
+    });
+    const manager = new SharedContextManager(config);
+
+    assert.equal(manager.dir, path.join(homeDir, "bench-workspace", "shared-context"));
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("explicit shared context directory overrides workspace fallback", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-explicit-memory-"));
+  const sharedDir = await mkdtemp(path.join(os.tmpdir(), "remnic-shared-explicit-dir-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      qmdEnabled: false,
+      sharedContextEnabled: true,
+      sharedContextDir: sharedDir,
+    });
+    const manager = new SharedContextManager(config);
+
+    assert.equal(manager.dir, sharedDir);
+    await manager.ensureStructure();
+
+    const priorities = await readFile(path.join(sharedDir, "priorities.md"), "utf-8");
+    assert.match(priorities, /# Priorities/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(sharedDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- default shared-context storage now resolves under the configured workspaceDir when sharedContextDir is not explicit
- expands leading `~` in sharedContextDir/workspaceDir before deriving paths
- keeps explicit sharedContextDir override behavior intact
- updates the compounding engine to use the same shared-context resolver so feedback ingestion remains isolated
- adds regression coverage for isolated workspace fallback, tilde expansion, explicit override, and compounding feedback reads

## Validation
- npx tsx --test tests/shared-context-tools.test.ts tests/compounding.test.ts
- npm run preflight:quick (still fails before project checks complete: packages/remnic-core/src/secure-store/kdf.ts cannot resolve @node-rs/argon2)
- npm run review:cursor (unavailable locally: macOS login keychain is locked)

## Benchmark impact
This prevents isolated benchmark profiles from reading ~/.openclaw/workspace/shared-context when sharedContextEnabled or compounding is active and workspaceDir is set to a run-local directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default filesystem paths for shared-context and compounding feedback, which could alter where data is read/written if callers relied on the previous home-directory fallback. Logic is small and test-covered, but impacts persistence locations across runs.
> 
> **Overview**
> **Shared-context storage is now isolated per configured `workspaceDir`.** When `sharedContextDir` is not explicitly set, `SharedContextManager` now resolves its base directory to `path.join(workspaceDir, "shared-context")` (including leading-`~` expansion) rather than a fixed home-directory location.
> 
> **Compounding feedback ingestion now follows the same resolver.** `CompoundingEngine` switches to `resolveSharedContextDir(config)` for locating `feedback/inbox.jsonl`, ensuring weekly synthesis reads feedback from the run’s workspace-scoped shared context.
> 
> **Regression coverage added.** New tests verify the workspace default, tilde expansion, explicit `sharedContextDir` override, and that compounding can read feedback from the workspace-scoped shared-context path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e63254b46b88791a9c23b3d808225c951c3602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->