### PR TITLE
feat(hermes): expose continuity identity tools

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -140,6 +140,14 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_entity_get` | Fetch one tracked entity by name |
 | `remnic_memory_capture` | Capture an explicit memory note |
 | `remnic_memory_action_apply` | Apply a memory action |
+| `remnic_continuity_audit_generate` | Generate a continuity audit report |
+| `remnic_continuity_incident_open` | Open a continuity incident |
+| `remnic_continuity_incident_close` | Close a continuity incident with verification |
+| `remnic_continuity_incident_list` | List continuity incidents by state |
+| `remnic_continuity_loop_add_or_update` | Add or update a continuity improvement loop |
+| `remnic_continuity_loop_review` | Review an existing continuity improvement loop |
+| `remnic_identity_anchor_get` | Read the identity continuity anchor |
+| `remnic_identity_anchor_update` | Conservatively merge identity anchor sections |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -104,6 +104,33 @@ def _register_issue_805_tools(  # type: ignore[no-untyped-def]
     )
 
 
+_CONTINUITY_IDENTITY_TOOLS = [
+    ("continuity_audit_generate", "continuity_audit_generate"),
+    ("continuity_incident_open", "continuity_incident_open"),
+    ("continuity_incident_close", "continuity_incident_close"),
+    ("continuity_incident_list", "continuity_incident_list"),
+    ("continuity_loop_add_or_update", "continuity_loop_add_or_update"),
+    ("continuity_loop_review", "continuity_loop_review"),
+    ("identity_anchor_get", "identity_anchor_get"),
+    ("identity_anchor_update", "identity_anchor_update"),
+]
+
+
+def _register_issue_806_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _CONTINUITY_IDENTITY_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -122,6 +149,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     )
     _register_recall_debug_tools(ctx, provider, "remnic")
     _register_issue_805_tools(ctx, provider, "remnic")
+    _register_issue_806_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -133,3 +161,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     )
     _register_recall_debug_tools(ctx, provider, "engram", legacy=True)
     _register_issue_805_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_806_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -196,6 +196,64 @@ class RemnicClient:
     async def memory_action_apply(self, action: str, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.memory_action_apply", {"action": action, **kwargs})
 
+    async def continuity_audit_generate(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.continuity_audit_generate", kwargs)
+
+    async def continuity_incident_open(self, symptom: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.continuity_incident_open", {"symptom": symptom, **kwargs})
+
+    async def continuity_incident_close(
+        self,
+        incident_id: str,
+        *,
+        fix_applied: str,
+        verification_result: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        return await self._mcp_tool(
+            "engram.continuity_incident_close",
+            {
+                "id": incident_id,
+                "fixApplied": fix_applied,
+                "verificationResult": verification_result,
+                **kwargs,
+            },
+        )
+
+    async def continuity_incident_list(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.continuity_incident_list", kwargs)
+
+    async def continuity_loop_add_or_update(
+        self,
+        loop_id: str,
+        *,
+        cadence: str,
+        purpose: str,
+        status: str,
+        kill_condition: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        return await self._mcp_tool(
+            "engram.continuity_loop_add_or_update",
+            {
+                "id": loop_id,
+                "cadence": cadence,
+                "purpose": purpose,
+                "status": status,
+                "killCondition": kill_condition,
+                **kwargs,
+            },
+        )
+
+    async def continuity_loop_review(self, loop_id: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.continuity_loop_review", {"id": loop_id, **kwargs})
+
+    async def identity_anchor_get(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.identity_anchor_get", kwargs)
+
+    async def identity_anchor_update(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.identity_anchor_update", kwargs)
+
     async def close(self) -> None:
         await self._http.aclose()
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -39,6 +39,9 @@ _ACTION_TYPES = [
     "discard",
     "link_graph",
 ]
+_CONTINUITY_INCIDENT_STATES = ["open", "closed", "all"]
+_CONTINUITY_LOOP_CADENCES = ["daily", "weekly", "monthly", "quarterly"]
+_CONTINUITY_LOOP_STATUSES = ["active", "paused", "retired"]
 
 
 def _schema(
@@ -521,6 +524,166 @@ class RemnicMemoryProvider:
         "Apply an Engram memory action.",
     )
 
+    # -- Issue #806 continuity / identity tool schemas --
+
+    continuity_audit_generate_schema = _schema(
+        "remnic_continuity_audit_generate",
+        "Generate a deterministic identity continuity audit report.",
+        {
+            "period": {"type": "string", "enum": ["weekly", "monthly"]},
+            "key": {
+                "type": "string",
+                "description": "Period key (weekly: YYYY-Www, monthly: YYYY-MM). Defaults to current.",
+            },
+        },
+    )
+    continuity_incident_open_schema = _schema(
+        "remnic_continuity_incident_open",
+        "Create a new continuity incident record in append-only storage.",
+        {
+            "symptom": {
+                "type": "string",
+                "description": "Observed continuity failure symptom.",
+            },
+            "namespace": _NAMESPACE,
+            "triggerWindow": {
+                "type": "string",
+                "description": "Time window when incident occurred.",
+            },
+            "suspectedCause": {"type": "string"},
+        },
+        ["symptom"],
+    )
+    continuity_incident_close_schema = _schema(
+        "remnic_continuity_incident_close",
+        "Close an open continuity incident with verification details.",
+        {
+            "id": {"type": "string", "description": "Incident ID to close."},
+            "namespace": _NAMESPACE,
+            "fixApplied": {"type": "string", "description": "What fix was applied."},
+            "verificationResult": {"type": "string", "description": "How closure was verified."},
+            "preventiveRule": {"type": "string", "description": "Optional preventive follow-up rule."},
+        },
+        ["id", "fixApplied", "verificationResult"],
+    )
+    continuity_incident_list_schema = _schema(
+        "remnic_continuity_incident_list",
+        "List continuity incidents, optionally filtered by state.",
+        {
+            "state": {"type": "string", "enum": _CONTINUITY_INCIDENT_STATES},
+            "namespace": _NAMESPACE,
+            "limit": {
+                "type": "number",
+                "description": "Max incidents (default 25, max 200).",
+            },
+        },
+    )
+    continuity_loop_add_or_update_schema = _schema(
+        "remnic_continuity_loop_add_or_update",
+        "Add or update a continuity improvement loop entry.",
+        {
+            "id": {"type": "string", "description": "Stable loop identifier."},
+            "cadence": {"type": "string", "enum": _CONTINUITY_LOOP_CADENCES},
+            "purpose": {"type": "string", "description": "What this recurring loop improves."},
+            "status": {"type": "string", "enum": _CONTINUITY_LOOP_STATUSES},
+            "killCondition": {
+                "type": "string",
+                "description": "Clear condition for retiring this loop.",
+            },
+            "namespace": _NAMESPACE,
+            "lastReviewed": {
+                "type": "string",
+                "description": "ISO timestamp for last review.",
+            },
+            "notes": {"type": "string"},
+        },
+        ["id", "cadence", "purpose", "status", "killCondition"],
+    )
+    continuity_loop_review_schema = _schema(
+        "remnic_continuity_loop_review",
+        "Update review metadata for an existing continuity improvement loop.",
+        {
+            "id": {"type": "string", "description": "Loop ID to review."},
+            "namespace": _NAMESPACE,
+            "status": {"type": "string", "enum": _CONTINUITY_LOOP_STATUSES},
+            "notes": {"type": "string"},
+            "reviewedAt": {
+                "type": "string",
+                "description": "ISO timestamp for review event.",
+            },
+        },
+        ["id"],
+    )
+    identity_anchor_get_schema = _schema(
+        "remnic_identity_anchor_get",
+        "Read the identity continuity anchor document.",
+        {"namespace": _NAMESPACE},
+    )
+    identity_anchor_update_schema = _schema(
+        "remnic_identity_anchor_update",
+        "Conservatively merge identity anchor sections without overwriting existing material.",
+        {
+            "namespace": _NAMESPACE,
+            "identityTraits": {
+                "type": "string",
+                "description": "Updates for 'Identity Traits' section.",
+            },
+            "communicationPreferences": {
+                "type": "string",
+                "description": "Updates for 'Communication Preferences' section.",
+            },
+            "operatingPrinciples": {
+                "type": "string",
+                "description": "Updates for 'Operating Principles' section.",
+            },
+            "continuityNotes": {
+                "type": "string",
+                "description": "Updates for 'Continuity Notes' section.",
+            },
+        },
+    )
+
+    legacy_continuity_audit_generate_schema = _legacy_schema(
+        continuity_audit_generate_schema,
+        "engram_continuity_audit_generate",
+        "Generate a deterministic Engram identity continuity audit report.",
+    )
+    legacy_continuity_incident_open_schema = _legacy_schema(
+        continuity_incident_open_schema,
+        "engram_continuity_incident_open",
+        "Create a new Engram continuity incident record.",
+    )
+    legacy_continuity_incident_close_schema = _legacy_schema(
+        continuity_incident_close_schema,
+        "engram_continuity_incident_close",
+        "Close an open Engram continuity incident.",
+    )
+    legacy_continuity_incident_list_schema = _legacy_schema(
+        continuity_incident_list_schema,
+        "engram_continuity_incident_list",
+        "List Engram continuity incidents.",
+    )
+    legacy_continuity_loop_add_or_update_schema = _legacy_schema(
+        continuity_loop_add_or_update_schema,
+        "engram_continuity_loop_add_or_update",
+        "Add or update an Engram continuity improvement loop.",
+    )
+    legacy_continuity_loop_review_schema = _legacy_schema(
+        continuity_loop_review_schema,
+        "engram_continuity_loop_review",
+        "Update review metadata for an Engram continuity improvement loop.",
+    )
+    legacy_identity_anchor_get_schema = _legacy_schema(
+        identity_anchor_get_schema,
+        "engram_identity_anchor_get",
+        "Read the Engram identity continuity anchor document.",
+    )
+    legacy_identity_anchor_update_schema = _legacy_schema(
+        identity_anchor_update_schema,
+        "engram_identity_anchor_update",
+        "Conservatively merge Engram identity anchor sections.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -662,6 +825,72 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.memory_action_apply(action=action, **kwargs)
+
+    async def continuity_audit_generate(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.continuity_audit_generate(**kwargs)
+
+    async def continuity_incident_open(self, symptom: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.continuity_incident_open(symptom=symptom, **kwargs)
+
+    async def continuity_incident_close(
+        self,
+        id: str,  # noqa: A002,N803
+        fixApplied: str,  # noqa: N803
+        verificationResult: str,  # noqa: N803
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.continuity_incident_close(
+            incident_id=id,
+            fix_applied=fixApplied,
+            verification_result=verificationResult,
+            **kwargs,
+        )
+
+    async def continuity_incident_list(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.continuity_incident_list(**kwargs)
+
+    async def continuity_loop_add_or_update(
+        self,
+        id: str,  # noqa: A002,N803
+        cadence: str,
+        purpose: str,
+        status: str,
+        killCondition: str,  # noqa: N803
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.continuity_loop_add_or_update(
+            loop_id=id,
+            cadence=cadence,
+            purpose=purpose,
+            status=status,
+            kill_condition=killCondition,
+            **kwargs,
+        )
+
+    async def continuity_loop_review(self, id: str, **kwargs: Any) -> dict[str, Any]:  # noqa: A002,N803
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.continuity_loop_review(loop_id=id, **kwargs)
+
+    async def identity_anchor_get(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.identity_anchor_get(**kwargs)
+
+    async def identity_anchor_update(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.identity_anchor_update(**kwargs)
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_806_continuity_identity_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_806_continuity_identity_tools.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_806_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.continuity_audit_generate(period="weekly", key="2026-W18")
+    await client.continuity_incident_open(
+        "identity drift",
+        namespace="project",
+        triggerWindow="today",
+        suspectedCause="stale context",
+    )
+    await client.continuity_incident_close(
+        "incident-1",
+        fix_applied="refreshed anchor",
+        verification_result="manual check passed",
+        preventiveRule="review weekly",
+    )
+    await client.continuity_incident_list(state="all", limit=10)
+    await client.continuity_loop_add_or_update(
+        "loop-1",
+        cadence="weekly",
+        purpose="Review continuity drift",
+        status="active",
+        kill_condition="No incidents for 90 days",
+        notes="Initial loop",
+    )
+    await client.continuity_loop_review("loop-1", status="paused", reviewedAt="2026-04-30T00:00:00Z")
+    await client.identity_anchor_get(namespace="project")
+    await client.identity_anchor_update(
+        identityTraits="Direct and pragmatic.",
+        communicationPreferences="Prefer concise updates.",
+    )
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.continuity_audit_generate",
+        "engram.continuity_incident_open",
+        "engram.continuity_incident_close",
+        "engram.continuity_incident_list",
+        "engram.continuity_loop_add_or_update",
+        "engram.continuity_loop_review",
+        "engram.identity_anchor_get",
+        "engram.identity_anchor_update",
+    ]
+    assert calls[1].kwargs["json"]["params"]["arguments"] == {
+        "symptom": "identity drift",
+        "namespace": "project",
+        "triggerWindow": "today",
+        "suspectedCause": "stale context",
+    }
+    assert calls[2].kwargs["json"]["params"]["arguments"] == {
+        "id": "incident-1",
+        "fixApplied": "refreshed anchor",
+        "verificationResult": "manual check passed",
+        "preventiveRule": "review weekly",
+    }
+    assert calls[4].kwargs["json"]["params"]["arguments"] == {
+        "id": "loop-1",
+        "cadence": "weekly",
+        "purpose": "Review continuity drift",
+        "status": "active",
+        "killCondition": "No incidents for 90 days",
+        "notes": "Initial loop",
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_806_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_continuity_audit_generate",
+        "remnic_continuity_incident_open",
+        "remnic_continuity_incident_close",
+        "remnic_continuity_incident_list",
+        "remnic_continuity_loop_add_or_update",
+        "remnic_continuity_loop_review",
+        "remnic_identity_anchor_get",
+        "remnic_identity_anchor_update",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_continuity_incident_open"]["schema"]["parameters"]["required"] == ["symptom"]
+    assert ctx.tools["remnic_continuity_incident_close"]["schema"]["parameters"]["required"] == [
+        "id",
+        "fixApplied",
+        "verificationResult",
+    ]
+    assert ctx.tools["remnic_continuity_loop_add_or_update"]["schema"]["parameters"]["required"] == [
+        "id",
+        "cadence",
+        "purpose",
+        "status",
+        "killCondition",
+    ]
+    assert ctx.tools["remnic_continuity_incident_list"]["schema"]["parameters"]["properties"]["state"]["enum"] == [
+        "open",
+        "closed",
+        "all",
+    ]
+    assert ctx.tools["remnic_continuity_loop_review"]["schema"]["parameters"]["properties"]["status"]["enum"] == [
+        "active",
+        "paused",
+        "retired",
+    ]
+    assert ctx.tools["engram_identity_anchor_update"]["schema"]["name"] == "engram_identity_anchor_update"
+
+
+@pytest.mark.asyncio
+async def test_issue_806_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.continuity_audit_generate() == {"error": "Not connected to Remnic"}
+    assert await provider.continuity_incident_open("drift") == {"error": "Not connected to Remnic"}
+    assert await provider.identity_anchor_get() == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -14,6 +14,16 @@ _RECALL_DEBUG_TOOL_SUFFIXES = [
     "memory_feedback_last_recall",
     "set_coding_context",
 ]
+_CONTINUITY_IDENTITY_TOOL_SUFFIXES = [
+    "continuity_audit_generate",
+    "continuity_incident_open",
+    "continuity_incident_close",
+    "continuity_incident_list",
+    "continuity_loop_add_or_update",
+    "continuity_loop_review",
+    "identity_anchor_get",
+    "identity_anchor_update",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -30,6 +40,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
     provider.legacy_lcm_search_schema = {"name": "engram_lcm_search"}
     provider.lcm_search = object()
     for suffix in _RECALL_DEBUG_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _CONTINUITY_IDENTITY_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -66,6 +80,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_lcm_search" in registered_tools
     assert "remnic_recall_explain" in registered_tools
     assert "engram_recall_explain" in registered_tools
+    assert "remnic_continuity_incident_open" in registered_tools
+    assert "engram_continuity_incident_open" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():


### PR DESCRIPTION
## Summary

- wires Hermes memory_provider tools for the issue #806 continuity and identity bundle
- adds Remnic primary tool names and Engram legacy aliases for the eight daemon-backed surfaces
- adds focused client, registration, schema, and disconnected-handler tests plus README coverage

Closes #806.

## Verification

- `uv run --project packages/plugin-hermes --extra test pytest -q`
- `uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests`
- `uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes`
- `npm run check-types`
- `npm run check-config-contract`
- `bash scripts/check-review-patterns.sh`
- `git diff --check`

Note: `npm run preflight:quick` was started after `pnpm install`, but the broad Node all-tests phase went idle for 9+ minutes inside unrelated tests and was interrupted. GitHub CI should run the full required surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive, but expands the Hermes-exposed MCP/tool surface and request payload shapes; mis-registration or schema/argument mismatches could break integrations at runtime.
> 
> **Overview**
> Adds eight new daemon-backed **continuity/identity** tools to the Hermes Remnic plugin (audit generation, incident open/close/list, improvement loop upsert/review, and identity anchor get/update), registered under both `remnic_*` primary names and `engram_*` legacy aliases.
> 
> Extends `RemnicClient` and `RemnicMemoryProvider` with matching handlers, schemas/enums, and “not connected” safeguards, and updates documentation and tests to cover tool registration and MCP call argument mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9f9ec07ff0279b4e82ddc4a11c4cfbc1b5d97d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->