### PR TITLE
chore(release): publish OpenClaw plugin compatibility fix

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.9",
+  "version": "9.3.10",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.9");
+  assert.equal(pkg.version, "9.3.10");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary
- bump `@remnic/plugin-openclaw` from `1.0.13` to `1.0.14`
- bump the legacy `@joshuaswarren/openclaw-engram` shim from `9.3.9` to `9.3.10`

## Why
PR #856 merged the OpenClaw startup compatibility fix, but the release workflow skipped publishing the affected npm packages because their package.json versions were already published:

- `@remnic/plugin-openclaw@1.0.13 already published; skipping`
- `@joshuaswarren/openclaw-engram@9.3.9 already published; skipping`

This bump makes the already-merged fix publishable for users hitting:

```text
plugin service failed (openclaw-remnic): hasEnabledLiveConnector is not a function
```

## Verification
- `pnpm --filter @remnic/plugin-openclaw run build`
- `pnpm --filter @joshuaswarren/openclaw-engram run build`
- `pnpm exec tsx --test tests/openclaw-live-connector-compat.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only package version bumps and a corresponding test assertion update; no runtime logic changes.
> 
> **Overview**
> Publishes the already-merged OpenClaw compatibility fix by bumping npm package versions: `@remnic/plugin-openclaw` `1.0.13` → `1.0.14` and the legacy shim `@joshuaswarren/openclaw-engram` `9.3.9` → `9.3.10`.
> 
> Updates the shim package manifest test to assert the new shim version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f282d2896af9c33a8b00801e20bae634115c7d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->