### PR TITLE
feat(core): add explicit cue recall

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2203,6 +2203,23 @@
         "default": 300,
         "description": "Max tokens for each TMT summary node. Default: 300."
       },
+      "explicitCueRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
+      },
+      "explicitCueRecallMaxChars": {
+        "type": "number",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the explicit cue evidence recall section."
+      },
+      "explicitCueRecallMaxReferences": {
+        "type": "number",
+        "default": 24,
+        "minimum": 0,
+        "description": "Maximum query-visible cues expanded by explicit cue recall."
+      },
       "queryExpansionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2192,6 +2192,23 @@
         "default": 300,
         "description": "Max tokens for each TMT summary node. Default: 300."
       },
+      "explicitCueRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
+      },
+      "explicitCueRecallMaxChars": {
+        "type": "number",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the explicit cue evidence recall section."
+      },
+      "explicitCueRecallMaxReferences": {
+        "type": "number",
+        "default": 24,
+        "minimum": 0,
+        "description": "Maximum query-visible cues expanded by explicit cue recall."
+      },
       "queryExpansionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -79,6 +79,58 @@ test("parseConfig activeRecallCacheTtlMs=500 preserves the explicit positive ttl
   assert.equal(result.activeRecallCacheTtlMs, 500);
 });
 
+test("parseConfig keeps explicit cue recall opt-in and budgets configurable", () => {
+  const defaults = parseConfig({});
+  assert.equal(defaults.explicitCueRecallEnabled, false);
+  assert.equal(defaults.explicitCueRecallMaxChars, 2400);
+  assert.equal(defaults.explicitCueRecallMaxReferences, 24);
+  assert.equal(
+    defaults.recallPipeline.find((section) => section.id === "explicit-cue")
+      ?.enabled,
+    false,
+  );
+
+  const cfg = parseConfig({
+    explicitCueRecallEnabled: true,
+    explicitCueRecallMaxChars: 0,
+    explicitCueRecallMaxReferences: 0,
+  });
+  assert.equal(cfg.explicitCueRecallEnabled, true);
+  assert.equal(cfg.explicitCueRecallMaxChars, 0);
+  assert.equal(cfg.explicitCueRecallMaxReferences, 0);
+  const section = cfg.recallPipeline.find((entry) => entry.id === "explicit-cue");
+  assert.equal(section?.enabled, true);
+  assert.equal(section?.maxChars, 0);
+  assert.equal(section?.maxResults, 0);
+
+  const cliStyle = parseConfig({
+    explicitCueRecallEnabled: "true",
+    explicitCueRecallMaxChars: "3200",
+    explicitCueRecallMaxReferences: "12",
+  });
+  assert.equal(cliStyle.explicitCueRecallEnabled, true);
+  assert.equal(cliStyle.explicitCueRecallMaxChars, 3200);
+  assert.equal(cliStyle.explicitCueRecallMaxReferences, 12);
+  const cliSection = cliStyle.recallPipeline.find(
+    (entry) => entry.id === "explicit-cue",
+  );
+  assert.equal(cliSection?.enabled, true);
+  assert.equal(cliSection?.maxChars, 3200);
+  assert.equal(cliSection?.maxResults, 12);
+});
+
+test("research-max preset enables explicit cue recall for benchmark-grade runs", () => {
+  const cfg = parseConfig({ memoryOsPreset: "research-max" });
+  assert.equal(cfg.explicitCueRecallEnabled, true);
+  assert.equal(cfg.explicitCueRecallMaxChars, 3200);
+  assert.equal(cfg.lcmEnabled, true);
+  assert.equal(
+    cfg.recallPipeline.find((section) => section.id === "explicit-cue")
+      ?.enabled,
+    true,
+  );
+});
+
 test("parseConfig activeRecallCacheTtlMs=-1 falls back to the default ttl", () => {
   const result = parseConfig({ activeRecallCacheTtlMs: -1 });
   assert.equal(result.activeRecallCacheTtlMs, 15000);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -337,6 +337,9 @@ const MEMORY_OS_PRESETS: Record<MemoryOsPresetName, Record<string, unknown>> = {
     contextCompressionActionsEnabled: true,
     compressionGuidelineLearningEnabled: true,
     compressionGuidelineSemanticRefinementEnabled: true,
+    explicitCueRecallEnabled: true,
+    explicitCueRecallMaxChars: 3200,
+    lcmEnabled: true,
     maxProactiveQuestionsPerExtraction: 4,
     maxCompressionTokensPerHour: 3000,
     behaviorLoopAutoTuneEnabled: true,
@@ -2701,6 +2704,15 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.tmtHourlyMinMemories === "number" ? cfg.tmtHourlyMinMemories : 3,
     tmtSummaryMaxTokens:
       typeof cfg.tmtSummaryMaxTokens === "number" ? cfg.tmtSummaryMaxTokens : 300,
+    explicitCueRecallEnabled: coerceBool(cfg.explicitCueRecallEnabled) === true,
+    explicitCueRecallMaxChars:
+      coerceNumber(cfg.explicitCueRecallMaxChars) !== undefined
+        ? Math.max(0, Math.floor(coerceNumber(cfg.explicitCueRecallMaxChars)!))
+        : 2400,
+    explicitCueRecallMaxReferences:
+      coerceNumber(cfg.explicitCueRecallMaxReferences) !== undefined
+        ? Math.max(0, Math.floor(coerceNumber(cfg.explicitCueRecallMaxReferences)!))
+        : 24,
     // Lossless Context Management (LCM)
     lcmEnabled: cfg.lcmEnabled === true,
     lcmLeafBatchSize:
@@ -3294,6 +3306,18 @@ function buildDefaultRecallPipeline(cfg: Record<string, unknown>): RecallSection
         typeof cfg.sharedContextMaxInjectChars === "number"
           ? Math.max(0, Math.floor(cfg.sharedContextMaxInjectChars))
           : 4000,
+    },
+    {
+      id: "explicit-cue",
+      enabled: coerceBool(cfg.explicitCueRecallEnabled) === true,
+      maxChars:
+        coerceNumber(cfg.explicitCueRecallMaxChars) !== undefined
+          ? Math.max(0, Math.floor(coerceNumber(cfg.explicitCueRecallMaxChars)!))
+          : 2400,
+      maxResults:
+        coerceNumber(cfg.explicitCueRecallMaxReferences) !== undefined
+          ? Math.max(0, Math.floor(coerceNumber(cfg.explicitCueRecallMaxReferences)!))
+          : 24,
     },
     {
       id: "profile",

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildExplicitCueRecallSection,
+  collectExplicitTurnReferences,
+  collectLexicalCues,
+  type ExplicitCueRecallEngine,
+} from "./explicit-cue-recall.js";
+
+type Message = { role: string; content: string; turnIndex?: number };
+
+class FakeCueEngine implements ExplicitCueRecallEngine {
+  constructor(private readonly sessions: Record<string, Message[]>) {}
+
+  async expandContext(
+    sessionId: string,
+    fromTurn: number,
+    toTurn: number,
+    _maxTokens: number,
+  ): Promise<Array<{ turn_index: number; role: string; content: string }>> {
+    const messages = this.sessions[sessionId] ?? [];
+    const from = Math.max(0, Math.floor(fromTurn));
+    const to = Math.floor(toTurn);
+    if (from > to) return [];
+    return messages
+      .map((message, offset) => ({
+        turn_index: message.turnIndex ?? offset,
+        role: message.role,
+        content: message.content,
+      }))
+      .filter((message) => message.turn_index >= from && message.turn_index <= to);
+  }
+
+  async searchContextFull(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<
+    Array<{
+      turn_index: number;
+      role: string;
+      content: string;
+      session_id: string;
+      score?: number;
+    }>
+  > {
+    const needle = normalizeForSearch(query);
+    const sessionEntries = Object.entries(this.sessions).filter(
+      ([candidateSessionId]) => !sessionId || candidateSessionId === sessionId,
+    );
+    const results: Array<{
+      turn_index: number;
+      role: string;
+      content: string;
+      session_id: string;
+      score?: number;
+    }> = [];
+    for (const [candidateSessionId, messages] of sessionEntries) {
+      for (let index = 0; index < messages.length; index += 1) {
+        const message = messages[index]!;
+        if (!normalizeForSearch(message.content).includes(needle)) continue;
+        results.push({
+          turn_index: message.turnIndex ?? index,
+          role: message.role,
+          content: message.content,
+          session_id: candidateSessionId,
+          score: 1,
+        });
+      }
+    }
+    return results.slice(0, Math.max(0, Math.floor(limit)));
+  }
+}
+
+test("collectExplicitTurnReferences parses turns, steps, ranges, and plural labels", () => {
+  assert.deepEqual(collectExplicitTurnReferences("Review turns 4-5 and step 8"), [
+    { number: 4, includeDirectTurn: true },
+    { number: 5, includeDirectTurn: true },
+    { number: 8, includeDirectTurn: false },
+  ]);
+  assert.deepEqual(
+    collectExplicitTurnReferences("Compare actions #2 through 4 and observations 7"),
+    [
+      { number: 2, includeDirectTurn: false },
+      { number: 3, includeDirectTurn: false },
+      { number: 4, includeDirectTurn: false },
+      { number: 7, includeDirectTurn: false },
+    ],
+  );
+});
+
+test("collectLexicalCues extracts visible ids, dates, and bracket labels", () => {
+  assert.deepEqual(
+    collectLexicalCues("Use D1:1 from session_alpha on 2026-04-30 [profile decision]."),
+    ["2026-04-30", "D1:1", "profile decision", "session_alpha"],
+  );
+});
+
+test("buildExplicitCueRecallSection expands paired action and observation references", async () => {
+  const messages = Array.from({ length: 22 }, (_, index) => ({
+    role: index % 2 === 0 ? "assistant" : "user",
+    content: `filler turn ${index}`,
+  }));
+  messages[16] = { role: "assistant", content: "[Action 8] opened the billing settings" };
+  messages[17] = { role: "user", content: "[Observation 8] plan limit was visible" };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What happened in Step 8?",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /^## Explicit Cue Evidence/);
+  assert.match(section, /Action 8/);
+  assert.match(section, /Observation 8/);
+});
+
+test("buildExplicitCueRecallSection expands direct turn references", async () => {
+  const engine = new FakeCueEngine({
+    "bench-session": [
+      { role: "user", content: "turn zero" },
+      { role: "assistant", content: "turn one" },
+      { role: "user", content: "turn two" },
+      { role: "assistant", content: "turn three target answer" },
+    ],
+  });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What was said at Turn 3?",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /turn three target answer/);
+});
+
+test("buildExplicitCueRecallSection does not bound sparse turn indexes by message count", async () => {
+  const engine = new FakeCueEngine({
+    "bench-session": [
+      {
+        turnIndex: 450,
+        role: "assistant",
+        content: "sparse retained turn target answer",
+      },
+    ],
+  });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What happened at Turn 450?",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /sparse retained turn target answer/);
+});
+
+test("buildExplicitCueRecallSection searches lexical cues across sessions when no session is bound", async () => {
+  const engine = new FakeCueEngine({
+    first: [{ role: "user", content: "ordinary context" }],
+    second: [{ role: "assistant", content: "[D1:1] Maya moved to Seattle" }],
+  });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    query: "What did D1:1 establish?",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /Maya moved to Seattle/);
+});
+
+test("buildExplicitCueRecallSection stays silent when disabled by budget or no cues", async () => {
+  const engine = new FakeCueEngine({
+    s1: [{ role: "user", content: "[D1:1] visible" }],
+  });
+
+  assert.equal(
+    await buildExplicitCueRecallSection({
+      engine,
+      sessionId: "s1",
+      query: "What should I do next?",
+      maxChars: 2000,
+    }),
+    "",
+  );
+  assert.equal(
+    await buildExplicitCueRecallSection({
+      engine,
+      sessionId: "s1",
+      query: "What does D1:1 say?",
+      maxChars: 0,
+    }),
+    "",
+  );
+  assert.equal(
+    await buildExplicitCueRecallSection({
+      engine,
+      sessionId: "s1",
+      query: "What does D1:1 say?",
+      maxChars: 2000,
+      maxReferences: 0,
+    }),
+    "",
+  );
+});
+
+function normalizeForSearch(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9:_-]+/g, " ").trim();
+}

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -1,0 +1,487 @@
+import { buildEvidencePack } from "./evidence-pack.js";
+
+export interface ExplicitCueRecallEngine {
+  expandContext(
+    sessionId: string,
+    fromTurn: number,
+    toTurn: number,
+    maxTokens: number,
+  ): Promise<Array<{ turn_index: number; role: string; content: string }>>;
+  searchContextFull(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<
+    Array<{
+      turn_index: number;
+      role: string;
+      content: string;
+      session_id: string;
+      score?: number;
+    }>
+  >;
+}
+
+export interface ExplicitCueRecallOptions {
+  engine: ExplicitCueRecallEngine | null | undefined;
+  sessionId?: string;
+  query: string;
+  maxChars: number;
+  maxItemChars?: number;
+  maxReferences?: number;
+}
+
+export type ExplicitTurnReference = {
+  number: number;
+  includeDirectTurn: boolean;
+};
+
+const DEFAULT_MAX_CHARS = 2_400;
+const DEFAULT_MAX_ITEM_CHARS = 1_200;
+const DEFAULT_MAX_REFERENCES = 24;
+const REFERENCE_SCAN_TOKEN_FACTOR = 3;
+const TURN_REFERENCE_WINDOW_RADIUS = 0;
+const LEXICAL_CUE_WINDOW_RADIUS = 1;
+const LEXICAL_CUE_SEARCH_LIMIT = 3;
+const LEXICAL_CUE_MAX_TOKENS = 400;
+
+export async function buildExplicitCueRecallSection(
+  options: ExplicitCueRecallOptions,
+): Promise<string> {
+  const engine = options.engine;
+  const query = options.query.trim();
+  const maxChars = normalizePositiveInteger(options.maxChars, DEFAULT_MAX_CHARS);
+  if (!engine || query.length === 0 || maxChars <= 0) {
+    return "";
+  }
+
+  const maxReferences = normalizePositiveInteger(
+    options.maxReferences,
+    DEFAULT_MAX_REFERENCES,
+  );
+  if (maxReferences <= 0) {
+    return "";
+  }
+
+  const evidenceItems: Array<{
+    id: string;
+    sessionId: string;
+    turnIndex: number;
+    role: string;
+    content: string;
+    score?: number;
+  }> = [];
+  const seenTurns = new Set<string>();
+
+  await collectTurnReferenceEvidence({
+    engine,
+    sessionId: options.sessionId,
+    query,
+    maxReferences,
+    evidenceItems,
+    seenTurns,
+  });
+
+  await collectLexicalCueEvidence({
+    engine,
+    sessionId: options.sessionId,
+    query,
+    maxReferences,
+    evidenceItems,
+    seenTurns,
+  });
+
+  return buildEvidencePack(evidenceItems, {
+    title: "Explicit Cue Evidence",
+    maxChars,
+    maxItemChars: normalizePositiveInteger(
+      options.maxItemChars,
+      DEFAULT_MAX_ITEM_CHARS,
+    ),
+  });
+}
+
+async function collectTurnReferenceEvidence(options: {
+  engine: ExplicitCueRecallEngine;
+  sessionId?: string;
+  query: string;
+  maxReferences: number;
+  evidenceItems: Array<{
+    id: string;
+    sessionId: string;
+    turnIndex: number;
+    role: string;
+    content: string;
+  }>;
+  seenTurns: Set<string>;
+}): Promise<void> {
+  if (!options.sessionId) {
+    return;
+  }
+
+  const references = collectExplicitTurnReferences(options.query).slice(
+    0,
+    options.maxReferences,
+  );
+  if (references.length === 0) {
+    return;
+  }
+
+  const windows = new Map<string, { fromTurn: number; toTurn: number }>();
+  for (const reference of references) {
+    for (const center of candidateTurnIndexesForReference(reference)) {
+      if (center < 0) {
+        continue;
+      }
+
+      const fromTurn = Math.max(0, center - TURN_REFERENCE_WINDOW_RADIUS);
+      const toTurn = center + TURN_REFERENCE_WINDOW_RADIUS;
+      windows.set(`${fromTurn}:${toTurn}`, { fromTurn, toTurn });
+    }
+  }
+
+  for (const window of [...windows.values()].sort(
+    (left, right) => left.fromTurn - right.fromTurn || left.toTurn - right.toTurn,
+  )) {
+    const expanded = await options.engine.expandContext(
+      options.sessionId,
+      window.fromTurn,
+      window.toTurn,
+      2_000,
+    );
+    appendExpandedEvidence(
+      options.evidenceItems,
+      options.seenTurns,
+      options.sessionId,
+      expanded,
+    );
+  }
+}
+
+async function collectLexicalCueEvidence(options: {
+  engine: ExplicitCueRecallEngine;
+  sessionId?: string;
+  query: string;
+  maxReferences: number;
+  evidenceItems: Array<{
+    id: string;
+    sessionId: string;
+    turnIndex: number;
+    role: string;
+    content: string;
+    score?: number;
+  }>;
+  seenTurns: Set<string>;
+}): Promise<void> {
+  const cues = collectLexicalCues(options.query).slice(0, options.maxReferences);
+  for (const cue of cues) {
+    const results = await options.engine.searchContextFull(
+      cue,
+      LEXICAL_CUE_SEARCH_LIMIT,
+      options.sessionId,
+    );
+    for (const result of results) {
+      const fromTurn = Math.max(0, result.turn_index - LEXICAL_CUE_WINDOW_RADIUS);
+      const toTurn = result.turn_index + LEXICAL_CUE_WINDOW_RADIUS;
+      const expanded = await options.engine.expandContext(
+        result.session_id,
+        fromTurn,
+        toTurn,
+        LEXICAL_CUE_MAX_TOKENS,
+      );
+      if (expanded.length === 0) {
+        appendEvidenceItem(options.evidenceItems, options.seenTurns, {
+          id: `${result.session_id}:${result.turn_index}`,
+          sessionId: result.session_id,
+          turnIndex: result.turn_index,
+          role: result.role,
+          content: result.content,
+          ...(typeof result.score === "number" ? { score: result.score } : {}),
+        });
+        continue;
+      }
+      appendExpandedEvidence(
+        options.evidenceItems,
+        options.seenTurns,
+        result.session_id,
+        expanded,
+      );
+    }
+  }
+}
+
+function appendExpandedEvidence(
+  evidenceItems: Array<{
+    id: string;
+    sessionId: string;
+    turnIndex: number;
+    role: string;
+    content: string;
+  }>,
+  seenTurns: Set<string>,
+  sessionId: string,
+  expanded: Array<{ turn_index: number; role: string; content: string }>,
+): void {
+  for (const message of expanded) {
+    appendEvidenceItem(evidenceItems, seenTurns, {
+      id: `${sessionId}:${message.turn_index}`,
+      sessionId,
+      turnIndex: message.turn_index,
+      role: message.role,
+      content: message.content,
+    });
+  }
+}
+
+function appendEvidenceItem<T extends { id: string }>(
+  evidenceItems: T[],
+  seenTurns: Set<string>,
+  item: T,
+): void {
+  if (seenTurns.has(item.id)) {
+    return;
+  }
+  seenTurns.add(item.id);
+  evidenceItems.push(item);
+}
+
+export function collectExplicitTurnReferences(
+  query: string,
+): ExplicitTurnReference[] {
+  const references = new Map<string, ExplicitTurnReference>();
+  const addReference = (value: number, label: string) => {
+    const existing = references.get(String(value));
+    references.set(String(value), {
+      number: value,
+      includeDirectTurn:
+        (existing?.includeDirectTurn ?? false) || label === "turn",
+    });
+  };
+
+  const tokens = tokenizeReferenceQuery(query);
+  for (let index = 0; index < tokens.length; index += 1) {
+    const label = normalizeReferenceLabel(tokens[index]);
+    if (!label) {
+      continue;
+    }
+
+    const parsed = parseReferenceNumbers(tokens, index + 1);
+    for (const number of parsed.numbers) {
+      addReference(number, label);
+    }
+    index = Math.max(index, parsed.nextIndex - 1);
+  }
+
+  return [...references.values()].sort((left, right) => left.number - right.number);
+}
+
+export function collectLexicalCues(query: string): string[] {
+  const cues = new Set<string>();
+
+  for (const match of query.matchAll(/\b[A-Za-z][A-Za-z0-9]{0,12}\d+:\d+\b/g)) {
+    cues.add(match[0]);
+  }
+  for (const match of query.matchAll(/\b\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?Z?)?\b/g)) {
+    cues.add(match[0]);
+  }
+  for (const match of query.matchAll(/\b(?:session|source|chat|plan|task|event|file|tool)[_-][A-Za-z0-9][A-Za-z0-9_.:-]{1,80}\b/gi)) {
+    cues.add(match[0]);
+  }
+  for (const match of query.matchAll(/\[([A-Za-z0-9][A-Za-z0-9_.:/ -]{1,80})\]/g)) {
+    const value = match[1]?.trim();
+    if (value) {
+      cues.add(value);
+    }
+  }
+
+  return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+function tokenizeReferenceQuery(query: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+
+  const flushCurrent = () => {
+    if (current) {
+      tokens.push(current);
+      current = "";
+    }
+  };
+
+  for (const char of query) {
+    if (isAsciiLetterOrDigit(char)) {
+      current += char;
+      continue;
+    }
+
+    flushCurrent();
+    if (char === "#" || char === ",") {
+      tokens.push(char);
+    } else if (isReferenceDash(char)) {
+      tokens.push("-");
+    }
+  }
+  flushCurrent();
+
+  return tokens;
+}
+
+function parseReferenceNumbers(
+  tokens: readonly string[],
+  startIndex: number,
+): { numbers: number[]; nextIndex: number } {
+  const numbers: number[] = [];
+  let lastNumber: number | undefined;
+  let pendingRangeStart: number | undefined;
+  let index = startIndex;
+  const scanEnd = Math.min(
+    tokens.length,
+    startIndex + DEFAULT_MAX_REFERENCES * REFERENCE_SCAN_TOKEN_FACTOR,
+  );
+
+  for (; index < scanEnd; index += 1) {
+    const token = tokens[index]!;
+    const normalized = token.toLowerCase();
+    const value = parseNonNegativeIntegerToken(token);
+    if (value !== undefined) {
+      if (pendingRangeStart !== undefined) {
+        numbers.push(...expandReferenceRange(pendingRangeStart, value));
+        pendingRangeStart = undefined;
+      } else {
+        numbers.push(value);
+      }
+      lastNumber = value;
+      continue;
+    }
+
+    if (normalized === "#" || normalized === "number" || normalized === ",") {
+      continue;
+    }
+
+    if (
+      normalized === "-" ||
+      normalized === "to" ||
+      normalized === "through" ||
+      normalized === "thru"
+    ) {
+      if (lastNumber !== undefined) {
+        if (numbers[numbers.length - 1] === lastNumber) {
+          numbers.pop();
+        }
+        pendingRangeStart = lastNumber;
+      }
+      continue;
+    }
+
+    if (normalized === "and" && numbers.length > 0) {
+      continue;
+    }
+
+    if (normalizeReferenceLabel(token)) {
+      break;
+    }
+
+    break;
+  }
+
+  if (pendingRangeStart !== undefined) {
+    numbers.push(pendingRangeStart);
+  }
+
+  return {
+    numbers: [...new Set(numbers)],
+    nextIndex: index,
+  };
+}
+
+function expandReferenceRange(start: number, end: number): number[] {
+  const low = Math.min(start, end);
+  const high = Math.max(start, end);
+  if (high - low + 1 > DEFAULT_MAX_REFERENCES) {
+    return [start, end];
+  }
+
+  const values: number[] = [];
+  for (let value = low; value <= high; value += 1) {
+    values.push(value);
+  }
+  return values;
+}
+
+function normalizeReferenceLabel(token: string | undefined): string | undefined {
+  const normalized = token?.toLowerCase();
+  switch (normalized) {
+    case "step":
+    case "steps":
+      return "step";
+    case "turn":
+    case "turns":
+      return "turn";
+    case "action":
+    case "actions":
+      return "action";
+    case "observation":
+    case "observations":
+      return "observation";
+    default:
+      return undefined;
+  }
+}
+
+function candidateTurnIndexesForReference(
+  reference: ExplicitTurnReference,
+): number[] {
+  const candidates = new Set<number>();
+  if (reference.includeDirectTurn) {
+    for (let offset = -1; offset <= 1; offset += 1) {
+      candidates.add(reference.number + offset);
+    }
+  }
+
+  const pairedBase = reference.number * 2;
+  for (let offset = -2; offset <= 3; offset += 1) {
+    candidates.add(pairedBase + offset);
+  }
+
+  return [...candidates].sort((left, right) => left - right);
+}
+
+function parseNonNegativeIntegerToken(token: string): number | undefined {
+  if (token.length === 0) {
+    return undefined;
+  }
+
+  let value = 0;
+  for (const char of token) {
+    const code = char.charCodeAt(0);
+    if (code < 48 || code > 57) {
+      return undefined;
+    }
+    value = value * 10 + (code - 48);
+  }
+  return value;
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function isAsciiLetterOrDigit(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122);
+}
+
+function isReferenceDash(char: string): boolean {
+  return char === "-"
+    || char === "\u2010"
+    || char === "\u2011"
+    || char === "\u2012"
+    || char === "\u2013"
+    || char === "\u2014"
+    || char === "\u2015";
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -163,6 +163,7 @@ import {
   entityRecentTranscriptLookbackHours,
   readRecentEntityTranscriptEntries,
 } from "./entity-retrieval.js";
+import { buildExplicitCueRecallSection } from "./explicit-cue-recall.js";
 import {
   hasBroadGraphIntent,
   inferIntentFromText,
@@ -8347,6 +8348,39 @@ export class Orchestrator {
     // 0. Shared context
     if (sharedCtx)
       this.appendRecallSection(sectionBuckets, "shared-context", sharedCtx);
+
+    // 0a. Explicit cue evidence
+    const explicitCueMaxChars =
+      this.getRecallSectionMaxChars("explicit-cue") ??
+      this.config.explicitCueRecallMaxChars;
+    if (
+      this.config.explicitCueRecallEnabled &&
+      this.isRecallSectionEnabled("explicit-cue") &&
+      explicitCueMaxChars !== 0 &&
+      this.lcmEngine?.enabled &&
+      (recallMode as RecallPlanMode) !== "no_recall"
+    ) {
+      try {
+        const explicitCueSection = await buildExplicitCueRecallSection({
+          engine: this.lcmEngine,
+          sessionId: sessionKey,
+          query: retrievalQuery,
+          maxChars: explicitCueMaxChars,
+          maxReferences:
+            this.getRecallSectionNumber("explicit-cue", "maxResults") ??
+            this.config.explicitCueRecallMaxReferences,
+        });
+        if (explicitCueSection) {
+          this.appendRecallSection(
+            sectionBuckets,
+            "explicit-cue",
+            explicitCueSection,
+          );
+        }
+      } catch (err) {
+        log.debug(`Explicit cue recall assembly error: ${err}`);
+      }
+    }
 
     // 1. Profile
     if (profile)

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1537,6 +1537,13 @@ export interface PluginConfig {
   temporalMemoryTreeEnabled: boolean;
   tmtHourlyMinMemories: number;
   tmtSummaryMaxTokens: number;
+  // Explicit cue recall
+  /** Front-load exact stored evidence for query-visible cues like turns, dates, ids, files, and tools. */
+  explicitCueRecallEnabled: boolean;
+  /** Character budget for the explicit cue evidence section. */
+  explicitCueRecallMaxChars: number;
+  /** Maximum query-visible cues expanded per recall. */
+  explicitCueRecallMaxReferences: number;
   // Lossless Context Management (LCM)
   lcmEnabled: boolean;
   lcmLeafBatchSize: number;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1967,6 +1967,23 @@
         "default": 300,
         "description": "Max tokens for each TMT summary node. Default: 300."
       },
+      "explicitCueRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Front-load exact LCM evidence for query-visible cues such as turns, dates, ids, files, and tools."
+      },
+      "explicitCueRecallMaxChars": {
+        "type": "number",
+        "default": 2400,
+        "minimum": 0,
+        "description": "Character budget for the explicit cue evidence recall section."
+      },
+      "explicitCueRecallMaxReferences": {
+        "type": "number",
+        "default": 24,
+        "minimum": 0,
+        "description": "Maximum query-visible cues expanded by explicit cue recall."
+      },
       "queryExpansionEnabled": {
         "type": "boolean",
         "default": false,

--- a/tests/config-memory-os-preset.test.ts
+++ b/tests/config-memory-os-preset.test.ts
@@ -44,6 +44,8 @@ test("parseConfig applies research-max preset defaults", () => {
   assert.equal(cfg.contextCompressionActionsEnabled, true);
   assert.equal(cfg.compressionGuidelineLearningEnabled, true);
   assert.equal(cfg.compressionGuidelineSemanticRefinementEnabled, true);
+  assert.equal(cfg.explicitCueRecallEnabled, true);
+  assert.equal(cfg.lcmEnabled, true);
   assert.equal(cfg.maxProactiveQuestionsPerExtraction, 4);
   assert.equal(cfg.maxCompressionTokensPerHour, 3000);
   assert.equal(cfg.behaviorLoopAutoTuneEnabled, true);

--- a/tests/recall-pipeline-assembly.test.ts
+++ b/tests/recall-pipeline-assembly.test.ts
@@ -73,3 +73,46 @@ test("custom recallPipeline reorders sections and can disable transcript injecti
   assert.equal(pIndex < sIndex, true);
   assert.equal(context.includes("TRANSCRIPT_SHOULD_NOT_APPEAR"), false);
 });
+
+test("disabled explicit-cue pipeline section skips LCM cue retrieval work", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-pipeline-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    sharedContextEnabled: false,
+    knowledgeIndexEnabled: false,
+    identityContinuityEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    explicitCueRecallEnabled: true,
+    lcmEnabled: true,
+    recallPipeline: [
+      { id: "explicit-cue", enabled: false },
+      { id: "memories", enabled: false },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  (orchestrator as any).lcmEngine = {
+    enabled: true,
+    searchContextFull: async () => {
+      throw new Error("explicit cue search should not run");
+    },
+    expandContext: async () => {
+      throw new Error("explicit cue expansion should not run");
+    },
+    searchStructuredParts: async () => [],
+    formatStructuredRecall: () => "",
+    assembleRecall: async () => "",
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "What happened at Turn 450?",
+    "user:test:recall-pipeline",
+  );
+
+  assert.equal(context, "");
+});


### PR DESCRIPTION
## Summary
- add a core explicit-cue recall section backed by LCM raw transcript search/expansion
- recognize query-visible cues such as turn/step/action/observation references, dates, dialogue ids, session/source/chat/plan/task/file/tool ids, and bracket labels
- expose config/schema knobs and enable the section in the research-max preset

Closes #841

## Verification
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts packages/remnic-core/src/config.test.ts
- npm run test:entity-hardening
- npm run check-types
- npm run check-config-contract
- git diff --check

Note: npm run preflight:quick reached the test phase after typecheck/config/review-pattern checks, but the existing register-multi-registry/QMD subprocess path did not exit cleanly. The direct register-multi-registry run printed its pass lines and also held a QMD child open, so I stopped that hung process rather than leaving it running.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new recall stage that searches/expands LCM transcripts based on query-visible cues, which can affect context assembly order, token/char budgets, and retrieval performance in recall-heavy flows.
> 
> **Overview**
> Adds an *opt-in* `explicit-cue` recall section that front-loads exact transcript evidence when the query references visible cues (e.g., turns/steps, IDs, dates, bracket labels), using LCM `searchContextFull` + `expandContext` to assemble an evidence pack.
> 
> Wires the section into recall pipeline assembly (after shared context) with new config/schema knobs (`explicitCueRecallEnabled`, `explicitCueRecallMaxChars`, `explicitCueRecallMaxReferences`), and enables it by default in the `research-max` preset. Includes new unit/integration tests covering config coercion, preset behavior, cue parsing, and pipeline gating when the section is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cbcc421fbcc692fbe688809762d139ef93c904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->