### PR TITLE
feat(hermes): wire LCM search tool

### DIFF
--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -201,7 +201,7 @@ Called before every LLM request. Behavior:
 
 1. Scans `messages` in reverse to find the last message with `role: "user"`.
 2. **Skips recall entirely** if the user message is absent or fewer than 3 words (whitespace-split). This avoids triggering recall on very short acknowledgments like "ok" or "thanks".
-3. Issues `POST /recall` with the user message as the query, `sessionKey`, `topK: 8`, and `mode: "minimal"`.
+3. Issues `POST /recall` with the user message as the query, `sessionKey`, and `topK: 8`. The plugin leaves recall mode unset so the daemon default can include LCM compressed-history sections when `lcmEnabled: true`.
 4. If the response has a non-empty `context` field and `count > 0`, returns a `<remnic-memory count="N">` block that Hermes injects into the system prompt.
 5. Exceptions are swallowed; returns `""` on any error so the LLM call proceeds normally.
 
@@ -230,10 +230,11 @@ Closes the `httpx.AsyncClient`. Safe to call when the client was never initializ
 | `remnic_recall` | `query: string` | Recall memories from Remnic matching a natural language query |
 | `remnic_store` | `content: string` | Store a memory in Remnic for future recall |
 | `remnic_search` | `query: string` | Full-text search across all Remnic memories |
+| `remnic_lcm_search` | `query: string`, `sessionKey?: string`, `namespace?: string`, `limit?: number` | Search the daemon-side LCM conversation archive |
 
 Each tool handler returns the raw JSON response from the daemon or `{"error": "Not connected to Remnic"}` when the client is not initialized.
 
-The `remnic_*` tools give the agent explicit control for cases where automatic recall is insufficient — for example, storing a specific fact the agent has derived mid-session.
+The `remnic_*` tools give the agent explicit control for cases where automatic recall is insufficient — for example, storing a specific fact the agent has derived mid-session, or searching the LCM archive directly.
 
 ---
 
@@ -299,6 +300,7 @@ During the Engram to Remnic rebrand, the plugin registers six tools instead of t
 | `engram_recall` | Legacy alias | Routes to the same handler as `remnic_recall` |
 | `engram_store` | Legacy alias | Routes to the same handler as `remnic_store` |
 | `engram_search` | Legacy alias | Routes to the same handler as `remnic_search` |
+| `engram_lcm_search` | Legacy alias | Routes to the same handler as `remnic_lcm_search` |
 
 The legacy tool schemas deliberately describe themselves as "Engram" tools (e.g., "Recall memories from Engram..."). This is intentional: when a language model surfaces the `engram_*` names, the description must agree with the name so the model does not confuse the two tool sets. Do not update these descriptions to say "Remnic".
 

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -45,7 +45,7 @@ If you have read documentation or third-party reviews suggesting Remnic must reg
    ```bash
    hermes --version && pip show remnic-hermes
    ```
-   Your agent should now have access to `remnic_recall`, `remnic_store`, and `remnic_search` tools. Call `remnic_recall` with any query to confirm memories are returned.
+Your agent should now have access to `remnic_recall`, `remnic_store`, `remnic_search`, and `remnic_lcm_search` tools. Call `remnic_recall` with any query to confirm memories are returned.
 
 ## Manual configuration
 
@@ -118,6 +118,7 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_recall` | Recall memories matching a natural language query |
 | `remnic_store` | Store a memory explicitly |
 | `remnic_search` | Full-text search across all stored memories |
+| `remnic_lcm_search` | Search the daemon-side LCM conversation archive |
 
 During the Engram to Remnic compat window, three legacy aliases are also registered: `engram_recall`, `engram_store`, `engram_search`. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 
@@ -177,6 +178,12 @@ remnic connectors remove hermes
 ```
 
 `remnic connectors remove hermes` revokes the token and removes the config entry from Hermes `config.yaml`.
+
+## LCM in Hermes
+
+`remnic_lcm_search` searches the Remnic daemon's Lossless Context Management archive on demand. The legacy `engram_lcm_search` alias is registered for existing Engram-era Hermes configurations.
+
+LCM runs daemon-side and reaches Hermes through the `memory_provider` recall path. Remnic does not register, and does not need, a Hermes `context_engine` slot for this feature.
 
 ## Further reading
 

--- a/packages/plugin-hermes/plugin.yaml
+++ b/packages/plugin-hermes/plugin.yaml
@@ -5,3 +5,12 @@ author: Joshua Warren
 homepage: https://github.com/joshuaswarren/remnic
 entry: remnic_hermes
 type: memory_provider
+tools:
+  - remnic_recall
+  - remnic_store
+  - remnic_search
+  - remnic_lcm_search
+  - engram_recall
+  - engram_store
+  - engram_search
+  - engram_lcm_search

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -33,9 +33,15 @@ def register(ctx):  # type: ignore[no-untyped-def]
     ctx.register_tool("remnic_recall", provider.recall_schema, provider.recall)
     ctx.register_tool("remnic_store", provider.store_schema, provider.store)
     ctx.register_tool("remnic_search", provider.search_schema, provider.search)
+    ctx.register_tool(
+        "remnic_lcm_search", provider.lcm_search_schema, provider.lcm_search
+    )
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
     ctx.register_tool("engram_recall", provider.legacy_recall_schema, provider.recall)
     ctx.register_tool("engram_store", provider.legacy_store_schema, provider.store)
     ctx.register_tool("engram_search", provider.legacy_search_schema, provider.search)
+    ctx.register_tool(
+        "engram_lcm_search", provider.legacy_lcm_search_schema, provider.lcm_search
+    )

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -44,16 +44,18 @@ class RemnicClient:
         *,
         session_key: str = "",
         top_k: int = 8,
-        mode: str = "minimal",
+        mode: str | None = None,
     ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "query": query,
+            "sessionKey": session_key,
+            "topK": top_k,
+        }
+        if mode:
+            body["mode"] = mode
         resp = await self._http.post(
             "/recall",
-            json={
-                "query": query,
-                "sessionKey": session_key,
-                "topK": top_k,
-                "mode": mode,
-            },
+            json=body,
         )
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]
@@ -77,6 +79,25 @@ class RemnicClient:
 
     async def search(self, query: str, *, top_k: int = 10) -> dict[str, Any]:
         resp = await self._http.post("/search", json={"query": query, "topK": top_k})
+        resp.raise_for_status()
+        return resp.json()  # type: ignore[no-any-return]
+
+    async def lcm_search(
+        self,
+        query: str,
+        *,
+        session_key: str = "",
+        namespace: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"query": query}
+        if session_key:
+            body["sessionKey"] = session_key
+        if namespace:
+            body["namespace"] = namespace
+        if limit is not None:
+            body["limit"] = limit
+        resp = await self._http.post("/lcm/search", json=body)
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -157,7 +157,12 @@ class RemnicMemoryProvider:
                 "query": {"type": "string", "description": "Search query"},
                 "sessionKey": {"type": "string", "description": "Optional session filter"},
                 "namespace": {"type": "string"},
-                "limit": {"type": "number", "description": "Max results to return"},
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Max results to return",
+                },
             },
             "required": ["query"],
             "additionalProperties": False,
@@ -221,7 +226,7 @@ class RemnicMemoryProvider:
             return {"error": "Not connected to Remnic"}
         return await self._client.lcm_search(
             query=query,
-            session_key=sessionKey or self._session_key,
+            session_key=sessionKey,
             namespace=namespace,
             limit=limit,
         )

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -63,7 +63,6 @@ class RemnicMemoryProvider:
                 query=query,
                 session_key=self._session_key,
                 top_k=8,
-                mode="minimal",
             )
             context = result.get("context", "")
             count = result.get("count", 0)
@@ -149,6 +148,21 @@ class RemnicMemoryProvider:
             "required": ["query"],
         },
     }
+    lcm_search_schema = {
+        "name": "remnic_lcm_search",
+        "description": "Search the daemon-side Lossless Context Management conversation archive",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "sessionKey": {"type": "string", "description": "Optional session filter"},
+                "namespace": {"type": "string"},
+                "limit": {"type": "number", "description": "Max results to return"},
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    }
 
     # Legacy schemas — same handlers, engram_* tool names. Kept so existing
     # Hermes configs that reference engram_recall / engram_store / engram_search
@@ -170,6 +184,11 @@ class RemnicMemoryProvider:
         "name": "engram_search",
         "description": "Full-text search across all Engram memories",
     }
+    legacy_lcm_search_schema = {
+        **lcm_search_schema,
+        "name": "engram_lcm_search",
+        "description": "Search the daemon-side Engram Lossless Context Management conversation archive",
+    }
 
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
@@ -188,6 +207,24 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.search(query=query)
+
+    async def lcm_search(
+        self,
+        query: str,
+        sessionKey: str = "",
+        namespace: str | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Tool handler for remnic_lcm_search / engram_lcm_search."""
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.lcm_search(
+            query=query,
+            session_key=sessionKey or self._session_key,
+            namespace=namespace,
+            limit=limit,
+        )
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_client.py
+++ b/packages/plugin-hermes/tests/test_client.py
@@ -34,6 +34,52 @@ class TestClientClose:
         client._http.aclose.assert_awaited_once()
 
 
+class TestClientRecall:
+    @pytest.mark.asyncio
+    async def test_recall_omits_mode_by_default(self, client):
+        response = MagicMock()
+        response.json.return_value = {"context": "memory", "count": 1}
+        client._http = MagicMock()
+        client._http.post = AsyncMock(return_value=response)
+
+        await client.recall("what did we decide", session_key="hermes-session")
+
+        client._http.post.assert_awaited_once_with(
+            "/recall",
+            json={
+                "query": "what did we decide",
+                "sessionKey": "hermes-session",
+                "topK": 8,
+            },
+        )
+
+
+class TestClientLcmSearch:
+    @pytest.mark.asyncio
+    async def test_lcm_search_posts_to_lcm_endpoint(self, client):
+        response = MagicMock()
+        response.json.return_value = {"query": "archive", "results": [], "count": 0}
+        client._http = MagicMock()
+        client._http.post = AsyncMock(return_value=response)
+
+        await client.lcm_search(
+            "archive",
+            session_key="hermes-session",
+            namespace="research",
+            limit=5,
+        )
+
+        client._http.post.assert_awaited_once_with(
+            "/lcm/search",
+            json={
+                "query": "archive",
+                "sessionKey": "hermes-session",
+                "namespace": "research",
+                "limit": 5,
+            },
+        )
+
+
 class TestLegacyAlias:
     def test_engram_client_is_alias(self):
         """The legacy EngramClient name resolves to RemnicClient."""

--- a/packages/plugin-hermes/tests/test_provider.py
+++ b/packages/plugin-hermes/tests/test_provider.py
@@ -96,6 +96,23 @@ class TestPreLlmCall:
             assert result.endswith("</remnic-memory>")
 
 
+    @pytest.mark.asyncio
+    async def test_default_recall_does_not_force_minimal_mode(self, provider):
+        """pre_llm_call should let daemon recall defaults include LCM sections."""
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health = AsyncMock()
+            instance.recall = AsyncMock(return_value={"context": "prior", "count": 1})
+
+            await provider.initialize()
+            await provider.pre_llm_call(
+                [{"role": "user", "content": "what did we decide last week"}]
+            )
+
+            _, kwargs = instance.recall.call_args
+            assert "mode" not in kwargs
+
+
 class TestSyncTurn:
     @pytest.mark.asyncio
     async def test_no_op_without_client(self, provider):
@@ -120,6 +137,37 @@ class TestSyncTurn:
             instance.observe.assert_awaited_once()
             call_args = instance.observe.call_args
             assert len(call_args.kwargs["messages"]) == 2
+
+
+class TestLcmSearchTool:
+    def test_lcm_schema_matches_daemon_surface(self, provider):
+        schema = provider.lcm_search_schema["parameters"]
+
+        assert provider.lcm_search_schema["name"] == "remnic_lcm_search"
+        assert schema["required"] == ["query"]
+        assert schema["additionalProperties"] is False
+        assert set(schema["properties"]) == {"query", "sessionKey", "namespace", "limit"}
+
+    @pytest.mark.asyncio
+    async def test_lcm_search_handler_uses_client(self, provider):
+        client = AsyncMock()
+        client.lcm_search = AsyncMock(return_value={"count": 1, "results": []})
+        provider._client = client
+
+        result = await provider.lcm_search(
+            "archive",
+            sessionKey="explicit-session",
+            namespace="research",
+            limit=3,
+        )
+
+        assert result == {"count": 1, "results": []}
+        client.lcm_search.assert_awaited_once_with(
+            query="archive",
+            session_key="explicit-session",
+            namespace="research",
+            limit=3,
+        )
 
 
 class TestLegacyAlias:

--- a/packages/plugin-hermes/tests/test_provider.py
+++ b/packages/plugin-hermes/tests/test_provider.py
@@ -147,6 +147,9 @@ class TestLcmSearchTool:
         assert schema["required"] == ["query"]
         assert schema["additionalProperties"] is False
         assert set(schema["properties"]) == {"query", "sessionKey", "namespace", "limit"}
+        assert schema["properties"]["limit"]["type"] == "integer"
+        assert schema["properties"]["limit"]["minimum"] == 1
+        assert schema["properties"]["limit"]["maximum"] == 100
 
     @pytest.mark.asyncio
     async def test_lcm_search_handler_uses_client(self, provider):
@@ -167,6 +170,21 @@ class TestLcmSearchTool:
             session_key="explicit-session",
             namespace="research",
             limit=3,
+        )
+
+    @pytest.mark.asyncio
+    async def test_lcm_search_handler_preserves_unscoped_calls(self, provider):
+        client = AsyncMock()
+        client.lcm_search = AsyncMock(return_value={"count": 2, "results": []})
+        provider._client = client
+
+        await provider.lcm_search("archive")
+
+        client.lcm_search.assert_awaited_once_with(
+            query="archive",
+            session_key="",
+            namespace=None,
+            limit=None,
         )
 
 

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -27,6 +27,9 @@ def test_register_prefers_remnic_config_key():
         provider.search_schema = {"name": "remnic_search"}
         provider.legacy_search_schema = {"name": "engram_search"}
         provider.search = object()
+        provider.lcm_search_schema = {"name": "remnic_lcm_search"}
+        provider.legacy_lcm_search_schema = {"name": "engram_lcm_search"}
+        provider.lcm_search = object()
 
         register(ctx)
 
@@ -37,9 +40,11 @@ def test_register_prefers_remnic_config_key():
     assert "remnic_recall" in registered_tools
     assert "remnic_store" in registered_tools
     assert "remnic_search" in registered_tools
+    assert "remnic_lcm_search" in registered_tools
     assert "engram_recall" in registered_tools
     assert "engram_store" in registered_tools
     assert "engram_search" in registered_tools
+    assert "engram_lcm_search" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():
@@ -61,6 +66,9 @@ def test_register_falls_back_to_engram_config_key():
         provider.search_schema = {}
         provider.legacy_search_schema = {}
         provider.search = object()
+        provider.lcm_search_schema = {}
+        provider.legacy_lcm_search_schema = {}
+        provider.lcm_search = object()
 
         register(ctx)
 


### PR DESCRIPTION
## Summary
- wire Hermes remnic_lcm_search and engram_lcm_search tools to the daemon LCM search endpoint
- leave recall mode unset so daemon defaults can include LCM recall sections
- document that LCM stays in the Hermes memory_provider path, not context_engine

Closes #803

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- npm run check-types && npm run check-config-contract && bash scripts/check-review-patterns.sh
- npm run review:cursor (script exited 0 but skipped because cursor-agent rejected --trust)
- npm run preflight:quick attempted; static gates completed, then npm test expanded to the full workspace suite and hit unrelated benchmark/runtime failures before hanging in unrelated core LCM tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the recall request payload and adds a new tool/endpoint integration; this can alter what context is injected into prompts and should be validated against daemon expectations.
> 
> **Overview**
> Hermes Remnic plugin now exposes an explicit LCM archive search tool (`remnic_lcm_search`) plus a legacy alias (`engram_lcm_search`) and declares these tools in `plugin.yaml` so Hermes can surface them.
> 
> Automatic recall no longer forces `mode: "minimal"`; the client now omits `mode` unless explicitly set, allowing daemon defaults (including LCM-enriched recall) to take effect. Docs and tests are updated to cover the new tool, new endpoint call (`POST /lcm/search`), and the revised recall payload behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7235a8bb3b11c804681ac967b29cac4c56a190a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->