### PR TITLE
docs(hermes): clarify Remnic uses memory_provider slot, not context_engine

### DIFF
--- a/docs/integration/hermes-setup.md
+++ b/docs/integration/hermes-setup.md
@@ -18,3 +18,9 @@ remnic connectors install hermes
 ```
 
 Then restart Hermes to pick up the new plugin.
+
+## Which Hermes plugin slot Remnic uses
+
+Remnic registers as a Hermes **`memory_provider`** plugin. **Remnic does not need to register as a Hermes `context_engine`** — that slot replaces Hermes' built-in `ContextCompressor` and is for compressing the agent's own outgoing history. All Remnic capabilities, including Lossless Context Management (LCM), are delivered through the `memory_provider` hook (`pre_llm_call`) and the recall envelope returned by the daemon.
+
+If guidance you encounter (including AI-generated review of the install) tells you LCM requires `register_context_engine`, that guidance is wrong. See the [Hermes plugin reference](../plugins/hermes.md#which-hermes-plugin-slot-remnic-uses) for the full explanation.

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -11,6 +11,7 @@ Canonical upstream references:
 
 ## Contents
 
+- [Which Hermes plugin slot Remnic uses](#which-hermes-plugin-slot-remnic-uses)
 - [Why MemoryProvider](#why-memoryprovider)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
@@ -25,6 +26,22 @@ Canonical upstream references:
 - [Troubleshooting](#troubleshooting)
 - [Migration notes (Engram era)](#migration-notes-engram-era)
 - [Uninstall](#uninstall)
+
+---
+
+## Which Hermes plugin slot Remnic uses
+
+Remnic registers as a Hermes **`memory_provider`** plugin (`plugin.yaml` declares `type: memory_provider`). This is the only slot Remnic occupies and the only slot it needs.
+
+**Remnic does not, and should not, register as a Hermes `context_engine`.** Hermes' `context_engine` slot replaces the built-in `ContextCompressor` — it controls how Hermes compresses *its own outgoing conversation history* before sending to the LLM. That is a different concern from external memory recall. Remnic delivers all of the following through the `memory_provider` hook chain (`pre_llm_call` → recall envelope), with no `context_engine` registration involved:
+
+- Recalled memories from the Remnic store
+- Lossless Context Management (LCM) compressed-history sections, when the Remnic daemon has `lcmEnabled: true`
+- Entity context, identity anchors, continuity loops, and any other recall-side enrichment served by the daemon
+
+If a static analysis tool, AI reviewer, or third-party guide tells you "Remnic needs `register_context_engine` in Hermes to enable LCM," that guidance is incorrect. LCM lives on the Remnic daemon. It is delivered to Hermes via the recall response. The `memory_provider` hook is the correct and sufficient integration point.
+
+A Remnic-backed `ContextEngine` (one that uses Remnic's LCM to compress Hermes' *local* history) is a possible future additive feature. It is not required for any of the capabilities Remnic exposes today.
 
 ---
 

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -13,6 +13,14 @@ MCP tools give an agent the ability to call memory functions, but only when the 
 | Latency | Tool call overhead | Pre-fetched, non-blocking |
 | Reliability | Agent may forget to call | Structural — cannot be skipped |
 
+## Which Hermes plugin slot does Remnic use?
+
+Remnic ships as a **`memory_provider`** plugin in Hermes (declared in `plugin.yaml` as `type: memory_provider`).
+
+**Remnic does not use, and does not need to use, Hermes' `context_engine` slot.** That slot replaces the built-in `ContextCompressor` — it is for *compressing the agent's own outgoing conversation history*. Remnic delivers external memory recall (and, when enabled daemon-side, Lossless Context Management archive content) through the `memory_provider` hook (`pre_llm_call`), which is the correct slot for this concern.
+
+If you have read documentation or third-party reviews suggesting Remnic must register as a `context_engine` to enable LCM in Hermes, that is incorrect. LCM runs on the Remnic daemon and arrives in Hermes through the recall envelope returned by the memory_provider — no `context_engine` registration is involved. The two slots are orthogonal: a future Remnic-backed `ContextEngine` plugin would be a separate, additive feature for replacing Hermes' local compressor, not a prerequisite for memory or LCM.
+
 ## Prerequisites
 
 - **Remnic daemon** running and accessible on port `4318` (default). See the [Remnic repository](https://github.com/joshuaswarren/remnic) for installation instructions.


### PR DESCRIPTION
## Summary

- Adds a "Which Hermes plugin slot Remnic uses" section to three Hermes-facing docs.
- States explicitly that Remnic registers as a Hermes \`memory_provider\` and does **not** need to register as a \`context_engine\` — Hermes' \`context_engine\` slot replaces the built-in \`ContextCompressor\` (compresses Hermes' own outgoing history) and is unrelated to external memory recall or to Remnic's daemon-side LCM.
- LCM runs on the Remnic daemon and arrives in Hermes via the recall envelope returned by \`pre_llm_call\`. The \`memory_provider\` hook is the correct and sufficient integration point.

## Why this PR exists

A user's pre-install Opus review of \`remnic-hermes\` concluded that LCM might not work in Hermes because the plugin registers as \`type: memory_provider\` only and has no \`register_context_engine\` call. The conclusion was wrong — but the docs gave the reviewer no way to reach the right answer. This PR closes the documentation gap so future static analysis and AI reviewers do not raise the same false alarm during install.

## Files changed

- \`packages/plugin-hermes/README.md\` — new section directly under the package title.
- \`docs/plugins/hermes.md\` — new section, linked from the table of contents.
- \`docs/integration/hermes-setup.md\` — short clarification block under Quick install with a link to the full plugin reference.

Total: 3 files, +31 lines, 0 deletions. No code changes.

## Related

- Umbrella issue for the broader Hermes parity work: #802
- Sub-issues #803–#816 track the actual capability gaps. This PR is **docs only** — it does not implement any new capability.

## Test plan

- [x] No code changed; nothing to run.
- [x] \`docs/plugins/hermes.md\` table of contents anchor matches the new heading.
- [x] All three sections cross-reference each other consistently (no contradictions, no broken links between them).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that clarify Hermes plugin integration; no runtime behavior, APIs, or config parsing changed.
> 
> **Overview**
> Adds a new **"Which Hermes plugin slot Remnic uses"** section across Hermes-facing docs to explicitly state Remnic registers only as a `memory_provider` (per `plugin.yaml`) and **does not** use Hermes’ `context_engine` slot.
> 
> Clarifies that Lossless Context Management (LCM) is delivered daemon-side via the `memory_provider` hook (`pre_llm_call` → recall envelope), and adds cross-references/TOC links to prevent guidance that incorrectly suggests `register_context_engine` is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 320bc47a2fdc72c91e00830d4491d197689b1bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->