### PR TITLE
fix(release): publish ClawHub package under owner

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -450,6 +450,7 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           CLAWHUB_PACKAGE_NAME: "@remnic/plugin-openclaw"
+          CLAWHUB_OWNER: "joshuaswarren"
         run: |
           if [ -z "${CLAWHUB_TOKEN:-}" ]; then
             echo "::notice title=ClawHub publish skipped::CLAWHUB_TOKEN secret is not configured."
@@ -476,9 +477,11 @@ jobs:
           fi
 
           source_commit="$(git rev-parse HEAD)"
-          clawhub package publish "${tarball}" \
+          publish_log="$(mktemp)"
+          if clawhub package publish "${tarball}" \
             --family code-plugin \
             --name "${CLAWHUB_PACKAGE_NAME}" \
+            --owner "${CLAWHUB_OWNER}" \
             --display-name "Remnic OpenClaw Plugin" \
             --version "${package_version}" \
             --host-targets openclaw \
@@ -487,6 +490,14 @@ jobs:
             --source-commit "${source_commit}" \
             --source-path packages/plugin-openclaw \
             --changelog "Publish ${CLAWHUB_PACKAGE_NAME}@${package_version} from the GitHub release workflow." \
-            --json
+            --json >"${publish_log}" 2>&1; then
+            cat "${publish_log}"
+            rm -f "${publish_log}"
+          else
+            publish_status=$?
+            cat "${publish_log}"
+            rm -f "${publish_log}"
+            exit "${publish_status}"
+          fi
 
           clawhub package rescan "${CLAWHUB_PACKAGE_NAME}" --yes --json || true


### PR DESCRIPTION
## Summary
- configure the ClawHub publish step with the existing ClawHub owner handle `joshuaswarren`
- publish `@remnic/plugin-openclaw` with `--owner "${CLAWHUB_OWNER}"` instead of relying on the npm scope `@remnic` as a ClawHub publisher
- keep ClawHub publish failures fatal now that the workflow targets the correct owner

## Verification
- `clawhub package inspect @remnic/plugin-openclaw --json` shows owner handle `joshuaswarren`
- `clawhub package publish --help` confirms `--owner <handle>` is supported
- `bash -n` on the extracted ClawHub publish shell block
