### PR TITLE
chore(hermes): declare manifest capabilities

### DIFF
--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -32,7 +32,9 @@ Canonical upstream references:
 
 ## Which Hermes plugin slot Remnic uses
 
-Remnic registers as a Hermes **`memory_provider`** plugin (`plugin.yaml` declares `type: memory_provider`). This is the only slot Remnic occupies and the only slot it needs.
+Remnic registers as a Hermes **memory provider** (`plugin.yaml` declares `kind: exclusive`, the Hermes manifest kind used for provider plugins selected through `memory.provider`). This is the only slot Remnic occupies and the only slot it needs.
+
+The manifest declares Hermes-supported capability metadata with `provides_tools` and `provides_hooks`. It does not declare or register a context engine.
 
 **Remnic does not, and should not, register as a Hermes `context_engine`.** Hermes' `context_engine` slot replaces the built-in `ContextCompressor` — it controls how Hermes compresses *its own outgoing conversation history* before sending to the LLM. That is a different concern from external memory recall. Remnic delivers all of the following through the `memory_provider` hook chain (`pre_llm_call` → recall envelope), with no `context_engine` registration involved:
 
@@ -232,7 +234,7 @@ Closes the `httpx.AsyncClient`. Safe to call when the client was never initializ
 
 Audit date: 2026-04-30. Upstream Hermes reference used: `NousResearch/hermes-agent` commit `1d8068d` (`2026-04-30T12:57:02-07:00`).
 
-Remnic remains a `memory_provider` plugin. The Hermes `context_engine` slot is still intentionally unused because it replaces Hermes' local `ContextCompressor`; it is not the right slot for recall, observation, heartbeat, dreams, or reset handling.
+Remnic remains a Hermes memory provider plugin. In `plugin.yaml`, `kind: exclusive` marks the package as an exclusive provider selected by `memory.provider`, `provides_tools` enumerates the Remnic and legacy Engram tool surfaces, and `provides_hooks` declares the wired `on_session_reset` hook. The Hermes `context_engine` slot is still intentionally unused because it replaces Hermes' local `ContextCompressor`; it is not the right slot for recall, observation, heartbeat, dreams, or reset handling.
 
 | OpenClaw surface | Hermes surface | Status | Remnic behavior |
 |------------------|----------------|--------|-----------------|

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -15,7 +15,7 @@ MCP tools give an agent the ability to call memory functions, but only when the 
 
 ## Which Hermes plugin slot does Remnic use?
 
-Remnic ships as a **`memory_provider`** plugin in Hermes (declared in `plugin.yaml` as `type: memory_provider`).
+Remnic ships as a Hermes memory provider plugin (declared in `plugin.yaml` as `kind: exclusive`, the Hermes manifest kind used for provider plugins selected through `memory.provider`).
 
 **Remnic does not use, and does not need to use, Hermes' `context_engine` slot.** That slot replaces the built-in `ContextCompressor` — it is for *compressing the agent's own outgoing conversation history*. Remnic delivers external memory recall (and, when enabled daemon-side, Lossless Context Management archive content) through the `memory_provider` hook (`pre_llm_call`), which is the correct slot for this concern.
 

--- a/packages/plugin-hermes/plugin.yaml
+++ b/packages/plugin-hermes/plugin.yaml
@@ -4,13 +4,128 @@ description: Universal memory for AI agents — Remnic MemoryProvider integratio
 author: Joshua Warren
 homepage: https://github.com/joshuaswarren/remnic
 entry: remnic_hermes
-type: memory_provider
-tools:
+# Hermes memory providers are exclusive provider plugins selected by
+# `memory.provider`. Remnic intentionally does not register as `context_engine`;
+# see docs/plugins/hermes.md#which-hermes-plugin-slot-remnic-uses.
+kind: exclusive
+provides_hooks:
+  - on_session_reset
+provides_tools:
   - remnic_recall
   - remnic_store
   - remnic_search
   - remnic_lcm_search
+  - remnic_recall_explain
+  - remnic_recall_tier_explain
+  - remnic_recall_xray
+  - remnic_memory_last_recall
+  - remnic_memory_intent_debug
+  - remnic_memory_qmd_debug
+  - remnic_memory_graph_explain
+  - remnic_memory_feedback_last_recall
+  - remnic_set_coding_context
+  - remnic_memory_get
+  - remnic_memory_store
+  - remnic_memory_timeline
+  - remnic_memory_profile
+  - remnic_memory_entities
+  - remnic_memory_questions
+  - remnic_memory_identity
+  - remnic_memory_promote
+  - remnic_memory_outcome
+  - remnic_entity_get
+  - remnic_memory_capture
+  - remnic_memory_action_apply
+  - remnic_continuity_audit_generate
+  - remnic_continuity_incident_open
+  - remnic_continuity_incident_close
+  - remnic_continuity_incident_list
+  - remnic_continuity_loop_add_or_update
+  - remnic_continuity_loop_review
+  - remnic_identity_anchor_get
+  - remnic_identity_anchor_update
+  - remnic_review_queue_list
+  - remnic_review_list
+  - remnic_review_resolve
+  - remnic_suggestion_submit
+  - remnic_work_task
+  - remnic_work_project
+  - remnic_work_board
+  - remnic_shared_context_write_output
+  - remnic_shared_feedback_record
+  - remnic_shared_priorities_append
+  - remnic_shared_context_cross_signals_run
+  - remnic_shared_context_curate_daily
+  - remnic_compounding_weekly_synthesize
+  - remnic_compounding_promote_candidate
+  - remnic_compression_guidelines_optimize
+  - remnic_compression_guidelines_activate
+  - remnic_memory_governance_run
+  - remnic_procedure_mining_run
+  - remnic_procedural_stats
+  - remnic_contradiction_scan_run
+  - remnic_memory_summarize_hourly
+  - remnic_conversation_index_update
+  - remnic_day_summary
+  - remnic_briefing
+  - remnic_context_checkpoint
+  - remnic_profiling_report
   - engram_recall
   - engram_store
   - engram_search
   - engram_lcm_search
+  - engram_recall_explain
+  - engram_recall_tier_explain
+  - engram_recall_xray
+  - engram_memory_last_recall
+  - engram_memory_intent_debug
+  - engram_memory_qmd_debug
+  - engram_memory_graph_explain
+  - engram_memory_feedback_last_recall
+  - engram_set_coding_context
+  - engram_memory_get
+  - engram_memory_store
+  - engram_memory_timeline
+  - engram_memory_profile
+  - engram_memory_entities
+  - engram_memory_questions
+  - engram_memory_identity
+  - engram_memory_promote
+  - engram_memory_outcome
+  - engram_entity_get
+  - engram_memory_capture
+  - engram_memory_action_apply
+  - engram_continuity_audit_generate
+  - engram_continuity_incident_open
+  - engram_continuity_incident_close
+  - engram_continuity_incident_list
+  - engram_continuity_loop_add_or_update
+  - engram_continuity_loop_review
+  - engram_identity_anchor_get
+  - engram_identity_anchor_update
+  - engram_review_queue_list
+  - engram_review_list
+  - engram_review_resolve
+  - engram_suggestion_submit
+  - engram_work_task
+  - engram_work_project
+  - engram_work_board
+  - engram_shared_context_write_output
+  - engram_shared_feedback_record
+  - engram_shared_priorities_append
+  - engram_shared_context_cross_signals_run
+  - engram_shared_context_curate_daily
+  - engram_compounding_weekly_synthesize
+  - engram_compounding_promote_candidate
+  - engram_compression_guidelines_optimize
+  - engram_compression_guidelines_activate
+  - engram_memory_governance_run
+  - engram_procedure_mining_run
+  - engram_procedural_stats
+  - engram_contradiction_scan_run
+  - engram_memory_summarize_hourly
+  - engram_conversation_index_update
+  - engram_day_summary
+  - engram_briefing
+  - engram_context_checkpoint
+  - engram_profiling_report

--- a/packages/plugin-hermes/tests/test_issue_816_plugin_manifest.py
+++ b/packages/plugin-hermes/tests/test_issue_816_plugin_manifest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from remnic_hermes import register
+from remnic_hermes.provider import RemnicMemoryProvider
+
+
+PLUGIN_MANIFEST = Path(__file__).resolve().parents[1] / "plugin.yaml"
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"remnic": {}}
+        self.provider: RemnicMemoryProvider | None = None
+        self.tools: dict[str, dict[str, Any]] = {}
+        self.hooks: dict[str, list[Callable[..., None]]] = {}
+
+    def register_memory_provider(self, provider: RemnicMemoryProvider) -> None:
+        self.provider = provider
+
+    def register_tool(self, name: str, schema: dict[str, Any], handler: Any) -> None:
+        self.tools[name] = {"schema": schema, "handler": handler}
+
+    def register_hook(self, name: str, handler: Callable[..., None]) -> None:
+        self.hooks.setdefault(name, []).append(handler)
+
+
+def _manifest_scalar(text: str, key: str) -> str | None:
+    prefix = f"{key}:"
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :].strip()
+    return None
+
+
+def _manifest_list(text: str, key: str) -> list[str]:
+    lines = text.splitlines()
+    marker = f"{key}:"
+    for index, line in enumerate(lines):
+        if line.startswith(marker):
+            values: list[str] = []
+            for item in lines[index + 1 :]:
+                if item.startswith("  - "):
+                    values.append(item.removeprefix("  - ").strip())
+                    continue
+                if item and not item.startswith(" ") and not item.startswith("#"):
+                    break
+            return values
+    return []
+
+
+def test_issue_816_manifest_uses_hermes_supported_capability_fields() -> None:
+    manifest = PLUGIN_MANIFEST.read_text()
+
+    assert _manifest_scalar(manifest, "kind") == "exclusive"
+    assert _manifest_scalar(manifest, "type") is None
+    assert _manifest_list(manifest, "tools") == []
+    assert "does not register as `context_engine`" in manifest
+    assert "docs/plugins/hermes.md#which-hermes-plugin-slot-remnic-uses" in manifest
+
+
+def test_issue_816_manifest_capabilities_match_registered_surfaces() -> None:
+    manifest = PLUGIN_MANIFEST.read_text()
+    ctx = FakeContext()
+
+    register(ctx)
+
+    assert set(_manifest_list(manifest, "provides_tools")) == set(ctx.tools)
+    assert set(_manifest_list(manifest, "provides_hooks")) == set(ctx.hooks)
+    assert "remnic_lcm_search" in _manifest_list(manifest, "provides_tools")
+    assert "engram_lcm_search" in _manifest_list(manifest, "provides_tools")
+    assert "on_session_reset" in _manifest_list(manifest, "provides_hooks")


### PR DESCRIPTION
Closes #816.

## Summary
- switch the Hermes manifest from Remnic-local `type` / `tools` metadata to Hermes-supported `kind: exclusive`, `provides_tools`, and `provides_hooks`
- add the inline manifest guardrail that Remnic uses the memory provider path and intentionally does not register as `context_engine`
- update Hermes docs and README text to match the manifest-level slot/capability declaration
- add a manifest test that compares `provides_tools` / `provides_hooks` against the surfaces actually registered by `remnic_hermes.register()`

## Verification
- `uv run --project packages/plugin-hermes --extra test pytest -q packages/plugin-hermes/tests/test_issue_816_plugin_manifest.py`
- `uv run --project packages/plugin-hermes --extra test pytest -q`
- `uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests`
- `uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes`
- `pnpm install`
- `npm run check-types`
- `npm run check-config-contract`
- `bash scripts/check-review-patterns.sh`
- `npx tsx --test tests/register-multi-registry.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching the Hermes plugin manifest schema (`type/tools` → `kind/provides_*`) can affect how Hermes discovers/loads the plugin and advertises tool/hook capabilities; errors here would break integration at startup. Changes are otherwise limited to docs and a manifest consistency test.
> 
> **Overview**
> Updates the Hermes plugin manifest to align with Hermes’ supported metadata by replacing Remnic-local `type`/`tools` fields with `kind: exclusive` plus explicit `provides_tools`/`provides_hooks` declarations, and adds an inline guardrail noting Remnic intentionally does not register a `context_engine`.
> 
> Adds a regression test (`test_issue_816_plugin_manifest.py`) that asserts the manifest uses the new fields and that `provides_tools`/`provides_hooks` exactly match what `remnic_hermes.register()` registers. Docs/README wording is updated to reflect the new manifest schema and clarify the memory-provider vs `context_engine` slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecefb25c31ca4da45789508b12fa74cad1397e9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->