### PR TITLE
test(openclaw): add plugin inspector gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ bench-datasets/
 # per-release by the leaderboard pipeline — see issue #566 slice 6).
 docs/benchmarks/results/
 
+# OpenClaw plugin-inspector run artifacts
+packages/plugin-openclaw/reports/
+
 # Published-benchmark datasets (LongMemEval, LoCoMo). Download via
 # `scripts/bench/fetch-datasets.sh --help`. Never commit raw dataset files.
 bench-datasets/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10167,6 +10167,7 @@
         "@remnic/core": "file:../remnic-core"
       },
       "devDependencies": {
+        "@openclaw/plugin-inspector": "0.3.10",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "engram-access": "bin/engram-access.js"
       },
       "devDependencies": {
+        "@openclaw/plugin-inspector": "0.3.10",
         "@types/better-sqlite3": "^7.6.13",
         "tsup": "^8.5.1",
         "tsx": "^4.0.0",
@@ -3210,6 +3211,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@openclaw/plugin-inspector": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@openclaw/plugin-inspector/-/plugin-inspector-0.3.10.tgz",
+      "integrity": "sha512-YApX9F58E2/HORbVgJMWfryTkQAjwq/6HuTxls4RP/d0RnZ6swRcFuc9d09OcLoENzB0nvKY5cjyuCnBArv8iA==",
+      "license": "MIT",
+      "bin": {
+        "plugin-inspector": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@orama/orama": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
     "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts' 'packages/export-weclone/src/**/*.test.ts' 'packages/import-weclone/src/**/*.test.ts'",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",
+    "plugin:inspect": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect",
+    "plugin:inspect:runtime": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect:runtime",
     "scan:openclaw-plugin": "node scripts/openclaw-plugin-security-scan.mjs packages/plugin-openclaw",
     "verify:openclaw-clawpack": "node scripts/verify-openclaw-clawpack.mjs",
     "bench:list": "node scripts/run-bench-cli.mjs list",
@@ -109,6 +111,7 @@
     "prepack": "npm run build"
   },
   "devDependencies": {
+    "@openclaw/plugin-inspector": "0.3.10",
     "@remnic/bench": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "tsup": "^8.5.1",

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -93,6 +93,21 @@ This plugin hooks into the OpenClaw gateway lifecycle:
 
 All memory processing uses [`@remnic/core`](https://www.npmjs.com/package/@remnic/core). Memory files stay on your local filesystem as plain markdown files. When the plugin is configured to use OpenAI or an OpenAI-compatible endpoint, conversation and memory excerpts may be sent to that configured model provider for extraction, consolidation, summarization, and embeddings. Use `modelSource: "gateway"` or local LLM settings when those operations should stay on your own OpenClaw/local model path.
 
+## Plugin Inspection
+
+Run the OpenClaw plugin inspector with:
+
+```bash
+npm run plugin:inspect
+npm run plugin:inspect:runtime
+```
+
+The inspector gate covers the static OpenClaw adapter manifest, hook, tool, and
+service surfaces. Some registrations are intentionally casted or dynamically
+guarded in the adapter, including `registerMemoryCapability`, `registerCli`,
+and `registerCommand`; keep runtime capture coverage for those surfaces in a
+separate adapter test slice.
+
 ## Slot Selection
 
 Remnic is an exclusive memory-slot plugin. When `plugins.slots.memory` points

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -48,6 +48,7 @@
     "openclaw": ">=2026.4.8"
   },
   "devDependencies": {
+    "@openclaw/plugin-inspector": "0.3.10",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -11,7 +11,8 @@
   },
   "files": [
     "dist",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "plugin-inspector.config.json"
   ],
   "publishConfig": {
     "access": "public",
@@ -36,6 +37,8 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "check-types": "tsc --noEmit",
+    "plugin:inspect": "plugin-inspector check --config plugin-inspector.config.json --no-openclaw",
+    "plugin:inspect:runtime": "pnpm run build && PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1 plugin-inspector check --config plugin-inspector.config.json --no-openclaw --runtime --mock-sdk",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -11,8 +11,7 @@
   },
   "files": [
     "dist",
-    "openclaw.plugin.json",
-    "plugin-inspector.config.json"
+    "openclaw.plugin.json"
   ],
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-openclaw/plugin-inspector.config.json
+++ b/packages/plugin-openclaw/plugin-inspector.config.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "plugin": {
+    "id": "openclaw-remnic",
+    "priority": "high",
+    "seams": [
+      "dynamic-tool",
+      "gateway-service",
+      "hook",
+      "manifest-contract",
+      "memory-capability",
+      "sdk-surface"
+    ],
+    "sourceRoot": "../../src",
+    "expect": {
+      "hooks": [
+        "before_agent_start",
+        "agent_end",
+        "before_compaction",
+        "after_compaction",
+        "before_reset",
+        "session_start",
+        "session_end",
+        "before_tool_call",
+        "after_tool_call",
+        "llm_output",
+        "commands.list"
+      ],
+      "registrations": [
+        "registerTool",
+        "registerService",
+        "registerMemoryPromptSection"
+      ],
+      "manifestContracts": [
+        "tools"
+      ]
+    }
+  },
+  "capture": {
+    "mockSdk": true
+  }
+}

--- a/packages/plugin-openclaw/plugin-inspector.config.json
+++ b/packages/plugin-openclaw/plugin-inspector.config.json
@@ -14,6 +14,7 @@
     "sourceRoot": "../../src",
     "expect": {
       "hooks": [
+        "before_prompt_build",
         "before_agent_start",
         "agent_end",
         "before_compaction",

--- a/packages/plugin-openclaw/plugin-inspector.config.json
+++ b/packages/plugin-openclaw/plugin-inspector.config.json
@@ -24,6 +24,8 @@
         "before_tool_call",
         "after_tool_call",
         "llm_output",
+        "subagent_spawning",
+        "subagent_ended",
         "commands.list"
       ],
       "registrations": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@openclaw/plugin-inspector':
+        specifier: 0.3.10
+        version: 0.3.10
       '@remnic/bench':
         specifier: workspace:*
         version: link:packages/bench
@@ -53,7 +56,7 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -82,7 +85,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -107,19 +110,19 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.1.0
-        version: 5.2.0(vite@7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.1.12
-        version: 7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
+        version: 7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/connector-replit:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -128,7 +131,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -144,7 +147,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -156,7 +159,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -168,7 +171,7 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -183,7 +186,7 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -199,7 +202,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -221,7 +224,7 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -236,7 +239,7 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -252,7 +255,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -275,11 +278,11 @@ importers:
         version: link:../remnic-core
       openai:
         specifier: ^6.0.0
-        version: 6.33.0(zod@4.0.0)
+        version: 6.33.0(ws@8.20.0)(zod@4.4.3)
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -319,7 +322,7 @@ importers:
         version: link:../import-weclone
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -358,7 +361,7 @@ importers:
         version: 12.3.0
       openai:
         specifier: ^6.0.0
-        version: 6.33.0(zod@3.25.76)
+        version: 6.33.0(ws@8.20.0)(zod@3.25.76)
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -368,7 +371,7 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -391,7 +394,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -407,7 +410,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -836,6 +839,11 @@ packages:
   '@node-rs/argon2@2.0.2':
     resolution: {integrity: sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg==}
     engines: {node: '>= 10'}
+
+  '@openclaw/plugin-inspector@0.3.10':
+    resolution: {integrity: sha512-YApX9F58E2/HORbVgJMWfryTkQAjwq/6HuTxls4RP/d0RnZ6swRcFuc9d09OcLoENzB0nvKY5cjyuCnBArv8iA==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
@@ -1270,6 +1278,10 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -1699,6 +1711,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -1716,6 +1740,9 @@ packages:
 
   zod@4.0.0:
     resolution: {integrity: sha512-9diLdTPc/L7w/5jI4C3gHYNiGHDV9IZYxo1e5LSD8cabi65WVTWWb+g2BGPEpUUCOxR4D+6O5B0AzyMdUAXwrw==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -2056,6 +2083,8 @@ snapshots:
       '@node-rs/argon2-win32-ia32-msvc': 2.0.2
       '@node-rs/argon2-win32-x64-msvc': 2.0.2
 
+  '@openclaw/plugin-inspector@0.3.10': {}
+
   '@orama/orama@3.1.18': {}
 
   '@orama/plugin-data-persistence@3.1.18':
@@ -2200,7 +2229,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2208,7 +2237,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -2428,6 +2457,9 @@ snapshots:
 
   isexe@4.0.0: {}
 
+  jiti@2.6.1:
+    optional: true
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -2516,13 +2548,19 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  openai@6.33.0(ws@8.20.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 3.25.76
+
+  openai@6.33.0(ws@8.20.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.4.3
+
   openai@6.33.0(zod@3.25.76):
     optionalDependencies:
       zod: 3.25.76
-
-  openai@6.33.0(zod@4.0.0):
-    optionalDependencies:
-      zod: 4.0.0
 
   pathe@2.0.3: {}
 
@@ -2538,13 +2576,20 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      jiti: 2.6.1
       postcss: 8.5.10
       tsx: 4.21.0
       yaml: 2.8.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
 
   postcss@8.5.10:
     dependencies:
@@ -2742,7 +2787,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -2753,7 +2798,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -2763,6 +2808,33 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.10
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.60.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -2803,7 +2875,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2814,6 +2886,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.2
       fsevents: 2.3.3
+      jiti: 2.6.1
       tsx: 4.21.0
       yaml: 2.8.3
 
@@ -2825,6 +2898,9 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.20.0:
+    optional: true
+
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
@@ -2834,3 +2910,6 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.0.0: {}
+
+  zod@4.4.3:
+    optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
         specifier: ^6.0.0
         version: 6.33.0(ws@8.20.0)(zod@4.4.3)
     devDependencies:
+      '@openclaw/plugin-inspector':
+        specifier: 0.3.10
+        version: 0.3.10
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -40,6 +40,7 @@ needs_entity_hardening() {
 # Core mandatory gate from docs/ops/pr-review-hardening-playbook.md
 run npm run check-types
 run npm run check-config-contract
+run npm run plugin:inspect
 run bash scripts/check-review-patterns.sh
 
 if needs_entity_hardening; then

--- a/src/index.ts
+++ b/src/index.ts
@@ -2155,11 +2155,7 @@ const pluginDefinition = {
 
       if (sdkCaps.hasBeforePromptBuild) {
         // New SDK path — literal string for compat checker detection
-        (api.on as (
-          event: string,
-          handler: (event: Record<string, unknown>, ctx: Record<string, unknown>) => Promise<unknown>,
-          opts?: { timeoutMs?: number },
-        ) => void)(
+        api.on(
           "before_prompt_build",
           async (
             event: Record<string, unknown>,
@@ -2196,7 +2192,7 @@ const pluginDefinition = {
             }
             return result;
           },
-          { timeoutMs: cfg.initGateTimeoutMs },
+          ...([{ timeoutMs: cfg.initGateTimeoutMs }] as unknown as []),
         );
       } else {
         // Legacy SDK path — literal string for compat checker detection.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2192,7 +2192,6 @@ const pluginDefinition = {
             }
             return result;
           },
-          ...([{ timeoutMs: cfg.initGateTimeoutMs }] as unknown as []),
         );
       } else {
         // Legacy SDK path — literal string for compat checker detection.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2154,45 +2154,59 @@ const pluginDefinition = {
         typeof (api as any).registerMemoryCapability === "function";
 
       if (sdkCaps.hasBeforePromptBuild) {
+        type HookApiWithOptions = {
+          on: (
+            event: string,
+            handler: (
+              event: Record<string, unknown>,
+              ctx: Record<string, unknown>,
+            ) => Promise<unknown>,
+            opts?: { timeoutMs?: number },
+          ) => void;
+        };
+
         // New SDK path — literal string for compat checker detection
-        api.on(
-          "before_prompt_build",
-          async (
-            event: Record<string, unknown>,
-            ctx: Record<string, unknown>,
-          ) => {
-            const sessionKey = (ctx?.sessionKey as string) ?? "default";
-            const sessionIdentity = resolveSessionIdentity(sessionKey, event, ctx);
-            // Reset the cache at the start of every turn so a recall miss
-            // can never serve stale memory from a prior turn through the
-            // capability promptBuilder fallback.
-            if (needsCacheFallback) {
-              cachePromptMemoryLines(
-                sessionKey,
-                sessionIdentity.providerThreadId,
-                null,
-              );
-            }
-            const result = await recallHookHandler("before_prompt_build", event, ctx);
-            // Populate cache for capability promptBuilder fallback using the
-            // same structured line format as the registerMemoryPromptSection path.
-            if (needsCacheFallback && result?.memoryLines) {
-              cachePromptMemoryLines(
-                sessionKey,
-                sessionIdentity.providerThreadId,
-                result.memoryLines,
-              );
-            }
-            // Strip the internal `memoryLines` field before returning to the
-            // gateway — it's a closure-private carrier for cache population
-            // and is not part of the hook contract.
-            if (result && "memoryLines" in result) {
-              const { memoryLines: _ml, ...gatewayResult } = result;
-              return Object.keys(gatewayResult).length > 0 ? gatewayResult : undefined;
-            }
-            return result;
-          },
-        );
+        ((api: HookApiWithOptions) => {
+          api.on(
+            "before_prompt_build",
+            async (
+              event: Record<string, unknown>,
+              ctx: Record<string, unknown>,
+            ) => {
+              const sessionKey = (ctx?.sessionKey as string) ?? "default";
+              const sessionIdentity = resolveSessionIdentity(sessionKey, event, ctx);
+              // Reset the cache at the start of every turn so a recall miss
+              // can never serve stale memory from a prior turn through the
+              // capability promptBuilder fallback.
+              if (needsCacheFallback) {
+                cachePromptMemoryLines(
+                  sessionKey,
+                  sessionIdentity.providerThreadId,
+                  null,
+                );
+              }
+              const result = await recallHookHandler("before_prompt_build", event, ctx);
+              // Populate cache for capability promptBuilder fallback using the
+              // same structured line format as the registerMemoryPromptSection path.
+              if (needsCacheFallback && result?.memoryLines) {
+                cachePromptMemoryLines(
+                  sessionKey,
+                  sessionIdentity.providerThreadId,
+                  result.memoryLines,
+                );
+              }
+              // Strip the internal `memoryLines` field before returning to the
+              // gateway — it's a closure-private carrier for cache population
+              // and is not part of the hook contract.
+              if (result && "memoryLines" in result) {
+                const { memoryLines: _ml, ...gatewayResult } = result;
+                return Object.keys(gatewayResult).length > 0 ? gatewayResult : undefined;
+              }
+              return result;
+            },
+            { timeoutMs: cfg.initGateTimeoutMs },
+          );
+        })(api as unknown as HookApiWithOptions);
       } else {
         // Legacy SDK path — literal string for compat checker detection.
         // Capability-only runtimes cannot reach this branch (they land on


### PR DESCRIPTION
## Summary
- add @openclaw/plugin-inspector config for @remnic/plugin-openclaw
- add root/package inspector scripts and ignore generated inspector reports
- wire the static inspector into quick preflight and document runtime-inspector gaps

Closes #887

## Verification
- npm run plugin:inspect
- npm run plugin:inspect:runtime
- npm run check-types
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds a new inspection tool and CI/preflight gating, with only a type-casting refactor around OpenClaw hook registration that should not change runtime behavior.
> 
> **Overview**
> Adds an OpenClaw `plugin-inspector` gate for `@remnic/plugin-openclaw`, including a new `plugin-inspector.config.json`, root and package `plugin:inspect`/`plugin:inspect:runtime` scripts, and documentation of what the inspector covers.
> 
> Wires `npm run plugin:inspect` into `scripts/pr-preflight.sh`, adds the inspector as a dev dependency (lockfiles updated), and ignores generated inspector reports under `packages/plugin-openclaw/reports/`. Also refactors the `before_prompt_build` hook registration in `src/index.ts` to use an explicit `HookApiWithOptions` cast instead of an inline function type (supporting static inspection/typing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e85772b88e5149607106b8c827750fe58493d1cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->