### PR TITLE
Use core explicit cue recall for AMA trajectories

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -178,11 +178,11 @@ test("adapter recall front-loads exact step references from the session trace", 
       24_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 8\]: move-8/);
     assert.match(recalled, /\[Observation 8\]: state-8/);
     assert.ok(
-      recalled.indexOf("## Exact session reference evidence") <
+      recalled.indexOf("## Explicit Cue Evidence") <
         recalled.indexOf("[Action 8]: move-8"),
     );
   } finally {
@@ -214,7 +214,7 @@ test("adapter recall recognizes plural multi-step reference prompts", async () =
       24_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 8\]: move-8/);
     assert.match(recalled, /\[Observation 8\]: state-8/);
     assert.match(recalled, /\[Action 9\]: move-9/);
@@ -248,7 +248,7 @@ test("adapter recall preserves trailing references after a parsed step range", a
       24_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 8\]: move-8/);
     assert.match(recalled, /\[Observation 10\]: state-10/);
     assert.match(recalled, /\[Action 12\]: move-12/);
@@ -282,7 +282,7 @@ test("adapter recall expands only the explicit range segment in mixed prompts", 
       24_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 8\]: move-8/);
     assert.match(recalled, /\[Action 10\]: move-10/);
     assert.match(recalled, /\[Observation 13\]: state-13/);
@@ -316,7 +316,7 @@ test("adapter recall treats unicode dashes as step range separators", async () =
       24_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 8\]: move-8/);
     assert.match(recalled, /\[Observation 9\]: state-9/);
     assert.match(recalled, /\[Action 10\]: move-10/);
@@ -349,7 +349,7 @@ test("adapter recall does not let stray labels consume later reference numbers",
       24_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 8\]: move-8/);
     assert.match(recalled, /\[Observation 8\]: state-8/);
   } finally {
@@ -381,7 +381,7 @@ test("adapter recall maps turn references to direct and paired turn candidates",
       24_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 4\]: move-4/);
     assert.match(recalled, /\[Action 8\]: move-8/);
     assert.match(recalled, /\[Observation 8\]: state-8/);
@@ -414,7 +414,7 @@ test("adapter recall preserves long explicit reference lists", async () => {
       24_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 1\]: move-1/);
     assert.match(recalled, /\[Observation 8\]: state-8/);
     assert.match(recalled, /\[Action 12\]: move-12/);
@@ -448,7 +448,7 @@ test("adapter recall expands ranges up to the configured reference cap", async (
       32_000,
     );
 
-    assert.match(recalled, /## Exact session reference evidence/);
+    assert.match(recalled, /## Explicit Cue Evidence/);
     assert.match(recalled, /\[Action 1\]: move-1/);
     assert.match(recalled, /\[Observation 12\]: state-12/);
     assert.match(recalled, /\[Action 20\]: move-20/);

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -6,7 +6,12 @@ import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { buildEvidencePack, Orchestrator, parseConfig } from "@remnic/core";
+import {
+  buildEvidencePack,
+  buildExplicitCueRecallSection,
+  Orchestrator,
+  parseConfig,
+} from "@remnic/core";
 import type {
   BenchJudge,
   BenchMemoryAdapter,
@@ -96,26 +101,9 @@ type OrchestratorTeardownView = {
 };
 
 const BENCH_TEARDOWN_DEFERRED_READY_WAIT_MS = 500;
-const EXACT_REFERENCE_MAX_CHARS = 18_000;
-const EXACT_REFERENCE_MAX_ITEM_CHARS = 2_400;
-const EXACT_REFERENCE_MAX_NUMBERS = 24;
-const EXACT_REFERENCE_SCAN_TOKEN_LIMIT = EXACT_REFERENCE_MAX_NUMBERS * 3;
-const EXACT_REFERENCE_WINDOW_RADIUS = 0;
-
-type BenchLcmExpansionEngine = {
-  getStats(sessionId?: string): Promise<{ totalMessages: number }>;
-  expandContext(
-    sessionId: string,
-    fromTurn: number,
-    toTurn: number,
-    maxTokens: number,
-  ): Promise<Array<{ turn_index: number; role: string; content: string }>>;
-};
-
-type ExplicitSessionReference = {
-  number: number;
-  includeDirectTurn: boolean;
-};
+const CORE_EXPLICIT_CUE_MAX_CHARS = 18_000;
+const CORE_EXPLICIT_CUE_MAX_ITEM_CHARS = 2_400;
+const CORE_EXPLICIT_CUE_MAX_REFERENCES = 24;
 
 function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
   return cloneBenchConfigValue(config) as Record<string, unknown>;
@@ -326,12 +314,14 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         const sections: string[] = [];
         let usedChars = 0;
 
-        const exactReferenceEvidence = await buildExactSessionReferenceEvidence(
+        const exactReferenceEvidence = await buildExplicitCueRecallSection({
           engine,
           sessionId,
           query,
-          Math.min(EXACT_REFERENCE_MAX_CHARS, Math.floor(budget * 0.4)),
-        );
+          maxChars: Math.min(CORE_EXPLICIT_CUE_MAX_CHARS, Math.floor(budget * 0.4)),
+          maxItemChars: CORE_EXPLICIT_CUE_MAX_ITEM_CHARS,
+          maxReferences: CORE_EXPLICIT_CUE_MAX_REFERENCES,
+        });
         if (exactReferenceEvidence) {
           sections.push(exactReferenceEvidence);
           usedChars += exactReferenceEvidence.length;
@@ -585,299 +575,4 @@ function nextBenchTranscriptTurnId(
     .digest("hex")
     .slice(0, 16);
   return `bench-${index}-${digest}`;
-}
-
-async function buildExactSessionReferenceEvidence(
-  engine: BenchLcmExpansionEngine,
-  sessionId: string,
-  query: string,
-  maxChars: number,
-): Promise<string> {
-  if (maxChars <= 0 || !query.trim()) {
-    return "";
-  }
-
-  const references = collectExplicitSessionReferences(query);
-  if (references.length === 0) {
-    return "";
-  }
-
-  const stats = await engine.getStats(sessionId);
-  if (stats.totalMessages <= 0) {
-    return "";
-  }
-
-  const windows = new Map<string, { fromTurn: number; toTurn: number }>();
-  for (const reference of references.slice(0, EXACT_REFERENCE_MAX_NUMBERS)) {
-    for (const center of candidateTurnIndexesForReference(reference)) {
-      if (center < 0 || center >= stats.totalMessages) {
-        continue;
-      }
-
-      const fromTurn = Math.max(0, center - EXACT_REFERENCE_WINDOW_RADIUS);
-      const toTurn = Math.min(
-        stats.totalMessages - 1,
-        center + EXACT_REFERENCE_WINDOW_RADIUS,
-      );
-      windows.set(`${fromTurn}:${toTurn}`, { fromTurn, toTurn });
-    }
-  }
-
-  const evidenceItems: Array<{
-    id: string;
-    sessionId: string;
-    turnIndex: number;
-    role: string;
-    content: string;
-  }> = [];
-  const seenTurns = new Set<string>();
-
-  for (const window of [...windows.values()].sort(
-    (left, right) => left.fromTurn - right.fromTurn || left.toTurn - right.toTurn,
-  )) {
-    const expanded = await engine.expandContext(
-      sessionId,
-      window.fromTurn,
-      window.toTurn,
-      2_000,
-    );
-
-    for (const message of expanded) {
-      const id = `${sessionId}:${message.turn_index}`;
-      if (seenTurns.has(id)) {
-        continue;
-      }
-      seenTurns.add(id);
-      evidenceItems.push({
-        id,
-        sessionId,
-        turnIndex: message.turn_index,
-        role: message.role,
-        content: message.content,
-      });
-    }
-  }
-
-  return buildEvidencePack(evidenceItems, {
-    title: "Exact session reference evidence",
-    maxChars,
-    maxItemChars: EXACT_REFERENCE_MAX_ITEM_CHARS,
-  });
-}
-
-function collectExplicitSessionReferences(query: string): ExplicitSessionReference[] {
-  const references = new Map<string, ExplicitSessionReference>();
-  const addReference = (value: string | undefined, label: string) => {
-    if (value === undefined) return;
-    const parsed = Number.parseInt(value, 10);
-    if (Number.isInteger(parsed) && parsed >= 0) {
-      const existing = references.get(String(parsed));
-      references.set(String(parsed), {
-        number: parsed,
-        includeDirectTurn:
-          (existing?.includeDirectTurn ?? false) || label === "turn",
-      });
-    }
-  };
-
-  const tokens = tokenizeReferenceQuery(query);
-  for (let index = 0; index < tokens.length; index += 1) {
-    const label = normalizeReferenceLabel(tokens[index]);
-    if (!label) {
-      continue;
-    }
-
-    const parsed = parseReferenceNumbers(tokens, index + 1);
-    for (const number of parsed.numbers) {
-      addReference(String(number), label);
-    }
-    index = Math.max(index, parsed.nextIndex - 1);
-  }
-
-  return [...references.values()].sort((left, right) => left.number - right.number);
-}
-
-function tokenizeReferenceQuery(query: string): string[] {
-  const tokens: string[] = [];
-  let current = "";
-
-  const flushCurrent = () => {
-    if (current) {
-      tokens.push(current);
-      current = "";
-    }
-  };
-
-  for (const char of query) {
-    if (isAsciiLetterOrDigit(char)) {
-      current += char;
-    } else {
-      flushCurrent();
-      if (char === "#" || char === ",") {
-        tokens.push(char);
-      } else if (isReferenceDash(char)) {
-        tokens.push("-");
-      }
-    }
-  }
-  flushCurrent();
-
-  return tokens;
-}
-
-function parseReferenceNumbers(
-  tokens: readonly string[],
-  startIndex: number,
-): { numbers: number[]; nextIndex: number } {
-  const numbers: number[] = [];
-  let lastNumber: number | undefined;
-  let pendingRangeStart: number | undefined;
-  let index = startIndex;
-  const scanEnd = Math.min(
-    tokens.length,
-    startIndex + EXACT_REFERENCE_SCAN_TOKEN_LIMIT,
-  );
-
-  for (; index < scanEnd; index += 1) {
-    const token = tokens[index]!;
-    const normalized = token.toLowerCase();
-    const value = parseNonNegativeIntegerToken(token);
-    if (value !== undefined) {
-      if (pendingRangeStart !== undefined) {
-        numbers.push(...expandReferenceRange(pendingRangeStart, value));
-        pendingRangeStart = undefined;
-      } else {
-        numbers.push(value);
-      }
-      lastNumber = value;
-      continue;
-    }
-
-    if (normalized === "#" || normalized === "number" || normalized === ",") {
-      continue;
-    }
-
-    if (
-      normalized === "-" ||
-      normalized === "to" ||
-      normalized === "through" ||
-      normalized === "thru"
-    ) {
-      if (lastNumber !== undefined) {
-        if (numbers[numbers.length - 1] === lastNumber) {
-          numbers.pop();
-        }
-        pendingRangeStart = lastNumber;
-      }
-      continue;
-    }
-
-    if (normalized === "and" && numbers.length > 0) {
-      continue;
-    }
-
-    if (normalizeReferenceLabel(token)) {
-      break;
-    }
-
-    break;
-  }
-
-  if (pendingRangeStart !== undefined) {
-    numbers.push(pendingRangeStart);
-  }
-
-  return {
-    numbers: dedupeReferenceNumbers(numbers),
-    nextIndex: index,
-  };
-}
-
-function dedupeReferenceNumbers(numbers: readonly number[]): number[] {
-  return [...new Set(numbers)];
-}
-
-function expandReferenceRange(start: number, end: number): number[] {
-  const low = Math.min(start, end);
-  const high = Math.max(start, end);
-  if (high - low + 1 > EXACT_REFERENCE_MAX_NUMBERS) {
-    return [start, end];
-  }
-
-  const values: number[] = [];
-  for (let value = low; value <= high; value += 1) {
-    values.push(value);
-  }
-  return values;
-}
-
-function normalizeReferenceLabel(token: string | undefined): string | undefined {
-  const normalized = token?.toLowerCase();
-  switch (normalized) {
-    case "step":
-    case "steps":
-      return "step";
-    case "turn":
-    case "turns":
-      return "turn";
-    case "action":
-    case "actions":
-      return "action";
-    case "observation":
-    case "observations":
-      return "observation";
-    default:
-      return undefined;
-  }
-}
-
-function parseNonNegativeIntegerToken(token: string): number | undefined {
-  if (token.length === 0) {
-    return undefined;
-  }
-
-  let value = 0;
-  for (const char of token) {
-    const code = char.charCodeAt(0);
-    if (code < 48 || code > 57) {
-      return undefined;
-    }
-    value = value * 10 + (code - 48);
-  }
-  return value;
-}
-
-function isAsciiLetterOrDigit(char: string): boolean {
-  const code = char.charCodeAt(0);
-  return (code >= 48 && code <= 57)
-    || (code >= 65 && code <= 90)
-    || (code >= 97 && code <= 122);
-}
-
-function isReferenceDash(char: string): boolean {
-  return char === "-"
-    || char === "\u2010"
-    || char === "\u2011"
-    || char === "\u2012"
-    || char === "\u2013"
-    || char === "\u2014"
-    || char === "\u2015";
-}
-
-function candidateTurnIndexesForReference(
-  reference: ExplicitSessionReference,
-): number[] {
-  const candidates = new Set<number>();
-  if (reference.includeDirectTurn) {
-    for (let offset = -1; offset <= 1; offset += 1) {
-      candidates.add(reference.number + offset);
-    }
-  }
-
-  const pairedBase = reference.number * 2;
-  for (let offset = -2; offset <= 3; offset += 1) {
-    candidates.add(pairedBase + offset);
-  }
-
-  return [...candidates].sort((left, right) => left - right);
 }

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
@@ -122,7 +122,7 @@ test("AMA-Bench records recommended and cross-judge protocol metrics", async () 
     system: {
       async store() {},
       async recall() {
-        return "Spanish";
+        return "## Explicit Cue Evidence\nSpanish\n## Embedded user note\n\n## Remnic recall pipeline\nSpanish";
       },
       async search() {
         return [];
@@ -161,6 +161,10 @@ test("AMA-Bench records recommended and cross-judge protocol metrics", async () 
   assert.equal(first.tokens.output >= 2, true);
   assert.equal(first.details?.amaBenchJudgeProtocol, "recommended");
   assert.equal(first.details?.amaBenchCrossJudgeModel, "cross-qwen3-32b");
+  assert.deepEqual(first.details?.recallSections, [
+    "Explicit Cue Evidence",
+    "Remnic recall pipeline",
+  ]);
   assert.equal(
     result.config.benchmarkOptions?.amaBenchJudgeProtocol,
     "recommended",

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -26,6 +26,13 @@ import {
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 
+const RECALL_SECTION_TITLES = new Set([
+  "Explicit Cue Evidence",
+  "Remnic recall pipeline",
+  "Search evidence",
+  "Raw messages",
+]);
+
 export const amaBenchDefinition: BenchmarkDefinition = {
   id: "ama-bench",
   title: "AMA-Bench",
@@ -157,6 +164,7 @@ export async function runAmaBenchBenchmark(
             numTurns: episode.num_turns,
             totalTokens: episode.total_tokens,
             recalledLength: recalledText.length,
+            recallSections: extractRecallSectionTitles(recalledText),
             answeredLength: answered.finalAnswer.length,
             recalledText,
             answeredText: answered.finalAnswer,
@@ -313,6 +321,17 @@ function applyLimit<T>(items: T[], limit: number | undefined): T[] {
     return [...items];
   }
   return items.slice(0, limit);
+}
+
+function extractRecallSectionTitles(recalledText: string): string[] {
+  const titles = new Set<string>();
+  for (const match of recalledText.matchAll(/^##\s+(.+)$/gm)) {
+    const title = match[1]?.trim();
+    if (title && RECALL_SECTION_TITLES.has(title)) {
+      titles.add(title);
+    }
+  }
+  return [...titles];
 }
 
 function parseEpisode(line: string, lineNumber: number): AMABenchEpisode {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -50,6 +50,14 @@ export {
   type EvidencePackItem,
   type EvidencePackOptions,
 } from "./evidence-pack.js";
+export {
+  buildExplicitCueRecallSection,
+  collectExplicitTurnReferences,
+  collectLexicalCues,
+  type ExplicitCueRecallEngine,
+  type ExplicitCueRecallOptions,
+  type ExplicitTurnReference,
+} from "./explicit-cue-recall.js";
 
 // ---------------------------------------------------------------------------
 // Storage


### PR DESCRIPTION
## Summary
- export the core explicit-cue recall helper through @remnic/core
- replace the benchmark adapter's AMA-style exact-reference parser with core explicit-cue recall
- record recall section titles in AMA-Bench task details so artifacts can verify prompt-visible evidence sections without using hidden labels or gold answers

Closes #842.

## Verification
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts packages/bench/src/adapters/remnic-adapter.test.ts packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
- npm run check-types
- git diff --check
- bash scripts/check-review-patterns.sh

Note: npm run preflight:quick passed typecheck, config-contract, review-patterns, and the relevant adapter/core/AMA tests inside the broad suite, but the repo script expands into the full test suite and hung after registry/sdk tests with lingering subprocesses. I stopped that local runaway run; CI should run the canonical gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates benchmark recall composition by swapping a bespoke AMA step/turn reference parser for `@remnic/core`’s explicit-cue recall helper and changes the emitted evidence section heading, which could affect downstream benchmark expectations and artifact parsing. Also expands the public `@remnic/core` API surface by exporting new helpers/types.
> 
> **Overview**
> AMA benchmark recall now uses `@remnic/core`’s `buildExplicitCueRecallSection` instead of the bench adapter’s custom “exact session reference” implementation, and the emitted evidence heading changes to **`## Explicit Cue Evidence`** (tests updated accordingly).
> 
> AMA-Bench task details now include `recallSections`, extracted from visible `##` headings in the recall text (e.g. “Explicit Cue Evidence”, “Remnic recall pipeline”), enabling artifact checks without relying on hidden labels; runner tests updated.
> 
> `@remnic/core` now re-exports explicit-cue recall utilities (`buildExplicitCueRecallSection`, cue/reference collectors, and related types) from its public `index.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbbff423d54be3cb1355fd03e8bb226a98caf62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->