### PR TITLE
feat(hermes): expose compounding tools

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -160,6 +160,8 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_shared_priorities_append` | Append priorities notes for curator merge |
 | `remnic_shared_context_cross_signals_run` | Generate shared-context cross-signal artifacts |
 | `remnic_shared_context_curate_daily` | Generate the daily shared-context roundtable |
+| `remnic_compounding_weekly_synthesize` | Generate weekly compounding outputs |
+| `remnic_compounding_promote_candidate` | Promote a compounding candidate into durable memory |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -200,6 +200,27 @@ def _register_issue_809_tools(  # type: ignore[no-untyped-def]
         )
 
 
+_COMPOUNDING_TOOLS = [
+    ("compounding_weekly_synthesize", "compounding_weekly_synthesize"),
+    ("compounding_promote_candidate", "compounding_promote_candidate"),
+]
+
+
+def _register_issue_810_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _COMPOUNDING_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -222,6 +243,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_807_tools(ctx, provider, "remnic")
     _register_issue_808_tools(ctx, provider, "remnic")
     _register_issue_809_tools(ctx, provider, "remnic")
+    _register_issue_810_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -237,3 +259,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_807_tools(ctx, provider, "engram", legacy=True)
     _register_issue_808_tools(ctx, provider, "engram", legacy=True)
     _register_issue_809_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_810_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -299,6 +299,20 @@ class RemnicClient:
     async def shared_context_curate_daily(self, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.shared_context_curate_daily", kwargs)
 
+    async def compounding_weekly_synthesize(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.compounding_weekly_synthesize", kwargs)
+
+    async def compounding_promote_candidate(
+        self,
+        week_id: str,
+        candidate_id: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        return await self._mcp_tool(
+            "engram.compounding_promote_candidate",
+            {"weekId": week_id, "candidateId": candidate_id, **kwargs},
+        )
+
     async def close(self) -> None:
         await self._http.aclose()
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -916,6 +916,35 @@ class RemnicMemoryProvider:
         "Generate an Engram daily roundtable summary.",
     )
 
+    # -- Issue #810 compounding learning tool schemas --
+
+    compounding_weekly_synthesize_schema = _schema(
+        "remnic_compounding_weekly_synthesize",
+        "Generate weekly compounding outputs.",
+        {"weekId": {"type": "string", "description": "ISO week ID (YYYY-Www). Defaults to current week."}},
+    )
+    compounding_promote_candidate_schema = _schema(
+        "remnic_compounding_promote_candidate",
+        "Promote a compounding candidate into durable memory.",
+        {
+            "weekId": {"type": "string"},
+            "candidateId": {"type": "string"},
+            "dryRun": {"type": "boolean", "description": "Preview without writing."},
+        },
+        ["weekId", "candidateId"],
+    )
+
+    legacy_compounding_weekly_synthesize_schema = _legacy_schema(
+        compounding_weekly_synthesize_schema,
+        "engram_compounding_weekly_synthesize",
+        "Generate weekly Engram compounding outputs.",
+    )
+    legacy_compounding_promote_candidate_schema = _legacy_schema(
+        compounding_promote_candidate_schema,
+        "engram_compounding_promote_candidate",
+        "Promote an Engram compounding candidate into durable memory.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -1204,6 +1233,25 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.shared_context_curate_daily(**kwargs)
+
+    async def compounding_weekly_synthesize(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.compounding_weekly_synthesize(**kwargs)
+
+    async def compounding_promote_candidate(
+        self,
+        weekId: str,  # noqa: N803
+        candidateId: str,  # noqa: N803
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.compounding_promote_candidate(
+            week_id=weekId,
+            candidate_id=candidateId,
+            **kwargs,
+        )
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_810_compounding_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_810_compounding_tools.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_810_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.compounding_weekly_synthesize(weekId="2026-W18")
+    await client.compounding_promote_candidate(
+        week_id="2026-W18",
+        candidate_id="candidate-1",
+        dryRun=True,
+    )
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.compounding_weekly_synthesize",
+        "engram.compounding_promote_candidate",
+    ]
+    assert calls[0].kwargs["json"]["params"]["arguments"] == {"weekId": "2026-W18"}
+    assert calls[1].kwargs["json"]["params"]["arguments"] == {
+        "weekId": "2026-W18",
+        "candidateId": "candidate-1",
+        "dryRun": True,
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_810_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_compounding_weekly_synthesize",
+        "remnic_compounding_promote_candidate",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_compounding_promote_candidate"]["schema"]["parameters"]["required"] == [
+        "weekId",
+        "candidateId",
+    ]
+    assert "weekId" in ctx.tools["remnic_compounding_weekly_synthesize"]["schema"]["parameters"]["properties"]
+    assert ctx.tools["engram_compounding_promote_candidate"]["schema"]["name"] == (
+        "engram_compounding_promote_candidate"
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_810_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.compounding_weekly_synthesize() == {"error": "Not connected to Remnic"}
+    assert await provider.compounding_promote_candidate("2026-W18", "candidate-1") == {
+        "error": "Not connected to Remnic"
+    }

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -42,6 +42,10 @@ _SHARED_CONTEXT_TOOL_SUFFIXES = [
     "shared_context_cross_signals_run",
     "shared_context_curate_daily",
 ]
+_COMPOUNDING_TOOL_SUFFIXES = [
+    "compounding_weekly_synthesize",
+    "compounding_promote_candidate",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -74,6 +78,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
     for suffix in _SHARED_CONTEXT_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _COMPOUNDING_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -118,6 +126,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_work_task" in registered_tools
     assert "remnic_shared_context_write_output" in registered_tools
     assert "engram_shared_context_write_output" in registered_tools
+    assert "remnic_compounding_weekly_synthesize" in registered_tools
+    assert "engram_compounding_weekly_synthesize" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():


### PR DESCRIPTION
Closes #810.

## Summary
- register Hermes memory_provider tools for weekly compounding synthesis and candidate promotion
- keep legacy engram_* aliases alongside remnic_* tool names
- add focused client/provider registration tests and README tool rows

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes
- npm run check-types
- npm run check-config-contract
- bash scripts/check-review-patterns.sh
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds new MCP tool registrations and thin client/provider wrappers, with no changes to auth, storage, or existing tool behavior.
> 
> **Overview**
> Adds two new Hermes-exposed compounding MCP tools: `remnic_compounding_weekly_synthesize` (weekly synthesis) and `remnic_compounding_promote_candidate` (promote a candidate, with optional `dryRun`). Both are registered under primary `remnic_*` names and legacy `engram_*` aliases, with matching schemas and provider handlers wired through the existing daemon MCP surface.
> 
> Updates the README tool list and adds focused tests to verify tool registration, client MCP call wiring/argument shaping, and provider “not connected” behavior before initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8020f24b2102ce905376b08dafc25eefc056d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->