### PR TITLE
fix(openclaw): prefer gateway LLMs for Remnic

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenClaw's built-in memory works for simple cases, but it doesn't scale. It lack
 
 ## The Solution
 
-Remnic is an open-source, local-first memory system that replaces OpenClaw's default memory with something much more capable — while keeping everything on your machine. It watches your agent conversations, extracts durable knowledge, and injects the right memories back at the start of every session. Use OpenAI or a **local LLM** (Ollama, LM Studio, etc.) for extraction — your choice.
+Remnic is an open-source, local-first memory system that replaces OpenClaw's default memory with something much more capable — while keeping everything on your machine. It watches your agent conversations, extracts durable knowledge, and injects the right memories back at the start of every session. Route extraction through the OpenClaw gateway model chain, OpenAI, or a **local LLM** (Ollama, LM Studio, etc.) — your choice.
 
 Remnic is the **universal memory layer for AI agents**. It works natively with **[OpenClaw](https://github.com/openclaw/openclaw)**, **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[Codex CLI](https://github.com/openai/codex)**, **[Hermes Agent](https://github.com/NousResearch/hermes-agent)**, and any **MCP-compatible client** (Replit, Cursor, etc.). When you tell any agent a preference, every agent knows it — they share one memory store.
 
@@ -194,18 +194,19 @@ After installation, add the Remnic bridge plugin to your `openclaw.json`:
       "openclaw-remnic": {
         "enabled": true,
         "config": {
-          // Option 1: Use OpenAI for extraction:
-          "openaiApiKey": "${OPENAI_API_KEY}"
+          // Recommended for OpenClaw: use the gateway model chain.
+          "modelSource": "gateway",
+          "gatewayAgentId": "remnic-llm",
+          "fastGatewayAgentId": "remnic-llm-fast",
 
-          // Option 2: Use Remnic's local LLM path (plugin mode only; no API key needed):
+          // Optional: Use Remnic's local LLM path (plugin mode only; no API key needed):
           // "localLlmEnabled": true,
           // "localLlmUrl": "http://localhost:1234/v1",
           // "localLlmModel": "qwen2.5-32b-instruct"
 
-          // Option 3: Use the gateway model chain (primary path in gateway mode):
-          // "modelSource": "gateway",
-          // "gatewayAgentId": "remnic-llm",
-          // "fastGatewayAgentId": "remnic-llm-fast"
+          // Optional: Use OpenAI directly (plugin mode only):
+          // "modelSource": "plugin",
+          // "openaiApiKey": "${OPENAI_API_KEY}"
         }
       }
     }
@@ -943,7 +944,8 @@ OpenClaw plugin settings live in `openclaw.json` under `plugins.entries.openclaw
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `openaiApiKey` | `(env)` | OpenAI API key (optional when using a local LLM) |
+| `modelSource` | `gateway` for new OpenClaw installs; `plugin` otherwise | `gateway` routes LLM calls through OpenClaw agent model chains; `plugin` uses Remnic's own OpenAI/local LLM config |
+| `openaiApiKey` | `(env in plugin mode)` | Optional OpenAI API key. Not needed when `modelSource` is `gateway`; Remnic does not inherit `OPENAI_API_KEY` in gateway mode. |
 | `localLlmEnabled` | `false` | Enable Remnic's local LLM path when `modelSource` is `plugin` |
 | `localLlmUrl` | unset | Local LLM endpoint (e.g., `http://localhost:1234/v1`) |
 | `localLlmModel` | unset | Local model name (e.g., `qwen2.5-32b-instruct`) |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -8,7 +8,7 @@ Use `openclaw engram config-review` for opinionated tuning recommendations and `
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `openaiApiKey` | `(env fallback)` | OpenAI API key or `${ENV_VAR}` reference |
+| `openaiApiKey` | `(env fallback in plugin mode)` | Optional OpenAI API key or `${ENV_VAR}` reference. When `modelSource` is `gateway`, Remnic does not inherit `OPENAI_API_KEY`; gateway provider auth is used instead. |
 | `openaiBaseUrl` | `(env fallback)` | Override OpenAI API base URL (e.g. for proxies or compatible endpoints); falls back to `OPENAI_BASE_URL` env var |
 | `model` | `gpt-5.2` | OpenAI model for extraction and consolidation |
 | `reasoningEffort` | `low` | `none`, `low`, `medium`, `high` |
@@ -16,6 +16,8 @@ Use `openclaw engram config-review` for opinionated tuning recommendations and `
 | `workspaceDir` | `~/.openclaw/workspace` | Workspace root (IDENTITY.md location) |
 | `captureMode` | `implicit` | Memory write policy: `implicit`, `explicit`, or `hybrid` |
 | `debug` | `false` | Enable debug logging |
+
+OpenClaw installs default new Remnic entries to `modelSource: "gateway"` so LLM calls use the gateway agent model chain instead of requiring a Remnic-specific OpenAI API key.
 
 `captureMode` behavior:
 
@@ -472,7 +474,7 @@ Route all Engram LLM calls through the OpenClaw gateway's agent model chain inst
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `modelSource` | `plugin` | `plugin` uses Engram's own openai/localLlm config; `gateway` delegates to a gateway agent's model chain |
+| `modelSource` | `gateway` for new OpenClaw installs; `plugin` otherwise | `gateway` delegates to a gateway agent's model chain; `plugin` uses Engram's own openai/localLlm config |
 | `gatewayAgentId` | `""` | Agent persona ID from `openclaw.json → agents.list[]` for primary LLM calls (extraction, consolidation, summarization). Falls back to `agents.defaults.model` if empty. |
 | `fastGatewayAgentId` | `""` | Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). Uses `gatewayAgentId` chain when empty. |
 
@@ -480,7 +482,7 @@ When `modelSource` is `gateway`:
 
 - `localLlmEnabled` and the direct OpenAI client are bypassed for primary LLM dispatch — all LLM calls flow through `FallbackLlmClient` with the configured agent chain
 - Extraction and consolidation start on the configured gateway chain directly; the historical "falling back to gateway" wording only applies when Engram is still in `plugin` mode
-- The existing `openaiApiKey`, `model`, and `localLlm*` settings are ignored for LLM dispatch but retained as config for backward compatibility
+- The existing `openaiApiKey`, `model`, and `localLlm*` settings are ignored for LLM dispatch but retained as config for backward compatibility; `OPENAI_API_KEY` is not inherited in gateway mode
 - `localLlmFast*` settings are also bypassed when `fastGatewayAgentId` is set
 - **Reranking** uses the `fastGatewayAgentId` chain (or `gatewayAgentId` if fast is unset) instead of the local LLM — this can dramatically reduce rerank latency when the fast chain points at a cloud provider
 
@@ -1078,7 +1080,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 
 | Setting | Default | Recommended |
 |---------|---------|-------------|
-| `openaiApiKey` | `(env fallback)` | `(env fallback)` |
+| `openaiApiKey` | `(env fallback in plugin mode)` | unset when `modelSource` is `gateway`; otherwise explicit key or `OPENAI_API_KEY` env fallback |
 | `openaiBaseUrl` | (unset) | (unset) |
 | `model` | `gpt-5.2` | `gpt-5.2` |
 | `reasoningEffort` | `low` | `low` |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -28,14 +28,14 @@
       "provider": "openai",
       "method": "api-key",
       "choiceId": "remnic-openai-api-key",
-      "choiceLabel": "OpenAI API key for Remnic memory extraction",
-      "choiceHint": "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
+      "choiceLabel": "Optional OpenAI API key for Remnic plugin-mode extraction",
+      "choiceHint": "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
       "groupId": "remnic-memory",
       "groupLabel": "Remnic memory",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",
-      "cliDescription": "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
+      "cliDescription": "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
       "onboardingScopes": [
         "text-inference"
       ]
@@ -107,7 +107,7 @@
     "properties": {
       "openaiApiKey": {
         "type": "string",
-        "description": "OpenAI API key (or set OPENAI_API_KEY env var). Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
+        "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
       },
       "openaiBaseUrl": {
         "type": "string",
@@ -2874,8 +2874,8 @@
           "plugin",
           "gateway"
         ],
-        "default": "plugin",
-        "description": "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[])."
+        "default": "gateway",
+        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {
         "type": "string",
@@ -4610,7 +4610,7 @@
       "label": "OpenAI API Key",
       "sensitive": true,
       "placeholder": "sk-...",
-      "help": "API key for OpenAI (or use ${OPENAI_API_KEY})"
+      "help": "Optional API key for plugin mode only. Not needed when Model Source is gateway."
     },
     "openaiBaseUrl": {
       "label": "OpenAI Base URL",
@@ -5058,7 +5058,7 @@
     },
     "modelSource": {
       "label": "Model Source",
-      "help": "Route LLM calls through the gateway's agent model chain instead of Engram's own config. When set to 'gateway', localLlm and openai settings are ignored."
+      "help": "Route LLM calls through the gateway's agent model chain instead of Engram's own config. Default for OpenClaw installs. When set to 'gateway', localLlm and openai settings are ignored."
     },
     "gatewayAgentId": {
       "label": "Gateway Agent ID",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2870,10 +2870,11 @@
       },
       "modelSource": {
         "type": "string",
-        "enum": [
-          "plugin",
-          "gateway"
-        ],
+      "enum": [
+        "plugin",
+        "gateway"
+      ],
+      "default": "gateway",
       "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2874,8 +2874,7 @@
           "plugin",
           "gateway"
         ],
-        "default": "gateway",
-        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
+      "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {
         "type": "string",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2853,10 +2853,11 @@
       },
       "modelSource": {
         "type": "string",
-        "enum": [
-          "plugin",
-          "gateway"
-        ],
+      "enum": [
+        "plugin",
+        "gateway"
+      ],
+      "default": "gateway",
       "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2857,8 +2857,7 @@
           "plugin",
           "gateway"
         ],
-        "default": "gateway",
-        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
+      "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {
         "type": "string",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -28,14 +28,14 @@
       "provider": "openai",
       "method": "api-key",
       "choiceId": "remnic-openai-api-key",
-      "choiceLabel": "OpenAI API key for Remnic memory extraction",
-      "choiceHint": "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
+      "choiceLabel": "Optional OpenAI API key for Remnic plugin-mode extraction",
+      "choiceHint": "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
       "groupId": "remnic-memory",
       "groupLabel": "Remnic memory",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",
-      "cliDescription": "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
+      "cliDescription": "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
       "onboardingScopes": [
         "text-inference"
       ]
@@ -107,7 +107,7 @@
     "properties": {
       "openaiApiKey": {
         "type": "string",
-        "description": "OpenAI API key (or set OPENAI_API_KEY env var). Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
+        "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
       },
       "openaiBaseUrl": {
         "type": "string",
@@ -2857,8 +2857,8 @@
           "plugin",
           "gateway"
         ],
-        "default": "plugin",
-        "description": "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[])."
+        "default": "gateway",
+        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {
         "type": "string",
@@ -4593,7 +4593,7 @@
       "label": "OpenAI API Key",
       "sensitive": true,
       "placeholder": "sk-...",
-      "help": "API key for OpenAI (or use ${OPENAI_API_KEY})"
+      "help": "Optional API key for plugin mode only. Not needed when Model Source is gateway."
     },
     "openaiBaseUrl": {
       "label": "OpenAI Base URL",
@@ -5041,7 +5041,7 @@
     },
     "modelSource": {
       "label": "Model Source",
-      "help": "Route LLM calls through the gateway's agent model chain instead of Engram's own config. When set to 'gateway', localLlm and openai settings are ignored."
+      "help": "Route LLM calls through the gateway's agent model chain instead of Engram's own config. Default for OpenClaw installs. When set to 'gateway', localLlm and openai settings are ignored."
     },
     "gatewayAgentId": {
       "label": "Gateway Agent ID",

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3409,6 +3409,7 @@ async function cmdXray(rest: string[]): Promise<void> {
   const config = parseConfig(remnicCfg);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
+  await orchestrator.deferredReady;
   const service = new EngramAccessService(orchestrator);
 
   try {
@@ -3421,8 +3422,8 @@ async function cmdXray(rest: string[]): Promise<void> {
       stdout: (line) => console.log(line),
     });
   } finally {
-    // Keep xray responsive like query: run recall against initialized state,
-    // then cancel deferred startup sync/warmup owned by this short-lived CLI.
+    // Xray is diagnostic, so it waits for deferred startup sync before recall;
+    // abort remains a no-op guard if startup behavior changes later.
     orchestrator.abortDeferredInit();
   }
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3205,75 +3205,80 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
   const config = parseConfig(remnicCfg);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
-  await orchestrator.deferredReady;
   const service = new EngramAccessService(orchestrator);
 
-  if (explain) {
-    // `query --explain` is a core-install feature; if @remnic/bench is
-    // installed we use its full tier-breakdown explainer, otherwise we
-    // fall back to a minimal "run the recall and show timing" path so
-    // the flag keeps working without forcing users to install an
-    // optional package. (Codex feedback on PR #545)
-    const bench = await tryLoadBenchModule();
-    if (bench?.runExplain) {
-      const result = await bench.runExplain(service, queryText);
-      if (json) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(`Query: ${result.query}`);
-        console.log(`Tiers used: ${result.tiersUsed.join(" → ")}`);
-        console.log(`Total duration: ${result.totalDurationMs}ms`);
-        for (const t of result.tierResults) {
-          console.log(`  ${t.tier}: ${t.latencyMs}ms (${t.resultsCount} results)`);
+  try {
+    if (explain) {
+      // `query --explain` is a core-install feature; if @remnic/bench is
+      // installed we use its full tier-breakdown explainer, otherwise we
+      // fall back to a minimal "run the recall and show timing" path so
+      // the flag keeps working without forcing users to install an
+      // optional package. (Codex feedback on PR #545)
+      const bench = await tryLoadBenchModule();
+      if (bench?.runExplain) {
+        const result = await bench.runExplain(service, queryText);
+        if (json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Query: ${result.query}`);
+          console.log(`Tiers used: ${result.tiersUsed.join(" → ")}`);
+          console.log(`Total duration: ${result.totalDurationMs}ms`);
+          for (const t of result.tierResults) {
+            console.log(`  ${t.tier}: ${t.latencyMs}ms (${t.resultsCount} results)`);
+          }
         }
+        return;
+      }
+
+      const explainStart = Date.now();
+      const recallResult = await service.recall({ query: queryText, mode: "auto" });
+      const totalDurationMs = Date.now() - explainStart;
+      // recall() returns { count, results, memoryIds, ... } (see
+      // EngramAccessRecallResponse). A prior version of this fallback
+      // read .memories, which doesn't exist, so resultsCount was always
+      // 0 and users saw misleading explain output. (Codex feedback on
+      // PR #545.) Prefer the numeric count and fall back to
+      // results.length for robustness across future schema tweaks.
+      const resultsCount =
+        typeof recallResult.count === "number"
+          ? recallResult.count
+          : Array.isArray(recallResult.results)
+            ? recallResult.results.length
+            : 0;
+      const minimalExplain = {
+        query: queryText,
+        totalDurationMs,
+        resultsCount,
+        note: "Install @remnic/bench for a full tier-level explain breakdown.",
+      };
+      if (json) {
+        console.log(JSON.stringify(minimalExplain, null, 2));
+      } else {
+        console.log(`Query: ${minimalExplain.query}`);
+        console.log(`Total duration: ${minimalExplain.totalDurationMs}ms`);
+        console.log(`Results: ${minimalExplain.resultsCount}`);
+        console.log(`Note: ${minimalExplain.note}`);
       }
       return;
     }
 
-    const explainStart = Date.now();
-    const recallResult = await service.recall({ query: queryText, mode: "auto" });
-    const totalDurationMs = Date.now() - explainStart;
-    // recall() returns { count, results, memoryIds, ... } (see
-    // EngramAccessRecallResponse). A prior version of this fallback
-    // read .memories, which doesn't exist, so resultsCount was always
-    // 0 and users saw misleading explain output. (Codex feedback on
-    // PR #545.) Prefer the numeric count and fall back to
-    // results.length for robustness across future schema tweaks.
-    const resultsCount =
-      typeof recallResult.count === "number"
-        ? recallResult.count
-        : Array.isArray(recallResult.results)
-          ? recallResult.results.length
-          : 0;
-    const minimalExplain = {
-      query: queryText,
-      totalDurationMs,
-      resultsCount,
-      note: "Install @remnic/bench for a full tier-level explain breakdown.",
-    };
+    const result = await service.recall({ query: queryText, mode: "auto" });
     if (json) {
-      console.log(JSON.stringify(minimalExplain, null, 2));
+      console.log(JSON.stringify(result, null, 2));
     } else {
-      console.log(`Query: ${minimalExplain.query}`);
-      console.log(`Total duration: ${minimalExplain.totalDurationMs}ms`);
-      console.log(`Results: ${minimalExplain.resultsCount}`);
-      console.log(`Note: ${minimalExplain.note}`);
+      const memories = (result as { memories?: Array<{ content: string }> }).memories ?? [];
+      if (memories.length === 0) {
+        console.log("No results.");
+        return;
+      }
+      for (const m of memories) {
+        console.log(`- ${m.content}`);
+      }
     }
-    return;
-  }
-
-  const result = await service.recall({ query: queryText, mode: "auto" });
-  if (json) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    const memories = (result as { memories?: Array<{ content: string }> }).memories ?? [];
-    if (memories.length === 0) {
-      console.log("No results.");
-      return;
-    }
-    for (const m of memories) {
-      console.log(`- ${m.content}`);
-    }
+  } finally {
+    // One-shot CLI calls should not wait for or orphan deferred QMD
+    // maintenance; the daemon/gateway process performs full warmup instead.
+    orchestrator.abortDeferredInit();
   }
 }
 
@@ -3404,17 +3409,22 @@ async function cmdXray(rest: string[]): Promise<void> {
   const config = parseConfig(remnicCfg);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
-  await orchestrator.deferredReady;
   const service = new EngramAccessService(orchestrator);
 
-  await runXrayCommand(rest, {
-    recallXray: (request) => service.recallXray(request),
-    writeFile: async (filePath, data) => {
-      const { writeFile: fsWriteFile } = await import("node:fs/promises");
-      await fsWriteFile(filePath, data, "utf8");
-    },
-    stdout: (line) => console.log(line),
-  });
+  try {
+    await runXrayCommand(rest, {
+      recallXray: (request) => service.recallXray(request),
+      writeFile: async (filePath, data) => {
+        const { writeFile: fsWriteFile } = await import("node:fs/promises");
+        await fsWriteFile(filePath, data, "utf8");
+      },
+      stdout: (line) => console.log(line),
+    });
+  } finally {
+    // Keep xray responsive like query: run recall against initialized state,
+    // then cancel deferred startup sync/warmup owned by this short-lived CLI.
+    orchestrator.abortDeferredInit();
+  }
 }
 
 // ── Page-level versioning (issue #371) ─────────────────────────────────────
@@ -6445,6 +6455,7 @@ async function cmdOpenclawInstall(opts: OpenclawInstallOptions): Promise<void> {
     ...legacyNonConfigFields,
     ...existingNewEntryFields,
     config: {
+      modelSource: "gateway",
       ...legacyConfigToMerge,
       ...existingNewEntryConfig,
       memoryDir,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -6418,6 +6418,7 @@ async function cmdOpenclawInstall(opts: OpenclawInstallOptions): Promise<void> {
     existingNewEntry?.config && typeof existingNewEntry.config === "object"
       ? (existingNewEntry.config as Record<string, unknown>)
       : {};
+  const defaultModelSource = !hasNew && !migrateLegacy ? "gateway" : "plugin";
 
   // Determine the final memoryDir. Operator-provided --memory-dir always wins.
   // On reinstall (no --memory-dir flag), preserve the currently configured value
@@ -6456,7 +6457,7 @@ async function cmdOpenclawInstall(opts: OpenclawInstallOptions): Promise<void> {
     ...legacyNonConfigFields,
     ...existingNewEntryFields,
     config: {
-      modelSource: "gateway",
+      modelSource: defaultModelSource,
       ...legacyConfigToMerge,
       ...existingNewEntryConfig,
       memoryDir,

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -95,6 +95,35 @@ test("parseConfig initGateTimeoutMs clamps unsafe values", () => {
   assert.equal(parseConfig({ initGateTimeoutMs: "abc" }).initGateTimeoutMs, 30_000);
 });
 
+test("parseConfig modelSource=gateway does not inherit OPENAI_API_KEY from the process env", () => {
+  const original = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";
+  try {
+    const cfg = parseConfig({ modelSource: "gateway" });
+    assert.equal(cfg.modelSource, "gateway");
+    assert.equal(cfg.openaiApiKey, undefined);
+  } finally {
+    if (original === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = original;
+  }
+});
+
+test("parseConfig modelSource=gateway still honors an explicit openaiApiKey override", () => {
+  const original = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";
+  try {
+    const cfg = parseConfig({
+      modelSource: "gateway",
+      openaiApiKey: "sk-explicit",
+    });
+    assert.equal(cfg.modelSource, "gateway");
+    assert.equal(cfg.openaiApiKey, "sk-explicit");
+  } finally {
+    if (original === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = original;
+  }
+});
+
 test("parseConfig keeps explicit cue recall opt-in and budgets configurable", () => {
   const defaults = parseConfig({});
   assert.equal(defaults.explicitCueRecallEnabled, false);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -434,9 +434,18 @@ export function parseConfig(raw: unknown): PluginConfig {
     cfg = baseCfg;
   }
 
+  const modelSource =
+    cfg.modelSource === "gateway" ? "gateway" : "plugin";
+
   let apiKey: string | undefined;
   if (typeof cfg.openaiApiKey === "string" && cfg.openaiApiKey.length > 0) {
     apiKey = resolveEnvVars(cfg.openaiApiKey);
+  } else if (modelSource === "gateway") {
+    // Gateway mode deliberately delegates LLM calls to OpenClaw's model chain.
+    // Do not implicitly capture OPENAI_API_KEY from the Remnic process env here:
+    // doing so makes diagnostics look OpenAI-dependent and can accidentally
+    // route extraction through a stale direct key before gateway fallback.
+    apiKey = undefined;
   } else {
     apiKey = readEnvVar("OPENAI_API_KEY");
   }
@@ -2142,8 +2151,7 @@ export function parseConfig(raw: unknown): PluginConfig {
     // Gateway config (passed from index.ts for fallback AI)
     gatewayConfig: cfg.gatewayConfig as PluginConfig["gatewayConfig"],
     // Gateway model source (v9.2) — route LLM calls through gateway agent model chain
-    modelSource:
-      cfg.modelSource === "gateway" ? "gateway" : "plugin",
+    modelSource,
     gatewayAgentId:
       typeof cfg.gatewayAgentId === "string" && cfg.gatewayAgentId.length > 0
         ? cfg.gatewayAgentId

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NamespaceSearchRouter } from "./search.js";
+import type { SearchBackend } from "../search/port.js";
+import type { PluginConfig, QmdSearchResult } from "../types.js";
+
+class FakeBackend implements SearchBackend {
+  updates = 0;
+
+  constructor(private readonly globalUpdate: boolean) {}
+
+  async probe(): Promise<boolean> {
+    return true;
+  }
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  debugStatus(): string {
+    return "fake";
+  }
+
+  async search(): Promise<QmdSearchResult[]> {
+    return [];
+  }
+
+  async searchGlobal(): Promise<QmdSearchResult[]> {
+    return [];
+  }
+
+  async bm25Search(): Promise<QmdSearchResult[]> {
+    return [];
+  }
+
+  async vectorSearch(): Promise<QmdSearchResult[]> {
+    return [];
+  }
+
+  async hybridSearch(): Promise<QmdSearchResult[]> {
+    return [];
+  }
+
+  async update(): Promise<void> {
+    this.updates += 1;
+  }
+
+  async updateCollection(): Promise<void> {}
+
+  updatesAllCollections(): boolean {
+    return this.globalUpdate;
+  }
+
+  async embed(): Promise<void> {}
+
+  async embedCollection(): Promise<void> {}
+
+  async ensureCollection(): Promise<"present"> {
+    return "present";
+  }
+}
+
+function config(): PluginConfig {
+  return {
+    qmdCollection: "openclaw-engram",
+    defaultNamespace: "main",
+    qmdMaxResults: 10,
+  } as PluginConfig;
+}
+
+test("updateNamespaces runs a global-update backend only once", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = new FakeBackend(true);
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  const updated = await router.updateNamespaces(["main", "shared", "main", "project"]);
+
+  assert.equal(updated, 1);
+  assert.equal(created.reduce((sum, backend) => sum + backend.updates, 0), 1);
+});
+
+test("updateNamespaces still updates every namespace for scoped backends", async () => {
+  const created: FakeBackend[] = [];
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => {
+      const backend = new FakeBackend(false);
+      created.push(backend);
+      return backend;
+    },
+  );
+
+  const updated = await router.updateNamespaces(["main", "shared", "main", "project"]);
+
+  assert.equal(updated, 3);
+  assert.equal(created.reduce((sum, backend) => sum + backend.updates, 0), 3);
+});

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -110,21 +110,26 @@ export class NamespaceSearchRouter {
     execution?: SearchExecutionOptions,
   ): Promise<number> {
     const unique = Array.from(new Set(namespaces.map((value) => value.trim()).filter(Boolean)));
-    let updated = 0;
-    let globalUpdateDone = false;
-    for (const namespace of unique) {
-      const record = await this.backendRecordFor(namespace);
-      if (!record.available || record.collectionState === "missing") continue;
-      if (globalUpdateDone && record.backend.updatesAllCollections?.() === true) {
-        continue;
-      }
-      await record.backend.update(execution);
-      updated += 1;
-      if (record.backend.updatesAllCollections?.() === true) {
-        globalUpdateDone = true;
-      }
-    }
-    return updated;
+    const eligible = (await Promise.all(
+      unique.map(async (namespace) => {
+        const record = await this.backendRecordFor(namespace);
+        return record.available && record.collectionState !== "missing"
+          ? record
+          : null;
+      }),
+    )).filter((record): record is NamespaceBackendRecord => record !== null);
+
+    const globalRecord = eligible.find((record) => record.backend.updatesAllCollections?.() === true);
+    const scopedRecords = globalRecord
+      ? eligible.filter((record) => record.backend.updatesAllCollections?.() !== true)
+      : eligible;
+
+    await Promise.all([
+      globalRecord ? globalRecord.backend.update(execution) : Promise.resolve(),
+      ...scopedRecords.map((record) => record.backend.update(execution)),
+    ]);
+
+    return (globalRecord ? 1 : 0) + scopedRecords.length;
   }
 
   async embedNamespaces(namespaces: string[]): Promise<void> {

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -110,15 +110,21 @@ export class NamespaceSearchRouter {
     execution?: SearchExecutionOptions,
   ): Promise<number> {
     const unique = Array.from(new Set(namespaces.map((value) => value.trim()).filter(Boolean)));
-    const results = await Promise.all(
-      unique.map(async (namespace) => {
-        const record = await this.backendRecordFor(namespace);
-        if (!record.available || record.collectionState === "missing") return 0;
-        await record.backend.update(execution);
-        return 1;
-      }),
-    );
-    return results.reduce<number>((sum, v) => sum + v, 0);
+    let updated = 0;
+    let globalUpdateDone = false;
+    for (const namespace of unique) {
+      const record = await this.backendRecordFor(namespace);
+      if (!record.available || record.collectionState === "missing") continue;
+      if (globalUpdateDone && record.backend.updatesAllCollections?.() === true) {
+        continue;
+      }
+      await record.backend.update(execution);
+      updated += 1;
+      if (record.backend.updatesAllCollections?.() === true) {
+        globalUpdateDone = true;
+      }
+    }
+    return updated;
   }
 
   async embedNamespaces(namespaces: string[]): Promise<void> {

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1683,6 +1683,10 @@ export class QmdClient implements SearchBackend {
     );
   }
 
+  updatesAllCollections(): boolean {
+    return true;
+  }
+
   private async runUpdateForCollection(
     collection: string,
     options: { perCollectionThrottle: boolean; strict?: boolean },

--- a/packages/remnic-core/src/search/noop-backend.ts
+++ b/packages/remnic-core/src/search/noop-backend.ts
@@ -45,6 +45,9 @@ export class NoopSearchBackend implements SearchBackend {
 
   async update(_execution?: SearchExecutionOptions): Promise<void> {}
   async updateCollection(_collection: string, _execution?: SearchExecutionOptions): Promise<void> {}
+  updatesAllCollections(): boolean {
+    return false;
+  }
   async embed(): Promise<void> {}
   async embedCollection(_collection: string): Promise<void> {}
 

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -63,6 +63,12 @@ export interface SearchBackend {
   update(execution?: SearchExecutionOptions): Promise<void>;
   updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void>;
   /**
+   * True when update() refreshes every indexed collection, not just this
+   * backend's configured collection. Namespace routers use this to avoid
+   * repeating the same expensive global update once per namespace.
+   */
+  updatesAllCollections?(): boolean;
+  /**
    * Optional strict refresh used by callers that must know whether a collection
    * was actually refreshed before writing success markers. Ordinary update
    * calls remain fail-open for migration/maintenance resilience.

--- a/tests/openclaw-install-cli.test.ts
+++ b/tests/openclaw-install-cli.test.ts
@@ -127,6 +127,48 @@ test("CLI writes openclaw-remnic entry and memory slot", async () => {
   );
 });
 
+test("CLI openclaw install defaults Remnic to gateway model source", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes('modelSource: "gateway"'),
+    "OpenClaw install should prefer gateway LLM routing instead of requiring a Remnic OpenAI key",
+  );
+});
+
+test("CLI query does not wait for deferred QMD startup maintenance", async () => {
+  const src = await readCli();
+  const queryStart = src.indexOf("async function cmdQuery");
+  const xrayStart = src.indexOf("async function cmdXray");
+  assert.ok(queryStart >= 0, "cmdQuery must exist");
+  assert.ok(xrayStart > queryStart, "cmdXray should follow cmdQuery in CLI source");
+  const cmdQueryBody = src.slice(queryStart, xrayStart);
+  assert.ok(
+    !cmdQueryBody.includes("await orchestrator.deferredReady"),
+    "remnic query should not block foreground recall on startup index maintenance",
+  );
+  assert.ok(
+    cmdQueryBody.includes("orchestrator.abortDeferredInit()"),
+    "remnic query should cancel its own deferred startup maintenance before exit",
+  );
+});
+
+test("CLI xray does not wait for deferred QMD startup maintenance", async () => {
+  const src = await readCli();
+  const xrayStart = src.indexOf("async function cmdXray");
+  const versionsStart = src.indexOf("async function cmdVersions");
+  assert.ok(xrayStart >= 0, "cmdXray must exist");
+  assert.ok(versionsStart > xrayStart, "cmdVersions should follow cmdXray in CLI source");
+  const cmdXrayBody = src.slice(xrayStart, versionsStart);
+  assert.ok(
+    !cmdXrayBody.includes("await orchestrator.deferredReady"),
+    "remnic xray should not block foreground recall on startup index maintenance",
+  );
+  assert.ok(
+    cmdXrayBody.includes("orchestrator.abortDeferredInit()"),
+    "remnic xray should cancel its own deferred startup maintenance before exit",
+  );
+});
+
 test("CLI openclaw subcommand is in the main switch statement", async () => {
   const src = await readCli();
   assert.ok(

--- a/tests/openclaw-install-cli.test.ts
+++ b/tests/openclaw-install-cli.test.ts
@@ -152,7 +152,7 @@ test("CLI query does not wait for deferred QMD startup maintenance", async () =>
   );
 });
 
-test("CLI xray does not wait for deferred QMD startup maintenance", async () => {
+test("CLI xray waits for deferred QMD startup maintenance before diagnostic recall", async () => {
   const src = await readCli();
   const xrayStart = src.indexOf("async function cmdXray");
   const versionsStart = src.indexOf("async function cmdVersions");
@@ -160,12 +160,12 @@ test("CLI xray does not wait for deferred QMD startup maintenance", async () => 
   assert.ok(versionsStart > xrayStart, "cmdVersions should follow cmdXray in CLI source");
   const cmdXrayBody = src.slice(xrayStart, versionsStart);
   assert.ok(
-    !cmdXrayBody.includes("await orchestrator.deferredReady"),
-    "remnic xray should not block foreground recall on startup index maintenance",
+    cmdXrayBody.includes("await orchestrator.deferredReady"),
+    "remnic xray should diagnose recall after startup index maintenance refreshes disk-backed search state",
   );
   assert.ok(
     cmdXrayBody.includes("orchestrator.abortDeferredInit()"),
-    "remnic xray should cancel its own deferred startup maintenance before exit",
+    "remnic xray should retain the deferred startup abort guard before exit",
   );
 });
 

--- a/tests/openclaw-install-cli.test.ts
+++ b/tests/openclaw-install-cli.test.ts
@@ -130,7 +130,7 @@ test("CLI writes openclaw-remnic entry and memory slot", async () => {
 test("CLI openclaw install defaults Remnic to gateway model source", async () => {
   const src = await readCli();
   assert.ok(
-    src.includes('modelSource: "gateway"'),
+    src.includes('const defaultModelSource = !hasNew && !migrateLegacy ? "gateway" : "plugin"'),
     "OpenClaw install should prefer gateway LLM routing instead of requiring a Remnic OpenAI key",
   );
 });

--- a/tests/openclaw-install-logic.test.ts
+++ b/tests/openclaw-install-logic.test.ts
@@ -59,6 +59,7 @@ function buildUpdatedOpenclawConfig(
 
   const newEntry: OpenclawPluginEntry = {
     config: {
+      modelSource: "gateway",
       ...legacyConfigToMerge,
       ...(existingNewEntry?.config && typeof existingNewEntry.config === "object" ? existingNewEntry.config : {}),
       memoryDir,
@@ -104,6 +105,11 @@ test("fresh install: creates openclaw-remnic entry and slot", () => {
     result.plugins!.entries!["openclaw-remnic"].config?.memoryDir,
     memoryDir,
     "memoryDir should match",
+  );
+  assert.equal(
+    result.plugins!.entries!["openclaw-remnic"].config?.modelSource,
+    "gateway",
+    "fresh OpenClaw installs should route Remnic LLM calls through the gateway by default",
   );
 });
 
@@ -179,6 +185,26 @@ test("collision: updates existing openclaw-remnic entry memoryDir", () => {
   assert.equal(result.plugins!.entries!["openclaw-remnic"].config?.memoryDir, "/new/path");
   // debug: true should be preserved
   assert.equal(result.plugins!.entries!["openclaw-remnic"].config?.debug, true);
+});
+
+test("collision: preserves an existing explicit modelSource", () => {
+  const existing: OpenclawConfig = {
+    plugins: {
+      entries: {
+        "openclaw-remnic": {
+          config: {
+            memoryDir: "/old/path",
+            modelSource: "plugin",
+          },
+        },
+      },
+      slots: { memory: "openclaw-remnic" },
+    },
+  };
+  const result = buildUpdatedOpenclawConfig(existing, "/new/path", false);
+
+  assert.equal(result.plugins!.entries!["openclaw-remnic"].config?.modelSource, "plugin");
+  assert.equal(result.plugins!.entries!["openclaw-remnic"].config?.memoryDir, "/new/path");
 });
 
 test("slot: always set to openclaw-remnic when no legacy entry", () => {

--- a/tests/openclaw-install-logic.test.ts
+++ b/tests/openclaw-install-logic.test.ts
@@ -56,10 +56,11 @@ function buildUpdatedOpenclawConfig(
     migrateLegacy && legacyEntry?.config && typeof legacyEntry.config === "object"
       ? (legacyEntry.config as Record<string, unknown>)
       : {};
+  const defaultModelSource = !existingNewEntry && !migrateLegacy ? "gateway" : "plugin";
 
   const newEntry: OpenclawPluginEntry = {
     config: {
-      modelSource: "gateway",
+      modelSource: defaultModelSource,
       ...legacyConfigToMerge,
       ...(existingNewEntry?.config && typeof existingNewEntry.config === "object" ? existingNewEntry.config : {}),
       memoryDir,
@@ -167,7 +168,28 @@ test("migration: merges legacy config values (except memoryDir)", () => {
   const newConfig = result.plugins!.entries!["openclaw-remnic"].config!;
   // Should inherit model from legacy
   assert.equal(newConfig.model, "gpt-5.2", "should inherit model from legacy entry");
+  assert.equal(newConfig.modelSource, "plugin", "implicit legacy installs should stay in plugin model mode");
   // memoryDir should be the new one (not the old one)
+  assert.equal(newConfig.memoryDir, "/new/path");
+});
+
+test("migration: preserves explicit legacy modelSource", () => {
+  const existing: OpenclawConfig = {
+    plugins: {
+      entries: {
+        "openclaw-engram": {
+          config: {
+            memoryDir: "/old/path",
+            modelSource: "gateway",
+          },
+        },
+      },
+    },
+  };
+  const result = buildUpdatedOpenclawConfig(existing, "/new/path", true);
+
+  const newConfig = result.plugins!.entries!["openclaw-remnic"].config!;
+  assert.equal(newConfig.modelSource, "gateway");
   assert.equal(newConfig.memoryDir, "/new/path");
 });
 

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -133,23 +133,41 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
       requiresRuntime: false,
     });
     assert.deepEqual(manifest.providerAuthEnvVars?.openai, ["OPENAI_API_KEY"]);
+    const expectedAuthChoice = manifest.id === "openclaw-engram"
+      ? {
+          provider: "openai",
+          method: "api-key",
+          choiceId: "remnic-openai-api-key",
+          choiceLabel: "OpenAI API key for Remnic memory extraction",
+          choiceHint:
+            "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
+          groupId: "remnic-memory",
+          groupLabel: "Remnic memory",
+          optionKey: "openaiApiKey",
+          cliFlag: "--openai-api-key",
+          cliOption: "--openai-api-key <key>",
+          cliDescription:
+            "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
+          onboardingScopes: ["text-inference"],
+        }
+      : {
+          provider: "openai",
+          method: "api-key",
+          choiceId: "remnic-openai-api-key",
+          choiceLabel: "Optional OpenAI API key for Remnic plugin-mode extraction",
+          choiceHint:
+            "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
+          groupId: "remnic-memory",
+          groupLabel: "Remnic memory",
+          optionKey: "openaiApiKey",
+          cliFlag: "--openai-api-key",
+          cliOption: "--openai-api-key <key>",
+          cliDescription:
+            "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
+          onboardingScopes: ["text-inference"],
+        };
     assert.deepEqual(manifest.providerAuthChoices, [
-      {
-        provider: "openai",
-        method: "api-key",
-        choiceId: "remnic-openai-api-key",
-        choiceLabel: "OpenAI API key for Remnic memory extraction",
-        choiceHint:
-          "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
-        groupId: "remnic-memory",
-        groupLabel: "Remnic memory",
-        optionKey: "openaiApiKey",
-        cliFlag: "--openai-api-key",
-        cliOption: "--openai-api-key <key>",
-        cliDescription:
-          "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
-        onboardingScopes: ["text-inference"],
-      },
+      expectedAuthChoice,
     ]);
     assert.match(
       manifest.configSchema?.properties?.openaiApiKey?.description ?? "",


### PR DESCRIPTION
## Summary
- default new OpenClaw Remnic installs and plugin metadata to `modelSource: "gateway"`
- avoid inheriting `OPENAI_API_KEY` when Remnic is explicitly in gateway mode
- keep `remnic query` and `remnic xray` responsive by skipping deferred QMD startup waits and aborting their own deferred maintenance before CLI exit
- update docs/tests for gateway-first OpenClaw setup while preserving explicit existing `modelSource` values

## Verification
- `pnpm run check:openclaw-plugin-sync`
- `pnpm exec tsx --test tests/openclaw-install-cli.test.ts tests/openclaw-install-logic.test.ts packages/remnic-core/src/config.test.ts`
- `pnpm run test:entity-hardening`
- `pnpm run check-types`
- `pnpm run check-config-contract`
- `bash scripts/check-review-patterns.sh`

Note: `pnpm run preflight:quick` was attempted, but the script invokes `npm test -- <file>` in a way that expands the full test globs in this local environment; I stopped that full-suite run after the static preflight gates completed and reran the intended file directly with `pnpm exec tsx --test tests/register-multi-registry.test.ts`, which executed the assertions but left an open handle and had to be interrupted after the passing assertions printed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default LLM routing and API-key resolution behavior for OpenClaw installs and adjusts search-index maintenance execution, which could affect extraction routing and startup/CLI responsiveness if misconfigured.
> 
> **Overview**
> **OpenClaw installs now default Remnic LLM routing to the gateway model chain** (`modelSource: "gateway"`) across install logic and plugin manifests, and docs/config tables were updated to position `openaiApiKey` as *plugin-mode only*.
> 
> **Config loading is tightened in gateway mode**: `parseConfig` no longer implicitly reads `OPENAI_API_KEY` from the process env when `modelSource` is `gateway` (but still honors an explicit `openaiApiKey`).
> 
> **CLI startup behavior is refined**: `remnic query` no longer waits for deferred QMD maintenance and explicitly aborts deferred init on exit; `remnic xray` keeps waiting for deferred readiness but also aborts on exit.
> 
> **Namespace search maintenance is optimized** by adding optional `updatesAllCollections()` to the search backend port; QMD reports global updates so namespace routers run expensive global updates only once per invocation, with new unit tests covering both global and per-namespace backends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f09bc2dde831b5432dfeb405b45e865e197e977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->