### PR TITLE
Add OpenClaw SDK surface drift check

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
     "check:openclaw-plugin-sync": "node scripts/check-openclaw-plugin-sync.mjs",
+    "check:openclaw-sdk-surface": "node scripts/check-openclaw-sdk-surface.mjs",
     "build": "pnpm run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
     "dev": "tsup --watch",
     "check-types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
     "check:openclaw-plugin-sync": "node scripts/check-openclaw-plugin-sync.mjs",
     "check:openclaw-sdk-surface": "node scripts/check-openclaw-sdk-surface.mjs",
+    "check:openclaw-sdk-surface:required": "node scripts/check-openclaw-sdk-surface.mjs --require",
     "build": "pnpm run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
     "dev": "tsup --watch",
     "check-types": "tsc --noEmit",

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -116,6 +116,9 @@ The adapter keeps a conservative OpenClaw SDK surface snapshot at
 with `-- --package-root <path>` to check a local OpenClaw checkout. When an
 upstream SDK change is intentional, review the adapter impact first, then
 refresh the snapshot with `npm run check:openclaw-sdk-surface -- --write`.
+CI jobs that provision OpenClaw should use
+`npm run check:openclaw-sdk-surface:required` or pass
+`-- --require --package-root <path>` so a missing SDK fails instead of skipping.
 
 ## Slot Selection
 

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -108,6 +108,15 @@ guarded in the adapter, including `registerMemoryCapability`, `registerCli`,
 and `registerCommand`; keep runtime capture coverage for those surfaces in a
 separate adapter test slice.
 
+## SDK Surface Drift Check
+
+The adapter keeps a conservative OpenClaw SDK surface snapshot at
+`openclaw-sdk-surface.expected.json`. Run
+`npm run check:openclaw-sdk-surface` after changing OpenClaw dependencies or
+with `-- --package-root <path>` to check a local OpenClaw checkout. When an
+upstream SDK change is intentional, review the adapter impact first, then
+refresh the snapshot with `npm run check:openclaw-sdk-surface -- --write`.
+
 ## Slot Selection
 
 Remnic is an exclusive memory-slot plugin. When `plugins.slots.memory` points

--- a/packages/plugin-openclaw/openclaw-sdk-surface.expected.json
+++ b/packages/plugin-openclaw/openclaw-sdk-surface.expected.json
@@ -32,6 +32,8 @@
     "before_prompt_build",
     "before_reset",
     "before_tool_call",
+    "gateway_start",
+    "gateway_stop",
     "llm_input",
     "llm_output",
     "session_end",

--- a/packages/plugin-openclaw/openclaw-sdk-surface.expected.json
+++ b/packages/plugin-openclaw/openclaw-sdk-surface.expected.json
@@ -1,0 +1,46 @@
+{
+  "description": "Conservative OpenClaw plugin SDK surface allow-list for Remnic adapter review. Refresh with `npm run check:openclaw-sdk-surface -- --write` after intentionally upgrading OpenClaw.",
+  "registrars": [
+    "registerCli",
+    "registerCliBackend",
+    "registerCommand",
+    "registerCompactionProvider",
+    "registerMemoryCapability",
+    "registerMemoryCorpusSupplement",
+    "registerMemoryEmbeddingProvider",
+    "registerMemoryFlushPlan",
+    "registerMemoryPromptSection",
+    "registerMemoryPromptSupplement",
+    "registerMemoryRuntime",
+    "registerService",
+    "registerTool",
+    "registerToolMetadata"
+  ],
+  "hooks": [
+    "after_compaction",
+    "after_tool_call",
+    "agent_end",
+    "agent_turn_prepare",
+    "before_agent_finalize",
+    "before_agent_reply",
+    "before_agent_start",
+    "before_compaction",
+    "before_dispatch",
+    "before_install",
+    "before_message_write",
+    "before_model_resolve",
+    "before_prompt_build",
+    "before_reset",
+    "before_tool_call",
+    "llm_input",
+    "llm_output",
+    "session_end",
+    "session_start"
+  ],
+  "manifestContracts": [
+    "commands",
+    "hooks",
+    "memoryEmbeddingProviders",
+    "tools"
+  ]
+}

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -135,8 +135,8 @@ async function resolveInstalledOpenClawRoot() {
   }
 
   const packageRoots = [
-    path.join(repoRoot, "node_modules", "openclaw"),
     path.join(repoRoot, "packages", "plugin-openclaw", "node_modules", "openclaw"),
+    path.join(repoRoot, "node_modules", "openclaw"),
   ];
   for (const packageRoot of packageRoots) {
     const packageInfo = await stat(path.join(packageRoot, "package.json")).catch(() => null);

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -57,7 +57,7 @@ if (!packageRoot) {
   const message =
     "OpenClaw SDK surface check skipped: `openclaw` is not installed. " +
     "Install the peer package or pass --package-root to check a specific checkout.";
-  if (process.env.REMNIC_OPENCLAW_SURFACE_REQUIRE === "1") {
+  if (args.require || process.env.REMNIC_OPENCLAW_SURFACE_REQUIRE === "1") {
     console.error(message);
     process.exit(1);
   }
@@ -100,6 +100,10 @@ function parseArgs(rawArgs) {
     const arg = rawArgs[index];
     if (arg === "--write") {
       parsed.write = true;
+      continue;
+    }
+    if (arg === "--require") {
+      parsed.require = true;
       continue;
     }
     if (arg === "--package-root" || arg === "--expected") {

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -70,7 +70,13 @@ if (!packageRootInfo?.isDirectory()) {
   process.exit(1);
 }
 
-const surface = await inspectOpenClawSurface(packageRoot);
+let surface;
+try {
+  surface = await inspectOpenClawSurface(packageRoot);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
 if (args.write) {
   await writeFile(expectedPath, `${JSON.stringify(surface, null, 2)}\n`);
   console.log(`Updated ${path.relative(repoRoot, expectedPath)}`);
@@ -149,6 +155,11 @@ async function resolveInstalledOpenClawRoot() {
 
 async function inspectOpenClawSurface(root) {
   const files = await collectFiles(root);
+  if (files.length === 0) {
+    throw new Error(
+      `OpenClaw SDK surface check failed: no SDK declaration files found under ${root}. Build OpenClaw or pass --package-root to a package containing dist/plugin-sdk declarations.`,
+    );
+  }
   const manifestFiles = files.filter((file) =>
     /^manifest(?:-registry)?\.d\.ts$/.test(path.basename(file)),
   );
@@ -219,7 +230,11 @@ async function collectFiles(root) {
         stack.push(fullPath);
         continue;
       }
-      if (!/\.(?:cjs|cts|d\.ts|js|json|mjs|mts|ts)$/.test(entry.name)) continue;
+      if (!/\.d\.ts$/.test(entry.name)) continue;
+      const relativePath = path.relative(root, fullPath).split(path.sep).join("/");
+      if (relativePath !== "plugin-sdk.d.ts" && !relativePath.includes("plugin-sdk/")) {
+        continue;
+      }
       const info = await stat(fullPath).catch(() => null);
       if (info && info.size <= 500_000) files.push(fullPath);
     }

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -35,6 +35,7 @@ const EXPECTED_HOOK_PREFIXES = [
   "agent_",
   "before_",
   "commands.",
+  "gateway_",
   "llm_",
   "session_",
 ];

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { readFile, readdir, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const defaultExpectedPath = path.join(
+  repoRoot,
+  "packages",
+  "plugin-openclaw",
+  "openclaw-sdk-surface.expected.json",
+);
+const SNAPSHOT_DESCRIPTION =
+  "Conservative OpenClaw plugin SDK surface allow-list for Remnic adapter review. Refresh with `npm run check:openclaw-sdk-surface -- --write` after intentionally upgrading OpenClaw.";
+const PREFERRED_SDK_SURFACE_FILES = [
+  "dist/plugin-sdk/src/plugins/types.d.ts",
+  "dist/plugin-sdk/src/plugins/hook-types.d.ts",
+  "dist/plugin-sdk/src/plugins/manifest.d.ts",
+  "dist/plugin-sdk/src/plugins/manifest-registry.d.ts",
+  "dist/plugin-sdk/src/plugins/memory-embedding-providers.d.ts",
+  "dist/plugin-sdk/src/plugins/compaction-provider.d.ts",
+];
+const EXPECTED_REGISTRAR_PREFIXES = [
+  "registerCli",
+  "registerCommand",
+  "registerCompaction",
+  "registerMemory",
+  "registerService",
+  "registerTool",
+];
+const EXPECTED_HOOK_PREFIXES = [
+  "after_",
+  "agent_",
+  "before_",
+  "commands.",
+  "llm_",
+  "session_",
+];
+const EXPECTED_CONTRACT_PREFIXES = [
+  "commands",
+  "hooks",
+  "memory",
+  "services",
+  "tools",
+];
+
+const args = parseArgs(process.argv.slice(2));
+const expectedPath = resolveUserPath(args.expected ?? defaultExpectedPath);
+const packageRoot = args.packageRoot
+  ? resolveUserPath(args.packageRoot)
+  : await resolveInstalledOpenClawRoot();
+
+if (!packageRoot) {
+  const message =
+    "OpenClaw SDK surface check skipped: `openclaw` is not installed. " +
+    "Install the peer package or pass --package-root to check a specific checkout.";
+  if (process.env.REMNIC_OPENCLAW_SURFACE_REQUIRE === "1") {
+    console.error(message);
+    process.exit(1);
+  }
+  console.log(message);
+  process.exit(0);
+}
+
+const packageRootInfo = await stat(packageRoot).catch(() => null);
+if (!packageRootInfo?.isDirectory()) {
+  console.error(`OpenClaw SDK surface check failed: --package-root is not a directory: ${packageRoot}`);
+  process.exit(1);
+}
+
+const surface = await inspectOpenClawSurface(packageRoot);
+if (args.write) {
+  await writeFile(expectedPath, `${JSON.stringify(surface, null, 2)}\n`);
+  console.log(`Updated ${path.relative(repoRoot, expectedPath)}`);
+  process.exit(0);
+}
+
+const expected = JSON.parse(await readFile(expectedPath, "utf-8"));
+const diffs = diffSurface(expected, surface);
+if (diffs.length > 0) {
+  console.error("OpenClaw SDK surface drift detected.");
+  console.error(`Package root: ${packageRoot}`);
+  for (const diff of diffs) console.error(`- ${diff}`);
+  console.error(
+    "Review the new surface, update the Remnic adapter if needed, then refresh the snapshot with `npm run check:openclaw-sdk-surface -- --write`.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `OpenClaw SDK surface matches expected snapshot (${surface.registrars.length} registrars, ${surface.hooks.length} hooks, ${surface.manifestContracts.length} manifest contracts).`,
+);
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
+    if (arg === "--write") {
+      parsed.write = true;
+      continue;
+    }
+    if (arg === "--package-root" || arg === "--expected") {
+      const value = rawArgs[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      parsed[arg.slice(2).replace(/-([a-z])/g, (_, char) => char.toUpperCase())] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function resolveUserPath(value) {
+  return path.resolve(expandTilde(value));
+}
+
+function expandTilde(value) {
+  if (value === "~") return os.homedir();
+  if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
+  return value;
+}
+
+async function resolveInstalledOpenClawRoot() {
+  try {
+    const require = createRequire(import.meta.url);
+    const packageJsonPath = require.resolve("openclaw/package.json");
+    return path.dirname(packageJsonPath);
+  } catch {
+    return null;
+  }
+}
+
+async function inspectOpenClawSurface(root) {
+  const files = await collectFiles(root);
+  const manifestFiles = files.filter((file) =>
+    /(?:^|\/)manifest(?:-registry)?\.d\.ts$/.test(file),
+  );
+  const contractFiles = manifestFiles.length > 0 ? manifestFiles : files;
+  const registrars = new Set();
+  const hooks = new Set();
+  const manifestContracts = new Set();
+
+  for (const file of files) {
+    const text = await readFile(file, "utf-8").catch(() => "");
+    for (const match of text.matchAll(/\b(register[A-Z][A-Za-z0-9]+)\b/g)) {
+      registrars.add(match[1]);
+    }
+    for (const match of text.matchAll(/["'`]([a-z]+(?:[._-][a-z0-9]+)+)["'`]/g)) {
+      const value = match[1];
+      if (looksLikeHookName(value)) hooks.add(value);
+    }
+  }
+
+  for (const file of contractFiles) {
+    const text = await readFile(file, "utf-8").catch(() => "");
+    for (const match of text.matchAll(/\b([A-Za-z][A-Za-z0-9]+Providers|tools|commands|hooks|services|memory[A-Za-z0-9]+)\b/g)) {
+      const value = match[1];
+      if (looksLikeManifestContract(value)) manifestContracts.add(value);
+    }
+  }
+
+  return {
+    description: SNAPSHOT_DESCRIPTION,
+    registrars: filterRelevant([...registrars], EXPECTED_REGISTRAR_PREFIXES),
+    hooks: filterRelevant([...hooks], EXPECTED_HOOK_PREFIXES),
+    manifestContracts: filterRelevant([...manifestContracts], EXPECTED_CONTRACT_PREFIXES),
+  };
+}
+
+function filterRelevant(values, prefixes) {
+  return values
+    .filter((value) => prefixes.some((prefix) => value.startsWith(prefix)))
+    .sort();
+}
+
+function looksLikeHookName(value) {
+  return EXPECTED_HOOK_PREFIXES.some((prefix) => value.startsWith(prefix));
+}
+
+function looksLikeManifestContract(value) {
+  return EXPECTED_CONTRACT_PREFIXES.some((prefix) => value.startsWith(prefix));
+}
+
+async function collectFiles(root) {
+  const preferredFiles = [];
+  for (const relativePath of PREFERRED_SDK_SURFACE_FILES) {
+    const fullPath = path.join(root, relativePath);
+    const info = await stat(fullPath).catch(() => null);
+    if (info?.isFile() && info.size <= 500_000) preferredFiles.push(fullPath);
+  }
+  if (preferredFiles.length > 0) return preferredFiles;
+
+  const files = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const entries = await readdir(current, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+      if (!/\.(?:cjs|cts|d\.ts|js|json|mjs|mts|ts)$/.test(entry.name)) continue;
+      const info = await stat(fullPath).catch(() => null);
+      if (info && info.size <= 500_000) files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function diffSurface(expected, actual) {
+  const diffs = [];
+  for (const key of ["registrars", "hooks", "manifestContracts"]) {
+    const expectedSet = new Set(expected[key] ?? []);
+    const actualSet = new Set(actual[key] ?? []);
+    const added = [...actualSet].filter((value) => !expectedSet.has(value)).sort();
+    const removed = [...expectedSet].filter((value) => !actualSet.has(value)).sort();
+    if (added.length > 0) diffs.push(`${key} added: ${added.join(", ")}`);
+    if (removed.length > 0) diffs.push(`${key} missing: ${removed.join(", ")}`);
+  }
+  return diffs;
+}

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { createRequire } from "node:module";
 import { readFile, readdir, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -135,19 +134,14 @@ async function resolveInstalledOpenClawRoot() {
     return null;
   }
 
-  const requireAnchors = [
-    import.meta.url,
-    path.join(repoRoot, "package.json"),
-    path.join(repoRoot, "packages", "plugin-openclaw", "package.json"),
+  const packageRoots = [
+    path.join(repoRoot, "node_modules", "openclaw"),
+    path.join(repoRoot, "packages", "plugin-openclaw", "node_modules", "openclaw"),
   ];
-  for (const anchor of requireAnchors) {
-    try {
-      const require = createRequire(anchor);
-      const packageJsonPath = require.resolve("openclaw/package.json");
-      return path.dirname(packageJsonPath);
-    } catch {
-      // Try the next workspace anchor. OpenClaw is a peer dependency and may be
-      // installed under a package-local node_modules in filtered installs.
+  for (const packageRoot of packageRoots) {
+    const packageInfo = await stat(path.join(packageRoot, "package.json")).catch(() => null);
+    if (packageInfo?.isFile()) {
+      return packageRoot;
     }
   }
   return null;
@@ -156,7 +150,7 @@ async function resolveInstalledOpenClawRoot() {
 async function inspectOpenClawSurface(root) {
   const files = await collectFiles(root);
   const manifestFiles = files.filter((file) =>
-    /(?:^|\/)manifest(?:-registry)?\.d\.ts$/.test(file),
+    /^manifest(?:-registry)?\.d\.ts$/.test(path.basename(file)),
   );
   const contractFiles = manifestFiles.length > 0 ? manifestFiles : files;
   const registrars = new Set();

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -131,13 +131,22 @@ function expandTilde(value) {
 }
 
 async function resolveInstalledOpenClawRoot() {
-  try {
-    const require = createRequire(import.meta.url);
-    const packageJsonPath = require.resolve("openclaw/package.json");
-    return path.dirname(packageJsonPath);
-  } catch {
-    return null;
+  const requireAnchors = [
+    import.meta.url,
+    path.join(repoRoot, "package.json"),
+    path.join(repoRoot, "packages", "plugin-openclaw", "package.json"),
+  ];
+  for (const anchor of requireAnchors) {
+    try {
+      const require = createRequire(anchor);
+      const packageJsonPath = require.resolve("openclaw/package.json");
+      return path.dirname(packageJsonPath);
+    } catch {
+      // Try the next workspace anchor. OpenClaw is a peer dependency and may be
+      // installed under a package-local node_modules in filtered installs.
+    }
   }
+  return null;
 }
 
 async function inspectOpenClawSurface(root) {

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -131,6 +131,10 @@ function expandTilde(value) {
 }
 
 async function resolveInstalledOpenClawRoot() {
+  if (process.env.REMNIC_OPENCLAW_SURFACE_DISABLE_AUTO_RESOLVE === "1") {
+    return null;
+  }
+
   const requireAnchors = [
     import.meta.url,
     path.join(repoRoot, "package.json"),

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -51,6 +51,7 @@ if [[ "$MODE" == "quick" ]]; then
   # Registration contract tests catch silent lifecycle breakage (issues #282, #285).
   # Run first — registration regressions are caught before slower tests.
   run pnpm exec tsx --test tests/openclaw-registration-capture.test.ts
+  run npm run check:openclaw-sdk-surface
   run pnpm exec tsx --test tests/openclaw-sdk-surface-check.test.ts
   run npm test -- tests/register-multi-registry.test.ts
   run npm test -- tests/intent.test.ts

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -41,7 +41,6 @@ needs_entity_hardening() {
 run npm run check-types
 run npm run check-config-contract
 run npm run plugin:inspect
-run env REMNIC_OPENCLAW_SURFACE_REQUIRE=1 npm run check:openclaw-sdk-surface
 run bash scripts/check-review-patterns.sh
 
 if needs_entity_hardening; then

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -41,7 +41,7 @@ needs_entity_hardening() {
 run npm run check-types
 run npm run check-config-contract
 run npm run plugin:inspect
-run npm run check:openclaw-sdk-surface
+run env REMNIC_OPENCLAW_SURFACE_REQUIRE=1 npm run check:openclaw-sdk-surface
 run bash scripts/check-review-patterns.sh
 
 if needs_entity_hardening; then

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -41,6 +41,7 @@ needs_entity_hardening() {
 run npm run check-types
 run npm run check-config-contract
 run npm run plugin:inspect
+run npm run check:openclaw-sdk-surface
 run bash scripts/check-review-patterns.sh
 
 if needs_entity_hardening; then
@@ -51,6 +52,7 @@ if [[ "$MODE" == "quick" ]]; then
   # Registration contract tests catch silent lifecycle breakage (issues #282, #285).
   # Run first — registration regressions are caught before slower tests.
   run pnpm exec tsx --test tests/openclaw-registration-capture.test.ts
+  run pnpm exec tsx --test tests/openclaw-sdk-surface-check.test.ts
   run npm test -- tests/register-multi-registry.test.ts
   run npm test -- tests/intent.test.ts
   run npm test -- tests/runtime-input-guards.test.ts

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -1,0 +1,237 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const SCRIPT = path.join(ROOT, "scripts", "check-openclaw-sdk-surface.mjs");
+
+test("OpenClaw SDK surface check passes when the scanned surface matches the snapshot", () => {
+  withFakeOpenClawSurface((fixture) => {
+    writeExpectedSurface(fixture.expectedPath);
+
+    const result = runCheck([
+      "--package-root",
+      fixture.packageRoot,
+      "--expected",
+      fixture.expectedPath,
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw SDK surface matches expected snapshot/);
+  });
+});
+
+test("OpenClaw SDK surface check reports added SDK names as actionable drift", () => {
+  withFakeOpenClawSurface((fixture) => {
+    writeExpectedSurface(fixture.expectedPath);
+    fs.appendFileSync(
+      fixture.sdkPath,
+      "\nexport function registerMemoryTimeline() {}\n",
+    );
+
+    const result = runCheck([
+      "--package-root",
+      fixture.packageRoot,
+      "--expected",
+      fixture.expectedPath,
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /OpenClaw SDK surface drift detected/);
+    assert.match(result.stderr, /registrars added: registerMemoryTimeline/);
+    assert.match(
+      result.stderr,
+      /npm run check:openclaw-sdk-surface -- --write/,
+    );
+  });
+});
+
+test("OpenClaw SDK surface check can refresh the snapshot for an intentional upgrade", () => {
+  withFakeOpenClawSurface((fixture) => {
+    fs.writeFileSync(
+      fixture.expectedPath,
+      JSON.stringify({ registrars: [], hooks: [], manifestContracts: [] }, null, 2),
+    );
+
+    const result = runCheck([
+      "--package-root",
+      fixture.packageRoot,
+      "--expected",
+      fixture.expectedPath,
+      "--write",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const refreshed = JSON.parse(fs.readFileSync(fixture.expectedPath, "utf-8"));
+    assert.match(refreshed.description, /Refresh with/);
+    assert.deepEqual(refreshed.registrars, expectedRegistrars);
+    assert.deepEqual(refreshed.hooks, expectedHooks);
+    assert.deepEqual(refreshed.manifestContracts, expectedManifestContracts);
+  });
+});
+
+test("OpenClaw SDK snapshot includes native memory registrar surfaces reviewed by the adapter spike", () => {
+  const snapshot = JSON.parse(
+    fs.readFileSync(
+      path.join(ROOT, "packages/plugin-openclaw/openclaw-sdk-surface.expected.json"),
+      "utf-8",
+    ),
+  );
+
+  assert.ok(snapshot.registrars.includes("registerMemoryEmbeddingProvider"));
+  assert.ok(snapshot.registrars.includes("registerMemoryCorpusSupplement"));
+  assert.ok(snapshot.registrars.includes("registerCompactionProvider"));
+  assert.ok(snapshot.manifestContracts.includes("memoryEmbeddingProviders"));
+});
+
+test("OpenClaw SDK surface check skips cleanly when OpenClaw is not installed", () => {
+  const result = runCheck([], {
+    NODE_PATH: path.join(os.tmpdir(), "remnic-missing-openclaw-node-path"),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /OpenClaw SDK surface check skipped/);
+});
+
+const expectedRegistrars = [
+  "registerCli",
+  "registerCliBackend",
+  "registerCommand",
+  "registerCompactionProvider",
+  "registerMemoryCapability",
+  "registerMemoryCorpusSupplement",
+  "registerMemoryEmbeddingProvider",
+  "registerMemoryFlushPlan",
+  "registerMemoryPromptSection",
+  "registerMemoryPromptSupplement",
+  "registerMemoryRuntime",
+  "registerService",
+  "registerTool",
+  "registerToolMetadata",
+];
+const expectedHooks = [
+  "after_compaction",
+  "after_tool_call",
+  "agent_end",
+  "agent_turn_prepare",
+  "before_agent_finalize",
+  "before_agent_reply",
+  "before_agent_start",
+  "before_compaction",
+  "before_dispatch",
+  "before_install",
+  "before_message_write",
+  "before_model_resolve",
+  "before_prompt_build",
+  "before_reset",
+  "before_tool_call",
+  "llm_input",
+  "llm_output",
+  "session_end",
+  "session_start",
+];
+const expectedManifestContracts = [
+  "commands",
+  "hooks",
+  "memoryEmbeddingProviders",
+  "tools",
+];
+
+function withFakeOpenClawSurface(
+  fn: (fixture: { packageRoot: string; expectedPath: string; sdkPath: string }) => void,
+) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-openclaw-sdk-"));
+  try {
+    const packageRoot = path.join(tempRoot, "openclaw");
+    fs.mkdirSync(packageRoot);
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "0.0.0-test" }, null, 2),
+    );
+    const sdkPath = path.join(packageRoot, "plugin-sdk.d.ts");
+    fs.writeFileSync(
+      sdkPath,
+      `
+export function registerCli(): void;
+export function registerCliBackend(): void;
+export function registerCommand(): void;
+export function registerCompactionProvider(): void;
+export function registerMemoryCapability(): void;
+export function registerMemoryCorpusSupplement(): void;
+export function registerMemoryEmbeddingProvider(): void;
+export function registerMemoryFlushPlan(): void;
+export function registerMemoryPromptSection(): void;
+export function registerMemoryPromptSupplement(): void;
+export function registerMemoryRuntime(): void;
+export function registerService(): void;
+export function registerTool(): void;
+export function registerToolMetadata(): void;
+
+export type HookName =
+  | "after_compaction"
+  | "after_tool_call"
+  | "agent_end"
+  | "agent_turn_prepare"
+  | "before_agent_finalize"
+  | "before_agent_reply"
+  | "before_agent_start"
+  | "before_compaction"
+  | "before_dispatch"
+  | "before_install"
+  | "before_message_write"
+  | "before_model_resolve"
+  | "before_prompt_build"
+  | "before_reset"
+  | "before_tool_call"
+  | "llm_input"
+  | "llm_output"
+  | "session_end"
+  | "session_start";
+
+export interface PluginContracts {
+  commands?: string[];
+  hooks?: HookName[];
+  memoryEmbeddingProviders?: string[];
+  tools?: string[];
+}
+`,
+    );
+    fn({
+      packageRoot,
+      expectedPath: path.join(tempRoot, "expected.json"),
+      sdkPath,
+    });
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+}
+
+function writeExpectedSurface(expectedPath: string) {
+  fs.writeFileSync(
+    expectedPath,
+    JSON.stringify(
+      {
+        description: "test snapshot",
+        registrars: expectedRegistrars,
+        hooks: expectedHooks,
+        manifestContracts: expectedManifestContracts,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function runCheck(args: string[], env: Record<string, string> = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: ROOT,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+}

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -89,7 +89,7 @@ test("OpenClaw SDK snapshot includes native memory registrar surfaces reviewed b
 
 test("OpenClaw SDK surface check skips cleanly when OpenClaw is not installed", () => {
   const result = runCheck([], {
-    NODE_PATH: path.join(os.tmpdir(), "remnic-missing-openclaw-node-path"),
+    REMNIC_OPENCLAW_SURFACE_DISABLE_AUTO_RESOLVE: "1",
   });
 
   assert.equal(result.status, 0, result.stderr);
@@ -98,7 +98,7 @@ test("OpenClaw SDK surface check skips cleanly when OpenClaw is not installed", 
 
 test("OpenClaw SDK surface check can require an installed OpenClaw package", () => {
   const result = runCheck(["--require"], {
-    NODE_PATH: path.join(os.tmpdir(), "remnic-missing-openclaw-node-path"),
+    REMNIC_OPENCLAW_SURFACE_DISABLE_AUTO_RESOLVE: "1",
   });
 
   assert.equal(result.status, 1);

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -96,6 +96,16 @@ test("OpenClaw SDK surface check skips cleanly when OpenClaw is not installed", 
   assert.match(result.stdout, /OpenClaw SDK surface check skipped/);
 });
 
+test("OpenClaw SDK surface check can require an installed OpenClaw package", () => {
+  const result = runCheck([], {
+    NODE_PATH: path.join(os.tmpdir(), "remnic-missing-openclaw-node-path"),
+    REMNIC_OPENCLAW_SURFACE_REQUIRE: "1",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /OpenClaw SDK surface check skipped/);
+});
+
 const expectedRegistrars = [
   "registerCli",
   "registerCliBackend",

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -97,9 +97,8 @@ test("OpenClaw SDK surface check skips cleanly when OpenClaw is not installed", 
 });
 
 test("OpenClaw SDK surface check can require an installed OpenClaw package", () => {
-  const result = runCheck([], {
+  const result = runCheck(["--require"], {
     NODE_PATH: path.join(os.tmpdir(), "remnic-missing-openclaw-node-path"),
-    REMNIC_OPENCLAW_SURFACE_REQUIRE: "1",
   });
 
   assert.equal(result.status, 1);

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -105,6 +105,26 @@ test("OpenClaw SDK surface check can require an installed OpenClaw package", () 
   assert.match(result.stderr, /OpenClaw SDK surface check skipped/);
 });
 
+test("OpenClaw SDK surface check resolves a package-local peer install", () => {
+  const packageNodeModules = path.join(ROOT, "packages/plugin-openclaw/node_modules");
+  const packageRoot = path.join(packageNodeModules, "openclaw");
+  if (fs.existsSync(packageRoot)) {
+    return;
+  }
+
+  try {
+    fs.mkdirSync(packageRoot, { recursive: true });
+    writeFakeOpenClawPackage(packageRoot);
+
+    const result = runCheck([]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw SDK surface matches expected snapshot/);
+  } finally {
+    fs.rmSync(packageRoot, { force: true, recursive: true });
+  }
+});
+
 const expectedRegistrars = [
   "registerCli",
   "registerCliBackend",
@@ -155,15 +175,27 @@ function withFakeOpenClawSurface(
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-openclaw-sdk-"));
   try {
     const packageRoot = path.join(tempRoot, "openclaw");
-    fs.mkdirSync(packageRoot);
-    fs.writeFileSync(
-      path.join(packageRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "0.0.0-test" }, null, 2),
-    );
+    writeFakeOpenClawPackage(packageRoot);
     const sdkPath = path.join(packageRoot, "plugin-sdk.d.ts");
-    fs.writeFileSync(
+    fn({
+      packageRoot,
+      expectedPath: path.join(tempRoot, "expected.json"),
       sdkPath,
-      `
+    });
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+}
+
+function writeFakeOpenClawPackage(packageRoot: string) {
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({ name: "openclaw", version: "0.0.0-test" }, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(packageRoot, "plugin-sdk.d.ts"),
+    `
 export function registerCli(): void;
 export function registerCliBackend(): void;
 export function registerCommand(): void;
@@ -207,15 +239,7 @@ export interface PluginContracts {
   tools?: string[];
 }
 `,
-    );
-    fn({
-      packageRoot,
-      expectedPath: path.join(tempRoot, "expected.json"),
-      sdkPath,
-    });
-  } finally {
-    fs.rmSync(tempRoot, { force: true, recursive: true });
-  }
+  );
 }
 
 function writeExpectedSurface(expectedPath: string) {

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -105,6 +105,28 @@ test("OpenClaw SDK surface check can require an installed OpenClaw package", () 
   assert.match(result.stderr, /OpenClaw SDK surface check skipped/);
 });
 
+test("OpenClaw SDK surface check fails clearly when SDK declarations are missing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-openclaw-no-sdk-"));
+  try {
+    fs.writeFileSync(
+      path.join(tempRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "0.0.0-test" }, null, 2),
+    );
+    fs.writeFileSync(
+      path.join(tempRoot, "internal.ts"),
+      "export function registerMemoryInternalHelper() {}\n",
+    );
+
+    const result = runCheck(["--package-root", tempRoot]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /no SDK declaration files found/);
+    assert.doesNotMatch(result.stderr, /registerMemoryInternalHelper/);
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
 test("OpenClaw SDK surface check resolves a package-local peer install", (t) => {
   const packageNodeModules = path.join(ROOT, "packages/plugin-openclaw/node_modules");
   const packageRoot = path.join(packageNodeModules, "openclaw");

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -180,6 +180,8 @@ const expectedHooks = [
   "before_prompt_build",
   "before_reset",
   "before_tool_call",
+  "gateway_start",
+  "gateway_stop",
   "llm_input",
   "llm_output",
   "session_end",
@@ -250,6 +252,8 @@ export type HookName =
   | "before_prompt_build"
   | "before_reset"
   | "before_tool_call"
+  | "gateway_start"
+  | "gateway_stop"
   | "llm_input"
   | "llm_output"
   | "session_end"

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -105,10 +105,11 @@ test("OpenClaw SDK surface check can require an installed OpenClaw package", () 
   assert.match(result.stderr, /OpenClaw SDK surface check skipped/);
 });
 
-test("OpenClaw SDK surface check resolves a package-local peer install", () => {
+test("OpenClaw SDK surface check resolves a package-local peer install", (t) => {
   const packageNodeModules = path.join(ROOT, "packages/plugin-openclaw/node_modules");
   const packageRoot = path.join(packageNodeModules, "openclaw");
   if (fs.existsSync(packageRoot)) {
+    t.skip("package-local OpenClaw peer already exists");
     return;
   }
 


### PR DESCRIPTION
Closes #890.

## Summary
- add an OpenClaw SDK surface snapshot for adapter-relevant registrars, hooks, and manifest contracts
- add `check:openclaw-sdk-surface` with actionable drift output and `--write` refresh support
- wire the focused check into quick preflight and document snapshot refresh

## Verification
- `pnpm exec tsx --test tests/openclaw-sdk-surface-check.test.ts`
- `npm run check:openclaw-sdk-surface`
- `npm run check-types`
- `npm run plugin:inspect`
- `npm run check:openclaw-plugin-sync`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a dev/CI guardrail script and tests that can fail preflight when OpenClaw SDK declarations drift, without changing runtime adapter behavior.
> 
> **Overview**
> Adds an **OpenClaw SDK surface drift gate** by snapshotting the adapter-relevant SDK API surface (`registrars`, hook names, and manifest contracts) in `openclaw-sdk-surface.expected.json` and introducing `scripts/check-openclaw-sdk-surface.mjs` to compare against an installed or provided OpenClaw checkout.
> 
> Wires the check into `preflight:quick`, adds npm scripts (including a `--require` variant for CI), documents snapshot refresh workflow in the plugin README, and includes a focused test suite validating drift detection, snapshot refresh (`--write`), and skip/require behaviors when OpenClaw isn’t installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef0cf3c5fb5ccfa8066dd5b6651a8d19963a200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->