### PR TITLE
feat(bench): harden MemoryArena plan cue recall

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -321,6 +321,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           maxChars: Math.min(CORE_EXPLICIT_CUE_MAX_CHARS, Math.floor(budget * 0.4)),
           maxItemChars: CORE_EXPLICIT_CUE_MAX_ITEM_CHARS,
           maxReferences: CORE_EXPLICIT_CUE_MAX_REFERENCES,
+          includeStructuredPlanCues: sessionId.startsWith("arena-"),
         });
         if (exactReferenceEvidence) {
           sections.push(exactReferenceEvidence);

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -112,7 +112,14 @@ export async function runMemoryArenaBenchmark(
           }
 
           if (!isScored) {
-            await storeCompletedSubtask(options, sessionId, questionIndex, question, expected);
+            await storeCompletedSubtask(
+              options,
+              sessionId,
+              questionIndex,
+              question,
+              expected,
+              expectedAnswer,
+            );
             continue;
           }
 
@@ -196,7 +203,14 @@ export async function runMemoryArenaBenchmark(
           });
 
           try {
-            await storeCompletedSubtask(options, sessionId, questionIndex, question, expected);
+            await storeCompletedSubtask(
+              options,
+              sessionId,
+              questionIndex,
+              question,
+              expected,
+              expectedAnswer,
+            );
           } catch (storeErr) {
             console.error(`  [WARN] memory-arena store failed for ${taskResultId}: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`);
           }
@@ -600,6 +614,9 @@ async function storeInitialTaskState(
   const plan = basePerson.daily_plans == null
     ? ""
     : answerToString(basePerson.daily_plans);
+  const planFieldAnchors = basePerson.daily_plans == null
+    ? []
+    : formatPlanFieldAnchorLines(basePerson.daily_plans);
   if (query.trim().length === 0 && plan.trim().length === 0) {
     return;
   }
@@ -617,6 +634,7 @@ async function storeInitialTaskState(
         `MemoryArena initial finalized plan for ${name}.`,
         query.trim().length > 0 ? `Base traveler request: ${query}` : "",
         plan.trim().length > 0 ? `Environment result: ${plan}` : "",
+        ...planFieldAnchors,
       ].filter((part) => part.length > 0).join("\n"),
     },
   ]);
@@ -799,6 +817,20 @@ function extractPlanFieldValues(answer: ArenaExpectedAnswer): PlanFieldExpectati
     }
   }
   return fields;
+}
+
+function formatPlanFieldAnchorLines(answer: ArenaExpectedAnswer): string[] {
+  const fields = extractPlanFieldValues(answer);
+  if (fields.length === 0) {
+    return [];
+  }
+  return [
+    "MemoryArena structured plan field anchors:",
+    ...fields.map((field) => {
+      const day = field.day === undefined ? "" : `Day ${field.day} `;
+      return `${day}${field.fieldKey.replace(/_/g, " ")}: ${field.value}`;
+    }),
+  ];
 }
 
 function normalizePlanText(value: string): string {
@@ -1106,7 +1138,9 @@ async function storeCompletedSubtask(
   questionIndex: number,
   question: string,
   expected: string,
+  expectedAnswer: ArenaExpectedAnswer,
 ): Promise<void> {
+  const planFieldAnchors = formatPlanFieldAnchorLines(expectedAnswer);
   await options.system.store(sessionId, [
     {
       role: "user",
@@ -1118,6 +1152,7 @@ async function storeCompletedSubtask(
         `MemoryArena completed subtask ${questionIndex + 1}.`,
         `Instruction: ${question}`,
         `Environment result: ${expected}`,
+        ...planFieldAnchors,
       ].join("\n"),
     },
   ]);

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -6,6 +6,7 @@ import {
   collectExplicitTurnReferences,
   collectLexicalCues,
   collectQuestionSlotCues,
+  collectStructuredPlanCues,
   collectTemporalLexicalCues,
   type ExplicitCueRecallEngine,
 } from "./explicit-cue-recall.js";
@@ -124,6 +125,18 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
   assert.deepEqual(
     collectLexicalCues("What city does the user live in now?"),
     ["city", "now"],
+  );
+  assert.deepEqual(
+    collectStructuredPlanCues("Join Jennifer for the same dinner and accommodation."),
+    ["accommodation", "dinner", "join", "same"],
+  );
+  assert.deepEqual(
+    collectStructuredPlanCues("Join the same team meeting."),
+    [],
+  );
+  assert.deepEqual(
+    collectLexicalCues("Join Jennifer for the same dinner and accommodation."),
+    ["accommodation", "dinner", "Jennifer", "join", "same"],
   );
 });
 
@@ -265,6 +278,31 @@ test("buildExplicitCueRecallSection prioritizes latest state updates for current
     section.indexOf("city: Denver") < section.indexOf("city: Austin"),
     "latest matching state should appear before superseded history",
   );
+});
+
+test("buildExplicitCueRecallSection searches structured plan field cues", async () => {
+  const engine = new FakeCueEngine({
+    arena: [
+      {
+        role: "assistant",
+        content: [
+          "MemoryArena structured plan field anchors:",
+          "Day 1 dinner: Coco Bambu, Dallas",
+          "Day 1 accommodation: Central Stay, Dallas",
+        ].join("\n"),
+      },
+    ],
+  });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "arena",
+    query: "Join Jennifer for the same dinner and accommodation.",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /Coco Bambu, Dallas/);
+  assert.match(section, /Central Stay, Dallas/);
 });
 
 test("buildExplicitCueRecallSection stays silent when disabled by budget or no cues", async () => {

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -136,6 +136,12 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
   );
   assert.deepEqual(
     collectLexicalCues("Join Jennifer for the same dinner and accommodation."),
+    ["Jennifer"],
+  );
+  assert.deepEqual(
+    collectLexicalCues("Join Jennifer for the same dinner and accommodation.", {
+      includeStructuredPlanCues: true,
+    }),
     ["accommodation", "dinner", "Jennifer", "join", "same"],
   );
 });
@@ -299,6 +305,7 @@ test("buildExplicitCueRecallSection searches structured plan field cues", async 
     sessionId: "arena",
     query: "Join Jennifer for the same dinner and accommodation.",
     maxChars: 2000,
+    includeStructuredPlanCues: true,
   });
 
   assert.match(section, /Coco Bambu, Dallas/);

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -55,6 +55,32 @@ const LATEST_STATE_CUES = new Set([
   "changed",
   "change",
 ]);
+const STRUCTURED_PLAN_FIELD_CUES = new Set([
+  "accommodation",
+  "attraction",
+  "breakfast",
+  "current city",
+  "dinner",
+  "flight",
+  "flights",
+  "hotel",
+  "lunch",
+  "restaurant",
+  "restaurants",
+  "transportation",
+  "traveler",
+  "travelers",
+]);
+const STRUCTURED_PLAN_DEPENDENCY_CUES = new Set([
+  "comparison",
+  "constraint",
+  "constraints",
+  "dependency",
+  "dependencies",
+  "join",
+  "same",
+  "shared",
+]);
 const RELATIVE_TEMPORAL_CUES = [
   "as of",
   "most recent",
@@ -127,6 +153,7 @@ const SPEAKER_NAME_STOPWORDS = new Set([
   "In",
   "Is",
   "It",
+  "Join",
   "Of",
   "On",
   "Or",
@@ -414,6 +441,9 @@ export function collectLexicalCues(query: string): string[] {
   for (const cue of collectQuestionSlotCues(query)) {
     cues.add(cue);
   }
+  for (const cue of collectStructuredPlanCues(query)) {
+    cues.add(cue);
+  }
   for (const match of query.matchAll(/\b(?:session|source|chat|plan|task|event|file|tool)[_-][A-Za-z0-9][A-Za-z0-9_.:-]{0,80}\b/gi)) {
     cues.add(match[0]);
   }
@@ -444,6 +474,44 @@ export function collectQuestionSlotCues(query: string): string[] {
     }
   }
   return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+export function collectStructuredPlanCues(query: string): string[] {
+  const cues = new Set<string>();
+  const normalizedQuery = query.toLowerCase().replace(/\s+/g, " ");
+  for (const cue of STRUCTURED_PLAN_FIELD_CUES) {
+    if (containsBoundedPhrase(normalizedQuery, cue)) {
+      cues.add(cue);
+    }
+  }
+  if (cues.size === 0) {
+    return [];
+  }
+  for (const cue of STRUCTURED_PLAN_DEPENDENCY_CUES) {
+    if (containsBoundedPhrase(normalizedQuery, cue)) {
+      cues.add(cue);
+    }
+  }
+  return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+function containsBoundedPhrase(normalizedHaystack: string, phrase: string): boolean {
+  let searchFrom = 0;
+  while (searchFrom < normalizedHaystack.length) {
+    const index = normalizedHaystack.indexOf(phrase, searchFrom);
+    if (index < 0) {
+      return false;
+    }
+    const afterIndex = index + phrase.length;
+    if (
+      isTemporalCueBoundary(normalizedHaystack[index - 1]) &&
+      isTemporalCueBoundary(normalizedHaystack[afterIndex])
+    ) {
+      return true;
+    }
+    searchFrom = afterIndex;
+  }
+  return false;
 }
 
 export function collectTemporalLexicalCues(query: string): string[] {

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -518,21 +518,8 @@ export function collectTemporalLexicalCues(query: string): string[] {
   const cues = new Set<string>();
   const normalizedQuery = query.toLowerCase().replace(/\s+/g, " ");
   for (const cue of RELATIVE_TEMPORAL_CUES) {
-    let searchFrom = 0;
-    while (searchFrom < normalizedQuery.length) {
-      const index = normalizedQuery.indexOf(cue, searchFrom);
-      if (index < 0) {
-        break;
-      }
-      const afterIndex = index + cue.length;
-      if (
-        isTemporalCueBoundary(normalizedQuery[index - 1]) &&
-        isTemporalCueBoundary(normalizedQuery[afterIndex])
-      ) {
-        cues.add(cue);
-        break;
-      }
-      searchFrom = afterIndex;
+    if (containsBoundedPhrase(normalizedQuery, cue)) {
+      cues.add(cue);
     }
   }
   return [...cues].sort((left, right) => left.localeCompare(right));

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -29,6 +29,7 @@ export interface ExplicitCueRecallOptions {
   maxChars: number;
   maxItemChars?: number;
   maxReferences?: number;
+  includeStructuredPlanCues?: boolean;
 }
 
 export type ExplicitTurnReference = {
@@ -233,6 +234,7 @@ export async function buildExplicitCueRecallSection(
     sessionId: options.sessionId,
     query,
     maxReferences,
+    includeStructuredPlanCues: options.includeStructuredPlanCues,
     evidenceItems,
     seenTurns,
   });
@@ -309,6 +311,7 @@ async function collectLexicalCueEvidence(options: {
   sessionId?: string;
   query: string;
   maxReferences: number;
+  includeStructuredPlanCues?: boolean;
   evidenceItems: Array<{
     id: string;
     sessionId: string;
@@ -319,7 +322,9 @@ async function collectLexicalCueEvidence(options: {
   }>;
   seenTurns: Set<string>;
 }): Promise<void> {
-  const cues = collectLexicalCues(options.query).slice(0, options.maxReferences);
+  const cues = collectLexicalCues(options.query, {
+    includeStructuredPlanCues: options.includeStructuredPlanCues,
+  }).slice(0, options.maxReferences);
   const preferLatest = hasLatestStateIntent(options.query);
   for (const cue of cues) {
     const results = sortLexicalCueResults(
@@ -426,7 +431,10 @@ export function collectExplicitTurnReferences(
   return [...references.values()].sort((left, right) => left.number - right.number);
 }
 
-export function collectLexicalCues(query: string): string[] {
+export function collectLexicalCues(
+  query: string,
+  options: { includeStructuredPlanCues?: boolean } = {},
+): string[] {
   const cues = new Set<string>();
 
   for (const match of query.matchAll(/\b[A-Za-z][A-Za-z0-9]{0,12}\d+:\d+\b/g)) {
@@ -441,8 +449,10 @@ export function collectLexicalCues(query: string): string[] {
   for (const cue of collectQuestionSlotCues(query)) {
     cues.add(cue);
   }
-  for (const cue of collectStructuredPlanCues(query)) {
-    cues.add(cue);
+  if (options.includeStructuredPlanCues) {
+    for (const cue of collectStructuredPlanCues(query)) {
+      cues.add(cue);
+    }
   }
   for (const match of query.matchAll(/\b(?:session|source|chat|plan|task|event|file|tool)[_-][A-Za-z0-9][A-Za-z0-9_.:-]{0,80}\b/gi)) {
     cues.add(match[0]);

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -55,6 +55,7 @@ export {
   collectExplicitTurnReferences,
   collectLexicalCues,
   collectQuestionSlotCues,
+  collectStructuredPlanCues,
   collectTemporalLexicalCues,
   type ExplicitCueRecallEngine,
   type ExplicitCueRecallOptions,

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -255,11 +255,75 @@ test("runBenchmark seeds memory-arena group travel with the base traveler plan",
 
   const task = result.results.tasks[0]!;
   assert.match(task.actual, /initial finalized plan for Jennifer/);
+  assert.match(task.actual, /MemoryArena structured plan field anchors:/);
+  assert.match(task.actual, /Day 1 dinner: Coco Bambu, Dallas/);
+  assert.match(task.actual, /Day 1 accommodation: Central Stay, Dallas/);
   assert.match(String(task.details?.promptQuestion), /complete finalized plan/);
   assert.equal(task.scores.plan_field_recall, 1);
   assert.equal(task.scores.soft_process_score, 1);
   assert.equal(task.scores.process_score, 1);
   assert.equal(task.scores.task_success_rate, 1);
+});
+
+test("runBenchmark stores completed group-travel subtasks as structured dependency evidence", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-dependency-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Dinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: [
+        "I am Jennifer. Generate my finalized plan.",
+        "I am Eric. Join Jennifer for the same dinner.",
+      ],
+      answers: [
+        [
+          {
+            days: 1,
+            current_city: "-",
+            transportation: "-",
+            breakfast: "-",
+            attraction: "-",
+            lunch: "-",
+            dinner: "Coco Bambu, Dallas",
+            accommodation: "-",
+          },
+        ],
+        [
+          {
+            days: 1,
+            current_city: "-",
+            transportation: "-",
+            breakfast: "-",
+            attraction: "-",
+            lunch: "-",
+            dinner: "Coco Bambu, Dallas",
+            accommodation: "-",
+          },
+        ],
+      ],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.match(String(task.details?.recalledText), /completed subtask 1/);
+  assert.match(
+    String(task.details?.recalledText),
+    /MemoryArena structured plan field anchors:/,
+  );
+  assert.match(String(task.details?.recalledText), /Day 1 dinner: Coco Bambu, Dallas/);
+  assert.equal(task.scores.plan_field_recall, 1);
 });
 
 test("runBenchmark treats null memory-arena base traveler plans as absent", async () => {


### PR DESCRIPTION
## Summary
- add core structured plan/dependency lexical cues for fields like dinner, accommodation, JOIN/same constraints, and travelers
- store MemoryArena structured plan field anchors for base traveler plans and completed subtasks only
- add tests proving previous group-travel subtasks become dependency evidence without injecting current expected answers

Fixes #846.

## Test plan
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts tests/bench-memory-arena-runner.test.ts
- pnpm exec tsx scripts/bench/bench-smoke.ts --seed 1
- npm run check-types
- git diff --check
- bash scripts/check-review-patterns.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends core cue-extraction and benchmark seeding logic, which can change what evidence is retrieved and thus benchmark outcomes, but it’s gated behind an opt-in flag and primarily used for `arena-*` benchmark sessions.
> 
> **Overview**
> Improves MemoryArena group-travel recall by **storing structured “plan field anchors”** (e.g., `Day 1 dinner: ...`, `accommodation: ...`) alongside the base traveler seed and completed subtasks, so later dependency questions can retrieve prior plan fields without injecting current expected answers.
> 
> Extends `@remnic/core` explicit cue recall with an opt-in `includeStructuredPlanCues` flag and new `collectStructuredPlanCues` to treat plan-field/dependency phrases (e.g., `dinner`, `accommodation`, `join`, `same`) as lexical cues; the bench `remnic-adapter` enables this automatically for `arena-*` sessions. Adds/updates tests covering structured cue extraction, cue-driven evidence search, and MemoryArena runner storage behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ca83de6001f1fa149f5111506460d509f4994a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->