### PR TITLE
Fix AMA-Bench artifact JSON and trajectory answer protocol

### DIFF
--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   answerBenchmarkQuestion,
+  buildAgenticMemoryBenchmarkQuestion,
   buildStrictBenchmarkQuestion,
   inferAnswerFormat,
 } from "./answering.ts";
@@ -78,6 +79,34 @@ test("default answering preserves legacy exact questions", async () => {
   assert.equal(result.finalAnswer, "The generated answer.");
 });
 
+test("agentic-memory answering asks responders to synthesize grounded trajectory inferences", async () => {
+  const result = await answerBenchmarkQuestion({
+    question: "What strategic goal did the up/up/right/right maneuver accomplish?",
+    recalledText: "[Action 39]: up\n[Observation 39]: ball blocks the row",
+    answerMode: "agentic-memory",
+    responder: {
+      async respond(question, recalledText) {
+        assert.match(question, /Agentic trajectory protocol:/);
+        assert.match(question, /causal, strategic, and temporal reasoning/);
+        assert.match(question, /requires inference/);
+        assert.match(question, /step numbers, action names, object names/);
+        assert.equal(
+          recalledText,
+          "[Action 39]: up\n[Observation 39]: ball blocks the row",
+        );
+        return {
+          text: "It repositioned around the blocking ball.",
+          tokens: { input: 12, output: 7 },
+          latencyMs: 3,
+          model: "test-model",
+        };
+      },
+    },
+  });
+
+  assert.equal(result.finalAnswer, "It repositioned around the blocking ball.");
+});
+
 test("strict question builder preserves structured protocols", () => {
   assert.equal(
     inferAnswerFormat("Choices:\nA. Tea\nB. Coffee\nPlease output the correct option"),
@@ -91,6 +120,17 @@ test("strict question builder preserves structured protocols", () => {
     buildStrictBenchmarkQuestion("Final output format:\n=== Traveler Plan ==="),
     /Preserve the requested structured output format exactly/,
   );
+});
+
+test("agentic-memory question builder preserves strict safety while allowing trajectory inference", () => {
+  const prompt = buildAgenticMemoryBenchmarkQuestion(
+    "What would have happened if the agent moved down?",
+  );
+
+  assert.match(prompt, /Use only the supplied Remnic memory context as evidence/);
+  assert.match(prompt, /what would have happened/);
+  assert.match(prompt, /synthesize the best-supported explanation/);
+  assert.match(prompt, /Do not answer "unknown" merely because the answer requires inference/);
 });
 
 test("strict question builder preserves free-form summarization prompts", () => {

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -1,6 +1,6 @@
 import type { BenchResponder } from "./adapters/types.js";
 
-export type BenchmarkAnswerMode = "default" | "strict";
+export type BenchmarkAnswerMode = "default" | "strict" | "agentic-memory";
 
 export type BenchmarkAnswerFormat =
   | "auto"
@@ -51,6 +51,8 @@ export async function answerBenchmarkQuestion(options: {
   const question =
     answerMode === "strict"
       ? buildStrictBenchmarkQuestion(options.question, answerFormat)
+      : answerMode === "agentic-memory"
+        ? buildAgenticMemoryBenchmarkQuestion(options.question, answerFormat)
       : options.question;
   const response = await options.responder.respond(
     question,
@@ -65,6 +67,23 @@ export async function answerBenchmarkQuestion(options: {
     tokens: response.tokens,
     model: response.model,
   };
+}
+
+export function buildAgenticMemoryBenchmarkQuestion(
+  question: string,
+  answerFormat: BenchmarkAnswerFormat = "auto",
+): string {
+  const prompt = buildStrictBenchmarkQuestion(question, answerFormat);
+  return [
+    prompt,
+    "",
+    "Agentic trajectory protocol:",
+    "- Treat action and observation sequences as evidence for causal, strategic, and temporal reasoning.",
+    "- When the question asks why an action mattered, what a maneuver accomplished, what would have happened, or what can be inferred, synthesize the best-supported explanation from the trajectory instead of looking only for an explicit quoted answer.",
+    "- Use step numbers, action names, object names, files, tools, commands, rewards, or state changes from the memory context when they support the answer.",
+    "- Do not answer \"unknown\" merely because the answer requires inference; reserve \"unknown\" for cases where the trajectory evidence is absent or contradictory.",
+    "- Keep the answer focused on the asked trajectory event and omit unrelated recalled history.",
+  ].join("\n");
 }
 
 export function buildStrictBenchmarkQuestion(

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -92,7 +92,7 @@ export async function runAmaBenchBenchmark(
           question: qa.question,
           recalledText,
           responder: options.system.responder,
-          answerMode: "strict",
+          answerMode: "agentic-memory",
         });
         const judgeResult = await llmJudgeScoreDetailed(
           options.system.judge,

--- a/packages/bench/src/reporter.test.ts
+++ b/packages/bench/src/reporter.test.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { redactBenchmarkResultSecrets, writeBenchmarkResult } from "./reporter.ts";
+import {
+  redactBenchmarkResultSecrets,
+  sanitizeBenchmarkResultForJson,
+  writeBenchmarkResult,
+} from "./reporter.ts";
 import type { BenchmarkResult } from "./types.js";
 
 function buildResult(): BenchmarkResult {
@@ -132,6 +136,49 @@ test("writeBenchmarkResult does not persist secret values", async () => {
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test("writeBenchmarkResult emits parseable JSON when model text contains lone surrogates", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-reporter-"));
+  try {
+    const result = buildResult();
+    result.results.tasks = [
+      {
+        taskId: "ama-q1",
+        question: "What happened?",
+        expected: "valid unicode",
+        actual: "orphan high surrogate: \uD83D and orphan low surrogate: \uDC4B",
+        scores: { llm_judge: 0 },
+        latencyMs: 1,
+        tokens: { input: 0, output: 0 },
+        details: {
+          "bad\uD83Dkey": "nested orphan \uD83D still parseable",
+          validPair: "wave \uD83D\uDC4B",
+        },
+      },
+    ];
+
+    const filePath = await writeBenchmarkResult(result, dir);
+    const raw = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as BenchmarkResult;
+
+    assert.doesNotMatch(raw, /\\ud83d(?!\\udc[0-9a-f]{2})/i);
+    assert.doesNotMatch(raw, /(?<!\\ud[89ab][0-9a-f]{2})\\udc[0-9a-f]{2}/i);
+    assert.match(parsed.results.tasks[0]?.actual ?? "", /�/);
+    assert.equal(parsed.results.tasks[0]?.details?.validPair, "wave 👋");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("sanitizeBenchmarkResultForJson preserves paired surrogate characters", () => {
+  const sanitized = sanitizeBenchmarkResultForJson({
+    text: "valid pair \uD83D\uDC4B",
+    bad: "invalid pair \uD83D",
+  });
+
+  assert.equal(sanitized.text, "valid pair 👋");
+  assert.equal(sanitized.bad, "invalid pair �");
 });
 
 test("writeBenchmarkResult preserves main result when leaderboard sidecar write fails", async () => {

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -22,6 +22,10 @@ export function redactBenchmarkResultSecrets<T>(value: T): T {
   return redactSecrets(value) as T;
 }
 
+export function sanitizeBenchmarkResultForJson<T>(value: T): T {
+  return sanitizeForJson(value) as T;
+}
+
 function redactSecrets(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => redactSecrets(item));
@@ -38,6 +42,52 @@ function redactSecrets(value: unknown): unknown {
       : redactSecrets(nestedValue);
   }
   return redacted;
+}
+
+function sanitizeForJson(value: unknown): unknown {
+  if (typeof value === "string") {
+    return replaceLoneSurrogates(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForJson(item));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    sanitized[replaceLoneSurrogates(key)] = sanitizeForJson(nestedValue);
+  }
+  return sanitized;
+}
+
+function replaceLoneSurrogates(value: string): string {
+  let out = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += value[index] + value[index + 1];
+        index += 1;
+      } else {
+        out += "\uFFFD";
+      }
+      continue;
+    }
+
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      out += "\uFFFD";
+      continue;
+    }
+
+    out += value[index];
+  }
+  return out;
 }
 
 export async function writeBenchmarkResult(
@@ -76,7 +126,10 @@ export async function writeBenchmarkResult(
     },
   };
 
-  await writeFile(filePath, JSON.stringify(redactBenchmarkResultSecrets(resultWithArtifacts), null, 2) + "\n");
+  const publicResult = sanitizeBenchmarkResultForJson(
+    redactBenchmarkResultSecrets(resultWithArtifacts),
+  );
+  await writeFile(filePath, JSON.stringify(publicResult, null, 2) + "\n");
   return filePath;
 }
 


### PR DESCRIPTION
## Summary
- sanitize benchmark result strings before JSON artifact writes so lone surrogate model output cannot produce invalid JSON
- add an agentic-memory answer protocol for AMA-Bench so responder prompts allow grounded causal/strategic trajectory inference while still requiring Remnic memory evidence
- wire AMA-Bench to the new protocol and add regression tests

## Why
The completed isolated AMA-Bench run produced a non-parseable result artifact due to a lone surrogate escape in model text, so it is not leaderboard-ready. The score analysis also showed many low-scored AMA examples had trajectory evidence but needed grounded inference rather than explicit-value lookup.

## Verification
- pnpm exec tsx --test packages/bench/src/answering.test.ts packages/bench/src/reporter.test.ts tests/bench-ama-bench-runner.test.ts
- npm run check-types
- git diff --check

## Note
- npm run preflight:quick was attempted, but the broad suite showed unrelated fallback-LLM failures and then stalled in unrelated long-running tests; I interrupted it after the focused gates above passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark prompting for AMA-Bench (switching from `strict` to a new `agentic-memory` protocol), which can materially shift scores/outputs. Also mutates result payloads before JSON serialization to handle invalid Unicode, which could affect downstream consumers expecting exact text.
> 
> **Overview**
> **AMA-Bench answering now uses a new `agentic-memory` mode** that layers an “Agentic trajectory protocol” onto the existing strict prompt, explicitly encouraging grounded causal/strategic/temporal inference from recalled trajectories (while still requiring Remnic memory evidence).
> 
> **Benchmark result artifact writing is hardened** by sanitizing all strings (including object keys) to replace lone surrogate code units with the Unicode replacement character before `JSON.stringify`, preventing non-parseable JSON when model output contains invalid Unicode. Regression tests cover the new prompt mode and the JSON-sanitization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e2e45393d16396c4576a177fd7c46baa069296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->