### PR TITLE
test(openclaw): capture adapter registrations

### DIFF
--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -50,6 +50,7 @@ fi
 if [[ "$MODE" == "quick" ]]; then
   # Registration contract tests catch silent lifecycle breakage (issues #282, #285).
   # Run first — registration regressions are caught before slower tests.
+  run pnpm exec tsx --test tests/openclaw-registration-capture.test.ts
   run npm test -- tests/register-multi-registry.test.ts
   run npm test -- tests/intent.test.ts
   run npm test -- tests/runtime-input-guards.test.ts

--- a/tests/helpers/openclaw-registration-harness.ts
+++ b/tests/helpers/openclaw-registration-harness.ts
@@ -35,12 +35,15 @@ export function captureOpenClawRegistrationApi(options: {
   logger?: Record<"debug" | "info" | "warn" | "error", (...args: unknown[]) => void>;
 } = {}): CapturedOpenClawApi {
   const captured: Record<string, RegistrationArgs[]> = {};
+  const pluginConfig = options.pluginConfig ?? {};
+  const config = buildGatewayConfig(options.config, pluginConfig);
   const target: Record<string, unknown> = {
     id: SERVICE_ID,
+    pluginId: SERVICE_ID,
     label: options.label ?? "capture",
     registrationMode: options.registrationMode ?? "full",
-    pluginConfig: options.pluginConfig ?? {},
-    config: options.config ?? {},
+    pluginConfig,
+    config,
     runtime: options.runtime ?? {
       version: "2026.5.3-1",
       agent: {
@@ -93,6 +96,33 @@ export function captureOpenClawRegistrationApi(options: {
         .map(([value, secondary]) => registrationId(value, secondary))
         .filter((value): value is string => typeof value === "string")
         .sort();
+    },
+  };
+}
+
+function buildGatewayConfig(
+  config: Record<string, unknown> | undefined,
+  pluginConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const plugins =
+    config?.plugins && typeof config.plugins === "object" && !Array.isArray(config.plugins)
+      ? (config.plugins as Record<string, unknown>)
+      : {};
+  const entries =
+    plugins.entries && typeof plugins.entries === "object" && !Array.isArray(plugins.entries)
+      ? (plugins.entries as Record<string, unknown>)
+      : {};
+
+  return {
+    ...config,
+    plugins: {
+      ...plugins,
+      entries: {
+        [SERVICE_ID]: {
+          config: pluginConfig,
+        },
+        ...entries,
+      },
     },
   };
 }

--- a/tests/helpers/openclaw-registration-harness.ts
+++ b/tests/helpers/openclaw-registration-harness.ts
@@ -140,14 +140,14 @@ function registrationId(value: unknown, secondary: unknown): string | undefined 
   if (secondary && typeof secondary === "object") {
     const record = secondary as Record<string, unknown>;
     if (Array.isArray(record.descriptors)) {
-      return record.descriptors
+      const names = record.descriptors
         .map((descriptor) =>
           descriptor && typeof descriptor === "object"
             ? (descriptor as Record<string, unknown>).name
             : undefined,
         )
-        .filter((name): name is string => typeof name === "string")
-        .join(", ");
+        .filter((name): name is string => typeof name === "string" && name.length > 0);
+      return names.length > 0 ? names.join(", ") : undefined;
     }
   }
   return undefined;

--- a/tests/helpers/openclaw-registration-harness.ts
+++ b/tests/helpers/openclaw-registration-harness.ts
@@ -1,0 +1,154 @@
+type RegistrationArgs = unknown[];
+
+export interface CapturedOpenClawApi {
+  api: Record<string, unknown>;
+  hooks(name?: string): RegistrationArgs[];
+  registrations(method?: string): RegistrationArgs[];
+  registrationNames(method: string): string[];
+}
+
+const SERVICE_ID = "openclaw-remnic";
+const GLOBAL_KEYS = [
+  `__openclawEngramRegistered::${SERVICE_ID}`,
+  `__openclawEngramHookApis::${SERVICE_ID}`,
+  `__openclawEngramOrchestrator::${SERVICE_ID}`,
+  `__openclawEngramAccessService::${SERVICE_ID}`,
+  `__openclawEngramAccessHttpServer::${SERVICE_ID}`,
+  `__openclawEngramAccessHttpAuthState::${SERVICE_ID}`,
+  `__openclawEngramServiceStarted::${SERVICE_ID}`,
+  `__openclawEngramInitPromise::${SERVICE_ID}`,
+  "__openclawEngramOrchestrator",
+  "__openclawEngramCliRegistered",
+  "__openclawEngramCliActiveServiceCount",
+  "__openclawEngramSessionCommandsRegistered",
+  "__openclawEngramMigrationPromise",
+] as const;
+
+const DISABLE_REGISTER_MIGRATION_ENV = "REMNIC_DISABLE_REGISTER_MIGRATION";
+
+export function captureOpenClawRegistrationApi(options: {
+  label?: string;
+  pluginConfig?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+  registrationMode?: "full" | "setup-only" | "setup-runtime";
+  runtime?: Record<string, unknown>;
+  logger?: Record<"debug" | "info" | "warn" | "error", (...args: unknown[]) => void>;
+} = {}): CapturedOpenClawApi {
+  const captured: Record<string, RegistrationArgs[]> = {};
+  const target: Record<string, unknown> = {
+    id: SERVICE_ID,
+    label: options.label ?? "capture",
+    registrationMode: options.registrationMode ?? "full",
+    pluginConfig: options.pluginConfig ?? {},
+    config: options.config ?? {},
+    runtime: options.runtime ?? {
+      version: "2026.5.3-1",
+      agent: {
+        id: "generalist",
+        workspaceDir: process.cwd(),
+      },
+    },
+    logger: options.logger ?? {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  };
+
+  const capture = (method: string, args: RegistrationArgs) => {
+    captured[method] ??= [];
+    captured[method].push(args);
+  };
+
+  const api = new Proxy(target, {
+    get(currentTarget, property) {
+      if (property in currentTarget) {
+        return currentTarget[property as keyof typeof currentTarget];
+      }
+      if (property === "on") {
+        return (...args: RegistrationArgs) => capture("on", args);
+      }
+      if (typeof property === "string" && property.startsWith("register")) {
+        return (...args: RegistrationArgs) => capture(property, args);
+      }
+      return undefined;
+    },
+  }) as Record<string, unknown>;
+
+  return {
+    api,
+    hooks(name?: string) {
+      const hooks = captured.on ?? [];
+      return name ? hooks.filter(([hookName]) => hookName === name) : [...hooks];
+    },
+    registrations(method?: string) {
+      if (method) return [...(captured[method] ?? [])];
+      return Object.entries(captured).flatMap(([name, argsList]) =>
+        name === "on" ? [] : argsList.map((args) => [name, ...args]),
+      );
+    },
+    registrationNames(method: string) {
+      return (captured[method] ?? [])
+        .map(([value, secondary]) => registrationId(value, secondary))
+        .filter((value): value is string => typeof value === "string")
+        .sort();
+    },
+  };
+}
+
+export function saveAndResetOpenClawRegistrationGlobals(): Map<string, unknown> {
+  const saved = new Map<string, unknown>();
+  for (const key of GLOBAL_KEYS) {
+    saved.set(key, (globalThis as Record<string, unknown>)[key]);
+    delete (globalThis as Record<string, unknown>)[key];
+  }
+  return saved;
+}
+
+export function restoreOpenClawRegistrationGlobals(saved: Map<string, unknown>): void {
+  for (const key of GLOBAL_KEYS) {
+    if (saved.get(key) === undefined) {
+      delete (globalThis as Record<string, unknown>)[key];
+    } else {
+      (globalThis as Record<string, unknown>)[key] = saved.get(key);
+    }
+  }
+}
+
+export function disableRegisterMigrationForCaptureTest(): string | undefined {
+  const previous = process.env[DISABLE_REGISTER_MIGRATION_ENV];
+  process.env[DISABLE_REGISTER_MIGRATION_ENV] = "1";
+  return previous;
+}
+
+export function restoreRegisterMigrationForCaptureTest(previous: string | undefined): void {
+  if (previous === undefined) {
+    delete process.env[DISABLE_REGISTER_MIGRATION_ENV];
+  } else {
+    process.env[DISABLE_REGISTER_MIGRATION_ENV] = previous;
+  }
+}
+
+function registrationId(value: unknown, secondary: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (typeof record.id === "string") return record.id;
+    if (typeof record.name === "string") return record.name;
+  }
+  if (secondary && typeof secondary === "object") {
+    const record = secondary as Record<string, unknown>;
+    if (Array.isArray(record.descriptors)) {
+      return record.descriptors
+        .map((descriptor) =>
+          descriptor && typeof descriptor === "object"
+            ? (descriptor as Record<string, unknown>).name
+            : undefined,
+        )
+        .filter((name): name is string => typeof name === "string")
+        .join(", ");
+    }
+  }
+  return undefined;
+}

--- a/tests/helpers/openclaw-registration-harness.ts
+++ b/tests/helpers/openclaw-registration-harness.ts
@@ -118,10 +118,10 @@ function buildGatewayConfig(
     plugins: {
       ...plugins,
       entries: {
+        ...entries,
         [SERVICE_ID]: {
           config: pluginConfig,
         },
-        ...entries,
       },
     },
   };

--- a/tests/openclaw-registration-capture.test.ts
+++ b/tests/openclaw-registration-capture.test.ts
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  captureOpenClawRegistrationApi,
+  disableRegisterMigrationForCaptureTest,
+  restoreOpenClawRegistrationGlobals,
+  restoreRegisterMigrationForCaptureTest,
+  saveAndResetOpenClawRegistrationGlobals,
+} from "./helpers/openclaw-registration-harness.js";
+
+async function withCapturedRegistration(
+  fn: (plugin: { register(api: unknown): void }) => Promise<void> | void,
+) {
+  const saved = saveAndResetOpenClawRegistrationGlobals();
+  const previousMigration = disableRegisterMigrationForCaptureTest();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+    await fn(plugin as { register(api: unknown): void });
+  } finally {
+    restoreRegisterMigrationForCaptureTest(previousMigration);
+    restoreOpenClawRegistrationGlobals(saved);
+  }
+}
+
+test("full modern registration captures hooks, commands, tools, memory capability, CLI, and service", async () => {
+  await withCapturedRegistration((plugin) => {
+    const capture = captureOpenClawRegistrationApi();
+
+    plugin.register(capture.api);
+
+    const hookNames = capture.hooks().map(([name]) => name).sort();
+    assert.ok(hookNames.includes("before_prompt_build"));
+    assert.ok(hookNames.includes("agent_end"));
+    assert.ok(hookNames.includes("before_reset"));
+    assert.ok(hookNames.includes("session_end"));
+
+    assert.ok(
+      capture.registrationNames("registerTool").includes("memory_search"),
+      "registerTool should expose Remnic memory search",
+    );
+    assert.ok(
+      capture.registrationNames("registerTool").includes("memory_get"),
+      "registerTool should expose Remnic memory read",
+    );
+    assert.ok(
+      capture.registrationNames("registerCommand").some((name) =>
+        name === "remnic",
+      ),
+      "registerCommand should expose session memory commands",
+    );
+    assert.equal(capture.registrations("registerCli").length, 1);
+    assert.deepEqual(capture.registrationNames("registerService"), [
+      "openclaw-remnic",
+    ]);
+
+    const [memoryCapability] = capture.registrations("registerMemoryCapability");
+    assert.ok(memoryCapability, "registerMemoryCapability should be called");
+    const capability = memoryCapability[0] as Record<string, unknown>;
+    assert.equal(typeof capability.promptBuilder, "function");
+    assert.equal(typeof capability.runtime, "object");
+    assert.equal(typeof capability.publicArtifacts, "object");
+
+    assert.equal(
+      capture.registrations("registerMemoryPromptSection").length,
+      1,
+      "modern SDKs should still receive the prompt-section registration",
+    );
+
+    assert.equal(capture.registrations("registerMemoryEmbeddingProvider").length, 0);
+    assert.equal(capture.registrations("registerMemoryCorpusSupplement").length, 0);
+    assert.equal(capture.registrations("registerCompactionProvider").length, 0);
+  });
+});
+
+test("setup-only mode does not register runtime hooks or services", async () => {
+  await withCapturedRegistration((plugin) => {
+    const capture = captureOpenClawRegistrationApi({
+      registrationMode: "setup-only",
+    });
+
+    plugin.register(capture.api);
+
+    assert.deepEqual(capture.hooks(), []);
+    assert.deepEqual(capture.registrations(), []);
+  });
+});
+
+test("passive slot mode suppresses active memory hooks and capability surfaces", async () => {
+  await withCapturedRegistration((plugin) => {
+    const capture = captureOpenClawRegistrationApi({
+      config: {
+        plugins: {
+          slots: {
+            memory: "another-memory-plugin",
+          },
+        },
+      },
+      pluginConfig: {
+        slotBehavior: {
+          onSlotMismatch: "silent",
+        },
+      },
+    });
+
+    plugin.register(capture.api);
+
+    assert.deepEqual(
+      capture.hooks(),
+      [],
+      "passive slot mode should not bind active memory lifecycle hooks",
+    );
+    assert.equal(capture.registrations("registerMemoryCapability").length, 0);
+    assert.equal(capture.registrations("registerMemoryPromptSection").length, 0);
+    assert.equal(capture.registrations("registerCommand").length, 0);
+
+    assert.ok(
+      capture.registrationNames("registerTool").includes("memory_search"),
+      "passive mode still exposes explicit tools",
+    );
+    assert.deepEqual(capture.registrationNames("registerService"), [
+      "openclaw-remnic",
+    ]);
+  });
+});
+
+test("per-registry surfaces repeat while central command surfaces stay guarded", async () => {
+  await withCapturedRegistration((plugin) => {
+    const first = captureOpenClawRegistrationApi({ label: "first" });
+    const second = captureOpenClawRegistrationApi({ label: "second" });
+
+    plugin.register(first.api);
+    plugin.register(second.api);
+
+    assert.ok(first.registrations("registerTool").length > 0);
+    assert.ok(second.registrations("registerTool").length > 0);
+    assert.deepEqual(first.registrationNames("registerService"), [
+      "openclaw-remnic",
+    ]);
+    assert.deepEqual(second.registrationNames("registerService"), [
+      "openclaw-remnic",
+    ]);
+    assert.ok(first.registrations("registerMemoryCapability").length > 0);
+    assert.ok(second.registrations("registerMemoryCapability").length > 0);
+
+    assert.equal(first.registrations("registerCli").length, 1);
+    assert.equal(
+      second.registrations("registerCli").length,
+      0,
+      "CLI registration is process-global and must not duplicate",
+    );
+    assert.ok(first.registrations("registerCommand").length > 0);
+    assert.equal(
+      second.registrations("registerCommand").length,
+      0,
+      "session command descriptors are centrally guarded",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a proxy-backed OpenClaw registration harness for tests
- cover modern registration, setup-only mode, passive memory-slot mode, and multi-registry guarded surfaces
- add the focused registration capture test to quick preflight

Closes #888

## Verification
- pnpm exec tsx --test tests/openclaw-registration-capture.test.ts
- npm run plugin:inspect
- npm run check-types
- git diff --check

Note: I started `npm run preflight:quick`, but stopped it during the existing `check-review-patterns` scan because it traversed checked-out `.claude/.worktrees` and emitted massive unrelated legacy-warning output before reaching the quick test list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding new registration-capture test harnesses and wiring an extra quick-preflight test, with no production runtime behavior modified.
> 
> **Overview**
> Adds a proxy-based OpenClaw registration harness that captures `on`/`register*` calls while isolating process globals and disabling register-migration side effects for deterministic tests.
> 
> Introduces `openclaw-registration-capture.test.ts` to assert registration contracts across full registration, `setup-only` mode, passive memory-slot mode, and multi-registry behavior (including guarded global surfaces like CLI/commands). The quick preflight script now runs this focused registration-capture test first to catch lifecycle regressions earlier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a25c777181ff294f01f2a9d5a83c76107f0edc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->