### PR TITLE
feat(hermes): expose compression guideline tools

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -162,6 +162,8 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_shared_context_curate_daily` | Generate the daily shared-context roundtable |
 | `remnic_compounding_weekly_synthesize` | Generate weekly compounding outputs |
 | `remnic_compounding_promote_candidate` | Promote a compounding candidate into durable memory |
+| `remnic_compression_guidelines_optimize` | Run compression-guideline policy optimization |
+| `remnic_compression_guidelines_activate` | Activate a staged compression-guideline draft |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -221,6 +221,27 @@ def _register_issue_810_tools(  # type: ignore[no-untyped-def]
         )
 
 
+_COMPRESSION_GUIDELINE_TOOLS = [
+    ("compression_guidelines_optimize", "compression_guidelines_optimize"),
+    ("compression_guidelines_activate", "compression_guidelines_activate"),
+]
+
+
+def _register_issue_811_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _COMPRESSION_GUIDELINE_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -244,6 +265,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_808_tools(ctx, provider, "remnic")
     _register_issue_809_tools(ctx, provider, "remnic")
     _register_issue_810_tools(ctx, provider, "remnic")
+    _register_issue_811_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -260,3 +282,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_808_tools(ctx, provider, "engram", legacy=True)
     _register_issue_809_tools(ctx, provider, "engram", legacy=True)
     _register_issue_810_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_811_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -313,6 +313,12 @@ class RemnicClient:
             {"weekId": week_id, "candidateId": candidate_id, **kwargs},
         )
 
+    async def compression_guidelines_optimize(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.compression_guidelines_optimize", kwargs)
+
+    async def compression_guidelines_activate(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.compression_guidelines_activate", kwargs)
+
     async def close(self) -> None:
         await self._http.aclose()
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -945,6 +945,36 @@ class RemnicMemoryProvider:
         "Promote an Engram compounding candidate into durable memory.",
     )
 
+    # -- Issue #811 compression guideline policy tool schemas --
+
+    compression_guidelines_optimize_schema = _schema(
+        "remnic_compression_guidelines_optimize",
+        "Run the compression guideline optimizer.",
+        {
+            "dryRun": {"type": "boolean"},
+            "eventLimit": {"type": "number"},
+        },
+    )
+    compression_guidelines_activate_schema = _schema(
+        "remnic_compression_guidelines_activate",
+        "Promote a staged compression guideline draft to active.",
+        {
+            "expectedContentHash": {"type": "string"},
+            "expectedGuidelineVersion": {"type": "number"},
+        },
+    )
+
+    legacy_compression_guidelines_optimize_schema = _legacy_schema(
+        compression_guidelines_optimize_schema,
+        "engram_compression_guidelines_optimize",
+        "Run the Engram compression guideline optimizer.",
+    )
+    legacy_compression_guidelines_activate_schema = _legacy_schema(
+        compression_guidelines_activate_schema,
+        "engram_compression_guidelines_activate",
+        "Promote a staged Engram compression guideline draft to active.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -1252,6 +1282,16 @@ class RemnicMemoryProvider:
             candidate_id=candidateId,
             **kwargs,
         )
+
+    async def compression_guidelines_optimize(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.compression_guidelines_optimize(**kwargs)
+
+    async def compression_guidelines_activate(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.compression_guidelines_activate(**kwargs)
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_811_compression_guideline_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_811_compression_guideline_tools.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_811_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.compression_guidelines_optimize(dryRun=True, eventLimit=25)
+    await client.compression_guidelines_activate(
+        expectedContentHash="sha256:abc",
+        expectedGuidelineVersion=3,
+    )
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.compression_guidelines_optimize",
+        "engram.compression_guidelines_activate",
+    ]
+    assert calls[0].kwargs["json"]["params"]["arguments"] == {
+        "dryRun": True,
+        "eventLimit": 25,
+    }
+    assert calls[1].kwargs["json"]["params"]["arguments"] == {
+        "expectedContentHash": "sha256:abc",
+        "expectedGuidelineVersion": 3,
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_811_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_compression_guidelines_optimize",
+        "remnic_compression_guidelines_activate",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert "dryRun" in ctx.tools["remnic_compression_guidelines_optimize"]["schema"]["parameters"]["properties"]
+    assert "eventLimit" in ctx.tools["remnic_compression_guidelines_optimize"]["schema"]["parameters"]["properties"]
+    assert "expectedContentHash" in (
+        ctx.tools["remnic_compression_guidelines_activate"]["schema"]["parameters"]["properties"]
+    )
+    assert ctx.tools["engram_compression_guidelines_activate"]["schema"]["name"] == (
+        "engram_compression_guidelines_activate"
+    )
+
+
+@pytest.mark.asyncio
+async def test_issue_811_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.compression_guidelines_optimize() == {"error": "Not connected to Remnic"}
+    assert await provider.compression_guidelines_activate() == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -46,6 +46,10 @@ _COMPOUNDING_TOOL_SUFFIXES = [
     "compounding_weekly_synthesize",
     "compounding_promote_candidate",
 ]
+_COMPRESSION_GUIDELINE_TOOL_SUFFIXES = [
+    "compression_guidelines_optimize",
+    "compression_guidelines_activate",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -82,6 +86,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
     for suffix in _COMPOUNDING_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _COMPRESSION_GUIDELINE_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -128,6 +136,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_shared_context_write_output" in registered_tools
     assert "remnic_compounding_weekly_synthesize" in registered_tools
     assert "engram_compounding_weekly_synthesize" in registered_tools
+    assert "remnic_compression_guidelines_optimize" in registered_tools
+    assert "engram_compression_guidelines_optimize" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():


### PR DESCRIPTION
Closes #811.

## Summary
- register Hermes memory_provider tools for compression guideline optimization and activation
- keep legacy engram_* aliases alongside remnic_* tool names
- add focused client/provider registration tests and README tool rows

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes
- npm run check-types
- npm run check-config-contract
- bash scripts/check-review-patterns.sh
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new MCP tool registrations and thin client/provider pass-through handlers, plus tests/docs, without altering existing recall/store flows.
> 
> **Overview**
> Adds support for compression guideline policy management by registering two new tools: `remnic_compression_guidelines_optimize` and `remnic_compression_guidelines_activate`, including **legacy** `engram_*` aliases during the compat window.
> 
> Implements the corresponding `RemnicClient` MCP calls and `RemnicMemoryProvider` schemas/handlers, updates `register()` to wire them in, and adds focused tests to validate MCP tool invocation, registration, and not-connected behavior. Documentation is updated to list the new tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c022caeeefaa4acbd16fe347a9bbdf4d1470f3d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->