### PR TITLE
feat(bench): harden AMemGym latest-state recall

### DIFF
--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -697,6 +697,14 @@ function buildSessionMessages(session: AMemGymSession): Message[] {
     });
   }
 
+  const stateDescription = formatExposedStateUpdate(session.exposed_states);
+  if (stateDescription) {
+    messages.push({
+      role: "user",
+      content: `[User state update]: ${stateDescription}`,
+    });
+  }
+
   if (session.query) {
     messages.push({
       role: "user",
@@ -711,17 +719,19 @@ function buildSessionMessages(session: AMemGymSession): Message[] {
     });
   }
 
-  if (messages.length === 0 && Object.keys(session.exposed_states).length > 0) {
-    const stateDescription = Object.entries(session.exposed_states)
-      .map(([key, value]) => `${key}: ${value}`)
-      .join(", ");
-    messages.push({
-      role: "user",
-      content: `[User state]: ${stateDescription}`,
-    });
-  }
-
   return messages;
+}
+
+function formatExposedStateUpdate(
+  exposedStates: Record<string, string>,
+): string | undefined {
+  const entries = Object.entries(exposedStates).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return entries.map(([key, value]) => `${key}: ${value}`).join(", ");
 }
 
 function normalizeRole(role: string): Message["role"] {

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -5,6 +5,7 @@ import {
   buildExplicitCueRecallSection,
   collectExplicitTurnReferences,
   collectLexicalCues,
+  collectQuestionSlotCues,
   collectTemporalLexicalCues,
   type ExplicitCueRecallEngine,
 } from "./explicit-cue-recall.js";
@@ -115,6 +116,14 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
   assert.deepEqual(
     collectLexicalCues("As of 2025-02-01, what changed yesterday?"),
     ["2025-02-01", "as of", "changed", "yesterday"],
+  );
+  assert.deepEqual(
+    collectQuestionSlotCues("What city does the user live in now?"),
+    ["city"],
+  );
+  assert.deepEqual(
+    collectLexicalCues("What city does the user live in now?"),
+    ["city", "now"],
   );
 });
 
@@ -232,6 +241,30 @@ test("buildExplicitCueRecallSection searches explicit temporal cues", async () =
 
   assert.match(section, /2025-02-01/);
   assert.match(section, /shellfish/);
+});
+
+test("buildExplicitCueRecallSection prioritizes latest state updates for current questions", async () => {
+  const engine = new FakeCueEngine({
+    amemgym: [
+      { role: "user", content: "[User state update]: city: Austin" },
+      { role: "user", content: "I am packing boxes this week." },
+      { role: "user", content: "[User state update]: city: Denver" },
+    ],
+  });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "amemgym",
+    query: "What city does the user live in now?",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /city: Denver/);
+  assert.match(section, /city: Austin/);
+  assert.ok(
+    section.indexOf("city: Denver") < section.indexOf("city: Austin"),
+    "latest matching state should appear before superseded history",
+  );
 });
 
 test("buildExplicitCueRecallSection stays silent when disabled by budget or no cues", async () => {

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -44,6 +44,17 @@ const TURN_REFERENCE_WINDOW_RADIUS = 0;
 const LEXICAL_CUE_WINDOW_RADIUS = 1;
 const LEXICAL_CUE_SEARCH_LIMIT = 3;
 const LEXICAL_CUE_MAX_TOKENS = 400;
+const LATEST_STATE_CUES = new Set([
+  "as of",
+  "currently",
+  "latest",
+  "most recent",
+  "newest",
+  "now",
+  "updated",
+  "changed",
+  "change",
+]);
 const RELATIVE_TEMPORAL_CUES = [
   "as of",
   "most recent",
@@ -137,6 +148,20 @@ const SPEAKER_NAME_STOPWORDS = new Set([
   "Why",
   "Will",
   "Would",
+]);
+const QUESTION_SLOT_STOPWORDS = new Set([
+  "answer",
+  "choice",
+  "did",
+  "does",
+  "do",
+  "is",
+  "should",
+  "single",
+  "the",
+  "user",
+  "was",
+  "were",
 ]);
 
 export async function buildExplicitCueRecallSection(
@@ -268,15 +293,20 @@ async function collectLexicalCueEvidence(options: {
   seenTurns: Set<string>;
 }): Promise<void> {
   const cues = collectLexicalCues(options.query).slice(0, options.maxReferences);
+  const preferLatest = hasLatestStateIntent(options.query);
   for (const cue of cues) {
-    const results = await options.engine.searchContextFull(
-      cue,
-      LEXICAL_CUE_SEARCH_LIMIT,
-      options.sessionId,
+    const results = sortLexicalCueResults(
+      await options.engine.searchContextFull(
+        cue,
+        LEXICAL_CUE_SEARCH_LIMIT,
+        options.sessionId,
+      ),
+      preferLatest,
     );
     for (const result of results) {
-      const fromTurn = Math.max(0, result.turn_index - LEXICAL_CUE_WINDOW_RADIUS);
-      const toTurn = result.turn_index + LEXICAL_CUE_WINDOW_RADIUS;
+      const windowRadius = preferLatest ? 0 : LEXICAL_CUE_WINDOW_RADIUS;
+      const fromTurn = Math.max(0, result.turn_index - windowRadius);
+      const toTurn = result.turn_index + windowRadius;
       const expanded = await options.engine.expandContext(
         result.session_id,
         fromTurn,
@@ -381,6 +411,9 @@ export function collectLexicalCues(query: string): string[] {
   for (const cue of collectTemporalLexicalCues(query)) {
     cues.add(cue);
   }
+  for (const cue of collectQuestionSlotCues(query)) {
+    cues.add(cue);
+  }
   for (const match of query.matchAll(/\b(?:session|source|chat|plan|task|event|file|tool)[_-][A-Za-z0-9][A-Za-z0-9_.:-]{0,80}\b/gi)) {
     cues.add(match[0]);
   }
@@ -397,6 +430,19 @@ export function collectLexicalCues(query: string): string[] {
     }
   }
 
+  return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+export function collectQuestionSlotCues(query: string): string[] {
+  const cues = new Set<string>();
+  for (const match of query.matchAll(
+    /\b(?:what|which)\s+([a-z][a-z0-9_-]{2,30})\s+(?:does|do|did|is|are|was|were|should|would|could|can|will)\b/gi,
+  )) {
+    const value = match[1]?.toLowerCase();
+    if (value && !QUESTION_SLOT_STOPWORDS.has(value)) {
+      cues.add(value);
+    }
+  }
   return [...cues].sort((left, right) => left.localeCompare(right));
 }
 
@@ -422,6 +468,39 @@ export function collectTemporalLexicalCues(query: string): string[] {
     }
   }
   return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+function hasLatestStateIntent(query: string): boolean {
+  return collectTemporalLexicalCues(query).some((cue) =>
+    LATEST_STATE_CUES.has(cue),
+  );
+}
+
+function sortLexicalCueResults<
+  T extends { session_id: string; turn_index: number; score?: number },
+>(results: T[], preferLatest: boolean): T[] {
+  return [...results].sort((left, right) => {
+    if (preferLatest) {
+      const sessionOrder = left.session_id.localeCompare(right.session_id);
+      if (sessionOrder !== 0) {
+        return sessionOrder;
+      }
+      const turnOrder = right.turn_index - left.turn_index;
+      if (turnOrder !== 0) {
+        return turnOrder;
+      }
+      return (right.score ?? 0) - (left.score ?? 0);
+    }
+    const scoreDelta = (right.score ?? 0) - (left.score ?? 0);
+    if (scoreDelta !== 0) {
+      return scoreDelta;
+    }
+    const sessionOrder = left.session_id.localeCompare(right.session_id);
+    if (sessionOrder !== 0) {
+      return sessionOrder;
+    }
+    return left.turn_index - right.turn_index;
+  });
 }
 
 function normalizeSpeakerNameCue(value: string): string | undefined {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -54,6 +54,7 @@ export {
   buildExplicitCueRecallSection,
   collectExplicitTurnReferences,
   collectLexicalCues,
+  collectQuestionSlotCues,
   collectTemporalLexicalCues,
   type ExplicitCueRecallEngine,
   type ExplicitCueRecallOptions,

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -148,6 +148,75 @@ function createDatasetProfile() {
   ];
 }
 
+function createUpdatedStateDatasetProfile() {
+  return [
+    {
+      id: "dataset-profile-updates",
+      start_time: "2025-02-01T00:00:00Z",
+      user_profile: {
+        uuid: "dataset-user-updates",
+        name: "Jordan",
+        age: 34,
+        gender: "nonbinary",
+      },
+      state_schema: {
+        city: { type: "string" },
+      },
+      periods: [
+        {
+          period_start: "2025-02-01T00:00:00Z",
+          period_end: "2025-02-28T23:59:59Z",
+          period_summary: "Jordan lived in Austin.",
+          sessions: [
+            {
+              event: "Jordan moved to Austin.",
+              exposed_states: { city: "Austin" },
+              query: "I live in Austin now.",
+              messages: [],
+              session_time: "2025-02-12T08:00:00Z",
+            },
+          ],
+          state: { city: "Austin" },
+          updates: { city: "Austin" },
+          update_cnts: { city: 1 },
+        },
+        {
+          period_start: "2025-03-01T00:00:00Z",
+          period_end: "2025-03-31T23:59:59Z",
+          period_summary: "Jordan moved again.",
+          sessions: [
+            {
+              event: "Jordan moved to Denver.",
+              exposed_states: { city: "Denver" },
+              query: "I moved again and live in Denver now.",
+              messages: [
+                {
+                  role: "assistant",
+                  content: "I will remember Denver as the current city.",
+                },
+              ],
+              session_time: "2025-03-12T08:00:00Z",
+            },
+          ],
+          state: { city: "Denver" },
+          updates: { city: "Denver" },
+          update_cnts: { city: 1 },
+        },
+      ],
+      qas: [
+        {
+          query: "What city does Jordan live in now?",
+          required_info: ["city"],
+          answer_choices: [
+            { state: ["Austin"], answer: "Austin" },
+            { state: ["Denver"], answer: "Denver" },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
 test("runBenchmark executes amemgym in quick mode through the phase-1 package API", async () => {
   const adapter = new FakeMemoryAdapter();
 
@@ -187,6 +256,41 @@ test("runBenchmark executes amemgym in full mode from an explicit dataset file",
 
   assert.equal(result.results.tasks.length, 1);
   assert.equal(result.results.tasks[0]?.expected, "Seattle");
+  const stored = adapter.sessions.get("amemgym-dataset-profile-1") ?? [];
+  assert.match(
+    stored.map((message) => message.content).join("\n"),
+    /\[User state update\]: city: Seattle/,
+  );
+});
+
+test("runBenchmark ingests repeated AMemGym state updates without final-state injection", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-updates-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("2"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createUpdatedStateDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "Denver");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.expectedChoiceIndex, 2);
+
+  const storedText = (adapter.sessions.get("amemgym-dataset-profile-updates") ?? [])
+    .map((message) => message.content)
+    .join("\n");
+  assert.match(storedText, /\[User state update\]: city: Austin/);
+  assert.match(storedText, /\[User state update\]: city: Denver/);
+  assert.doesNotMatch(storedText, /Answer choices:/);
 });
 
 test("runBenchmark scores amemgym using the benchmark multiple-choice protocol", async () => {


### PR DESCRIPTION
## Summary
- ingest AMemGym per-session exposed state updates as source evidence even when the session also has normal dialogue
- add core question-slot cues such as `city` from current-state questions
- prioritize later same-session evidence for `now`/latest/current queries while retaining older state history

Fixes #845.

## Test plan
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts tests/bench-amemgym-runner.test.ts
- pnpm exec tsx scripts/bench/bench-smoke.ts --seed 1
- npm run check-types
- git diff --check
- bash scripts/check-review-patterns.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cue extraction and evidence ordering in `explicit-cue-recall`, which can shift what context is surfaced for many queries (especially those asking for the latest/current state). Risk is limited to recall quality/benchmark behavior, with added tests covering the new semantics.
> 
> **Overview**
> Improves AMemGym ingestion and explicit-cue recall so *per-session* `exposed_states` are always stored as `[User state update]` messages (even when the session also contains normal dialogue), with stable key ordering.
> 
> Extends `explicit-cue-recall` to extract “question-slot” cues (e.g. `city` from “What city does the user…”) and, for queries indicating *latest/current* intent (`now`, `latest`, `as of`, etc.), prioritize later turn matches and tighten the expansion window to favor the most recent state update while still including older superseded state history.
> 
> Adds/updates tests to verify cue extraction, latest-state ordering, and AMemGym benchmark ingestion across repeated state updates without injecting unrelated prompt text (e.g. answer choices).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5284cb7e03534e0eeb3a9051827c70546dccc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->