### PR TITLE
feat(hermes): expose profiling report tool

### DIFF
--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -45,7 +45,7 @@ If you have read documentation or third-party reviews suggesting Remnic must reg
    ```bash
    hermes --version && pip show remnic-hermes
    ```
-Your agent should now have access to `remnic_recall`, `remnic_store`, `remnic_search`, and `remnic_lcm_search` tools. Call `remnic_recall` with any query to confirm memories are returned.
+Your agent should now have access to `remnic_recall`, `remnic_store`, `remnic_search`, `remnic_lcm_search`, and `remnic_profiling_report` tools. Call `remnic_recall` with any query to confirm memories are returned.
 
 ## Manual configuration
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -289,6 +289,26 @@ def _register_issue_813_tools(  # type: ignore[no-untyped-def]
         )
 
 
+_PROFILING_TOOLS = [
+    ("profiling_report", "profiling_report"),
+]
+
+
+def _register_issue_814_tools(  # type: ignore[no-untyped-def]
+    ctx,
+    provider: RemnicMemoryProvider,
+    prefix: str,
+    legacy: bool = False,
+):
+    schema_prefix = "legacy_" if legacy else ""
+    for tool_suffix, handler_name in _PROFILING_TOOLS:
+        ctx.register_tool(
+            f"{prefix}_{tool_suffix}",
+            getattr(provider, f"{schema_prefix}{tool_suffix}_schema"),
+            getattr(provider, handler_name),
+        )
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -315,6 +335,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_811_tools(ctx, provider, "remnic")
     _register_issue_812_tools(ctx, provider, "remnic")
     _register_issue_813_tools(ctx, provider, "remnic")
+    _register_issue_814_tools(ctx, provider, "remnic")
 
     # Legacy tool aliases — existing Hermes configs may reference the engram_*
     # names. Keep them wired until the compat window closes.
@@ -334,3 +355,4 @@ def register(ctx):  # type: ignore[no-untyped-def]
     _register_issue_811_tools(ctx, provider, "engram", legacy=True)
     _register_issue_812_tools(ctx, provider, "engram", legacy=True)
     _register_issue_813_tools(ctx, provider, "engram", legacy=True)
+    _register_issue_814_tools(ctx, provider, "engram", legacy=True)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -337,6 +337,9 @@ class RemnicClient:
     async def conversation_index_update(self, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.conversation_index_update", kwargs)
 
+    async def profiling_report(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.profiling_report", kwargs)
+
     async def day_summary(self, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.day_summary", kwargs)
 

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -1099,6 +1099,22 @@ class RemnicMemoryProvider:
         "Save a structured Engram context checkpoint for a session.",
     )
 
+    # -- Issue #814 profiling tool schema --
+
+    profiling_report_schema = _schema(
+        "remnic_profiling_report",
+        "Return timing and performance data for Remnic recall and extraction pipelines.",
+        {
+            "format": {"type": "string", "enum": ["ascii", "json"]},
+            "limit": {"type": "number", "minimum": 1, "maximum": 20},
+        },
+    )
+    legacy_profiling_report_schema = _legacy_schema(
+        profiling_report_schema,
+        "engram_profiling_report",
+        "Return timing and performance data for Engram recall and extraction pipelines.",
+    )
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
@@ -1446,6 +1462,11 @@ class RemnicMemoryProvider:
         if not self._client:
             return {"error": "Not connected to Remnic"}
         return await self._client.conversation_index_update(**kwargs)
+
+    async def profiling_report(self, **kwargs: Any) -> dict[str, Any]:
+        if not self._client:
+            return {"error": "Not connected to Remnic"}
+        return await self._client.profiling_report(**kwargs)
 
     async def day_summary(self, **kwargs: Any) -> dict[str, Any]:
         if not self._client:

--- a/packages/plugin-hermes/tests/test_issue_814_profiling_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_814_profiling_tools.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from remnic_hermes import register
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+@pytest.fixture
+def client() -> RemnicClient:
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token")
+
+
+@pytest.mark.asyncio
+async def test_issue_814_client_method_calls_daemon_mcp_tool(client: RemnicClient) -> None:
+    response = MagicMock()
+    response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"enabled": True}}
+    client._http = MagicMock()
+    client._http.post = AsyncMock(return_value=response)
+
+    await client.profiling_report(format="json", limit=3)
+
+    call = client._http.post.await_args
+    assert call.kwargs["json"]["params"]["name"] == "engram.profiling_report"
+    assert call.kwargs["json"]["params"]["arguments"] == {
+        "format": "json",
+        "limit": 3,
+    }
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+
+def test_issue_814_tool_is_registered_with_primary_and_legacy_names() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    assert "remnic_profiling_report" in ctx.tools
+    assert "engram_profiling_report" in ctx.tools
+    assert ctx.tools["remnic_profiling_report"]["schema"]["parameters"]["properties"]["format"]["enum"] == [
+        "ascii",
+        "json",
+    ]
+    assert ctx.tools["remnic_profiling_report"]["schema"]["parameters"]["properties"]["limit"]["maximum"] == 20
+    assert ctx.tools["engram_profiling_report"]["schema"]["name"] == "engram_profiling_report"
+
+
+@pytest.mark.asyncio
+async def test_issue_814_provider_handler_returns_not_connected_before_initialize() -> None:
+    provider = RemnicMemoryProvider({})
+
+    assert await provider.profiling_report(format="ascii") == {"error": "Not connected to Remnic"}

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -63,6 +63,9 @@ _CONTEXT_RECAP_TOOL_SUFFIXES = [
     "briefing",
     "context_checkpoint",
 ]
+_PROFILING_TOOL_SUFFIXES = [
+    "profiling_report",
+]
 
 
 def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
@@ -111,6 +114,10 @@ def _populate_provider_mock(provider):  # type: ignore[no-untyped-def]
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
     for suffix in _CONTEXT_RECAP_TOOL_SUFFIXES:
+        setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
+        setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
+        setattr(provider, suffix, object())
+    for suffix in _PROFILING_TOOL_SUFFIXES:
         setattr(provider, f"{suffix}_schema", {"name": f"remnic_{suffix}"})
         setattr(provider, f"legacy_{suffix}_schema", {"name": f"engram_{suffix}"})
         setattr(provider, suffix, object())
@@ -163,6 +170,8 @@ def test_register_prefers_remnic_config_key():
     assert "engram_memory_governance_run" in registered_tools
     assert "remnic_day_summary" in registered_tools
     assert "engram_day_summary" in registered_tools
+    assert "remnic_profiling_report" in registered_tools
+    assert "engram_profiling_report" in registered_tools
 
 
 def test_register_falls_back_to_engram_config_key():

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -45,6 +45,13 @@ function makeMockService(briefingFn?: () => Promise<unknown>): EngramAccessServi
     workProject: () => Promise.resolve({ ok: true }),
     memorySummarizeHourly: () => Promise.resolve({ ok: true }),
     conversationIndexUpdate: () => Promise.resolve({ ok: true }),
+    profilingReport: () => Promise.resolve({
+      enabled: true,
+      format: "json",
+      traces: [],
+      stats: {},
+      bottleneck: null,
+    }),
   } as unknown as EngramAccessService;
 }
 
@@ -236,4 +243,53 @@ test("MCP maintenance: conversation index update rejects non-string sessionKey",
 
   assert.equal(called, false);
   assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, true);
+});
+
+test("MCP profiling report dispatches sanitized args to the access service", async () => {
+  let received: Record<string, unknown> | undefined;
+  const service = {
+    ...makeMockService(),
+    profilingReport: async (args: Record<string, unknown>) => {
+      received = args;
+      return { enabled: true, format: "json", traces: [], stats: {}, bottleneck: null };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const response = await server.handleRequest(
+    makeToolRequest("remnic.profiling_report", {
+      format: "json",
+      limit: 3,
+    }),
+  );
+
+  assert.deepEqual(received, { format: "json", limit: 3 });
+  assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, false);
+});
+
+test("MCP profiling report rejects invalid argument types before dispatch", async () => {
+  let called = false;
+  const service = {
+    ...makeMockService(),
+    profilingReport: async () => {
+      called = true;
+      return { enabled: true };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const badFormat = await server.handleRequest(
+    makeToolRequest("engram.profiling_report", {
+      format: false,
+    }),
+  );
+  const badLimit = await server.handleRequest(
+    makeToolRequest("engram.profiling_report", {
+      limit: "5",
+    }),
+  );
+
+  assert.equal(called, false);
+  assert.equal((badFormat as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, true);
+  assert.equal((badLimit as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, true);
 });

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1164,6 +1164,28 @@ export class EngramMcpServer {
         },
       },
       {
+        name: "engram.profiling_report",
+        description:
+          "Return timing and performance data for Remnic recall and extraction pipelines. Requires profilingEnabled: true.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            format: {
+              type: "string",
+              enum: ["ascii", "json"],
+              description: "Output format. Defaults to ascii.",
+            },
+            limit: {
+              type: "integer",
+              minimum: 1,
+              maximum: 20,
+              description: "Number of recent traces to include. Defaults to 5.",
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.graph_edge_decay_run",
         description:
           "Run the graph-edge-confidence decay maintenance pass (issue #681 PR 2/3). Respects graphEdgeDecayEnabled; writes a structured telemetry record to state/graph-edge-decay-status.json.",
@@ -2362,6 +2384,19 @@ export class EngramMcpServer {
           sessionKey,
           hours: typeof args.hours === "number" && Number.isFinite(args.hours) ? args.hours : undefined,
           embed: typeof args.embed === "boolean" ? args.embed : undefined,
+        });
+      }
+      case "engram.profiling_report":
+      case "remnic.profiling_report": {
+        if ("format" in args && args.format !== undefined && typeof args.format !== "string") {
+          throw new EngramAccessInputError("format must be a string when provided");
+        }
+        if ("limit" in args && args.limit !== undefined && typeof args.limit !== "number") {
+          throw new EngramAccessInputError("limit must be a number when provided");
+        }
+        return this.service.profilingReport({
+          format: typeof args.format === "string" ? args.format : undefined,
+          limit: typeof args.limit === "number" ? args.limit : undefined,
         });
       }
       case "engram.graph_edge_decay_run":

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -129,8 +129,25 @@ import {
   defaultCapsulesDir,
   type CapsuleListEntry,
 } from "./capsule-cli.js";
+import { formatProfileTraceAscii } from "./profiling.js";
 
 export class EngramAccessInputError extends Error {}
+
+type AccessProfilingReportRequest = {
+  format?: string;
+  limit?: number;
+};
+
+type AccessProfilingReportResponse = {
+  enabled: boolean;
+  format?: "ascii" | "json";
+  report?: string;
+  traces?: unknown[];
+  stats?: unknown;
+  bottleneck?: string | null;
+  reason?: string;
+  message?: string;
+};
 
 let cachedPackageVersion: string | null = null;
 
@@ -3004,6 +3021,86 @@ export class EngramAccessService {
       skipped,
       skippedSessionKeys,
       embeddedRuns,
+    };
+  }
+
+  async profilingReport(
+    request: AccessProfilingReportRequest = {},
+  ): Promise<AccessProfilingReportResponse> {
+    const profiler = this.orchestrator.profiler;
+    if (!profiler.isEnabled) {
+      return {
+        enabled: false,
+        reason: "disabled",
+        message: "Profiling is disabled. Set profilingEnabled: true in your plugin config to enable.",
+      };
+    }
+
+    const format = request.format ?? "ascii";
+    if (format !== "ascii" && format !== "json") {
+      throw new EngramAccessInputError("format must be one of: ascii, json");
+    }
+
+    const limit = request.limit ?? 5;
+    if (!Number.isInteger(limit) || limit < 1 || limit > 20) {
+      throw new EngramAccessInputError("limit must be an integer between 1 and 20");
+    }
+
+    const traces = profiler.getRecentTraces(limit);
+    const stats = profiler.getStats();
+    const bottleneck = profiler.identifyBottleneck();
+
+    if (format === "json") {
+      return {
+        enabled: true,
+        format,
+        traces,
+        stats,
+        bottleneck,
+      };
+    }
+
+    const lines: string[] = [];
+    lines.push("Engram Profiling Report");
+    lines.push("=".repeat(60));
+    lines.push("");
+
+    type BucketEntry = { count: number; avgMs: number; p50Ms: number; p95Ms: number; maxMs: number };
+    const allBuckets: Array<[string, Record<string, BucketEntry>]> = [
+      ["byKind", stats.byKind],
+      ["bySpan", stats.bySpan],
+    ];
+    const hasStats = allBuckets.some(([, entries]) => Object.keys(entries).length > 0);
+    if (hasStats) {
+      lines.push("Aggregate Stats (all retained traces):");
+      for (const [bucket, entries] of allBuckets) {
+        for (const [key, summary] of Object.entries(entries)) {
+          lines.push(
+            `  ${bucket}/${key}: avg=${summary.avgMs}ms p50=${summary.p50Ms}ms p95=${summary.p95Ms}ms max=${summary.maxMs}ms (n=${summary.count})`,
+          );
+        }
+      }
+      lines.push("");
+    }
+
+    if (bottleneck) {
+      lines.push(`Bottleneck: ${bottleneck}`);
+      lines.push("");
+    }
+
+    if (traces.length === 0) {
+      lines.push("No traces recorded yet. Trigger a recall or extraction to see timing data.");
+    } else {
+      for (const trace of traces) {
+        lines.push(formatProfileTraceAscii(trace));
+        lines.push("");
+      }
+    }
+
+    return {
+      enabled: true,
+      format,
+      report: lines.join("\n"),
     };
   }
 

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -380,6 +380,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.contradiction_scan_run",
     "engram.memory_summarize_hourly",
     "engram.conversation_index_update",
+    "engram.profiling_report",
     "engram.graph_edge_decay_run",
     "engram.live_connectors_run",
     "engram.peer_list",


### PR DESCRIPTION
Closes #814.

## Summary
- add daemon access MCP support for `engram.profiling_report` / `remnic.profiling_report`
- wire Hermes `remnic_profiling_report` plus the legacy `engram_profiling_report` alias
- add MCP and Hermes registration/client coverage, and document the new tool

## Verification
- `uv run --project packages/plugin-hermes --extra test pytest -q`
- `uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests`
- `uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes`
- `git diff --check`
- `npm run check-types`
- `npm run check-config-contract`
- `bash scripts/check-review-patterns.sh`
- `npx tsx --test packages/remnic-core/src/access-mcp.test.ts tests/access-mcp.test.ts`
- `npx tsx --test tests/register-multi-registry.test.ts`

Note: `npm run preflight:quick` completed check-types, check-config-contract, and review-pattern checks, then its registry test command expanded to the repo-wide `npm test` suite in this worktree. I stopped that broad run after several minutes and ran the intended registry test directly with `npx tsx --test tests/register-multi-registry.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `profiling_report` tool path end-to-end (MCP dispatcher, access service, and Hermes plugin). Risk is mainly in argument validation/formatting and ensuring profiling remains properly gated by `profilingEnabled` to avoid unexpected data exposure or performance impact.
> 
> **Overview**
> Exposes a new profiling report tool end-to-end: `engram.profiling_report` / `remnic.profiling_report` is added to the MCP tool list and dispatcher, and `EngramAccessService.profilingReport` returns either JSON trace/stats output or an ASCII-formatted report built from recent profiler traces (with `profilingEnabled` gating and input validation for `format`/`limit`).
> 
> Hermes now registers `remnic_profiling_report` plus the legacy `engram_profiling_report` alias, adds a `RemnicClient.profiling_report` MCP call + provider handler, updates docs to mention the tool, and adds focused unit tests for MCP dispatch/validation and Hermes registration/client behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7b9721c418be6dfef7d7c8c487520a3649aa2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->