### PR TITLE
feat(hermes): expose memory inspection tools

### DIFF
--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -240,10 +240,22 @@ Closes the `httpx.AsyncClient`. Safe to call when the client was never initializ
 | `remnic_memory_graph_explain` | `namespace?: string` | Inspect graph recall expansion from the last recall |
 | `remnic_memory_feedback_last_recall` | `memoryId: string`, `vote: up|down`, `note?: string` | Record relevance feedback for a recalled memory |
 | `remnic_set_coding_context` | `sessionKey: string`, `codingContext?: object|null`, `projectTag?: string` | Attach coding project context to a session |
+| `remnic_memory_get` | `memoryId: string`, `namespace?: string` | Fetch one stored memory by id |
+| `remnic_memory_store` | `content: string`, plus memory metadata fields | Store a memory with the daemon's richer memory-store schema |
+| `remnic_memory_timeline` | `memoryId: string`, `namespace?: string`, `limit?: number` | Fetch the timeline for one stored memory |
+| `remnic_memory_profile` | `namespace?: string` | Read the user profile surface |
+| `remnic_memory_entities` | `namespace?: string` | List tracked entities |
+| `remnic_memory_questions` | `namespace?: string` | List open memory questions |
+| `remnic_memory_identity` | `namespace?: string` | Read identity memory state |
+| `remnic_memory_promote` | `memoryId: string`, `namespace?: string`, `sessionKey?: string` | Promote a memory candidate or stored memory |
+| `remnic_memory_outcome` | `memoryId: string`, `outcome: success|failure`, `namespace?: string`, `sessionKey?: string`, `timestamp?: string` | Record or inspect a memory outcome |
+| `remnic_entity_get` | `name: string`, `namespace?: string` | Fetch one tracked entity by name |
+| `remnic_memory_capture` | `content: string`, plus memory metadata fields | Capture an explicit memory note |
+| `remnic_memory_action_apply` | `action: string`, plus action-specific fields | Apply a memory action |
 
-Each tool handler returns the raw JSON response from the daemon or `{"error": "Not connected to Remnic"}` when the client is not initialized. Debug and explain tools are forwarded through the daemon's MCP endpoint because those surfaces are MCP-native.
+Each tool handler returns the raw JSON response from the daemon or `{"error": "Not connected to Remnic"}` when the client is not initialized. Direct memory tools use the daemon's REST endpoints where available; debug, explain, and MCP-native memory surfaces are forwarded through the daemon MCP endpoint.
 
-The `remnic_*` tools give the agent explicit control for cases where automatic recall is insufficient — for example, storing a specific fact the agent has derived mid-session, searching the LCM archive directly, or inspecting why a recall result appeared.
+The `remnic_*` tools give the agent explicit control for cases where automatic recall is insufficient — for example, storing a specific fact the agent has derived mid-session, searching the LCM archive directly, inspecting why a recall result appeared, or curating stored memories.
 
 ---
 

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -128,8 +128,22 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_memory_graph_explain` | Inspect graph recall expansion from the last recall |
 | `remnic_memory_feedback_last_recall` | Record relevance feedback for a recalled memory |
 | `remnic_set_coding_context` | Attach coding project context to a session |
+| `remnic_memory_get` | Fetch one stored memory by id |
+| `remnic_memory_store` | Store a memory with the daemon's richer memory-store schema |
+| `remnic_memory_timeline` | Fetch the timeline for one stored memory |
+| `remnic_memory_profile` | Read the user profile surface |
+| `remnic_memory_entities` | List tracked entities |
+| `remnic_memory_questions` | List open memory questions |
+| `remnic_memory_identity` | Read identity memory state |
+| `remnic_memory_promote` | Promote a memory candidate or stored memory |
+| `remnic_memory_outcome` | Record or inspect a memory outcome |
+| `remnic_entity_get` | Fetch one tracked entity by name |
+| `remnic_memory_capture` | Capture an explicit memory note |
+| `remnic_memory_action_apply` | Apply a memory action |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
+
+The existing simple `remnic_store` / `engram_store` compatibility tools remain available. Use `remnic_memory_store` / `engram_memory_store` when the caller needs the richer daemon schema.
 
 ## Profiles and namespaces
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -43,11 +43,73 @@ def _register_recall_debug_tools(ctx, provider: RemnicMemoryProvider, prefix: st
         )
 
 
+def _register_issue_805_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    ctx.register_tool(
+        f"{prefix}_memory_get",
+        getattr(provider, f"{schema_prefix}memory_get_schema"),
+        provider.memory_get,
+    )
+    ctx.register_tool(
+        f"{prefix}_memory_store",
+        getattr(provider, f"{schema_prefix}memory_store_schema"),
+        provider.memory_store,
+    )
+    ctx.register_tool(
+        f"{prefix}_memory_timeline",
+        getattr(provider, f"{schema_prefix}memory_timeline_schema"),
+        provider.memory_timeline,
+    )
+    ctx.register_tool(
+        f"{prefix}_memory_profile",
+        getattr(provider, f"{schema_prefix}memory_profile_schema"),
+        provider.memory_profile,
+    )
+    ctx.register_tool(
+        f"{prefix}_memory_entities",
+        getattr(provider, f"{schema_prefix}memory_entities_schema"),
+        provider.memory_entities,
+    )
+    ctx.register_tool(
+        f"{prefix}_memory_questions",
+        getattr(provider, f"{schema_prefix}memory_questions_schema"),
+        provider.memory_questions,
+    )
+    ctx.register_tool(
+        f"{prefix}_memory_identity",
+        getattr(provider, f"{schema_prefix}memory_identity_schema"),
+        provider.memory_identity,
+    )
+    ctx.register_tool(
+        f"{prefix}_memory_promote",
+        getattr(provider, f"{schema_prefix}memory_promote_schema"),
+        provider.memory_promote,
+    )
+    ctx.register_tool(
+        f"{prefix}_memory_outcome",
+        getattr(provider, f"{schema_prefix}memory_outcome_schema"),
+        provider.memory_outcome,
+    )
+    ctx.register_tool(f"{prefix}_entity_get", getattr(provider, f"{schema_prefix}entity_get_schema"), provider.entity_get)
+    ctx.register_tool(f"{prefix}_memory_capture", getattr(provider, f"{schema_prefix}memory_capture_schema"), provider.memory_capture)
+    ctx.register_tool(
+        f"{prefix}_memory_action_apply",
+        getattr(provider, f"{schema_prefix}memory_action_apply_schema"),
+        provider.memory_action_apply,
+    )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
     if not isinstance(config, dict):
         config = ctx.config.get("engram", {})
+
     provider = RemnicMemoryProvider(config)
     ctx.register_memory_provider(provider)
 
@@ -59,6 +121,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
         "remnic_lcm_search", provider.lcm_search_schema, provider.lcm_search
     )
     _register_recall_debug_tools(ctx, provider, "remnic")
+    _register_issue_805_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -69,3 +132,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
         "engram_lcm_search", provider.legacy_lcm_search_schema, provider.lcm_search
     )
     _register_recall_debug_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_805_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -40,6 +41,21 @@ class RemnicClient:
             },
         )
 
+    async def _post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        resp = await self._http.post(path, json=payload)
+        resp.raise_for_status()
+        return resp.json()  # type: ignore[no-any-return]
+
+    async def _get_json(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        clean_params = {
+            key: value
+            for key, value in (params or {}).items()
+            if value is not None
+        }
+        resp = await self._http.get(path, params=clean_params)
+        resp.raise_for_status()
+        return resp.json()  # type: ignore[no-any-return]
+
     async def _mcp_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         self._mcp_request_id += 1
         resp = await self._http.post(
@@ -55,7 +71,10 @@ class RemnicClient:
             },
         )
         resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+        payload = resp.json()
+        if "error" in payload:
+            raise RuntimeError(str(payload["error"]))
+        return payload.get("result", payload)  # type: ignore[no-any-return]
 
     async def recall(
         self,
@@ -72,34 +91,24 @@ class RemnicClient:
         }
         if mode:
             body["mode"] = mode
-        resp = await self._http.post(
-            "/recall",
-            json=body,
-        )
-        resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+        return await self._post_json("/recall", body)
 
     async def observe(
         self,
         session_key: str,
         messages: list[dict[str, str]],
+        **kwargs: Any,
     ) -> dict[str, Any]:
-        resp = await self._http.post(
+        return await self._post_json(
             "/observe",
-            json={"sessionKey": session_key, "messages": messages},
+            {"sessionKey": session_key, "messages": messages, **kwargs},
         )
-        resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
 
     async def store(self, content: str, **kwargs: Any) -> dict[str, Any]:
-        resp = await self._http.post("/memories", json={"content": content, **kwargs})
-        resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+        return await self._post_json("/memories", {"content": content, **kwargs})
 
     async def search(self, query: str, *, top_k: int = 10) -> dict[str, Any]:
-        resp = await self._http.post("/search", json={"query": query, "topK": top_k})
-        resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+        return await self._post_json("/search", {"query": query, "topK": top_k})
 
     async def lcm_search(
         self,
@@ -116,9 +125,7 @@ class RemnicClient:
             body["namespace"] = namespace
         if limit is not None:
             body["limit"] = limit
-        resp = await self._http.post("/lcm/search", json=body)
-        resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+        return await self._post_json("/lcm/search", body)
 
     async def recall_explain(self, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.recall_explain", kwargs)
@@ -151,9 +158,43 @@ class RemnicClient:
         )
 
     async def health(self) -> dict[str, Any]:
-        resp = await self._http.get("/health")
-        resp.raise_for_status()
-        return resp.json()  # type: ignore[no-any-return]
+        return await self._get_json("/health")
+
+    async def memory_get(self, memory_id: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._get_json(f"/memories/{quote(memory_id, safe='')}", kwargs)
+
+    async def memory_store(self, content: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._post_json("/memories", {"content": content, **kwargs})
+
+    async def memory_timeline(self, memory_id: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._get_json(f"/memories/{quote(memory_id, safe='')}/timeline", kwargs)
+
+    async def memory_entities(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_entities_list", kwargs)
+
+    async def entity_get(self, name: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._get_json(f"/entities/{quote(name, safe='')}", kwargs)
+
+    async def memory_profile(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_profile", kwargs)
+
+    async def memory_questions(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_questions", kwargs)
+
+    async def memory_identity(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_identity", kwargs)
+
+    async def memory_promote(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_promote", kwargs)
+
+    async def memory_outcome(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_outcome", kwargs)
+
+    async def memory_capture(self, content: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_store", {"content": content, **kwargs})
+
+    async def memory_action_apply(self, action: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_action_apply", {"action": action, **kwargs})
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -12,6 +12,33 @@ from remnic_hermes.config import RemnicHermesConfig
 _NAMESPACE = {"type": "string"}
 _STRING_ARRAY = {"type": "array", "items": {"type": "string"}}
 _DISCLOSURE = {"type": "string", "enum": ["chunk", "section", "raw"]}
+_MEMORY_CATEGORY = {
+    "type": "string",
+    "enum": [
+        "fact",
+        "preference",
+        "correction",
+        "entity",
+        "decision",
+        "relationship",
+        "principle",
+        "commitment",
+        "moment",
+        "skill",
+        "rule",
+        "procedure",
+        "reasoning_trace",
+    ],
+}
+_ACTION_TYPES = [
+    "store_episode",
+    "store_note",
+    "update_note",
+    "create_artifact",
+    "summarize_node",
+    "discard",
+    "link_graph",
+]
 
 
 def _schema(
@@ -39,14 +66,6 @@ def _legacy_schema(schema: dict[str, Any], name: str, description: str) -> dict[
 class RemnicMemoryProvider:
     """MemoryProvider that delegates to the Remnic daemon via HTTP.
 
-    Lifecycle:
-      - initialize()        → connect to Remnic, verify health
-      - pre_llm_call()      → recall relevant memories, inject into system prompt
-      - sync_turn()         → observe the latest conversation turn
-      - extract_memories()  → structured extraction at session end
-      - shutdown()          → close HTTP client
-    """
-
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         cfg = RemnicHermesConfig.from_hermes_config(config or {})
         self._host = cfg.host
@@ -65,17 +84,17 @@ class RemnicMemoryProvider:
             client_id="hermes",
             timeout=self._timeout,
         )
+
         try:
             await self._client.health()
         except Exception:
-            pass  # Non-fatal — daemon might start later
+            pass  # Non-fatal — daemon might start later.
 
     async def pre_llm_call(self, messages: list[dict[str, str]]) -> str:
         """Recall relevant memories and return context to inject into system prompt."""
         if not self._client:
             return ""
 
-        # Use the last user message as the recall query
         query = ""
         for msg in reversed(messages):
             if msg.get("role") == "user":
@@ -105,8 +124,8 @@ class RemnicMemoryProvider:
         if not self._client or not transcript:
             return
 
-        # Send the last 2 messages (user + assistant)
         recent = transcript[-2:] if len(transcript) >= 2 else transcript
+
         try:
             await self._client.observe(
                 session_key=self._session_key,
@@ -332,6 +351,176 @@ class RemnicMemoryProvider:
         "Search the daemon-side Engram Lossless Context Management conversation archive",
     )
 
+    # -- Issue #805 memory CRUD / inspection tool schemas --
+
+    memory_get_schema = _schema(
+        "remnic_memory_get",
+        "Fetch one stored memory by id.",
+        {"memoryId": {"type": "string"}, "namespace": _NAMESPACE},
+        ["memoryId"],
+    )
+    memory_store_schema = _schema(
+        "remnic_memory_store",
+        "Store a memory with the daemon's rich memory_store schema.",
+        {
+            "schemaVersion": {"type": "number"},
+            "idempotencyKey": {"type": "string"},
+            "dryRun": {"type": "boolean"},
+            "sessionKey": {"type": "string"},
+            "content": {"type": "string"},
+            "category": {"type": "string"},
+            "confidence": {"type": "number"},
+            "namespace": _NAMESPACE,
+            "tags": _STRING_ARRAY,
+            "entityRef": {"type": "string"},
+            "ttl": {"type": "string"},
+            "sourceReason": {"type": "string"},
+        },
+        ["content"],
+    )
+    memory_timeline_schema = _schema(
+        "remnic_memory_timeline",
+        "Read the event timeline for a stored memory.",
+        {"memoryId": {"type": "string"}, "namespace": _NAMESPACE, "limit": {"type": "number"}},
+        ["memoryId"],
+    )
+    memory_profile_schema = _schema(
+        "remnic_memory_profile",
+        "Read the user's behavioral profile.",
+        {"namespace": _NAMESPACE},
+    )
+    memory_entities_schema = _schema(
+        "remnic_memory_entities",
+        "List tracked entities.",
+        {"namespace": _NAMESPACE},
+    )
+    memory_questions_schema = _schema(
+        "remnic_memory_questions",
+        "List open memory questions.",
+        {"namespace": _NAMESPACE},
+    )
+    memory_identity_schema = _schema(
+        "remnic_memory_identity",
+        "Read identity memory state.",
+        {"namespace": _NAMESPACE},
+    )
+    memory_promote_schema = _schema(
+        "remnic_memory_promote",
+        "Promote a memory candidate or review item.",
+        {
+            "memoryId": {"type": "string"},
+            "namespace": _NAMESPACE,
+            "sessionKey": {"type": "string"},
+        },
+        ["memoryId"],
+    )
+    memory_outcome_schema = _schema(
+        "remnic_memory_outcome",
+        "Record or inspect an outcome for a memory action.",
+        {
+            "memoryId": {"type": "string"},
+            "outcome": {"type": "string", "enum": ["success", "failure"]},
+            "namespace": _NAMESPACE,
+            "sessionKey": {"type": "string"},
+            "timestamp": {
+                "type": "string",
+                "description": "Optional ISO-8601 timestamp of the observation.",
+            },
+        },
+        ["memoryId", "outcome"],
+    )
+    entity_get_schema = _schema(
+        "remnic_entity_get",
+        "Fetch one tracked entity by name.",
+        {"name": {"type": "string"}, "namespace": _NAMESPACE},
+        ["name"],
+    )
+    memory_capture_schema = _schema(
+        "remnic_memory_capture",
+        "Capture an explicit memory using the OpenClaw memory_capture surface.",
+        {
+            "content": {"type": "string"},
+            "namespace": _NAMESPACE,
+            "category": _MEMORY_CATEGORY,
+            "tags": _STRING_ARRAY,
+            "entityRef": {"type": "string"},
+            "confidence": {"type": "number"},
+            "ttl": {"type": "string"},
+            "sourceReason": {"type": "string"},
+        },
+        ["content"],
+    )
+    memory_action_apply_schema = _schema(
+        "remnic_memory_action_apply",
+        "Apply a memory action using the OpenClaw memory_action_apply surface.",
+        {
+            "action": {
+                "type": "string",
+                "enum": _ACTION_TYPES,
+            },
+            "category": _MEMORY_CATEGORY,
+            "content": {"type": "string"},
+            "outcome": {"type": "string", "enum": ["applied", "skipped", "failed"]},
+            "reason": {"type": "string"},
+            "memoryId": {"type": "string"},
+            "sessionKey": {"type": "string"},
+            "linkTargetId": {"type": "string"},
+            "linkType": {"type": "string"},
+            "linkStrength": {"type": "number"},
+            "artifactType": {"type": "string"},
+            "execute": {"type": "boolean"},
+            "sourcePrompt": {"type": "string"},
+            "namespace": _NAMESPACE,
+            "dryRun": {"type": "boolean"},
+        },
+        ["action"],
+    )
+
+    legacy_memory_get_schema = _legacy_schema(memory_get_schema, "engram_memory_get", "Fetch one Engram memory by id.")
+    legacy_memory_store_schema = _legacy_schema(memory_store_schema, "engram_memory_store", "Store a memory in Engram.")
+    legacy_memory_timeline_schema = _legacy_schema(
+        memory_timeline_schema,
+        "engram_memory_timeline",
+        "Read an Engram memory timeline.",
+    )
+    legacy_memory_profile_schema = _legacy_schema(
+        memory_profile_schema,
+        "engram_memory_profile",
+        "Read the Engram behavioral profile.",
+    )
+    legacy_memory_entities_schema = _legacy_schema(
+        memory_entities_schema,
+        "engram_memory_entities",
+        "List Engram tracked entities.",
+    )
+    legacy_memory_questions_schema = _legacy_schema(
+        memory_questions_schema,
+        "engram_memory_questions",
+        "List Engram memory questions.",
+    )
+    legacy_memory_identity_schema = _legacy_schema(
+        memory_identity_schema,
+        "engram_memory_identity",
+        "Read Engram identity memory state.",
+    )
+    legacy_memory_promote_schema = _legacy_schema(
+        memory_promote_schema,
+        "engram_memory_promote",
+        "Promote an Engram memory candidate.",
+    )
+    legacy_memory_outcome_schema = _legacy_schema(
+        memory_outcome_schema,
+        "engram_memory_outcome",
+        "Record or inspect an Engram memory outcome.",
+    )
+    legacy_entity_get_schema = _legacy_schema(entity_get_schema, "engram_entity_get", "Fetch one Engram tracked entity by name.")
+    legacy_memory_capture_schema = _legacy_schema(memory_capture_schema, "engram_memory_capture", "Capture an explicit Engram memory.")
+    legacy_memory_action_apply_schema = _legacy_schema(
+        memory_action_apply_schema,
+        "engram_memory_action_apply",
+        "Apply an Engram memory action.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -412,6 +601,67 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.set_coding_context(sessionKey, **kwargs)
+
+    async def memory_get(self, memoryId: str, **kwargs: Any) -> dict[str, Any]:  # noqa: N803
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_get(memoryId, **kwargs)
+
+    async def memory_store(self, content: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        session_key = kwargs.pop("sessionKey", self._session_key)
+        return await self._client.memory_store(content=content, sessionKey=session_key, **kwargs)
+
+    async def memory_timeline(self, memoryId: str, **kwargs: Any) -> dict[str, Any]:  # noqa: N803
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_timeline(memoryId, **kwargs)
+
+    async def memory_profile(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_profile(**kwargs)
+
+    async def memory_entities(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_entities(**kwargs)
+
+    async def memory_questions(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_questions(**kwargs)
+
+    async def memory_identity(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_identity(**kwargs)
+
+    async def memory_promote(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_promote(**kwargs)
+
+    async def memory_outcome(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_outcome(**kwargs)
+
+    async def entity_get(self, name: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.entity_get(name, **kwargs)
+
+    async def memory_capture(self, content: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_capture(content=content, **kwargs)
+
+    async def memory_action_apply(self, action: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_action_apply(action=action, **kwargs)
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -64,7 +64,7 @@ def _legacy_schema(schema: dict[str, Any], name: str, description: str) -> dict[
 
 
 class RemnicMemoryProvider:
-    """MemoryProvider that delegates to the Remnic daemon via HTTP.
+    """MemoryProvider that delegates to the Remnic daemon via HTTP."""
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         cfg = RemnicHermesConfig.from_hermes_config(config or {})

--- a/packages/plugin-hermes/tests/test_issue_805_memory_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_805_memory_tools.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class FakeAsyncClient:
+    instances: list["FakeAsyncClient"] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+        self.gets: list[tuple[str, dict[str, Any] | None]] = []
+        self.closed = False
+        FakeAsyncClient.instances.append(self)
+
+    async def post(self, path: str, *, json: dict[str, Any]) -> FakeResponse:
+        self.posts.append((path, json))
+        return FakeResponse({"ok": True, "path": path, "json": json})
+
+    async def get(self, path: str, *, params: dict[str, Any] | None = None) -> FakeResponse:
+        self.gets.append((path, params))
+        return FakeResponse({"ok": True, "path": path, "params": params})
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def fake_httpx(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeAsyncClient.instances = []
+    monkeypatch.setattr("remnic_hermes.client.httpx.AsyncClient", FakeAsyncClient)
+
+
+@pytest.mark.asyncio
+async def test_issue_805_client_methods_call_daemon_surfaces() -> None:
+    client = RemnicClient(host="127.0.0.1", port=4318, token="token")
+    http = FakeAsyncClient.instances[-1]
+
+    await client.memory_get("fact 1", namespace="ns")
+    await client.memory_store("remember this", category="fact", dryRun=True)
+    await client.memory_timeline("fact 1", limit=10)
+    await client.memory_entities(namespace="ns")
+    await client.entity_get("Alice Example", namespace="ns")
+    await client.memory_profile(namespace="ns")
+    await client.memory_questions(namespace="ns")
+    await client.memory_identity(namespace="ns")
+    await client.memory_promote(memoryId="fact-1", sessionKey="hermes-session")
+    await client.memory_outcome(memoryId="fact-1", outcome="success")
+    await client.memory_capture("capture me", category="fact")
+    await client.memory_action_apply("store_note", content="note")
+
+    assert http.gets[:5] == [
+        ("/memories/fact%201", {"namespace": "ns"}),
+        ("/memories/fact%201/timeline", {"limit": 10}),
+        ("/entities/Alice%20Example", {"namespace": "ns"}),
+    ]
+
+    assert http.posts[0] == (
+        "/memories",
+        {"content": "remember this", "category": "fact", "dryRun": True},
+    )
+
+    mcp_calls = [payload["params"] for path, payload in http.posts if path == "http://127.0.0.1:4318/mcp"]
+    assert mcp_calls == [
+        {"name": "engram.memory_entities_list", "arguments": {"namespace": "ns"}},
+        {"name": "engram.memory_profile", "arguments": {"namespace": "ns"}},
+        {"name": "engram.memory_questions", "arguments": {"namespace": "ns"}},
+        {"name": "engram.memory_identity", "arguments": {"namespace": "ns"}},
+        {"name": "engram.memory_promote", "arguments": {"memoryId": "fact-1", "sessionKey": "hermes-session"}},
+        {"name": "engram.memory_outcome", "arguments": {"memoryId": "fact-1", "outcome": "success"}},
+        {"name": "memory_capture", "arguments": {"content": "capture me", "category": "fact"}},
+        {"name": "memory_action_apply", "arguments": {"action": "store_note", "content": "note"}},
+    ]
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_805_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_memory_get",
+        "remnic_memory_store",
+        "remnic_memory_timeline",
+        "remnic_memory_profile",
+        "remnic_memory_entities",
+        "remnic_memory_questions",
+        "remnic_memory_identity",
+        "remnic_memory_promote",
+        "remnic_memory_outcome",
+        "remnic_entity_get",
+        "remnic_memory_capture",
+        "remnic_memory_action_apply",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert {"remnic_store", "engram_store"}.issubset(ctx.tools)
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_memory_store"]["schema"]["name"] == "remnic_memory_store"
+    assert ctx.tools["engram_memory_store"]["schema"]["name"] == "engram_memory_store"
+    assert ctx.tools["remnic_store"]["handler"] is not ctx.tools["remnic_memory_store"]["handler"]
+    assert ctx.tools["remnic_memory_store"]["schema"]["parameters"]["properties"]["category"] == {
+        "type": "string"
+    }
+    assert ctx.tools["remnic_memory_promote"]["schema"]["parameters"]["required"] == ["memoryId"]
+    assert ctx.tools["remnic_memory_outcome"]["schema"]["parameters"]["required"] == [
+        "memoryId",
+        "outcome",
+    ]

--- a/packages/plugin-hermes/tests/test_issue_805_memory_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_805_memory_tools.py
@@ -85,8 +85,8 @@ async def test_issue_805_client_methods_call_daemon_surfaces() -> None:
         {"name": "engram.memory_identity", "arguments": {"namespace": "ns"}},
         {"name": "engram.memory_promote", "arguments": {"memoryId": "fact-1", "sessionKey": "hermes-session"}},
         {"name": "engram.memory_outcome", "arguments": {"memoryId": "fact-1", "outcome": "success"}},
-        {"name": "memory_capture", "arguments": {"content": "capture me", "category": "fact"}},
-        {"name": "memory_action_apply", "arguments": {"action": "store_note", "content": "note"}},
+        {"name": "engram.memory_store", "arguments": {"content": "capture me", "category": "fact"}},
+        {"name": "engram.memory_action_apply", "arguments": {"action": "store_note", "content": "note"}},
     ]
 
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1563,6 +1563,12 @@ export class EngramAccessHttpServer {
       typeof toolArgs === "object" &&
       !Array.isArray(toolArgs) &&
       (toolArgs as { dryRun?: unknown }).dryRun === true;
+    const memoryActionApplyDryRun =
+      (toolName === "engram.memory_action_apply" || toolName === "remnic.memory_action_apply") &&
+      toolArgs !== null &&
+      typeof toolArgs === "object" &&
+      !Array.isArray(toolArgs) &&
+      (toolArgs as { dryRun?: unknown }).dryRun === true;
     const isMcpWrite =
       request.method === "tools/call" &&
       (
@@ -1579,6 +1585,13 @@ export class EngramAccessHttpServer {
         (
           !dreamsRunDryRun &&
           (toolName === "engram.dreams_run" || toolName === "remnic.dreams_run")
+        ) ||
+        (
+          !memoryActionApplyDryRun &&
+          (
+            toolName === "engram.memory_action_apply" ||
+            toolName === "remnic.memory_action_apply"
+          )
         )
       );
     if (isMcpWrite) {

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1033,6 +1033,44 @@ export class EngramMcpServer {
         },
       },
       {
+        name: "engram.memory_action_apply",
+        description:
+          "Record a memory-action application event for policy-learning telemetry.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            action: {
+              type: "string",
+              enum: [
+                "store_episode",
+                "store_note",
+                "update_note",
+                "create_artifact",
+                "summarize_node",
+                "discard",
+                "link_graph",
+              ],
+            },
+            category: { type: "string" },
+            content: { type: "string" },
+            outcome: { type: "string", enum: ["applied", "skipped", "failed"] },
+            reason: { type: "string" },
+            memoryId: { type: "string" },
+            sessionKey: { type: "string" },
+            linkTargetId: { type: "string" },
+            linkType: { type: "string" },
+            linkStrength: { type: "number" },
+            artifactType: { type: "string" },
+            execute: { type: "boolean" },
+            sourcePrompt: { type: "string" },
+            namespace: { type: "string" },
+            dryRun: { type: "boolean" },
+          },
+          required: ["action"],
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.context_checkpoint",
         description: "Save a structured context checkpoint for a session (preserves conversation state to disk).",
         inputSchema: {
@@ -2207,6 +2245,25 @@ export class EngramMcpServer {
           timestamp: typeof args.timestamp === "string" ? args.timestamp : undefined,
         });
       }
+      case "engram.memory_action_apply":
+        return this.service.memoryActionApply({
+          action: typeof args.action === "string" ? args.action : "",
+          outcome: typeof args.outcome === "string" ? args.outcome : undefined,
+          reason: typeof args.reason === "string" ? args.reason : undefined,
+          memoryId: typeof args.memoryId === "string" ? args.memoryId : undefined,
+          namespace: typeof args.namespace === "string" ? args.namespace : undefined,
+          principal: effectivePrincipal,
+          sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
+          content: typeof args.content === "string" ? args.content : undefined,
+          category: typeof args.category === "string" ? args.category : undefined,
+          linkTargetId: typeof args.linkTargetId === "string" ? args.linkTargetId : undefined,
+          linkType: typeof args.linkType === "string" ? args.linkType : undefined,
+          linkStrength: typeof args.linkStrength === "number" ? args.linkStrength : undefined,
+          artifactType: typeof args.artifactType === "string" ? args.artifactType : undefined,
+          execute: typeof args.execute === "boolean" ? args.execute : undefined,
+          sourcePrompt: typeof args.sourcePrompt === "string" ? args.sourcePrompt : undefined,
+          dryRun: args.dryRun === true,
+        });
       case "engram.context_checkpoint":
         return this.service.contextCheckpoint({
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : "",

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1,6 +1,7 @@
 import { stat } from "node:fs/promises";
 import * as nodeFs from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
+import { createHash } from "node:crypto";
 import { ZodError } from "zod";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
 import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
@@ -88,6 +89,8 @@ import {
 import type {
   EntityFile,
   MemoryFile,
+  MemoryActionOutcome,
+  MemoryActionType,
   MemoryLifecycleEvent,
   MemoryStatus,
   PluginConfig,
@@ -4123,6 +4126,96 @@ export class EngramAccessService {
       updated: new Date().toISOString(),
     });
     return { promoted: true, memoryId: request.memoryId };
+  }
+
+  async memoryActionApply(request: {
+    action: string;
+    outcome?: string;
+    reason?: string;
+    memoryId?: string;
+    namespace?: string;
+    principal?: string;
+    sessionKey?: string;
+    content?: string;
+    category?: string;
+    linkTargetId?: string;
+    linkType?: string;
+    linkStrength?: number;
+    artifactType?: string;
+    execute?: boolean;
+    sourcePrompt?: string;
+    dryRun?: boolean;
+  }): Promise<unknown> {
+    const actionTypes = new Set<MemoryActionType>([
+      "store_episode",
+      "store_note",
+      "update_note",
+      "create_artifact",
+      "summarize_node",
+      "discard",
+      "link_graph",
+    ]);
+    if (!actionTypes.has(request.action as MemoryActionType)) {
+      throw new EngramAccessInputError(
+        `memory_action_apply: invalid action ${JSON.stringify(request.action)}`,
+      );
+    }
+
+    if (this.orchestrator.config.contextCompressionActionsEnabled !== true) {
+      throw new EngramAccessInputError(
+        "memory_action_apply is disabled; enable contextCompressionActionsEnabled to use this tool",
+      );
+    }
+
+    const outcome = request.outcome ?? "skipped";
+    if (outcome !== "applied" && outcome !== "skipped" && outcome !== "failed") {
+      throw new EngramAccessInputError(
+        `memory_action_apply: outcome must be "applied", "skipped", or "failed"; got ${JSON.stringify(outcome)}`,
+      );
+    }
+
+    const resolvedNs = this.resolveWritableNamespace(
+      request.namespace,
+      request.sessionKey,
+      request.principal,
+    );
+    const inputSummaryParts = [
+      request.content,
+      request.category ? `category=${request.category}` : undefined,
+      request.linkTargetId ? `linkTargetId=${request.linkTargetId}` : undefined,
+      request.linkType ? `linkType=${request.linkType}` : undefined,
+      typeof request.linkStrength === "number"
+        ? `linkStrength=${request.linkStrength}`
+        : undefined,
+      request.artifactType ? `artifactType=${request.artifactType}` : undefined,
+      typeof request.execute === "boolean" ? `execute=${request.execute}` : undefined,
+    ].filter((part): part is string => typeof part === "string" && part.length > 0);
+
+    const event = {
+      action: request.action as MemoryActionType,
+      outcome: outcome as MemoryActionOutcome,
+      namespace: resolvedNs,
+      actor: "access.memory_action_apply",
+      subsystem: "access.memory_action_apply",
+      reason: request.reason,
+      memoryId: request.memoryId,
+      sourceSessionKey: request.sessionKey,
+      inputSummary: inputSummaryParts.length > 0
+        ? inputSummaryParts.join(" | ").slice(0, 500)
+        : undefined,
+      dryRun: request.dryRun === true,
+      promptHash:
+        typeof request.sourcePrompt === "string" && request.sourcePrompt.length > 0
+          ? createHash("sha256").update(request.sourcePrompt).digest("hex")
+          : undefined,
+    };
+    const preview = this.orchestrator.previewMemoryActionEvent(event);
+    if (request.dryRun === true) {
+      return { recorded: false, dryRun: true, event: preview };
+    }
+
+    const recorded = await this.orchestrator.appendMemoryActionEvent(event);
+    return { recorded, event: preview };
   }
 
   async contextCheckpoint(request: {

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -2157,6 +2157,10 @@ test("access HTTP server rate-limits MCP write tool calls", async () => {
         durationMs: 1,
         itemsProcessed: 1,
       }),
+      memoryActionApply: async ({ dryRun }: { dryRun?: boolean }) => ({
+        recorded: dryRun !== true,
+        dryRun: dryRun === true,
+      }),
     } as unknown as EngramAccessService,
     host: "127.0.0.1",
     port: 0,
@@ -2224,6 +2228,40 @@ test("access HTTP server rate-limits MCP write tool calls", async () => {
       result: { structuredContent: { dryRun: boolean } };
     };
     assert.equal(previewPayload.result.structuredContent.dryRun, true);
+
+    const previewMemoryAction = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1004,
+        method: "tools/call",
+        params: {
+          name: "engram.memory_action_apply",
+          arguments: { action: "store_note", dryRun: true },
+        },
+      }),
+    });
+    assert.equal(previewMemoryAction.status, 200);
+    const previewMemoryActionPayload = await previewMemoryAction.json() as {
+      result: { structuredContent: { dryRun: boolean } };
+    };
+    assert.equal(previewMemoryActionPayload.result.structuredContent.dryRun, true);
+
+    const limitedMemoryAction = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1005,
+        method: "tools/call",
+        params: {
+          name: "engram.memory_action_apply",
+          arguments: { action: "store_note" },
+        },
+      }),
+    });
+    assert.equal(limitedMemoryAction.status, 429);
 
     const limitedDreamsRun = await fetch(`${base}/mcp`, {
       method: "POST",

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -85,6 +85,17 @@ function createFakeService(): EngramAccessService {
       status: dryRun === true ? "validated" : "stored",
       memoryId: "fact-new",
     }),
+    memoryActionApply: async (request) => ({
+      recorded: true,
+      event: {
+        action: request.action,
+        outcome: request.outcome ?? "skipped",
+        inputSummary: [
+          request.category ? `category=${request.category}` : undefined,
+          typeof request.execute === "boolean" ? `execute=${request.execute}` : undefined,
+        ].filter(Boolean).join(" | "),
+      },
+    }),
     suggestionSubmit: async ({ dryRun }) => ({
       schemaVersion: 1,
       operation: "suggestion_submit",
@@ -361,6 +372,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.memory_feedback",
     "engram.memory_promote",
     "engram.memory_outcome",
+    "engram.memory_action_apply",
     "engram.context_checkpoint",
     "engram.briefing",
     "engram.review_list",
@@ -405,6 +417,27 @@ test("MCP server advertises tools and dispatches recall", async () => {
   });
   const storeResult = store?.result as { structuredContent: { status: string } };
   assert.equal(storeResult.structuredContent.status, "stored");
+
+  const memoryAction = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 44,
+    method: "tools/call",
+    params: {
+      name: "engram.memory_action_apply",
+      arguments: {
+        action: "store_note",
+        content: "Keep the category.",
+        category: "fact",
+        execute: true,
+      },
+    },
+  });
+  const memoryActionResult = memoryAction?.result as {
+    structuredContent: { event: { outcome: string; inputSummary: string } };
+  };
+  assert.equal(memoryActionResult.structuredContent.event.outcome, "skipped");
+  assert.match(memoryActionResult.structuredContent.event.inputSummary, /category=fact/);
+  assert.match(memoryActionResult.structuredContent.event.inputSummary, /execute=true/);
 
   const governance = await server.handleRequest({
     jsonrpc: "2.0",

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -106,6 +106,60 @@ function createService(dreamsPhases = dreamsPhasesConfig()) {
   return new EngramAccessService(orchestrator as any);
 }
 
+function createMemoryActionService(contextCompressionActionsEnabled: boolean) {
+  const capturedEvents: any[] = [];
+  const service = new EngramAccessService({
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      contextCompressionActionsEnabled,
+    },
+    previewMemoryActionEvent: (event: any) => ({
+      timestamp: "2026-04-30T00:00:00.000Z",
+      namespace: event.namespace ?? "global",
+      ...event,
+    }),
+    appendMemoryActionEvent: async (event: any) => {
+      capturedEvents.push(event);
+      return true;
+    },
+  } as any);
+  return { service, capturedEvents };
+}
+
+test("memoryActionApply is gated by context compression actions", async () => {
+  const { service, capturedEvents } = createMemoryActionService(false);
+
+  await assert.rejects(
+    () => service.memoryActionApply({ action: "store_note", content: "Remember this." }),
+    (err: unknown) =>
+      err instanceof EngramAccessInputError &&
+      /contextCompressionActionsEnabled/.test(err.message),
+  );
+  assert.equal(capturedEvents.length, 0);
+});
+
+test("memoryActionApply defaults missing outcome to skipped and preserves action fields", async () => {
+  const { service, capturedEvents } = createMemoryActionService(true);
+
+  const result = await service.memoryActionApply({
+    action: "store_note",
+    content: "Remember this.",
+    category: "fact",
+    execute: true,
+    sourcePrompt: "Please remember this fact.",
+  }) as { recorded: boolean; event: { outcome: string; inputSummary?: string } };
+
+  assert.equal(result.recorded, true);
+  assert.equal(result.event.outcome, "skipped");
+  assert.equal(capturedEvents[0]?.outcome, "skipped");
+  assert.match(capturedEvents[0]?.inputSummary ?? "", /category=fact/);
+  assert.match(capturedEvents[0]?.inputSummary ?? "", /execute=true/);
+  assert.equal(typeof capturedEvents[0]?.promptHash, "string");
+  assert.equal(capturedEvents[0]?.promptHash.length, 64);
+});
+
 test("dreamsRun rejects deepSleep when the phase is explicitly disabled", async () => {
   const service = createService(dreamsPhasesConfig(false, true));
 


### PR DESCRIPTION
## Summary
- expose Hermes memory get/store/timeline/profile/entities/questions/identity/promote/outcome/entity tools
- add Hermes registrations for memory_capture and memory_action_apply with OpenClaw-compatible schemas
- document primary remnic_* names and legacy engram_* aliases

Closes #805

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- npm run check-types && npm run check-config-contract && bash scripts/check-review-patterns.sh
- npm run review:cursor (script exited 0 but skipped because cursor-agent rejected --trust)
- gtimeout 90s npm run preflight:quick; static gates completed, then npm test expanded to the full workspace suite and the bounded run ended with unrelated benchmark/runtime failures plus many pending tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new tool endpoints and a new MCP write path (`memory_action_apply`) with gating and rate-limiting, which could affect daemon write behavior and client error handling if miswired or if config flags are incorrect.
> 
> **Overview**
> Exposes a new set of Hermes plugin tools for **direct memory inspection and richer CRUD** (`remnic_memory_get/store/timeline/profile/entities/questions/identity/promote/outcome`, plus `remnic_entity_get`) and registers matching legacy `engram_*` aliases, with updated docs/README describing the expanded tool surface and when to use the richer `memory_store` vs the existing `remnic_store` compatibility tool.
> 
> Extends the Hermes Python client/provider to call the new daemon REST and MCP surfaces (including URL-quoting path params and improved MCP error handling), and adds test coverage to ensure the new tools are registered and route to the correct endpoints.
> 
> Adds a new daemon-side MCP tool `engram.memory_action_apply` (OpenClaw-compatible) that records/gates memory-action telemetry (including dry-run behavior and prompt hashing), and updates MCP write rate-limiting logic/tests so `memory_action_apply` is treated as a write unless `dryRun: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd5911169012bb458588b01dfc0e7fe2666ae73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->