### PR TITLE
feat(hermes): expose shared context tools

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -155,6 +155,11 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_work_task` | Manage work-layer tasks |
 | `remnic_work_project` | Manage work-layer projects |
 | `remnic_work_board` | Export or import work-layer board snapshots and markdown |
+| `remnic_shared_context_write_output` | Write agent work product into shared context |
+| `remnic_shared_feedback_record` | Record shared feedback for peer modeling |
+| `remnic_shared_priorities_append` | Append priorities notes for curator merge |
+| `remnic_shared_context_cross_signals_run` | Generate shared-context cross-signal artifacts |
+| `remnic_shared_context_curate_daily` | Generate the daily shared-context roundtable |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -176,6 +176,30 @@ def _register_issue_808_tools(  # type: ignore[no-untyped-def]
         )
 
 
+_SHARED_CONTEXT_TOOLS = [
+    ("shared_context_write_output", "shared_context_write_output"),
+    ("shared_feedback_record", "shared_feedback_record"),
+    ("shared_priorities_append", "shared_priorities_append"),
+    ("shared_context_cross_signals_run", "shared_context_cross_signals_run"),
+    ("shared_context_curate_daily", "shared_context_curate_daily"),
+]
+
+
+def _register_issue_809_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _SHARED_CONTEXT_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -197,6 +221,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_806_tools(ctx, provider, "remnic")
     _register_issue_807_tools(ctx, provider, "remnic")
     _register_issue_808_tools(ctx, provider, "remnic")
+    _register_issue_809_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -211,3 +236,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_806_tools(ctx, provider, "engram", legacy=True)
     _register_issue_807_tools(ctx, provider, "engram", legacy=True)
     _register_issue_808_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_809_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -275,6 +275,30 @@ class RemnicClient:
     async def work_board(self, action: str, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.work_board", {"action": action, **kwargs})
 
+    async def shared_context_write_output(self, agent_id: str, title: str, content: str) -> dict[str, Any]:
+        return await self._mcp_tool(
+            "engram.shared_context_write_output",
+            {"agentId": agent_id, "title": title, "content": content},
+        )
+
+    async def shared_feedback_record(self, agent: str, decision: str, reason: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool(
+            "engram.shared_feedback_record",
+            {"agent": agent, "decision": decision, "reason": reason, **kwargs},
+        )
+
+    async def shared_priorities_append(self, agent_id: str, text: str) -> dict[str, Any]:
+        return await self._mcp_tool(
+            "engram.shared_priorities_append",
+            {"agentId": agent_id, "text": text},
+        )
+
+    async def shared_context_cross_signals_run(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.shared_context_cross_signals_run", kwargs)
+
+    async def shared_context_curate_daily(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.shared_context_curate_daily", kwargs)
+
     async def close(self) -> None:
         await self._http.aclose()
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -50,6 +50,8 @@ _WORK_TASK_PRIORITIES = ["low", "medium", "high"]
 _WORK_PROJECT_ACTIONS = ["create", "get", "list", "update", "delete", "link_task"]
 _WORK_PROJECT_STATUSES = ["active", "on_hold", "completed", "archived"]
 _WORK_BOARD_ACTIONS = ["export_markdown", "export_snapshot", "import_snapshot"]
+_SHARED_FEEDBACK_DECISIONS = ["approved", "approved_with_feedback", "rejected"]
+_SHARED_FEEDBACK_SEVERITIES = ["low", "medium", "high"]
 
 
 def _schema(
@@ -836,6 +838,84 @@ class RemnicMemoryProvider:
         "Export/import Engram work-layer board snapshots and markdown.",
     )
 
+    # -- Issue #809 shared context / peer modeling tool schemas --
+
+    shared_context_write_output_schema = _schema(
+        "remnic_shared_context_write_output",
+        "Write agent work product into the shared-context directory.",
+        {
+            "agentId": {"type": "string", "description": "Agent ID producing this output."},
+            "title": {"type": "string", "description": "Short title for the output."},
+            "content": {"type": "string", "description": "Markdown content to write."},
+        },
+        ["agentId", "title", "content"],
+    )
+    shared_feedback_record_schema = _schema(
+        "remnic_shared_feedback_record",
+        "Append an approval/rejection decision into the shared-context feedback inbox.",
+        {
+            "agent": {"type": "string", "description": "Agent name that produced the output."},
+            "decision": {"type": "string", "enum": _SHARED_FEEDBACK_DECISIONS},
+            "reason": {"type": "string"},
+            "date": {"type": "string", "description": "ISO timestamp. Defaults to now."},
+            "learning": {"type": "string"},
+            "outcome": {"type": "string"},
+            "severity": {"type": "string", "enum": _SHARED_FEEDBACK_SEVERITIES},
+            "confidence": {"type": "number", "description": "Confidence 0-1."},
+            "workflow": {"type": "string"},
+            "tags": _STRING_ARRAY,
+            "evidenceWindowStart": {"type": "string"},
+            "evidenceWindowEnd": {"type": "string"},
+            "refs": _STRING_ARRAY,
+        },
+        ["agent", "decision", "reason"],
+    )
+    shared_priorities_append_schema = _schema(
+        "remnic_shared_priorities_append",
+        "Append priorities text into the shared-context inbox.",
+        {
+            "agentId": {"type": "string"},
+            "text": {"type": "string", "description": "Priority notes (markdown)."},
+        },
+        ["agentId", "text"],
+    )
+    shared_context_cross_signals_run_schema = _schema(
+        "remnic_shared_context_cross_signals_run",
+        "Generate cross-signal markdown and JSON artifacts.",
+        {"date": {"type": "string", "description": "YYYY-MM-DD. Defaults to today."}},
+    )
+    shared_context_curate_daily_schema = _schema(
+        "remnic_shared_context_curate_daily",
+        "Generate a daily roundtable summary.",
+        {"date": {"type": "string", "description": "YYYY-MM-DD. Defaults to today."}},
+    )
+
+    legacy_shared_context_write_output_schema = _legacy_schema(
+        shared_context_write_output_schema,
+        "engram_shared_context_write_output",
+        "Write agent work product into the Engram shared-context directory.",
+    )
+    legacy_shared_feedback_record_schema = _legacy_schema(
+        shared_feedback_record_schema,
+        "engram_shared_feedback_record",
+        "Append an approval/rejection decision into the Engram shared-context feedback inbox.",
+    )
+    legacy_shared_priorities_append_schema = _legacy_schema(
+        shared_priorities_append_schema,
+        "engram_shared_priorities_append",
+        "Append priorities text into the Engram shared-context inbox.",
+    )
+    legacy_shared_context_cross_signals_run_schema = _legacy_schema(
+        shared_context_cross_signals_run_schema,
+        "engram_shared_context_cross_signals_run",
+        "Generate Engram cross-signal markdown and JSON artifacts.",
+    )
+    legacy_shared_context_curate_daily_schema = _legacy_schema(
+        shared_context_curate_daily_schema,
+        "engram_shared_context_curate_daily",
+        "Generate an Engram daily roundtable summary.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -1079,6 +1159,51 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.work_board(action=action, **kwargs)
+
+    async def shared_context_write_output(
+        self,
+        agentId: str,  # noqa: N803
+        title: str,
+        content: str,
+    ) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.shared_context_write_output(
+            agent_id=agentId,
+            title=title,
+            content=content,
+        )
+
+    async def shared_feedback_record(
+        self,
+        agent: str,
+        decision: str,
+        reason: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.shared_feedback_record(
+            agent=agent,
+            decision=decision,
+            reason=reason,
+            **kwargs,
+        )
+
+    async def shared_priorities_append(self, agentId: str, text: str) -> dict[str, Any]:  # noqa: N803
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.shared_priorities_append(agent_id=agentId, text=text)
+
+    async def shared_context_cross_signals_run(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.shared_context_cross_signals_run(**kwargs)
+
+    async def shared_context_curate_daily(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.shared_context_curate_daily(**kwargs)
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_809_shared_context_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_809_shared_context_tools.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_809_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.shared_context_write_output(
+        agent_id="reviewer",
+        title="API review",
+        content="Looks good.",
+    )
+    await client.shared_feedback_record(
+        agent="reviewer",
+        decision="approved_with_feedback",
+        reason="Accepted with one style note.",
+        tags=["api", "review"],
+    )
+    await client.shared_priorities_append(
+        agent_id="planner",
+        text="- Ship Hermes parity",
+    )
+    await client.shared_context_cross_signals_run(date="2026-04-30")
+    await client.shared_context_curate_daily(date="2026-04-30")
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.shared_context_write_output",
+        "engram.shared_feedback_record",
+        "engram.shared_priorities_append",
+        "engram.shared_context_cross_signals_run",
+        "engram.shared_context_curate_daily",
+    ]
+    assert calls[0].kwargs["json"]["params"]["arguments"] == {
+        "agentId": "reviewer",
+        "title": "API review",
+        "content": "Looks good.",
+    }
+    assert calls[1].kwargs["json"]["params"]["arguments"] == {
+        "agent": "reviewer",
+        "decision": "approved_with_feedback",
+        "reason": "Accepted with one style note.",
+        "tags": ["api", "review"],
+    }
+    assert calls[2].kwargs["json"]["params"]["arguments"] == {
+        "agentId": "planner",
+        "text": "- Ship Hermes parity",
+    }
+    assert calls[3].kwargs["json"]["params"]["arguments"] == {"date": "2026-04-30"}
+    assert calls[4].kwargs["json"]["params"]["arguments"] == {"date": "2026-04-30"}
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_809_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_shared_context_write_output",
+        "remnic_shared_feedback_record",
+        "remnic_shared_priorities_append",
+        "remnic_shared_context_cross_signals_run",
+        "remnic_shared_context_curate_daily",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_shared_context_write_output"]["schema"]["parameters"]["required"] == [
+        "agentId",
+        "title",
+        "content",
+    ]
+    assert ctx.tools["remnic_shared_feedback_record"]["schema"]["parameters"]["required"] == [
+        "agent",
+        "decision",
+        "reason",
+    ]
+    assert ctx.tools["remnic_shared_feedback_record"]["schema"]["parameters"]["properties"]["decision"]["enum"] == [
+        "approved",
+        "approved_with_feedback",
+        "rejected",
+    ]
+    assert ctx.tools["remnic_shared_feedback_record"]["schema"]["parameters"]["properties"]["severity"]["enum"] == [
+        "low",
+        "medium",
+        "high",
+    ]
+    assert ctx.tools["engram_shared_context_curate_daily"]["schema"]["name"] == (
+        "engram_shared_context_curate_daily"
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_809_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.shared_context_write_output("agent", "title", "content") == {
+        "error": "Not connected to Remnic"
+    }
+    assert await provider.shared_feedback_record("agent", "approved", "reason") == {
+        "error": "Not connected to Remnic"
+    }
+    assert await provider.shared_priorities_append("agent", "notes") == {"error": "Not connected to Remnic"}
+    assert await provider.shared_context_cross_signals_run() == {"error": "Not connected to Remnic"}
+    assert await provider.shared_context_curate_daily() == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -35,6 +35,13 @@ _WORK_BOARD_TOOL_SUFFIXES = [
     "work_project",
     "work_board",
 ]
+_SHARED_CONTEXT_TOOL_SUFFIXES = [
+    "shared_context_write_output",
+    "shared_feedback_record",
+    "shared_priorities_append",
+    "shared_context_cross_signals_run",
+    "shared_context_curate_daily",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -63,6 +70,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
     for suffix in _WORK_BOARD_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _SHARED_CONTEXT_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -105,6 +116,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_review_queue_list" in registered_tools
     assert "remnic_work_task" in registered_tools
     assert "engram_work_task" in registered_tools
+    assert "remnic_shared_context_write_output" in registered_tools
+    assert "engram_shared_context_write_output" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():


### PR DESCRIPTION
Closes #809.

## Summary
- register Hermes memory_provider tools for shared-context output, feedback, priorities, cross-signal synthesis, and daily curation
- keep legacy engram_* aliases alongside remnic_* tool names
- add focused client/provider registration tests and README tool rows

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes
- npm run check-types
- npm run check-config-contract
- bash scripts/check-review-patterns.sh
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive tool registration and schemas; main risk is mis-specified MCP argument/schema fields causing runtime tool-call failures, but legacy aliases and existing flows are unchanged.
> 
> **Overview**
> Adds **Issue #809 shared-context/peer modeling MCP tools** to the Hermes Remnic plugin, registering new `remnic_*` tools (and matching `engram_*` legacy aliases) for writing shared outputs, recording feedback, appending priorities, generating cross-signal artifacts, and daily curation.
> 
> Extends `RemnicClient` and `RemnicMemoryProvider` with handlers/schemas for these new tools (including decision/severity enums), updates registration tests accordingly, and documents the new tool names in the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6c8b9c67fd8c80a3191e7577a0406f72b9038d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->