### PR TITLE
docs(openclaw): use npm install prefix

### DIFF
--- a/.changeset/openclaw-2026-5-install-prefix.md
+++ b/.changeset/openclaw-2026-5-install-prefix.md
@@ -1,0 +1,9 @@
+---
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Update OpenClaw install instructions for the 2026.5.2 plugin resolver so fresh
+installs use the explicit `clawhub:` source prefix now that Remnic is published
+on ClawHub, while npm fallback/rollback commands use the explicit `npm:` source
+prefix.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you have OpenClaw installed, the fastest path to working Remnic memory is:
 
 ```bash
 # 1. Install the plugin package
-openclaw plugins install @remnic/plugin-openclaw --pin
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 
 # 2. Wire up the memory slot automatically
 remnic openclaw install
@@ -95,7 +95,7 @@ OpenClaw memory slot to `openclaw-remnic`. See the
 ### Option 1: Install from the CLI
 
 ```bash
-openclaw plugins install @remnic/plugin-openclaw --pin
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 ```
 
 ### Option 2: Ask your OpenClaw agent to install it

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@
 ### Option A: npm (recommended)
 
 ```bash
-openclaw plugins install @remnic/plugin-openclaw --pin
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 ```
 
 ### Option B: Developer install (from Git)

--- a/docs/guides/migrations.md
+++ b/docs/guides/migrations.md
@@ -16,7 +16,7 @@ remnic doctor                    # standalone users
 npm test                         # 672 tests pass
 ```
 
-**Rollback:** `openclaw plugins install @remnic/plugin-openclaw@<previous-version> --pin`
+**Rollback:** `openclaw plugins install npm:@remnic/plugin-openclaw@<previous-version>`
 
 ---
 

--- a/docs/guides/platform-migration.md
+++ b/docs/guides/platform-migration.md
@@ -256,7 +256,7 @@ If the upgrade causes issues:
 **OpenClaw plugin users** — pin to the previous version:
 
 ```bash
-openclaw plugins install @remnic/plugin-openclaw@<previous-version> --pin
+openclaw plugins install npm:@remnic/plugin-openclaw@<previous-version>
 ```
 
 **Standalone CLI users** — the legacy shim package (`@joshuaswarren/openclaw-engram`) only exposes `engram-access`, not the full CLI. Full CLI rollback requires building from source at the desired version tag:

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -17,8 +17,14 @@ Canonical upstream references for this adapter:
 ## Install
 
 ```bash
-openclaw plugins install @remnic/plugin-openclaw --pin
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 ```
+
+OpenClaw 2026.5.2+ resolves bare plugin package names through ClawHub first and
+then falls back to npm. Remnic is published on ClawHub as
+`@remnic/plugin-openclaw`, so the explicit `clawhub:` prefix keeps fresh installs
+deterministic. For npm-only fallback or rollback versions, use the explicit
+`npm:` source prefix, such as `npm:@remnic/plugin-openclaw@<version>`.
 
 Or use the Remnic installer:
 

--- a/llms.txt
+++ b/llms.txt
@@ -188,10 +188,15 @@ QUICK START (STANDALONE)
 
 QUICK START (OPENCLAW)
 
-  openclaw plugins install @remnic/plugin-openclaw --pin
+  openclaw plugins install clawhub:@remnic/plugin-openclaw
   remnic openclaw install
   launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
   remnic doctor
+
+  OpenClaw 2026.5.2+ resolves bare plugin package names through ClawHub before
+  npm fallback. Remnic is published on ClawHub as @remnic/plugin-openclaw; for
+  npm-only fallback or rollback versions, use the explicit npm source prefix
+  npm:@remnic/plugin-openclaw@<version>.
 
 OPENCLAW PLUGIN COMPATIBILITY
 

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -7,7 +7,7 @@ Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory 
 ## Install
 
 ```bash
-openclaw plugins install @remnic/plugin-openclaw --pin
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 ```
 
 Or ask your OpenClaw agent:

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.16",
+  "version": "1.0.18",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,16 @@
     "plugin": "./openclaw.plugin.json",
     "extensions": [
       "./dist/index.js"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.4.8"
+    },
+    "build": {
+      "openclawVersion": "2026.5.2"
+    },
+    "install": {
+      "minHostVersion": ">=2026.4.8"
+    }
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts",

--- a/packages/shim-openclaw-engram/README.md
+++ b/packages/shim-openclaw-engram/README.md
@@ -7,7 +7,7 @@
 Replace this package with the canonical one:
 
 ```bash
-openclaw plugins install @remnic/plugin-openclaw --pin
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 ```
 
 Your existing memories, configuration, and settings will continue to work. The rename only changes the package name -- all functionality is preserved.

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.12",
+  "version": "9.3.14",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.12");
+  assert.equal(pkg.version, "9.3.14");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary\n- update Remnic OpenClaw install examples now that @remnic/plugin-openclaw is live on ClawHub\n- use explicit clawhub:@remnic/plugin-openclaw for fresh installs, while retaining npm: for npm-only rollback/fallback versions\n- add ClawHub-required package metadata and bump the OpenClaw plugin/shim package versions so npm/ClawHub artifacts can publish the corrected READMEs\n\n## Test Plan\n- pnpm exec tsx --test tests/shim-openclaw-engram-package.test.ts\n- npm view @remnic/plugin-openclaw@1.0.18 version --json || true\n- npm view @joshuaswarren/openclaw-engram@9.3.14 version --json || true\n- clawhub package publish packages/plugin-openclaw --family code-plugin --name @remnic/plugin-openclaw --version 1.0.18 --source-repo joshuaswarren/remnic --source-ref fix/openclaw-2026-5-install-docs --source-path packages/plugin-openclaw --dry-run --json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly documentation/changeset updates plus small package metadata/version bumps; no runtime logic changes beyond publish-time metadata interpretation by OpenClaw.
> 
> **Overview**
> Updates OpenClaw install/rollback docs to use explicit source prefixes: fresh installs now use `clawhub:@remnic/plugin-openclaw`, while rollback/fallback commands use `npm:@remnic/plugin-openclaw@<version>` to match the OpenClaw 2026.5.2 resolver behavior.
> 
> Bumps patch versions for `@remnic/plugin-openclaw` and the legacy `@joshuaswarren/openclaw-engram` shim, adds a changeset, and extends the OpenClaw plugin package metadata (`openclaw.compat/build/install`) so published artifacts declare the intended minimum host/plugin API versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b98dbdc3266f3648d4dfc23f2afb5e3b6ea3bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->