### PR TITLE
fix(hermes): implement current MemoryProvider interface

### DIFF
--- a/packages/plugin-hermes/plugin.yaml
+++ b/packages/plugin-hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: remnic
-version: 1.0.3
+version: 1.0.4
 description: Universal memory for AI agents — Remnic MemoryProvider integration for Hermes
 author: Joshua Warren
 homepage: https://github.com/joshuaswarren/remnic

--- a/packages/plugin-hermes/pyproject.toml
+++ b/packages/plugin-hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "remnic-hermes"
-version = "1.0.3"
+version = "1.0.4"
 description = "Remnic MemoryProvider plugin for Hermes Agent"
 readme = "README.md"
 license = "MIT"

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import threading
 import uuid
+from collections import OrderedDict
+from concurrent.futures import Future, TimeoutError as FutureTimeoutError
+from time import monotonic
 from typing import Any
 
 from remnic_hermes.client import RemnicClient
 from remnic_hermes.config import RemnicHermesConfig
+
+try:  # Hermes Agent is present when loaded as an installed memory provider.
+    from agent.memory_provider import MemoryProvider as HermesMemoryProvider
+except Exception:  # pragma: no cover - keeps package importable outside Hermes.
+    HermesMemoryProvider = object
 
 
 _NAMESPACE = {"type": "string"}
@@ -54,6 +65,48 @@ _SHARED_FEEDBACK_DECISIONS = ["approved", "approved_with_feedback", "rejected"]
 _SHARED_FEEDBACK_SEVERITIES = ["low", "medium", "high"]
 _GOVERNANCE_MODES = ["shadow", "apply"]
 
+_loop: asyncio.AbstractEventLoop | None = None
+_loop_thread: threading.Thread | None = None
+_loop_lock = threading.Lock()
+
+
+def _get_loop() -> asyncio.AbstractEventLoop:
+    global _loop, _loop_thread
+    with _loop_lock:
+        if _loop is not None and not _loop.is_closed():
+            return _loop
+        loop = asyncio.new_event_loop()
+        _loop = loop
+
+        def _run() -> None:
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        _loop_thread = threading.Thread(target=_run, daemon=True, name="remnic-hermes-loop")
+        _loop_thread.start()
+        return loop
+
+
+def _run_sync(coro: Any, timeout: float) -> Any:
+    future = asyncio.run_coroutine_threadsafe(coro, _get_loop())
+    try:
+        return future.result(timeout=timeout)
+    except FutureTimeoutError as err:
+        future.cancel()
+        raise TimeoutError("Remnic operation timed out") from err
+
+
+def _schedule(coro: Any) -> None:
+    future = asyncio.run_coroutine_threadsafe(coro, _get_loop())
+
+    def _consume_result(done: Any) -> None:
+        try:
+            done.result()
+        except Exception:
+            pass
+
+    future.add_done_callback(_consume_result)
+
 
 def _schema(
     name: str,
@@ -77,7 +130,7 @@ def _legacy_schema(schema: dict[str, Any], name: str, description: str) -> dict[
     return {**schema, "name": name, "description": description}
 
 
-class RemnicMemoryProvider:
+class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
     """MemoryProvider that delegates to the Remnic daemon via HTTP."""
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
@@ -89,9 +142,28 @@ class RemnicMemoryProvider:
         self._configured_session_key = bool(cfg.session_key)
         self._session_key = cfg.session_key or f"hermes-{uuid.uuid4().hex[:12]}"
         self._client: RemnicClient | None = None
+        self._prefetch_cache: OrderedDict[str, tuple[str, float]] = OrderedDict()
+        self._prefetch_inflight: set[str] = set()
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_wait_timeout = min(cfg.timeout, 0.1)
+        self._prefetch_cache_ttl = 60.0
+        self._prefetch_cache_max_entries = 128
 
-    async def initialize(self, config: dict[str, Any] | None = None) -> None:
+    @property
+    def name(self) -> str:
+        return "remnic"
+
+    def is_available(self) -> bool:
+        return bool(self._token)
+
+    def initialize(self, session_id: Any = "", **kwargs: Any) -> None:
         """Connect to Remnic daemon and verify health."""
+        del kwargs
+        if isinstance(session_id, str) and session_id and not self._configured_session_key:
+            self._session_key = session_id
+        _run_sync(self._initialize_async(), self._timeout)
+
+    async def _initialize_async(self) -> None:
         self._client = RemnicClient(
             host=self._host,
             port=self._port,
@@ -105,11 +177,120 @@ class RemnicMemoryProvider:
         except Exception:
             pass  # Non-fatal — daemon might start later.
 
-    async def pre_llm_call(self, messages: list[dict[str, str]]) -> str:
-        """Recall relevant memories and return context to inject into system prompt."""
+    def system_prompt_block(self) -> str:
+        return ""
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
         if not self._client:
             return ""
+        if not query or len(query.split()) < 3:
+            return ""
 
+        session_key = session_id or self._session_key
+        cache_key = f"{session_key}\0{query}"
+        future: Future[Any] | None = None
+        with self._prefetch_lock:
+            cached = self._get_prefetch_cache_locked(cache_key)
+            if cached is not None:
+                return cached
+            if cache_key not in self._prefetch_inflight:
+                future = self._queue_prefetch_locked(cache_key, query, session_key)
+
+        if future is not None:
+            try:
+                return future.result(timeout=self._prefetch_wait_timeout) or ""
+            except FutureTimeoutError:
+                return ""
+            except Exception:
+                return ""
+
+        return ""
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if not self._client:
+            return
+        if not query or len(query.split()) < 3:
+            return
+
+        session_key = session_id or self._session_key
+        cache_key = f"{session_key}\0{query}"
+        with self._prefetch_lock:
+            if self._get_prefetch_cache_locked(cache_key) is not None or cache_key in self._prefetch_inflight:
+                return
+            self._queue_prefetch_locked(cache_key, query, session_key)
+
+    def _get_prefetch_cache_locked(self, cache_key: str) -> str | None:
+        cached = self._prefetch_cache.get(cache_key)
+        if cached is None:
+            return None
+        block, inserted_at = cached
+        if monotonic() - inserted_at > self._prefetch_cache_ttl:
+            self._prefetch_cache.pop(cache_key, None)
+            return None
+        self._prefetch_cache.move_to_end(cache_key)
+        return block
+
+    def _set_prefetch_cache_locked(self, cache_key: str, block: str) -> None:
+        self._prefetch_cache[cache_key] = (block, monotonic())
+        self._prefetch_cache.move_to_end(cache_key)
+        while len(self._prefetch_cache) > self._prefetch_cache_max_entries:
+            self._prefetch_cache.popitem(last=False)
+
+    def _clear_prefetch_cache(self, session_key: str | None = None) -> None:
+        with self._prefetch_lock:
+            if session_key is None:
+                self._prefetch_cache.clear()
+                return
+            prefix = f"{session_key}\0"
+            for cache_key in list(self._prefetch_cache.keys()):
+                if cache_key.startswith(prefix):
+                    self._prefetch_cache.pop(cache_key, None)
+
+    def _queue_prefetch_locked(self, cache_key: str, query: str, session_key: str) -> Future[Any]:
+        self._prefetch_inflight.add(cache_key)
+        future = asyncio.run_coroutine_threadsafe(
+            self._prefetch_async(cache_key, query, session_key),
+            _get_loop(),
+        )
+
+        def _consume_result(done: Future[Any]) -> None:
+            try:
+                done.result()
+            except Exception:
+                pass
+
+        future.add_done_callback(_consume_result)
+        return future
+
+    async def _prefetch_async(self, cache_key: str, query: str, session_key: str) -> str:
+        try:
+            block = await self._recall_block(query=query, session_key=session_key)
+            if block:
+                with self._prefetch_lock:
+                    self._set_prefetch_cache_locked(cache_key, block)
+            return block
+        except Exception:
+            return ""
+        finally:
+            with self._prefetch_lock:
+                self._prefetch_inflight.discard(cache_key)
+
+    async def _recall_block(self, *, query: str, session_key: str) -> str:
+        if not self._client:
+            return ""
+        result = await self._client.recall(
+            query=query,
+            session_key=session_key,
+            top_k=8,
+        )
+        context = result.get("context", "")
+        count = result.get("count", 0)
+        if context and count > 0:
+            return f"<remnic-memory count=\"{count}\">\n{context}\n</remnic-memory>"
+        return ""
+
+    async def pre_llm_call(self, messages: list[dict[str, str]]) -> str:
+        """Recall relevant memories and return context to inject into system prompt."""
         query = ""
         for msg in reversed(messages):
             if msg.get("role") == "user":
@@ -118,51 +299,82 @@ class RemnicMemoryProvider:
 
         if not query or len(query.split()) < 3:
             return ""
-
         try:
-            result = await self._client.recall(
-                query=query,
-                session_key=self._session_key,
-                top_k=8,
-            )
-            context = result.get("context", "")
-            count = result.get("count", 0)
-            if context and count > 0:
-                return f"<remnic-memory count=\"{count}\">\n{context}\n</remnic-memory>"
+            return await self._recall_block(query=query, session_key=self._session_key)
         except Exception:
-            pass
+            return ""
 
-        return ""
-
-    async def sync_turn(self, transcript: list[dict[str, Any]]) -> None:
+    def sync_turn(
+        self,
+        user_content: str | list[dict[str, Any]],
+        assistant_content: str | None = None,
+        *,
+        session_id: str = "",
+    ) -> None:
         """Observe the latest conversation turn."""
-        if not self._client or not transcript:
+        if not self._client:
             return
 
-        recent = transcript[-2:] if len(transcript) >= 2 else transcript
+        if isinstance(user_content, list):
+            if not user_content:
+                return
+            messages = user_content[-2:] if len(user_content) >= 2 else user_content
+        else:
+            messages = [{"role": "user", "content": user_content}]
+            if assistant_content:
+                messages.append({"role": "assistant", "content": assistant_content})
 
-        try:
-            await self._client.observe(
-                session_key=self._session_key,
-                messages=recent,
-            )
-        except Exception:
-            pass
+        session_key = session_id or self._session_key
+        _schedule(self._observe_and_invalidate_async(session_key=session_key, messages=messages))
+
+    async def _observe_and_invalidate_async(self, *, session_key: str, messages: list[dict[str, Any]]) -> None:
+        if not self._client:
+            return
+        await self._client.observe(
+            session_key=session_key,
+            messages=messages,
+        )
+        self._clear_prefetch_cache(session_key)
+
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
+        self._observe_messages(messages)
+
+    def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:
+        self._observe_messages(messages)
+        return ""
 
     async def extract_memories(self, session: dict[str, Any]) -> None:
         """Structured extraction at session end — send full transcript for deep analysis."""
         if not self._client:
             return
-
         messages = session.get("messages", [])
         if not messages:
             return
-
         try:
             await self._client.observe(
                 session_key=self._session_key,
                 messages=messages,
             )
+            self._clear_prefetch_cache(self._session_key)
+        except Exception:
+            pass
+
+    def _observe_messages(self, messages: list[dict[str, Any]]) -> None:
+        if not self._client:
+            return
+
+        if not messages:
+            return
+
+        try:
+            _run_sync(
+                self._client.observe(
+                    session_key=self._session_key,
+                    messages=messages,
+                ),
+                self._timeout,
+            )
+            self._clear_prefetch_cache(self._session_key)
         except Exception:
             pass
 
@@ -181,12 +393,55 @@ class RemnicMemoryProvider:
         normalized = new_session_id.strip()
         if normalized:
             self._session_key = normalized
+            self._clear_prefetch_cache()
 
-    async def shutdown(self) -> None:
+    def shutdown(self) -> None:
         """Close the HTTP client."""
         if self._client:
-            await self._client.close()
+            _run_sync(self._client.close(), self._timeout)
             self._client = None
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        schemas: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for attr_name in dir(self):
+            if not attr_name.endswith("_schema"):
+                continue
+            schema = getattr(self, attr_name, None)
+            if not isinstance(schema, dict):
+                continue
+            name = schema.get("name")
+            if not isinstance(name, str) or name in seen:
+                continue
+            schemas.append(schema)
+            seen.add(name)
+        return sorted(schemas, key=lambda schema: str(schema.get("name", "")))
+
+    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:
+        del kwargs
+        handler_name = self._handler_name_for_tool(tool_name)
+        if not handler_name:
+            return json.dumps({"error": f"Unknown Remnic memory tool: {tool_name}"})
+        handler = getattr(self, handler_name, None)
+        if not callable(handler):
+            return json.dumps({"error": f"Remnic memory tool is not implemented: {tool_name}"})
+        try:
+            return json.dumps(_run_sync(handler(**(args or {})), self._timeout))
+        except Exception as err:
+            return json.dumps({"error": str(err)})
+
+    def _handler_name_for_tool(self, tool_name: str) -> str | None:
+        for attr_name in dir(self):
+            if not attr_name.endswith("_schema"):
+                continue
+            schema = getattr(self, attr_name, None)
+            if not isinstance(schema, dict) or schema.get("name") != tool_name:
+                continue
+            suffix = attr_name.removesuffix("_schema")
+            if suffix.startswith("legacy_"):
+                suffix = suffix.removeprefix("legacy_")
+            return suffix
+        return None
 
     # -- Existing explicit tool schemas for Hermes tool registration --
 

--- a/packages/plugin-hermes/tests/test_provider.py
+++ b/packages/plugin-hermes/tests/test_provider.py
@@ -1,10 +1,21 @@
 """Tests for the RemnicMemoryProvider lifecycle and methods."""
 
-import pytest
+import asyncio
+import json
+import time
 from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from remnic_hermes import EngramMemoryProvider
 from remnic_hermes.provider import RemnicMemoryProvider
+
+
+def _wait_for_await(mock: AsyncMock, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while mock.await_count == 0 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert mock.await_count > 0
 
 
 @pytest.fixture
@@ -14,18 +25,26 @@ def provider():
 
 
 class TestProviderLifecycle:
-    @pytest.mark.asyncio
-    async def test_initialize_creates_client(self, provider):
+    def test_current_hermes_memory_provider_shape(self, provider):
+        """Provider exposes Hermes Agent's current sync MemoryProvider surface."""
+        assert provider.name == "remnic"
+        assert provider.is_available() is True
+        assert callable(provider.initialize)
+        assert callable(provider.prefetch)
+        assert callable(provider.sync_turn)
+        assert callable(provider.get_tool_schemas)
+        assert callable(provider.handle_tool_call)
+
+    def test_initialize_creates_client(self, provider):
         """initialize() should create a RemnicClient."""
         with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
-            await provider.initialize()
+            provider.initialize("test-session")
             MockClient.assert_called_once()
             instance.health.assert_awaited_once()
 
-    @pytest.mark.asyncio
-    async def test_initialize_forwards_timeout(self):
+    def test_initialize_forwards_timeout(self):
         """initialize() must pass the configured timeout to RemnicClient."""
         provider = RemnicMemoryProvider(
             {"host": "127.0.0.1", "port": 4318, "token": "test-token", "timeout": 60.0}
@@ -33,31 +52,45 @@ class TestProviderLifecycle:
         with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
-            await provider.initialize()
+            provider.initialize("test-session")
             _, kwargs = MockClient.call_args
             assert kwargs.get("timeout") == 60.0, (
                 "timeout from config must be forwarded to RemnicClient"
             )
 
-    @pytest.mark.asyncio
-    async def test_initialize_uses_default_timeout(self, provider):
+    def test_initialize_uses_default_timeout(self, provider):
         """initialize() passes the default timeout (30.0) when not configured."""
         with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
-            await provider.initialize()
+            provider.initialize("test-session")
             _, kwargs = MockClient.call_args
             assert kwargs.get("timeout") == 30.0
 
-    @pytest.mark.asyncio
-    async def test_shutdown_closes_client(self, provider):
+    def test_initialize_uses_hermes_session_id_when_not_pinned(self, provider):
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health = AsyncMock()
+            provider.initialize("hermes-session-123")
+            assert provider._session_key == "hermes-session-123"
+
+    def test_initialize_ignores_legacy_config_dict_argument(self, provider):
+        """Mixed-version callers may still pass initialize(config); it must not become the session key."""
+        original_session_key = provider._session_key
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health = AsyncMock()
+            provider.initialize({"session_key": "legacy-config-session"})
+            assert provider._session_key == original_session_key
+
+    def test_shutdown_closes_client(self, provider):
         """shutdown() should close the HTTP client."""
         with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
             instance.close = AsyncMock()
-            await provider.initialize()
-            await provider.shutdown()
+            provider.initialize("test-session")
+            provider.shutdown()
             instance.close.assert_awaited_once()
 
 
@@ -75,7 +108,7 @@ class TestPreLlmCall:
             instance = MockClient.return_value
             instance.health = AsyncMock()
             instance.recall = AsyncMock()
-            await provider.initialize()
+            provider.initialize("test-session")
             result = await provider.pre_llm_call([{"role": "user", "content": "hi"}])
             assert result == ""
             instance.recall.assert_not_awaited()
@@ -87,7 +120,7 @@ class TestPreLlmCall:
             instance = MockClient.return_value
             instance.health = AsyncMock()
             instance.recall = AsyncMock(return_value={"context": "prior memories", "count": 3})
-            await provider.initialize()
+            provider.initialize("test-session")
             result = await provider.pre_llm_call(
                 [{"role": "user", "content": "what did we decide last week"}]
             )
@@ -104,7 +137,7 @@ class TestPreLlmCall:
             instance.health = AsyncMock()
             instance.recall = AsyncMock(return_value={"context": "prior", "count": 1})
 
-            await provider.initialize()
+            provider.initialize("test-session")
             await provider.pre_llm_call(
                 [{"role": "user", "content": "what did we decide last week"}]
             )
@@ -113,30 +146,241 @@ class TestPreLlmCall:
             assert "mode" not in kwargs
 
 
-class TestSyncTurn:
-    @pytest.mark.asyncio
-    async def test_no_op_without_client(self, provider):
-        """sync_turn is a no-op before initialize."""
-        await provider.sync_turn([{"role": "user", "content": "test"}])
+class TestPrefetch:
+    def test_prefetch_returns_fast_first_fetch_and_caches_memory(self, provider):
+        client = AsyncMock()
+        client.recall = AsyncMock(return_value={"context": "cached prior", "count": 1})
+        provider._client = client
 
-    @pytest.mark.asyncio
-    async def test_sends_recent_messages(self, provider):
+        first = provider.prefetch("what did we decide last week", session_id="prefetch-session")
+        assert first.startswith('<remnic-memory count="1">')
+        assert "cached prior" in first
+
+        second = provider.prefetch("what did we decide last week", session_id="prefetch-session")
+        assert second.startswith('<remnic-memory count="1">')
+        assert "cached prior" in second
+        client.recall.assert_awaited_once_with(
+            query="what did we decide last week",
+            session_key="prefetch-session",
+            top_k=8,
+        )
+
+    def test_prefetch_does_not_block_on_slow_daemon_recall(self, provider):
+        client = AsyncMock()
+
+        async def slow_recall(**kwargs):
+            await asyncio.sleep(0.25)
+            return {"context": "late prior", "count": 1}
+
+        client.recall = AsyncMock(side_effect=slow_recall)
+        provider._client = client
+
+        started = time.monotonic()
+        result = provider.prefetch("what did we decide last week")
+        elapsed = time.monotonic() - started
+
+        assert result == ""
+        assert elapsed < 0.15
+        _wait_for_await(client.recall)
+
+    def test_prefetch_does_not_cache_transient_failures_as_empty(self, provider):
+        client = AsyncMock()
+        calls = 0
+
+        async def flaky_recall(**kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError("daemon warming up")
+            return {"context": "recovered prior", "count": 1}
+
+        client.recall = AsyncMock(side_effect=flaky_recall)
+        provider._client = client
+
+        first = provider.prefetch("what did we decide last week")
+        second = provider.prefetch("what did we decide last week")
+
+        assert first == ""
+        assert second.startswith('<remnic-memory count="1">')
+        assert "recovered prior" in second
+        assert client.recall.await_count == 2
+
+    def test_queue_prefetch_warms_cache_for_later_prefetch(self, provider):
+        client = AsyncMock()
+        client.recall = AsyncMock(return_value={"context": "queued prior", "count": 1})
+        provider._client = client
+
+        provider.queue_prefetch("what did we decide last week", session_id="prefetch-session")
+        _wait_for_await(client.recall)
+
+        result = provider.prefetch("what did we decide last week", session_id="prefetch-session")
+        assert "queued prior" in result
+        client.recall.assert_awaited_once()
+
+    def test_sync_turn_invalidates_cached_prefetch_for_session(self, provider):
+        client = AsyncMock()
+        client.observe = AsyncMock(return_value={})
+        recalls = [
+            {"context": "before update", "count": 1},
+            {"context": "after update", "count": 1},
+        ]
+        client.recall = AsyncMock(side_effect=recalls)
+        provider._client = client
+
+        first = provider.prefetch("what did we decide last week", session_id="prefetch-session")
+        assert "before update" in first
+
+        provider.sync_turn("new fact", "got it", session_id="prefetch-session")
+        _wait_for_await(client.observe)
+
+        second = provider.prefetch("what did we decide last week", session_id="prefetch-session")
+        assert "after update" in second
+        assert client.recall.await_count == 2
+
+    def test_prefetch_cache_evicts_old_entries(self, provider):
+        client = AsyncMock()
+
+        async def recall(**kwargs):
+            return {"context": f"memory for {kwargs['query']}", "count": 1}
+
+        client.recall = AsyncMock(side_effect=recall)
+        provider._client = client
+        provider._prefetch_cache_max_entries = 2
+
+        provider.prefetch("what did we decide first", session_id="prefetch-session")
+        provider.prefetch("what did we decide second", session_id="prefetch-session")
+        provider.prefetch("what did we decide third", session_id="prefetch-session")
+
+        assert len(provider._prefetch_cache) == 2
+        assert "prefetch-session\0what did we decide first" not in provider._prefetch_cache
+
+
+class TestSyncTurn:
+    def test_no_op_without_client(self, provider):
+        """sync_turn is a no-op before initialize."""
+        provider.sync_turn("test", "reply")
+
+    def test_sends_recent_messages_from_legacy_transcript_shape(self, provider):
         """sync_turn sends last 2 messages to observe endpoint."""
         with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
             instance.observe = AsyncMock(return_value={})
-            await provider.initialize()
+            provider.initialize("test-session")
             messages = [
                 {"role": "user", "content": "first"},
                 {"role": "assistant", "content": "reply1"},
                 {"role": "user", "content": "second"},
                 {"role": "assistant", "content": "reply2"},
             ]
-            await provider.sync_turn(messages)
+            provider.sync_turn(messages)
+            _wait_for_await(instance.observe)
             instance.observe.assert_awaited_once()
             call_args = instance.observe.call_args
             assert len(call_args.kwargs["messages"]) == 2
+
+    def test_sends_completed_turn_from_current_hermes_signature(self, provider):
+        """sync_turn(user, assistant, session_id=...) matches Hermes' current ABC."""
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health = AsyncMock()
+            instance.observe = AsyncMock(return_value={})
+            provider.initialize("initial-session")
+
+            provider.sync_turn("hello", "hi there", session_id="turn-session")
+
+            _wait_for_await(instance.observe)
+            instance.observe.assert_awaited_once_with(
+                session_key="turn-session",
+                messages=[
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi there"},
+                ],
+            )
+
+    def test_sync_turn_does_not_block_on_slow_daemon_observe(self, provider):
+        """Hermes calls sync_turn in the turn path, so daemon latency must stay backgrounded."""
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health = AsyncMock()
+
+            async def slow_observe(**kwargs):
+                await asyncio.sleep(0.25)
+                return {}
+
+            instance.observe = AsyncMock(side_effect=slow_observe)
+            provider.initialize("initial-session")
+
+            started = time.monotonic()
+            provider.sync_turn("hello", "hi there", session_id="turn-session")
+            elapsed = time.monotonic() - started
+
+            assert elapsed < 0.1
+            _wait_for_await(instance.observe)
+
+
+class TestAsyncLegacyHooks:
+    @pytest.mark.asyncio
+    async def test_extract_memories_awaits_client_without_sync_wrapper(self, provider):
+        client = AsyncMock()
+        client.observe = AsyncMock(return_value={})
+        provider._client = client
+
+        await provider.extract_memories({"messages": [{"role": "user", "content": "remember this"}]})
+
+        client.observe.assert_awaited_once_with(
+            session_key=provider._session_key,
+            messages=[{"role": "user", "content": "remember this"}],
+        )
+
+
+class TestCurrentHermesToolSurface:
+    def test_get_tool_schemas_exposes_remnic_and_legacy_tools(self, provider):
+        names = {schema["name"] for schema in provider.get_tool_schemas()}
+
+        assert "remnic_recall" in names
+        assert "remnic_memory_store" in names
+        assert "remnic_profiling_report" in names
+        assert "engram_recall" in names
+        assert "engram_memory_store" in names
+
+    def test_handle_tool_call_dispatches_sync_result_json(self, provider):
+        client = AsyncMock()
+        client.recall = AsyncMock(return_value={"context": "prior", "count": 1})
+        provider._client = client
+
+        result = provider.handle_tool_call("remnic_recall", {"query": "what did we decide"})
+
+        assert json.loads(result) == {"context": "prior", "count": 1}
+        client.recall.assert_awaited_once_with(
+            query="what did we decide",
+            session_key=provider._session_key,
+        )
+
+    def test_handle_tool_call_reports_unknown_tools(self, provider):
+        result = provider.handle_tool_call("remnic_missing", {})
+
+        assert "Unknown Remnic memory tool" in json.loads(result)["error"]
+
+    def test_handle_tool_call_cancels_timed_out_mutating_tools(self, provider):
+        client = AsyncMock()
+        committed = False
+
+        async def slow_memory_store(**kwargs):
+            nonlocal committed
+            await asyncio.sleep(0.2)
+            committed = True
+            return {"stored": True}
+
+        client.memory_store = AsyncMock(side_effect=slow_memory_store)
+        provider._client = client
+        provider._timeout = 0.01
+
+        result = provider.handle_tool_call("remnic_memory_store", {"content": "remember this"})
+
+        assert json.loads(result) == {"error": "Remnic operation timed out"}
+        time.sleep(0.25)
+        assert committed is False
 
 
 class TestLcmSearchTool:

--- a/tests/integration/plugin-structure.test.ts
+++ b/tests/integration/plugin-structure.test.ts
@@ -121,8 +121,12 @@ test("plugin-hermes provider implements MemoryProvider protocol", () => {
   const provider = path.join(PACKAGES, "plugin-hermes", "remnic_hermes", "provider.py");
   assert.ok(fs.existsSync(provider));
   const content = fs.readFileSync(provider, "utf-8");
-  const requiredMethods = ["pre_llm_call", "sync_turn", "extract_memories", "shutdown", "initialize"];
-  for (const method of requiredMethods) {
+  const requiredSyncMethods = ["prefetch", "sync_turn", "shutdown", "initialize", "get_tool_schemas", "handle_tool_call"];
+  for (const method of requiredSyncMethods) {
+    assert.ok(content.includes(`def ${method}`), `Must implement ${method}()`);
+  }
+  const legacyAsyncMethods = ["pre_llm_call", "extract_memories"];
+  for (const method of legacyAsyncMethods) {
     assert.ok(content.includes(`async def ${method}`), `Must implement ${method}()`);
   }
 });


### PR DESCRIPTION
## Summary
- expose the current Hermes Agent sync `MemoryProvider` surface from `remnic-hermes` (`name`, `is_available`, `initialize(session_id, ...)`, `prefetch`, `sync_turn`, `get_tool_schemas`, `handle_tool_call`, `shutdown`)
- keep Remnic HTTP calls on an internal async loop while presenting synchronous Hermes hooks
- preserve legacy transcript sync and plugin registration compatibility where practical
- bump `remnic-hermes` / plugin manifest to 1.0.4 so PyPI publish will ship the fix

Fixes part of #859.

## Verification
- ../../.venv/bin/python -m pytest tests/ -q
- ../../.venv/bin/python -m mypy remnic_hermes/ --ignore-missing-imports
- ../../.venv/bin/python -m ruff check remnic_hermes/
- ../../.venv/bin/python -m build
- ../../.venv/bin/python -m twine check dist/*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Hermes plugin to a new synchronous provider interface and introduces a background asyncio event loop with caching and timeouts, which could affect runtime behavior under load or during shutdown/session switching. Risk is mitigated by added unit/integration tests but still touches core memory/tool dispatch paths.
> 
> **Overview**
> Updates `remnic-hermes` to match Hermes Agent’s current *synchronous* `MemoryProvider` interface: adds `name`, `is_available`, `initialize(session_id, ...)`, `prefetch`, sync `sync_turn`, `get_tool_schemas`, `handle_tool_call`, and sync `shutdown`, while keeping legacy async hooks (`pre_llm_call`, `extract_memories`) for compatibility.
> 
> Implements a dedicated background asyncio loop to run HTTP calls from these sync hooks, adds a TTL/LRU-style `prefetch` cache with non-blocking behavior, and invalidates cached recalls on `sync_turn`, session switches, and transcript observation.
> 
> Bumps the Hermes plugin/package version to `1.0.4` and expands tests (plus integration assertions) to cover the new interface surface, tool dispatch/timeout behavior, and prefetch caching semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f08f03d8bed954b21bf9421bd0e9b7446575bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->