### PR TITLE
Fix OpenClaw prompt hook init timeout

### DIFF
--- a/.changeset/openclaw-init-gate-timeout.md
+++ b/.changeset/openclaw-init-gate-timeout.md
@@ -1,0 +1,10 @@
+---
+"@remnic/core": patch
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Register the OpenClaw `before_prompt_build` hook with Remnic's configurable
+`initGateTimeoutMs` budget and use the same setting for Remnic's internal
+cold-start init gate so slow first-turn startup can complete without the host's
+generic hook timeout aborting recall.

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -164,7 +164,8 @@ Relevant settings:
       "openclaw-remnic": {
         "config": {
           "flushOnResetEnabled": true,
-          "beforeResetTimeoutMs": 2000
+          "beforeResetTimeoutMs": 2000,
+          "initGateTimeoutMs": 30000
         }
       }
     }
@@ -177,6 +178,10 @@ Relevant settings:
 - `beforeResetTimeoutMs` bounds how long Remnic will wait before returning
   control to OpenClaw. Timeout is fail-open: reset continues even if the flush
   path is slow.
+- `initGateTimeoutMs` bounds Remnic's cold-start init wait during recall and is
+  also registered as the `before_prompt_build` hook timeout on OpenClaw versions
+  that support per-hook options. Increase it for slow first-turn startup on
+  OpenClaw 2026.5.2+; older OpenClaw builds ignore the hook option safely.
 
 Reset cleanup currently clears:
 

--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,12 @@ Packages:
   @remnic/hermes-provider TypeScript HTTP client for remote Remnic instances.
   remnic-hermes           Python PyPI package, MemoryProvider for Hermes Agent.
 
+OpenClaw adapter note:
+  The OpenClaw plugin registers `before_prompt_build` with Remnic's
+  `initGateTimeoutMs` as the per-hook timeout on SDKs that support hook
+  options. The same config bounds Remnic's internal cold-start init gate for
+  recall and day summaries. Default: 30000ms; accepted range: 1000-120000ms.
+
 Three-phase flow:
   1. Recall   Before each agent turn, inject relevant memories into context.
   2. Buffer   After each turn, accumulate content until a trigger fires.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -670,6 +670,13 @@
         "default": 2000,
         "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
       },
+      "initGateTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 30000,
+        "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
+      },
       "flushOnResetEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -170,7 +170,8 @@ Reset handling is configurable:
       "openclaw-remnic": {
         "config": {
           "flushOnResetEnabled": true,
-          "beforeResetTimeoutMs": 2000
+          "beforeResetTimeoutMs": 2000,
+          "initGateTimeoutMs": 30000
         }
       }
     }
@@ -181,6 +182,11 @@ Reset handling is configurable:
 The reset path clears per-session prompt caches and workspace override state.
 If `flushOnResetEnabled` is true, Remnic also attempts a bounded extraction
 flush before the reset completes.
+
+`initGateTimeoutMs` controls Remnic's cold-start init wait during recall and is
+registered as the `before_prompt_build` hook timeout on OpenClaw versions with
+per-hook timeout support. Raise it if first-turn recall is timing out during
+slow startup; older OpenClaw versions ignore the extra hook option safely.
 
 Session-scoped recall controls are exposed through OpenClaw's command
 discovery surface:

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -670,6 +670,13 @@
         "default": 2000,
         "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
       },
+      "initGateTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 30000,
+        "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
+      },
       "flushOnResetEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -79,6 +79,22 @@ test("parseConfig activeRecallCacheTtlMs=500 preserves the explicit positive ttl
   assert.equal(result.activeRecallCacheTtlMs, 500);
 });
 
+test("parseConfig initGateTimeoutMs defaults to OpenClaw cold-start budget", () => {
+  const result = parseConfig({});
+  assert.equal(result.initGateTimeoutMs, 30_000);
+});
+
+test("parseConfig initGateTimeoutMs accepts CLI-style numeric strings", () => {
+  const result = parseConfig({ initGateTimeoutMs: "45000" });
+  assert.equal(result.initGateTimeoutMs, 45_000);
+});
+
+test("parseConfig initGateTimeoutMs clamps unsafe values", () => {
+  assert.equal(parseConfig({ initGateTimeoutMs: 0 }).initGateTimeoutMs, 1_000);
+  assert.equal(parseConfig({ initGateTimeoutMs: 300_000 }).initGateTimeoutMs, 120_000);
+  assert.equal(parseConfig({ initGateTimeoutMs: "abc" }).initGateTimeoutMs, 30_000);
+});
+
 test("parseConfig keeps explicit cue recall opt-in and budgets configurable", () => {
   const defaults = parseConfig({});
   assert.equal(defaults.explicitCueRecallEnabled, false);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -48,6 +48,19 @@ const DEFAULT_WORKSPACE_DIR = path.join(
   "workspace",
 );
 
+const DEFAULT_INIT_GATE_TIMEOUT_MS = 30_000;
+
+function parseBoundedIntegerMs(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const coerced = coerceNumber(value);
+  if (coerced === undefined) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(coerced)));
+}
+
 // Coerce common string/number representations of a boolean to a real boolean.
 // Returns `undefined` when the value cannot be interpreted, so callers can
 // fall back to their own default. Guards against the "string `false` is
@@ -1493,6 +1506,12 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.beforeResetTimeoutMs === "number"
         ? Math.min(30_000, Math.max(100, Math.floor(cfg.beforeResetTimeoutMs)))
         : 2_000,
+    initGateTimeoutMs: parseBoundedIntegerMs(
+      cfg.initGateTimeoutMs,
+      DEFAULT_INIT_GATE_TIMEOUT_MS,
+      1_000,
+      120_000,
+    ),
     flushOnResetEnabled: cfg.flushOnResetEnabled !== false,
     commandsListEnabled: cfg.commandsListEnabled !== false,
     openclawToolsEnabled: cfg.openclawToolsEnabled !== false,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3612,7 +3612,10 @@ export class Orchestrator {
         await Promise.race([
           this.initPromise.catch(() => undefined),
           new Promise((resolve) => {
-            initGateTimeoutHandle = setTimeout(resolve, 15_000);
+            initGateTimeoutHandle = setTimeout(
+              resolve,
+              this.config.initGateTimeoutMs,
+            );
           }),
         ]);
       } finally {
@@ -4572,18 +4575,18 @@ export class Orchestrator {
       options.abortSignal?.addEventListener("abort", onAbort, { once: true });
     }
 
-    // Wait for initialization to complete before attempting recall.
-    // Timeout after 15s in case initialize() never fires (edge case).
+    // Wait for initialization to complete before attempting recall. The timeout
+    // is configurable so OpenClaw's per-hook budget and Remnic's internal init
+    // gate can stay aligned during cold starts.
     let initGateTimeoutHandle: NodeJS.Timeout | null = null;
     let onInitGateAbort: (() => void) | null = null;
     if (this.initPromise) {
-      const INIT_GATE_TIMEOUT_MS = 15_000;
       const gateResult = await Promise.race([
         this.initPromise.then(() => "ok" as const),
         new Promise<"timeout">((resolve) => {
           initGateTimeoutHandle = setTimeout(
             () => resolve("timeout"),
-            INIT_GATE_TIMEOUT_MS,
+            this.config.initGateTimeoutMs,
           );
         }),
         abortController.signal.aborted

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -789,6 +789,7 @@ export interface PluginConfig {
   // Requires OC fork with PR #29985 (api.resetSession).
   compactionResetEnabled: boolean;
   beforeResetTimeoutMs: number;
+  initGateTimeoutMs: number;
   flushOnResetEnabled: boolean;
   commandsListEnabled: boolean;
   openclawToolsEnabled: boolean;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -670,6 +670,13 @@
         "default": 2000,
         "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
       },
+      "initGateTimeoutMs": {
+        "type": "integer",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 30000,
+        "description": "Maximum time Remnic waits for cold-start initialization during recall; also registered as the OpenClaw before_prompt_build hook timeout on SDKs that support per-hook options."
+      },
       "flushOnResetEnabled": {
         "type": "boolean",
         "default": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2155,7 +2155,11 @@ const pluginDefinition = {
 
       if (sdkCaps.hasBeforePromptBuild) {
         // New SDK path — literal string for compat checker detection
-        api.on(
+        (api.on as (
+          event: string,
+          handler: (event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<unknown>,
+          opts?: { timeoutMs?: number },
+        ) => void)(
           "before_prompt_build",
           async (
             event: Record<string, unknown>,
@@ -2192,6 +2196,7 @@ const pluginDefinition = {
             }
             return result;
           },
+          { timeoutMs: cfg.initGateTimeoutMs },
         );
       } else {
         // Legacy SDK path — literal string for compat checker detection.
@@ -2241,7 +2246,11 @@ const pluginDefinition = {
     if (useMemoryPromptSection && api.registerMemoryPromptSection) {
       // Async pre-compute: run recall in before_prompt_build and cache result.
       // The hook receives both event and ctx — session identity is in ctx.
-      api.on(
+      (api.on as (
+        event: string,
+        handler: (event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<unknown>,
+        opts?: { timeoutMs?: number },
+      ) => void)(
         "before_prompt_build",
         async (
           event: Record<string, unknown>,
@@ -2264,6 +2273,7 @@ const pluginDefinition = {
           }
           return result;
         },
+        { timeoutMs: cfg.initGateTimeoutMs },
       );
 
       // Synchronous builder: returns the pre-computed lines for the

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -11,6 +11,7 @@ const REQUIRED_RUNTIME_SURFACE_KEYS = [
   "openclawToolsEnabled",
   "openclawToolSnippetMaxChars",
   "sessionTogglesEnabled",
+  "initGateTimeoutMs",
   "verboseRecallVisibility",
   "recallTranscriptsEnabled",
   "recallTranscriptRetentionDays",
@@ -185,6 +186,7 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
     );
 
     assert.equal(properties.beforeResetTimeoutMs?.default, 2000);
+    assert.equal(properties.initGateTimeoutMs?.default, 30000);
     assert.equal(properties.flushOnResetEnabled?.default, true);
     assert.equal(properties.commandsListEnabled?.default, true);
     assert.deepEqual(

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -129,7 +129,7 @@ interface MockApi {
   registerTool: (spec: unknown) => void;
   registerCli: (spec: unknown) => void;
   registerService: (spec: { id: string; start: () => Promise<void>; stop: () => Promise<void> }) => void;
-  on: (event: string, handler: unknown) => void;
+  on: (event: string, handler: unknown, opts?: unknown) => void;
   registerHook?: (events: unknown, handler: unknown, opts?: unknown) => void;
   runtime?: { version: string; agent?: { id?: string; workspaceDir?: string } };
   registrationMode?: string;
@@ -138,6 +138,7 @@ interface MockApi {
   registerCommand?: (spec: unknown) => void;
   _registeredHooks: string[];
   _hookHandlers: Map<string, unknown>;
+  _hookOptions: Map<string, unknown>;
   _registeredToolCount: number;
   _registeredToolNames: string[];
   _registeredToolSpecs: unknown[];
@@ -172,6 +173,7 @@ function buildNewSdkApi(label: string): MockApi {
     config: {},
     _registeredHooks: [],
     _hookHandlers: new Map(),
+    _hookOptions: new Map(),
     _registeredToolCount: 0,
     _registeredToolNames: [],
     _registeredToolSpecs: [],
@@ -192,9 +194,10 @@ function buildNewSdkApi(label: string): MockApi {
     registerService(spec) {
       api._registeredServiceIds.push(spec.id);
     },
-    on(event: string, _handler: unknown) {
+    on(event: string, _handler: unknown, opts?: unknown) {
       api._registeredHooks.push(event);
       api._hookHandlers.set(event, _handler);
+      api._hookOptions.set(event, opts);
     },
     registerHook(_events: unknown, _handler: unknown, _opts?: unknown) {},
     runtime: { version: "2026.3.22" },
@@ -214,6 +217,7 @@ function buildLegacySdkApi(label: string): MockApi {
     config: {},
     _registeredHooks: [],
     _hookHandlers: new Map(),
+    _hookOptions: new Map(),
     _registeredToolCount: 0,
     _registeredToolNames: [],
     _registeredToolSpecs: [],
@@ -231,9 +235,10 @@ function buildLegacySdkApi(label: string): MockApi {
     registerService(spec) {
       api._registeredServiceIds.push(spec.id);
     },
-    on(event: string, _handler: unknown) {
+    on(event: string, _handler: unknown, opts?: unknown) {
       api._registeredHooks.push(event);
       api._hookHandlers.set(event, _handler);
+      api._hookOptions.set(event, opts);
     },
     // No runtime, no registrationMode, no registerMemoryPromptSection
   };
@@ -258,6 +263,11 @@ test("new SDK api gets all new hooks + memory section", async () => {
     assert.ok(
       api._registeredHooks.includes("before_prompt_build"),
       "before_prompt_build should be registered for async pre-compute when registerMemoryPromptSection is available",
+    );
+    assert.deepEqual(
+      api._hookOptions.get("before_prompt_build"),
+      { timeoutMs: 30_000 },
+      "before_prompt_build should register Remnic's init-gate timeout with OpenClaw",
     );
 
     // before_agent_start should NOT be registered (legacy path)
@@ -328,6 +338,28 @@ test("new SDK api gets all new hooks + memory section", async () => {
     assert.ok(
       api._registeredServiceIds.includes("openclaw-remnic"),
       "service should be registered",
+    );
+  } finally {
+    await awaitPendingMigration();
+    restoreRegisterMigrationEnv(previousDisableMigration);
+    resetGlobals();
+  }
+});
+
+test("new SDK before_prompt_build hook uses configured initGateTimeoutMs", async () => {
+  resetGlobals();
+  const previousDisableMigration = disableRegisterMigrationForTest();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+
+    const api = buildNewSdkApi("new-sdk-timeout-config");
+    api.pluginConfig = { initGateTimeoutMs: "45000" };
+    plugin.register(api as any);
+
+    assert.deepEqual(
+      api._hookOptions.get("before_prompt_build"),
+      { timeoutMs: 45_000 },
+      "before_prompt_build should use the configured Remnic init-gate timeout",
     );
   } finally {
     await awaitPendingMigration();
@@ -849,6 +881,39 @@ test("capability-only SDK with allowPromptInjection=false skips recall hook regi
     assert.ok(
       cap.publicArtifacts,
       "publicArtifacts must still be registered — policy only gates prompt injection",
+    );
+  } finally {
+    await fixture.cleanup();
+    await awaitPendingMigration();
+    restoreRegisterMigrationEnv(previousDisableMigration);
+    resetGlobals();
+  }
+});
+
+test("capability-only before_prompt_build hook uses configured initGateTimeoutMs", async () => {
+  resetGlobals();
+  const previousDisableMigration = disableRegisterMigrationForTest();
+  const fixture = await makeMemoryFixture();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+
+    const api = buildNewSdkApi("capability-only-timeout-config");
+    api.pluginConfig = {
+      initGateTimeoutMs: 60_000,
+      memoryDir: fixture.memoryDir,
+      workspaceDir: fixture.workspaceDir,
+    };
+    delete api.registerMemoryPromptSection;
+    api.registerMemoryCapability = (spec: any) => {
+      api._registeredMemoryCapability = spec;
+    };
+
+    plugin.register(api as any);
+
+    assert.deepEqual(
+      api._hookOptions.get("before_prompt_build"),
+      { timeoutMs: 60_000 },
+      "capability-only before_prompt_build should pass the configured timeout to OpenClaw",
     );
   } finally {
     await fixture.cleanup();


### PR DESCRIPTION
## Summary
- add configurable `initGateTimeoutMs` for Remnic cold-start recall initialization
- register OpenClaw `before_prompt_build` hooks with that timeout on SDKs that support per-hook options, while remaining compatible with older SDKs
- document the setting in OpenClaw docs, README, llms.txt, and plugin manifests

Fixes #878.

## Verification
- `pnpm run check-types`
- `pnpm exec tsx --test packages/remnic-core/src/config.test.ts tests/sdk-compat-integration.test.ts tests/openclaw-plugin-runtime-surfaces.test.ts`
- `npm run check-config-contract`
- `node scripts/check-openclaw-plugin-sync.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall initialization gating and hook registration timeouts, which can affect first-turn reliability and latency under cold starts across OpenClaw SDK versions. Risk is moderate due to new config plumbing and altered timeout behavior, but bounded and covered by tests.
> 
> **Overview**
> Adds a new `initGateTimeoutMs` config (default 30s, clamped 1–120s) and uses it to control Remnic’s cold-start initialization gate for recall/day summaries instead of a fixed 15s timeout.
> 
> On OpenClaw SDKs that support per-hook options, registers `before_prompt_build` with `{ timeoutMs: initGateTimeoutMs }` so host hook timeouts match Remnic’s internal init budget; legacy SDK paths remain unchanged. Updates plugin manifests, docs/README/`llms.txt`, and tests to surface and validate the new setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee90464b5b7fe5d49192fbf413841acaee08404e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->