### PR TITLE
fix(openclaw): avoid core export skew in live connector startup

### DIFF
--- a/.changeset/openclaw-live-connector-core-compat.md
+++ b/.changeset/openclaw-live-connector-core-compat.md
@@ -1,0 +1,12 @@
+---
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Avoid a fragile startup-time named import from `@remnic/core` for the OpenClaw
+live-connector cron gate.
+
+Older installed core builds may not export `hasEnabledLiveConnector`, causing
+OpenClaw plugin startup to fail before Remnic can degrade gracefully. The
+OpenClaw adapter now performs the simple parsed-config check locally, so plugin
+startup remains compatible across core patch-version skew.

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,13 +73,13 @@ import { planRecallMode } from "../packages/remnic-core/src/intent.js";
 import {
   resolvePrincipal,
   resolveAgentAccessAuthToken,
-  hasEnabledLiveConnector,
 } from "@remnic/core";
 import { findGatewayRuntimeModules } from "./resolve-provider-secret.js";
 import { createDreamsSurface } from "../packages/remnic-core/src/surfaces/dreams.js";
 import { createHeartbeatSurface, type HeartbeatEntry } from "../packages/remnic-core/src/surfaces/heartbeat.js";
 import type { ConsolidationObservation } from "../packages/remnic-core/src/types.js";
 import { ensureLiveConnectorCron } from "./openclaw-live-connector-cron.js";
+import { hasEnabledLiveConnectorConfig } from "./openclaw-live-connector-config.js";
 
 /**
  * Per-plugin runtime state is scoped by `serviceId` so a single process can host
@@ -311,7 +311,7 @@ function readPluginHooksPolicy(
 }
 
 async function maybeRegisterLiveConnectorCron(orchestrator: Orchestrator): Promise<void> {
-  if (!hasEnabledLiveConnector(orchestrator.config.connectors)) return;
+  if (!hasEnabledLiveConnectorConfig(orchestrator.config.connectors)) return;
 
   const jobsPath = path.join(resolveHomeDir(), ".openclaw", "cron", "jobs.json");
   try {

--- a/src/openclaw-live-connector-config.ts
+++ b/src/openclaw-live-connector-config.ts
@@ -1,0 +1,9 @@
+export function hasEnabledLiveConnectorConfig(config: unknown): boolean {
+  if (!config || typeof config !== "object" || Array.isArray(config)) return false;
+  return Object.values(config as Record<string, unknown>).some((connector) => {
+    if (!connector || typeof connector !== "object" || Array.isArray(connector)) {
+      return false;
+    }
+    return (connector as { enabled?: unknown }).enabled === true;
+  });
+}

--- a/tests/openclaw-live-connector-compat.test.ts
+++ b/tests/openclaw-live-connector-compat.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+import { hasEnabledLiveConnectorConfig } from "../src/openclaw-live-connector-config.js";
+
+test("OpenClaw live connector cron gate detects enabled connector configs", () => {
+  assert.equal(hasEnabledLiveConnectorConfig(undefined), false);
+  assert.equal(hasEnabledLiveConnectorConfig({}), false);
+  assert.equal(
+    hasEnabledLiveConnectorConfig({
+      googleDrive: { enabled: false },
+      notion: { enabled: false },
+    }),
+    false,
+  );
+  assert.equal(
+    hasEnabledLiveConnectorConfig({
+      googleDrive: { enabled: false },
+      notion: { enabled: true },
+    }),
+    true,
+  );
+});
+
+test("OpenClaw adapter does not import live connector cron gate from @remnic/core", async () => {
+  const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+  const coreImportBlocks = source.matchAll(
+    /import\s*\{(?<names>[\s\S]*?)\}\s*from\s*["@']@remnic\/core["@']/g,
+  );
+
+  for (const match of coreImportBlocks) {
+    assert.doesNotMatch(
+      match.groups?.names ?? "",
+      /\bhasEnabledLiveConnector\b/,
+      "OpenClaw startup must not statically import this optional core helper",
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- remove the OpenClaw adapter's startup-time named import of `hasEnabledLiveConnector` from `@remnic/core`
- add a dependency-free local connector-enabled config gate for live connector cron registration
- add regression coverage to prevent reintroducing the fragile core import
- add a patch changeset for `@remnic/plugin-openclaw` and the legacy `@joshuaswarren/openclaw-engram` shim

## Why
A user reported OpenClaw plugin startup failing with:

```text
plugin service failed (openclaw-remnic): hasEnabledLiveConnector is not a function
```

That helper is only used to decide whether to auto-register the live connector cron. Keeping the simple parsed-config check inside the OpenClaw adapter avoids a hard ESM startup failure when the installed plugin and core package are skewed by a patch release.

The separate `qmd update -c openclaw-engram timed out after 90000ms` log remains non-fatal QMD maintenance pressure; this PR removes the plugin startup crash so Remnic can degrade/report normally instead of failing during service load.

## Verification
- `pnpm exec tsx --test tests/openclaw-live-connector-compat.test.ts`
- `pnpm exec tsx --test tests/openclaw-live-connector-compat.test.ts packages/plugin-openclaw/src/runtime-surfaces.test.ts packages/plugin-openclaw/src/slot-validator.test.ts`
- `pnpm --filter @remnic/plugin-openclaw run build`
- inspected `packages/plugin-openclaw/dist/index.js`: no `hasEnabledLiveConnector` import from `@remnic/core`
- `npm run preflight:quick` was started; typecheck/config/review-pattern phases passed, then the broad `npm test` phase showed unrelated benchmark adapter failures and later hung in `packages/remnic-core/src/lcm-engine.test.ts`, so I interrupted my isolated test process rather than leave it running

## Notes
`pnpm --filter @remnic/plugin-openclaw run check-types` still fails on the package's existing `../../../src/index.js` re-export/rootDir structure and a pre-existing WorkerOptions type issue; the package build succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk compatibility fix: only changes the boolean gate used to decide whether to auto-register the live-connector cron job, plus adds targeted regression tests.
> 
> **Overview**
> Prevents OpenClaw plugin startup from failing when older `@remnic/core` builds don’t export `hasEnabledLiveConnector` by removing that named import and performing the connector-enabled check locally.
> 
> Adds `hasEnabledLiveConnectorConfig` and uses it to gate `maybeRegisterLiveConnectorCron`, plus introduces tests that validate the config check and ensure `src/index.ts` never reintroduces the fragile static import. Includes a patch changeset for `@remnic/plugin-openclaw` and the legacy `@joshuaswarren/openclaw-engram` shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de46e9d00495942ec6d38b4f4d8ef184d112475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->