### PR TITLE
feat(bench): harden BEAM visible cue recall

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -321,6 +321,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           maxChars: Math.min(CORE_EXPLICIT_CUE_MAX_CHARS, Math.floor(budget * 0.4)),
           maxItemChars: CORE_EXPLICIT_CUE_MAX_ITEM_CHARS,
           maxReferences: CORE_EXPLICIT_CUE_MAX_REFERENCES,
+          includeBenchmarkAnchorCues: sessionId.startsWith("beam-"),
           includeStructuredPlanCues: sessionId.startsWith("arena-"),
         });
         if (exactReferenceEvidence) {

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -924,10 +924,13 @@ function buildMessages(
   turns: BeamChatTurn[],
   anchors?: BeamSessionAnchorInput,
 ): Message[] {
-  const messages = turns.map((turn) => ({
-    role: normalizeRole(turn.role),
-    content: turn.content,
-  }));
+  const messages = turns.map((turn) => {
+    const turnAnchor = buildBeamTurnAnchor(turn);
+    return {
+      role: normalizeRole(turn.role),
+      content: turnAnchor ? `${turnAnchor}\n${turn.content}` : turn.content,
+    };
+  });
   if (!anchors || messages.length === 0) {
     return messages;
   }
@@ -961,16 +964,24 @@ function buildBeamAnchorMessage(input: BeamSessionAnchorInput): Message {
     .filter((id) => id.length > 0);
   if (chatIds.length > 0) {
     fields.push(`chat_ids=${chatIds.join(",")}`);
-    for (const chatId of chatIds) {
-      fields.push(`chat_id=${chatId}`);
-      fields.push(`source_chat_id=${chatId}`);
-    }
   }
 
   return {
     role: "system",
     content: `BEAM evidence anchors: ${fields.join("; ")}`,
   };
+}
+
+function buildBeamTurnAnchor(turn: BeamChatTurn): string | undefined {
+  const id = turn.id;
+  if (typeof id !== "string" && typeof id !== "number") {
+    return undefined;
+  }
+  const chatId = String(id).trim();
+  if (chatId.length === 0) {
+    return undefined;
+  }
+  return `BEAM turn anchors: chat_id=${chatId}; source_chat_id=${chatId}`;
 }
 
 function normalizeRole(role: string): Message["role"] {

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -928,7 +928,7 @@ function buildMessages(
     role: normalizeRole(turn.role),
     content: turn.content,
   }));
-  if (!anchors) {
+  if (!anchors || messages.length === 0) {
     return messages;
   }
   return [buildBeamAnchorMessage(anchors), ...messages];

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -94,6 +94,19 @@ interface BeamSession {
   messages: Message[];
 }
 
+interface BeamSessionAnchorInput {
+  sessionId: string;
+  scale: string;
+  conversationId: string;
+  kind: "main" | "plan";
+  planId?: string;
+  mapPlanId?: string;
+  mapIndex?: number;
+  batchIndex?: number;
+  turnBatchIndex?: number;
+  turns: BeamChatTurn[];
+}
+
 interface BeamDatasetSource {
   totalTasks?: number;
   entries(): AsyncIterable<BeamDatasetEntry>;
@@ -754,17 +767,36 @@ function collectSessions(
 
   if (isPlanChatMapCollection(conversation.chat)) {
     flattenPlanChatMapCollection(conversation.chat).forEach((batch) => {
+      const sessionId =
+        `beam-${scale}-${conversationId}-main-${batch.planId}-${batch.mapIndex + 1}-${batch.batchIndex + 1}-${batch.turnBatchIndex + 1}`;
       sessions.push({
-        sessionId:
-          `beam-${scale}-${conversationId}-main-${batch.planId}-${batch.mapIndex + 1}-${batch.batchIndex + 1}-${batch.turnBatchIndex + 1}`,
-        messages: buildMessages(batch.turns),
+        sessionId,
+        messages: buildMessages(batch.turns, {
+          sessionId,
+          scale,
+          conversationId,
+          kind: "main",
+          mapPlanId: batch.planId,
+          mapIndex: batch.mapIndex,
+          batchIndex: batch.batchIndex,
+          turnBatchIndex: batch.turnBatchIndex,
+          turns: batch.turns,
+        }),
       });
     });
   } else {
     flattenChatCollection(conversation.chat).forEach((batch, batchIndex) => {
+      const sessionId = `beam-${scale}-${conversationId}-main-${batchIndex + 1}`;
       sessions.push({
-        sessionId: `beam-${scale}-${conversationId}-main-${batchIndex + 1}`,
-        messages: buildMessages(batch),
+        sessionId,
+        messages: buildMessages(batch, {
+          sessionId,
+          scale,
+          conversationId,
+          kind: "main",
+          batchIndex,
+          turns: batch,
+        }),
       });
     });
   }
@@ -776,20 +808,43 @@ function collectSessions(
 
     if (isPlanChatMapCollection(plan.chat)) {
       flattenPlanChatMapCollection(plan.chat).forEach((batch) => {
+        const planId = String(plan.plan_id ?? planIndex);
+        const sessionId =
+          `beam-${scale}-${conversationId}-plan-${planId}-${batch.planId}-${batch.mapIndex + 1}-${batch.batchIndex + 1}-${batch.turnBatchIndex + 1}`;
         sessions.push({
-          sessionId:
-            `beam-${scale}-${conversationId}-plan-${String(plan.plan_id ?? planIndex)}-${batch.planId}-${batch.mapIndex + 1}-${batch.batchIndex + 1}-${batch.turnBatchIndex + 1}`,
-          messages: buildMessages(batch.turns),
+          sessionId,
+          messages: buildMessages(batch.turns, {
+            sessionId,
+            scale,
+            conversationId,
+            kind: "plan",
+            planId,
+            mapPlanId: batch.planId,
+            mapIndex: batch.mapIndex,
+            batchIndex: batch.batchIndex,
+            turnBatchIndex: batch.turnBatchIndex,
+            turns: batch.turns,
+          }),
         });
       });
       return;
     }
 
     flattenChatCollection(plan.chat).forEach((batch, batchIndex) => {
+      const planId = String(plan.plan_id ?? planIndex);
+      const sessionId =
+        `beam-${scale}-${conversationId}-plan-${planId}-${batchIndex + 1}`;
       sessions.push({
-        sessionId:
-          `beam-${scale}-${conversationId}-plan-${String(plan.plan_id ?? planIndex)}-${batchIndex + 1}`,
-        messages: buildMessages(batch),
+        sessionId,
+        messages: buildMessages(batch, {
+          sessionId,
+          scale,
+          conversationId,
+          kind: "plan",
+          planId,
+          batchIndex,
+          turns: batch,
+        }),
       });
     });
   });
@@ -865,11 +920,57 @@ function comparePlanIds(left: string, right: string): number {
   return left.localeCompare(right);
 }
 
-function buildMessages(turns: BeamChatTurn[]): Message[] {
-  return turns.map((turn) => ({
+function buildMessages(
+  turns: BeamChatTurn[],
+  anchors?: BeamSessionAnchorInput,
+): Message[] {
+  const messages = turns.map((turn) => ({
     role: normalizeRole(turn.role),
     content: turn.content,
   }));
+  if (!anchors) {
+    return messages;
+  }
+  return [buildBeamAnchorMessage(anchors), ...messages];
+}
+
+function buildBeamAnchorMessage(input: BeamSessionAnchorInput): Message {
+  const fields = [
+    `session_id=${input.sessionId}`,
+    `scale=${input.scale}`,
+    `conversation_id=${input.conversationId}`,
+    `kind=${input.kind}`,
+    `batch=${input.batchIndex === undefined ? 1 : input.batchIndex + 1}`,
+  ];
+  if (input.planId !== undefined) {
+    fields.push(`plan_id=${input.planId}`);
+  }
+  if (input.mapPlanId !== undefined) {
+    fields.push(`map_plan_id=${input.mapPlanId}`);
+  }
+  if (input.mapIndex !== undefined) {
+    fields.push(`map_index=${input.mapIndex + 1}`);
+  }
+  if (input.turnBatchIndex !== undefined) {
+    fields.push(`turn_batch=${input.turnBatchIndex + 1}`);
+  }
+  const chatIds = input.turns
+    .map((turn) => turn.id)
+    .filter((id): id is string | number => typeof id === "string" || typeof id === "number")
+    .map((id) => String(id).trim())
+    .filter((id) => id.length > 0);
+  if (chatIds.length > 0) {
+    fields.push(`chat_ids=${chatIds.join(",")}`);
+    for (const chatId of chatIds.slice(0, 16)) {
+      fields.push(`chat_id=${chatId}`);
+      fields.push(`source_chat_id=${chatId}`);
+    }
+  }
+
+  return {
+    role: "system",
+    content: `BEAM evidence anchors: ${fields.join("; ")}`,
+  };
 }
 
 function normalizeRole(role: string): Message["role"] {

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -961,7 +961,7 @@ function buildBeamAnchorMessage(input: BeamSessionAnchorInput): Message {
     .filter((id) => id.length > 0);
   if (chatIds.length > 0) {
     fields.push(`chat_ids=${chatIds.join(",")}`);
-    for (const chatId of chatIds.slice(0, 16)) {
+    for (const chatId of chatIds) {
       fields.push(`chat_id=${chatId}`);
       fields.push(`source_chat_id=${chatId}`);
     }

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -151,6 +151,10 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
     ["chat_id=27", "chat-27"].sort((left, right) => left.localeCompare(right)),
   );
   assert.deepEqual(
+    collectBenchmarkAnchorCues("Using chat id 27 late-arriving evidence, who owns it?"),
+    ["chat_id=27", "chat-27"].sort((left, right) => left.localeCompare(right)),
+  );
+  assert.deepEqual(
     collectLexicalCues("What city does the user live in now?"),
     ["city", "now"],
   );

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -147,6 +147,10 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
     ),
   );
   assert.deepEqual(
+    collectBenchmarkAnchorCues("Using chat id 27, who owns the late evidence?"),
+    ["chat_id=27", "chat-27"].sort((left, right) => left.localeCompare(right)),
+  );
+  assert.deepEqual(
     collectLexicalCues("What city does the user live in now?"),
     ["city", "now"],
   );

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -137,6 +137,10 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
     ].sort((left, right) => left.localeCompare(right)),
   );
   assert.deepEqual(
+    collectBenchmarkAnchorCues("Use chat id 7."),
+    ["chat_id=7", "chat-7"],
+  );
+  assert.deepEqual(
     collectLexicalCues("What city does the user live in now?"),
     ["city", "now"],
   );

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -194,6 +194,7 @@ test("buildExplicitCueRecallSection searches benchmark anchor cues", async () =>
     sessionId: "beam",
     query: "For information extraction, use plan plan-1 and chat id 7.",
     maxChars: 2000,
+    includeBenchmarkAnchorCues: true,
   });
 
   assert.match(section, /plan-specific deployment owner is Nia/);

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildExplicitCueRecallSection,
+  collectBenchmarkAnchorCues,
   collectExplicitTurnReferences,
   collectLexicalCues,
   collectQuestionSlotCues,
@@ -123,6 +124,19 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
     ["city"],
   );
   assert.deepEqual(
+    collectBenchmarkAnchorCues("Use plan 1, chat id 7, and source chat 8 for information extraction."),
+    [
+      "ability=information_extraction",
+      "chat-7",
+      "chat_id=7",
+      "plan-1",
+      "plan_id=1",
+      "source_chat-8",
+      "source_chat_id=8",
+      "chat_id=8",
+    ].sort((left, right) => left.localeCompare(right)),
+  );
+  assert.deepEqual(
     collectLexicalCues("What city does the user live in now?"),
     ["city", "now"],
   );
@@ -144,6 +158,31 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
     }),
     ["accommodation", "dinner", "Jennifer", "join", "same"],
   );
+});
+
+test("buildExplicitCueRecallSection searches benchmark anchor cues", async () => {
+  const engine = new FakeCueEngine({
+    beam: [
+      {
+        role: "system",
+        content:
+          "BEAM evidence anchors: session_id=beam-100K-demo-plan-plan-1-1; plan_id=plan-1; chat_id=7; ability=information_extraction",
+      },
+      {
+        role: "user",
+        content: "The plan-specific deployment owner is Nia.",
+      },
+    ],
+  });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "beam",
+    query: "For information extraction, use plan plan-1 and chat id 7.",
+    maxChars: 2000,
+  });
+
+  assert.match(section, /plan-specific deployment owner is Nia/);
 });
 
 test("buildExplicitCueRecallSection expands paired action and observation references", async () => {

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -124,7 +124,7 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
     ["city"],
   );
   assert.deepEqual(
-    collectBenchmarkAnchorCues("Use plan 1, chat id 7, and source chat 8 for information extraction."),
+    collectBenchmarkAnchorCues("Use plan 1, chat ids 7, and source chat ids 8 for information extraction."),
     [
       "ability=information_extraction",
       "chat-7",

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -138,7 +138,13 @@ test("collectLexicalCues extracts visible ids, dates, and bracket labels", () =>
   );
   assert.deepEqual(
     collectBenchmarkAnchorCues("Use chat id 7."),
-    ["chat_id=7", "chat-7"],
+    ["chat_id=7", "chat-7"].sort((left, right) => left.localeCompare(right)),
+  );
+  assert.deepEqual(
+    collectBenchmarkAnchorCues("Use chat ids 7 and 8 for the answer."),
+    ["chat_id=7", "chat-7", "chat_id=8", "chat-8"].sort((left, right) =>
+      left.localeCompare(right),
+    ),
   );
   assert.deepEqual(
     collectLexicalCues("What city does the user live in now?"),

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -505,23 +505,79 @@ export function collectBenchmarkAnchorCues(query: string): string[] {
     }
   }
 
-  for (const match of query.matchAll(
-    /\b(source(?:\s+chat)?|chat|plan|rubric|ability)\s+(?:id\s+)?([A-Za-z0-9][A-Za-z0-9_.:-]{0,80})\b/gi,
-  )) {
-    const rawPrefix = match[1]?.toLowerCase().replace(/\s+/g, "_");
-    const rawValue = match[2]?.replace(/[.,;:!?]+$/g, "");
-    if (!rawPrefix || !rawValue) {
+  const tokens = tokenizeAnchorQuery(query);
+  for (let index = 0; index < tokens.length; index += 1) {
+    let prefix = normalizeBenchmarkAnchorPrefix(tokens[index]);
+    if (!prefix) {
       continue;
     }
-    const prefix = rawPrefix === "source_chat" ? "source_chat" : rawPrefix;
+
+    let valueIndex = index + 1;
+    if (
+      prefix === "source" &&
+      tokens[valueIndex]?.toLowerCase() === "chat"
+    ) {
+      prefix = "source_chat";
+      valueIndex += 1;
+    }
+    const maybeIdLabel = tokens[valueIndex]?.toLowerCase();
+    if (maybeIdLabel === "id" || maybeIdLabel === "ids") {
+      valueIndex += 1;
+    }
+
+    const rawValue = tokens[valueIndex];
+    if (!rawValue || normalizeBenchmarkAnchorPrefix(rawValue)) {
+      continue;
+    }
     cues.add(`${prefix}_id=${rawValue}`);
     cues.add(`${prefix}-${rawValue}`);
     if (prefix === "source_chat") {
       cues.add(`chat_id=${rawValue}`);
     }
+    index = valueIndex;
   }
 
   return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeBenchmarkAnchorPrefix(token: string | undefined): string | undefined {
+  switch (token?.toLowerCase()) {
+    case "ability":
+    case "chat":
+    case "plan":
+    case "rubric":
+    case "source":
+      return token.toLowerCase();
+    default:
+      return undefined;
+  }
+}
+
+function tokenizeAnchorQuery(query: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  const push = () => {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = "";
+    }
+  };
+
+  for (const char of query) {
+    if (
+      isAsciiLetterOrDigit(char) ||
+      char === "_" ||
+      char === "-" ||
+      char === "." ||
+      char === ":"
+    ) {
+      current += char;
+      continue;
+    }
+    push();
+  }
+  push();
+  return tokens;
 }
 
 export function collectStructuredPlanCues(query: string): string[] {

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -82,6 +82,13 @@ const STRUCTURED_PLAN_DEPENDENCY_CUES = new Set([
   "same",
   "shared",
 ]);
+const BENCHMARK_ABILITY_CUES = new Map([
+  ["information extraction", "ability=information_extraction"],
+  ["knowledge update", "ability=knowledge_update"],
+  ["multi session reasoning", "ability=multi_session_reasoning"],
+  ["multi-session reasoning", "ability=multi_session_reasoning"],
+  ["instruction following", "ability=instruction_following"],
+]);
 const RELATIVE_TEMPORAL_CUES = [
   "as of",
   "most recent",
@@ -449,6 +456,9 @@ export function collectLexicalCues(
   for (const cue of collectQuestionSlotCues(query)) {
     cues.add(cue);
   }
+  for (const cue of collectBenchmarkAnchorCues(query)) {
+    cues.add(cue);
+  }
   if (options.includeStructuredPlanCues) {
     for (const cue of collectStructuredPlanCues(query)) {
       cues.add(cue);
@@ -483,6 +493,34 @@ export function collectQuestionSlotCues(query: string): string[] {
       cues.add(value);
     }
   }
+  return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+export function collectBenchmarkAnchorCues(query: string): string[] {
+  const cues = new Set<string>();
+  const normalizedQuery = query.toLowerCase().replace(/\s+/g, " ");
+  for (const [phrase, cue] of BENCHMARK_ABILITY_CUES) {
+    if (containsBoundedPhrase(normalizedQuery, phrase)) {
+      cues.add(cue);
+    }
+  }
+
+  for (const match of query.matchAll(
+    /\b(source(?:\s+chat)?|chat|plan|rubric|ability)\s+(?:id\s+)?([A-Za-z0-9][A-Za-z0-9_.:-]{0,80})\b/gi,
+  )) {
+    const rawPrefix = match[1]?.toLowerCase().replace(/\s+/g, "_");
+    const rawValue = match[2]?.replace(/[.,;:!?]+$/g, "");
+    if (!rawPrefix || !rawValue) {
+      continue;
+    }
+    const prefix = rawPrefix === "source_chat" ? "source_chat" : rawPrefix;
+    cues.add(`${prefix}_id=${rawValue}`);
+    cues.add(`${prefix}-${rawValue}`);
+    if (prefix === "source_chat") {
+      cues.add(`chat_id=${rawValue}`);
+    }
+  }
+
   return [...cues].sort((left, right) => left.localeCompare(right));
 }
 

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -89,6 +89,20 @@ const BENCHMARK_ABILITY_CUES = new Map([
   ["multi-session reasoning", "ability=multi_session_reasoning"],
   ["instruction following", "ability=instruction_following"],
 ]);
+const BENCHMARK_ANCHOR_VALUE_STOPWORDS = new Set([
+  "a",
+  "about",
+  "an",
+  "for",
+  "from",
+  "in",
+  "on",
+  "the",
+  "to",
+  "use",
+  "using",
+  "with",
+]);
 const RELATIVE_TEMPORAL_CUES = [
   "as of",
   "most recent",
@@ -525,19 +539,45 @@ export function collectBenchmarkAnchorCues(query: string): string[] {
       valueIndex += 1;
     }
 
-    const rawValue = tokens[valueIndex];
-    if (!rawValue || normalizeBenchmarkAnchorPrefix(rawValue)) {
+    let consumedValue = false;
+    for (
+      let currentValueIndex = valueIndex;
+      currentValueIndex < tokens.length;
+      currentValueIndex += 1
+    ) {
+      const rawValue = tokens[currentValueIndex];
+      const normalizedValue = rawValue?.toLowerCase();
+      if (!rawValue || normalizeBenchmarkAnchorPrefix(rawValue)) {
+        break;
+      }
+      if (normalizedValue === "and" || normalizedValue === "or") {
+        continue;
+      }
+      if (BENCHMARK_ANCHOR_VALUE_STOPWORDS.has(normalizedValue)) {
+        break;
+      }
+      addBenchmarkAnchorCues(cues, prefix, rawValue);
+      consumedValue = true;
+      index = currentValueIndex;
+    }
+    if (!consumedValue) {
       continue;
     }
-    cues.add(`${prefix}_id=${rawValue}`);
-    cues.add(`${prefix}-${rawValue}`);
-    if (prefix === "source_chat") {
-      cues.add(`chat_id=${rawValue}`);
-    }
-    index = valueIndex;
   }
 
   return [...cues].sort((left, right) => left.localeCompare(right));
+}
+
+function addBenchmarkAnchorCues(
+  cues: Set<string>,
+  prefix: string,
+  rawValue: string,
+): void {
+  cues.add(`${prefix}_id=${rawValue}`);
+  cues.add(`${prefix}-${rawValue}`);
+  if (prefix === "source_chat") {
+    cues.add(`chat_id=${rawValue}`);
+  }
 }
 
 function normalizeBenchmarkAnchorPrefix(token: string | undefined): string | undefined {

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -557,10 +557,11 @@ function tokenizeAnchorQuery(query: string): string[] {
   const tokens: string[] = [];
   let current = "";
   const push = () => {
-    if (current.length > 0) {
-      tokens.push(current);
-      current = "";
+    const token = trimTrailingAnchorTokenPunctuation(current);
+    if (token.length > 0) {
+      tokens.push(token);
     }
+    current = "";
   };
 
   for (const char of query) {
@@ -578,6 +579,24 @@ function tokenizeAnchorQuery(query: string): string[] {
   }
   push();
   return tokens;
+}
+
+function trimTrailingAnchorTokenPunctuation(token: string): string {
+  let end = token.length;
+  while (end > 0) {
+    const char = token[end - 1];
+    if (
+      char !== "." &&
+      char !== ":" &&
+      char !== ";" &&
+      char !== "!" &&
+      char !== "?"
+    ) {
+      break;
+    }
+    end -= 1;
+  }
+  return token.slice(0, end);
 }
 
 export function collectStructuredPlanCues(query: string): string[] {

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -594,13 +594,7 @@ function addBenchmarkAnchorCues(
 
 function isBenchmarkAnchorValue(token: string): boolean {
   for (const char of token) {
-    if (
-      isAsciiDigitChar(char) ||
-      char === "_" ||
-      char === "-" ||
-      char === "." ||
-      char === ":"
-    ) {
+    if (isAsciiDigitChar(char)) {
       return true;
     }
   }

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -556,6 +556,9 @@ export function collectBenchmarkAnchorCues(query: string): string[] {
       if (BENCHMARK_ANCHOR_VALUE_STOPWORDS.has(normalizedValue)) {
         break;
       }
+      if (!isBenchmarkAnchorValue(rawValue)) {
+        break;
+      }
       addBenchmarkAnchorCues(cues, prefix, rawValue);
       consumedValue = true;
       index = currentValueIndex;
@@ -578,6 +581,26 @@ function addBenchmarkAnchorCues(
   if (prefix === "source_chat") {
     cues.add(`chat_id=${rawValue}`);
   }
+}
+
+function isBenchmarkAnchorValue(token: string): boolean {
+  for (const char of token) {
+    if (
+      isAsciiDigitChar(char) ||
+      char === "_" ||
+      char === "-" ||
+      char === "." ||
+      char === ":"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isAsciiDigitChar(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code >= 48 && code <= 57;
 }
 
 function normalizeBenchmarkAnchorPrefix(token: string | undefined): string | undefined {

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -29,6 +29,7 @@ export interface ExplicitCueRecallOptions {
   maxChars: number;
   maxItemChars?: number;
   maxReferences?: number;
+  includeBenchmarkAnchorCues?: boolean;
   includeStructuredPlanCues?: boolean;
 }
 
@@ -255,6 +256,7 @@ export async function buildExplicitCueRecallSection(
     sessionId: options.sessionId,
     query,
     maxReferences,
+    includeBenchmarkAnchorCues: options.includeBenchmarkAnchorCues,
     includeStructuredPlanCues: options.includeStructuredPlanCues,
     evidenceItems,
     seenTurns,
@@ -332,6 +334,7 @@ async function collectLexicalCueEvidence(options: {
   sessionId?: string;
   query: string;
   maxReferences: number;
+  includeBenchmarkAnchorCues?: boolean;
   includeStructuredPlanCues?: boolean;
   evidenceItems: Array<{
     id: string;
@@ -344,6 +347,7 @@ async function collectLexicalCueEvidence(options: {
   seenTurns: Set<string>;
 }): Promise<void> {
   const cues = collectLexicalCues(options.query, {
+    includeBenchmarkAnchorCues: options.includeBenchmarkAnchorCues,
     includeStructuredPlanCues: options.includeStructuredPlanCues,
   }).slice(0, options.maxReferences);
   const preferLatest = hasLatestStateIntent(options.query);
@@ -454,7 +458,10 @@ export function collectExplicitTurnReferences(
 
 export function collectLexicalCues(
   query: string,
-  options: { includeStructuredPlanCues?: boolean } = {},
+  options: {
+    includeBenchmarkAnchorCues?: boolean;
+    includeStructuredPlanCues?: boolean;
+  } = {},
 ): string[] {
   const cues = new Set<string>();
 
@@ -470,8 +477,10 @@ export function collectLexicalCues(
   for (const cue of collectQuestionSlotCues(query)) {
     cues.add(cue);
   }
-  for (const cue of collectBenchmarkAnchorCues(query)) {
-    cues.add(cue);
+  if (options.includeBenchmarkAnchorCues) {
+    for (const cue of collectBenchmarkAnchorCues(query)) {
+      cues.add(cue);
+    }
   }
   if (options.includeStructuredPlanCues) {
     for (const cue of collectStructuredPlanCues(query)) {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -53,6 +53,7 @@ export {
 export {
   buildExplicitCueRecallSection,
   collectExplicitTurnReferences,
+  collectBenchmarkAnchorCues,
   collectLexicalCues,
   collectQuestionSlotCues,
   collectStructuredPlanCues,

--- a/tests/bench-beam-runner.test.ts
+++ b/tests/bench-beam-runner.test.ts
@@ -292,6 +292,50 @@ test("runBenchmark keeps hidden beam source metadata reporting-only", async () =
   assert.equal(String(task.details.recalledText).includes("hidden-plan-reference"), false);
 });
 
+test("runBenchmark does not create beam sessions for empty turn batches", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-empty-batch-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-empty-batch-1",
+        chat: [
+          [],
+          [
+            {
+              id: 1,
+              role: "user",
+              content: "Only the non-empty batch should become a BEAM session.",
+            },
+          ],
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Which batch should become a BEAM session?",
+              answer: "Only the non-empty batch",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.sessionCount, 1);
+  assert.equal([...adapter.sessions.keys()].length, 1);
+});
+
 test("runBenchmark indexes later beam chat ids as memory evidence", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-chat-cue-"));
   const datasetDir = path.join(tmpDir, "datasets", "beam");

--- a/tests/bench-beam-runner.test.ts
+++ b/tests/bench-beam-runner.test.ts
@@ -79,6 +79,22 @@ class FakeMemoryAdapter implements BenchMemoryAdapter {
   async destroy(): Promise<void> {}
 }
 
+class QueryVisibleBeamAdapter extends FakeMemoryAdapter {
+  readonly recallQueries: Array<{ sessionId: string; query: string }> = [];
+
+  async recall(sessionId: string, query: string): Promise<string> {
+    this.recallQueries.push({ sessionId, query });
+    const messages = this.sessions.get(sessionId) ?? [];
+    const content = messages.map((message) => message.content).join("\n");
+    const visiblePlanMatch = query.match(/\bplan\s+([A-Za-z0-9_.:-]+)/i);
+    if (visiblePlanMatch) {
+      const planId = visiblePlanMatch[1]!.replace(/[.,;:!?]+$/g, "");
+      return content.includes(`plan_id=${planId}`) ? content : "";
+    }
+    return content;
+  }
+}
+
 test("runBenchmark executes beam in quick mode with the bundled smoke fixture", async () => {
   const adapter = new FakeMemoryAdapter();
 
@@ -153,6 +169,124 @@ test("runBenchmark loads beam full-mode datasets and includes 10M plan chats in 
   assert.equal(result.results.tasks[0]?.actual.includes("Micah"), true);
   assert.equal(result.results.tasks[0]?.details.scale, "10M");
   assert.equal(result.results.tasks[0]?.details.sessionCount, 2);
+});
+
+test("runBenchmark stores query-visible beam plan anchors as memory evidence", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-plan-cue-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new QueryVisibleBeamAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-visible-plan-1",
+        chat: [
+          [
+            {
+              id: 1,
+              role: "user",
+              content: "The main chat is unrelated to release approvals.",
+            },
+          ],
+        ],
+        plans: [
+          {
+            plan_id: "plan-needle",
+            chat: [
+              [
+                {
+                  id: 7,
+                  role: "user",
+                  content: "Serena owns release approvals for the visible plan.",
+                },
+              ],
+            ],
+          },
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Using plan plan-needle, who owns release approvals?",
+              answer: "Serena",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual.includes("Serena"), true);
+  assert.match(String(task.details.recalledText), /plan_id=plan-needle/);
+  assert.equal(
+    adapter.recallQueries.every(({ query }) => query.includes("plan-needle")),
+    true,
+  );
+});
+
+test("runBenchmark keeps hidden beam source metadata reporting-only", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-hidden-source-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new QueryVisibleBeamAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-hidden-source-1",
+        chat: [
+          [
+            {
+              id: 1,
+              role: "user",
+              content: "Talia owns release readiness.",
+            },
+          ],
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Who owns release readiness?",
+              answer: "Talia",
+              plan_reference: "hidden-plan-reference",
+              source_chat_ids: ["hidden-source-77"],
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.deepEqual(task.details.sourceChatIds, ["hidden-source-77"]);
+  assert.equal(task.details.planReference, "hidden-plan-reference");
+  assert.equal(
+    adapter.recallQueries.some(({ query }) => query.includes("hidden-source-77")),
+    false,
+  );
+  assert.equal(
+    adapter.recallQueries.some(({ query }) => query.includes("hidden-plan-reference")),
+    false,
+  );
+  assert.equal(String(task.details.recalledText).includes("hidden-source-77"), false);
+  assert.equal(String(task.details.recalledText).includes("hidden-plan-reference"), false);
 });
 
 test("runBenchmark streams beam JSON arrays without misreading braces in strings", async () => {

--- a/tests/bench-beam-runner.test.ts
+++ b/tests/bench-beam-runner.test.ts
@@ -91,6 +91,9 @@ class QueryVisibleBeamAdapter extends FakeMemoryAdapter {
       const planId = visiblePlanMatch[1]!.replace(/[.,;:!?]+$/g, "");
       return content.includes(`plan_id=${planId}`) ? content : "";
     }
+    if (query.toLowerCase().includes("chat id 27")) {
+      return content.includes("chat_id=27") ? content : "";
+    }
     return content;
   }
 }
@@ -287,6 +290,51 @@ test("runBenchmark keeps hidden beam source metadata reporting-only", async () =
   );
   assert.equal(String(task.details.recalledText).includes("hidden-source-77"), false);
   assert.equal(String(task.details.recalledText).includes("hidden-plan-reference"), false);
+});
+
+test("runBenchmark indexes later beam chat ids as memory evidence", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-chat-cue-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new QueryVisibleBeamAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-visible-chat-1",
+        chat: [
+          Array.from({ length: 27 }, (_, index) => ({
+            id: index + 1,
+            role: "user",
+            content:
+              index === 26
+                ? "Marisol owns the late referenced chat evidence."
+                : `Filler BEAM chat turn ${index + 1}.`,
+          })),
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Using chat id 27, who owns the late referenced chat evidence?",
+              answer: "Marisol",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual.includes("Marisol"), true);
+  assert.match(String(task.details.recalledText), /chat_id=27/);
 });
 
 test("runBenchmark streams beam JSON arrays without misreading braces in strings", async () => {


### PR DESCRIPTION
## Summary
- add core benchmark anchor cue extraction for query-visible plan/chat/source ids and BEAM ability phrases
- store BEAM structural provenance anchors as ingested memory evidence instead of routing from hidden probe metadata
- add tests for query-visible plan-id recall and hidden source metadata remaining reporting-only

Closes #847

## Test Plan
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts tests/bench-beam-runner.test.ts
- pnpm exec tsx --test packages/bench/src/benchmarks/published/beam/runner.test.ts
- npm run check-types
- git diff --check
- pnpm exec tsx scripts/bench/bench-smoke.ts --seed 1
- bash scripts/check-review-patterns.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BEAM ingestion/recall behavior by injecting anchor metadata into stored messages and expanding explicit-cue recall to parse benchmark-specific anchors, which could affect benchmark scoring and recall outputs across sessions.
> 
> **Overview**
> Improves BEAM benchmark reliability by **embedding query-visible provenance anchors into stored memory** (a `system` “BEAM evidence anchors” message per session plus per-turn `chat_id`/`source_chat_id` prefixes), so plan/chat IDs referenced in questions can be retrieved via normal recall/search.
> 
> Extends core `buildExplicitCueRecallSection`/`collectLexicalCues` with an opt-in `includeBenchmarkAnchorCues` path that extracts BEAM-style cues (ability phrases plus `plan`/`chat`/`source chat` IDs) and uses them for lexical evidence search; the bench `remnic-adapter` enables this automatically for `beam-*` sessions.
> 
> Adds focused tests ensuring plan/chat-id cues are recallable, hidden BEAM metadata remains reporting-only (not used as recall query text), and empty BEAM turn batches do not produce sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79423c11370eaca7bfef46367fe2053a6f7a1db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->