### PR TITLE
Document OpenClaw native memory registrar spike

### DIFF
--- a/docs/plugins/openclaw-native-memory-registrars.md
+++ b/docs/plugins/openclaw-native-memory-registrars.md
@@ -1,0 +1,41 @@
+# OpenClaw Native Memory Registrar Spike
+
+Checked on 2026-05-04 against:
+
+- `openclaw/openclaw` `358cd87ff300fd515bf35f9725dd59198fb9c416`
+- `openclaw/kitchen-sink` `f57a0fc7c430c928bbe8049e5d69e6c7b806ed12`
+
+The OpenClaw kitchen-sink plugin exercises three native memory-related
+registrars that are adjacent to Remnic:
+
+- `registerMemoryEmbeddingProvider()`
+- `registerMemoryCorpusSupplement()`
+- `registerCompactionProvider()`
+
+## Decision
+
+Keep Remnic on `registerMemoryCapability()` as the primary OpenClaw integration
+point for now. Do not register OpenClaw embedding, corpus supplement, or
+compaction providers until a product need requires one of those host-native
+surfaces directly.
+
+## Surface Map
+
+| OpenClaw surface | Current upstream contract | Remnic mapping | Decision |
+|---|---|---|---|
+| `registerMemoryEmbeddingProvider()` | Registers an embedding-provider adapter with `create()`, `embedQuery()`, `embedBatch()`, optional multimodal support, and runtime batch metadata. | Remnic already owns embedding and index lifecycle inside `@remnic/core` and its QMD/runtime manager. Registering here would make OpenClaw call Remnic as an embedding backend for OpenClaw-owned memory, which is the wrong ownership direction. | Not a fit yet. Keep embeddings behind Remnic's runtime manager. |
+| `registerMemoryCorpusSupplement()` | Registers an additive corpus supplement with `search({ query, maxResults, agentSessionKey })` and `get({ lookup, fromLine, lineCount, agentSessionKey })`. Supplements live alongside, not instead of, the active memory capability. | Remnic can already expose search/read through `registerMemoryCapability({ runtime })`, `memory_search`, `memory_get`, and public artifacts. As a supplement, Remnic could duplicate results when it owns the memory slot and would need explicit passive-mode ranking/citation semantics when another plugin owns the slot. | Defer. Revisit only for a read-only passive bridge alongside another memory-slot owner. |
+| `registerCompactionProvider()` | Registers a provider with `summarize({ messages, signal, compressionRatio, customInstructions, summarizationInstructions, previousSummary })` that can replace OpenClaw's built-in transcript compaction summarizer. | Remnic observes compaction/reset boundaries, saves checkpoints, and flushes memory around lifecycle events. It does not own the user-facing transcript summary OpenClaw needs for context management. | Not applicable. Keep compaction hooks and checkpointing, not summary replacement. |
+
+## Why `registerMemoryCapability()` Still Fits
+
+`registerMemoryCapability()` matches Remnic's shape as a complete memory adapter:
+prompt building, runtime search/read, backend status, flush planning, and public
+artifacts can live under one exclusive memory-slot capability. That keeps
+OpenClaw-specific code thin while preserving Remnic core ownership of storage,
+retrieval, extraction, consolidation, and QMD behavior.
+
+Future work can revisit `registerMemoryCorpusSupplement()` if Remnic needs an
+explicit passive-mode, read-only bridge. That should be implemented as a
+separate PR with ranking, citation, and duplicate-result expectations documented
+before code changes.

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -120,6 +120,12 @@ CI jobs that provision OpenClaw should use
 `npm run check:openclaw-sdk-surface:required` or pass
 `-- --require --package-root <path>` so a missing SDK fails instead of skipping.
 
+Native memory registrars are tracked separately in
+[`docs/plugins/openclaw-native-memory-registrars.md`](../../docs/plugins/openclaw-native-memory-registrars.md).
+That spike explains why Remnic currently uses `registerMemoryCapability()` as
+the primary integration point instead of OpenClaw embedding, corpus supplement,
+or compaction-provider registrars.
+
 ## Slot Selection
 
 Remnic is an exclusive memory-slot plugin. When `plugins.slots.memory` points


### PR DESCRIPTION
Closes #891

## Summary
- add a focused design note mapping OpenClaw native memory registrars to Remnic integration points
- record the upstream OpenClaw and kitchen-sink commits used for the spike
- link the design note from the OpenClaw plugin README

## Verification
- git diff --check
- npm run check:openclaw-sdk-surface (skips cleanly because OpenClaw peer package is not installed)
- npm run preflight:quick (stopped during warning-only review-pattern scans across historical .claude/.worktrees after check-types, check-config-contract, and plugin:inspect passed locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that don’t affect runtime behavior.
> 
> **Overview**
> Adds a design note (`docs/plugins/openclaw-native-memory-registrars.md`) mapping OpenClaw’s native memory registrars to Remnic, and documents the decision to *only* integrate via `registerMemoryCapability()` for now.
> 
> Updates the OpenClaw plugin README to link to this spike and clarify why embedding, corpus-supplement, and compaction-provider registrars are currently not used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c6724bc21263e3c6703fcc92d00fbc58f978205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->