### PR TITLE
Fix AMA explicit trajectory label recall

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -424,6 +424,44 @@ test("adapter recall keeps AMA explicit step prompts focused on the cited window
   }
 });
 
+test("adapter recall resolves AMA step labels when stored transcript turns are offset", async () => {
+  const adapter = await createRemnicAdapter();
+
+  try {
+    const preamble = Array.from({ length: 60 }, (_, index) => ({
+      role: (index % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+      content: `preamble turn ${index}`,
+    }));
+    const trace = Array.from({ length: 52 }, (_, index) => [
+      {
+        role: "user" as const,
+        content: `[Action ${index}]: move-${index}`,
+      },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${index}]: state-${index}`,
+      },
+    ]).flat();
+
+    await adapter.store("ama-ep-offset", [...preamble, ...trace]);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "ama-ep-offset",
+      "In steps 47 and 48, what did the maneuver accomplish?",
+      24_000,
+    );
+
+    assert.match(recalled, /## Explicit Cue Evidence/);
+    assert.match(recalled, /\[Observation 46\]: state-46/);
+    assert.match(recalled, /\[Action 47\]: move-47/);
+    assert.match(recalled, /\[Observation 48\]: state-48/);
+    assert.doesNotMatch(recalled, /\[Action 49\]: move-49/);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
 test("adapter recall preserves long explicit reference lists", async () => {
   const adapter = await createRemnicAdapter();
 

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -252,6 +252,198 @@ test("buildExplicitCueRecallSection does not leak the next action into step wind
   assert.doesNotMatch(section, /Action 24/);
 });
 
+test("buildExplicitCueRecallSection resolves action and observation labels when transcript turns are offset", async () => {
+  const messages = Array.from({ length: 130 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  messages[101] = {
+    role: "assistant",
+    content: "[Observation 46]: rule `door` 3 steps to the left",
+  };
+  messages[102] = { role: "user", content: "[Action 47]: left" };
+  messages[103] = {
+    role: "assistant",
+    content: "[Observation 47]: rule `door` 2 steps to the left",
+  };
+  messages[104] = { role: "user", content: "[Action 48]: up" };
+  messages[105] = {
+    role: "assistant",
+    content: "[Observation 48]: rule `door` 2 steps to the left and 1 step down",
+  };
+  messages[106] = {
+    role: "user",
+    content: "[Action 49]: future action should not appear",
+  };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "In steps 47 and 48, what did the left then up maneuver do?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /Observation 46/);
+  assert.match(section, /Action 47/);
+  assert.match(section, /Observation 47/);
+  assert.match(section, /Action 48/);
+  assert.match(section, /Observation 48/);
+  assert.doesNotMatch(section, /Action 49/);
+});
+
+test("buildExplicitCueRecallSection ignores quoted labels when resolving trajectory turns", async () => {
+  const messages = Array.from({ length: 120 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  messages[94] = { role: "user", content: "[Action 47]: fallback move" };
+  messages[95] = { role: "assistant", content: "[Observation 47]: fallback state" };
+  messages[101] = {
+    role: "assistant",
+    content: "The user later quoted [Action 47] while explaining an unrelated review.",
+  };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What happened in step 47?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /fallback move/);
+  assert.match(section, /fallback state/);
+  assert.doesNotMatch(section, /unrelated review/);
+});
+
+test("buildExplicitCueRecallSection keeps searching past short quoted-label clusters", async () => {
+  const messages = Array.from({ length: 150 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  for (let index = 0; index < 10; index += 1) {
+    const turnIndex = 70 + index * 2;
+    messages[turnIndex] = {
+      role: "assistant",
+      content: `[Action 47]: quoted by assistant ${index}`,
+    };
+    messages[turnIndex + 1] = {
+      role: "user",
+      content: `[Observation 47]: quoted by user ${index}`,
+    };
+  }
+  messages[110] = { role: "user", content: "[Action 47]: true move" };
+  messages[111] = { role: "assistant", content: "[Observation 47]: true state" };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What happened in step 47?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /true move/);
+  assert.match(section, /true state/);
+  assert.doesNotMatch(section, /quoted by assistant/);
+  assert.doesNotMatch(section, /quoted by user/);
+});
+
+test("buildExplicitCueRecallSection keeps numeric fallback when label search is saturated", async () => {
+  const messages = Array.from({ length: 180 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  for (let index = 0; index < 70; index += 1) {
+    messages[index] = {
+      role: index % 2 === 0 ? "user" : "assistant",
+      content:
+        index % 2 === 0
+          ? `[Action 47]: earlier duplicate ${index}`
+          : `[Observation 47]: earlier duplicate ${index}`,
+    };
+  }
+  messages[93] = { role: "assistant", content: "[Observation 46]: true prior" };
+  messages[94] = { role: "user", content: "[Action 47]: true move" };
+  messages[95] = { role: "assistant", content: "[Observation 47]: true state" };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What happened in step 47?",
+    maxChars: 8000,
+  });
+
+  assert.match(section, /true prior/);
+  assert.match(section, /true move/);
+  assert.match(section, /true state/);
+});
+
+test("buildExplicitCueRecallSection skips unpaired label clusters before fallback evidence", async () => {
+  const messages = Array.from({ length: 140 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  for (let index = 0; index < 35; index += 1) {
+    messages[index] = {
+      role: "user",
+      content: `[Action 47]: same-role quote ${index}`,
+    };
+  }
+  messages[93] = { role: "assistant", content: "[Observation 46] true prior" };
+  messages[94] = { role: "user", content: "[Action 47] true legacy move" };
+  messages[95] = { role: "assistant", content: "[Observation 47] true legacy state" };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What happened in step 47?",
+    maxChars: 3000,
+  });
+
+  assert.match(section, /true prior/);
+  assert.match(section, /true legacy move/);
+  assert.match(section, /true legacy state/);
+  assert.doesNotMatch(section, /same-role quote/);
+});
+
+test("buildExplicitCueRecallSection prefers nearby legacy labels over early long quote pairs", async () => {
+  const messages = Array.from({ length: 140 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  for (let index = 0; index < 3; index += 1) {
+    const turnIndex = index * 2;
+    const longQuote = "quoted detail ".repeat(250);
+    messages[turnIndex] = {
+      role: "user",
+      content: `[Action 47]: early quote pair ${index} ${longQuote}`,
+    };
+    messages[turnIndex + 1] = {
+      role: "assistant",
+      content: `[Observation 47]: early quote pair ${index} ${longQuote}`,
+    };
+  }
+  messages[93] = { role: "assistant", content: "[Observation 46] true prior" };
+  messages[94] = { role: "user", content: "[Action 47] true legacy move" };
+  messages[95] = { role: "assistant", content: "[Observation 47] true legacy state" };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What happened in step 47?",
+    maxChars: 3000,
+  });
+
+  assert.match(section, /true legacy move/);
+  assert.match(section, /true legacy state/);
+  assert.doesNotMatch(section, /early quote pair/);
+});
+
 test("buildExplicitCueRecallSection expands direct turn references", async () => {
   const engine = new FakeCueEngine({
     "bench-session": [

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -46,6 +46,9 @@ const TURN_REFERENCE_WINDOW_RADIUS = 0;
 const LEXICAL_CUE_WINDOW_RADIUS = 1;
 const LEXICAL_CUE_SEARCH_LIMIT = 3;
 const LEXICAL_CUE_MAX_TOKENS = 400;
+const CONTENT_LABEL_SEARCH_LIMIT = 64;
+const CONTENT_LABEL_MAX_TOKENS = 2_000;
+const CONTENT_LABEL_MAX_PAIRED_WINDOWS_PER_REFERENCE = 1;
 const LATEST_STATE_CUES = new Set([
   "as of",
   "currently",
@@ -298,6 +301,14 @@ async function collectTurnReferenceEvidence(options: {
     return;
   }
 
+  await collectContentLabelReferenceEvidence({
+    engine: options.engine,
+    sessionId: options.sessionId,
+    references,
+    evidenceItems: options.evidenceItems,
+    seenTurns: options.seenTurns,
+  });
+
   const windows = new Map<string, { fromTurn: number; toTurn: number }>();
   for (const reference of references) {
     for (const center of candidateTurnIndexesForReference(reference)) {
@@ -327,6 +338,214 @@ async function collectTurnReferenceEvidence(options: {
       expanded,
     );
   }
+}
+
+async function collectContentLabelReferenceEvidence(options: {
+  engine: ExplicitCueRecallEngine;
+  sessionId?: string;
+  references: ExplicitTurnReference[];
+  evidenceItems: Array<{
+    id: string;
+    sessionId: string;
+    turnIndex: number;
+    role: string;
+    content: string;
+  }>;
+  seenTurns: Set<string>;
+}): Promise<Set<number>> {
+  const resolved = new Set<number>();
+
+  for (const reference of options.references) {
+    if (reference.includeDirectTurn) {
+      continue;
+    }
+
+    const hits = await searchReferenceContentLabels(
+      options.engine,
+      reference.number,
+      options.sessionId,
+    );
+    if (hits.length === 0) {
+      continue;
+    }
+
+    resolved.add(reference.number);
+    let appendedWindows = 0;
+    for (const hit of hits) {
+      if (appendedWindows >= CONTENT_LABEL_MAX_PAIRED_WINDOWS_PER_REFERENCE) {
+        break;
+      }
+
+      const { fromTurn, toTurn } = contentLabelEvidenceWindow(hit);
+      const expanded = await options.engine.expandContext(
+        hit.session_id,
+        fromTurn,
+        toTurn,
+        CONTENT_LABEL_MAX_TOKENS,
+      );
+      if (!expandedHasPairedTrajectoryLabels(expanded, reference.number)) {
+        continue;
+      }
+      if (expanded.length === 0) {
+        appendEvidenceItem(options.evidenceItems, options.seenTurns, {
+          id: `${hit.session_id}:${hit.turn_index}`,
+          sessionId: hit.session_id,
+          turnIndex: hit.turn_index,
+          role: hit.role,
+          content: hit.content,
+        });
+        continue;
+      }
+      appendExpandedEvidence(
+        options.evidenceItems,
+        options.seenTurns,
+        hit.session_id,
+        expanded,
+      );
+      appendedWindows += 1;
+    }
+  }
+
+  return resolved;
+}
+
+async function searchReferenceContentLabels(
+  engine: ExplicitCueRecallEngine,
+  referenceNumber: number,
+  sessionId?: string,
+): Promise<
+  Array<{
+    turn_index: number;
+    role: string;
+    content: string;
+    session_id: string;
+    labelKind: "action" | "observation";
+  }>
+> {
+  const hits = new Map<
+    string,
+    {
+      turn_index: number;
+      role: string;
+      content: string;
+      session_id: string;
+      labelKind: "action" | "observation";
+    }
+  >();
+
+  for (const labelKind of ["action", "observation"] as const) {
+    const label = labelKind === "action" ? "Action" : "Observation";
+    for (const query of [`[${label} ${referenceNumber}]`, `${label} ${referenceNumber}`]) {
+      const results = await engine.searchContextFull(
+        query,
+        CONTENT_LABEL_SEARCH_LIMIT,
+        sessionId,
+      );
+      for (const result of results) {
+        if (
+          !isReferenceLabelRole(result.role, labelKind) ||
+          !contentHasReferenceLabel(result.content, labelKind, referenceNumber)
+        ) {
+          continue;
+        }
+        hits.set(`${result.session_id}:${result.turn_index}:${labelKind}`, {
+          turn_index: result.turn_index,
+          role: result.role,
+          content: result.content,
+          session_id: result.session_id,
+          labelKind,
+        });
+      }
+    }
+  }
+
+  const numericCandidates = candidateTurnIndexesForReference({
+    number: referenceNumber,
+    includeDirectTurn: false,
+  });
+  return [...hits.values()].sort((left, right) => {
+    const sessionOrder = left.session_id.localeCompare(right.session_id);
+    if (sessionOrder !== 0) {
+      return sessionOrder;
+    }
+    const leftDistance = nearestTurnDistance(left.turn_index, numericCandidates);
+    const rightDistance = nearestTurnDistance(right.turn_index, numericCandidates);
+    if (leftDistance !== rightDistance) {
+      return leftDistance - rightDistance;
+    }
+    return left.turn_index - right.turn_index || left.labelKind.localeCompare(right.labelKind);
+  });
+}
+
+function nearestTurnDistance(turnIndex: number, candidates: readonly number[]): number {
+  let nearest = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    nearest = Math.min(nearest, Math.abs(turnIndex - candidate));
+  }
+  return nearest;
+}
+
+function contentLabelEvidenceWindow(hit: {
+  turn_index: number;
+  labelKind: "action" | "observation";
+}): { fromTurn: number; toTurn: number } {
+  if (hit.labelKind === "action") {
+    return {
+      fromTurn: Math.max(0, hit.turn_index - 1),
+      toTurn: hit.turn_index + 1,
+    };
+  }
+
+  return {
+    fromTurn: Math.max(0, hit.turn_index - 1),
+    toTurn: hit.turn_index,
+  };
+}
+
+function contentHasReferenceLabel(
+  content: string,
+  labelKind: "action" | "observation",
+  referenceNumber: number,
+): boolean {
+  const label = labelKind === "action" ? "Action" : "Observation";
+  const escapedNumber = String(referenceNumber).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `^\\s*\\[\\s*${label}\\s+${escapedNumber}\\s*\\]\\s*(?::\\s*)?`,
+    "i",
+  ).test(content);
+}
+
+function isReferenceLabelRole(
+  role: string,
+  labelKind: "action" | "observation",
+): boolean {
+  if (labelKind === "action") {
+    return role === "user";
+  }
+  return role === "assistant";
+}
+
+function expandedHasPairedTrajectoryLabels(
+  expanded: Array<{ role: string; content: string }>,
+  referenceNumber: number,
+): boolean {
+  let hasAction = false;
+  let hasObservation = false;
+  for (const message of expanded) {
+    if (
+      isReferenceLabelRole(message.role, "action") &&
+      contentHasReferenceLabel(message.content, "action", referenceNumber)
+    ) {
+      hasAction = true;
+    }
+    if (
+      isReferenceLabelRole(message.role, "observation") &&
+      contentHasReferenceLabel(message.content, "observation", referenceNumber)
+    ) {
+      hasObservation = true;
+    }
+  }
+  return hasAction && hasObservation;
 }
 
 async function collectLexicalCueEvidence(options: {


### PR DESCRIPTION
## Summary
- Resolve explicit action/observation step references by searching stored content labels before falling back to paired-turn math.
- Preserve focused trajectory windows without leaking future actions.
- Add core and benchmark-adapter regressions for offset transcripts, matching the AMA-Bench failure mode from the latest full run.

## Validation
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts
- pnpm exec tsx --test packages/bench/src/adapters/remnic-adapter.test.ts
- pnpm --filter @remnic/core check-types
- pnpm --filter @remnic/bench check-types

## Note
- npm run preflight:quick was started, but the broad repository test phase stalled in long-running compatibility tests and was interrupted after focused verification had passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core explicit-cue recall selection logic, which can affect what evidence is surfaced (and potentially relevance/ordering) across many recall queries. Risk is mitigated by multiple new regression tests covering offsets, quoted-label noise, and saturation scenarios.
> 
> **Overview**
> Fixes explicit step/trajectory recall when stored transcripts have extra preamble turns by **searching for `[Action N]` / `[Observation N]` labels in content** before relying on numeric paired-turn math.
> 
> Adds guardrails to ignore quoted/duplicate label clusters and only include windows that contain a valid action+observation pair, preventing future-step leakage. Introduces new regressions in `explicit-cue-recall.test.ts` and the bench `remnic-adapter` tests for the offset AMA failure mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968afbe740ed09eab879b2f01e3f659674c31a42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->