### PR TITLE
fix(openclaw): add legacy Engram migration path

### DIFF
--- a/.changeset/openclaw-engram-migration.md
+++ b/.changeset/openclaw-engram-migration.md
@@ -1,0 +1,12 @@
+---
+"@remnic/cli": patch
+"@remnic/core": patch
+---
+
+Add `remnic openclaw migrate-engram` for legacy `@joshuaswarren/openclaw-engram`
+operators moving to `@remnic/plugin-openclaw`, including legacy extension backup,
+canonical `openclaw-remnic` config migration, and updated migration docs.
+
+Also align OpenAI GPT-5 chat-completions compatibility by using
+`max_completion_tokens` and omitting `temperature` for native OpenAI `gpt-5*`
+models.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ remnic doctor
 
 `remnic openclaw install` writes `plugins.entries["openclaw-remnic"]` and `plugins.slots.memory = "openclaw-remnic"` to `~/.openclaw/openclaw.json`. Without the slot, hooks never fire — see [Troubleshooting: hooks aren't firing](#troubleshooting-hooks-arent-firing) for details.
 
+Migrating from the legacy `@joshuaswarren/openclaw-engram` package? Run
+`remnic openclaw migrate-engram --yes`; it backs up the legacy extension,
+installs `@remnic/plugin-openclaw`, preserves `memoryDir`, and switches the
+OpenClaw memory slot to `openclaw-remnic`. See the
+[OpenClaw Engram to Remnic migration guide](docs/guides/openclaw-engram-to-remnic.md).
+
 ## Installation
 
 ### Option 1: Install from the CLI

--- a/docs/guides/openclaw-engram-to-remnic.md
+++ b/docs/guides/openclaw-engram-to-remnic.md
@@ -1,0 +1,120 @@
+# OpenClaw Engram to Remnic Migration
+
+This guide is for OpenClaw users moving from the legacy
+`@joshuaswarren/openclaw-engram` package to the canonical
+`@remnic/plugin-openclaw` package.
+
+Use it when an OpenClaw upgrade reports `0 plugins updated, 1 unchanged,
+1 skipped`, or when `engram-http` starts but `/engram/v1/health` never
+responds after moving to a newer OpenClaw bundle.
+
+## Short Answer
+
+Run the Remnic migration command:
+
+```bash
+npm install -g @remnic/cli
+remnic openclaw migrate-engram --yes
+```
+
+Then restart OpenClaw:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
+remnic doctor
+```
+
+## What the Command Changes
+
+`remnic openclaw migrate-engram` is a focused wrapper around the safe OpenClaw
+upgrade path. It:
+
+- backs up `~/.openclaw/openclaw.json`;
+- backs up the canonical extension directory, if present;
+- backs up the legacy `~/.openclaw/extensions/openclaw-engram` directory, if present;
+- installs a clean `@remnic/plugin-openclaw` package into
+  `~/.openclaw/extensions/openclaw-remnic`;
+- writes or updates `plugins.entries["openclaw-remnic"]`;
+- sets `plugins.slots.memory = "openclaw-remnic"`;
+- preserves the existing memory directory instead of relocating data.
+
+The legacy `plugins.entries["openclaw-engram"]` entry is intentionally retained
+during migration. Keep it until the gateway log shows Remnic starting under the
+canonical id and `remnic doctor` passes. After that, it can be removed manually.
+
+## Config Key
+
+Use this key after migration:
+
+```json
+{
+  "plugins": {
+    "slots": {
+      "memory": "openclaw-remnic"
+    },
+    "entries": {
+      "openclaw-remnic": {
+        "config": {
+          "memoryDir": "~/.openclaw/workspace/memory/local"
+        }
+      }
+    }
+  }
+}
+```
+
+Do not rename the package to `remnic-workspace` in `plugins.entries`. The npm
+workspace root is named `remnic-workspace`, but the OpenClaw plugin id is
+`openclaw-remnic`.
+
+## Preserving Local Patches
+
+If your legacy `@joshuaswarren/openclaw-engram` tree contains local edits, the
+migration command leaves that tree in place and also copies it into the timestamped
+backup directory printed by the command.
+
+Recommended flow:
+
+1. Run `remnic openclaw migrate-engram --yes --no-restart`.
+2. Diff your backed-up `openclaw-engram` directory against the new
+   `openclaw-remnic` directory.
+3. Re-apply only still-needed patches to `openclaw-remnic`.
+4. Restart the OpenClaw gateway.
+5. Run `remnic doctor`.
+
+For GPT-5-family OpenAI chat-completions models, Remnic now sends
+`max_completion_tokens` instead of `max_tokens` and omits `temperature` for
+native OpenAI `gpt-5*` models. Local compatibility patches for that behavior
+should not be needed after this release.
+
+## Useful Flags
+
+```bash
+remnic openclaw migrate-engram --dry-run
+remnic openclaw migrate-engram --yes --version latest
+remnic openclaw migrate-engram --yes --no-restart
+remnic openclaw migrate-engram --yes --config ~/.openclaw/openclaw.json
+remnic openclaw migrate-engram --yes --memory-dir ~/.openclaw/workspace/memory/local
+remnic openclaw migrate-engram --yes --legacy-plugin-dir ~/.openclaw/extensions/openclaw-engram
+```
+
+## Verification
+
+After restarting OpenClaw:
+
+```bash
+remnic doctor
+grep -i remnic ~/.openclaw/logs/gateway.log | tail -50
+curl -fsS -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" \
+  http://127.0.0.1:4318/engram/v1/health
+```
+
+Look for:
+
+- `plugins.slots.memory = "openclaw-remnic"`;
+- `plugins.entries["openclaw-remnic"]`;
+- `[remnic] gateway_start fired` in the gateway log;
+- a successful health response from the loopback Remnic HTTP server.
+
+If the gateway does not start, restore `openclaw.json` or the extension
+directory from the timestamped backup printed by the command.

--- a/docs/guides/platform-migration.md
+++ b/docs/guides/platform-migration.md
@@ -2,6 +2,12 @@
 
 This guide covers the migration from the old single-package Engram plugin to the Remnic platform architecture introduced in v9.1.36. If you are an existing OpenClaw user upgrading through the normal plugin update path, most changes are transparent.
 
+If you are moving from the legacy `@joshuaswarren/openclaw-engram` package to
+the canonical `@remnic/plugin-openclaw` package, start with
+[OpenClaw Engram to Remnic migration](openclaw-engram-to-remnic.md). That guide
+covers `plugins.entries.openclaw-engram` vs `plugins.entries.openclaw-remnic`,
+the `remnic openclaw migrate-engram` tooling, and local patch preservation.
+
 ---
 
 ## What Changed (M0-M7)

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -26,6 +26,16 @@ Or use the Remnic installer:
 remnic openclaw install
 ```
 
+If you are migrating from the legacy `@joshuaswarren/openclaw-engram` package,
+use the dedicated migration guide and command:
+
+```bash
+remnic openclaw migrate-engram --yes
+```
+
+See [OpenClaw Engram to Remnic migration](../guides/openclaw-engram-to-remnic.md)
+for config-key behavior, backup behavior, and local patch preservation notes.
+
 ## Configure
 
 Minimal configuration:

--- a/llms.txt
+++ b/llms.txt
@@ -160,6 +160,9 @@ DOCUMENTATION
   docs/api.md                  HTTP, MCP, and CLI reference
   docs/architecture/           Per-feature architecture docs
   docs/guides/                 Standalone, Codex, Claude Code, local LLM, etc.
+  docs/guides/openclaw-engram-to-remnic.md
+                               Legacy OpenClaw Engram -> Remnic migration:
+                               package rename, config keys, backups, patches
   docs/getting-started.md      Quick start
   docs/operations.md           Operations guide
   docs/search-backends.md      Search backend comparison
@@ -189,6 +192,21 @@ QUICK START (OPENCLAW)
   remnic openclaw install
   launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
   remnic doctor
+
+LEGACY OPENCLAW ENGRAM MIGRATION
+
+  Use this for @joshuaswarren/openclaw-engram 9.2.x -> @remnic/plugin-openclaw.
+  Canonical OpenClaw plugin id: openclaw-remnic.
+  Legacy plugin id: openclaw-engram.
+  Do not use remnic-workspace as an OpenClaw plugin id; it is the npm workspace
+  root package name, not the OpenClaw runtime id.
+
+  remnic openclaw migrate-engram --yes
+
+  This backs up openclaw.json, backs up the legacy openclaw-engram extension
+  directory, installs @remnic/plugin-openclaw into openclaw-remnic, writes
+  plugins.entries["openclaw-remnic"], sets plugins.slots.memory to
+  "openclaw-remnic", and preserves the memoryDir.
 
 CONNECTING OTHER AGENTS
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2973,6 +2973,11 @@ function resolveOpenclawPluginDir(cliPath?: string): string {
   return path.join(resolveHomeDir(), ".openclaw", "extensions", REMNIC_OPENCLAW_PLUGIN_ID);
 }
 
+function resolveOpenclawLegacyPluginDir(cliPath?: string): string {
+  if (cliPath) return path.resolve(expandTilde(cliPath));
+  return path.join(resolveHomeDir(), ".openclaw", "extensions", REMNIC_OPENCLAW_LEGACY_PLUGIN_ID);
+}
+
 function formatOpenclawUpgradeStamp(now = new Date()): string {
   const yyyy = now.getFullYear().toString();
   const mm = String(now.getMonth() + 1).padStart(2, "0");
@@ -6182,6 +6187,7 @@ interface OpenclawUpgradeOptions extends OpenclawInstallOptions {
   pluginDir?: string;
   version?: string;
   restartGateway: boolean;
+  legacyPluginDirForBackup?: string;
 }
 
 async function promptYesNo(question: string, defaultYes = true): Promise<boolean> {
@@ -6553,6 +6559,9 @@ async function cmdOpenclawInstall(opts: OpenclawInstallOptions): Promise<void> {
 async function cmdOpenclawUpgrade(opts: OpenclawUpgradeOptions): Promise<void> {
   const configPath = resolveOpenclawConfigPath(opts.configPath);
   const pluginDir = resolveOpenclawPluginDir(opts.pluginDir);
+  const legacyPluginDirForBackup = opts.legacyPluginDirForBackup
+    ? resolveOpenclawLegacyPluginDir(opts.legacyPluginDirForBackup)
+    : undefined;
   const fallbackMemoryDir = path.join(resolveHomeDir(), ".openclaw", "workspace", "memory", "local");
   const packageSpec = `@remnic/plugin-openclaw@${opts.version ?? "latest"}`;
 
@@ -6569,17 +6578,29 @@ async function cmdOpenclawUpgrade(opts: OpenclawUpgradeOptions): Promise<void> {
   );
   const configBackupPath = path.join(backupDir, "openclaw.json");
   const pluginBackupDir = path.join(backupDir, "extensions", REMNIC_OPENCLAW_PLUGIN_ID);
+  const legacyPluginBackupDir = legacyPluginDirForBackup
+    ? path.join(backupDir, "extensions", REMNIC_OPENCLAW_LEGACY_PLUGIN_ID)
+    : undefined;
 
   assertDirectoryPathOrMissing(pluginDir, "OpenClaw plugin dir");
+  if (legacyPluginDirForBackup) {
+    assertDirectoryPathOrMissing(legacyPluginDirForBackup, "Legacy OpenClaw plugin dir");
+  }
 
   console.log(`OpenClaw config: ${configPath}`);
   console.log(`Plugin dir:      ${pluginDir}`);
+  if (legacyPluginDirForBackup) {
+    console.log(`Legacy dir:      ${legacyPluginDirForBackup}`);
+  }
   console.log(`Memory dir:      ${preservedMemoryDir}`);
   console.log(`Package spec:    ${packageSpec}`);
   console.log(`Backup dir:      ${backupDir}`);
 
   const plannedActions = [
     `backup openclaw.json and the existing ${REMNIC_OPENCLAW_PLUGIN_ID} extension`,
+    ...(legacyPluginDirForBackup
+      ? [`backup the existing ${REMNIC_OPENCLAW_LEGACY_PLUGIN_ID} extension without modifying it`]
+      : []),
     `npm pack ${packageSpec} and stage a clean plugin copy before swap`,
     `re-run remnic openclaw install with the preserved memory dir`,
     opts.restartGateway
@@ -6616,6 +6637,13 @@ async function cmdOpenclawUpgrade(opts: OpenclawUpgradeOptions): Promise<void> {
     backupNotes.push(`+ Backed up plugin dir to ${pluginBackupDir}`);
   } else {
     backupNotes.push(`  No existing plugin dir found at ${pluginDir}; a fresh install will be staged`);
+  }
+  if (legacyPluginDirForBackup && legacyPluginBackupDir) {
+    if (backupPathIfPresent(legacyPluginDirForBackup, legacyPluginBackupDir)) {
+      backupNotes.push(`+ Backed up legacy plugin dir to ${legacyPluginBackupDir}`);
+    } else {
+      backupNotes.push(`  No existing legacy plugin dir found at ${legacyPluginDirForBackup}; nothing to preserve`);
+    }
   }
 
   let installResult: { rollbackDir?: string; version?: string } | undefined;
@@ -6696,6 +6724,23 @@ async function cmdOpenclawUpgrade(opts: OpenclawUpgradeOptions): Promise<void> {
     console.log("Run this manually when you're ready:");
     console.log(`  launchctl kickstart -k gui/$(id -u)/${OPENCLAW_GATEWAY_LABEL}`);
   }
+}
+
+async function cmdOpenclawMigrateEngram(opts: OpenclawUpgradeOptions): Promise<void> {
+  console.log(
+    `Migrating legacy ${REMNIC_OPENCLAW_LEGACY_PLUGIN_ID} installs to ${REMNIC_OPENCLAW_PLUGIN_ID}.`,
+  );
+  console.log(
+    "The legacy config entry and extension directory are preserved for rollback and custom patch reference.",
+  );
+  await cmdOpenclawUpgrade({
+    ...opts,
+    legacyPluginDirForBackup: opts.legacyPluginDirForBackup ?? resolveOpenclawLegacyPluginDir(),
+  });
+  console.log("\nMigration notes:");
+  console.log(`  - plugins.entries["${REMNIC_OPENCLAW_PLUGIN_ID}"] is the canonical entry.`);
+  console.log(`  - plugins.entries["${REMNIC_OPENCLAW_LEGACY_PLUGIN_ID}"] is retained temporarily for rollback.`);
+  console.log("  - Re-apply any local source patches to the new package only after verifying the published build.");
 }
 
 // ── Taxonomy commands (#366) ─────────────────────────────────────────────────
@@ -7853,15 +7898,16 @@ Run 'remnic capsule <subcommand> --help' for subcommand details.`);
         const memoryDir = resolveRequiredValueFlag(args, "--memory-dir");
         const configOverride = resolveRequiredValueFlag(args, "--config");
         await cmdOpenclawInstall({ yes, dryRun, memoryDir, configPath: configOverride });
-      } else if (subAction === "upgrade") {
+      } else if (subAction === "upgrade" || subAction === "migrate-engram") {
         const yes = args.includes("--yes") || args.includes("-y") || args.includes("--force");
         const dryRun = args.includes("--dry-run");
         const memoryDir = resolveRequiredValueFlag(args, "--memory-dir");
         const configOverride = resolveRequiredValueFlag(args, "--config");
         const version = resolveRequiredValueFlag(args, "--version");
         const pluginDir = resolveRequiredValueFlag(args, "--plugin-dir");
+        const legacyPluginDir = resolveRequiredValueFlag(args, "--legacy-plugin-dir");
         const restartGateway = !args.includes("--no-restart");
-        await cmdOpenclawUpgrade({
+        const opts = {
           yes,
           dryRun,
           memoryDir,
@@ -7869,12 +7915,21 @@ Run 'remnic capsule <subcommand> --help' for subcommand details.`);
           pluginDir,
           version,
           restartGateway,
-        });
+          legacyPluginDirForBackup: legacyPluginDir,
+        };
+        if (subAction === "migrate-engram") {
+          await cmdOpenclawMigrateEngram(opts);
+        } else {
+          await cmdOpenclawUpgrade(opts);
+        }
       } else {
-        console.log(`Usage: remnic openclaw <install|upgrade>
+        console.log(`Usage: remnic openclaw <install|upgrade|migrate-engram>
 
   install    Configure OpenClaw to use Remnic as the memory plugin.
   upgrade    Backup the current setup, refresh the published npm package, and re-apply the config.
+  migrate-engram
+             Migrate a legacy @joshuaswarren/openclaw-engram install to
+             @remnic/plugin-openclaw while backing up the legacy extension.
 
              Sets plugins.entries["${REMNIC_OPENCLAW_PLUGIN_ID}"] and plugins.slots.memory
              in ~/.openclaw/openclaw.json (or $OPENCLAW_CONFIG_PATH).
@@ -7886,6 +7941,8 @@ Options:
   --config <path>         Override OpenClaw config path
   --version <tag>         Upgrade @remnic/plugin-openclaw from a specific npm tag/version
   --plugin-dir <path>     Override OpenClaw extension dir (~/.openclaw/extensions/openclaw-remnic)
+  --legacy-plugin-dir <path>
+                          Override legacy extension dir backed up by migrate-engram
   --no-restart            Skip the final launchctl kickstart after upgrade`);
       }
       break;
@@ -7909,12 +7966,15 @@ Usage:
   remnic config                Show current config
   remnic openclaw install      Configure OpenClaw to use Remnic memory (sets slot + entry)
   remnic openclaw upgrade      Safe OpenClaw npm upgrade with backups and gateway restart
+  remnic openclaw migrate-engram
+    Migrate legacy @joshuaswarren/openclaw-engram installs with legacy extension backup
     --yes / -y / --force       Skip prompts
     --dry-run                  Preview changes without writing
     --memory-dir <path>        Custom memory directory
     --config <path>            Custom OpenClaw config path
     --version <tag>            Upgrade @remnic/plugin-openclaw from a specific npm tag/version
     --plugin-dir <path>        Custom OpenClaw extension directory
+    --legacy-plugin-dir <path> Custom legacy extension directory for migration backup
     --no-restart               Skip the final launchctl kickstart after upgrade
   remnic daemon <start|stop|restart|install|uninstall|status>  Manage background server
   remnic token <generate|list|revoke> [connector-id]  Manage auth tokens

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -2,6 +2,7 @@ import { log } from "./logger.js";
 import type { GatewayConfig, ModelProviderConfig, AgentPersona } from "./types.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import {
+  buildChatCompletionTemperature,
   buildChatCompletionTokenLimit,
   shouldAssumeOpenAiChatCompletions,
 } from "./openai-chat-compat.js";
@@ -493,7 +494,9 @@ export class FallbackLlmClient {
     const body = {
       model: modelId,
       messages,
-      temperature: options.temperature ?? 0.3,
+      ...buildChatCompletionTemperature(modelId, options.temperature ?? 0.3, {
+        assumeOpenAI,
+      }),
       ...buildChatCompletionTokenLimit(modelId, options.maxTokens ?? 4096, {
         assumeOpenAI,
       }),
@@ -582,7 +585,9 @@ export class FallbackLlmClient {
       model: modelId,
       input,
       max_output_tokens: Math.max(0, Math.floor(options.maxTokens ?? 4096)),
-      temperature: options.temperature ?? 0.3,
+      ...buildChatCompletionTemperature(modelId, options.temperature ?? 0.3, {
+        assumeOpenAI: shouldAssumeOpenAiChatCompletions(config.baseUrl),
+      }),
     };
     if (instructions.length > 0) {
       body.instructions = instructions;

--- a/packages/remnic-core/src/openai-chat-compat.ts
+++ b/packages/remnic-core/src/openai-chat-compat.ts
@@ -37,3 +37,20 @@ export function buildChatCompletionTokenLimit(
   }
   return { max_tokens: safeMaxTokens };
 }
+
+export function supportsTemperature(model: string, options?: { assumeOpenAI?: boolean }): boolean {
+  const normalized = normalizedModel(model);
+  if (options?.assumeOpenAI === true && matchesModelFamily(normalized, /^gpt-5(?:$|[-.])/)) {
+    return false;
+  }
+  return true;
+}
+
+export function buildChatCompletionTemperature(
+  model: string,
+  temperature: number,
+  options?: { assumeOpenAI?: boolean },
+): { temperature: number } | Record<string, never> {
+  if (!supportsTemperature(model, options)) return {};
+  return { temperature };
+}

--- a/tests/openai-chat-compat.test.ts
+++ b/tests/openai-chat-compat.test.ts
@@ -1,8 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildChatCompletionTemperature,
   buildChatCompletionTokenLimit,
   shouldAssumeOpenAiChatCompletions,
+  supportsTemperature,
   usesMaxCompletionTokens,
 } from "../src/openai-chat-compat.ts";
 import { parseConfig } from "../src/config.ts";
@@ -39,6 +41,18 @@ test("buildChatCompletionTokenLimit selects max_completion_tokens for gpt-5 mode
   });
   assert.deepEqual(buildChatCompletionTokenLimit("o2-local", 2048, { assumeOpenAI: true }), {
     max_tokens: 2048,
+  });
+});
+
+test("buildChatCompletionTemperature omits temperature for native OpenAI gpt-5 chat completions", () => {
+  assert.equal(supportsTemperature("gpt-5.4-mini", { assumeOpenAI: true }), false);
+  assert.equal(supportsTemperature("gpt-5.4-mini"), true);
+  assert.deepEqual(buildChatCompletionTemperature("gpt-5.4-mini", 0.3, { assumeOpenAI: true }), {});
+  assert.deepEqual(buildChatCompletionTemperature("gpt-4o-mini", 0.3, { assumeOpenAI: true }), {
+    temperature: 0.3,
+  });
+  assert.deepEqual(buildChatCompletionTemperature("gpt-5.4-mini", 0.3), {
+    temperature: 0.3,
   });
 });
 
@@ -181,6 +195,7 @@ test("fallback OpenAI client uses max_completion_tokens for gpt-5 providers", as
     assert.equal(requestBody?.model, "gpt-5.2");
     assert.equal(requestBody?.max_completion_tokens, 1234);
     assert.equal("max_tokens" in (requestBody ?? {}), false);
+    assert.equal("temperature" in (requestBody ?? {}), false);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -281,6 +296,7 @@ test("fallback OpenAI client keeps max_tokens for custom base URLs", async () =>
     assert.equal(requestBody?.model, "gpt-5.2");
     assert.equal(requestBody?.max_tokens, 256);
     assert.equal("max_completion_tokens" in (requestBody ?? {}), false);
+    assert.equal(requestBody?.temperature, 0.3);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/openclaw-install-cli.test.ts
+++ b/tests/openclaw-install-cli.test.ts
@@ -74,6 +74,14 @@ test("CLI has cmdOpenclawUpgrade function", async () => {
   );
 });
 
+test("CLI has cmdOpenclawMigrateEngram function", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes("cmdOpenclawMigrateEngram"),
+    "CLI must define explicit legacy Engram migration tooling",
+  );
+});
+
 test("CLI --yes / -y / --force flags are supported", async () => {
   const src = await readCli();
   assert.ok(
@@ -143,6 +151,20 @@ test("CLI openclaw upgrade supports release and restart flags", async () => {
   assert.ok(
     src.includes("--no-restart") || src.includes("restartGateway"),
     "CLI upgrade must handle restart control",
+  );
+});
+
+test("CLI openclaw migrate-engram backs up legacy extension dir", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes('subAction === "migrate-engram"'),
+    "CLI must wire remnic openclaw migrate-engram",
+  );
+  assert.ok(
+    src.includes("--legacy-plugin-dir") &&
+      src.includes("legacyPluginDirForBackup") &&
+      src.includes("Backed up legacy plugin dir"),
+    "migrate-engram must support and report legacy extension backup",
   );
 });
 


### PR DESCRIPTION
## Summary
- add `remnic openclaw migrate-engram` as an explicit legacy `@joshuaswarren/openclaw-engram` -> `@remnic/plugin-openclaw` migration command
- back up the legacy `openclaw-engram` extension directory while preserving the canonical safe upgrade/install path
- document config-key behavior, custom patch preservation, verification steps, and agent discoverability in `llms.txt`
- omit `temperature` for native OpenAI `gpt-5*` chat-completions requests while keeping `max_completion_tokens`

Fixes #871.

## Test Plan
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec tsx --test tests/openai-chat-compat.test.ts tests/openclaw-install-cli.test.ts tests/openclaw-install-logic.test.ts`
- `npm run check-config-contract`
- `bash scripts/check-review-patterns.sh`
- `npm run build`

Note: `npm run preflight:quick` started successfully through type/config/review-pattern checks, but in this worktree it expands into the full test glob, showed unrelated benchmark adapter failures, then stalled in unrelated LCM tests. I stopped that hung run and used focused verification above for this patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new OpenClaw migration/upgrade command that modifies on-disk plugin installs and backup behavior, and changes request payload shaping for OpenAI-compatible chat calls (GPT-5), which could impact upgrade flows and provider compatibility if incorrect.
> 
> **Overview**
> Adds an explicit `remnic openclaw migrate-engram` command to migrate legacy `@joshuaswarren/openclaw-engram` installs to `@remnic/plugin-openclaw`, extending the existing upgrade flow to *also back up* the legacy extension directory (with a new `--legacy-plugin-dir` override) while preserving `memoryDir` and setting the canonical `openclaw-remnic` slot/entry.
> 
> Updates docs and discoverability (README, OpenClaw docs, platform migration guide, `llms.txt`) with a dedicated migration guide covering backups, config keys, patch preservation, and verification steps.
> 
> Improves OpenAI GPT-5 chat-completions compatibility by omitting `temperature` for native OpenAI `gpt-5*` models while continuing to use `max_completion_tokens`; adds helper APIs and expands tests to lock in the new request-shaping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d711e56f5eceae1ef39c3464361ead409cd142c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->