### PR TITLE
fix: verify better-sqlite3 native binding on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "files": [
     "dist",
     "bin/engram-access.js",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "scripts/ensure-better-sqlite3.mjs"
   ],
   "dependencies": {
     "@remnic/core": "workspace:^",
@@ -65,6 +66,7 @@
     "apache-arrow": "^18.1.0",
     "better-sqlite3": "^12.6.2",
     "meilisearch": "^0.46.0",
+    "node-gyp": "^12.3.0",
     "openai": "^6.0.0",
     "zod": "^3.24.0"
   },
@@ -103,7 +105,7 @@
     "review:patterns": "bash scripts/check-review-patterns.sh",
     "hooks:install": "bash scripts/install-git-hooks.sh",
     "migrate": "tsx scripts/migrate.ts",
-    "postinstall": "pnpm rebuild better-sqlite3",
+    "postinstall": "node scripts/ensure-better-sqlite3.mjs",
     "prepack": "npm run build"
   },
   "devDependencies": {

--- a/packages/remnic-core/src/runtime/better-sqlite.test.ts
+++ b/packages/remnic-core/src/runtime/better-sqlite.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isLikelyBetterSqlite3NativeBindingError,
+  openBetterSqlite3,
+} from "./better-sqlite.js";
+
+test("isLikelyBetterSqlite3NativeBindingError recognizes missing and mismatched native bindings", () => {
+  assert.equal(
+    isLikelyBetterSqlite3NativeBindingError(
+      new Error("Could not locate the bindings file. Tried: better_sqlite3.node"),
+    ),
+    true,
+  );
+  assert.equal(
+    isLikelyBetterSqlite3NativeBindingError(
+      new Error("The module was compiled against a different Node.js version using NODE_MODULE_VERSION 127"),
+    ),
+    true,
+  );
+  assert.equal(isLikelyBetterSqlite3NativeBindingError(new Error("SQLITE_BUSY: database is locked")), false);
+});
+
+test("openBetterSqlite3 can open an in-memory database after install verification", () => {
+  const db = openBetterSqlite3(":memory:");
+  try {
+    const row = db.prepare("SELECT 42 AS answer").get() as { answer: number };
+    assert.equal(row.answer, 42);
+  } finally {
+    db.close();
+  }
+});

--- a/packages/remnic-core/src/runtime/better-sqlite.ts
+++ b/packages/remnic-core/src/runtime/better-sqlite.ts
@@ -3,6 +3,7 @@ import type BetterSqlite3 from "better-sqlite3";
 
 export type BetterSqlite3Database = BetterSqlite3.Database;
 type BetterSqlite3Ctor = typeof BetterSqlite3;
+type RuntimeRequire = ReturnType<typeof createRequire>;
 
 let cachedCtor: BetterSqlite3Ctor | null = null;
 
@@ -12,27 +13,10 @@ function loadBetterSqlite3(): BetterSqlite3Ctor {
   const require = createRequire(import.meta.url);
 
   try {
-    const loaded = require("better-sqlite3") as
-      | BetterSqlite3Ctor
-      | { default?: BetterSqlite3Ctor };
-    const ctor = typeof loaded === "function" ? loaded : loaded.default;
-
-    if (typeof ctor !== "function") {
-      throw new Error("module did not export a constructor");
-    }
-
-    cachedCtor = ctor;
-    return ctor;
+    cachedCtor = requireBetterSqlite3Ctor(require);
+    return cachedCtor;
   } catch (error) {
-    const detail =
-      error instanceof Error && error.message.length > 0
-        ? ` (${error.message})`
-        : "";
-    throw new Error(
-      "better-sqlite3 is unavailable. Rebuild it in the plugin install with `npm rebuild better-sqlite3 --build-from-source` before using SQLite-backed Engram features" +
-        detail,
-      { cause: error instanceof Error ? error : undefined },
-    );
+    throw unavailableError(error);
   }
 }
 
@@ -42,4 +26,51 @@ export function openBetterSqlite3(
 ): BetterSqlite3Database {
   const Database = loadBetterSqlite3();
   return new Database(file, options);
+}
+
+function requireBetterSqlite3Ctor(require: RuntimeRequire): BetterSqlite3Ctor {
+  const loaded = require("better-sqlite3") as
+    | BetterSqlite3Ctor
+    | { default?: BetterSqlite3Ctor };
+  const ctor = typeof loaded === "function" ? loaded : loaded.default;
+
+  if (typeof ctor !== "function") {
+    throw new Error("module did not export a constructor");
+  }
+
+  return ctor;
+}
+
+export function isLikelyBetterSqlite3NativeBindingError(error: unknown): boolean {
+  const detail = errorDetail(error);
+  return (
+    detail.includes("Could not locate the bindings file") ||
+    detail.includes("better_sqlite3.node") ||
+    (detail.includes("node-v") && detail.includes("better-sqlite3")) ||
+    (detail.includes("NODE_MODULE_VERSION") && detail.includes("better-sqlite3")) ||
+    detail.includes("was compiled against a different Node.js version")
+  );
+}
+
+function unavailableError(error: unknown): Error {
+  const detail = errorDetail(error);
+  const nativeBindingHint = isLikelyBetterSqlite3NativeBindingError(error)
+    ? " This usually means the better-sqlite3 native binding was not compiled for this Node.js/platform combination. " +
+      "Run `node scripts/ensure-better-sqlite3.mjs` from the Remnic install directory, or run " +
+      "`npx node-gyp rebuild --directory=node_modules/better-sqlite3` if the verification script is unavailable."
+    : "";
+  return new Error(
+    "better-sqlite3 is unavailable. Remnic attempted to load the native SQLite binding and could not." +
+      nativeBindingHint +
+      (detail ? ` Original error: ${detail}` : ""),
+    { cause: error instanceof Error ? error : undefined },
+  );
+}
+
+function errorDetail(error: unknown): string {
+  if (error instanceof Error) {
+    const stack = error.stack && error.stack !== error.message ? `\n${error.stack}` : "";
+    return `${error.message}${stack}`;
+  }
+  return String(error ?? "");
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       meilisearch:
         specifier: ^0.46.0
         version: 0.46.0
+      node-gyp:
+        specifier: ^12.3.0
+        version: 12.3.0
       openai:
         specifier: ^6.0.0
         version: 6.33.0(zod@3.25.76)
@@ -659,6 +662,10 @@ packages:
   '@honcho-ai/sdk@2.1.0':
     resolution: {integrity: sha512-GPyeKTDRhg5jd77RAh63LwrxLxnbluLdYUF1gsI6g6CU4eTyv8s1+KJ3/OTCiBwJ/dhjznNvQUngkUjjnNzUTA==}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1028,6 +1035,10 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1106,6 +1117,10 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1172,6 +1187,10 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1184,6 +1203,9 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1225,6 +1247,9 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1237,6 +1262,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1289,6 +1318,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -1313,8 +1350,18 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  node-gyp@12.3.0:
+    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1379,6 +1426,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -1503,6 +1554,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -1576,6 +1631,10 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1625,6 +1684,11 @@ packages:
       yaml:
         optional: true
 
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   wordwrapjs@5.1.1:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
     engines: {node: '>=12.17'}
@@ -1634,6 +1698,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -1857,6 +1925,10 @@ snapshots:
   '@honcho-ai/sdk@2.1.0':
     dependencies:
       zod: 4.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2137,6 +2209,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  abbrev@4.0.0: {}
+
   acorn@8.16.0: {}
 
   ansi-styles@4.3.0:
@@ -2217,6 +2291,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  chownr@3.0.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2269,6 +2345,8 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  env-paths@2.2.1: {}
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -2302,6 +2380,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  exponential-backoff@3.1.3: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2333,6 +2413,8 @@ snapshots:
 
   github-from-package@0.0.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-flag@4.0.0: {}
 
   ieee754@1.2.1: {}
@@ -2340,6 +2422,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  isexe@4.0.0: {}
 
   joycon@3.1.1: {}
 
@@ -2373,6 +2457,12 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
@@ -2398,7 +2488,24 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-gyp@12.3.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.7.4
+      tar: 7.5.13
+      tinyglobby: 0.2.15
+      undici: 6.25.0
+      which: 6.0.1
+
   node-releases@2.0.37: {}
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
 
   object-assign@4.1.1: {}
 
@@ -2456,6 +2563,8 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  proc-log@6.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -2601,6 +2710,14 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -2673,6 +2790,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@6.25.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2695,11 +2814,17 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   wordwrapjs@5.1.1: {}
 
   wrappy@1.0.2: {}
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.3: {}
 

--- a/scripts/ensure-better-sqlite3.mjs
+++ b/scripts/ensure-better-sqlite3.mjs
@@ -1,0 +1,124 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+if (process.env.REMNIC_SKIP_BETTER_SQLITE3_VERIFY === "1") {
+  console.log("[remnic] Skipping better-sqlite3 verification by request.");
+  process.exit(0);
+}
+
+try {
+  verifyBetterSqlite3();
+  console.log("[remnic] better-sqlite3 native binding verified.");
+  process.exit(0);
+} catch (error) {
+  console.warn(`[remnic] better-sqlite3 verification failed: ${errorMessage(error)}`);
+}
+
+const packageDir = betterSqlite3PackageDir();
+if (!packageDir) {
+  console.error("[remnic] Could not resolve better-sqlite3/package.json.");
+  process.exit(1);
+}
+
+const rebuild = rebuildBetterSqlite3(packageDir);
+if (!rebuild.ok) {
+  console.error("[remnic] better-sqlite3 native rebuild failed.");
+  if (rebuild.output) console.error(rebuild.output);
+  console.error(
+    `[remnic] Try manually from this install directory: npx node-gyp rebuild --directory=${packageDir}`,
+  );
+  process.exit(rebuild.status ?? 1);
+}
+
+try {
+  clearBetterSqlite3RequireCache(packageDir);
+  verifyBetterSqlite3();
+  console.log("[remnic] better-sqlite3 native binding rebuilt and verified.");
+} catch (error) {
+  console.error(
+    `[remnic] better-sqlite3 rebuild completed but the binding still does not load: ${errorMessage(error)}`,
+  );
+  process.exit(1);
+}
+
+function verifyBetterSqlite3() {
+  const loaded = require("better-sqlite3");
+  const Database = typeof loaded === "function" ? loaded : loaded?.default;
+  if (typeof Database !== "function") {
+    throw new Error("module did not export a constructor");
+  }
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = MEMORY");
+  db.close();
+}
+
+function betterSqlite3PackageDir() {
+  try {
+    return path.dirname(require.resolve("better-sqlite3/package.json"));
+  } catch {
+    return null;
+  }
+}
+
+function rebuildBetterSqlite3(cwd) {
+  const localNodeGyp = resolveOptional("node-gyp/bin/node-gyp.js");
+  if (localNodeGyp) {
+    return runRebuild(process.execPath, [localNodeGyp, "rebuild", "--release"], cwd);
+  }
+
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  return runRebuild(
+    npm,
+    ["exec", "--yes", "node-gyp", "--", "rebuild", "--release"],
+    cwd,
+  );
+}
+
+function resolveOptional(specifier) {
+  try {
+    return require.resolve(specifier);
+  } catch {
+    return null;
+  }
+}
+
+function runRebuild(command, args, cwd) {
+  console.log(`[remnic] Rebuilding better-sqlite3 native binding in ${cwd}`);
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      npm_config_build_from_source: "true",
+    },
+    windowsHide: true,
+  });
+
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    output: [
+      result.error ? String(result.error) : "",
+      result.stdout ?? "",
+      result.stderr ?? "",
+    ]
+      .filter((part) => part.trim().length > 0)
+      .join("\n")
+      .trim(),
+  };
+}
+
+function clearBetterSqlite3RequireCache(packageDir) {
+  for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(packageDir)) {
+      delete require.cache[key];
+    }
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary
- Replace the fragile `pnpm rebuild better-sqlite3` postinstall with a verifier that actually loads an in-memory SQLite database.
- If the native binding is missing, rebuild `better-sqlite3` with `node-gyp rebuild --release`, clear the require cache, and verify the binding again.
- Publish the verifier script with the root package and keep runtime code non-spawning so the OpenClaw plugin bundle stays clean.
- Improve the runtime SQLite loader error to point users at the verifier/manual `node-gyp` recovery path.

## Verification
- Reproduced issue #827 locally after `pnpm install`: `require("better-sqlite3")` failed with the missing native binding error.
- `node scripts/ensure-better-sqlite3.mjs` rebuilt and verified the native binding.
- `pnpm exec tsc --noEmit`
- `pnpm exec tsx --test packages/remnic-core/src/runtime/better-sqlite.test.ts`
- `pnpm exec tsx --test tests/openclaw-plugin-dangerous-scan.test.ts`
- `pnpm exec tsx --test tests/register-multi-registry.test.ts tests/intent.test.ts tests/runtime-input-guards.test.ts tests/artifact-recall-limit.test.ts tests/artifact-status-snapshot.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts packages/remnic-core/src/runtime/better-sqlite.test.ts tests/openclaw-plugin-dangerous-scan.test.ts`
- `npm run build`
- `npm run preflight:quick` completed type/config/static checks and one full `npm test` pass (`6400 pass / 0 fail / 7 skipped`), then was stopped during a redundant second full-suite pass caused by `npm test -- <file>` expanding the repo-wide globs again.

Fixes #827

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the install-time behavior to verify and potentially rebuild a native dependency (`better-sqlite3`) via `node-gyp`, which can impact developer/CI environments and platform-specific installs if the rebuild path fails or behaves differently.
> 
> **Overview**
> Replaces the `postinstall` `pnpm rebuild better-sqlite3` step with a new `scripts/ensure-better-sqlite3.mjs` verifier that *actually loads* `better-sqlite3` and opens an in-memory DB; on failure it rebuilds the native binding via `node-gyp`, clears the require cache, and re-verifies (with an opt-out env var).
> 
> Updates the runtime `better-sqlite3` loader to produce more actionable errors, including detection of likely native-binding/version mismatch failures and guidance to run the new verifier or a manual `node-gyp rebuild`. Adds targeted tests covering the error-classifier and the ability to open a DB after verification, and ships the new script in the published package plus a `node-gyp` dependency (lockfile updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28ac5ce1b00ea196097a28d843c74b03f68b37a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->