### PR TITLE
chore(plugin-openclaw): bump package for core repair

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- bump `@remnic/plugin-openclaw` from `1.0.11` to `1.0.12`

## Why

`@remnic/core@1.1.4` is already published with the better-sqlite3 verifier in the package-owned postinstall path. Fresh installs of `@remnic/plugin-openclaw@1.0.11` already resolve that fixed core version through the existing semver range, but publishing a new plugin patch gives updater-driven plugin flows a new plugin artifact to notice and install.

The packed `@remnic/plugin-openclaw@1.0.12` metadata rewrites the workspace dependency to `@remnic/core: ^1.1.4`.

## Verification

- `pnpm install`
- `pnpm --filter @remnic/plugin-openclaw build`
- `pnpm --filter @remnic/plugin-openclaw pack --pack-destination /tmp/remnic-plugin-openclaw-pack --json`
- inspected packed `package/package.json`: version `1.0.12`, dependency `@remnic/core: ^1.1.4`
- `bash scripts/check-review-patterns.sh`
- `git diff --check`
- `npm view @remnic/plugin-openclaw@1.0.12 version --json` returns 404 before publish, confirming the target version is unused

Note: `pnpm --filter @remnic/plugin-openclaw check-types` still fails on the package's pre-existing rootDir/cross-package TypeScript setup (`src/index.ts` imports the root compatibility entrypoint outside `packages/plugin-openclaw/src`). The package build succeeds and the PR CI covers the normal repo gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This is a patch-level version bump only, with no code or dependency changes in the repository; risk is limited to publishing/upgrade mechanics.
> 
> **Overview**
> Publishes a new patch release of `@remnic/plugin-openclaw` by bumping its `package.json` version from `1.0.11` to `1.0.12`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71198a6907e54b5f4be04ec3f40a46256c397312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->