### PR TITLE
chore(openclaw): publish Remnic plugin 1.0.22

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump @remnic/plugin-openclaw to 1.0.22
- keep root and package OpenClaw manifests in sync at 1.0.22
- unblock npm/ClawHub publishing for the gateway-default fixes merged in PR #884

## Verification
- pnpm run check:openclaw-plugin-sync
- pnpm exec tsx --test tests/openclaw-plugin-runtime-surfaces.test.ts tests/openclaw-install-cli.test.ts tests/openclaw-install-logic.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump only; no runtime logic changes, just publishing metadata updates.
> 
> **Overview**
> Bumps the Remnic OpenClaw plugin version to `1.0.22` and keeps the root `openclaw.plugin.json` and `packages/plugin-openclaw/openclaw.plugin.json` manifests in sync.
> 
> Also updates `@remnic/plugin-openclaw` package version to `1.0.22` for npm/registry publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b4e6eff71de417e5cf0a35b9329802d4bce60a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->