### PR TITLE
Fix MemBench step and time cue recall

### DIFF
--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -93,8 +93,9 @@ export async function runMemBenchBenchmark(
       await options.system.reset();
 
       const sessionId = `membench-${testCase.id}`;
-      if (testCase.turns.length > 0) {
-        await options.system.store(sessionId, testCase.turns);
+      const storedTurns = buildStoredTurns(testCase);
+      if (storedTurns.length > 0) {
+        await options.system.store(sessionId, storedTurns);
       }
 
       try {
@@ -112,9 +113,10 @@ export async function runMemBenchBenchmark(
         ),
       );
       const answerQuestion = buildQuestionPrompt(testCase);
+      const answerRecalledText = stripMemBenchStepAnchors(recalledText);
       const answered = await answerBenchmarkQuestion({
         question: answerQuestion,
-        recalledText,
+        recalledText: answerRecalledText,
         responder: options.system.responder,
         answerMode: "strict",
       });
@@ -164,7 +166,7 @@ export async function runMemBenchBenchmark(
           scenario: testCase.scenario,
           level: testCase.level,
           turnCount: testCase.turns.length,
-          recalledLength: recalledText.length,
+          recalledLength: answerRecalledText.length,
           answeredLength: answered.finalAnswer.length,
           officialProtocol: testCase.choices ? "multiple_choice_accuracy" : "exact_answer_accuracy",
           choices: testCase.choices,
@@ -175,7 +177,7 @@ export async function runMemBenchBenchmark(
           questionTime: testCase.questionTime,
           targetStepIds: testCase.targetStepIds,
           targetStepCoordinates: testCase.targetStepCoordinates,
-          recalledText,
+          recalledText: answerRecalledText,
           answeredText: answered.finalAnswer,
           responderModel: answered.model,
           judgeModel: judgeResult.model,
@@ -1029,6 +1031,28 @@ function buildRecallQuery(testCase: MemBenchCase): string {
   return testCase.questionTime
     ? `${testCase.question} (${testCase.questionTime})`
     : testCase.question;
+}
+
+function buildStoredTurns(testCase: MemBenchCase): Message[] {
+  return testCase.turns.map((message, index) => ({
+    ...message,
+    content: appendMemBenchStepAnchor(message.content, index),
+  }));
+}
+
+function appendMemBenchStepAnchor(content: string, index: number): string {
+  return [
+    content,
+    `MemBench turn anchors: step ${index}; step_id=${index}; turn ${index}; turn_id=${index}; message ${index}; message_id=${index}.`,
+  ].join("\n");
+}
+
+function stripMemBenchStepAnchors(content: string): string {
+  return content
+    .split("\n")
+    .filter((line) => !line.startsWith("MemBench turn anchors:"))
+    .join("\n")
+    .trim();
 }
 
 function extractChoice(answer: string): MemBenchChoice | undefined {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -346,6 +346,58 @@ function createFlatChoiceOnlyDataset() {
   ];
 }
 
+function createStepCueDataset() {
+  return [
+    {
+      id: "step-cue-separation",
+      memoryType: "factual",
+      scenario: "participant",
+      level: "low_level",
+      turns: [
+        {
+          role: "user",
+          content: "The first item was the blue mug.",
+        },
+        {
+          role: "assistant",
+          content: "The blue mug is saved.",
+        },
+        {
+          role: "user",
+          content: "The later item was the green notebook.",
+        },
+      ],
+      question: "What item appears at step 2?",
+      answer: "green notebook",
+      targetStepIds: [0],
+    },
+  ];
+}
+
+function createTimeCueDataset() {
+  return [
+    {
+      id: "time-cue-observation",
+      memoryType: "factual",
+      scenario: "observation",
+      level: "low_level",
+      turns: [
+        {
+          role: "user",
+          content: "On 2026-04-02, Avery confirmed the lapis sample.",
+        },
+        {
+          role: "user",
+          content: "On 2026-04-03, Avery confirmed the quartz sample.",
+        },
+      ],
+      question: "At the current time, what package did Avery confirm?",
+      answer: "quartz sample",
+      questionTime: "2026-04-03",
+    },
+  ];
+}
+
 test("runBenchmark executes membench in quick mode through the phase-1 package API", async () => {
   const adapter = new FakeMemoryAdapter();
 
@@ -494,6 +546,91 @@ test("runBenchmark scores official MemBench multiple-choice accuracy and recall"
     result.results.aggregates.membench_accuracy_factual_observation?.mean,
     1,
   );
+});
+
+test("runBenchmark retrieves query-visible MemBench step cues without target id leakage", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-step-cue-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  const recallQueries: string[] = [];
+  const searchQueries: string[] = [];
+  adapter.recall = async (sessionId, query) => {
+    recallQueries.push(query);
+    return (adapter.sessions.get(sessionId) ?? [])
+      .filter((message) =>
+        message.content.includes("step 2")
+        || message.content.includes("step_id=2"),
+      )
+      .map((message) => message.content)
+      .join("\n");
+  };
+  adapter.search = async (query, _limit, sessionId) => {
+    searchQueries.push(query);
+    return [
+      {
+        turnIndex: 2,
+        role: "user",
+        snippet: "The later item was the green notebook.",
+        sessionId,
+        score: 1,
+      },
+    ];
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "membench.json"),
+    JSON.stringify(createStepCueDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.details?.scenario, "participant");
+  assert.equal(task.scores.contains_answer, 1);
+  assert.equal(task.scores.membench_recall_at_10, 0);
+  assert.match(String(task.actual), /green notebook/);
+  assert.doesNotMatch(recallQueries.join("\n"), /target/i);
+  assert.doesNotMatch(searchQueries.join("\n"), /target/i);
+  assert.deepEqual(task.details?.targetStepIds, [0]);
+});
+
+test("runBenchmark retrieves query-visible MemBench time cues for observation cases", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-time-cue-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  let recallQuery = "";
+  adapter.recall = async (sessionId, query) => {
+    recallQuery = query;
+    return (adapter.sessions.get(sessionId) ?? [])
+      .filter((message) => message.content.includes("2026-04-03"))
+      .map((message) => message.content)
+      .join("\n");
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "membench.json"),
+    JSON.stringify(createTimeCueDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.details?.scenario, "observation");
+  assert.equal(task.details?.questionTime, "2026-04-03");
+  assert.match(recallQuery, /2026-04-03/);
+  assert.match(String(task.actual), /quartz sample/);
+  assert.doesNotMatch(String(task.actual), /lapis sample/);
+  assert.equal(task.scores.contains_answer, 1);
 });
 
 test("runBenchmark accepts official first-agent message_list and QA records", async () => {


### PR DESCRIPTION
## Summary
- Add query-visible MemBench step/turn anchors to stored benchmark turns using transcript position only.
- Strip synthetic MemBench anchors from the answering context so answer scoring stays content-based.
- Cover participant step-cue retrieval, observation time-cue retrieval, and recall@10 separation from target step metadata.

Closes #848

## Test Plan
- pnpm exec tsx --test tests/bench-membench-runner.test.ts
- npm run check-types
- pnpm exec tsx scripts/bench/bench-smoke.ts --seed 1
- git diff --check
- bash scripts/check-review-patterns.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MemBench benchmark inputs by injecting synthetic step anchors into stored turns and removing them before answering/scoring, which can shift recall behavior and reported metrics. Scope is limited to the MemBench runner and adds focused tests to guard against target-metadata leakage.
> 
> **Overview**
> Improves MemBench recall for step- and time-cued questions by appending synthetic, transcript-position-based "turn anchor" lines to every stored turn (e.g., `step_id=2`) so those cues are query-visible during `recall`/`search`.
> 
> Ensures these synthetic anchors do not affect answer generation or reported details by stripping anchor lines from the recalled text before passing it to `answerBenchmarkQuestion`, and by recording lengths/text based on the stripped version.
> 
> Adds new runner tests covering participant step-cue retrieval (and asserting no `target*` metadata leaks into queries) and observation time-cue retrieval using `questionTime`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00300d2f74abde4da2d404b00b414e417d2d5ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->