### PR TITLE
feat(hermes): expose review and suggestion tools

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -148,6 +148,10 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_continuity_loop_review` | Review an existing continuity improvement loop |
 | `remnic_identity_anchor_get` | Read the identity continuity anchor |
 | `remnic_identity_anchor_update` | Conservatively merge identity anchor sections |
+| `remnic_review_queue_list` | Fetch the latest review queue artifact bundle |
+| `remnic_review_list` | List contradiction review items |
+| `remnic_review_resolve` | Resolve a contradiction review pair |
+| `remnic_suggestion_submit` | Queue a suggested memory for review |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -131,6 +131,29 @@ def _register_issue_806_tools(  # type: ignore[no-untyped-def]
         )
 
 
+_REVIEW_SUGGESTION_TOOLS = [
+    ("review_queue_list", "review_queue_list"),
+    ("review_list", "review_list"),
+    ("review_resolve", "review_resolve"),
+    ("suggestion_submit", "suggestion_submit"),
+]
+
+
+def _register_issue_807_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _REVIEW_SUGGESTION_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -150,6 +173,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_recall_debug_tools(ctx, provider, "remnic")
     _register_issue_805_tools(ctx, provider, "remnic")
     _register_issue_806_tools(ctx, provider, "remnic")
+    _register_issue_807_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -162,3 +186,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_recall_debug_tools(ctx, provider, "engram", legacy=True)
     _register_issue_805_tools(ctx, provider, "engram", legacy=True)
     _register_issue_806_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_807_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -254,6 +254,18 @@ class RemnicClient:
     async def identity_anchor_update(self, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.identity_anchor_update", kwargs)
 
+    async def review_queue_list(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.review_queue_list", kwargs)
+
+    async def review_list(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.review_list", kwargs)
+
+    async def review_resolve(self, pair_id: str, verb: str) -> dict[str, Any]:
+        return await self._mcp_tool("engram.review_resolve", {"pairId": pair_id, "verb": verb})
+
+    async def suggestion_submit(self, content: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.suggestion_submit", {"content": content, **kwargs})
+
     async def close(self) -> None:
         await self._http.aclose()
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -42,6 +42,8 @@ _ACTION_TYPES = [
 _CONTINUITY_INCIDENT_STATES = ["open", "closed", "all"]
 _CONTINUITY_LOOP_CADENCES = ["daily", "weekly", "monthly", "quarterly"]
 _CONTINUITY_LOOP_STATUSES = ["active", "paused", "retired"]
+_REVIEW_FILTERS = ["all", "unresolved", "contradicts", "independent", "duplicates", "needs-user"]
+_REVIEW_RESOLUTION_VERBS = ["keep-a", "keep-b", "merge", "both-valid", "needs-more-context"]
 
 
 def _schema(
@@ -684,6 +686,83 @@ class RemnicMemoryProvider:
         "Conservatively merge Engram identity anchor sections.",
     )
 
+    # -- Issue #807 review queue / suggestions tool schemas --
+
+    review_queue_list_schema = _schema(
+        "remnic_review_queue_list",
+        "Fetch the latest review queue artifact bundle.",
+        {"runId": {"type": "string"}, "namespace": _NAMESPACE},
+    )
+    review_list_schema = _schema(
+        "remnic_review_list",
+        "List contradiction review items pending user resolution.",
+        {
+            "filter": {
+                "type": "string",
+                "enum": _REVIEW_FILTERS,
+                "description": "Filter by verdict type. Default: unresolved.",
+            },
+            "namespace": _NAMESPACE,
+            "limit": {"type": "number", "description": "Max items to return (default 50)."},
+        },
+    )
+    review_resolve_schema = _schema(
+        "remnic_review_resolve",
+        "Resolve a contradiction pair with a chosen verb.",
+        {
+            "pairId": {
+                "type": "string",
+                "description": "The contradiction pair ID to resolve.",
+            },
+            "verb": {
+                "type": "string",
+                "enum": _REVIEW_RESOLUTION_VERBS,
+                "description": "Resolution action.",
+            },
+        },
+        ["pairId", "verb"],
+    )
+    suggestion_submit_schema = _schema(
+        "remnic_suggestion_submit",
+        "Queue a suggested memory for review.",
+        {
+            "schemaVersion": {"type": "number"},
+            "idempotencyKey": {"type": "string"},
+            "dryRun": {"type": "boolean"},
+            "sessionKey": {"type": "string"},
+            "content": {"type": "string"},
+            "category": {"type": "string"},
+            "confidence": {"type": "number"},
+            "namespace": _NAMESPACE,
+            "tags": _STRING_ARRAY,
+            "entityRef": {"type": "string"},
+            "ttl": {"type": "string"},
+            "sourceReason": {"type": "string"},
+        },
+        ["content"],
+    )
+
+    legacy_review_queue_list_schema = _legacy_schema(
+        review_queue_list_schema,
+        "engram_review_queue_list",
+        "Fetch the latest Engram review queue artifact bundle.",
+    )
+    legacy_review_list_schema = _legacy_schema(
+        review_list_schema,
+        "engram_review_list",
+        "List Engram contradiction review items pending user resolution.",
+    )
+    legacy_review_resolve_schema = _legacy_schema(
+        review_resolve_schema,
+        "engram_review_resolve",
+        "Resolve an Engram contradiction pair with a chosen verb.",
+    )
+    legacy_suggestion_submit_schema = _legacy_schema(
+        suggestion_submit_schema,
+        "engram_suggestion_submit",
+        "Queue a suggested Engram memory for review.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -891,6 +970,27 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.identity_anchor_update(**kwargs)
+
+    async def review_queue_list(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.review_queue_list(**kwargs)
+
+    async def review_list(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.review_list(**kwargs)
+
+    async def review_resolve(self, pairId: str, verb: str, **kwargs: Any) -> dict[str, Any]:  # noqa: N803
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.review_resolve(pair_id=pairId, verb=verb)
+
+    async def suggestion_submit(self, content: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        session_key = kwargs.pop("sessionKey", self._session_key)
+        return await self._client.suggestion_submit(content=content, sessionKey=session_key, **kwargs)
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_807_reviews_suggestions_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_807_reviews_suggestions_tools.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_807_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.review_queue_list(runId="run-1", namespace="project")
+    await client.review_list(filter="duplicates", namespace="project", limit=5)
+    await client.review_resolve("pair-1", "merge")
+    await client.suggestion_submit("Remember this after review.", category="fact", dryRun=True)
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.review_queue_list",
+        "engram.review_list",
+        "engram.review_resolve",
+        "engram.suggestion_submit",
+    ]
+    assert calls[0].kwargs["json"]["params"]["arguments"] == {
+        "runId": "run-1",
+        "namespace": "project",
+    }
+    assert calls[1].kwargs["json"]["params"]["arguments"] == {
+        "filter": "duplicates",
+        "namespace": "project",
+        "limit": 5,
+    }
+    assert calls[2].kwargs["json"]["params"]["arguments"] == {
+        "pairId": "pair-1",
+        "verb": "merge",
+    }
+    assert calls[3].kwargs["json"]["params"]["arguments"] == {
+        "content": "Remember this after review.",
+        "category": "fact",
+        "dryRun": True,
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_807_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_review_queue_list",
+        "remnic_review_list",
+        "remnic_review_resolve",
+        "remnic_suggestion_submit",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_review_resolve"]["schema"]["parameters"]["required"] == ["pairId", "verb"]
+    assert ctx.tools["remnic_review_list"]["schema"]["parameters"]["properties"]["filter"]["enum"] == [
+        "all",
+        "unresolved",
+        "contradicts",
+        "independent",
+        "duplicates",
+        "needs-user",
+    ]
+    assert ctx.tools["remnic_review_resolve"]["schema"]["parameters"]["properties"]["verb"]["enum"] == [
+        "keep-a",
+        "keep-b",
+        "merge",
+        "both-valid",
+        "needs-more-context",
+    ]
+    assert ctx.tools["remnic_suggestion_submit"]["schema"]["parameters"]["required"] == ["content"]
+    assert ctx.tools["engram_suggestion_submit"]["schema"]["name"] == "engram_suggestion_submit"
+
+
+@pytest.mark.asyncio
+async def test_issue_807_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.review_queue_list() == {"error": "Not connected to Remnic"}
+    assert await provider.review_resolve("pair-1", "merge") == {"error": "Not connected to Remnic"}
+    assert await provider.suggestion_submit("remember this") == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -24,6 +24,12 @@ _CONTINUITY_IDENTITY_TOOL_SUFFIXES = [
     "identity_anchor_get",
     "identity_anchor_update",
 ]
+_REVIEW_SUGGESTION_TOOL_SUFFIXES = [
+    "review_queue_list",
+    "review_list",
+    "review_resolve",
+    "suggestion_submit",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -44,6 +50,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
     for suffix in _CONTINUITY_IDENTITY_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _REVIEW_SUGGESTION_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -82,6 +92,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_recall_explain" in registered_tools
     assert "remnic_continuity_incident_open" in registered_tools
     assert "engram_continuity_incident_open" in registered_tools
+    assert "remnic_review_queue_list" in registered_tools
+    assert "engram_review_queue_list" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():


### PR DESCRIPTION
Closes #807.

## Summary
- register Hermes memory_provider tools for Remnic review queue, review list, review resolution, and suggestion submission
- keep legacy engram_* aliases alongside remnic_* tool names
- add focused client/provider registration tests and README tool rows

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes
- npm run check-types
- npm run check-config-contract
- bash scripts/check-review-patterns.sh
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change: registers new MCP tools and client/provider passthroughs while preserving existing `engram_*` aliases; main risk is mismatched schema/argument names causing tool-call failures.
> 
> **Overview**
> Adds Hermes tool exposure for Remnic review workflows by registering `remnic_review_queue_list`, `remnic_review_list`, `remnic_review_resolve`, and `remnic_suggestion_submit` (plus `engram_*` legacy aliases) and wiring them through the plugin `register()` path.
> 
> Extends `RemnicClient`/`RemnicMemoryProvider` with matching methods and JSON schemas (including enums for review filters and resolution verbs, and `sessionKey` handling for suggestions), updates the README tool table, and adds focused tests to validate MCP tool names, argument payloads, and tool registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99043230ee1f9ce907864b52038fcbebdbee4b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->