### PR TITLE
Harden LoCoMo dialogue cue recall

### DIFF
--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -92,6 +92,15 @@ export interface HarnessTrial {
     extraDetails?: Record<string, unknown>;
   }>;
   /**
+   * Optional benchmark-specific redaction for prompt-visible recall context.
+   * This must not use gold answers to add evidence; it is only for removing
+   * benchmark-private labels from already-recalled text before answering.
+   */
+  recallTextTransform?: (args: {
+    question: string;
+    recalledText: string;
+  }) => string;
+  /**
    * Optional extra per-task metrics computed by the caller up-front
    * (not a function of recall state). Merged into the final
    * `TaskResult.scores`.
@@ -272,7 +281,13 @@ async function executeTrial(
         ctx.options.system.recall(sessionId, trial.question, recallBudget),
       ),
     );
-    return recalledSessions.filter(Boolean).join("\n\n");
+    const rawRecalledText = recalledSessions.filter(Boolean).join("\n\n");
+    return trial.recallTextTransform
+      ? trial.recallTextTransform({
+          question: trial.question,
+          recalledText: rawRecalledText,
+        })
+      : rawRecalledText;
   });
   const answered = await answerBenchmarkQuestion({
     question: trial.question,

--- a/packages/bench/src/benchmarks/published/locomo/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.test.ts
@@ -12,6 +12,7 @@ test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from th
   const datasetPath = path.join(tempDir, "locomo10.json");
   const storedMessages: Message[] = [];
   const respondentQuestions: string[] = [];
+  const respondentContexts: string[] = [];
 
   try {
     await writeFile(
@@ -33,7 +34,7 @@ test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from th
           },
           qa: [
             {
-              question: "What year did Maya move?",
+              question: "According to D1:1, what year did Maya move?",
               answer: 2022,
               evidence: ["D1:1"],
               category: 1,
@@ -60,9 +61,9 @@ test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from th
         },
         async recall(_sessionId, question) {
           if (question.includes("year")) {
-            return "2022";
+            return "[D1:1] Maya: I moved in 2022.";
           }
-          return "blue";
+          return "D1:2 Maya: The jacket was blue.";
         },
         async search() {
           return [];
@@ -73,8 +74,9 @@ test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from th
           return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
         },
         responder: {
-          async respond(question) {
+          async respond(question, recalledText) {
             respondentQuestions.push(question);
+            respondentContexts.push(recalledText);
             return {
               text: question.includes("jacket") ? "blue" : "2022",
               tokens: { input: 1, output: 1 },
@@ -105,6 +107,15 @@ test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from th
     assert.equal(result.results.tasks[0]?.actual, "2022");
     assert.equal(result.results.tasks[1]?.actual, "blue");
     assert.equal(result.results.tasks[0]?.details.answerFormat, "short");
+    assert.equal(
+      result.results.tasks[0]?.scores.locomo_hidden_evidence_id_leak,
+      1,
+    );
+    assert.equal(result.results.tasks[0]?.details.hiddenEvidenceIdLeakCount, 0);
+    assert.equal(result.results.tasks[1]?.details.hiddenEvidenceIdLeakCount, 0);
+    assert.match(respondentContexts[0] ?? "", /\[D1:1\]/);
+    assert.equal(/\[D\d+:\d+\]/.test(respondentContexts[1] ?? ""), false);
+    assert.match(respondentContexts[0] ?? "", /Maya: I moved in 2022/);
     assert.ok(
       respondentQuestions.every((question) =>
         /shortest complete answer/.test(question),

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -37,6 +37,7 @@ const CATEGORY_NAMES: Record<number, string> = {
   4: "open_domain",
   5: "adversarial",
 };
+const DIALOGUE_ID_PATTERN = /\bD\d+:\d+\b/g;
 
 /** Extract sessions from the conversation dict as ordered (sessionId, turns) pairs. */
 function extractSessions(
@@ -148,6 +149,21 @@ function buildTrial(
     expected: qa.answer,
     recallSessionIds: sessionIds,
     answerFormat: "short",
+    recallTextTransform: sanitizeLoCoMoRecallText,
+    postAnswerHook: async ({ question, recalledText }) => {
+      const hiddenEvidenceIdLeakCount = countHiddenEvidenceIdsInRecall(
+        qa.evidence,
+        question,
+        recalledText,
+      );
+      return {
+        extraScores: {
+          locomo_hidden_evidence_id_leak:
+            hiddenEvidenceIdLeakCount === 0 ? 1 : 0,
+        },
+        extraDetails: { hiddenEvidenceIdLeakCount },
+      };
+    },
     extraDetails: {
       category: qa.category,
       categoryName,
@@ -156,6 +172,46 @@ function buildTrial(
       sessionIds,
     },
   };
+}
+
+function sanitizeLoCoMoRecallText(args: {
+  question: string;
+  recalledText: string;
+}): string {
+  const queryVisibleIds = collectDialogueIds(args.question);
+  return args.recalledText
+    .replace(/\[(D\d+:\d+)\]\s*/g, (match, id: string) =>
+      queryVisibleIds.has(id) ? match : "",
+    )
+    .replace(DIALOGUE_ID_PATTERN, (id: string) =>
+      queryVisibleIds.has(id) ? id : "",
+    );
+}
+
+function countHiddenEvidenceIdsInRecall(
+  evidence: readonly string[] | undefined,
+  question: string,
+  recalledText: string,
+): number {
+  const queryVisibleIds = collectDialogueIds(question);
+  let count = 0;
+  for (const id of evidence ?? []) {
+    if (queryVisibleIds.has(id)) {
+      continue;
+    }
+    if (new RegExp(`\\b${escapeRegExp(id)}\\b`).test(recalledText)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function collectDialogueIds(text: string): Set<string> {
+  return new Set(text.match(DIALOGUE_ID_PATTERN) ?? []);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 async function loadDataset(

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -95,6 +95,18 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
     collectLexicalCues("Use D1:1 from session_alpha on 2026-04-30 [profile decision]."),
     ["2026-04-30", "D1:1", "profile decision", "session_alpha"],
   );
+  assert.deepEqual(
+    collectLexicalCues("What did Maya Chen tell Jordan about session_2?"),
+    ["Jordan", "Maya Chen", "session_2"],
+  );
+  assert.deepEqual(
+    collectLexicalCues("Can Maya Chen remember what Jordan said?"),
+    ["Jordan", "Maya Chen"],
+  );
+  assert.deepEqual(
+    collectLexicalCues("Were Maya Chen and Jordan aligned?"),
+    ["Jordan", "Maya Chen"],
+  );
 });
 
 test("buildExplicitCueRecallSection expands paired action and observation references", async () => {
@@ -172,6 +184,24 @@ test("buildExplicitCueRecallSection searches lexical cues across sessions when n
   });
 
   assert.match(section, /Maya moved to Seattle/);
+});
+
+test("buildExplicitCueRecallSection searches query-visible speaker names", async () => {
+  const engine = new FakeCueEngine({
+    locomo: [
+      { role: "user", content: "[D1:1] Maya Chen: I moved to Austin in 2022." },
+      { role: "assistant", content: "[D1:2] Jordan: The jacket was blue." },
+    ],
+  });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    query: "When did Maya Chen move?",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /Maya Chen/);
+  assert.match(section, /2022/);
 });
 
 test("buildExplicitCueRecallSection stays silent when disabled by budget or no cues", async () => {

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -44,6 +44,51 @@ const TURN_REFERENCE_WINDOW_RADIUS = 0;
 const LEXICAL_CUE_WINDOW_RADIUS = 1;
 const LEXICAL_CUE_SEARCH_LIMIT = 3;
 const LEXICAL_CUE_MAX_TOKENS = 400;
+const SPEAKER_NAME_STOPWORDS = new Set([
+  "A",
+  "According",
+  "An",
+  "And",
+  "Are",
+  "At",
+  "Before",
+  "Can",
+  "Compare",
+  "Could",
+  "Did",
+  "Do",
+  "Does",
+  "For",
+  "From",
+  "Had",
+  "Has",
+  "Have",
+  "How",
+  "In",
+  "Is",
+  "It",
+  "Of",
+  "On",
+  "Or",
+  "Please",
+  "Review",
+  "Step",
+  "Tell",
+  "The",
+  "To",
+  "Turn",
+  "Use",
+  "Was",
+  "Were",
+  "What",
+  "When",
+  "Where",
+  "Which",
+  "Who",
+  "Why",
+  "Will",
+  "Would",
+]);
 
 export async function buildExplicitCueRecallSection(
   options: ExplicitCueRecallOptions,
@@ -284,8 +329,14 @@ export function collectLexicalCues(query: string): string[] {
   for (const match of query.matchAll(/\b\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?Z?)?\b/g)) {
     cues.add(match[0]);
   }
-  for (const match of query.matchAll(/\b(?:session|source|chat|plan|task|event|file|tool)[_-][A-Za-z0-9][A-Za-z0-9_.:-]{1,80}\b/gi)) {
+  for (const match of query.matchAll(/\b(?:session|source|chat|plan|task|event|file|tool)[_-][A-Za-z0-9][A-Za-z0-9_.:-]{0,80}\b/gi)) {
     cues.add(match[0]);
+  }
+  for (const match of query.matchAll(/\b[A-Z][a-z]{1,30}(?:\s+[A-Z][a-z]{1,30}){0,2}\b/g)) {
+    const value = normalizeSpeakerNameCue(match[0]);
+    if (value) {
+      cues.add(value);
+    }
   }
   for (const match of query.matchAll(/\[([A-Za-z0-9][A-Za-z0-9_.:/ -]{1,80})\]/g)) {
     const value = match[1]?.trim();
@@ -295,6 +346,17 @@ export function collectLexicalCues(query: string): string[] {
   }
 
   return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeSpeakerNameCue(value: string): string | undefined {
+  const words = value.trim().split(/\s+/).filter(Boolean);
+  while (words.length > 0 && SPEAKER_NAME_STOPWORDS.has(words[0]!)) {
+    words.shift();
+  }
+  while (words.length > 0 && SPEAKER_NAME_STOPWORDS.has(words[words.length - 1]!)) {
+    words.pop();
+  }
+  return words.length > 0 ? words.join(" ") : undefined;
 }
 
 function tokenizeReferenceQuery(query: string): string[] {


### PR DESCRIPTION
## Summary
- teach core explicit-cue recall to collect query-visible speaker names and one-character session cues like session_2
- add a harness recall text transform hook for benchmark-private redaction without adding evidence
- strip non-query-visible LoCoMo dialogue ids from answer context and add a post-hoc leak metric/detail count

Closes #843.

## Verification
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts packages/bench/src/benchmarks/published/locomo/runner.test.ts packages/bench/src/benchmarks/published/harness.test.ts
- npm run check-types
- git diff --check
- bash scripts/check-review-patterns.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark harness input to responders via a new `recallTextTransform` hook and adds LoCoMo-specific redaction/metrics, which can affect published benchmark scoring and comparability if misapplied.
> 
> **Overview**
> Adds an optional `HarnessTrial.recallTextTransform` hook so benchmarks can *redact/transform recalled context before it is shown to the responder*, without changing what was actually recalled.
> 
> Hardens LoCoMo by stripping non-question-visible dialogue IDs (e.g. `D1:2`) from recall context, and by adding a post-answer metric/detail (`locomo_hidden_evidence_id_leak`, `hiddenEvidenceIdLeakCount`) to detect when hidden evidence IDs appear in recall text.
> 
> Extends explicit-cue recall lexical cue extraction to include query-visible speaker names and allow one-character session cues (e.g. `session_2`), with new tests covering the behavior and LoCoMo context redaction expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9165487d291cf219064a6f10eda0c4bae1b141e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->