### PR TITLE
fix(core): resolve Hermes gateway provider aliases

### DIFF
--- a/.changeset/hermes-gateway-provider-parity.md
+++ b/.changeset/hermes-gateway-provider-parity.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Make gateway model-source extraction tolerate OpenClaw provider catalog drift by resolving legacy `openai-codex/...` model refs through the current `codex` provider and by supplying safe built-in Anthropic defaults when the materialized provider catalog is unavailable.

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -122,6 +122,314 @@ test("fallback llm falls back to models.json for built-in providers missing from
   }
 });
 
+test("fallback llm resolves legacy openai-codex model refs through the codex provider", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai-codex/gpt-5.5",
+        },
+      },
+    },
+    models: {
+      providers: {
+        codex: {
+          baseUrl: "https://codex.example/v1",
+          api: "openai-codex-responses",
+          apiKey: "codex-test-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  globalThis.fetch = (async (url) => {
+    capturedUrl = String(url);
+    return new Response(
+      JSON.stringify({
+        output_text: "ok from codex alias",
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    assert.equal(response?.content, "ok from codex alias");
+    assert.equal(response?.modelUsed, "openai-codex/gpt-5.5");
+    assert.equal(capturedUrl, "https://codex.example/v1/responses");
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm prefers requested canonical models.json provider before legacy aliases", { concurrency: false }, async () => {
+  __setModelsJsonForTest({
+    codex: {
+      baseUrl: "https://codex.example/v1",
+      api: "openai-responses",
+      apiKey: "codex-test-key",
+      models: [],
+    },
+    "openai-codex": {
+      baseUrl: "https://legacy-codex.example/v1",
+      api: "openai-responses",
+      apiKey: "secretref-managed",
+      models: [],
+    },
+  });
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "codex/gpt-5.5",
+        },
+      },
+    },
+    models: {
+      providers: {},
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  globalThis.fetch = (async (url) => {
+    capturedUrl = String(url);
+    return new Response(
+      JSON.stringify({
+        output_text: "ok from canonical codex",
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    assert.equal(response?.content, "ok from canonical codex");
+    assert.equal(capturedUrl, "https://codex.example/v1/responses");
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm has built-in anthropic defaults when the gateway provider catalog is unavailable", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const previousAnthropicKey = process.env.ANTHROPIC_API_KEY;
+  process.env.ANTHROPIC_API_KEY = "anthropic-test-key";
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "anthropic/claude-sonnet-4-6",
+        },
+      },
+    },
+    models: {
+      providers: {},
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  let capturedAuth = "";
+  globalThis.fetch = (async (url, init) => {
+    capturedUrl = String(url);
+    capturedAuth = String((init?.headers as Record<string, string> | undefined)?.["x-api-key"] ?? "");
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: "ok from anthropic default" }],
+        usage: { input_tokens: 2, output_tokens: 3 },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    assert.equal(response?.content, "ok from anthropic default");
+    assert.equal(capturedUrl, "https://api.anthropic.com/v1/messages");
+    assert.equal(capturedAuth, "anthropic-test-key");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousAnthropicKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = previousAnthropicKey;
+    }
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm prefers configured alias providers before built-in defaults", { concurrency: false }, async () => {
+  __setModelsJsonForTest({
+    "claude-cli": {
+      baseUrl: "https://materialized-claude-cli.example/v1",
+      api: "anthropic-messages",
+      apiKey: "materialized-claude-cli-key",
+      models: [],
+    },
+  });
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "claude-cli/claude-sonnet-4-6",
+        },
+      },
+    },
+    models: {
+      providers: {
+        anthropic: {
+          baseUrl: "https://configured-anthropic.example/custom",
+          api: "anthropic-messages",
+          apiKey: "configured-anthropic-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  let capturedAuth = "";
+  globalThis.fetch = (async (url, init) => {
+    capturedUrl = String(url);
+    capturedAuth = String((init?.headers as Record<string, string> | undefined)?.["x-api-key"] ?? "");
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: "ok from configured alias" }],
+        usage: { input_tokens: 2, output_tokens: 3 },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    assert.equal(response?.content, "ok from configured alias");
+    assert.equal(capturedUrl, "https://configured-anthropic.example/custom/v1/messages");
+    assert.equal(capturedAuth, "configured-anthropic-key");
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm resolves claude-cli refs through the anthropic built-in fallback", { concurrency: false }, async () => {
+  __setModelsJsonForTest({
+    "claude-cli": {
+      baseUrl: "https://materialized-claude-cli.example/v1",
+      api: "anthropic-messages",
+      apiKey: "secretref-managed",
+      models: [],
+    },
+  });
+  clearSecretCache();
+
+  const previousAnthropicKey = process.env.ANTHROPIC_API_KEY;
+  process.env.ANTHROPIC_API_KEY = "anthropic-test-key";
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "claude-cli/claude-sonnet-4-6",
+        },
+      },
+    },
+    models: {
+      providers: {},
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  let capturedAuth = "";
+  globalThis.fetch = (async (url, init) => {
+    capturedUrl = String(url);
+    capturedAuth = String((init?.headers as Record<string, string> | undefined)?.["x-api-key"] ?? "");
+    return new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: "ok from anthropic alias default" }],
+        usage: { input_tokens: 2, output_tokens: 3 },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    assert.equal(response?.content, "ok from anthropic alias default");
+    assert.equal(response?.modelUsed, "claude-cli/claude-sonnet-4-6");
+    assert.equal(capturedUrl, "https://api.anthropic.com/v1/messages");
+    assert.equal(capturedAuth, "anthropic-test-key");
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousAnthropicKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = previousAnthropicKey;
+    }
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 test("fallback llm uses the Responses API for openai-responses transports", { concurrency: false }, async () => {
   clearModelsJsonCache();
   clearSecretCache();

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -38,6 +38,23 @@ interface ModelRef {
   modelString: string;
 }
 
+const PROVIDER_ALIASES: Record<string, readonly string[]> = {
+  "openai-codex": ["codex"],
+  codex: ["openai-codex"],
+  "claude-cli": ["anthropic"],
+};
+
+const LEGACY_PROVIDER_IDS = new Set(["openai-codex", "claude-cli"]);
+
+const BUILT_IN_PROVIDER_FALLBACKS: Record<string, ModelProviderConfig> = {
+  anthropic: {
+    baseUrl: "https://api.anthropic.com/v1",
+    api: "anthropic-messages",
+    apiKey: "secretref-managed",
+    models: [],
+  },
+};
+
 /**
  * Generic fallback LLM client that uses the gateway's default AI configuration
  * and walks through the full fallback chain (primary + fallbacks).
@@ -246,20 +263,73 @@ export class FallbackLlmClient {
       return null;
     }
 
-    const providerId = parts[0];
+    const requestedProviderId = parts[0];
     const modelId = parts.slice(1).join("/"); // Handle cases like "openai/gpt-5.2-turbo"
 
     // Respect the active gateway config first so profile-local overrides and
     // credentials win. Fall back to the materialized models.json only when
     // the provider is absent from the loaded config (for built-in providers
     // registered by the gateway at runtime).
-    const providerConfig = providers[providerId] ?? this.resolveFromModelsJson(providerId);
+    const resolvedProvider = this.resolveProviderConfig(requestedProviderId, providers);
+    const providerConfig = resolvedProvider?.config;
     if (!providerConfig) {
-      log.warn(`fallback LLM: provider not found: ${providerId}`);
+      log.warn(
+        `fallback LLM: provider not found: ${requestedProviderId} ` +
+        `(tried: ${this.providerResolutionCandidates(requestedProviderId).join(", ")})`,
+      );
       return null;
     }
 
-    return { providerId, modelId, providerConfig, modelString };
+    return {
+      providerId: resolvedProvider.providerId,
+      modelId,
+      providerConfig,
+      modelString,
+    };
+  }
+
+  private resolveProviderConfig(
+    providerId: string,
+    providers: Record<string, ModelProviderConfig>,
+  ): { providerId: string; config: ModelProviderConfig } | null {
+    const candidates = this.providerResolutionCandidates(providerId);
+    const aliasCandidates = candidates.filter((candidate) => candidate !== providerId);
+    const fallbackCandidates = LEGACY_PROVIDER_IDS.has(providerId)
+      ? [...aliasCandidates, providerId]
+      : [providerId, ...aliasCandidates];
+    for (const candidate of candidates) {
+      const config = providers[candidate];
+      if (config) {
+        if (candidate !== providerId) {
+          log.debug(`fallback LLM: provider "${providerId}" resolved via alias "${candidate}"`);
+        }
+        return { providerId: candidate, config };
+      }
+    }
+    for (const candidate of fallbackCandidates) {
+      const config = this.resolveFromModelsJson(candidate);
+      if (config) {
+        if (candidate !== providerId) {
+          log.debug(`fallback LLM: provider "${providerId}" resolved via models.json alias "${candidate}"`);
+        }
+        return { providerId: candidate, config };
+      }
+      const builtInConfig = BUILT_IN_PROVIDER_FALLBACKS[candidate];
+      if (builtInConfig) {
+        if (candidate === providerId) {
+          log.debug(`fallback LLM: provider "${providerId}" resolved from built-in defaults`);
+          return { providerId, config: builtInConfig };
+        }
+        log.debug(`fallback LLM: provider "${providerId}" resolved via built-in alias "${candidate}"`);
+        return { providerId: candidate, config: builtInConfig };
+      }
+    }
+    return null;
+  }
+
+  private providerResolutionCandidates(providerId: string): string[] {
+    const candidates = [providerId, ...(PROVIDER_ALIASES[providerId] ?? [])];
+    return [...new Set(candidates)];
   }
 
   /**


### PR DESCRIPTION
## Summary
- resolve legacy OpenClaw `openai-codex/...` model refs through the current `codex` provider when the catalog has drifted
- provide safe built-in Anthropic fallback provider config so Hermes standalone gateway extraction can use OpenClaw auth/env credentials when models.json is unavailable
- add focused fallback LLM regression tests for issue #859

Fixes part of #859.

## Verification
- pnpm exec tsx --test packages/remnic-core/src/fallback-llm.test.ts
- pnpm --filter @remnic/core run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider resolution logic for LLM calls by introducing aliasing and built-in fallbacks, which could reroute requests/auth if misconfigured. Mitigated by added regression tests covering legacy/canonical precedence and missing catalog behavior.
> 
> **Overview**
> Improves `FallbackLlmClient` provider lookup to tolerate gateway provider-catalog drift by resolving model refs through **provider aliases** (notably `openai-codex`↔`codex` and `claude-cli`→`anthropic`) and by emitting clearer warnings with the tried resolution candidates.
> 
> Adds **built-in Anthropic provider defaults** when `models.json` (materialized provider catalog) is unavailable, while preserving precedence for explicitly configured providers/canonical IDs over legacy aliases.
> 
> Extends `fallback-llm.test.ts` with focused regression tests covering legacy Codex resolution, canonical-vs-alias precedence, and Anthropic built-in fallback behavior, and ships a patch changeset for `@remnic/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 786a3b11ff04c22cf1161a49ca295f4dd5c1ff33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->