### PR TITLE
test(openclaw): declare adapter manifest contracts

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5705,7 +5705,6 @@
       "remnic"
     ],
     "onCapabilities": [
-      "memory",
       "tool",
       "hook"
     ]

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5695,8 +5695,9 @@
   },
   "commandAliases": [
     {
-      "command": "remnic",
-      "pluginId": "openclaw-remnic"
+      "name": "remnic",
+      "kind": "runtime-slash",
+      "cliCommand": "remnic"
     }
   ],
   "activation": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -50,6 +50,34 @@
     "beforeReset": true
   },
   "contracts": {
+    "commands": [
+      "remnic"
+    ],
+    "hooks": [
+      "before_prompt_build",
+      "before_agent_start",
+      "agent_end",
+      "before_compaction",
+      "after_compaction",
+      "before_reset",
+      "session_start",
+      "session_end",
+      "before_tool_call",
+      "after_tool_call",
+      "llm_output",
+      "subagent_spawning",
+      "subagent_ended",
+      "commands.list"
+    ],
+    "memoryCapabilities": [
+      "openclaw-remnic"
+    ],
+    "memoryPromptSections": [
+      "engram-memory"
+    ],
+    "services": [
+      "openclaw-remnic"
+    ],
     "tools": [
       "compounding_promote_candidate",
       "compounding_weekly_synthesize",
@@ -2870,12 +2898,12 @@
       },
       "modelSource": {
         "type": "string",
-      "enum": [
-        "plugin",
-        "gateway"
-      ],
-      "default": "gateway",
-      "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
+        "enum": [
+          "plugin",
+          "gateway"
+        ],
+        "default": "gateway",
+        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {
         "type": "string",
@@ -5664,5 +5692,21 @@
       "advanced": true,
       "help": "Promote stored reasoning_trace memories to the top of recall results when the incoming query reads like a problem-solving ask. Default off; enable after benchmarking (issue #564)."
     }
+  },
+  "commandAliases": [
+    {
+      "command": "remnic",
+      "pluginId": "openclaw-remnic"
+    }
+  ],
+  "activation": {
+    "onCommands": [
+      "remnic"
+    ],
+    "onCapabilities": [
+      "memory",
+      "tool",
+      "hook"
+    ]
   }
 }

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -5705,7 +5705,6 @@
       "remnic"
     ],
     "onCapabilities": [
-      "memory",
       "tool",
       "hook"
     ]

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -50,6 +50,34 @@
     "beforeReset": true
   },
   "contracts": {
+    "commands": [
+      "remnic"
+    ],
+    "hooks": [
+      "before_prompt_build",
+      "before_agent_start",
+      "agent_end",
+      "before_compaction",
+      "after_compaction",
+      "before_reset",
+      "session_start",
+      "session_end",
+      "before_tool_call",
+      "after_tool_call",
+      "llm_output",
+      "subagent_spawning",
+      "subagent_ended",
+      "commands.list"
+    ],
+    "memoryCapabilities": [
+      "openclaw-remnic"
+    ],
+    "memoryPromptSections": [
+      "engram-memory"
+    ],
+    "services": [
+      "openclaw-remnic"
+    ],
     "tools": [
       "compounding_promote_candidate",
       "compounding_weekly_synthesize",
@@ -1688,14 +1716,25 @@
           "authToken": {
             "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
             "anyOf": [
-              { "type": "string" },
+              {
+                "type": "string"
+              },
               {
                 "type": "object",
-                "required": ["source"],
+                "required": [
+                  "source"
+                ],
                 "properties": {
-                  "source": { "type": "string", "minLength": 1 },
-                  "provider": { "type": "string" },
-                  "id": { "type": "string" },
+                  "source": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
                   "command": {}
                 }
               }
@@ -2525,8 +2564,14 @@
       },
       "patternReinforcementCategories": {
         "type": "array",
-        "items": { "type": "string" },
-        "default": ["preference", "fact", "decision"],
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "preference",
+          "fact",
+          "decision"
+        ],
         "description": "Memory categories the pattern-reinforcement job considers. Skips procedural memories so it stays disjoint from procedural mining. Default: preference, fact, decision."
       },
       "reinforcementRecallBoostEnabled": {
@@ -2853,12 +2898,12 @@
       },
       "modelSource": {
         "type": "string",
-      "enum": [
-        "plugin",
-        "gateway"
-      ],
-      "default": "gateway",
-      "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
+        "enum": [
+          "plugin",
+          "gateway"
+        ],
+        "default": "gateway",
+        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {
         "type": "string",
@@ -5647,5 +5692,21 @@
       "advanced": true,
       "help": "Promote stored reasoning_trace memories to the top of recall results when the incoming query reads like a problem-solving ask. Default off; enable after benchmarking (issue #564)."
     }
+  },
+  "commandAliases": [
+    {
+      "command": "remnic",
+      "pluginId": "openclaw-remnic"
+    }
+  ],
+  "activation": {
+    "onCommands": [
+      "remnic"
+    ],
+    "onCapabilities": [
+      "memory",
+      "tool",
+      "hook"
+    ]
   }
 }

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -5695,8 +5695,9 @@
   },
   "commandAliases": [
     {
-      "command": "remnic",
-      "pluginId": "openclaw-remnic"
+      "name": "remnic",
+      "kind": "runtime-slash",
+      "cliCommand": "remnic"
     }
   ],
   "activation": {

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -5705,7 +5705,6 @@
       "remnic"
     ],
     "onCapabilities": [
-      "memory",
       "tool",
       "hook"
     ]

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -5695,8 +5695,9 @@
   },
   "commandAliases": [
     {
-      "command": "remnic",
-      "pluginId": "openclaw-engram"
+      "name": "remnic",
+      "kind": "runtime-slash",
+      "cliCommand": "remnic"
     }
   ],
   "activation": {

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -50,6 +50,34 @@
     "beforeReset": true
   },
   "contracts": {
+    "commands": [
+      "remnic"
+    ],
+    "hooks": [
+      "before_prompt_build",
+      "before_agent_start",
+      "agent_end",
+      "before_compaction",
+      "after_compaction",
+      "before_reset",
+      "session_start",
+      "session_end",
+      "before_tool_call",
+      "after_tool_call",
+      "llm_output",
+      "subagent_spawning",
+      "subagent_ended",
+      "commands.list"
+    ],
+    "memoryCapabilities": [
+      "openclaw-engram"
+    ],
+    "memoryPromptSections": [
+      "engram-memory"
+    ],
+    "services": [
+      "openclaw-engram"
+    ],
     "tools": [
       "compounding_promote_candidate",
       "compounding_weekly_synthesize",
@@ -5664,5 +5692,21 @@
       "advanced": true,
       "help": "Promote stored reasoning_trace memories to the top of recall results when the incoming query reads like a problem-solving ask. Default off; enable after benchmarking (issue #564)."
     }
+  },
+  "commandAliases": [
+    {
+      "command": "remnic",
+      "pluginId": "openclaw-engram"
+    }
+  ],
+  "activation": {
+    "onCommands": [
+      "remnic"
+    ],
+    "onCapabilities": [
+      "memory",
+      "tool",
+      "hook"
+    ]
   }
 }

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -46,6 +46,22 @@ const OPENCLAW_MANIFEST_PATHS = [
   "packages/plugin-openclaw/openclaw.plugin.json",
   "packages/shim-openclaw-engram/openclaw.plugin.json",
 ];
+const EXPECTED_LIFECYCLE_HOOK_CONTRACTS = [
+  "after_compaction",
+  "after_tool_call",
+  "agent_end",
+  "before_agent_start",
+  "before_compaction",
+  "before_prompt_build",
+  "before_reset",
+  "before_tool_call",
+  "commands.list",
+  "llm_output",
+  "session_end",
+  "session_start",
+  "subagent_ended",
+  "subagent_spawning",
+];
 const TOOL_SOURCE_PATHS = [
   "src/tools.ts",
   "packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.ts",
@@ -111,6 +127,29 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
       readSourceToolNames(),
       "OpenClaw 2026.5 rejects plugin tools not declared in openclaw.plugin.json#contracts.tools",
     );
+  });
+
+  test(`${manifestPath} declares OpenClaw adapter command, memory, service, and hook contracts`, () => {
+    const manifest = readManifest(manifestPath);
+
+    assert.deepEqual(manifest.commandAliases, [
+      {
+        command: "remnic",
+        pluginId: manifest.id,
+      },
+    ]);
+    assert.deepEqual(manifest.activation, {
+      onCommands: ["remnic"],
+      onCapabilities: ["memory", "tool", "hook"],
+    });
+    assert.deepEqual(manifest.contracts?.commands, ["remnic"]);
+    assert.deepEqual(
+      [...(manifest.contracts?.hooks ?? [])].sort(),
+      EXPECTED_LIFECYCLE_HOOK_CONTRACTS,
+    );
+    assert.deepEqual(manifest.contracts?.memoryCapabilities, [manifest.id]);
+    assert.deepEqual(manifest.contracts?.memoryPromptSections, ["engram-memory"]);
+    assert.deepEqual(manifest.contracts?.services, [manifest.id]);
   });
 
   test(`${manifestPath} declares pre-runtime auth metadata for OpenAI-backed memory extraction`, () => {

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -134,8 +134,9 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
 
     assert.deepEqual(manifest.commandAliases, [
       {
-        command: "remnic",
-        pluginId: manifest.id,
+        name: "remnic",
+        kind: "runtime-slash",
+        cliCommand: "remnic",
       },
     ]);
     assert.deepEqual(manifest.activation, {

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -141,7 +141,7 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
     ]);
     assert.deepEqual(manifest.activation, {
       onCommands: ["remnic"],
-      onCapabilities: ["memory", "tool", "hook"],
+      onCapabilities: ["tool", "hook"],
     });
     assert.deepEqual(manifest.contracts?.commands, ["remnic"]);
     assert.deepEqual(


### PR DESCRIPTION
## Summary
- add OpenClaw command alias and activation metadata for the existing `remnic` command
- declare existing adapter contracts for commands, lifecycle hooks, memory capability, prompt section, service, and tools
- extend manifest drift tests across canonical and legacy OpenClaw manifests

Closes #889

## Verification
- pnpm exec tsx --test tests/openclaw-plugin-runtime-surfaces.test.ts
- npm run check:openclaw-plugin-sync
- npm run plugin:inspect
- npm run check-types
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to plugin manifest metadata and tests, with no runtime logic changes; main risk is mis-declared contracts/activation causing OpenClaw to reject or incorrectly activate the plugin.
> 
> **Overview**
> Declares the Remnic OpenClaw adapter’s explicit runtime contracts across all shipped manifests: adds `contracts.commands` for `remnic`, enumerates lifecycle `contracts.hooks`, and declares `memoryCapabilities`, `memoryPromptSections`, and `services` so OpenClaw can validate the plugin surface.
> 
> Adds `commandAliases` plus `activation` metadata to ensure the existing `remnic` slash command activates the plugin when commands/tools/hooks are used. Updates/extends `tests/openclaw-plugin-runtime-surfaces.test.ts` to assert these contracts and keep the root/packaged manifests in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b7a83b6fb88880cd0bc5d2afa798f65385732b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->