### PR TITLE
feat(hermes): expose recall debug tools

### DIFF
--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -230,11 +230,20 @@ Closes the `httpx.AsyncClient`. Safe to call when the client was never initializ
 | `remnic_recall` | `query: string` | Recall memories from Remnic matching a natural language query |
 | `remnic_store` | `content: string` | Store a memory in Remnic for future recall |
 | `remnic_search` | `query: string` | Full-text search across all Remnic memories |
-| `remnic_lcm_search` | `query: string`, `sessionKey?: string`, `namespace?: string`, `limit?: number` | Search the daemon-side LCM conversation archive |
+| `remnic_lcm_search` | `query: string`, `sessionKey?: string`, `namespace?: string`, `limit?: integer` | Search the daemon-side LCM conversation archive |
+| `remnic_recall_explain` | `sessionKey?: string`, `namespace?: string` | Return the last recall snapshot |
+| `remnic_recall_tier_explain` | `sessionKey?: string`, `namespace?: string` | Return tier attribution for the last direct-answer recall |
+| `remnic_recall_xray` | `query: string`, `sessionKey?: string`, `namespace?: string`, `budget?: integer`, `disclosure?: chunk|section|raw` | Run recall with X-ray attribution capture |
+| `remnic_memory_last_recall` | `sessionKey?: string` | Fetch the memory IDs injected in the last recall |
+| `remnic_memory_intent_debug` | `namespace?: string` | Inspect the latest intent/planner snapshot |
+| `remnic_memory_qmd_debug` | `namespace?: string` | Inspect the latest QMD recall snapshot |
+| `remnic_memory_graph_explain` | `namespace?: string` | Inspect graph recall expansion from the last recall |
+| `remnic_memory_feedback_last_recall` | `memoryId: string`, `vote: up|down`, `note?: string` | Record relevance feedback for a recalled memory |
+| `remnic_set_coding_context` | `sessionKey: string`, `codingContext?: object|null`, `projectTag?: string` | Attach coding project context to a session |
 
-Each tool handler returns the raw JSON response from the daemon or `{"error": "Not connected to Remnic"}` when the client is not initialized.
+Each tool handler returns the raw JSON response from the daemon or `{"error": "Not connected to Remnic"}` when the client is not initialized. Debug and explain tools are forwarded through the daemon's MCP endpoint because those surfaces are MCP-native.
 
-The `remnic_*` tools give the agent explicit control for cases where automatic recall is insufficient — for example, storing a specific fact the agent has derived mid-session, or searching the LCM archive directly.
+The `remnic_*` tools give the agent explicit control for cases where automatic recall is insufficient — for example, storing a specific fact the agent has derived mid-session, searching the LCM archive directly, or inspecting why a recall result appeared.
 
 ---
 
@@ -290,13 +299,14 @@ curl -s http://127.0.0.1:4318/engram/v1/health
 
 ## Engram compat window
 
-During the Engram to Remnic rebrand, the plugin registers six tools instead of three:
+During the Engram to Remnic rebrand, the plugin registers legacy aliases for every Remnic tool:
 
 | Tool name | Status | Notes |
 |-----------|--------|-------|
 | `remnic_recall` | Current | Use for new integrations |
 | `remnic_store` | Current | Use for new integrations |
 | `remnic_search` | Current | Use for new integrations |
+| `remnic_lcm_search` | Current | Use for new integrations |
 | `engram_recall` | Legacy alias | Routes to the same handler as `remnic_recall` |
 | `engram_store` | Legacy alias | Routes to the same handler as `remnic_store` |
 | `engram_search` | Legacy alias | Routes to the same handler as `remnic_search` |

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -119,8 +119,17 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_store` | Store a memory explicitly |
 | `remnic_search` | Full-text search across all stored memories |
 | `remnic_lcm_search` | Search the daemon-side LCM conversation archive |
+| `remnic_recall_explain` | Inspect the last recall snapshot |
+| `remnic_recall_tier_explain` | Inspect tier attribution for the last direct-answer recall |
+| `remnic_recall_xray` | Run recall with X-ray attribution capture |
+| `remnic_memory_last_recall` | Fetch the memory IDs injected in the last recall |
+| `remnic_memory_intent_debug` | Inspect the latest intent/planner snapshot |
+| `remnic_memory_qmd_debug` | Inspect the latest QMD recall snapshot |
+| `remnic_memory_graph_explain` | Inspect graph recall expansion from the last recall |
+| `remnic_memory_feedback_last_recall` | Record relevance feedback for a recalled memory |
+| `remnic_set_coding_context` | Attach coding project context to a session |
 
-During the Engram to Remnic compat window, three legacy aliases are also registered: `engram_recall`, `engram_store`, `engram_search`. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
+During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 
 ## Profiles and namespaces
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -20,6 +20,28 @@ __all__ = [
     "register",
 ]
 
+_RECALL_DEBUG_TOOLS = [
+    ("recall_explain", "recall_explain"),
+    ("recall_tier_explain", "recall_tier_explain"),
+    ("recall_xray", "recall_xray"),
+    ("memory_last_recall", "memory_last_recall"),
+    ("memory_intent_debug", "memory_intent_debug"),
+    ("memory_qmd_debug", "memory_qmd_debug"),
+    ("memory_graph_explain", "memory_graph_explain"),
+    ("memory_feedback_last_recall", "memory_feedback_last_recall"),
+    ("set_coding_context", "set_coding_context"),
+]
+
+
+def _register_recall_debug_tools(ctx, provider: RemnicMemoryProvider, prefix: str, legacy: bool = False):  # type: ignore[no-untyped-def]
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _RECALL_DEBUG_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
 
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
@@ -36,6 +58,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     ctx.register_tool(
         "remnic_lcm_search", provider.lcm_search_schema, provider.lcm_search
     )
+    _register_recall_debug_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -45,3 +68,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     ctx.register_tool(
         "engram_lcm_search", provider.legacy_lcm_search_schema, provider.lcm_search
     )
+    _register_recall_debug_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -26,8 +26,10 @@ class RemnicClient:
         timeout: float = 30.0,
     ) -> None:
         self.base_url = f"http://{host}:{port}/engram/v1"
+        self.mcp_url = f"http://{host}:{port}/mcp"
         self.token = token
         self.client_id = client_id
+        self._mcp_request_id = 0
         self._http = httpx.AsyncClient(
             base_url=self.base_url,
             timeout=timeout,
@@ -37,6 +39,23 @@ class RemnicClient:
                 "X-Engram-Client-Id": client_id,
             },
         )
+
+    async def _mcp_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        self._mcp_request_id += 1
+        resp = await self._http.post(
+            self.mcp_url,
+            json={
+                "jsonrpc": "2.0",
+                "id": self._mcp_request_id,
+                "method": "tools/call",
+                "params": {
+                    "name": name,
+                    "arguments": arguments,
+                },
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()  # type: ignore[no-any-return]
 
     async def recall(
         self,
@@ -100,6 +119,36 @@ class RemnicClient:
         resp = await self._http.post("/lcm/search", json=body)
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]
+
+    async def recall_explain(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.recall_explain", kwargs)
+
+    async def recall_tier_explain(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.recall_tier_explain", kwargs)
+
+    async def recall_xray(self, query: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.recall_xray", {"query": query, **kwargs})
+
+    async def memory_last_recall(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_last_recall", kwargs)
+
+    async def memory_intent_debug(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_intent_debug", kwargs)
+
+    async def memory_qmd_debug(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_qmd_debug", kwargs)
+
+    async def memory_graph_explain(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_graph_explain", kwargs)
+
+    async def memory_feedback_last_recall(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_feedback", kwargs)
+
+    async def set_coding_context(self, session_key: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool(
+            "engram.set_coding_context",
+            {"sessionKey": session_key, **kwargs},
+        )
 
     async def health(self) -> dict[str, Any]:
         resp = await self._http.get("/health")

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -9,6 +9,33 @@ from remnic_hermes.client import RemnicClient
 from remnic_hermes.config import RemnicHermesConfig
 
 
+_NAMESPACE = {"type": "string"}
+_STRING_ARRAY = {"type": "array", "items": {"type": "string"}}
+_DISCLOSURE = {"type": "string", "enum": ["chunk", "section", "raw"]}
+
+
+def _schema(
+    name: str,
+    description: str,
+    properties: dict[str, Any],
+    required: list[str] | None = None,
+    *,
+    additional_properties: bool = False,
+) -> dict[str, Any]:
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": additional_properties,
+    }
+    if required:
+        parameters["required"] = required
+    return {"name": name, "description": description, "parameters": parameters}
+
+
+def _legacy_schema(schema: dict[str, Any], name: str, description: str) -> dict[str, Any]:
+    return {**schema, "name": name, "description": description}
+
+
 class RemnicMemoryProvider:
     """MemoryProvider that delegates to the Remnic daemon via HTTP.
 
@@ -111,89 +138,199 @@ class RemnicMemoryProvider:
             await self._client.close()
             self._client = None
 
-    # -- Explicit tool schemas for Hermes tool registration --
+    # -- Existing explicit tool schemas for Hermes tool registration --
 
-    recall_schema = {
-        "name": "remnic_recall",
-        "description": "Recall memories from Remnic matching a natural language query",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string", "description": "Natural language recall query"},
-            },
-            "required": ["query"],
-        },
-    }
+    recall_schema = _schema(
+        "remnic_recall",
+        "Recall memories from Remnic matching a natural language query",
+        {"query": {"type": "string", "description": "Natural language recall query"}},
+        ["query"],
+    )
+    store_schema = _schema(
+        "remnic_store",
+        "Store a memory in Remnic for future recall",
+        {"content": {"type": "string", "description": "Memory content to store"}},
+        ["content"],
+        additional_properties=True,
+    )
+    search_schema = _schema(
+        "remnic_search",
+        "Full-text search across all Remnic memories",
+        {"query": {"type": "string", "description": "Search query"}},
+        ["query"],
+    )
 
-    store_schema = {
-        "name": "remnic_store",
-        "description": "Store a memory in Remnic for future recall",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "content": {"type": "string", "description": "Memory content to store"},
-            },
-            "required": ["content"],
-        },
-    }
+    legacy_recall_schema = _legacy_schema(
+        recall_schema,
+        "engram_recall",
+        "Recall memories from Engram matching a natural language query",
+    )
+    legacy_store_schema = _legacy_schema(
+        store_schema,
+        "engram_store",
+        "Store a memory in Engram for future recall",
+    )
+    legacy_search_schema = _legacy_schema(
+        search_schema,
+        "engram_search",
+        "Full-text search across all Engram memories",
+    )
 
-    search_schema = {
-        "name": "remnic_search",
-        "description": "Full-text search across all Remnic memories",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string", "description": "Search query"},
-            },
-            "required": ["query"],
-        },
-    }
-    lcm_search_schema = {
-        "name": "remnic_lcm_search",
-        "description": "Search the daemon-side Lossless Context Management conversation archive",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string", "description": "Search query"},
-                "sessionKey": {"type": "string", "description": "Optional session filter"},
-                "namespace": {"type": "string"},
-                "limit": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 100,
-                    "description": "Max results to return",
-                },
-            },
-            "required": ["query"],
-            "additionalProperties": False,
-        },
-    }
+    # -- Issue #804 recall debug / explain tool schemas --
 
-    # Legacy schemas — same handlers, engram_* tool names. Kept so existing
-    # Hermes configs that reference engram_recall / engram_store / engram_search
-    # continue to resolve. Descriptions keep the Engram brand so the tool name
-    # and description agree when LLMs surface the legacy names. Remove once
-    # the compat window closes.
-    legacy_recall_schema = {
-        **recall_schema,
-        "name": "engram_recall",
-        "description": "Recall memories from Engram matching a natural language query",
-    }
-    legacy_store_schema = {
-        **store_schema,
-        "name": "engram_store",
-        "description": "Store a memory in Engram for future recall",
-    }
-    legacy_search_schema = {
-        **search_schema,
-        "name": "engram_search",
-        "description": "Full-text search across all Engram memories",
-    }
-    legacy_lcm_search_schema = {
-        **lcm_search_schema,
-        "name": "engram_lcm_search",
-        "description": "Search the daemon-side Engram Lossless Context Management conversation archive",
-    }
+    recall_explain_schema = _schema(
+        "remnic_recall_explain",
+        "Return the last recall snapshot for a Hermes session or the most recent one.",
+        {"sessionKey": {"type": "string"}, "namespace": _NAMESPACE},
+    )
+    recall_tier_explain_schema = _schema(
+        "remnic_recall_tier_explain",
+        "Return structured tier attribution for the last direct-answer-eligible recall.",
+        {"sessionKey": {"type": "string"}, "namespace": _NAMESPACE},
+    )
+    recall_xray_schema = _schema(
+        "remnic_recall_xray",
+        "Run recall with X-ray attribution capture enabled.",
+        {
+            "query": {"type": "string", "description": "Query to recall against."},
+            "sessionKey": {"type": "string"},
+            "namespace": _NAMESPACE,
+            "budget": {"type": "integer", "minimum": 1},
+            "disclosure": _DISCLOSURE,
+        },
+        ["query"],
+    )
+    memory_last_recall_schema = _schema(
+        "remnic_memory_last_recall",
+        "Fetch the last set of memory IDs injected into context for a session.",
+        {"sessionKey": {"type": "string"}},
+    )
+    memory_intent_debug_schema = _schema(
+        "remnic_memory_intent_debug",
+        "Inspect the last persisted planner/intent snapshot.",
+        {"namespace": _NAMESPACE},
+    )
+    memory_qmd_debug_schema = _schema(
+        "remnic_memory_qmd_debug",
+        "Inspect the last persisted QMD recall snapshot.",
+        {"namespace": _NAMESPACE},
+    )
+    memory_graph_explain_schema = _schema(
+        "remnic_memory_graph_explain",
+        "Inspect the last graph-mode recall expansion snapshot.",
+        {"namespace": _NAMESPACE},
+    )
+    memory_feedback_last_recall_schema = _schema(
+        "remnic_memory_feedback_last_recall",
+        "Record relevance feedback for a memory returned by recall.",
+        {
+            "memoryId": {"type": "string"},
+            "vote": {"type": "string", "enum": ["up", "down"]},
+            "note": {"type": "string"},
+        },
+        ["memoryId", "vote"],
+    )
+    set_coding_context_schema = _schema(
+        "remnic_set_coding_context",
+        "Attach or clear coding context for a Hermes session.",
+        {
+            "sessionKey": {"type": "string"},
+            "codingContext": {
+                "anyOf": [
+                    {"type": "null"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "projectId": {"type": "string"},
+                            "branch": {"type": ["string", "null"]},
+                            "rootPath": {"type": "string"},
+                            "defaultBranch": {"type": ["string", "null"]},
+                        },
+                        "required": [
+                            "projectId",
+                            "branch",
+                            "rootPath",
+                            "defaultBranch",
+                        ],
+                        "additionalProperties": False,
+                    },
+                ]
+            },
+            "projectTag": {"type": "string"},
+        },
+        ["sessionKey"],
+    )
+    set_coding_context_schema["parameters"]["anyOf"] = [
+        {"required": ["codingContext"]},
+        {"required": ["projectTag"]},
+    ]
+    lcm_search_schema = _schema(
+        "remnic_lcm_search",
+        "Search the daemon-side Lossless Context Management conversation archive",
+        {
+            "query": {"type": "string", "description": "Search query"},
+            "sessionKey": {"type": "string", "description": "Optional session filter"},
+            "namespace": {"type": "string"},
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "description": "Max results to return",
+            },
+        },
+        ["query"],
+    )
+
+    legacy_recall_explain_schema = _legacy_schema(
+        recall_explain_schema,
+        "engram_recall_explain",
+        "Return the last Engram recall snapshot for a session or the most recent one.",
+    )
+    legacy_recall_tier_explain_schema = _legacy_schema(
+        recall_tier_explain_schema,
+        "engram_recall_tier_explain",
+        "Return structured Engram tier attribution for the last recall.",
+    )
+    legacy_recall_xray_schema = _legacy_schema(
+        recall_xray_schema,
+        "engram_recall_xray",
+        "Run Engram recall with X-ray attribution capture enabled.",
+    )
+    legacy_memory_last_recall_schema = _legacy_schema(
+        memory_last_recall_schema,
+        "engram_memory_last_recall",
+        "Fetch the last set of Engram memory IDs injected into context.",
+    )
+    legacy_memory_intent_debug_schema = _legacy_schema(
+        memory_intent_debug_schema,
+        "engram_memory_intent_debug",
+        "Inspect the last persisted Engram planner/intent snapshot.",
+    )
+    legacy_memory_qmd_debug_schema = _legacy_schema(
+        memory_qmd_debug_schema,
+        "engram_memory_qmd_debug",
+        "Inspect the last persisted Engram QMD recall snapshot.",
+    )
+    legacy_memory_graph_explain_schema = _legacy_schema(
+        memory_graph_explain_schema,
+        "engram_memory_graph_explain",
+        "Inspect the last Engram graph-mode recall expansion snapshot.",
+    )
+    legacy_memory_feedback_last_recall_schema = _legacy_schema(
+        memory_feedback_last_recall_schema,
+        "engram_memory_feedback_last_recall",
+        "Record Engram relevance feedback for a memory returned by recall.",
+    )
+    legacy_set_coding_context_schema = _legacy_schema(
+        set_coding_context_schema,
+        "engram_set_coding_context",
+        "Attach or clear coding context for an Engram session.",
+    )
+    legacy_lcm_search_schema = _legacy_schema(
+        lcm_search_schema,
+        "engram_lcm_search",
+        "Search the daemon-side Engram Lossless Context Management conversation archive",
+    )
 
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
@@ -230,6 +367,51 @@ class RemnicMemoryProvider:
             namespace=namespace,
             limit=limit,
         )
+
+    async def recall_explain(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.recall_explain(**kwargs)
+
+    async def recall_tier_explain(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.recall_tier_explain(**kwargs)
+
+    async def recall_xray(self, query: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.recall_xray(query=query, **kwargs)
+
+    async def memory_last_recall(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_last_recall(**kwargs)
+
+    async def memory_intent_debug(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_intent_debug(**kwargs)
+
+    async def memory_qmd_debug(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_qmd_debug(**kwargs)
+
+    async def memory_graph_explain(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_graph_explain(**kwargs)
+
+    async def memory_feedback_last_recall(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_feedback_last_recall(**kwargs)
+
+    async def set_coding_context(self, sessionKey: str, **kwargs: Any) -> dict[str, Any]:  # noqa: N803
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.set_coding_context(sessionKey, **kwargs)
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_804_recall_debug_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_804_recall_debug_tools.py
@@ -32,12 +32,7 @@ async def test_issue_804_client_methods_call_daemon_mcp_tools(client: RemnicClie
     await client.memory_feedback_last_recall(memoryId="fact-1", vote="down", note="stale")
     await client.set_coding_context(
         "hermes-session",
-        codingContext={
-            "projectId": "root:abc",
-            "branch": "main",
-            "rootPath": "/repo",
-            "defaultBranch": "main",
-        },
+        codingContext=None,
     )
 
     calls = client._http.post.await_args_list
@@ -63,6 +58,10 @@ async def test_issue_804_client_methods_call_daemon_mcp_tools(client: RemnicClie
         "memoryId": "fact-1",
         "vote": "down",
         "note": "stale",
+    }
+    assert calls[8].kwargs["json"]["params"]["arguments"] == {
+        "sessionKey": "hermes-session",
+        "codingContext": None,
     }
 
 
@@ -101,6 +100,10 @@ def test_issue_804_tools_are_registered_with_primary_and_legacy_names() -> None:
     assert expected_legacy.issubset(ctx.tools)
     assert ctx.tools["remnic_recall_xray"]["schema"]["parameters"]["required"] == ["query"]
     assert ctx.tools["remnic_set_coding_context"]["schema"]["parameters"]["required"] == ["sessionKey"]
+    assert ctx.tools["remnic_set_coding_context"]["schema"]["parameters"]["anyOf"] == [
+        {"required": ["codingContext"]},
+        {"required": ["projectTag"]},
+    ]
     assert ctx.tools["engram_memory_feedback_last_recall"]["schema"]["name"] == "engram_memory_feedback_last_recall"
 
 

--- a/packages/plugin-hermes/tests/test_issue_804_recall_debug_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_804_recall_debug_tools.py
@@ -99,6 +99,7 @@ def test_issue_804_tools_are_registered_with_primary_and_legacy_names() -> None:
     assert expected_primary.issubset(ctx.tools)
     assert expected_legacy.issubset(ctx.tools)
     assert ctx.tools["remnic_recall_xray"]["schema"]["parameters"]["required"] == ["query"]
+    assert ctx.tools["remnic_store"]["schema"]["parameters"]["additionalProperties"] is True
     assert ctx.tools["remnic_set_coding_context"]["schema"]["parameters"]["required"] == ["sessionKey"]
     assert ctx.tools["remnic_set_coding_context"]["schema"]["parameters"]["anyOf"] == [
         {"required": ["codingContext"]},

--- a/packages/plugin-hermes/tests/test_issue_804_recall_debug_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_804_recall_debug_tools.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_804_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.recall_explain(sessionKey="hermes-session", namespace="project")
+    await client.recall_tier_explain(namespace="project")
+    await client.recall_xray("why this memory", budget=1200, disclosure="section")
+    await client.memory_last_recall(sessionKey="hermes-session")
+    await client.memory_intent_debug(namespace="project")
+    await client.memory_qmd_debug(namespace="project")
+    await client.memory_graph_explain(namespace="project")
+    await client.memory_feedback_last_recall(memoryId="fact-1", vote="down", note="stale")
+    await client.set_coding_context(
+        "hermes-session",
+        codingContext={
+            "projectId": "root:abc",
+            "branch": "main",
+            "rootPath": "/repo",
+            "defaultBranch": "main",
+        },
+    )
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.recall_explain",
+        "engram.recall_tier_explain",
+        "engram.recall_xray",
+        "engram.memory_last_recall",
+        "engram.memory_intent_debug",
+        "engram.memory_qmd_debug",
+        "engram.memory_graph_explain",
+        "engram.memory_feedback",
+        "engram.set_coding_context",
+    ]
+    assert calls[0].args == ("http://127.0.0.1:4318/mcp",)
+    assert calls[2].kwargs["json"]["params"]["arguments"] == {
+        "query": "why this memory",
+        "budget": 1200,
+        "disclosure": "section",
+    }
+    assert calls[7].kwargs["json"]["params"]["arguments"] == {
+        "memoryId": "fact-1",
+        "vote": "down",
+        "note": "stale",
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_804_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_recall_explain",
+        "remnic_recall_tier_explain",
+        "remnic_recall_xray",
+        "remnic_memory_last_recall",
+        "remnic_memory_intent_debug",
+        "remnic_memory_qmd_debug",
+        "remnic_memory_graph_explain",
+        "remnic_memory_feedback_last_recall",
+        "remnic_set_coding_context",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_recall_xray"]["schema"]["parameters"]["required"] == ["query"]
+    assert ctx.tools["remnic_set_coding_context"]["schema"]["parameters"]["required"] == ["sessionKey"]
+    assert ctx.tools["engram_memory_feedback_last_recall"]["schema"]["name"] == "engram_memory_feedback_last_recall"
+
+
+@pytest.mark.asyncio
+async def test_issue_804_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.recall_explain() == {"error": "Not connected to Remnic"}
+    assert await provider.recall_xray("why this memory") == {"error": "Not connected to Remnic"}
+    assert await provider.set_coding_context("session") == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -3,6 +3,37 @@ from unittest.mock import patch
 
 from remnic_hermes import register
 
+_RECALL_DEBUG_TOOL_SUFFIXES = [
+    "recall_explain",
+    "recall_tier_explain",
+    "recall_xray",
+    "memory_last_recall",
+    "memory_intent_debug",
+    "memory_qmd_debug",
+    "memory_graph_explain",
+    "memory_feedback_last_recall",
+    "set_coding_context",
+]
+
+
+def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
+    provider.recall_schema = {"name": "remnic_recall"}
+    provider.legacy_recall_schema = {"name": "engram_recall"}
+    provider.recall = object()
+    provider.store_schema = {"name": "remnic_store"}
+    provider.legacy_store_schema = {"name": "engram_store"}
+    provider.store = object()
+    provider.search_schema = {"name": "remnic_search"}
+    provider.legacy_search_schema = {"name": "engram_search"}
+    provider.search = object()
+    provider.lcm_search_schema = {"name": "remnic_lcm_search"}
+    provider.legacy_lcm_search_schema = {"name": "engram_lcm_search"}
+    provider.lcm_search = object()
+    for suffix in _RECALL_DEBUG_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+
 
 def test_register_prefers_remnic_config_key():
     """Hermes registration should pass remnic-keyed config to the provider."""
@@ -17,19 +48,7 @@ def test_register_prefers_remnic_config_key():
     )
 
     with patch("remnic_hermes.RemnicMemoryProvider") as mock_provider:
-        provider = mock_provider.return_value
-        provider.recall_schema = {"name": "remnic_recall"}
-        provider.legacy_recall_schema = {"name": "engram_recall"}
-        provider.recall = object()
-        provider.store_schema = {"name": "remnic_store"}
-        provider.legacy_store_schema = {"name": "engram_store"}
-        provider.store = object()
-        provider.search_schema = {"name": "remnic_search"}
-        provider.legacy_search_schema = {"name": "engram_search"}
-        provider.search = object()
-        provider.lcm_search_schema = {"name": "remnic_lcm_search"}
-        provider.legacy_lcm_search_schema = {"name": "engram_lcm_search"}
-        provider.lcm_search = object()
+        _populate_provider_mock(mock_provider.return_value)
 
         register(ctx)
 
@@ -45,6 +64,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_store" in registered_tools
     assert "engram_search" in registered_tools
     assert "engram_lcm_search" in registered_tools
+    assert "remnic_recall_explain" in registered_tools
+    assert "engram_recall_explain" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():
@@ -56,19 +77,7 @@ def test_register_falls_back_to_engram_config_key():
     )
 
     with patch("remnic_hermes.RemnicMemoryProvider") as mock_provider:
-        provider = mock_provider.return_value
-        provider.recall_schema = {}
-        provider.legacy_recall_schema = {}
-        provider.recall = object()
-        provider.store_schema = {}
-        provider.legacy_store_schema = {}
-        provider.store = object()
-        provider.search_schema = {}
-        provider.legacy_search_schema = {}
-        provider.search = object()
-        provider.lcm_search_schema = {}
-        provider.legacy_lcm_search_schema = {}
-        provider.lcm_search = object()
+        _populate_provider_mock(mock_provider.return_value)
 
         register(ctx)
 


### PR DESCRIPTION
## Summary
- expose Hermes recall explain, tier explain, xray, last recall, intent, QMD, graph explain, feedback, and coding context tools
- forward tool calls to the daemon MCP JSON-RPC endpoint while preserving response shape
- document primary remnic_* names and legacy engram_* aliases

Closes #804

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- npm run check-types && npm run check-config-contract && bash scripts/check-review-patterns.sh
- npm run review:cursor (script exited 0 but skipped because cursor-agent rejected --trust)
- gtimeout 180s npm run preflight:quick; static gates completed, then npm test expanded to the full workspace suite and the bounded run was interrupted with unrelated tests still pending

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive, but introduces a new JSON-RPC call path to the daemon (`/mcp`) and expands the registered tool surface, which could cause runtime errors if the daemon MCP contract diverges or schema expectations are wrong.
> 
> **Overview**
> Exposes a new set of recall *debug/explain* tools in the Hermes Remnic plugin (e.g. `remnic_recall_explain`, `remnic_recall_xray`, intent/QMD/graph explain, feedback, and coding-context attachment), and registers matching legacy `engram_*` aliases during the compat window.
> 
> Implements MCP JSON-RPC forwarding in `RemnicClient` via a new `/mcp` endpoint helper and wires new provider handlers/schemas plus shared registration helper logic; updates docs/README accordingly and adds tests to verify tool registration and MCP call payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26678edbea30b2f8ec95be99e7638385e886bdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->