### PR TITLE
chore(release): publish issue 799 package surfaces

### DIFF
--- a/packages/hermes-provider/package.json
+++ b/packages/hermes-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/hermes-provider",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Typed HTTP client for the Remnic memory API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/import-lossless-claw/package.json
+++ b/packages/import-lossless-claw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/import-lossless-claw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Import lossless-claw (LCM) SQLite databases into Remnic's LCM mode",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/plugin-hermes/plugin.yaml
+++ b/packages/plugin-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: remnic
-version: 1.0.2
+version: 1.0.3
 description: Universal memory for AI agents — Remnic MemoryProvider integration for Hermes
 author: Joshua Warren
 homepage: https://github.com/joshuaswarren/remnic

--- a/packages/plugin-hermes/pyproject.toml
+++ b/packages/plugin-hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "remnic-hermes"
-version = "1.0.2"
+version = "1.0.3"
 description = "Remnic MemoryProvider plugin for Hermes Agent"
 readme = "README.md"
 license = "MIT"

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "CLI for Remnic memory — init, query, doctor, daemon management",
   "type": "module",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
     "@remnic/import-chatgpt": "^0.1.0",
     "@remnic/import-claude": "^0.1.0",
     "@remnic/import-gemini": "^0.1.0",
-    "@remnic/import-lossless-claw": "^0.1.0",
+    "@remnic/import-lossless-claw": "^0.1.1",
     "@remnic/import-mem0": "^0.1.0"
   },
   "peerDependenciesMeta": {

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump @remnic/core so issue #799 structured message parts ship to npm users
- bump changed adapter/import surfaces: CLI, OpenClaw plugin, Hermes provider, lossless-claw importer
- bump the Hermes plugin manifest/package version for the new observe message-part shape

## Verification
- pnpm install --lockfile-only
- git diff --check

Follows #838 / fixes #799 package publishing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates package/plugin version metadata and one peer dependency range, with no runtime code changes.
> 
> **Overview**
> Publishes a coordinated release by bumping versions across `@remnic/core`, `@remnic/cli`, `@remnic/plugin-openclaw`, `@remnic/hermes-provider`, `@remnic/import-lossless-claw`, and the Hermes plugin (`plugin.yaml`/`pyproject.toml`).
> 
> Updates `@remnic/cli` peer dependency on `@remnic/import-lossless-claw` to `^0.1.1` to match the new importer release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4f1ff547b1bb9cf8f4baf0c1b562152a3036bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->