### PR TITLE
fix(core): support Hermes root config installs

### DIFF
--- a/.changeset/hermes-root-config-layout.md
+++ b/.changeset/hermes-root-config-layout.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Support Hermes Agent's default `~/.hermes/config.yaml` layout when installing the Hermes connector, while preserving explicit profile-directory installs for named Hermes profiles.

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -1006,7 +1006,7 @@ export function installConnector(options: InstallOptions): InstallResult {
           `tokens.json restored but config.yaml rollback ALSO failed ` +
           `(${yamlRollbackErrMsg}). ` +
           `Hermes daemon may be in an inconsistent state: config references a stale token. ` +
-          `Manually inspect ~/.hermes/profiles/${hermesProfile}/config.yaml and reinstall.`;
+          `Manually inspect ${yamlResult.configPath} and reinstall.`;
       } else if (yamlRolledBack && !tokensRolledBack) {
         message =
           `Hermes install failed during token commit — ` +
@@ -1022,7 +1022,7 @@ export function installConnector(options: InstallOptions): InstallResult {
           `BOTH rollbacks failed: config.yaml rollback failed (${yamlRollbackErrMsg}); ` +
           `tokens.json rollback failed (${tokensRollbackErrMsg}). ` +
           `Hermes daemon is likely in an inconsistent state. ` +
-          `Manually inspect ~/.hermes/profiles/${hermesProfile}/config.yaml ` +
+          `Manually inspect ${yamlResult.configPath} ` +
           `and ~/.remnic/tokens.json, then reinstall.`;
       }
       return {
@@ -1095,6 +1095,22 @@ export function installConnector(options: InstallOptions): InstallResult {
     const notes: string[] = [];
     notes.push(`Updated Hermes config: ${yamlResult.configPath}`);
 
+    // If a migrated default-profile install now writes to Hermes' root config,
+    // remove stale Remnic credentials from the legacy default profile file too.
+    if (hermesProfile === "default") {
+      const legacyDefaultConfigPath = hermesDefaultProfileConfigPath();
+      if (!sameHermesConfigTarget(yamlResult.configPath, legacyDefaultConfigPath)) {
+        try {
+          const legacyDefaultCleanResult = removeHermesConfigFile(legacyDefaultConfigPath);
+          if (legacyDefaultCleanResult.updated) {
+            notes.push(`Cleaned stale remnic: block from legacy default profile: ${legacyDefaultConfigPath}`);
+          }
+        } catch {
+          notes.push("Note: could not clean stale remnic: block from legacy default profile");
+        }
+      }
+    }
+
     // Clean up the old profile's remnic: block if the profile changed.
     // Compare resolved config paths (not raw strings) so that case-insensitive
     // filesystems (macOS default) don't treat "Research" and "research" as
@@ -1104,7 +1120,7 @@ export function installConnector(options: InstallOptions): InstallResult {
     if (hermesSavedProfile !== undefined) {
       try {
         oldProfileResolvesToDifferentFile =
-          hermesConfigPath(hermesSavedProfile) !== hermesConfigPath(hermesProfile);
+          !sameHermesConfigTarget(hermesConfigPath(hermesSavedProfile), hermesConfigPath(hermesProfile));
       } catch {
         // If either profile fails sanitization the comparison is moot; skip cleanup.
         oldProfileResolvesToDifferentFile = false;
@@ -1769,6 +1785,20 @@ export function removeConnector(connectorId: string): RemoveResult {
       const yamlResult = removeHermesConfig({ profile: storedProfile });
       if (yamlResult.updated) {
         notes.push(`Removed remnic: block from Hermes config: ${yamlResult.configPath}`);
+      } else if (yamlResult.reason?.startsWith("Hermes config cleanup partially failed:")) {
+        const tokenStatus = tokenRevoked
+          ? "the connector registry config was deleted and the token was revoked"
+          : "the connector registry config was deleted but TOKEN REVOCATION ALSO FAILED — " +
+            "inspect ~/.remnic/tokens.json and revoke manually";
+        return {
+          connectorId,
+          configPath,
+          status: "error",
+          message:
+            `Hermes remove partially succeeded: ${tokenStatus}, but ${yamlResult.reason}. ` +
+            `Updated paths: ${yamlResult.configPath}. Manually remove any stale remnic: ` +
+            `block and token material from the failed Hermes config path.`,
+        };
       } else if (yamlResult.skipped) {
         notes.push(`Hermes config cleanup skipped: ${yamlResult.reason}`);
       }
@@ -1837,7 +1867,15 @@ function sanitizeHermesProfile(profile: string): string {
 
 function hermesConfigPath(profile: string): string {
   const safeProfile = sanitizeHermesProfile(profile);
-  const profilesRoot = path.resolve(resolveHomeDir(), ".hermes", "profiles");
+  const hermesRoot = path.resolve(resolveHomeDir(), ".hermes");
+  const rootConfigPath = path.join(hermesRoot, "config.yaml");
+  const profilesRoot = path.join(hermesRoot, "profiles");
+  if (safeProfile === "default") {
+    const defaultProfileDir = path.join(profilesRoot, safeProfile);
+    if (isFile(rootConfigPath) || (!fs.existsSync(rootConfigPath) && !isDirectory(defaultProfileDir))) {
+      return rootConfigPath;
+    }
+  }
   const cfgPath = path.resolve(profilesRoot, safeProfile, "config.yaml");
   // Defense in depth: ensure the resolved path is still under profilesRoot.
   const rel = path.relative(profilesRoot, cfgPath);
@@ -1847,6 +1885,48 @@ function hermesConfigPath(profile: string): string {
     );
   }
   return cfgPath;
+}
+
+function isDirectory(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function hermesConfigTarget(filePath: string): string {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+function sameHermesConfigTarget(leftPath: string, rightPath: string): boolean {
+  return hermesConfigTarget(leftPath) === hermesConfigTarget(rightPath);
+}
+
+function hermesDefaultProfileConfigPath(): string {
+  const hermesRoot = path.resolve(resolveHomeDir(), ".hermes");
+  return path.join(hermesRoot, "profiles", "default", "config.yaml");
+}
+
+function hermesConfigCleanupPaths(profile: string): string[] {
+  const cfgPath = hermesConfigPath(profile);
+  const safeProfile = sanitizeHermesProfile(profile);
+  if (safeProfile !== "default") {
+    return [cfgPath];
+  }
+  return [...new Set([cfgPath, hermesDefaultProfileConfigPath()])];
 }
 
 /**
@@ -1987,7 +2067,7 @@ export function upsertHermesConfig(opts: {
     throw new Error("Invalid Hermes token: contains non-alphanumeric characters");
   }
 
-  if (!fs.existsSync(profileDir)) {
+  if (!isDirectory(profileDir)) {
     return {
       updated: false,
       skipped: true,
@@ -2109,8 +2189,55 @@ export function upsertHermesConfig(opts: {
  * Idempotent — if the block is absent, returns skipped.
  */
 export function removeHermesConfig(opts: { profile: string }): HermesConfigResult {
-  const cfgPath = hermesConfigPath(opts.profile);
+  const cfgPaths = hermesConfigCleanupPaths(opts.profile);
+  const results = cfgPaths.map((cfgPath) => {
+    try {
+      return removeHermesConfigFile(cfgPath);
+    } catch (err) {
+      return {
+        updated: false,
+        skipped: true,
+        reason: `Hermes config cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+        configPath: cfgPath,
+      };
+    }
+  });
+  const updated = results.filter((result) => result.updated);
+  const cleanupFailures = results.filter((result) => result.reason?.startsWith("Hermes config cleanup failed:"));
 
+  if (updated.length > 0) {
+    const updatedPaths = updated.map((result) => result.configPath).join(", ");
+    if (cleanupFailures.length > 0) {
+      const failedPaths = cleanupFailures.map((result) => result.configPath).join(", ");
+      return {
+        updated: false,
+        skipped: true,
+        reason: `Hermes config cleanup partially failed: updated ${updatedPaths}; failed ${failedPaths}`,
+        configPath: `${updatedPaths}; failed: ${failedPaths}`,
+      };
+    }
+    return {
+      updated: true,
+      skipped: false,
+      configPath: updatedPaths,
+    };
+  }
+
+  const cleanupFailure = cleanupFailures[0];
+  if (cleanupFailure) {
+    return cleanupFailure;
+  }
+
+  const existingWithoutBlock = results.find((result) => result.reason !== "Hermes config.yaml not found");
+  return existingWithoutBlock ?? results[0] ?? {
+    updated: false,
+    skipped: true,
+    reason: "Hermes config.yaml not found",
+    configPath: hermesConfigPath(opts.profile),
+  };
+}
+
+function removeHermesConfigFile(cfgPath: string): HermesConfigResult {
   if (!fs.existsSync(cfgPath)) {
     return {
       updated: false,

--- a/tests/integration/connectors-hermes.test.ts
+++ b/tests/integration/connectors-hermes.test.ts
@@ -166,6 +166,389 @@ test("upsertHermesConfig creates config.yaml when profile dir exists but file do
   });
 });
 
+test("upsertHermesConfig supports Hermes default root config.yaml layout", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        const hermesDir = path.join(tmpHome, ".hermes");
+        fs.mkdirSync(hermesDir, { recursive: true });
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        fs.writeFileSync(rootCfgPath, "model:\n  provider: anthropic\n", { mode: 0o600 });
+
+        const result = mod.upsertHermesConfig({
+          profile: "default",
+          host: "127.0.0.1",
+          port: 4318,
+          token: "remnic_hm_SYNTHETICROOTCONFIG",
+        });
+
+        assert.equal(result.updated, true, "root config update must report updated");
+        assert.equal(result.skipped, false, "root config update must not skip");
+        assert.equal(result.configPath, rootCfgPath, "default profile should target ~/.hermes/config.yaml");
+
+        const written = fs.readFileSync(rootCfgPath, "utf-8");
+        assert.ok(written.includes("model:"), "existing root Hermes config must be preserved");
+        assert.ok(written.includes("remnic:"), "root config must receive remnic block");
+        assert.ok(written.includes("remnic_hm_SYNTHETICROOTCONFIG"), "root config must receive token");
+        assert.ok(
+          !fs.existsSync(path.join(hermesDir, "profiles", "default", "config.yaml")),
+          "default profile config must not be created when Hermes uses root config",
+        );
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("upsertHermesConfig treats non-directory default profile path as root-layout Hermes", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        const hermesDir = path.join(tmpHome, ".hermes");
+        fs.mkdirSync(path.join(hermesDir, "profiles"), { recursive: true });
+        fs.writeFileSync(path.join(hermesDir, "profiles", "default"), "not a directory");
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        fs.writeFileSync(rootCfgPath, "model:\n  provider: anthropic\n", { mode: 0o600 });
+
+        const result = mod.upsertHermesConfig({
+          profile: "default",
+          host: "127.0.0.1",
+          port: 4318,
+          token: "remnic_hm_SYNTHETICFILEPROFILE",
+        });
+
+        assert.equal(result.updated, true, "root config update must report updated");
+        assert.equal(result.configPath, rootCfgPath, "file-valued default profile path must fall back to root config");
+        assert.ok(
+          fs.readFileSync(rootCfgPath, "utf-8").includes("remnic_hm_SYNTHETICFILEPROFILE"),
+          "root config must receive the token instead of throwing ENOTDIR",
+        );
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("upsertHermesConfig falls back to default profile when root config path is not a file", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        const hermesDir = path.join(tmpHome, ".hermes");
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        const legacyProfileDir = path.join(hermesDir, "profiles", "default");
+        const legacyCfgPath = path.join(legacyProfileDir, "config.yaml");
+        fs.mkdirSync(rootCfgPath, { recursive: true });
+        fs.mkdirSync(legacyProfileDir, { recursive: true });
+        fs.writeFileSync(legacyCfgPath, "model:\n  provider: anthropic\n", { mode: 0o600 });
+
+        const result = mod.upsertHermesConfig({
+          profile: "default",
+          host: "127.0.0.1",
+          port: 4318,
+          token: "remnic_hm_SYNTHETICROOTDIR",
+        });
+
+        assert.equal(result.updated, true, "legacy default profile update must report updated");
+        assert.equal(result.configPath, legacyCfgPath, "directory-valued root config path must not be selected");
+        assert.ok(
+          fs.readFileSync(legacyCfgPath, "utf-8").includes("remnic_hm_SYNTHETICROOTDIR"),
+          "legacy profile config must receive the token instead of throwing EISDIR",
+        );
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("removeHermesConfig cleans root and legacy default profile configs", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        const hermesDir = path.join(tmpHome, ".hermes");
+        const legacyProfileDir = path.join(hermesDir, "profiles", "default");
+        fs.mkdirSync(legacyProfileDir, { recursive: true });
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        const legacyCfgPath = path.join(legacyProfileDir, "config.yaml");
+        const rootToken = "remnic_hm_SYNTHETICROOTREMOVE";
+        const legacyToken = "remnic_hm_SYNTHETICLEGACYREMOVE";
+
+        fs.writeFileSync(
+          rootCfgPath,
+          `model:\n  provider: anthropic\nremnic:\n  host: "127.0.0.1"\n  port: 4318\n  token: "${rootToken}"\n`,
+          { mode: 0o600 },
+        );
+        fs.writeFileSync(
+          legacyCfgPath,
+          `plugins:\n  - remnic\nremnic:\n  host: "127.0.0.1"\n  port: 4318\n  token: "${legacyToken}"\n`,
+          { mode: 0o600 },
+        );
+
+        const result = mod.removeHermesConfig({ profile: "default" });
+
+        assert.equal(result.updated, true, "removeHermesConfig must update when either config has remnic");
+        assert.ok(result.configPath.includes(rootCfgPath), "cleanup should include root config");
+        assert.ok(result.configPath.includes(legacyCfgPath), "cleanup should include legacy default profile config");
+        const rootAfter = fs.readFileSync(rootCfgPath, "utf-8");
+        const legacyAfter = fs.readFileSync(legacyCfgPath, "utf-8");
+        assert.ok(!rootAfter.includes("remnic:"), "root remnic block must be removed");
+        assert.ok(!legacyAfter.includes("remnic:"), "legacy profile remnic block must be removed");
+        assert.ok(!legacyAfter.includes(legacyToken), "legacy token material must be removed");
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("removeHermesConfig continues default cleanup when one candidate path fails", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        const hermesDir = path.join(tmpHome, ".hermes");
+        const legacyProfileDir = path.join(hermesDir, "profiles", "default");
+        fs.mkdirSync(legacyProfileDir, { recursive: true });
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        const legacyCfgPath = path.join(legacyProfileDir, "config.yaml");
+        const rootToken = "remnic_hm_SYNTHETICROOTCONTINUE";
+
+        fs.writeFileSync(
+          rootCfgPath,
+          `model:\n  provider: anthropic\nremnic:\n  host: "127.0.0.1"\n  port: 4318\n  token: "${rootToken}"\n`,
+          { mode: 0o600 },
+        );
+        fs.mkdirSync(legacyCfgPath, { recursive: true });
+
+        const result = mod.removeHermesConfig({ profile: "default" });
+
+        assert.equal(result.updated, false, "partial cleanup must not be mistaken for full success");
+        assert.equal(result.skipped, true, "partial cleanup must be surfaced as a non-success cleanup result");
+        assert.ok(result.configPath.includes(rootCfgPath), "cleanup should include the successfully updated root config");
+        assert.ok(result.configPath.includes(legacyCfgPath), "cleanup should identify the failed legacy config path");
+        assert.match(
+          result.reason ?? "",
+          /Hermes config cleanup partially failed/,
+          "partial cleanup failures must be surfaced even when another path was updated",
+        );
+        const rootAfter = fs.readFileSync(rootCfgPath, "utf-8");
+        assert.ok(!rootAfter.includes("remnic:"), "root remnic block must be removed despite bad legacy path");
+        assert.ok(!rootAfter.includes(rootToken), "root token material must be removed despite bad legacy path");
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("removeHermesConfig surfaces cleanup failure when no candidate was updated", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        const hermesDir = path.join(tmpHome, ".hermes");
+        const legacyProfileDir = path.join(hermesDir, "profiles", "default");
+        fs.mkdirSync(legacyProfileDir, { recursive: true });
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        const legacyCfgPath = path.join(legacyProfileDir, "config.yaml");
+
+        fs.writeFileSync(rootCfgPath, "model:\n  provider: anthropic\n", { mode: 0o600 });
+        fs.mkdirSync(legacyCfgPath, { recursive: true });
+
+        const result = mod.removeHermesConfig({ profile: "default" });
+
+        assert.equal(result.updated, false, "cleanup must not report updated when no file changed");
+        assert.equal(result.skipped, true, "cleanup failure should still be a skipped cleanup result");
+        assert.match(
+          result.reason ?? "",
+          /Hermes config cleanup failed:/,
+          "cleanup failure must not be hidden by a benign no-block result",
+        );
+        assert.equal(result.configPath, legacyCfgPath, "failure should identify the bad config path");
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("removeConnector hermes reports error when config cleanup partially fails", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        mod.removeConnector("hermes");
+        const hermesDir = path.join(tmpHome, ".hermes");
+        const legacyProfileDir = path.join(hermesDir, "profiles", "default");
+        fs.mkdirSync(legacyProfileDir, { recursive: true });
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        const legacyCfgPath = path.join(legacyProfileDir, "config.yaml");
+        fs.writeFileSync(rootCfgPath, "memory:\n  provider: builtin\n", { mode: 0o600 });
+
+        const install = mod.installConnector({
+          connectorId: "hermes",
+          config: { host: "127.0.0.1", port: 4318 },
+        });
+        assert.equal(install.status, "installed", install.message);
+
+        fs.mkdirSync(legacyCfgPath, { recursive: true });
+
+        const removed = mod.removeConnector("hermes");
+
+        assert.equal(removed.status, "error", "partial Hermes config cleanup must be an error result");
+        assert.match(removed.message, /Hermes remove partially succeeded/);
+        assert.match(removed.message, /Hermes config cleanup partially failed/);
+        assert.ok(removed.message.includes(legacyCfgPath), "message must identify the failed legacy config path");
+
+        const rootAfter = fs.readFileSync(rootCfgPath, "utf-8");
+        assert.ok(!rootAfter.includes("remnic:"), "successful cleanup path should still be cleaned");
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("installConnector hermes succeeds against default root config.yaml layout", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        mod.removeConnector("hermes");
+        const hermesDir = path.join(tmpHome, ".hermes");
+        fs.mkdirSync(hermesDir, { recursive: true });
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        fs.writeFileSync(rootCfgPath, "memory:\n  provider: builtin\n", { mode: 0o600 });
+
+        const install = mod.installConnector({
+          connectorId: "hermes",
+          config: { host: "127.0.0.1", port: 4318 },
+        });
+
+        assert.equal(install.status, "installed", install.message);
+        assert.ok(install.message.includes(rootCfgPath), "install message should point at root config.yaml");
+
+        const written = fs.readFileSync(rootCfgPath, "utf-8");
+        assert.ok(written.includes("memory:"), "existing Hermes root config must be preserved");
+        assert.ok(written.includes("remnic:"), "install must write remnic block to root config");
+        assert.ok(written.includes("remnic_hm_"), "install must write generated Hermes token to root config");
+        assert.ok(
+          !fs.existsSync(path.join(hermesDir, "profiles", "default", "config.yaml")),
+          "install must not require or create ~/.hermes/profiles/default/config.yaml",
+        );
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("installConnector hermes cleans legacy default remnic block when switching to root config", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        mod.removeConnector("hermes");
+        const hermesDir = path.join(tmpHome, ".hermes");
+        const legacyProfileDir = path.join(hermesDir, "profiles", "default");
+        fs.mkdirSync(legacyProfileDir, { recursive: true });
+        const legacyCfgPath = path.join(legacyProfileDir, "config.yaml");
+
+        const install1 = mod.installConnector({
+          connectorId: "hermes",
+          config: { host: "127.0.0.1", port: 4318 },
+        });
+        assert.equal(install1.status, "installed", install1.message);
+
+        const legacyBefore = fs.readFileSync(legacyCfgPath, "utf-8");
+        assert.ok(legacyBefore.includes("remnic:"), "legacy default profile must receive first install");
+        assert.ok(legacyBefore.includes("remnic_hm_"), "legacy default profile must contain first token");
+
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        fs.writeFileSync(rootCfgPath, "memory:\n  provider: builtin\n", { mode: 0o600 });
+
+        const install2 = mod.installConnector({
+          connectorId: "hermes",
+          force: true,
+          config: { host: "127.0.0.1", port: 4318 },
+        });
+
+        assert.equal(install2.status, "installed", install2.message);
+        assert.ok(install2.message.includes(rootCfgPath), "force reinstall should write to root config");
+
+        const rootAfter = fs.readFileSync(rootCfgPath, "utf-8");
+        assert.ok(rootAfter.includes("memory:"), "root Hermes config must be preserved");
+        assert.ok(rootAfter.includes("remnic:"), "root Hermes config must receive remnic block");
+        assert.ok(rootAfter.includes("remnic_hm_"), "root Hermes config must contain replacement token");
+
+        const legacyAfter = fs.readFileSync(legacyCfgPath, "utf-8");
+        assert.ok(!legacyAfter.includes("remnic:"), "legacy default profile remnic block must be removed");
+        assert.ok(!legacyAfter.includes("remnic_hm_"), "legacy default profile stale token must be removed");
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+test("installConnector hermes does not clean legacy default symlink to active root config", async () => {
+  const mod = await import("../../packages/remnic-core/src/connectors/index.ts");
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      withTempHome((tmpHome) => {
+        mod.removeConnector("hermes");
+        const hermesDir = path.join(tmpHome, ".hermes");
+        const legacyProfileDir = path.join(hermesDir, "profiles", "default");
+        fs.mkdirSync(legacyProfileDir, { recursive: true });
+        const rootCfgPath = path.join(hermesDir, "config.yaml");
+        const legacyCfgPath = path.join(legacyProfileDir, "config.yaml");
+        fs.writeFileSync(rootCfgPath, "memory:\n  provider: builtin\n", { mode: 0o600 });
+        fs.symlinkSync(rootCfgPath, legacyCfgPath);
+
+        const install = mod.installConnector({
+          connectorId: "hermes",
+          config: { host: "127.0.0.1", port: 4318 },
+        });
+
+        assert.equal(install.status, "installed", install.message);
+        assert.ok(install.message.includes(rootCfgPath), "install should write to root config");
+        const rootAfter = fs.readFileSync(rootCfgPath, "utf-8");
+        assert.ok(rootAfter.includes("memory:"), "root Hermes config must be preserved");
+        assert.ok(rootAfter.includes("remnic:"), "root remnic block must remain after compatibility symlink cleanup");
+        assert.ok(rootAfter.includes("remnic_hm_"), "root Hermes config must retain generated token");
+      });
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
 test("upsertHermesConfig round-trip: existing YAML with other keys is preserved", () => {
   withTempHome((tmpHome) => {
     const profileDir = path.join(tmpHome, ".hermes", "profiles", "default");


### PR DESCRIPTION
## Summary
- support the current Hermes default `~/.hermes/config.yaml` layout for the default profile
- preserve named profile installs under `~/.hermes/profiles/<profile>/config.yaml`
- add regression coverage for direct upsert and `remnic connectors install hermes` against the root config layout

Fixes part of #859.

## Verification
- pnpm exec tsx --test tests/integration/connectors-hermes.test.ts
- pnpm --filter @remnic/core run build
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Hermes connector install/remove to target either `~/.hermes/config.yaml` or the legacy profile file, including new multi-path cleanup and symlink/realpath comparisons; mistakes could leave stale tokens/config blocks behind or clean the wrong file on some filesystems.
> 
> **Overview**
> Hermes connector install now supports Hermes Agent’s default root config layout by resolving the `default` profile to `~/.hermes/config.yaml` when appropriate, while continuing to use `~/.hermes/profiles/<profile>/config.yaml` for named profiles.
> 
> Removal and post-install cleanup were updated to handle *both* possible default config locations, compare targets via realpath to avoid case/symlink issues, and surface partial-cleanup failures as errors (with updated user-facing paths in messages).
> 
> Adds extensive integration tests covering root-layout installs, fallback behavior when paths are files/dirs, legacy-default cleanup, partial cleanup failure reporting, and end-to-end `installConnector`/`removeConnector` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3549aaed93da67b4dfefe8cb1741aafc2c2a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->