### PR TITLE
Publish OpenClaw timeout fix and automate ClawHub

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -445,3 +445,48 @@ jobs:
           trap 'rm -f ~/.ssh/release_deploy_key' EXIT
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o StrictHostKeyChecking=no"
           git push "git@github.com:${{ github.repository }}.git" "${RELEASE_COMMIT}:refs/heads/main"
+
+      - name: Publish OpenClaw plugin to ClawHub
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+          CLAWHUB_PACKAGE_NAME: "@remnic/plugin-openclaw"
+        run: |
+          if [ -z "${CLAWHUB_TOKEN:-}" ]; then
+            echo "::notice title=ClawHub publish skipped::CLAWHUB_TOKEN secret is not configured."
+            exit 0
+          fi
+
+          npm install -g clawhub@0.12.2
+          clawhub login --token "${CLAWHUB_TOKEN}" --no-browser
+
+          package_version="$(node -p "require('./packages/plugin-openclaw/package.json').version")"
+          if clawhub package inspect "${CLAWHUB_PACKAGE_NAME}" --version "${package_version}" --json >/dev/null 2>&1; then
+            echo "::notice title=ClawHub publish skipped::${CLAWHUB_PACKAGE_NAME}@${package_version} is already published."
+            exit 0
+          fi
+
+          pack_dir="${RUNNER_TEMP}/clawhub-openclaw-pack"
+          rm -rf "${pack_dir}"
+          mkdir -p "${pack_dir}"
+          pnpm --filter "${CLAWHUB_PACKAGE_NAME}" pack --pack-destination "${pack_dir}"
+          tarball="$(find "${pack_dir}" -maxdepth 1 -name '*.tgz' -print -quit)"
+          if [ -z "${tarball}" ]; then
+            echo "No ${CLAWHUB_PACKAGE_NAME} tarball produced" >&2
+            exit 1
+          fi
+
+          source_commit="$(git rev-parse HEAD)"
+          clawhub package publish "${tarball}" \
+            --family code-plugin \
+            --name "${CLAWHUB_PACKAGE_NAME}" \
+            --display-name "Remnic OpenClaw Plugin" \
+            --version "${package_version}" \
+            --host-targets openclaw \
+            --source-repo "${GITHUB_REPOSITORY}" \
+            --source-ref "${{ steps.version.outputs.tag_name }}" \
+            --source-commit "${source_commit}" \
+            --source-path packages/plugin-openclaw \
+            --changelog "Publish ${CLAWHUB_PACKAGE_NAME}@${package_version} from the GitHub release workflow." \
+            --json
+
+          clawhub package rescan "${CLAWHUB_PACKAGE_NAME}" --yes --json || true

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "providerAuthEnvVars": {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "providerAuthEnvVars": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-engram",
   "name": "Remnic OpenClaw Plugin",
-  "version": "9.3.15",
+  "version": "9.3.16",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "providerAuthEnvVars": {

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.15",
+  "version": "9.3.16",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.15");
+  assert.equal(pkg.version, "9.3.16");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary
- bump `@remnic/core`, `@remnic/plugin-openclaw`, and the legacy OpenClaw shim so the #878 timeout fix publishes to npm
- publish the built OpenClaw plugin tarball to ClawHub from the GitHub release workflow when `CLAWHUB_TOKEN` is configured
- keep ClawHub publish metadata tied to the release tag, commit, and `packages/plugin-openclaw` source path

## Verification
- `pnpm run check-types`
- `node scripts/check-openclaw-plugin-sync.mjs`
- `pnpm exec tsx --test tests/release-workflow-public-packages.test.ts tests/openclaw-plugin-runtime-surfaces.test.ts tests/shim-openclaw-engram-package.test.ts`
- `pnpm --filter @remnic/plugin-openclaw build && npm run verify:openclaw-clawpack`
- local `clawhub package publish ... --dry-run --json` with the packed `@remnic/plugin-openclaw@1.0.20` tarball

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the release workflow to add an additional publish target (ClawHub) using a new secret token; failures or misconfiguration could affect release automation but not runtime behavior.
> 
> **Overview**
> Updates the GitHub `release-and-publish.yml` workflow to optionally publish the packed `@remnic/plugin-openclaw` tarball to ClawHub (token-gated, skips if the version already exists, and records source tag/commit/path metadata).
> 
> Bumps versions for `@remnic/core`, `@remnic/plugin-openclaw`, and the legacy `@joshuaswarren/openclaw-engram` shim (plus corresponding `openclaw.plugin.json` manifests) and updates the shim package test to match the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e0a2ebcc2abf156bab1fdd709754d202b4b8d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->