### PR TITLE
chore(release): publish core Hermes parity fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10180,7 +10180,7 @@
     },
     "packages/remnic-core": {
       "name": "@remnic/core",
-      "version": "1.0.0",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@honcho-ai/sdk": "^2.0.0",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary\n- bump @remnic/core to 1.1.6 so the issue #859 gateway and Hermes connector fixes publish to npm\n- update package-lock metadata for the core package version\n\n## Verification\n- pnpm --filter @remnic/core run build\n- git diff --check\n\nFollow-up to #859 after #860/#861/#863 merged and the release workflow skipped @remnic/core@1.1.5 because it was already published.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates version metadata (no runtime code changes), primarily affecting release/publishing behavior.
> 
> **Overview**
> Bumps `@remnic/core` from `1.1.5` to `1.1.6` in `packages/remnic-core/package.json` and updates the corresponding `package-lock.json` entry so the new core release can be published/consumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b30ade67299f832cc1735dc3298fee93641d875b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->