### PR TITLE
Support OpenClaw 2026.5.3 setup metadata

### DIFF
--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -144,6 +144,10 @@ The plugin manifest advertises compatibility on two surfaces:
 - `supports` stays in place for OpenClaw 2026.4-era slot and lifecycle routing.
 - `contracts.tools` declares every Remnic-owned tool name for OpenClaw 2026.5+
   descriptor planning and tool ownership validation.
+- `setup.providers` mirrors the OpenAI auth env metadata for OpenClaw 2026.5.3+
+  setup/status discovery.
+- `providerAuthEnvVars` remains for older OpenClaw builds during the upstream
+  deprecation window.
 
 Keep both blocks. `contracts.tools` is additive for older OpenClaw runtimes, but
 OpenClaw 2026.5 rejects plugin tool registration when a runtime tool is missing

--- a/llms.txt
+++ b/llms.txt
@@ -215,6 +215,10 @@ OPENCLAW PLUGIN COMPATIBILITY
   The OpenClaw adapter keeps both manifest compatibility surfaces:
   supports: legacy/current slot, active-memory, heartbeat, command, and reset
   routing for OpenClaw 2026.4-era runtimes.
+  setup.providers mirrors OpenAI env-var auth metadata for OpenClaw 2026.5.3+
+  setup/status discovery. providerAuthEnvVars remains for older OpenClaw builds
+  during the upstream deprecation window. Keep both synchronized with
+  providerAuthChoices and configSchema.openaiApiKey.
   contracts.tools: required by OpenClaw 2026.5+ plugin descriptor planning and
   tool ownership validation. Add every Remnic-owned registerTool name here when
   adding OpenClaw tools, including conditional LCM aliases.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,9 +1,23 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+  "setup": {
+    "providers": [
+      {
+        "id": "openai",
+        "authMethods": [
+          "api-key"
+        ],
+        "envVars": [
+          "OPENAI_API_KEY"
+        ]
+      }
+    ],
+    "requiresRuntime": false
+  },
   "providerAuthEnvVars": {
     "openai": [
       "OPENAI_API_KEY"

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,9 +1,23 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+  "setup": {
+    "providers": [
+      {
+        "id": "openai",
+        "authMethods": [
+          "api-key"
+        ],
+        "envVars": [
+          "OPENAI_API_KEY"
+        ]
+      }
+    ],
+    "requiresRuntime": false
+  },
   "providerAuthEnvVars": {
     "openai": [
       "OPENAI_API_KEY"

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,9 +1,23 @@
 {
   "id": "openclaw-engram",
   "name": "Remnic OpenClaw Plugin",
-  "version": "9.3.16",
+  "version": "9.3.17",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+  "setup": {
+    "providers": [
+      {
+        "id": "openai",
+        "authMethods": [
+          "api-key"
+        ],
+        "envVars": [
+          "OPENAI_API_KEY"
+        ]
+      }
+    ],
+    "requiresRuntime": false
+  },
   "providerAuthEnvVars": {
     "openai": [
       "OPENAI_API_KEY"

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.16",
+  "version": "9.3.17",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -122,6 +122,16 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
 
     assert.equal(manifest.name, "Remnic OpenClaw Plugin");
     assert.equal(manifest.version, packageJson.version);
+    assert.deepEqual(manifest.setup, {
+      providers: [
+        {
+          id: "openai",
+          authMethods: ["api-key"],
+          envVars: ["OPENAI_API_KEY"],
+        },
+      ],
+      requiresRuntime: false,
+    });
     assert.deepEqual(manifest.providerAuthEnvVars?.openai, ["OPENAI_API_KEY"]);
     assert.deepEqual(manifest.providerAuthChoices, [
       {

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.16");
+  assert.equal(pkg.version, "9.3.17");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary
- mirror Remnic's OpenAI auth env metadata into openclaw.plugin.json setup.providers for OpenClaw 2026.5.3+ setup/status discovery
- keep providerAuthEnvVars for older OpenClaw builds during the upstream deprecation window
- bump the OpenClaw plugin/shim package versions for npm and ClawHub publication

## Verification
- node scripts/check-openclaw-plugin-sync.mjs
- pnpm exec tsx --test tests/openclaw-plugin-runtime-surfaces.test.ts tests/shim-openclaw-engram-package.test.ts tests/release-workflow-public-packages.test.ts
- npm run check-config-contract
- pnpm --filter @remnic/plugin-openclaw build && npm run verify:openclaw-clawpack
- pnpm run check-types
- HOME=/tmp/remnic-openclaw-beta-patched-home npm exec --yes openclaw@2026.5.3-beta.1 -- plugins install /tmp/remnic-openclaw-beta-patched/remnic-plugin-openclaw-1.0.21.tgz --pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to plugin/shim manifest metadata and version bumps, with tests updated to assert the new manifest surface.
> 
> **Overview**
> Adds `setup.providers` (OpenAI `api-key` + `OPENAI_API_KEY`) to the OpenClaw plugin manifests so OpenClaw 2026.5.3+ can discover auth requirements via `setup/status`, while keeping `providerAuthEnvVars` for older runtime compatibility.
> 
> Bumps published versions for `@remnic/plugin-openclaw` (1.0.21) and the legacy `@joshuaswarren/openclaw-engram` shim (9.3.17), and updates docs plus runtime-surface tests to enforce the new `setup` block and keep manifest copies in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3676140ad8f71a0df6630695c6e9efc89a5068f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->