### PR TITLE
feat(hermes): expose context recap tools

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -170,6 +170,9 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `remnic_contradiction_scan_run` | Run an on-demand contradiction scan |
 | `remnic_memory_summarize_hourly` | Generate hourly conversation summaries |
 | `remnic_conversation_index_update` | Update the conversation index |
+| `remnic_day_summary` | Generate a structured end-of-day summary |
+| `remnic_briefing` | Generate a daily context briefing |
+| `remnic_context_checkpoint` | Save a structured context checkpoint for a session |
 
 During the Engram to Remnic compat window, legacy `engram_*` aliases are also registered for each tool. These route to the same handlers. Their schema descriptions intentionally say "Engram" (not "Remnic") so that tool names and descriptions agree when a language model surfaces the legacy names. The `engram_*` aliases will be removed in a future major release. New integrations should use the `remnic_*` names.
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -267,6 +267,28 @@ def _register_issue_812_tools(  # type: ignore[no-untyped-def]
         )
 
 
+_CONTEXT_RECAP_TOOLS = [
+    ("day_summary", "day_summary"),
+    ("briefing", "briefing"),
+    ("context_checkpoint", "context_checkpoint"),
+]
+
+
+def _register_issue_813_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _CONTEXT_RECAP_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -292,6 +314,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_810_tools(ctx, provider, "remnic")
     _register_issue_811_tools(ctx, provider, "remnic")
     _register_issue_812_tools(ctx, provider, "remnic")
+    _register_issue_813_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -310,3 +333,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_810_tools(ctx, provider, "engram", legacy=True)
     _register_issue_811_tools(ctx, provider, "engram", legacy=True)
     _register_issue_812_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_813_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -337,6 +337,18 @@ class RemnicClient:
     async def conversation_index_update(self, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.conversation_index_update", kwargs)
 
+    async def day_summary(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.day_summary", kwargs)
+
+    async def briefing(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.briefing", kwargs)
+
+    async def context_checkpoint(self, session_key: str, context: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool(
+            "engram.context_checkpoint",
+            {"sessionKey": session_key, "context": context, **kwargs},
+        )
+
     async def close(self) -> None:
         await self._http.aclose()
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -1050,6 +1050,55 @@ class RemnicMemoryProvider:
         "Chunk Engram transcript history into conversation-index documents.",
     )
 
+    # -- Issue #813 context recap tool schemas --
+
+    day_summary_schema = _schema(
+        "remnic_day_summary",
+        "Generate a structured end-of-day summary.",
+        {
+            "memories": {"type": "string"},
+            "sessionKey": {"type": "string"},
+            "namespace": _NAMESPACE,
+        },
+    )
+    briefing_schema = _schema(
+        "remnic_briefing",
+        "Generate a daily context briefing.",
+        {
+            "since": {"type": "string", "description": "Lookback window, e.g. yesterday, 3d, 1w, or 24h."},
+            "focus": {"type": "string", "description": "Optional filter, e.g. person:Jane Doe or project:remnic."},
+            "namespace": _NAMESPACE,
+            "format": {"type": "string", "enum": ["markdown", "json"]},
+            "maxFollowups": {"type": "number"},
+        },
+    )
+    context_checkpoint_schema = _schema(
+        "remnic_context_checkpoint",
+        "Save a structured context checkpoint for a session.",
+        {
+            "sessionKey": {"type": "string"},
+            "context": {"type": "string"},
+            "namespace": _NAMESPACE,
+        },
+        ["sessionKey", "context"],
+    )
+
+    legacy_day_summary_schema = _legacy_schema(
+        day_summary_schema,
+        "engram_day_summary",
+        "Generate a structured Engram end-of-day summary.",
+    )
+    legacy_briefing_schema = _legacy_schema(
+        briefing_schema,
+        "engram_briefing",
+        "Generate an Engram daily context briefing.",
+    )
+    legacy_context_checkpoint_schema = _legacy_schema(
+        context_checkpoint_schema,
+        "engram_context_checkpoint",
+        "Save a structured Engram context checkpoint for a session.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -1397,6 +1446,30 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.conversation_index_update(**kwargs)
+
+    async def day_summary(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.day_summary(**kwargs)
+
+    async def briefing(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.briefing(**kwargs)
+
+    async def context_checkpoint(
+        self,
+        sessionKey: str,  # noqa: N803
+        context: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.context_checkpoint(
+            session_key=sessionKey,
+            context=context,
+            **kwargs,
+        )
 
 
 # Legacy class alias — import path compat for pre-rename consumers.

--- a/packages/plugin-hermes/tests/test_issue_813_context_recap_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_813_context_recap_tools.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_813_client_methods_call_daemon_mcp_tools(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.day_summary(memories="fact A", sessionKey="session-1", namespace="project")
+    await client.briefing(since="yesterday", focus="project:remnic", format="markdown", maxFollowups=1)
+    await client.context_checkpoint("session-1", "Current task state", namespace="project")
+
+    calls = client._http.post.await_args_list
+    tool_names = [call.kwargs["json"]["params"]["name"] for call in calls]
+    assert tool_names == [
+        "engram.day_summary",
+        "engram.briefing",
+        "engram.context_checkpoint",
+    ]
+    assert calls[0].kwargs["json"]["params"]["arguments"] == {
+        "memories": "fact A",
+        "sessionKey": "session-1",
+        "namespace": "project",
+    }
+    assert calls[1].kwargs["json"]["params"]["arguments"] == {
+        "since": "yesterday",
+        "focus": "project:remnic",
+        "format": "markdown",
+        "maxFollowups": 1,
+    }
+    assert calls[2].kwargs["json"]["params"]["arguments"] == {
+        "sessionKey": "session-1",
+        "context": "Current task state",
+        "namespace": "project",
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_813_tools_are_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    expected_primary = {
+        "remnic_day_summary",
+        "remnic_briefing",
+        "remnic_context_checkpoint",
+    }
+    expected_legacy = {name.replace("remnic_", "engram_") for name in expected_primary}
+
+    assert expected_primary.issubset(ctx.tools)
+    assert expected_legacy.issubset(ctx.tools)
+    assert ctx.tools["remnic_day_summary"]["schema"]["parameters"]["properties"]["namespace"]["type"] == "string"
+    assert ctx.tools["remnic_briefing"]["schema"]["parameters"]["properties"]["format"]["enum"] == [
+        "markdown",
+        "json",
+    ]
+    assert ctx.tools["remnic_context_checkpoint"]["schema"]["parameters"]["required"] == [
+        "sessionKey",
+        "context",
+    ]
+    assert ctx.tools["engram_context_checkpoint"]["schema"]["name"] == "engram_context_checkpoint"
+
+
+@pytest.mark.asyncio
+async def test_issue_813_provider_handlers_return_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.day_summary() == {"error": "Not connected to Remnic"}
+    assert await provider.briefing() == {"error": "Not connected to Remnic"}
+    assert await provider.context_checkpoint("session-1", "context", framework_metadata=True) == {
+        "error": "Not connected to Remnic",
+    }

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -58,6 +58,11 @@ _GOVERNANCE_HYGIENE_TOOL_SUFFIXES = [
     "memory_summarize_hourly",
     "conversation_index_update",
 ]
+_CONTEXT_RECAP_TOOL_SUFFIXES = [
+    "day_summary",
+    "briefing",
+    "context_checkpoint",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -102,6 +107,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
     for suffix in _GOVERNANCE_HYGIENE_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _CONTEXT_RECAP_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -152,6 +161,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_compression_guidelines_optimize" in registered_tools
     assert "remnic_memory_governance_run" in registered_tools
     assert "engram_memory_governance_run" in registered_tools
+    assert "remnic_day_summary" in registered_tools
+    assert "engram_day_summary" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():


### PR DESCRIPTION
## Summary
- add Hermes client/provider wrappers for day summary, briefing, and context checkpoint daemon MCP tools
- register primary `remnic_*` tools and legacy `engram_*` aliases
- document the new Hermes tool surface and add focused registration/client/provider tests

Closes #813.

## Verification
- `uv run --project packages/plugin-hermes --extra test pytest -q`
- `uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests`
- `uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes`
- `git diff --check`
- `pnpm install` (fresh worktree dependency bootstrap; lockfile unchanged)
- `npm run check-types`
- `npm run check-config-contract`
- `bash scripts/check-review-patterns.sh` (passed with existing baseline warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Hermes tool registrations and thin client/provider wrappers without altering existing memory-provider recall/observe behavior; main risk is mismatched tool schema/argument names when calling the daemon.
> 
> **Overview**
> Adds three new **context recap** daemon MCP tools to the Hermes Remnic plugin: `remnic_day_summary`, `remnic_briefing`, and `remnic_context_checkpoint`, each also registered with legacy `engram_*` aliases.
> 
> Implements corresponding `RemnicClient` methods and `RemnicMemoryProvider` schemas/handlers, wires them into plugin `register()`, updates the README tool list, and adds focused tests to verify MCP tool calls, registration of primary/legacy names, and provider “not connected” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266b0136a9e41797f12bee0b85c9d9c6953dd286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->