### PR TITLE
Fix PersonaMem preference cue recall

### DIFF
--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -34,6 +34,8 @@ const DATASET_FILE_CANDIDATES = [
   "benchmark.csv",
 ] as const;
 
+const PERSONAMEM_ANCHOR_PREFIX = "PersonaMem visible anchors:";
+
 interface RawPersonaMemRow {
   persona_id: string;
   chat_history_32k_link: string;
@@ -99,10 +101,11 @@ export async function runPersonaMemBenchmark(
         console.error(`  [WARN] personamem drain failed for ${taskId}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
       }
 
+      const recallQuery = buildPersonaMemRecallQuery(sample.userQuery);
       const { result: recalledText, durationMs } = await timed(async () =>
         options.system.recall(
           sessionId,
-          sample.userQuery,
+          recallQuery,
           DEFAULT_BENCH_RECALL_BUDGET_CHARS,
         ),
       );
@@ -111,6 +114,7 @@ export async function runPersonaMemBenchmark(
         10,
         sessionId,
       );
+      const answerRecalledText = stripPersonaMemAnchors(recalledText);
       const mcq =
         sample.incorrectAnswers && sample.incorrectAnswers.length > 0
           ? buildMcqPrompt(sample, options.seed ?? 0)
@@ -124,7 +128,7 @@ export async function runPersonaMemBenchmark(
         : sample.userQuery;
       const answered = await answerBenchmarkQuestion({
         question: evaluationQuestion,
-        recalledText,
+        recalledText: answerRecalledText,
         responder: options.system.responder,
         answerMode: "strict",
       });
@@ -180,9 +184,9 @@ export async function runPersonaMemBenchmark(
           mcqOptions: mcq?.options,
           correctMcqOption: mcq?.correctOption,
           predictedMcqOption,
-          recalledLength: recalledText.length,
+          recalledLength: answerRecalledText.length,
           answeredLength: answered.finalAnswer.length,
-          recalledText,
+          recalledText: answerRecalledText,
           answeredText: answered.finalAnswer,
           responderModel: answered.model,
           judgeModel: judgeResult.model,
@@ -750,10 +754,91 @@ function parseChatHistory(
 function buildMessages(chatHistory: PersonaMemChatHistory["chat_history"]): Message[] {
   return chatHistory
     .filter((message) => message.content.trim().length > 0)
-    .map((message) => ({
+    .map((message, index) => buildPersonaMemMessage({
       role: normalizeRole(message.role),
       content: message.content,
-    }));
+    }, index));
+}
+
+function buildPersonaMemMessage(message: Message, index: number): Message {
+  const anchors = collectPersonaMemAnchors(message.content, index);
+  if (anchors.length === 0) {
+    return message;
+  }
+  return {
+    ...message,
+    content: [
+      message.content,
+      `${PERSONAMEM_ANCHOR_PREFIX} ${anchors.join("; ")}.`,
+    ].join("\n"),
+  };
+}
+
+function collectPersonaMemAnchors(content: string, index: number): string[] {
+  const normalized = content.toLowerCase();
+  const anchors = new Set<string>();
+
+  if (hasPreferenceIntent(normalized)) {
+    anchors.add("preference");
+    anchors.add("personal preference");
+    anchors.add("persona preference");
+    anchors.add(`turn ${index}`);
+  }
+  if (hasPreferenceUpdateIntent(normalized)) {
+    anchors.add("current preference");
+    anchors.add("latest preference");
+    anchors.add("updated preference");
+    anchors.add(`turn ${index}`);
+  }
+  for (const match of content.matchAll(/\b\d{4}-\d{2}-\d{2}\b/g)) {
+    anchors.add(match[0]);
+    anchors.add(`date=${match[0]}`);
+  }
+
+  return [...anchors].sort((left, right) => left.localeCompare(right));
+}
+
+function buildPersonaMemRecallQuery(userQuery: string): string {
+  const normalized = userQuery.toLowerCase();
+  const cues = new Set<string>();
+  if (hasPreferenceIntent(normalized) || /\b(?:usually|recommend|should|for me|my)\b/.test(normalized)) {
+    cues.add("preference");
+    cues.add("personal preference");
+    cues.add("persona preference");
+  }
+  if (hasPreferenceUpdateIntent(normalized)) {
+    cues.add("current preference");
+    cues.add("latest preference");
+    cues.add("updated preference");
+  }
+  if (cues.size === 0) {
+    return userQuery;
+  }
+  return `${userQuery}\n${[...cues].sort((left, right) => left.localeCompare(right)).join("; ")}.`;
+}
+
+function stripPersonaMemAnchors(content: string): string {
+  const lines: string[] = [];
+  for (const line of content.split("\n")) {
+    const anchorIndex = line.indexOf(PERSONAMEM_ANCHOR_PREFIX);
+    if (anchorIndex < 0) {
+      lines.push(line);
+      continue;
+    }
+    const cleanedLine = line.slice(0, anchorIndex).trimEnd();
+    if (cleanedLine.trim().length > 0) {
+      lines.push(cleanedLine);
+    }
+  }
+  return lines.join("\n").trim();
+}
+
+function hasPreferenceIntent(normalized: string): boolean {
+  return /\b(?:prefer|preference|favorite|favourite|like|love|enjoy|usually|always|recommend|dislike)\b/.test(normalized);
+}
+
+function hasPreferenceUpdateIntent(normalized: string): boolean {
+  return /\b(?:now|current|currently|latest|updated|changed|switch(?:ed)?|instead|these days)\b/.test(normalized);
 }
 
 function normalizeRole(role: string): Message["role"] {

--- a/tests/bench-personamem-runner.test.ts
+++ b/tests/bench-personamem-runner.test.ts
@@ -13,6 +13,8 @@ import { runBenchmark } from "../packages/bench/src/index.js";
 
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
+  readonly recallCalls: Array<{ sessionId: string; query: string }> = [];
+  readonly searchCalls: Array<{ sessionId?: string; query: string; limit: number }> = [];
 
   constructor(readonly responder?: BenchResponder) {}
 
@@ -21,7 +23,8 @@ class FakeMemoryAdapter implements BenchMemoryAdapter {
     this.sessions.set(sessionId, [...existing, ...messages]);
   }
 
-  async recall(sessionId: string, _query: string): Promise<string> {
+  async recall(sessionId: string, query: string): Promise<string> {
+    this.recallCalls.push({ sessionId, query });
     return (this.sessions.get(sessionId) ?? [])
       .map((message) => message.content)
       .join("\n");
@@ -32,6 +35,7 @@ class FakeMemoryAdapter implements BenchMemoryAdapter {
     limit: number,
     sessionId?: string,
   ): Promise<SearchResult[]> {
+    this.searchCalls.push({ sessionId, query, limit });
     const haystack = sessionId
       ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
       : [...this.sessions.entries()];
@@ -326,6 +330,209 @@ test("runBenchmark prefers explicit final MCQ answers over broad answer labels",
   assert.equal(task.details?.correctMcqOption, "B");
   assert.equal(task.details?.predictedMcqOption, "B");
   assert.equal(task.scores.mcq_accuracy, 1);
+});
+
+test("runBenchmark retrieves implicit personamem preferences from visible chat history", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-implicit-pref-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const chatHistoryDir = path.join(datasetDir, "data", "chat_history_32k");
+  const adapter = new FakeMemoryAdapter();
+  adapter.recall = async (sessionId, query) => {
+    adapter.recallCalls.push({ sessionId, query });
+    return (adapter.sessions.get(sessionId) ?? [])
+      .filter((message) =>
+        query.includes("personal preference")
+        && message.content.includes("persona preference")
+        && message.content.includes("aisle seats"),
+      )
+      .map((message) => message.content)
+      .join("\n");
+  };
+  await mkdir(benchmarkDir, { recursive: true });
+  await mkdir(chatHistoryDir, { recursive: true });
+  await writeFile(
+    path.join(chatHistoryDir, "persona-1.json"),
+    JSON.stringify({
+      chat_history: [
+        {
+          role: "user",
+          content: "I usually pick aisle seats on flights because I like easy exits.",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    toCsv(
+      ["persona_id", "chat_history_32k_link", "user_query", "correct_answer"],
+      [
+        "persona-1",
+        "data/chat_history_32k/persona-1.json",
+        "{'role': 'user', 'content': 'Which seat should you pick for my flight?'}",
+        "aisle seats",
+      ],
+    ),
+    "utf8",
+  );
+
+  const result = await runBenchmark("personamem", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.match(String(task.actual), /aisle seats/);
+  assert.doesNotMatch(String(task.actual), /PersonaMem visible anchors/);
+  assert.match(adapter.recallCalls[0]?.query ?? "", /personal preference/);
+  assert.doesNotMatch(adapter.recallCalls[0]?.query ?? "", /Visible PersonaMem recall cues/);
+  assert.doesNotMatch(adapter.searchCalls[0]?.query ?? "", /personal preference|persona preference/);
+});
+
+test("runBenchmark retrieves topic-specific personamem preferences", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-topic-pref-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const chatHistoryDir = path.join(datasetDir, "data", "chat_history_32k");
+  const adapter = new FakeMemoryAdapter();
+  adapter.recall = async (sessionId, query) => {
+    adapter.recallCalls.push({ sessionId, query });
+    return (adapter.sessions.get(sessionId) ?? [])
+      .filter((message) =>
+        /headphone/i.test(query)
+        && message.content.includes("headphones")
+        && message.content.includes("warm sound"),
+      )
+      .map((message) => message.content)
+      .join("\n");
+  };
+  await mkdir(benchmarkDir, { recursive: true });
+  await mkdir(chatHistoryDir, { recursive: true });
+  await writeFile(
+    path.join(chatHistoryDir, "persona-1.json"),
+    JSON.stringify({
+      chat_history: [
+        { role: "user", content: "For headphones I like a warm sound with soft treble." },
+        { role: "user", content: "Desk speakers in my office use neutral tuning." },
+      ],
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    toCsv(
+      [
+        "persona_id",
+        "chat_history_32k_link",
+        "user_query",
+        "correct_answer",
+        "topic_query",
+        "preference",
+      ],
+      [
+        "persona-1",
+        "data/chat_history_32k/persona-1.json",
+        "{'role': 'user', 'content': 'What headphone sound should you recommend for me?'}",
+        "warm sound",
+        "hidden headphone topic",
+        "hidden warm answer label",
+      ],
+    ),
+    "utf8",
+  );
+
+  const result = await runBenchmark("personamem", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  const storedMessages = adapter.sessions.get("personamem-persona-1") ?? [];
+  assert.match(String(task.actual), /warm sound/);
+  assert.doesNotMatch(String(task.actual), /neutral tuning/);
+  assert.doesNotMatch(adapter.recallCalls[0]?.query ?? "", /hidden headphone topic|hidden warm answer label/);
+  assert.doesNotMatch(storedMessages[1]?.content ?? "", /PersonaMem visible anchors|turn 1/);
+});
+
+test("runBenchmark retrieves latest personamem preference updates", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-updated-pref-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const chatHistoryDir = path.join(datasetDir, "data", "chat_history_32k");
+  const adapter = new FakeMemoryAdapter();
+  adapter.recall = async (sessionId, query) => {
+    adapter.recallCalls.push({ sessionId, query });
+    const messages = adapter.sessions.get(sessionId) ?? [];
+    const latest = [...messages]
+      .reverse()
+      .find((message) => message.content.includes("latest preference"));
+    return /latest preference|current preference/i.test(query) && latest
+      ? [
+          `[personamem-persona-1, turn 1]: ${latest.content.replaceAll("\n", "\n[personamem-persona-1, turn 1]: ")}`,
+          "",
+          "[personamem-persona-1, note]: Follow-up paragraph.",
+        ].join("\n")
+      : messages.map((message) => message.content).join("\n");
+  };
+  await mkdir(benchmarkDir, { recursive: true });
+  await mkdir(chatHistoryDir, { recursive: true });
+  await writeFile(
+    path.join(chatHistoryDir, "persona-1.json"),
+    JSON.stringify({
+      chat_history: [
+        { role: "user", content: "I used to prefer coffee for morning writing." },
+        { role: "user", content: "I switched drinks; now I prefer Earl Grey for morning writing." },
+      ],
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    toCsv(
+      [
+        "persona_id",
+        "chat_history_32k_link",
+        "user_query",
+        "correct_answer",
+        "related_conversation_snippet",
+        "updated",
+        "prev_pref",
+      ],
+      [
+        "persona-1",
+        "data/chat_history_32k/persona-1.json",
+        "{'role': 'user', 'content': 'Which drink do I prefer now for morning writing?'}",
+        "Earl Grey",
+        "hidden related snippet says Earl Grey",
+        "hidden updated timestamp",
+        "hidden old coffee preference",
+      ],
+    ),
+    "utf8",
+  );
+
+  const result = await runBenchmark("personamem", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  const storedMessages = adapter.sessions.get("personamem-persona-1") ?? [];
+  assert.match(String(task.actual), /Earl Grey/);
+  assert.doesNotMatch(String(task.actual), /coffee/);
+  assert.doesNotMatch(String(task.actual), /PersonaMem visible anchors/);
+  assert.match(String(task.details?.recalledText), /\n\n\[personamem-persona-1, note\]/);
+  assert.doesNotMatch(storedMessages[0]?.content ?? "", /latest preference|current preference|updated preference/);
+  assert.doesNotMatch(
+    adapter.recallCalls[0]?.query ?? "",
+    /hidden related snippet|hidden updated timestamp|hidden old coffee preference/,
+  );
+  assert.equal(task.details?.updated, "hidden updated timestamp");
+  assert.equal(task.details?.prevPref, "hidden old coffee preference");
 });
 
 test("runBenchmark rejects personamem full mode without datasetDir", async () => {


### PR DESCRIPTION
## Summary
- Add visible preference/update anchors derived from PersonaMem chat history.
- Expand recall queries with user-visible preference/latest cues and strip synthetic anchors before scoring.
- Cover implicit preferences, topic-specific preferences, updated preference resolution, and hidden metadata non-leakage.

Closes #850

## Test Plan
- pnpm exec tsx --test tests/bench-personamem-runner.test.ts
- npm run check-types
- pnpm exec tsx scripts/bench/bench-smoke.ts --seed 1
- git diff --check
- bash scripts/check-review-patterns.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PersonaMem benchmark recall inputs/outputs via new heuristic cue/anchor logic, which can shift benchmark scores and behavior across adapters. Risk is limited to benchmarking but may affect result comparability and adapter expectations around recall queries.
> 
> **Overview**
> Improves PersonaMem benchmark recall by injecting *visible* preference/update/date anchors into stored chat-history messages and expanding `recall` queries with preference cues when the user query implies personalization.
> 
> Strips these synthetic anchors back out of `recalledText` before answering/scoring and updates task details to record the cleaned recall text/length. Adds tests to verify implicit/topic-specific/latest-preference recall works and that hidden metadata does not leak into recall/search queries or final answers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9069a7a8e8731daa61d992b38246d6521697dc91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->