### PR TITLE
docs(hermes): refresh parity guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Remnic gives AI agents long-term memory that survives across conversations. Deci
 > [`@remnic/cli`](https://www.npmjs.com/package/@remnic/cli).
 > OpenClaw installs should use [`@remnic/plugin-openclaw`](https://www.npmjs.com/package/@remnic/plugin-openclaw).
 > The legacy `engram` CLI name remains available as a forwarder during the rename window.
-> Python users: [`remnic-hermes`](https://pypi.org/project/remnic-hermes/) on PyPI.
+> Hermes users: [`remnic-hermes`](https://pypi.org/project/remnic-hermes/) v1.0.2 on PyPI.
 
 ## Support Remnic
 
@@ -153,7 +153,8 @@ Once the Remnic daemon is running, connect any supported agent:
 remnic connectors install claude-code   # Claude Code (hooks + MCP)
 remnic connectors install codex-cli     # Codex CLI (hooks + MCP + memory extension)
 remnic connectors install replit        # Replit (MCP only)
-pip install remnic-hermes               # Hermes Agent (Python MemoryProvider)
+pip install --upgrade remnic-hermes     # Hermes Agent (Python MemoryProvider)
+remnic connectors install hermes        # Writes Hermes config + token
 ```
 
 For Codex CLI, installation also drops a phase-2 memory extension at
@@ -163,6 +164,8 @@ consolidation sub-agent auto-discovers Remnic. Opt out with
 yourself.
 
 Each connector generates a unique auth token, installs the appropriate plugin/hooks, and verifies the connection. All agents share the same memory store — tell one agent your preference, and every agent remembers it.
+
+Hermes uses Remnic as a Hermes **MemoryProvider**, not a `context_engine`. Automatic recall runs in `pre_llm_call`, observations run after each turn, and the provider now registers the full Remnic parity tool surface (`remnic_lcm_search`, recall explain/X-ray, memory CRUD, continuity, identity, governance, work-board, shared-context, compounding, day-summary, briefing, checkpoint, and profiling tools) plus legacy `engram_*` aliases. Lossless Context Management is delivered through the daemon recall envelope when `lcmEnabled` is on; no Hermes `context_engine` registration is required. See [docs/plugins/hermes.md](docs/plugins/hermes.md) for the full reference.
 
 | Platform | Integration | Auto-recall | Auto-observe |
 |----------|------------|-------------|--------------|

--- a/docs/integration/hermes-setup.md
+++ b/docs/integration/hermes-setup.md
@@ -13,11 +13,13 @@ See:
 ## Quick install
 
 ```bash
-pip install remnic-hermes
+pip install --upgrade remnic-hermes
 remnic connectors install hermes
 ```
 
 Then restart Hermes to pick up the new plugin.
+
+`remnic-hermes` v1.0.2 includes the full Remnic parity surface in Hermes: automatic MemoryProvider recall/observation, daemon-side LCM recall enrichment, session reset scoping, and explicit `remnic_*` tools for recall debugging, LCM search, memory CRUD, continuity, identity, governance, work boards, shared context, compounding, day summaries, briefings, context checkpoints, and profiling. Legacy `engram_*` aliases are still registered during the compatibility window.
 
 ## Which Hermes plugin slot Remnic uses
 

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -265,7 +265,7 @@ No upstream Hermes feature request is needed from this audit: each OpenClaw life
 | `remnic_memory_feedback_last_recall` | `memoryId: string`, `vote: up|down`, `note?: string` | Record relevance feedback for a recalled memory |
 | `remnic_set_coding_context` | `sessionKey: string`, `codingContext?: object|null`, `projectTag?: string` | Attach coding project context to a session |
 | `remnic_memory_get` | `memoryId: string`, `namespace?: string` | Fetch one stored memory by id |
-| `remnic_memory_store` | `content: string`, plus memory metadata fields | Store a memory with the daemon's richer memory-store schema |
+| `remnic_memory_store` | `content: string`, `sessionKey?: string`, `category?: string`, `confidence?: number`, `namespace?: string`, `tags?: string[]`, `entityRef?: string`, `ttl?: string`, `sourceReason?: string` | Store a memory with the daemon's richer memory-store schema |
 | `remnic_memory_timeline` | `memoryId: string`, `namespace?: string`, `limit?: number` | Fetch the timeline for one stored memory |
 | `remnic_memory_profile` | `namespace?: string` | Read the user profile surface |
 | `remnic_memory_entities` | `namespace?: string` | List tracked entities |
@@ -274,42 +274,42 @@ No upstream Hermes feature request is needed from this audit: each OpenClaw life
 | `remnic_memory_promote` | `memoryId: string`, `namespace?: string`, `sessionKey?: string` | Promote a memory candidate or stored memory |
 | `remnic_memory_outcome` | `memoryId: string`, `outcome: success|failure`, `namespace?: string`, `sessionKey?: string`, `timestamp?: string` | Record or inspect a memory outcome |
 | `remnic_entity_get` | `name: string`, `namespace?: string` | Fetch one tracked entity by name |
-| `remnic_memory_capture` | `content: string`, plus memory metadata fields | Capture an explicit memory note |
-| `remnic_memory_action_apply` | `action: string`, plus action-specific fields | Apply a memory action |
-| `remnic_continuity_audit_generate` | `namespace?: string` and audit options | Generate a continuity audit report |
-| `remnic_continuity_incident_open` | `symptom: string`, plus incident metadata | Open a continuity incident |
-| `remnic_continuity_incident_close` | `id: string`, `fixApplied: string`, `verificationResult: string` | Close a continuity incident with verification |
-| `remnic_continuity_incident_list` | `state?: open|closed|all`, `namespace?: string` | List continuity incidents by state |
+| `remnic_memory_capture` | `content: string`, `namespace?: string`, `category?: string`, `tags?: string[]`, `entityRef?: string`, `confidence?: number`, `ttl?: string`, `sourceReason?: string` | Capture an explicit memory note |
+| `remnic_memory_action_apply` | `action: string`, `category?: string`, `content?: string`, `outcome?: applied|skipped|failed`, `reason?: string`, `memoryId?: string`, `sessionKey?: string`, `namespace?: string`, `dryRun?: boolean` | Apply a memory action |
+| `remnic_continuity_audit_generate` | `period?: weekly|monthly`, `key?: string` | Generate a continuity audit report |
+| `remnic_continuity_incident_open` | `symptom: string`, `namespace?: string`, `triggerWindow?: string`, `suspectedCause?: string` | Open a continuity incident |
+| `remnic_continuity_incident_close` | `id: string`, `fixApplied: string`, `verificationResult: string`, `namespace?: string`, `preventiveRule?: string` | Close a continuity incident with verification |
+| `remnic_continuity_incident_list` | `state?: open|closed|all`, `namespace?: string`, `limit?: number` | List continuity incidents by state |
 | `remnic_continuity_loop_add_or_update` | `id: string`, `cadence: string`, `purpose: string`, `status: string`, `killCondition: string` | Add or update a continuity improvement loop |
-| `remnic_continuity_loop_review` | `id: string` | Review an existing continuity improvement loop |
+| `remnic_continuity_loop_review` | `id: string`, `namespace?: string`, `status?: string`, `notes?: string`, `reviewedAt?: string` | Review an existing continuity improvement loop |
 | `remnic_identity_anchor_get` | `namespace?: string` | Read the identity continuity anchor |
-| `remnic_identity_anchor_update` | identity anchor fields | Conservatively merge identity anchor sections |
-| `remnic_review_queue_list` | review queue filters | Fetch the latest review queue artifact bundle |
-| `remnic_review_list` | contradiction review filters | List contradiction review items |
+| `remnic_identity_anchor_update` | `namespace?: string`, `identityTraits?: string`, `communicationPreferences?: string`, `operatingPrinciples?: string`, `continuityNotes?: string` | Conservatively merge identity anchor sections |
+| `remnic_review_queue_list` | `runId?: string`, `namespace?: string` | Fetch the latest review queue artifact bundle |
+| `remnic_review_list` | `filter?: string`, `namespace?: string`, `limit?: number` | List contradiction review items |
 | `remnic_review_resolve` | `pairId: string`, `verb: string` | Resolve a contradiction review pair |
-| `remnic_suggestion_submit` | `content: string`, plus suggestion metadata | Queue a suggested memory for review |
-| `remnic_work_task` | `action: string`, plus task fields | Manage work-layer tasks |
-| `remnic_work_project` | `action: string`, plus project fields | Manage work-layer projects |
-| `remnic_work_board` | `action: string`, plus board fields | Export or import work-layer board snapshots and markdown |
+| `remnic_suggestion_submit` | `content: string`, `schemaVersion?: number`, `idempotencyKey?: string`, `dryRun?: boolean`, `sessionKey?: string`, `category?: string`, `confidence?: number`, `namespace?: string`, `tags?: string[]`, `entityRef?: string`, `ttl?: string`, `sourceReason?: string` | Queue a suggested memory for review |
+| `remnic_work_task` | `action: string`, `id?: string`, `title?: string`, `description?: string`, `status?: string`, `priority?: string`, `owner?: string`, `assignee?: string`, `projectId?: string`, `tags?: string[]`, `dueAt?: string` | Manage work-layer tasks |
+| `remnic_work_project` | `action: string`, `id?: string`, `name?: string`, `description?: string`, `status?: string`, `owner?: string`, `tags?: string[]`, `taskId?: string`, `projectId?: string` | Manage work-layer projects |
+| `remnic_work_board` | `action: string`, `projectId?: string`, `snapshotJson?: string`, `linkToMemory?: boolean` | Export or import work-layer board snapshots and markdown |
 | `remnic_shared_context_write_output` | `agentId: string`, `title: string`, `content: string` | Write agent work product into shared context |
 | `remnic_shared_feedback_record` | `agent: string`, `decision: string`, `reason: string` | Record shared feedback for peer modeling |
 | `remnic_shared_priorities_append` | `agentId: string`, `text: string` | Append priorities notes for curator merge |
-| `remnic_shared_context_cross_signals_run` | shared-context options | Generate shared-context cross-signal artifacts |
-| `remnic_shared_context_curate_daily` | curation options | Generate the daily shared-context roundtable |
-| `remnic_compounding_weekly_synthesize` | compounding options | Generate weekly compounding outputs |
+| `remnic_shared_context_cross_signals_run` | `date?: string` | Generate shared-context cross-signal artifacts |
+| `remnic_shared_context_curate_daily` | `date?: string` | Generate the daily shared-context roundtable |
+| `remnic_compounding_weekly_synthesize` | `weekId?: string` | Generate weekly compounding outputs |
 | `remnic_compounding_promote_candidate` | `weekId: string`, `candidateId: string` | Promote a compounding candidate into durable memory |
-| `remnic_compression_guidelines_optimize` | optimization options | Run compression-guideline policy optimization |
-| `remnic_compression_guidelines_activate` | activation options | Activate a staged compression-guideline draft |
-| `remnic_memory_governance_run` | governance options | Run memory governance in shadow or apply mode |
-| `remnic_procedure_mining_run` | procedure mining options | Run procedural memory mining |
+| `remnic_compression_guidelines_optimize` | `dryRun?: boolean`, `eventLimit?: number` | Run compression-guideline policy optimization |
+| `remnic_compression_guidelines_activate` | `expectedContentHash?: string`, `expectedGuidelineVersion?: number` | Activate a staged compression-guideline draft |
+| `remnic_memory_governance_run` | `namespace?: string`, `mode?: shadow|apply`, `recentDays?: number`, `maxMemories?: number`, `batchSize?: number` | Run memory governance in shadow or apply mode |
+| `remnic_procedure_mining_run` | `namespace?: string` | Run procedural memory mining |
 | `remnic_procedural_stats` | `namespace?: string` | Read procedural memory stats |
-| `remnic_contradiction_scan_run` | scan options | Run an on-demand contradiction scan |
+| `remnic_contradiction_scan_run` | `namespace?: string` | Run an on-demand contradiction scan |
 | `remnic_memory_summarize_hourly` | none | Generate hourly conversation summaries |
-| `remnic_conversation_index_update` | indexing options | Update the conversation index |
-| `remnic_day_summary` | summary options | Generate a structured end-of-day summary |
-| `remnic_briefing` | briefing options | Generate a daily context briefing |
-| `remnic_context_checkpoint` | `sessionKey: string`, `context: string`, plus checkpoint metadata | Save a structured context checkpoint for a session |
-| `remnic_profiling_report` | profiling options | Generate a profiling report |
+| `remnic_conversation_index_update` | `sessionKey?: string`, `hours?: number`, `embed?: boolean` | Update the conversation index |
+| `remnic_day_summary` | `memories?: string`, `sessionKey?: string`, `namespace?: string` | Generate a structured end-of-day summary |
+| `remnic_briefing` | `since?: string`, `focus?: string`, `namespace?: string`, `format?: markdown|json`, `maxFollowups?: number` | Generate a daily context briefing |
+| `remnic_context_checkpoint` | `sessionKey: string`, `context: string`, `namespace?: string` | Save a structured context checkpoint for a session |
+| `remnic_profiling_report` | `format?: ascii|json`, `limit?: number` | Generate a profiling report |
 
 Each tool handler returns the raw JSON response from the daemon or `{"error": "Not connected to Remnic"}` when the client is not initialized. Direct memory tools use the daemon's REST endpoints where available; debug, explain, and MCP-native memory surfaces are forwarded through the daemon MCP endpoint.
 

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -279,7 +279,7 @@ No upstream Hermes feature request is needed from this audit: each OpenClaw life
 | `remnic_continuity_audit_generate` | `namespace?: string` and audit options | Generate a continuity audit report |
 | `remnic_continuity_incident_open` | `symptom: string`, plus incident metadata | Open a continuity incident |
 | `remnic_continuity_incident_close` | `id: string`, `fixApplied: string`, `verificationResult: string` | Close a continuity incident with verification |
-| `remnic_continuity_incident_list` | `status?: string`, `namespace?: string` | List continuity incidents by state |
+| `remnic_continuity_incident_list` | `state?: open|closed|all`, `namespace?: string` | List continuity incidents by state |
 | `remnic_continuity_loop_add_or_update` | `id: string`, `cadence: string`, `purpose: string`, `status: string`, `killCondition: string` | Add or update a continuity improvement loop |
 | `remnic_continuity_loop_review` | `id: string` | Review an existing continuity improvement loop |
 | `remnic_identity_anchor_get` | `namespace?: string` | Read the identity continuity anchor |

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -76,7 +76,7 @@ The plugin also registers the `remnic_*` tools for cases where the agent should 
 ### Option A: pip + CLI (recommended)
 
 ```bash
-pip install remnic-hermes
+pip install --upgrade remnic-hermes
 remnic connectors install hermes
 ```
 
@@ -85,7 +85,7 @@ remnic connectors install hermes
 ### Option B: pip only (manual config)
 
 ```bash
-pip install remnic-hermes
+pip install --upgrade remnic-hermes
 ```
 
 Then add the config block manually — see [Configuration reference](#configuration-reference).
@@ -276,10 +276,44 @@ No upstream Hermes feature request is needed from this audit: each OpenClaw life
 | `remnic_entity_get` | `name: string`, `namespace?: string` | Fetch one tracked entity by name |
 | `remnic_memory_capture` | `content: string`, plus memory metadata fields | Capture an explicit memory note |
 | `remnic_memory_action_apply` | `action: string`, plus action-specific fields | Apply a memory action |
+| `remnic_continuity_audit_generate` | `namespace?: string` and audit options | Generate a continuity audit report |
+| `remnic_continuity_incident_open` | `symptom: string`, plus incident metadata | Open a continuity incident |
+| `remnic_continuity_incident_close` | `id: string`, `fixApplied: string`, `verificationResult: string` | Close a continuity incident with verification |
+| `remnic_continuity_incident_list` | `status?: string`, `namespace?: string` | List continuity incidents by state |
+| `remnic_continuity_loop_add_or_update` | `id: string`, `cadence: string`, `purpose: string`, `status: string`, `killCondition: string` | Add or update a continuity improvement loop |
+| `remnic_continuity_loop_review` | `id: string` | Review an existing continuity improvement loop |
+| `remnic_identity_anchor_get` | `namespace?: string` | Read the identity continuity anchor |
+| `remnic_identity_anchor_update` | identity anchor fields | Conservatively merge identity anchor sections |
+| `remnic_review_queue_list` | review queue filters | Fetch the latest review queue artifact bundle |
+| `remnic_review_list` | contradiction review filters | List contradiction review items |
+| `remnic_review_resolve` | `pairId: string`, `verb: string` | Resolve a contradiction review pair |
+| `remnic_suggestion_submit` | `content: string`, plus suggestion metadata | Queue a suggested memory for review |
+| `remnic_work_task` | `action: string`, plus task fields | Manage work-layer tasks |
+| `remnic_work_project` | `action: string`, plus project fields | Manage work-layer projects |
+| `remnic_work_board` | `action: string`, plus board fields | Export or import work-layer board snapshots and markdown |
+| `remnic_shared_context_write_output` | `agentId: string`, `title: string`, `content: string` | Write agent work product into shared context |
+| `remnic_shared_feedback_record` | `agent: string`, `decision: string`, `reason: string` | Record shared feedback for peer modeling |
+| `remnic_shared_priorities_append` | `agentId: string`, `text: string` | Append priorities notes for curator merge |
+| `remnic_shared_context_cross_signals_run` | shared-context options | Generate shared-context cross-signal artifacts |
+| `remnic_shared_context_curate_daily` | curation options | Generate the daily shared-context roundtable |
+| `remnic_compounding_weekly_synthesize` | compounding options | Generate weekly compounding outputs |
+| `remnic_compounding_promote_candidate` | `weekId: string`, `candidateId: string` | Promote a compounding candidate into durable memory |
+| `remnic_compression_guidelines_optimize` | optimization options | Run compression-guideline policy optimization |
+| `remnic_compression_guidelines_activate` | activation options | Activate a staged compression-guideline draft |
+| `remnic_memory_governance_run` | governance options | Run memory governance in shadow or apply mode |
+| `remnic_procedure_mining_run` | procedure mining options | Run procedural memory mining |
+| `remnic_procedural_stats` | `namespace?: string` | Read procedural memory stats |
+| `remnic_contradiction_scan_run` | scan options | Run an on-demand contradiction scan |
+| `remnic_memory_summarize_hourly` | none | Generate hourly conversation summaries |
+| `remnic_conversation_index_update` | indexing options | Update the conversation index |
+| `remnic_day_summary` | summary options | Generate a structured end-of-day summary |
+| `remnic_briefing` | briefing options | Generate a daily context briefing |
+| `remnic_context_checkpoint` | `sessionKey: string`, `context: string`, plus checkpoint metadata | Save a structured context checkpoint for a session |
+| `remnic_profiling_report` | profiling options | Generate a profiling report |
 
 Each tool handler returns the raw JSON response from the daemon or `{"error": "Not connected to Remnic"}` when the client is not initialized. Direct memory tools use the daemon's REST endpoints where available; debug, explain, and MCP-native memory surfaces are forwarded through the daemon MCP endpoint.
 
-The `remnic_*` tools give the agent explicit control for cases where automatic recall is insufficient — for example, storing a specific fact the agent has derived mid-session, searching the LCM archive directly, inspecting why a recall result appeared, or curating stored memories.
+The `remnic_*` tools give the agent explicit control for cases where automatic recall is insufficient — for example, storing a specific fact the agent has derived mid-session, searching the LCM archive directly, inspecting why a recall result appeared, opening a continuity incident, curating stored memories, saving a checkpoint, or generating a profiling report.
 
 ---
 
@@ -389,7 +423,7 @@ which python && pip show remnic-hermes
 hermes --version
 ```
 
-Install into the correct environment: `<path-to-hermes-python> -m pip install remnic-hermes`.
+Install into the correct environment: `<path-to-hermes-python> -m pip install --upgrade remnic-hermes`.
 
 ### Memories not appearing in context
 
@@ -415,7 +449,7 @@ Or leave it blank to rely on the Remnic daemon's global search (the daemon index
 
 If you are upgrading from a configuration that used the `engram-hermes` package or an `engram:` config block:
 
-1. `pip install remnic-hermes` replaces `engram-hermes`. Uninstall the old package first: `pip uninstall engram-hermes`.
+1. `pip install --upgrade remnic-hermes` replaces `engram-hermes`. Uninstall the old package first: `pip uninstall engram-hermes`.
 2. Your `config.yaml` `engram:` block continues to work without changes. You can rename it to `remnic:` at any time — both are accepted.
 3. Tool calls to `engram_recall`, `engram_store`, and `engram_search` continue to work. No Hermes system prompt or tool-list changes are required.
 4. Python imports of `EngramMemoryProvider`, `EngramClient`, and `EngramHermesConfig` continue to resolve.

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -2,6 +2,8 @@
 
 Remnic MemoryProvider plugin for [Hermes Agent](https://github.com/NousResearch/hermes-agent). Automatically injects memories into every LLM call and observes every conversation turn — no agent code changes required.
 
+Current PyPI package: `remnic-hermes` v1.0.2. This release includes automatic MemoryProvider recall/observation, daemon-side LCM recall enrichment, session reset scoping, the full explicit Remnic tool parity surface, and legacy `engram_*` aliases for existing configs.
+
 ## Why MemoryProvider
 
 MCP tools give an agent the ability to call memory functions, but only when the agent decides to. With the MemoryProvider protocol, recall happens structurally on every turn before the LLM is called, and observation happens after every response. The agent cannot forget to recall because the hook is not optional. A plain MCP integration requires the LLM to recognize that it should search for memories and then choose to call the tool; the MemoryProvider removes that dependency entirely.
@@ -31,7 +33,7 @@ If you have read documentation or third-party reviews suggesting Remnic must reg
 
 1. Install the plugin:
    ```bash
-   pip install remnic-hermes
+   pip install --upgrade remnic-hermes
    ```
 
 2. Wire Hermes to Remnic (generates an auth token, writes the Hermes config entry, and checks daemon health):
@@ -45,7 +47,7 @@ If you have read documentation or third-party reviews suggesting Remnic must reg
    ```bash
    hermes --version && pip show remnic-hermes
    ```
-Your agent should now have access to `remnic_recall`, `remnic_store`, `remnic_search`, `remnic_lcm_search`, and `remnic_profiling_report` tools. Call `remnic_recall` with any query to confirm memories are returned.
+Your agent should now have structural memory on every turn plus explicit tools such as `remnic_recall`, `remnic_lcm_search`, `remnic_recall_xray`, `remnic_memory_store`, `remnic_context_checkpoint`, and `remnic_profiling_report`. Call `remnic_recall` with any query to confirm memories are returned.
 
 ## Manual configuration
 
@@ -109,6 +111,7 @@ The plugin searches for a `connector: "hermes"` entry first, then falls back to 
 | `pre_llm_call` | Before every LLM call | Recalls up to 8 memories using the last user message as the query. Skipped if the user message is fewer than 3 words. Injects a `<remnic-memory>` block into the system prompt when results are found. |
 | `sync_turn` | After every response | Sends the last 2 messages (user + assistant) to the Remnic daemon for real-time observation. |
 | `extract_memories` | Session ends | Sends the full session transcript to the daemon for deep structured extraction. |
+| `on_session_switch` / `on_session_reset` | Hermes session boundary | Keeps generated session keys aligned with the active Hermes session while preserving configured stable keys. |
 | `shutdown` | Plugin unloads | Closes the HTTP client. |
 
 ## Tools it registers
@@ -178,6 +181,12 @@ During the Engram to Remnic compat window, legacy `engram_*` aliases are also re
 
 The existing simple `remnic_store` / `engram_store` compatibility tools remain available. Use `remnic_memory_store` / `engram_memory_store` when the caller needs the richer daemon schema.
 
+In practice:
+
+- Automatic recall/observation is always handled by the MemoryProvider hooks.
+- Use explicit tools when Hermes needs to search a different query, write a specific fact, inspect recall attribution, search LCM directly, curate memory, manage continuity/work-board state, create a checkpoint, or generate reports.
+- Lossless Context Management does not require Hermes `context_engine`; LCM results arrive through the daemon recall envelope when enabled in Remnic.
+
 ## Profiles and namespaces
 
 Hermes isolates agent state per profile under `~/.hermes/profiles/<name>/`. Each profile loads its own `config.yaml`, so you can run separate `remnic:` blocks with different `session_key` values to keep memory contexts distinct. See [docs/plugins/hermes.md](../../docs/plugins/hermes.md) for a worked example.
@@ -216,7 +225,7 @@ which python && pip show remnic-hermes
 hermes --version
 ```
 
-If they differ, install into the correct environment: `<path-to-hermes-python> -m pip install remnic-hermes`.
+If they differ, install into the correct environment: `<path-to-hermes-python> -m pip install --upgrade remnic-hermes`.
 
 **Memories not appearing in context**
 


### PR DESCRIPTION
## Summary\n- update the README and Hermes setup docs for remnic-hermes v1.0.2\n- document the full Hermes explicit tool parity surface and session reset behavior\n- clarify that LCM reaches Hermes through MemoryProvider recall, not context_engine\n\n## Verification\n- git diff --check\n- ./node_modules/.bin/tsx --test tests/register-multi-registry.test.ts\n- uv run --project packages/plugin-hermes --extra test pytest -q\n- npm run preflight:quick (typecheck/config/review-patterns passed; stopped after the npm test step expanded into the wider suite and hung in packages/remnic-core/src/lcm-engine.test.ts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only; primary risk is user confusion if the updated Hermes integration/tooling guidance is inaccurate.
> 
> **Overview**
> Documents the `remnic-hermes` v1.0.2 release across the main `README`, `docs/integration/hermes-setup.md`, `docs/plugins/hermes.md`, and the plugin `README`, including switching install instructions to `pip install --upgrade remnic-hermes` and calling out the current PyPI version.
> 
> Expands Hermes guidance to emphasize that Remnic integrates as a Hermes **MemoryProvider** (not a `context_engine`), clarifies session reset/switch scoping behavior, and updates the described explicit `remnic_*` (and legacy `engram_*`) tool surface—including richer parameter schemas and newly documented continuity/work-board/shared-context/compounding/checkpoint/profiling capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f315419b40a2c1d64960158d75163658ef96a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->