### PR TITLE
fix(bench): front-load exact session references

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -154,6 +154,309 @@ test("direct adapter recall expands search hits with adjacent stored results", a
   }
 });
 
+test("adapter recall front-loads exact step references from the session trace", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 12 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "At Step 8, why did the agent's action matter?",
+      24_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 8\]: move-8/);
+    assert.match(recalled, /\[Observation 8\]: state-8/);
+    assert.ok(
+      recalled.indexOf("## Exact session reference evidence") <
+        recalled.indexOf("[Action 8]: move-8"),
+    );
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("adapter recall recognizes plural multi-step reference prompts", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 12 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "Compare steps 8 and 9 before answering.",
+      24_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 8\]: move-8/);
+    assert.match(recalled, /\[Observation 8\]: state-8/);
+    assert.match(recalled, /\[Action 9\]: move-9/);
+    assert.match(recalled, /\[Observation 9\]: state-9/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("adapter recall preserves trailing references after a parsed step range", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 14 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "Compare steps 8-10 and 12 before answering.",
+      24_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 8\]: move-8/);
+    assert.match(recalled, /\[Observation 10\]: state-10/);
+    assert.match(recalled, /\[Action 12\]: move-12/);
+    assert.match(recalled, /\[Observation 12\]: state-12/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("adapter recall expands only the explicit range segment in mixed prompts", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 16 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "Compare steps 8 and 10-15 before answering.",
+      24_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 8\]: move-8/);
+    assert.match(recalled, /\[Action 10\]: move-10/);
+    assert.match(recalled, /\[Observation 13\]: state-13/);
+    assert.match(recalled, /\[Observation 15\]: state-15/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("adapter recall treats unicode dashes as step range separators", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 12 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "Compare steps 8\u201310 before answering.",
+      24_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 8\]: move-8/);
+    assert.match(recalled, /\[Observation 9\]: state-9/);
+    assert.match(recalled, /\[Action 10\]: move-10/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("adapter recall does not let stray labels consume later reference numbers", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 10 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "Think step by step. Turn 8 is relevant.",
+      24_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 8\]: move-8/);
+    assert.match(recalled, /\[Observation 8\]: state-8/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("adapter recall maps turn references to direct and paired turn candidates", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 10 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "Turn 8 is relevant.",
+      24_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 4\]: move-4/);
+    assert.match(recalled, /\[Action 8\]: move-8/);
+    assert.match(recalled, /\[Observation 8\]: state-8/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("adapter recall preserves long explicit reference lists", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 18 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "Compare steps 1,2,3,4,5,6,7,8,9,10,11,12 before answering.",
+      24_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 1\]: move-1/);
+    assert.match(recalled, /\[Observation 8\]: state-8/);
+    assert.match(recalled, /\[Action 12\]: move-12/);
+    assert.match(recalled, /\[Observation 12\]: state-12/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("adapter recall expands ranges up to the configured reference cap", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 22 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-session", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-session",
+      "Compare steps 1-20 before answering.",
+      32_000,
+    );
+
+    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /\[Action 1\]: move-1/);
+    assert.match(recalled, /\[Observation 12\]: state-12/);
+    assert.match(recalled, /\[Action 20\]: move-20/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
 test("runtime-backed adapter stores benchmark turns into Remnic recall surfaces", async () => {
   const adapter = await createRemnicAdapter({
     configOverrides: {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -96,6 +96,26 @@ type OrchestratorTeardownView = {
 };
 
 const BENCH_TEARDOWN_DEFERRED_READY_WAIT_MS = 500;
+const EXACT_REFERENCE_MAX_CHARS = 18_000;
+const EXACT_REFERENCE_MAX_ITEM_CHARS = 2_400;
+const EXACT_REFERENCE_MAX_NUMBERS = 24;
+const EXACT_REFERENCE_SCAN_TOKEN_LIMIT = EXACT_REFERENCE_MAX_NUMBERS * 3;
+const EXACT_REFERENCE_WINDOW_RADIUS = 0;
+
+type BenchLcmExpansionEngine = {
+  getStats(sessionId?: string): Promise<{ totalMessages: number }>;
+  expandContext(
+    sessionId: string,
+    fromTurn: number,
+    toTurn: number,
+    maxTokens: number,
+  ): Promise<Array<{ turn_index: number; role: string; content: string }>>;
+};
+
+type ExplicitSessionReference = {
+  number: number;
+  includeDirectTurn: boolean;
+};
 
 function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
   return cloneBenchConfigValue(config) as Record<string, unknown>;
@@ -306,8 +326,25 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         const sections: string[] = [];
         let usedChars = 0;
 
+        const exactReferenceEvidence = await buildExactSessionReferenceEvidence(
+          engine,
+          sessionId,
+          query,
+          Math.min(EXACT_REFERENCE_MAX_CHARS, Math.floor(budget * 0.4)),
+        );
+        if (exactReferenceEvidence) {
+          sections.push(exactReferenceEvidence);
+          usedChars += exactReferenceEvidence.length;
+        }
+
         if (useCoreMemoryPipeline) {
-          const coreBudget = Math.max(0, Math.floor(budget * 0.55));
+          const coreBudget = Math.max(
+            0,
+            Math.min(
+              Math.floor(budget * 0.55),
+              Math.floor((budget - usedChars) * 0.7),
+            ),
+          );
           const coreRecall = await state.orchestrator.recall(query, sessionId, {
             budgetCharsOverride: coreBudget,
             mode: "full",
@@ -323,7 +360,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           const remainingAfterCore = Math.max(0, budget - usedChars);
           const searchBudget = useCoreMemoryPipeline
             ? Math.max(0, Math.floor(remainingAfterCore * 0.75))
-            : Math.max(0, Math.floor(budget * 0.7));
+            : Math.max(0, Math.floor(remainingAfterCore * 0.7));
           const searchLimit = Math.max(6, Math.min(18, Math.floor(budget / 2_000)));
           const searchResults = await engine.searchContextFull(
             query,
@@ -548,4 +585,299 @@ function nextBenchTranscriptTurnId(
     .digest("hex")
     .slice(0, 16);
   return `bench-${index}-${digest}`;
+}
+
+async function buildExactSessionReferenceEvidence(
+  engine: BenchLcmExpansionEngine,
+  sessionId: string,
+  query: string,
+  maxChars: number,
+): Promise<string> {
+  if (maxChars <= 0 || !query.trim()) {
+    return "";
+  }
+
+  const references = collectExplicitSessionReferences(query);
+  if (references.length === 0) {
+    return "";
+  }
+
+  const stats = await engine.getStats(sessionId);
+  if (stats.totalMessages <= 0) {
+    return "";
+  }
+
+  const windows = new Map<string, { fromTurn: number; toTurn: number }>();
+  for (const reference of references.slice(0, EXACT_REFERENCE_MAX_NUMBERS)) {
+    for (const center of candidateTurnIndexesForReference(reference)) {
+      if (center < 0 || center >= stats.totalMessages) {
+        continue;
+      }
+
+      const fromTurn = Math.max(0, center - EXACT_REFERENCE_WINDOW_RADIUS);
+      const toTurn = Math.min(
+        stats.totalMessages - 1,
+        center + EXACT_REFERENCE_WINDOW_RADIUS,
+      );
+      windows.set(`${fromTurn}:${toTurn}`, { fromTurn, toTurn });
+    }
+  }
+
+  const evidenceItems: Array<{
+    id: string;
+    sessionId: string;
+    turnIndex: number;
+    role: string;
+    content: string;
+  }> = [];
+  const seenTurns = new Set<string>();
+
+  for (const window of [...windows.values()].sort(
+    (left, right) => left.fromTurn - right.fromTurn || left.toTurn - right.toTurn,
+  )) {
+    const expanded = await engine.expandContext(
+      sessionId,
+      window.fromTurn,
+      window.toTurn,
+      2_000,
+    );
+
+    for (const message of expanded) {
+      const id = `${sessionId}:${message.turn_index}`;
+      if (seenTurns.has(id)) {
+        continue;
+      }
+      seenTurns.add(id);
+      evidenceItems.push({
+        id,
+        sessionId,
+        turnIndex: message.turn_index,
+        role: message.role,
+        content: message.content,
+      });
+    }
+  }
+
+  return buildEvidencePack(evidenceItems, {
+    title: "Exact session reference evidence",
+    maxChars,
+    maxItemChars: EXACT_REFERENCE_MAX_ITEM_CHARS,
+  });
+}
+
+function collectExplicitSessionReferences(query: string): ExplicitSessionReference[] {
+  const references = new Map<string, ExplicitSessionReference>();
+  const addReference = (value: string | undefined, label: string) => {
+    if (value === undefined) return;
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isInteger(parsed) && parsed >= 0) {
+      const existing = references.get(String(parsed));
+      references.set(String(parsed), {
+        number: parsed,
+        includeDirectTurn:
+          (existing?.includeDirectTurn ?? false) || label === "turn",
+      });
+    }
+  };
+
+  const tokens = tokenizeReferenceQuery(query);
+  for (let index = 0; index < tokens.length; index += 1) {
+    const label = normalizeReferenceLabel(tokens[index]);
+    if (!label) {
+      continue;
+    }
+
+    const parsed = parseReferenceNumbers(tokens, index + 1);
+    for (const number of parsed.numbers) {
+      addReference(String(number), label);
+    }
+    index = Math.max(index, parsed.nextIndex - 1);
+  }
+
+  return [...references.values()].sort((left, right) => left.number - right.number);
+}
+
+function tokenizeReferenceQuery(query: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+
+  const flushCurrent = () => {
+    if (current) {
+      tokens.push(current);
+      current = "";
+    }
+  };
+
+  for (const char of query) {
+    if (isAsciiLetterOrDigit(char)) {
+      current += char;
+    } else {
+      flushCurrent();
+      if (char === "#" || char === ",") {
+        tokens.push(char);
+      } else if (isReferenceDash(char)) {
+        tokens.push("-");
+      }
+    }
+  }
+  flushCurrent();
+
+  return tokens;
+}
+
+function parseReferenceNumbers(
+  tokens: readonly string[],
+  startIndex: number,
+): { numbers: number[]; nextIndex: number } {
+  const numbers: number[] = [];
+  let lastNumber: number | undefined;
+  let pendingRangeStart: number | undefined;
+  let index = startIndex;
+  const scanEnd = Math.min(
+    tokens.length,
+    startIndex + EXACT_REFERENCE_SCAN_TOKEN_LIMIT,
+  );
+
+  for (; index < scanEnd; index += 1) {
+    const token = tokens[index]!;
+    const normalized = token.toLowerCase();
+    const value = parseNonNegativeIntegerToken(token);
+    if (value !== undefined) {
+      if (pendingRangeStart !== undefined) {
+        numbers.push(...expandReferenceRange(pendingRangeStart, value));
+        pendingRangeStart = undefined;
+      } else {
+        numbers.push(value);
+      }
+      lastNumber = value;
+      continue;
+    }
+
+    if (normalized === "#" || normalized === "number" || normalized === ",") {
+      continue;
+    }
+
+    if (
+      normalized === "-" ||
+      normalized === "to" ||
+      normalized === "through" ||
+      normalized === "thru"
+    ) {
+      if (lastNumber !== undefined) {
+        if (numbers[numbers.length - 1] === lastNumber) {
+          numbers.pop();
+        }
+        pendingRangeStart = lastNumber;
+      }
+      continue;
+    }
+
+    if (normalized === "and" && numbers.length > 0) {
+      continue;
+    }
+
+    if (normalizeReferenceLabel(token)) {
+      break;
+    }
+
+    break;
+  }
+
+  if (pendingRangeStart !== undefined) {
+    numbers.push(pendingRangeStart);
+  }
+
+  return {
+    numbers: dedupeReferenceNumbers(numbers),
+    nextIndex: index,
+  };
+}
+
+function dedupeReferenceNumbers(numbers: readonly number[]): number[] {
+  return [...new Set(numbers)];
+}
+
+function expandReferenceRange(start: number, end: number): number[] {
+  const low = Math.min(start, end);
+  const high = Math.max(start, end);
+  if (high - low + 1 > EXACT_REFERENCE_MAX_NUMBERS) {
+    return [start, end];
+  }
+
+  const values: number[] = [];
+  for (let value = low; value <= high; value += 1) {
+    values.push(value);
+  }
+  return values;
+}
+
+function normalizeReferenceLabel(token: string | undefined): string | undefined {
+  const normalized = token?.toLowerCase();
+  switch (normalized) {
+    case "step":
+    case "steps":
+      return "step";
+    case "turn":
+    case "turns":
+      return "turn";
+    case "action":
+    case "actions":
+      return "action";
+    case "observation":
+    case "observations":
+      return "observation";
+    default:
+      return undefined;
+  }
+}
+
+function parseNonNegativeIntegerToken(token: string): number | undefined {
+  if (token.length === 0) {
+    return undefined;
+  }
+
+  let value = 0;
+  for (const char of token) {
+    const code = char.charCodeAt(0);
+    if (code < 48 || code > 57) {
+      return undefined;
+    }
+    value = value * 10 + (code - 48);
+  }
+  return value;
+}
+
+function isAsciiLetterOrDigit(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122);
+}
+
+function isReferenceDash(char: string): boolean {
+  return char === "-"
+    || char === "\u2010"
+    || char === "\u2011"
+    || char === "\u2012"
+    || char === "\u2013"
+    || char === "\u2014"
+    || char === "\u2015";
+}
+
+function candidateTurnIndexesForReference(
+  reference: ExplicitSessionReference,
+): number[] {
+  const candidates = new Set<number>();
+  if (reference.includeDirectTurn) {
+    for (let offset = -1; offset <= 1; offset += 1) {
+      candidates.add(reference.number + offset);
+    }
+  }
+
+  const pairedBase = reference.number * 2;
+  for (let offset = -2; offset <= 3; offset += 1) {
+    candidates.add(pairedBase + offset);
+  }
+
+  return [...candidates].sort((left, right) => left - right);
 }


### PR DESCRIPTION
## Summary
- Add an exact session reference evidence section to the Remnic benchmark adapter for queries that mention concrete Step/Turn/Action/Observation numbers.
- Pull the evidence from Remnic's lossless LCM transcript before core recall/search packaging, so long-horizon benchmark answerers see the referenced trajectory turns first.
- Cover the behavior with an adapter test that verifies Step 8 recall includes Action/Observation 8 evidence at the front of the recall pack.

## Why
The completed AMA-Bench full run was mechanically valid but not SOTA (`ama_bench_recommended_accuracy=0.3337`, `cross=0.4852`). Failure sampling showed all failed tasks had recall text, but referenced trajectory evidence was sometimes missing or buried behind shared context/recent/search noise. This change exposes Remnic's stored exact session trace more directly instead of relying only on semantic search and compressed recall.

## Verification
- `npx tsx --test packages/bench/src/adapters/remnic-adapter.test.ts`
- `npm run -w @remnic/bench build`
- Local AMA episode recall smoke confirmed exact Action/Observation references are front-loaded.

Known unrelated failure:
- `npm run preflight:quick` still fails at `packages/remnic-core/src/secure-store/kdf.ts(37,36): Cannot find module '@node-rs/argon2' or its corresponding type declarations.`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the benchmark adapter recall composition to inject transcript-derived evidence ahead of core recall/search, which can materially change recall outputs and budget allocation for benchmarks.
> 
> **Overview**
> Front-loads an **"Exact session reference evidence"** section in `remnic-adapter` recall output whenever the query contains explicit `step/turn/action/observation` numbers, expanding the referenced turns directly from the lossless LCM transcript.
> 
> Adds parsing/normalization for explicit reference patterns (plural labels, comma lists, ranges including unicode dashes, and `turn` vs `step` mapping) with caps on characters/items/numbers, and adjusts downstream core/search budget calculations accordingly.
> 
> Extends `remnic-adapter.test.ts` with coverage for single/multi-step references, mixed ranges/lists, unicode dash ranges, and turn-number handling to ensure referenced evidence appears early in the recall pack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02223aad3e27096db076b5f57fea82df26bcaedd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->