### PR TITLE
feat(bench): harden LongMemEval temporal recall

### DIFF
--- a/packages/bench/src/benchmarks/published/longmemeval/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.test.ts
@@ -43,14 +43,20 @@ test("LongMemEval runner wires the shared harness with per-item postAnswerHook",
     );
 
     let searchCalls = 0;
+    const storedSessions = new Map<string, string[]>();
     const result = await runLongMemEvalBenchmark({
       benchmark: longMemEvalDefinition,
       mode: "full",
       datasetDir: tempDir,
       system: {
-        async store() {},
-        async recall(_sessionId, _question) {
-          return "I live in Paris.";
+        async store(sessionId, messages) {
+          storedSessions.set(
+            sessionId,
+            messages.map((message) => message.content),
+          );
+        },
+        async recall(sessionId, _question) {
+          return (storedSessions.get(sessionId) ?? []).join("\n");
         },
         async search(_query, _limit) {
           searchCalls += 1;
@@ -102,6 +108,128 @@ test("LongMemEval runner wires the shared harness with per-item postAnswerHook",
       (task.details as Record<string, unknown>).questionType,
       "single-session-user",
     );
+    assert.equal(
+      storedSessions.get("s-1")?.[0],
+      "I live in Paris.",
+      "non-temporal questions should keep the original answer surface",
+    );
+    const audit = (task.details as Record<string, unknown>)
+      .temporalRecallAudit as Record<string, unknown>;
+    assert.deepEqual(audit.matchedSourceDates, []);
+    assert.equal(audit.answerSessionIdsUsedForRecall, false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("LongMemEval runner preserves temporal source metadata without narrowing recall to gold sessions", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-lme-temporal-"));
+  try {
+    await writeFile(
+      path.join(tempDir, "longmemeval_oracle.json"),
+      JSON.stringify([
+        {
+          question_id: "temporal-1",
+          question_type: "multi-session-update",
+          question:
+            "As of 2025-02-01, what was the latest allergy update?",
+          answer: "shellfish",
+          question_date: "2025-02-02",
+          haystack_sessions: [
+            [
+              { role: "user", content: "My allergy is pollen." },
+              { role: "assistant", content: "I will remember pollen." },
+            ],
+            [
+              { role: "user", content: "Latest allergy update: shellfish." },
+              { role: "assistant", content: "I will remember shellfish." },
+            ],
+          ],
+          haystack_session_ids: ["old-session", "latest-session"],
+          haystack_dates: ["2025-01-01", "2025-02-01"],
+          answer_session_ids: ["latest-session"],
+        },
+      ]),
+      "utf8",
+    );
+
+    const storedSessions = new Map<string, string[]>();
+    const recallSessionIds: string[] = [];
+    const result = await runLongMemEvalBenchmark({
+      benchmark: longMemEvalDefinition,
+      mode: "full",
+      datasetDir: tempDir,
+      system: {
+        async store(sessionId, messages) {
+          storedSessions.set(
+            sessionId,
+            messages.map((message) => message.content),
+          );
+        },
+        async recall(sessionId, _question) {
+          recallSessionIds.push(sessionId);
+          return (storedSessions.get(sessionId) ?? []).join("\n");
+        },
+        async search(_query, _limit) {
+          return [
+            {
+              id: "latest",
+              text: storedSessions.get("latest-session")?.join("\n") ?? "",
+            },
+          ];
+        },
+        async reset() {},
+        async destroy() {},
+        async getStats() {
+          return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+        },
+        responder: {
+          async respond() {
+            return {
+              text: "shellfish",
+              tokens: { input: 1, output: 1 },
+              latencyMs: 1,
+              model: "smoke-responder",
+            };
+          },
+        },
+        judge: {
+          async score() {
+            return 1;
+          },
+          async scoreWithMetrics() {
+            return {
+              score: 1,
+              tokens: { input: 0, output: 0 },
+              latencyMs: 0,
+              model: "smoke-judge",
+            };
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(recallSessionIds, ["old-session", "latest-session"]);
+    assert.match(
+      storedSessions.get("latest-session")?.[0] ?? "",
+      /^\[source_session: latest-session\] \[source_date: 2025-02-01\]/,
+    );
+
+    const task = result.results.tasks[0]!;
+    const audit = (task.details as Record<string, unknown>)
+      .temporalRecallAudit as Record<string, unknown>;
+    assert.deepEqual(audit.questionDates, ["2025-02-01"]);
+    assert.deepEqual(audit.temporalCues, ["as of", "latest"]);
+    assert.deepEqual(audit.matchedQuestionDates, ["2025-02-01"]);
+    assert.deepEqual(audit.matchedSourceDates, [
+      "2025-01-01",
+      "2025-02-01",
+    ]);
+    assert.deepEqual(audit.matchedSourceSessionIds, [
+      "old-session",
+      "latest-session",
+    ]);
+    assert.equal(audit.answerSessionIdsUsedForRecall, false);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/packages/bench/src/benchmarks/published/longmemeval/runner.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.ts
@@ -7,6 +7,8 @@
  * `LongMemEvalItem` into a `HarnessPlan`.
  */
 
+import { collectTemporalLexicalCues } from "@remnic/core";
+
 import { type LongMemEvalItem } from "./fixture.js";
 import {
   LONG_MEM_EVAL_DATASET_FILENAMES,
@@ -69,6 +71,7 @@ function buildPlan(
 ): HarnessPlan {
   const ingestSessions: HarnessPlan["ingestSessions"] = [];
   const sessionIds: string[] = [];
+  const annotateTemporalSources = shouldAnnotateTemporalSources(item.question);
   for (
     let sessionIndex = 0;
     sessionIndex < item.haystack_sessions.length;
@@ -76,10 +79,16 @@ function buildPlan(
   ) {
     const sessionId =
       item.haystack_session_ids[sessionIndex] ?? `session-${sessionIndex}`;
+    const haystackDate = item.haystack_dates[sessionIndex];
     const messages = item.haystack_sessions[sessionIndex]!.map<Message>(
       (turn) => ({
         role: turn.role,
-        content: turn.content,
+        content: annotateTemporalSources
+          ? formatLongMemEvalTurn(turn.content, {
+              sessionId,
+              haystackDate,
+            })
+          : turn.content,
       }),
     );
     sessionIds.push(sessionId);
@@ -98,13 +107,76 @@ function buildPlan(
       haystackSessionIds: item.haystack_session_ids,
       answerSessionIds: item.answer_session_ids,
     },
-    postAnswerHook: async ({ question }) => {
+    postAnswerHook: async ({ question, recalledText }) => {
       const searchResults = await options.system.search(question, 10);
-      return { extraScores: { search_hits: searchResults.length } };
+      return {
+        extraScores: { search_hits: searchResults.length },
+        extraDetails: {
+          temporalRecallAudit: buildTemporalRecallAudit({
+            item,
+            question,
+            recalledText,
+          }),
+        },
+      };
     },
   };
 
   return { ingestSessions, trials: [trial] };
+}
+
+function formatLongMemEvalTurn(
+  content: string,
+  metadata: { sessionId: string; haystackDate?: string },
+): string {
+  const fields = [`source_session: ${metadata.sessionId}`];
+  if (metadata.haystackDate) {
+    fields.push(`source_date: ${metadata.haystackDate}`);
+  }
+  return `[${fields.join("] [")}] ${content}`;
+}
+
+function shouldAnnotateTemporalSources(question: string): boolean {
+  return (
+    collectIsoDateCues(question).length > 0 ||
+    collectTemporalLexicalCues(question).length > 0
+  );
+}
+
+function buildTemporalRecallAudit(options: {
+  item: LongMemEvalItem;
+  question: string;
+  recalledText: string;
+}): Record<string, unknown> {
+  const questionDates = collectIsoDateCues(options.question);
+  const temporalCues = collectTemporalLexicalCues(options.question);
+  const recalledText = options.recalledText;
+  return {
+    questionDates,
+    temporalCues,
+    matchedQuestionDates: questionDates.filter((date) =>
+      recalledText.includes(date),
+    ),
+    matchedTemporalCues: temporalCues.filter((cue) =>
+      recalledText.toLowerCase().includes(cue.toLowerCase()),
+    ),
+    matchedSourceDates: options.item.haystack_dates.filter((date) =>
+      recalledText.includes(date),
+    ),
+    matchedSourceSessionIds: options.item.haystack_session_ids.filter(
+      (sessionId) => recalledText.includes(`source_session: ${sessionId}`),
+    ),
+    answerSessionIdsUsedForRecall: false,
+  };
+}
+
+function collectIsoDateCues(value: string): string[] {
+  return [
+    ...new Set(
+      [...value.matchAll(/\b\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?Z?)?\b/g)]
+        .map((match) => match[0]),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
 }
 
 async function loadDataset(

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -5,6 +5,7 @@ import {
   buildExplicitCueRecallSection,
   collectExplicitTurnReferences,
   collectLexicalCues,
+  collectTemporalLexicalCues,
   type ExplicitCueRecallEngine,
 } from "./explicit-cue-recall.js";
 
@@ -107,6 +108,14 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
     collectLexicalCues("Were Maya Chen and Jordan aligned?"),
     ["Jordan", "Maya Chen"],
   );
+  assert.deepEqual(
+    collectTemporalLexicalCues("As of 2025-02-01, what changed yesterday?"),
+    ["as of", "changed", "yesterday"],
+  );
+  assert.deepEqual(
+    collectLexicalCues("As of 2025-02-01, what changed yesterday?"),
+    ["2025-02-01", "as of", "changed", "yesterday"],
+  );
 });
 
 test("buildExplicitCueRecallSection expands paired action and observation references", async () => {
@@ -202,6 +211,27 @@ test("buildExplicitCueRecallSection searches query-visible speaker names", async
 
   assert.match(section, /Maya Chen/);
   assert.match(section, /2022/);
+});
+
+test("buildExplicitCueRecallSection searches explicit temporal cues", async () => {
+  const engine = new FakeCueEngine({
+    old: [{ role: "user", content: "[date: 2025-01-01] allergy: pollen" }],
+    latest: [
+      {
+        role: "user",
+        content: "[date: 2025-02-01] latest allergy update: shellfish",
+      },
+    ],
+  });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    query: "As of 2025-02-01, what was the latest allergy update?",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /2025-02-01/);
+  assert.match(section, /shellfish/);
 });
 
 test("buildExplicitCueRecallSection stays silent when disabled by budget or no cues", async () => {

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -44,12 +44,61 @@ const TURN_REFERENCE_WINDOW_RADIUS = 0;
 const LEXICAL_CUE_WINDOW_RADIUS = 1;
 const LEXICAL_CUE_SEARCH_LIMIT = 3;
 const LEXICAL_CUE_MAX_TOKENS = 400;
+const RELATIVE_TEMPORAL_CUES = [
+  "as of",
+  "most recent",
+  "last time",
+  "last week",
+  "last month",
+  "last year",
+  "last session",
+  "last conversation",
+  "next time",
+  "next week",
+  "next month",
+  "next year",
+  "next session",
+  "next conversation",
+  "previous time",
+  "previous week",
+  "previous month",
+  "previous year",
+  "previous session",
+  "previous conversation",
+  "prior time",
+  "prior week",
+  "prior month",
+  "prior year",
+  "prior session",
+  "prior conversation",
+  "today",
+  "yesterday",
+  "tomorrow",
+  "tonight",
+  "earlier",
+  "later",
+  "recently",
+  "previously",
+  "currently",
+  "now",
+  "latest",
+  "newest",
+  "oldest",
+  "earliest",
+  "before",
+  "after",
+  "since",
+  "updated",
+  "changed",
+  "change",
+];
 const SPEAKER_NAME_STOPWORDS = new Set([
   "A",
   "According",
   "An",
   "And",
   "Are",
+  "As",
   "At",
   "Before",
   "Can",
@@ -329,6 +378,9 @@ export function collectLexicalCues(query: string): string[] {
   for (const match of query.matchAll(/\b\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?Z?)?\b/g)) {
     cues.add(match[0]);
   }
+  for (const cue of collectTemporalLexicalCues(query)) {
+    cues.add(cue);
+  }
   for (const match of query.matchAll(/\b(?:session|source|chat|plan|task|event|file|tool)[_-][A-Za-z0-9][A-Za-z0-9_.:-]{0,80}\b/gi)) {
     cues.add(match[0]);
   }
@@ -348,6 +400,30 @@ export function collectLexicalCues(query: string): string[] {
   return [...cues].sort((left, right) => left.localeCompare(right));
 }
 
+export function collectTemporalLexicalCues(query: string): string[] {
+  const cues = new Set<string>();
+  const normalizedQuery = query.toLowerCase().replace(/\s+/g, " ");
+  for (const cue of RELATIVE_TEMPORAL_CUES) {
+    let searchFrom = 0;
+    while (searchFrom < normalizedQuery.length) {
+      const index = normalizedQuery.indexOf(cue, searchFrom);
+      if (index < 0) {
+        break;
+      }
+      const afterIndex = index + cue.length;
+      if (
+        isTemporalCueBoundary(normalizedQuery[index - 1]) &&
+        isTemporalCueBoundary(normalizedQuery[afterIndex])
+      ) {
+        cues.add(cue);
+        break;
+      }
+      searchFrom = afterIndex;
+    }
+  }
+  return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
 function normalizeSpeakerNameCue(value: string): string | undefined {
   const words = value.trim().split(/\s+/).filter(Boolean);
   while (words.length > 0 && SPEAKER_NAME_STOPWORDS.has(words[0]!)) {
@@ -357,6 +433,13 @@ function normalizeSpeakerNameCue(value: string): string | undefined {
     words.pop();
   }
   return words.length > 0 ? words.join(" ") : undefined;
+}
+
+function isTemporalCueBoundary(char: string | undefined): boolean {
+  if (!char) {
+    return true;
+  }
+  return !isAsciiLetterOrDigit(char);
 }
 
 function tokenizeReferenceQuery(query: string): string[] {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -54,6 +54,7 @@ export {
   buildExplicitCueRecallSection,
   collectExplicitTurnReferences,
   collectLexicalCues,
+  collectTemporalLexicalCues,
   type ExplicitCueRecallEngine,
   type ExplicitCueRecallOptions,
   type ExplicitTurnReference,


### PR DESCRIPTION
## Summary
- add core temporal cue extraction for query-visible relative/date recall cues
- annotate LongMemEval haystack turns with source session/date metadata during ingest without using gold answer sessions to select recall
- add LongMemEval temporal recall audit details and focused tests for multi-session update questions

Fixes #844.

## Test plan
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts packages/bench/src/benchmarks/published/longmemeval/runner.test.ts packages/bench/src/benchmarks/published/harness.test.ts
- npm run check-types
- git diff --check
- bash scripts/check-review-patterns.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes cue extraction heuristics in `@remnic/core` and alters LongMemEval ingest text formatting for some queries, which could affect recall/benchmark outcomes and downstream consumers of `collectLexicalCues`. Covered by new focused tests but still behavior-changing.
> 
> **Overview**
> LongMemEval now conditionally annotates ingested haystack turns with `[source_session: ...]` and `[source_date: ...]` when the question contains explicit ISO dates or relative temporal phrases, while keeping non-temporal questions unmodified.
> 
> The runner’s `postAnswerHook` now emits a `temporalRecallAudit` in task details, capturing detected temporal cues/dates and which source session/date metadata appeared in the recalled text (without restricting recall to `answer_session_ids`).
> 
> In `@remnic/core`, adds `collectTemporalLexicalCues` (and folds it into `collectLexicalCues`) to recognize relative temporal phrases like `as of`, `latest`, and `yesterday`, with new unit tests covering temporal cue search and the LongMemEval temporal metadata path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e85c409c5e71dd930786bf46d8f6c437e4e5e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->