### PR TITLE
feat(hermes): expose work board tools

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -152,6 +152,9 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_review_list` | List contradiction review items |
 | `remnic_review_resolve` | Resolve a contradiction review pair |
 | `remnic_suggestion_submit` | Queue a suggested memory for review |
+| `remnic_work_task` | Manage work-layer tasks |
+| `remnic_work_project` | Manage work-layer projects |
+| `remnic_work_board` | Export or import work-layer board snapshots and markdown |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -154,6 +154,28 @@ def _register_issue_807_tools(  # type: ignore[no-untyped-def]
         )
 
 
+_WORK_BOARD_TOOLS = [
+    ("work_task", "work_task"),
+    ("work_project", "work_project"),
+    ("work_board", "work_board"),
+]
+
+
+def _register_issue_808_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _WORK_BOARD_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -174,6 +196,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_805_tools(ctx, provider, "remnic")
     _register_issue_806_tools(ctx, provider, "remnic")
     _register_issue_807_tools(ctx, provider, "remnic")
+    _register_issue_808_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -187,3 +210,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_805_tools(ctx, provider, "engram", legacy=True)
     _register_issue_806_tools(ctx, provider, "engram", legacy=True)
     _register_issue_807_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_808_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -266,6 +266,15 @@ class RemnicClient:
     async def suggestion_submit(self, content: str, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.suggestion_submit", {"content": content, **kwargs})
 
+    async def work_task(self, action: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.work_task", {"action": action, **kwargs})
+
+    async def work_project(self, action: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.work_project", {"action": action, **kwargs})
+
+    async def work_board(self, action: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.work_board", {"action": action, **kwargs})
+
     async def close(self) -> None:
         await self._http.aclose()
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -44,6 +44,12 @@ _CONTINUITY_LOOP_CADENCES = ["daily", "weekly", "monthly", "quarterly"]
 _CONTINUITY_LOOP_STATUSES = ["active", "paused", "retired"]
 _REVIEW_FILTERS = ["all", "unresolved", "contradicts", "independent", "duplicates", "needs-user"]
 _REVIEW_RESOLUTION_VERBS = ["keep-a", "keep-b", "merge", "both-valid", "needs-more-context"]
+_WORK_TASK_ACTIONS = ["create", "get", "list", "update", "transition", "delete"]
+_WORK_TASK_STATUSES = ["todo", "in_progress", "blocked", "done", "cancelled"]
+_WORK_TASK_PRIORITIES = ["low", "medium", "high"]
+_WORK_PROJECT_ACTIONS = ["create", "get", "list", "update", "delete", "link_task"]
+_WORK_PROJECT_STATUSES = ["active", "on_hold", "completed", "archived"]
+_WORK_BOARD_ACTIONS = ["export_markdown", "export_snapshot", "import_snapshot"]
 
 
 def _schema(
@@ -763,6 +769,73 @@ class RemnicMemoryProvider:
         "Queue a suggested Engram memory for review.",
     )
 
+    # -- Issue #808 work boards / peer co-tracking tool schemas --
+
+    work_task_schema = _schema(
+        "remnic_work_task",
+        "Manage work-layer tasks (create, get, list, update, transition, delete).",
+        {
+            "action": {"type": "string", "enum": _WORK_TASK_ACTIONS},
+            "id": {"type": "string"},
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "status": {"type": "string", "enum": _WORK_TASK_STATUSES},
+            "priority": {"type": "string", "enum": _WORK_TASK_PRIORITIES},
+            "owner": {"type": "string"},
+            "assignee": {"type": "string"},
+            "projectId": {"type": "string"},
+            "tags": _STRING_ARRAY,
+            "dueAt": {"type": "string"},
+        },
+        ["action"],
+    )
+    work_project_schema = _schema(
+        "remnic_work_project",
+        "Manage work-layer projects (create, get, list, update, delete, link_task).",
+        {
+            "action": {"type": "string", "enum": _WORK_PROJECT_ACTIONS},
+            "id": {"type": "string"},
+            "name": {"type": "string"},
+            "description": {"type": "string"},
+            "status": {"type": "string", "enum": _WORK_PROJECT_STATUSES},
+            "owner": {"type": "string"},
+            "tags": _STRING_ARRAY,
+            "taskId": {"type": "string", "description": "Task ID for link_task."},
+            "projectId": {"type": "string", "description": "Project ID for link_task."},
+        },
+        ["action"],
+    )
+    work_board_schema = _schema(
+        "remnic_work_board",
+        "Export/import work-layer board snapshots and markdown.",
+        {
+            "action": {"type": "string", "enum": _WORK_BOARD_ACTIONS},
+            "projectId": {"type": "string"},
+            "snapshotJson": {"type": "string", "description": "Snapshot JSON for import_snapshot."},
+            "linkToMemory": {
+                "type": "boolean",
+                "description": "If true, output can be retained as long-term memory.",
+            },
+        },
+        ["action"],
+    )
+
+    legacy_work_task_schema = _legacy_schema(
+        work_task_schema,
+        "engram_work_task",
+        "Manage Engram work-layer tasks.",
+    )
+    legacy_work_project_schema = _legacy_schema(
+        work_project_schema,
+        "engram_work_project",
+        "Manage Engram work-layer projects.",
+    )
+    legacy_work_board_schema = _legacy_schema(
+        work_board_schema,
+        "engram_work_board",
+        "Export/import Engram work-layer board snapshots and markdown.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -991,6 +1064,21 @@ class RemnicMemoryProvider:
             return {"error": "Not connected to Remnic"}
         session_key = kwargs.pop("sessionKey", self._session_key)
         return await self._client.suggestion_submit(content=content, sessionKey=session_key, **kwargs)
+
+    async def work_task(self, action: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.work_task(action=action, **kwargs)
+
+    async def work_project(self, action: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.work_project(action=action, **kwargs)
+
+    async def work_board(self, action: str, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.work_board(action=action, **kwargs)
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_808_work_board_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_808_work_board_tools.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_808_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.work_task(
+        "create",
+        title="Draft launch plan",
+        status="todo",
+        priority="high",
+        tags=["launch", "docs"],
+    )
+    await client.work_project(
+        "link_task",
+        taskId="task-1",
+        projectId="project-1",
+    )
+    await client.work_board(
+        "export_snapshot",
+        projectId="project-1",
+        linkToMemory=True,
+    )
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.work_task",
+        "engram.work_project",
+        "engram.work_board",
+    ]
+    assert calls[0].kwargs["json"]["params"]["arguments"] == {
+        "action": "create",
+        "title": "Draft launch plan",
+        "status": "todo",
+        "priority": "high",
+        "tags": ["launch", "docs"],
+    }
+    assert calls[1].kwargs["json"]["params"]["arguments"] == {
+        "action": "link_task",
+        "taskId": "task-1",
+        "projectId": "project-1",
+    }
+    assert calls[2].kwargs["json"]["params"]["arguments"] == {
+        "action": "export_snapshot",
+        "projectId": "project-1",
+        "linkToMemory": True,
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_808_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_work_task",
+        "remnic_work_project",
+        "remnic_work_board",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_work_task"]["schema"]["parameters"]["required"] == ["action"]
+    assert ctx.tools["remnic_work_task"]["schema"]["parameters"]["properties"]["action"]["enum"] == [
+        "create",
+        "get",
+        "list",
+        "update",
+        "transition",
+        "delete",
+    ]
+    assert ctx.tools["remnic_work_project"]["schema"]["parameters"]["properties"]["action"]["enum"] == [
+        "create",
+        "get",
+        "list",
+        "update",
+        "delete",
+        "link_task",
+    ]
+    assert ctx.tools["remnic_work_board"]["schema"]["parameters"]["properties"]["action"]["enum"] == [
+        "export_markdown",
+        "export_snapshot",
+        "import_snapshot",
+    ]
+    assert ctx.tools["engram_work_board"]["schema"]["name"] == "engram_work_board"
+
+
+@pytest.mark.asyncio
+async def test_issue_808_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.work_task("list") == {"error": "Not connected to Remnic"}
+    assert await provider.work_project("list") == {"error": "Not connected to Remnic"}
+    assert await provider.work_board("export_markdown") == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -30,6 +30,11 @@ _REVIEW_SUGGESTION_TOOL_SUFFIXES = [
     "review_resolve",
     "suggestion_submit",
 ]
+_WORK_BOARD_TOOL_SUFFIXES = [
+    "work_task",
+    "work_project",
+    "work_board",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -54,6 +59,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
     for suffix in _REVIEW_SUGGESTION_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _WORK_BOARD_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -94,6 +103,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_continuity_incident_open" in registered_tools
     assert "remnic_review_queue_list" in registered_tools
     assert "engram_review_queue_list" in registered_tools
+    assert "remnic_work_task" in registered_tools
+    assert "engram_work_task" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():


### PR DESCRIPTION
Closes #808.

## Summary
- register Hermes memory_provider tools for work tasks, projects, and board import/export
- keep legacy engram_* aliases alongside remnic_* tool names
- add focused client/provider registration tests and README tool rows

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes
- npm run check-types
- npm run check-config-contract
- bash scripts/check-review-patterns.sh
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new MCP tool schemas/handlers and registers them under both `remnic_*` and legacy `engram_*` names, with tests covering wiring; no changes to existing recall/store behavior.
> 
> **Overview**
> Adds new Hermes-exposed work-layer MCP tools for issue #808: `remnic_work_task`, `remnic_work_project`, and `remnic_work_board` (plus legacy `engram_*` aliases), including schema definitions and provider handlers.
> 
> Extends `RemnicClient` with corresponding `work_*` methods that call the daemon’s `engram.work_*` MCP endpoints, updates plugin registration to include these tools, and documents them in the README. Adds focused tests to verify client MCP calls, tool registration for both namespaces, and provider “not connected” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75fe1d80c15698c62898cff1ad158856e9dc6401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->