### PR TITLE
feat(hermes): audit lifecycle hook parity

### DIFF
--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -19,6 +19,7 @@ Canonical upstream references:
 - [Environment variable overrides](#environment-variable-overrides)
 - [Token bootstrap](#token-bootstrap)
 - [How the provider works](#how-the-provider-works)
+- [Lifecycle parity audit](#lifecycle-parity-audit)
 - [Tools registered](#tools-registered)
 - [Profile and session isolation](#profile-and-session-isolation)
 - [Error handling philosophy](#error-handling-philosophy)
@@ -217,9 +218,30 @@ Called when the session ends. Receives a `session` dict; reads `session["message
 
 Exceptions are swallowed.
 
+### `on_session_switch`
+
+Called by Hermes when its active session id changes without tearing down the provider. If `remnic.session_key` is explicitly configured, Remnic preserves that stable key. If `session_key` is omitted and the plugin generated an ephemeral key, Remnic updates it to the new Hermes session id so recalls and observations remain scoped to the current Hermes conversation after `/new`, `/reset`, or similar session-boundary operations.
+
 ### `shutdown`
 
 Closes the `httpx.AsyncClient`. Safe to call when the client was never initialized.
+
+---
+
+## Lifecycle parity audit
+
+Audit date: 2026-04-30. Upstream Hermes reference used: `NousResearch/hermes-agent` commit `1d8068d` (`2026-04-30T12:57:02-07:00`).
+
+Remnic remains a `memory_provider` plugin. The Hermes `context_engine` slot is still intentionally unused because it replaces Hermes' local `ContextCompressor`; it is not the right slot for recall, observation, heartbeat, dreams, or reset handling.
+
+| OpenClaw surface | Hermes surface | Status | Remnic behavior |
+|------------------|----------------|--------|-----------------|
+| `agent_heartbeat` | Hermes cron scheduler (`cron/scheduler.py`) and agent/tool jobs | Equivalent but different | Remnic does not register a plugin tick hook. Hermes scheduled jobs can call Remnic maintenance tools such as `remnic_memory_summarize_hourly`, `remnic_conversation_index_update`, `remnic_dreams_run`, and `remnic_compounding_weekly_synthesize`. |
+| `before_reset` | Plugin hooks `on_session_finalize` and `on_session_reset`, plus MemoryProvider `on_session_end` / `on_session_switch` | Wired for session scoping | Remnic registers an `on_session_reset` hook when Hermes exposes `ctx.register_hook`, and the provider implements `on_session_switch` so generated session keys follow the new Hermes session id. Stable configured `session_key` values are preserved. |
+| `commands.list` / `registerCommand` | `ctx.register_command` for in-session slash commands and `ctx.register_cli_command` for `hermes <subcommand>` commands | Available, not wired | Remnic exposes explicit capabilities as agent tools rather than Hermes slash/CLI commands today. The command surfaces exist upstream and can be used later for operator-style commands if there is a concrete UX need. |
+| `dreaming` slot | No dedicated dreaming plugin slot; Hermes uses cron/background jobs and context-engine lifecycle for compression only | Equivalent but different | Remnic keeps dream/consolidation semantics inside the daemon. Hermes can invoke them through `remnic_dreams_status` and `remnic_dreams_run`; recurring background execution should be modeled as a Hermes cron job, not as a `context_engine`. |
+
+No upstream Hermes feature request is needed from this audit: each OpenClaw lifecycle surface has either a direct Hermes plugin hook or a supported Hermes scheduling/command equivalent. The only non-equivalent detail is naming: Hermes does not have an OpenClaw-style `dreaming` slot, but its cron/background-task model is the correct host-native way to schedule Remnic dream work.
 
 ---
 

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -309,6 +309,22 @@ def _register_issue_814_tools(  # type: ignore[no-untyped-def]
         )
 
 
+def _register_issue_815_hooks(ctx, provider: RemnicMemoryProvider):  # type: ignore[no-untyped-def]
+    register_hook = getattr(ctx, "register_hook", None)
+    if not callable(register_hook):
+        return
+
+    def _on_session_reset(session_id: str = "", **kwargs):  # type: ignore[no-untyped-def]
+        provider.on_session_switch(
+            session_id,
+            reset=True,
+            reason="hermes_session_reset",
+            **kwargs,
+        )
+
+    register_hook("on_session_reset", _on_session_reset)
+
+
 def register(ctx):  # type: ignore[no-untyped-def]
     """Hermes plugin entry point. Registers the MemoryProvider and explicit tools."""
     config = ctx.config.get("remnic")
@@ -317,6 +333,7 @@ def register(ctx):  # type: ignore[no-untyped-def]
 
     provider = RemnicMemoryProvider(config)
     ctx.register_memory_provider(provider)
+    _register_issue_815_hooks(ctx, provider)
 
     # Primary tool names (Remnic-branded).
     ctx.register_tool("remnic_recall", provider.recall_schema, provider.recall)

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -86,6 +86,7 @@ class RemnicMemoryProvider:
         self._port = cfg.port
         self._token = cfg.token
         self._timeout = cfg.timeout
+        self._configured_session_key = bool(cfg.session_key)
         self._session_key = cfg.session_key or f"hermes-{uuid.uuid4().hex[:12]}"
         self._client: RemnicClient | None = None
 
@@ -164,6 +165,22 @@ class RemnicMemoryProvider:
             )
         except Exception:
             pass
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Refresh daemon session scoping when Hermes rotates its session id."""
+        del parent_session_id, reset, kwargs
+        if self._configured_session_key:
+            return
+        normalized = new_session_id.strip()
+        if normalized:
+            self._session_key = normalized
 
     async def shutdown(self) -> None:
         """Close the HTTP client."""

--- a/packages/plugin-hermes/tests/test_issue_815_lifecycle_hooks.py
+++ b/packages/plugin-hermes/tests/test_issue_815_lifecycle_hooks.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from remnic_hermes import register
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+class FakeContext:
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        self.config: dict[str, Any] = config or {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+        self.hooks: dict[str, list[Callable[..., None]]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+    def register_hook(self, name: str, handler: Callable[..., None]) -> None:
+        self.hooks.setdefault(name, []).append(handler)
+
+
+def test_issue_815_registers_session_reset_hook_when_supported() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+
+    assert "on_session_reset" in ctx.hooks
+    assert len(ctx.hooks["on_session_reset"]) == 1
+
+
+def test_issue_815_session_reset_hook_updates_generated_session_key() -> None:
+    ctx = FakeContext()
+
+    register(ctx)
+    assert ctx.provider is not None
+    original_key = ctx.provider._session_key
+
+    ctx.hooks["on_session_reset"][0](session_id="hermes-reset-session", platform="cli")
+
+    assert original_key.startswith("hermes-")
+    assert ctx.provider._session_key == "hermes-reset-session"
+
+
+def test_issue_815_session_reset_hook_preserves_explicit_session_key() -> None:
+    ctx = FakeContext({"remnic": {"session_key": "configured-session"}})
+
+    register(ctx)
+    assert ctx.provider is not None
+
+    ctx.hooks["on_session_reset"][0](session_id="hermes-reset-session", platform="cli")
+
+    assert ctx.provider._session_key == "configured-session"


### PR DESCRIPTION
Closes #815.

## Summary
- register the Hermes `on_session_reset` hook when the host exposes `ctx.register_hook`
- add provider-side `on_session_switch` handling so generated Remnic session keys follow Hermes session boundaries while explicit `remnic.session_key` values remain stable
- document the Hermes lifecycle parity audit against upstream Hermes commit `1d8068d`, including `agent_heartbeat`, `before_reset`, `commands.list` / `registerCommand`, and `dreaming` slot status without using `context_engine`

## Verification
- `uv run --project packages/plugin-hermes --extra test pytest -q packages/plugin-hermes/tests/test_issue_815_lifecycle_hooks.py`
- `uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests/test_issue_815_lifecycle_hooks.py`
- `uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes`
- `uv run --project packages/plugin-hermes --extra test pytest -q`
- `npm run check-types`
- `npm run check-config-contract`
- `bash scripts/check-review-patterns.sh`
- `npx tsx --test tests/register-multi-registry.test.ts`
- `git diff --check`

Note: I ran the direct preflight components because this fresh worktree needed dependency bootstrap, and the repo-local `preflight:quick` registry step currently expands into the wider test suite; the intended registry gate was run directly above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Hermes lifecycle hook and changes how auto-generated `session_key` values are updated on session resets, which can affect memory recall/observe scoping across conversations if miswired. Changes are contained to the Hermes plugin adapter with test coverage, reducing overall risk.
> 
> **Overview**
> Improves Hermes lifecycle parity by **registering an `on_session_reset` hook (when `ctx.register_hook` is available)** and routing it to the provider so Remnic can react to Hermes session-boundary operations.
> 
> Adds provider-side `on_session_switch` logic that **updates the daemon `session_key` to the new Hermes session id only when the key was auto-generated**, while preserving explicitly configured `remnic.session_key` values. Includes a focused test verifying hook registration and session-key update/preservation behavior, and expands the Hermes plugin docs with an explicit lifecycle parity audit and `on_session_switch` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73bb53a162d8db0c88f1a2190bd6b36e0a343ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->