### PR TITLE
feat(hermes): expose governance and hygiene tools

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -164,6 +164,12 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_compounding_promote_candidate` | Promote a compounding candidate into durable memory |
 | `remnic_compression_guidelines_optimize` | Run compression-guideline policy optimization |
 | `remnic_compression_guidelines_activate` | Activate a staged compression-guideline draft |
+| `remnic_memory_governance_run` | Run memory governance in shadow or apply mode |
+| `remnic_procedure_mining_run` | Run procedural memory mining |
+| `remnic_procedural_stats` | Read procedural memory stats |
+| `remnic_contradiction_scan_run` | Run an on-demand contradiction scan |
+| `remnic_memory_summarize_hourly` | Generate hourly conversation summaries |
+| `remnic_conversation_index_update` | Update the conversation index |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -242,6 +242,31 @@ def _register_issue_811_tools(  # type: ignore[no-untyped-def]
         )
 
 
+_GOVERNANCE_HYGIENE_TOOLS = [
+    ("memory_governance_run", "memory_governance_run"),
+    ("procedure_mining_run", "procedure_mining_run"),
+    ("procedural_stats", "procedural_stats"),
+    ("contradiction_scan_run", "contradiction_scan_run"),
+    ("memory_summarize_hourly", "memory_summarize_hourly"),
+    ("conversation_index_update", "conversation_index_update"),
+]
+
+
+def _register_issue_812_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _GOVERNANCE_HYGIENE_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -266,6 +291,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_809_tools(ctx, provider, "remnic")
     _register_issue_810_tools(ctx, provider, "remnic")
     _register_issue_811_tools(ctx, provider, "remnic")
+    _register_issue_812_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -283,3 +309,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_809_tools(ctx, provider, "engram", legacy=True)
     _register_issue_810_tools(ctx, provider, "engram", legacy=True)
     _register_issue_811_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_812_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -319,6 +319,24 @@ class RemnicClient:
     async def compression_guidelines_activate(self, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.compression_guidelines_activate", kwargs)
 
+    async def memory_governance_run(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_governance_run", kwargs)
+
+    async def procedure_mining_run(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.procedure_mining_run", kwargs)
+
+    async def procedural_stats(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.procedural_stats", kwargs)
+
+    async def contradiction_scan_run(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.contradiction_scan_run", kwargs)
+
+    async def memory_summarize_hourly(self) -> dict[str, Any]:
+        return await self._mcp_tool("engram.memory_summarize_hourly", {})
+
+    async def conversation_index_update(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.conversation_index_update", kwargs)
+
     async def close(self) -> None:
         await self._http.aclose()
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -1388,7 +1388,7 @@ class RemnicMemoryProvider:
             return {"error": "Not connected to Remnic"}
         return await self._client.contradiction_scan_run(**kwargs)
 
-    async def memory_summarize_hourly(self) -> dict[str, Any]:
+    async def memory_summarize_hourly(self, **kwargs: Any) -> dict[str, Any]:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.memory_summarize_hourly()

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -52,6 +52,7 @@ _WORK_PROJECT_STATUSES = ["active", "on_hold", "completed", "archived"]
 _WORK_BOARD_ACTIONS = ["export_markdown", "export_snapshot", "import_snapshot"]
 _SHARED_FEEDBACK_DECISIONS = ["approved", "approved_with_feedback", "rejected"]
 _SHARED_FEEDBACK_SEVERITIES = ["low", "medium", "high"]
+_GOVERNANCE_MODES = ["shadow", "apply"]
 
 
 def _schema(
@@ -975,6 +976,80 @@ class RemnicMemoryProvider:
         "Promote a staged Engram compression guideline draft to active.",
     )
 
+    # -- Issue #812 governance / hygiene tool schemas --
+
+    memory_governance_run_schema = _schema(
+        "remnic_memory_governance_run",
+        "Run Remnic memory governance in a bounded shadow/apply pass.",
+        {
+            "namespace": _NAMESPACE,
+            "mode": {"type": "string", "enum": _GOVERNANCE_MODES},
+            "recentDays": {"type": "number"},
+            "maxMemories": {"type": "number"},
+            "batchSize": {"type": "number"},
+        },
+    )
+    procedure_mining_run_schema = _schema(
+        "remnic_procedure_mining_run",
+        "Run procedural memory mining.",
+        {"namespace": _NAMESPACE},
+    )
+    procedural_stats_schema = _schema(
+        "remnic_procedural_stats",
+        "Read procedural memory stats.",
+        {"namespace": _NAMESPACE},
+    )
+    contradiction_scan_run_schema = _schema(
+        "remnic_contradiction_scan_run",
+        "Run an on-demand contradiction scan over the memory corpus.",
+        {"namespace": _NAMESPACE},
+    )
+    memory_summarize_hourly_schema = _schema(
+        "remnic_memory_summarize_hourly",
+        "Generate hourly summaries for recent conversations.",
+        {},
+    )
+    conversation_index_update_schema = _schema(
+        "remnic_conversation_index_update",
+        "Chunk transcript history into conversation-index documents.",
+        {
+            "sessionKey": {"type": "string"},
+            "hours": {"type": "number", "description": "How many hours of transcript history to include."},
+            "embed": {"type": "boolean", "description": "Run QMD embed after update for this invocation."},
+        },
+    )
+
+    legacy_memory_governance_run_schema = _legacy_schema(
+        memory_governance_run_schema,
+        "engram_memory_governance_run",
+        "Run Engram memory governance in a bounded shadow/apply pass.",
+    )
+    legacy_procedure_mining_run_schema = _legacy_schema(
+        procedure_mining_run_schema,
+        "engram_procedure_mining_run",
+        "Run Engram procedural memory mining.",
+    )
+    legacy_procedural_stats_schema = _legacy_schema(
+        procedural_stats_schema,
+        "engram_procedural_stats",
+        "Read Engram procedural memory stats.",
+    )
+    legacy_contradiction_scan_run_schema = _legacy_schema(
+        contradiction_scan_run_schema,
+        "engram_contradiction_scan_run",
+        "Run an on-demand Engram contradiction scan over the memory corpus.",
+    )
+    legacy_memory_summarize_hourly_schema = _legacy_schema(
+        memory_summarize_hourly_schema,
+        "engram_memory_summarize_hourly",
+        "Generate hourly summaries for recent Engram conversations.",
+    )
+    legacy_conversation_index_update_schema = _legacy_schema(
+        conversation_index_update_schema,
+        "engram_conversation_index_update",
+        "Chunk Engram transcript history into conversation-index documents.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -1292,6 +1367,36 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.compression_guidelines_activate(**kwargs)
+
+    async def memory_governance_run(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_governance_run(**kwargs)
+
+    async def procedure_mining_run(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.procedure_mining_run(**kwargs)
+
+    async def procedural_stats(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.procedural_stats(**kwargs)
+
+    async def contradiction_scan_run(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.contradiction_scan_run(**kwargs)
+
+    async def memory_summarize_hourly(self) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.memory_summarize_hourly()
+
+    async def conversation_index_update(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.conversation_index_update(**kwargs)
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_812_governance_hygiene_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_812_governance_hygiene_tools.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_812_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.memory_governance_run(namespace="project", mode="shadow", maxMemories=5)
+    await client.procedure_mining_run(namespace="project")
+    await client.procedural_stats(namespace="project")
+    await client.contradiction_scan_run(namespace="project")
+    await client.memory_summarize_hourly()
+    await client.conversation_index_update(sessionKey="session-1", hours=12, embed=True)
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.memory_governance_run",
+        "engram.procedure_mining_run",
+        "engram.procedural_stats",
+        "engram.contradiction_scan_run",
+        "engram.memory_summarize_hourly",
+        "engram.conversation_index_update",
+    ]
+    assert calls[0].kwargs["json"]["params"]["arguments"] == {
+        "namespace": "project",
+        "mode": "shadow",
+        "maxMemories": 5,
+    }
+    assert calls[4].kwargs["json"]["params"]["arguments"] == {}
+    assert calls[5].kwargs["json"]["params"]["arguments"] == {
+        "sessionKey": "session-1",
+        "hours": 12,
+        "embed": True,
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_812_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_memory_governance_run",
+        "remnic_procedure_mining_run",
+        "remnic_procedural_stats",
+        "remnic_contradiction_scan_run",
+        "remnic_memory_summarize_hourly",
+        "remnic_conversation_index_update",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_memory_governance_run"]["schema"]["parameters"]["properties"]["mode"]["enum"] == [
+        "shadow",
+        "apply",
+    ]
+    assert ctx.tools["remnic_memory_summarize_hourly"]["schema"]["parameters"]["properties"] == {}
+    assert "embed" in ctx.tools["remnic_conversation_index_update"]["schema"]["parameters"]["properties"]
+    assert ctx.tools["engram_conversation_index_update"]["schema"]["name"] == "engram_conversation_index_update"
+
+
+@pytest.mark.asyncio
+async def test_issue_812_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.memory_governance_run() == {"error": "Not connected to Remnic"}
+    assert await provider.procedure_mining_run() == {"error": "Not connected to Remnic"}
+    assert await provider.procedural_stats() == {"error": "Not connected to Remnic"}
+    assert await provider.contradiction_scan_run() == {"error": "Not connected to Remnic"}
+    assert await provider.memory_summarize_hourly() == {"error": "Not connected to Remnic"}
+    assert await provider.conversation_index_update() == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_issue_812_governance_hygiene_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_812_governance_hygiene_tools.py
@@ -99,5 +99,5 @@ async def test_issue_812_provider_handlers_return_not_connected_before_initializ
     assert await provider.procedure_mining_run() == {"error": "Not connected to Remnic"}
     assert await provider.procedural_stats() == {"error": "Not connected to Remnic"}
     assert await provider.contradiction_scan_run() == {"error": "Not connected to Remnic"}
-    assert await provider.memory_summarize_hourly() == {"error": "Not connected to Remnic"}
+    assert await provider.memory_summarize_hourly(framework_metadata=True) == {"error": "Not connected to Remnic"}
     assert await provider.conversation_index_update() == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -50,6 +50,14 @@ _COMPRESSION_GUIDELINE_TOOL_SUFFIXES = [
     "compression_guidelines_optimize",
     "compression_guidelines_activate",
 ]
+_GOVERNANCE_HYGIENE_TOOL_SUFFIXES = [
+    "memory_governance_run",
+    "procedure_mining_run",
+    "procedural_stats",
+    "contradiction_scan_run",
+    "memory_summarize_hourly",
+    "conversation_index_update",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -90,6 +98,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
     for suffix in _COMPRESSION_GUIDELINE_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _GOVERNANCE_HYGIENE_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -138,6 +150,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_compounding_weekly_synthesize" in registered_tools
     assert "remnic_compression_guidelines_optimize" in registered_tools
     assert "engram_compression_guidelines_optimize" in registered_tools
+    assert "remnic_memory_governance_run" in registered_tools
+    assert "engram_memory_governance_run" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -192,3 +192,27 @@ test("MCP maintenance: conversation index update sanitizes optional args", async
   });
   assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, false);
 });
+
+test("MCP maintenance: conversation index update preserves omitted embed default", async () => {
+  let received: Record<string, unknown> | undefined;
+  const service = {
+    ...makeMockService(),
+    conversationIndexUpdate: async (args: Record<string, unknown>) => {
+      received = args;
+      return { ok: true };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  await server.handleRequest(
+    makeToolRequest("engram.conversation_index_update", {
+      sessionKey: "session-1",
+    }),
+  );
+
+  assert.deepEqual(received, {
+    sessionKey: "session-1",
+    hours: undefined,
+    embed: undefined,
+  });
+});

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -43,6 +43,8 @@ function makeMockService(briefingFn?: () => Promise<unknown>): EngramAccessServi
     continuityLoopReview: () => Promise.resolve({ ok: true }),
     workTask: () => Promise.resolve({ ok: true }),
     workProject: () => Promise.resolve({ ok: true }),
+    memorySummarizeHourly: () => Promise.resolve({ ok: true }),
+    conversationIndexUpdate: () => Promise.resolve({ ok: true }),
   } as unknown as EngramAccessService;
 }
 
@@ -54,6 +56,18 @@ function makeRequest(format: unknown): Record<string, unknown> {
     params: {
       name: "engram.briefing",
       arguments: { format },
+    },
+  };
+}
+
+function makeToolRequest(name: string, args: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name,
+      arguments: args,
     },
   };
 }
@@ -133,4 +147,48 @@ test("MCP briefing: arbitrary invalid format strings are rejected", async () => 
     const result = (response as Record<string, unknown> & { result?: { isError?: boolean } }).result;
     assert.equal(result?.isError, true, `format="${bad}" should produce isError=true`);
   }
+});
+
+test("MCP maintenance: hourly summarization dispatches to the access service", async () => {
+  let called = false;
+  const service = {
+    ...makeMockService(),
+    memorySummarizeHourly: async () => {
+      called = true;
+      return { ok: true };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const response = await server.handleRequest(makeToolRequest("engram.memory_summarize_hourly"));
+
+  assert.equal(called, true, "memorySummarizeHourly should be dispatched");
+  assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, false);
+});
+
+test("MCP maintenance: conversation index update sanitizes optional args", async () => {
+  let received: Record<string, unknown> | undefined;
+  const service = {
+    ...makeMockService(),
+    conversationIndexUpdate: async (args: Record<string, unknown>) => {
+      received = args;
+      return { ok: true };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const response = await server.handleRequest(
+    makeToolRequest("engram.conversation_index_update", {
+      sessionKey: "session-1",
+      hours: 12,
+      embed: true,
+    }),
+  );
+
+  assert.deepEqual(received, {
+    sessionKey: "session-1",
+    hours: 12,
+    embed: true,
+  });
+  assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, false);
 });

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -216,3 +216,24 @@ test("MCP maintenance: conversation index update preserves omitted embed default
     embed: undefined,
   });
 });
+
+test("MCP maintenance: conversation index update rejects non-string sessionKey", async () => {
+  let called = false;
+  const service = {
+    ...makeMockService(),
+    conversationIndexUpdate: async () => {
+      called = true;
+      return { ok: true };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const response = await server.handleRequest(
+    makeToolRequest("engram.conversation_index_update", {
+      sessionKey: 123,
+    }),
+  );
+
+  assert.equal(called, false);
+  assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, true);
+});

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2357,7 +2357,7 @@ export class EngramMcpServer {
         return this.service.conversationIndexUpdate({
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
           hours: typeof args.hours === "number" && Number.isFinite(args.hours) ? args.hours : undefined,
-          embed: args.embed === true,
+          embed: typeof args.embed === "boolean" ? args.embed : undefined,
         });
       case "engram.graph_edge_decay_run":
       case "remnic.graph_edge_decay_run": {

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1142,6 +1142,28 @@ export class EngramMcpServer {
         },
       },
       {
+        name: "engram.memory_summarize_hourly",
+        description: "Generate hourly summaries for recent conversations.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.conversation_index_update",
+        description: "Chunk transcript history into conversation-index documents.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            sessionKey: { type: "string" },
+            hours: { type: "number", description: "How many hours of transcript history to include." },
+            embed: { type: "boolean", description: "If true, run QMD embed after update for this invocation." },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.graph_edge_decay_run",
         description:
           "Run the graph-edge-confidence decay maintenance pass (issue #681 PR 2/3). Respects graphEdgeDecayEnabled; writes a structured telemetry record to state/graph-edge-decay-status.json.",
@@ -2327,6 +2349,16 @@ export class EngramMcpServer {
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
         });
       }
+      case "engram.memory_summarize_hourly":
+      case "remnic.memory_summarize_hourly":
+        return this.service.memorySummarizeHourly();
+      case "engram.conversation_index_update":
+      case "remnic.conversation_index_update":
+        return this.service.conversationIndexUpdate({
+          sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
+          hours: typeof args.hours === "number" && Number.isFinite(args.hours) ? args.hours : undefined,
+          embed: args.embed === true,
+        });
       case "engram.graph_edge_decay_run":
       case "remnic.graph_edge_decay_run": {
         // Issue #681 PR 2/3 — gated by config; tool always callable, but

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2353,12 +2353,17 @@ export class EngramMcpServer {
       case "remnic.memory_summarize_hourly":
         return this.service.memorySummarizeHourly();
       case "engram.conversation_index_update":
-      case "remnic.conversation_index_update":
+      case "remnic.conversation_index_update": {
+        if ("sessionKey" in args && args.sessionKey !== undefined && typeof args.sessionKey !== "string") {
+          throw new Error("sessionKey must be a string when provided");
+        }
+        const sessionKey = typeof args.sessionKey === "string" ? args.sessionKey : undefined;
         return this.service.conversationIndexUpdate({
-          sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
+          sessionKey,
           hours: typeof args.hours === "number" && Number.isFinite(args.hours) ? args.hours : undefined,
           embed: typeof args.embed === "boolean" ? args.embed : undefined,
         });
+      }
       case "engram.graph_edge_decay_run":
       case "remnic.graph_edge_decay_run": {
         // Issue #681 PR 2/3 — gated by config; tool always callable, but

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2903,6 +2903,102 @@ export class EngramAccessService {
     return { namespace: resolvedNamespace, ...report };
   }
 
+  async memorySummarizeHourly(): Promise<{
+    ok: true;
+    message: string;
+  }> {
+    await this.orchestrator.summarizer.runHourly();
+    return {
+      ok: true,
+      message: "Hourly summarization completed. Check the summaries directory for results.",
+    };
+  }
+
+  async conversationIndexUpdate(
+    request: {
+      sessionKey?: string;
+      hours?: number;
+      embed?: boolean;
+    } = {},
+  ): Promise<{
+    enabled: boolean;
+    sessionKey?: string;
+    sessions: number;
+    chunks: number;
+    skipped: number;
+    skippedSessionKeys: string[];
+    embeddedRuns: number;
+    reason?: string;
+    retryAfterMs?: number;
+  }> {
+    if (!this.orchestrator.config.conversationIndexEnabled) {
+      return {
+        enabled: false,
+        sessions: 0,
+        chunks: 0,
+        skipped: 0,
+        skippedSessionKeys: [],
+        embeddedRuns: 0,
+        reason: "disabled",
+      };
+    }
+
+    const hours =
+      typeof request.hours === "number" && Number.isFinite(request.hours)
+        ? Math.max(1, Math.floor(request.hours))
+        : 24;
+
+    if (request.sessionKey) {
+      const result = await this.orchestrator.updateConversationIndex(
+        request.sessionKey,
+        hours,
+        { embed: request.embed },
+      );
+      return {
+        enabled: true,
+        sessionKey: request.sessionKey,
+        sessions: 1,
+        chunks: result.chunks,
+        skipped: result.skipped ? 1 : 0,
+        skippedSessionKeys: result.skipped ? [request.sessionKey] : [],
+        embeddedRuns: result.embedded ? 1 : 0,
+        reason: result.reason,
+        retryAfterMs: result.retryAfterMs,
+      };
+    }
+
+    const sessionKeys = await this.orchestrator.transcript.listSessionKeys();
+    let chunks = 0;
+    let skipped = 0;
+    const skippedSessionKeys: string[] = [];
+    let embeddedRuns = 0;
+
+    for (const sessionKey of sessionKeys) {
+      const result = await this.orchestrator.updateConversationIndex(
+        sessionKey,
+        hours,
+        { embed: request.embed },
+      );
+      chunks += result.chunks;
+      if (result.skipped) {
+        skipped += 1;
+        skippedSessionKeys.push(sessionKey);
+      }
+      if (result.embedded) {
+        embeddedRuns += 1;
+      }
+    }
+
+    return {
+      enabled: true,
+      sessions: sessionKeys.length,
+      chunks,
+      skipped,
+      skippedSessionKeys,
+      embeddedRuns,
+    };
+  }
+
   async trustZoneStatus(namespace?: string, principal?: string): Promise<EngramAccessTrustZoneStatusResponse> {
     const resolvedNamespace = this.resolveReadableNamespace(namespace, principal);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2948,19 +2948,27 @@ export class EngramAccessService {
         ? Math.max(1, Math.floor(request.hours))
         : 24;
 
-    if (request.sessionKey) {
+    let sessionKey: string | undefined;
+    if (request.sessionKey !== undefined) {
+      if (typeof request.sessionKey !== "string" || request.sessionKey.trim().length === 0) {
+        throw new EngramAccessInputError("sessionKey must be a non-empty string when provided");
+      }
+      sessionKey = request.sessionKey.trim();
+    }
+
+    if (sessionKey) {
       const result = await this.orchestrator.updateConversationIndex(
-        request.sessionKey,
+        sessionKey,
         hours,
         { embed: request.embed },
       );
       return {
         enabled: true,
-        sessionKey: request.sessionKey,
+        sessionKey,
         sessions: 1,
         chunks: result.chunks,
         skipped: result.skipped ? 1 : 0,
-        skippedSessionKeys: result.skipped ? [request.sessionKey] : [],
+        skippedSessionKeys: result.skipped ? [sessionKey] : [],
         embeddedRuns: result.embedded ? 1 : 0,
         reason: result.reason,
         retryAfterMs: result.retryAfterMs,

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -378,6 +378,8 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.review_list",
     "engram.review_resolve",
     "engram.contradiction_scan_run",
+    "engram.memory_summarize_hourly",
+    "engram.conversation_index_update",
     "engram.graph_edge_decay_run",
     "engram.live_connectors_run",
     "engram.peer_list",

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -128,6 +128,30 @@ function createMemoryActionService(contextCompressionActionsEnabled: boolean) {
   return { service, capturedEvents };
 }
 
+test("conversationIndexUpdate rejects blank sessionKey instead of updating every session", async () => {
+  const service = new EngramAccessService({
+    config: {
+      memoryDir: "/tmp/engram",
+      conversationIndexEnabled: true,
+    },
+    transcript: {
+      listSessionKeys: async () => {
+        throw new Error("all-session update should not run");
+      },
+    },
+    updateConversationIndex: async () => {
+      throw new Error("single-session update should not run");
+    },
+  } as any);
+
+  await assert.rejects(
+    () => service.conversationIndexUpdate({ sessionKey: "   " }),
+    (err: unknown) =>
+      err instanceof EngramAccessInputError &&
+      /sessionKey must be a non-empty string/.test(err.message),
+  );
+});
+
 test("memoryActionApply is gated by context compression actions", async () => {
   const { service, capturedEvents } = createMemoryActionService(false);
 


### PR DESCRIPTION
Closes #812.

## Summary
- register Hermes memory_provider tools for governance, procedure mining/stats, contradiction scans, hourly summaries, and conversation index updates
- expose daemon MCP endpoints for hourly summaries and conversation index updates so the Hermes tools call real daemon surfaces
- keep legacy engram_* aliases alongside remnic_* tool names
- add focused Hermes client/provider tests plus access MCP dispatcher coverage

## Verification
- uv run --project packages/plugin-hermes --extra test pytest -q
- uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests
- uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes
- npm run check-types
- npm run check-config-contract
- npx tsx --test packages/remnic-core/src/access-mcp.test.ts
- bash scripts/check-review-patterns.sh
- git diff --check

Note: an attempted `pnpm --filter @remnic/core test -- src/access-mcp.test.ts` expanded to the full core src test suite and was interrupted after several minutes of unrelated all-pass output; the targeted MCP dispatcher command above was then run directly and passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new maintenance/governance tool surfaces that can trigger summarization and conversation-index updates, which may write/modify stored artifacts and run potentially expensive background work. Input validation is added, but misconfiguration or misuse could still impact performance or data outputs.
> 
> **Overview**
> Hermes now registers additional Remnic *governance/hygiene* tools—`memory_governance_run`, `procedure_mining_run`, `procedural_stats`, `contradiction_scan_run`, `memory_summarize_hourly`, and `conversation_index_update`—including `engram_*` legacy aliases, plus matching client/provider handlers and updated README tool docs.
> 
> On the daemon side, MCP tool definitions and dispatch are extended to support `memory_summarize_hourly` and `conversation_index_update` (with argument sanitization for `sessionKey`/`hours`/`embed`), and the access service implements the hourly summarizer trigger and a gated conversation-index update workflow. Tests were added/expanded to cover Hermes registration/client calls and MCP/service validation behavior (including rejecting blank `sessionKey`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 644ffcffb417d9dcb6ef6f235f638b0d4c9fb7c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->