### PR TITLE
chore(hermes): prepare parity package release

### DIFF
--- a/packages/plugin-hermes/plugin.yaml
+++ b/packages/plugin-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: remnic
-version: 1.0.0
+version: 1.0.2
 description: Universal memory for AI agents — Remnic MemoryProvider integration for Hermes
 author: Joshua Warren
 homepage: https://github.com/joshuaswarren/remnic

--- a/packages/plugin-hermes/pyproject.toml
+++ b/packages/plugin-hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "remnic-hermes"
-version = "1.0.1"
+version = "1.0.2"
 description = "Remnic MemoryProvider plugin for Hermes Agent"
 readme = "README.md"
 license = "MIT"
@@ -45,6 +45,7 @@ Issues = "https://github.com/joshuaswarren/remnic/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["remnic_hermes"]
+force-include = { "plugin.yaml" = "plugin.yaml" }
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
Follow-up for #802.

## Summary
- bump `remnic-hermes` to `1.0.2` so the fully implemented Hermes parity package can be published
- align `plugin.yaml` version with the Python package version
- include `plugin.yaml` in the built wheel so Hermes manifest capability metadata ships with the library

## Verification
- `uv build --project packages/plugin-hermes`
- inspected `packages/plugin-hermes/dist/remnic_hermes-1.0.2-py3-none-any.whl` for `plugin.yaml`, `remnic_lcm_search`, `remnic_profiling_report`, `remnic_context_checkpoint`, `on_session_reset`, and client `lcm_search`
- `uv run --project packages/plugin-hermes --extra test pytest -q`
- `uv run --project packages/plugin-hermes --extra dev ruff check packages/plugin-hermes/remnic_hermes packages/plugin-hermes/tests`
- `uv run --project packages/plugin-hermes --extra dev mypy packages/plugin-hermes/remnic_hermes`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release/packaging change: bumps versions and adjusts wheel contents without modifying runtime code paths.
> 
> **Overview**
> Prepares the `remnic-hermes` parity release by bumping the package and `plugin.yaml` manifest versions to `1.0.2`.
> 
> Updates Hatch build config to **force-include `plugin.yaml` in the wheel**, ensuring Hermes plugin metadata is distributed with the published artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b74ebcc41c7fc3ec5c196585fb5a566e37ec40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->