### PR TITLE
Fix AMA trajectory evidence focus

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -390,6 +390,40 @@ test("adapter recall maps turn references to direct and paired turn candidates",
   }
 });
 
+test("adapter recall keeps AMA explicit step prompts focused on the cited window", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const messages = Array.from({ length: 30 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-ep-test", messages);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-ep-test",
+      "Between steps 20 and 23, which single action mattered?",
+      24_000,
+    );
+
+    assert.match(recalled, /## Explicit Cue Evidence/);
+    assert.match(recalled, /\[Action 20\]: move-20/);
+    assert.match(recalled, /\[Action 23\]: move-23/);
+    assert.doesNotMatch(recalled, /\[Action 24\]: move-24/);
+    assert.doesNotMatch(recalled, /\[Action 29\]: move-29/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
 test("adapter recall preserves long explicit reference lists", async () => {
   const adapter = await createRemnicAdapter();
 

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import {
   buildEvidencePack,
   buildExplicitCueRecallSection,
+  collectExplicitTurnReferences,
   Orchestrator,
   parseConfig,
 } from "@remnic/core";
@@ -313,6 +314,10 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
 
         const sections: string[] = [];
         let usedChars = 0;
+        const hasExplicitReferences =
+          collectExplicitTurnReferences(query).length > 0;
+        const preferFocusedExplicitContext =
+          hasExplicitReferences && sessionId.startsWith("ama-");
 
         const exactReferenceEvidence = await buildExplicitCueRecallSection({
           engine,
@@ -333,8 +338,10 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           const coreBudget = Math.max(
             0,
             Math.min(
-              Math.floor(budget * 0.55),
-              Math.floor((budget - usedChars) * 0.7),
+              Math.floor(budget * (preferFocusedExplicitContext ? 0.25 : 0.55)),
+              Math.floor(
+                (budget - usedChars) * (preferFocusedExplicitContext ? 0.35 : 0.7),
+              ),
             ),
           );
           const coreRecall = await state.orchestrator.recall(query, sessionId, {
@@ -346,6 +353,11 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
             sections.push(section);
             usedChars += section.length;
           }
+        }
+
+        if (preferFocusedExplicitContext && exactReferenceEvidence) {
+          const joined = sections.join("\n\n");
+          return joined.length > budget ? joined.slice(0, budget) : joined;
         }
 
         if (query) {

--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -90,6 +90,8 @@ test("agentic-memory answering asks responders to synthesize grounded trajectory
         assert.match(question, /causal, strategic, and temporal reasoning/);
         assert.match(question, /requires inference/);
         assert.match(question, /step numbers, action names, object names/);
+        assert.match(question, /anchor the answer to those exact numbers/);
+        assert.match(question, /Do not assume an object disappeared/);
         assert.equal(
           recalledText,
           "[Action 39]: up\n[Observation 39]: ball blocks the row",
@@ -130,6 +132,7 @@ test("agentic-memory question builder preserves strict safety while allowing tra
   assert.match(prompt, /Use only the supplied Remnic memory context as evidence/);
   assert.match(prompt, /what would have happened/);
   assert.match(prompt, /synthesize the best-supported explanation/);
+  assert.match(prompt, /do not name a later action outside the range/);
   assert.match(prompt, /Do not answer "unknown" merely because the answer requires inference/);
 });
 

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -80,7 +80,11 @@ export function buildAgenticMemoryBenchmarkQuestion(
     "Agentic trajectory protocol:",
     "- Treat action and observation sequences as evidence for causal, strategic, and temporal reasoning.",
     "- When the question asks why an action mattered, what a maneuver accomplished, what would have happened, or what can be inferred, synthesize the best-supported explanation from the trajectory instead of looking only for an explicit quoted answer.",
+    "- For explicit step, action, observation, or turn references, anchor the answer to those exact numbers. Do not shift the answer to a neighboring step unless the question explicitly asks for the next or previous step.",
+    "- For cited step ranges, identify the action or state change inside that range; do not name a later action outside the range as the answer.",
+    "- If a game or tool trajectory requires a strategic abstraction, name the concrete mechanism being prepared or avoided, such as pushing a rule block, breaking a rule, opening a path, collecting an object, or undoing a loop.",
     "- Use step numbers, action names, object names, files, tools, commands, rewards, or state changes from the memory context when they support the answer.",
+    "- Do not assume an object disappeared because it was collected, pushed, or overlapped unless the before/after observations or active rules support that mechanism.",
     "- Do not answer \"unknown\" merely because the answer requires inference; reserve \"unknown\" for cases where the trajectory evidence is absent or contradictory.",
     "- Keep the answer focused on the asked trajectory event and omit unrelated recalled history.",
   ].join("\n");

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -225,6 +225,33 @@ test("buildExplicitCueRecallSection expands paired action and observation refere
   assert.match(section, /Observation 8/);
 });
 
+test("buildExplicitCueRecallSection does not leak the next action into step windows", async () => {
+  const messages = Array.from({ length: 54 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  messages[39] = { role: "assistant", content: "[Observation 19] before the range" };
+  messages[40] = { role: "user", content: "[Action 20] right" };
+  messages[41] = { role: "assistant", content: "[Observation 20] after right" };
+  messages[46] = { role: "user", content: "[Action 23] down" };
+  messages[47] = { role: "assistant", content: "[Observation 23] after down" };
+  messages[48] = { role: "user", content: "[Action 24] future action should not appear" };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "Between steps 20 and 23, which single action mattered?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /Observation 19/);
+  assert.match(section, /Action 20/);
+  assert.match(section, /Action 23/);
+  assert.match(section, /Observation 23/);
+  assert.doesNotMatch(section, /Action 24/);
+});
+
 test("buildExplicitCueRecallSection expands direct turn references", async () => {
   const engine = new FakeCueEngine({
     "bench-session": [

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -907,7 +907,13 @@ function candidateTurnIndexesForReference(
   }
 
   const pairedBase = reference.number * 2;
-  for (let offset = -2; offset <= 3; offset += 1) {
+  // Action/observation traces are stored as paired turns:
+  //   turn 2N     => [Action N]
+  //   turn 2N + 1 => [Observation N]
+  // Include the preceding observation so transition questions can compare the
+  // state before and after the action, but avoid pulling in Action N+1. Future
+  // actions caused explicit step questions to drift to the next step.
+  for (let offset = -1; offset <= 1; offset += 1) {
     candidates.add(pairedBase + offset);
   }
 


### PR DESCRIPTION
## Summary
- tighten core explicit step/action recall windows so cited trajectory steps do not include the next action
- keep AMA explicit-step prompts focused on cited evidence instead of broad late-episode context
- strengthen AMA answer instructions for exact step anchoring and supported game-mechanic inference

## Validation
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts
- pnpm exec tsx --test packages/bench/src/answering.test.ts
- pnpm exec tsx --test packages/bench/src/adapters/remnic-adapter.test.ts
- pnpm --filter @remnic/core check-types
- pnpm --filter @remnic/bench check-types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall budgeting and explicit-step window expansion logic, which can materially alter what evidence is surfaced and therefore benchmark answers. Risk is limited to recall/prompt behavior (no auth/data persistence changes), but could affect evaluation results and downstream expectations.
> 
> **Overview**
> Tightens explicit step/turn evidence expansion so step-based windows include the prior observation and the referenced action/observation, but *do not* pull in the next step’s action (fixing step-window “drift”). Adds a regression test ensuring `buildExplicitCueRecallSection` doesn’t leak a future action for a cited step range.
> 
> Updates the bench `Remnic` adapter recall path to detect explicit step/turn references for `ama-*` sessions and prefer a **focused** recall: allocate less budget to the broader core recall pipeline and, when explicit evidence exists, return early without adding search/assembled recall context. Adds a bench test covering that AMA step-range prompts stay within the cited window.
> 
> Strengthens the `agentic-memory` answer prompt to require anchoring to exact cited steps/ranges and to avoid unsupported assumptions about trajectory mechanics, with tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80dd8b75dce4ed52ce9e9bffe7a59fcacf57bc36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->