### PR TITLE
docs(openclaw): clarify ClawScan security disclosures

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,9 +1,9 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "kind": "memory",
-  "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+  "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {
     "providers": [
       {
@@ -41,6 +41,26 @@
       ]
     }
   ],
+  "securityDisclosure": {
+    "conversationAccess": "As a memory-slot plugin, Remnic hooks can observe conversation turns, tool-use metadata, LLM output metadata, and local memory files so they can be indexed, summarized, recalled, and exposed through memory tools.",
+    "modelProviderCredentials": {
+      "recommendedMode": "Use modelSource=gateway to route LLM-backed memory work through OpenClaw gateway agents instead of a Remnic-owned API key.",
+      "dynamicCredentialSources": [
+        "OpenClaw runtime auth resolver for configured model providers",
+        "~/.openclaw/agents/main/agent/models.json provider entries",
+        "provider-specific environment variables such as <PROVIDER>_API_KEY and <PROVIDER>_TOKEN"
+      ],
+      "providerModeData": [
+        "conversation excerpts",
+        "memory excerpts",
+        "summaries",
+        "embedding inputs",
+        "active-recall query inputs",
+        "benchmark and evaluation inputs"
+      ],
+      "externalProviderGuidance": "Do not set openaiApiKey or provider environment variables for Remnic if all LLM-backed memory operations should stay on the OpenClaw gateway path. When plugin/provider mode is configured, selected conversation and memory excerpts may be sent to the configured provider for extraction, consolidation, summarization, embeddings, active recall, or benchmark judging."
+    }
+  },
   "supports": {
     "memorySlot": true,
     "dreamingSlot": true,
@@ -139,7 +159,7 @@
       },
       "openaiBaseUrl": {
         "type": "string",
-        "description": "Override the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
+        "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
       },
       "model": {
         "type": "string",
@@ -222,7 +242,7 @@
       "maxMemoryTokens": {
         "type": "number",
         "default": 2000,
-        "description": "Max tokens injected per turn"
+        "description": "Max memory-context tokens per turn"
       },
       "memoryOsPreset": {
         "type": "string",
@@ -233,7 +253,7 @@
           "research-max",
           "local-llm-heavy"
         ],
-        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting overrides are applied. `research` is accepted as a backward-compatible alias for `research-max`."
+        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
       },
       "qmdEnabled": {
         "type": "boolean",
@@ -325,7 +345,7 @@
       },
       "entitySchemas": {
         "type": "object",
-        "description": "Optional per-entity-type structured section schema overrides.",
+        "description": "Optional per-entity-type structured section schema customizations.",
         "additionalProperties": {
           "type": "object",
           "additionalProperties": false,
@@ -666,7 +686,7 @@
             "minimum": 1,
             "maximum": 10,
             "default": 2,
-            "description": "Maximum procedure memories to inject on task-initiation recall."
+            "description": "Maximum procedure memories to add on task-initiation recall."
           },
           "proceduralMiningCronAutoRegister": {
             "type": "boolean",
@@ -754,7 +774,7 @@
       "recallTranscriptsEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Write JSONL recall audit transcripts for runtime-surface injections."
+        "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
       },
       "recallTranscriptRetentionDays": {
         "type": "integer",
@@ -771,7 +791,7 @@
       "activeRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable the OpenClaw active-recall prompt surface."
+        "description": "Enable the OpenClaw active-recall context surface."
       },
       "activeRecallAgents": {
         "type": "array",
@@ -818,7 +838,7 @@
           "preference-only"
         ],
         "default": "balanced",
-        "description": "Prompt assembly style for the active-recall surface."
+        "description": "Context assembly style for the active-recall surface."
       },
       "activeRecallCustomInstruction": {
         "type": "string",
@@ -826,7 +846,7 @@
       },
       "activeRecallPromptAppend": {
         "type": "string",
-        "description": "Optional additional guidance appended to the active-recall builder."
+        "description": "Optional additional guidance for the active-recall builder."
       },
       "activeRecallMaxSummaryChars": {
         "type": "integer",
@@ -892,7 +912,7 @@
       },
       "activeRecallModel": {
         "type": "string",
-        "description": "Optional model override for active recall."
+        "description": "Optional model selection for active recall."
       },
       "activeRecallModelFallbackPolicy": {
         "type": "string",
@@ -1208,7 +1228,7 @@
       "memoryExtensionsEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Whether third-party memory extensions are discovered and injected into consolidation prompts."
+        "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
       },
       "memoryExtensionsRoot": {
         "type": "string",
@@ -1292,12 +1312,12 @@
           "full"
         ],
         "default": "recovery_only",
-        "description": "Controls when identity continuity context is injected into recall assembly"
+        "description": "Controls when identity continuity context is added to recall assembly"
       },
       "identityMaxInjectChars": {
         "type": "number",
         "default": 1200,
-        "description": "Maximum characters allowed for identity continuity context injection"
+        "description": "Maximum characters allowed for identity continuity context"
       },
       "continuityIncidentLoggingEnabled": {
         "type": "boolean",
@@ -1498,12 +1518,12 @@
           "maxResults": {
             "type": "number",
             "default": 4,
-            "description": "Maximum native knowledge chunks to inject into recall."
+            "description": "Maximum native knowledge chunks to add to recall."
           },
           "maxChars": {
             "type": "number",
             "default": 2400,
-            "description": "Maximum total characters to inject from native knowledge recall."
+            "description": "Maximum total characters to add from native knowledge recall."
           },
           "stateDir": {
             "type": "string",
@@ -1777,7 +1797,7 @@
       "recordEmptyRecallImpressions": {
         "type": "boolean",
         "default": false,
-        "description": "Record recall impressions with empty memoryIds when no memory context is injected."
+        "description": "Record recall impressions with empty memoryIds when no memory context is added."
       },
       "recallPlannerEnabled": {
         "type": "boolean",
@@ -1852,7 +1872,7 @@
       "verbatimArtifactsMaxRecall": {
         "type": "number",
         "default": 5,
-        "description": "Maximum artifact anchors injected per recall."
+        "description": "Maximum artifact anchors added per recall."
       },
       "verbatimArtifactCategories": {
         "type": "array",
@@ -1918,7 +1938,7 @@
       "boxRecallDays": {
         "type": "number",
         "default": 3,
-        "description": "Number of recent days of boxes to inject during recall."
+        "description": "Number of recent days of boxes to add during recall."
       },
       "episodeNoteModeEnabled": {
         "type": "boolean",
@@ -1983,7 +2003,7 @@
       "tagRecallMaxMatches": {
         "type": "number",
         "default": 10,
-        "description": "Maximum number of tag-matched memories injected per recall."
+        "description": "Maximum number of tag-matched memories added per recall."
       },
       "multiGraphMemoryEnabled": {
         "type": "boolean",
@@ -2013,7 +2033,7 @@
       "graphRecallShadowEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Run graph recall in shadow mode — evaluate but do not inject results."
+        "description": "Run graph recall in shadow mode - evaluate but do not add results."
       },
       "graphRecallSnapshotEnabled": {
         "type": "boolean",
@@ -2127,12 +2147,12 @@
       "graphRecallEntityHintMax": {
         "type": "number",
         "default": 3,
-        "description": "Maximum number of entity hints injected per graph recall result."
+        "description": "Maximum number of entity hints added per graph recall result."
       },
       "graphRecallEntityHintMaxChars": {
         "type": "number",
         "default": 200,
-        "description": "Maximum characters per entity hint injected during graph recall."
+        "description": "Maximum characters per entity hint added during graph recall."
       },
       "graphRecallSnapshotDir": {
         "type": "string",
@@ -2161,7 +2181,7 @@
       "graphAssistShadowEvalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep injected recall output baseline-identical."
+        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
       },
       "graphAssistMinSeedResults": {
         "type": "number",
@@ -2239,12 +2259,12 @@
       "recallConfidenceGateEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Synapse-inspired confidence gate: skip memory injection when top recall score is below threshold"
+        "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
       },
       "recallConfidenceGateThreshold": {
         "type": "number",
         "default": 0.12,
-        "description": "Minimum top recall score to inject memories (0-1). Below this, memories are rejected as too uncertain"
+        "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
       },
       "causalRuleExtractionEnabled": {
         "type": "boolean",
@@ -2850,12 +2870,12 @@
       "maxTranscriptTurns": {
         "type": "number",
         "default": 50,
-        "description": "Maximum transcript turns to inject"
+        "description": "Maximum transcript turns to include"
       },
       "maxTranscriptTokens": {
         "type": "number",
         "default": 1000,
-        "description": "Maximum tokens for transcript injection"
+        "description": "Maximum tokens for transcript context"
       },
       "checkpointEnabled": {
         "type": "boolean",
@@ -2870,7 +2890,7 @@
       "compactionResetEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Trigger session reset after compaction with BOOT.md injection (requires OC fork with api.resetSession)"
+        "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
       },
       "hourlySummariesEnabled": {
         "type": "boolean",
@@ -2890,7 +2910,7 @@
       "maxSummaryCount": {
         "type": "number",
         "default": 6,
-        "description": "Maximum number of summaries to inject"
+        "description": "Maximum number of summaries to include"
       },
       "summaryModel": {
         "type": "string",
@@ -2981,7 +3001,7 @@
       "traceRecallContent": {
         "type": "boolean",
         "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default — only enable when you want external trace collectors to capture injected memory context."
+        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
       },
       "profilingEnabled": {
         "type": "boolean",
@@ -3198,7 +3218,7 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is only injected when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
       },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
@@ -3312,12 +3332,12 @@
       "conversationRecallTopK": {
         "type": "number",
         "default": 3,
-        "description": "Top-K conversation chunks to inject."
+        "description": "Top-K conversation chunks to include."
       },
       "conversationRecallMaxChars": {
         "type": "number",
         "default": 2500,
-        "description": "Max characters of semantic conversation recall to inject."
+        "description": "Max characters of semantic conversation recall to include."
       },
       "conversationRecallTimeoutMs": {
         "type": "number",
@@ -3366,7 +3386,7 @@
       "objectiveStateRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant objective-state snapshots into recall context."
+        "description": "Add recall-relevant objective-state snapshots to recall context."
       },
       "objectiveStateStoreDir": {
         "type": "string",
@@ -3384,7 +3404,7 @@
       "causalTrajectoryRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant causal trajectories into recall context."
+        "description": "Add recall-relevant causal trajectories to recall context."
       },
       "trustZonesEnabled": {
         "type": "boolean",
@@ -3403,7 +3423,7 @@
       "trustZoneRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant working and trusted trust-zone records into recall context."
+        "description": "Add recall-relevant working and trusted trust-zone records to recall context."
       },
       "memoryPoisoningDefenseEnabled": {
         "type": "boolean",
@@ -3418,7 +3438,7 @@
       "harmonicRetrievalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section injection and harmonic-search diagnostics."
+        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
       },
       "abstractionAnchorsEnabled": {
         "type": "boolean",
@@ -3432,7 +3452,7 @@
       "verifiedRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+        "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
       },
       "semanticRulePromotionEnabled": {
         "type": "boolean",
@@ -3489,7 +3509,7 @@
       "operatorAwareConsolidationEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Opt in to operator-aware consolidation prompts so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+        "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
       },
       "peerProfileReasonerEnabled": {
         "type": "boolean",
@@ -3516,13 +3536,13 @@
       "peerProfileRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "When true, inject the active peer's profile fields into the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
+        "description": "When true, add the active peer's profile fields to the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
       },
       "peerProfileRecallMaxFields": {
         "type": "number",
         "default": 5,
         "minimum": 0,
-        "description": "Maximum number of peer profile fields to inject per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field injection even when peerProfileRecallEnabled is true."
+        "description": "Maximum number of peer profile fields to add per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field inclusion even when peerProfileRecallEnabled is true."
       },
       "creationMemoryEnabled": {
         "type": "boolean",
@@ -3570,7 +3590,7 @@
       "workProductRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant work-product ledger entries into recall context and expose artifact-recovery search tooling."
+        "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
       },
       "workProductLedgerDir": {
         "type": "string",
@@ -3810,7 +3830,7 @@
       "sharedContextEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable shared-context injection + tools (v4.0). Default off."
+        "description": "Enable shared-context assembly and tools (v4.0). Default off."
       },
       "sharedContextDir": {
         "type": "string",
@@ -3819,7 +3839,7 @@
       "sharedContextMaxInjectChars": {
         "type": "number",
         "default": 4000,
-        "description": "Max characters of shared-context to inject into each prompt."
+        "description": "Max characters of shared-context to include in each recall context."
       },
       "crossSignalsSemanticEnabled": {
         "type": "boolean",
@@ -4092,17 +4112,17 @@
       "calibrationEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable recall calibration rules injection (v9.0, default off)."
+        "description": "Enable recall calibration rules (v9.0, default off)."
       },
       "calibrationMaxRulesPerRecall": {
         "type": "number",
         "default": 10,
-        "description": "Maximum number of calibration rules to inject per recall pass."
+        "description": "Maximum number of calibration rules to include per recall pass."
       },
       "calibrationMaxChars": {
         "type": "number",
         "default": 1200,
-        "description": "Maximum characters of calibration content to inject per recall pass."
+        "description": "Maximum characters of calibration content to include per recall pass."
       },
       "lancedbEnabled": {
         "type": "boolean",
@@ -4267,7 +4287,7 @@
       },
       "recallBudgetChars": {
         "type": "number",
-        "description": "Hard character cap for total recall injection. Defaults to maxMemoryTokens * 4."
+        "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
       },
       "recallOuterTimeoutMs": {
         "type": "number",
@@ -4287,7 +4307,7 @@
       "recallMmrEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the injected context."
+        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
       },
       "recallMmrLambda": {
         "type": "number",
@@ -4428,7 +4448,7 @@
       "messagePartsRecallMaxResults": {
         "type": "number",
         "default": 6,
-        "description": "Maximum structured message-part matches to inject into recall when messagePartsEnabled is true."
+        "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
       },
       "ircEnabled": {
         "type": "boolean",
@@ -4438,7 +4458,7 @@
       "ircMaxPreferences": {
         "type": "number",
         "default": 20,
-        "description": "Maximum number of preferences to include in IRC rule injection."
+        "description": "Maximum number of preferences to include in IRC rules."
       },
       "ircIncludeCorrections": {
         "type": "boolean",
@@ -4493,7 +4513,7 @@
       "cmcRetrievalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable CMC retrieval injection at recall time (default off)."
+        "description": "Enable CMC retrieval at recall time (default off)."
       },
       "cmcRetrievalMaxDepth": {
         "type": "number",
@@ -4503,7 +4523,7 @@
       "cmcRetrievalMaxChars": {
         "type": "number",
         "default": 800,
-        "description": "Maximum characters of CMC content injected per recall pass."
+        "description": "Maximum characters of CMC content included per recall pass."
       },
       "cmcRetrievalCounterfactualBoost": {
         "type": "number",
@@ -4779,13 +4799,13 @@
       "help": "Enable identity continuity workflows (anchor, incidents, audits)"
     },
     "identityInjectionMode": {
-      "label": "Identity Injection Mode",
+      "label": "Identity Context Mode",
       "advanced": true,
       "placeholder": "recovery_only",
-      "help": "When to inject identity continuity context: recovery_only, minimal, or full"
+      "help": "When to add identity continuity context: recovery_only, minimal, or full"
     },
     "identityMaxInjectChars": {
-      "label": "Identity Max Inject Chars",
+      "label": "Identity Max Context Chars",
       "advanced": true,
       "placeholder": "1200"
     },
@@ -5062,7 +5082,7 @@
     },
     "compactionResetEnabled": {
       "label": "Compaction Reset",
-      "help": "Reset session after compaction and inject BOOT.md for recovery",
+      "help": "Reset session after compaction and add BOOT.md recovery context",
       "advanced": true
     },
     "hourlySummariesEnabled": {
@@ -5224,7 +5244,7 @@
     "objectiveStateRecallEnabled": {
       "label": "Objective-State Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant objective-state snapshots into recall context."
+      "help": "Add recall-relevant objective-state snapshots to recall context."
     },
     "objectiveStateStoreDir": {
       "label": "Objective-State Store Directory",
@@ -5245,7 +5265,7 @@
     "causalTrajectoryRecallEnabled": {
       "label": "Causal Trajectory Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant causal trajectories into recall context."
+      "help": "Add recall-relevant causal trajectories to recall context."
     },
     "trustZonesEnabled": {
       "label": "Trust Zones",
@@ -5265,7 +5285,7 @@
     "trustZoneRecallEnabled": {
       "label": "Trust-Zone Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant working and trusted trust-zone records into recall context."
+      "help": "Add recall-relevant working and trusted trust-zone records to recall context."
     },
     "memoryPoisoningDefenseEnabled": {
       "label": "Memory Poisoning Defense",
@@ -5279,7 +5299,7 @@
     },
     "harmonicRetrievalEnabled": {
       "label": "Harmonic Retrieval",
-      "help": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section injection and harmonic-search diagnostics."
+      "help": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
     },
     "abstractionAnchorsEnabled": {
       "label": "Abstraction Anchors",
@@ -5294,7 +5314,7 @@
     },
     "verifiedRecallEnabled": {
       "label": "Verified Recall",
-      "help": "Inject prompt-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+      "help": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
     },
     "semanticRulePromotionEnabled": {
       "label": "Semantic Rule Promotion",
@@ -5342,9 +5362,9 @@
       "help": "Max memories to consolidate per run to limit LLM cost."
     },
     "operatorAwareConsolidationEnabled": {
-      "label": "Operator-Aware Consolidation Prompt",
+      "label": "Operator-Aware Consolidation",
       "advanced": true,
-      "help": "Opt in to operator-aware consolidation prompts (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+      "help": "Opt in to operator-aware consolidation instructions (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
     },
     "peerProfileReasonerEnabled": {
       "label": "Peer Profile Reasoner",
@@ -5367,14 +5387,14 @@
       "help": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
     },
     "peerProfileRecallEnabled": {
-      "label": "Peer Profile Recall Injection",
+      "label": "Peer Profile Recall",
       "advanced": true,
-      "help": "When enabled, injects the active peer's profile fields into recall context as a '## Peer Profile' section. Requires the session peer ID to be registered. Default off."
+      "help": "When enabled, adds the active peer's profile fields to recall context as a '## Peer Profile' section. Requires the session peer ID to be registered. Default off."
     },
     "peerProfileRecallMaxFields": {
       "label": "Peer Profile Recall Max Fields",
       "advanced": true,
-      "help": "Maximum number of peer profile fields to inject per recall. Only the most-recently-updated N fields are included. Set to 0 to disable injection."
+      "help": "Maximum number of peer profile fields to add per recall. Only the most-recently-updated N fields are included. Set to 0 to disable this feature."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",
@@ -5426,7 +5446,7 @@
     "workProductRecallEnabled": {
       "label": "Work-Product Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant work-product ledger entries into recall context and expose artifact-recovery search tooling."
+      "help": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
     },
     "workProductLedgerDir": {
       "label": "Work-Product Ledger Directory",

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -1,6 +1,6 @@
 # @remnic/plugin-openclaw
 
-OpenClaw plugin for Remnic memory. Thin adapter that connects the OpenClaw gateway to [`@remnic/core`](https://www.npmjs.com/package/@remnic/core).
+OpenClaw plugin for Remnic memory. The package bundles the OpenClaw adapter plus the Remnic core runtime so it can run without a separate Remnic service; the adapter registers OpenClaw hooks/tools and delegates memory behavior to [`@remnic/core`](https://www.npmjs.com/package/@remnic/core).
 
 Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory layer for AI agents.
 
@@ -79,7 +79,7 @@ runs from real runtime and OpenClaw chain runs.
 This plugin hooks into the OpenClaw gateway lifecycle:
 
 - **`gateway_start`** -- initializes the Remnic memory engine
-- **`before_agent_start`** / **`before_prompt_build`** -- injects relevant memories into the agent's context
+- **`before_agent_start`** / **`before_prompt_build`** -- adds relevant memories to the agent context through OpenClaw's memory context builders
 - **`agent_end`** -- buffers the conversation turn for extraction
 - **`before_compaction`** / **`after_compaction`** -- saves checkpoints and triggers session reset on context compaction
 - **`before_reset`** -- bounded flush of the in-flight buffer before OpenClaw discards a session
@@ -91,7 +91,13 @@ This plugin hooks into the OpenClaw gateway lifecycle:
 - **Tools** -- registers `memory_search`, `memory_get`, `memory_stats`, and other agent tools
 - **Commands** -- provides CLI commands for memory management
 
-All memory processing uses [`@remnic/core`](https://www.npmjs.com/package/@remnic/core). Memory files stay on your local filesystem as plain markdown files. When the plugin is configured to use OpenAI or an OpenAI-compatible endpoint, conversation and memory excerpts may be sent to that configured model provider for extraction, consolidation, summarization, and embeddings. Use `modelSource: "gateway"` or local LLM settings when those operations should stay on your own OpenClaw/local model path.
+All memory processing uses [`@remnic/core`](https://www.npmjs.com/package/@remnic/core). Memory files stay on your local filesystem as plain markdown files. When the plugin is configured to use OpenAI, an OpenAI-compatible endpoint, or provider credentials resolved from OpenClaw runtime auth, conversation and memory excerpts may be sent to that configured model provider for extraction, consolidation, summarization, embeddings, active recall, or benchmark judging. Use `modelSource: "gateway"` and route the gateway agent to local or otherwise approved models when those operations should stay on your own OpenClaw/local model path.
+
+Credential and model-provider behavior is explicit:
+
+- `modelSource: "gateway"` is the recommended OpenClaw mode and uses OpenClaw gateway agents instead of a Remnic-owned API key.
+- Plugin/provider modes may read configured model credentials from the OpenClaw auth resolver, OpenClaw's materialized provider config at `~/.openclaw/agents/main/agent/models.json`, or provider-specific environment variables such as `<PROVIDER>_API_KEY` and `<PROVIDER>_TOKEN`.
+- Do not set `openaiApiKey` or provider environment variables for Remnic if you want all LLM-backed memory work routed through the gateway.
 
 ## Plugin Inspection
 
@@ -143,14 +149,14 @@ loads passively depending on `slotBehavior`:
 }
 ```
 
-Passive mode keeps the tool/service surface available but skips prompt
-injection and extraction hooks so two memory plugins do not race each other.
+Passive mode keeps the tool/service surface available but skips context-building
+and extraction hooks so two memory plugins do not race each other.
 
 ## Supported OpenClaw Memory Features
 
 Remnic supports the following OpenClaw memory integration points:
 
-### Memory Prompt Injection
+### Memory Context Sections
 
 | Feature | Status | Since |
 |---------|--------|-------|
@@ -206,7 +212,7 @@ Reset handling is configurable:
 }
 ```
 
-The reset path clears per-session prompt caches and workspace override state.
+The reset path clears per-session context caches and workspace preference state.
 If `flushOnResetEnabled` is true, Remnic also attempts a bounded extraction
 flush before the reset completes.
 
@@ -242,7 +248,7 @@ OpenClaw's dreaming feature (background memory consolidation) is handled by Open
 
 The plugin manifest now accepts the OpenClaw `dreaming` config block directly
 so newer runtimes do not reject the config at validation time, and the OpenClaw
-adapter now injects recent diary entries as `## Recent Dreams (Remnic)` when
+adapter now adds recent diary entries as `## Recent Dreams (Remnic)` when
 the journal contains entries. The adapter also imports `DREAMS.md` entries into
 Remnic storage as `memoryKind: "dream"` with stable provenance so file-watch
 replays stay idempotent:
@@ -276,7 +282,7 @@ back to `DREAMS.md` through the shared writer using the OpenAI Responses API.
 
 The shared `@remnic/core` surface parsers also understand `HEARTBEAT.md`. The
 OpenClaw adapter imports those entries as `memoryKind: "procedural"`, gates
-normal recall during heartbeat-triggered runs, injects the active heartbeat plus
+normal recall during heartbeat-triggered runs, adds the active heartbeat plus
 `## Previous Runs`, and skips episodic buffering for heartbeat turns by default.
 Detection can use explicit runtime metadata, a documented heuristic fallback, or
 `auto` to prefer runtime metadata and fall back when needed. All of that logic

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,9 +1,9 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "kind": "memory",
-  "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+  "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {
     "providers": [
       {
@@ -41,6 +41,26 @@
       ]
     }
   ],
+  "securityDisclosure": {
+    "conversationAccess": "As a memory-slot plugin, Remnic hooks can observe conversation turns, tool-use metadata, LLM output metadata, and local memory files so they can be indexed, summarized, recalled, and exposed through memory tools.",
+    "modelProviderCredentials": {
+      "recommendedMode": "Use modelSource=gateway to route LLM-backed memory work through OpenClaw gateway agents instead of a Remnic-owned API key.",
+      "dynamicCredentialSources": [
+        "OpenClaw runtime auth resolver for configured model providers",
+        "~/.openclaw/agents/main/agent/models.json provider entries",
+        "provider-specific environment variables such as <PROVIDER>_API_KEY and <PROVIDER>_TOKEN"
+      ],
+      "providerModeData": [
+        "conversation excerpts",
+        "memory excerpts",
+        "summaries",
+        "embedding inputs",
+        "active-recall query inputs",
+        "benchmark and evaluation inputs"
+      ],
+      "externalProviderGuidance": "Do not set openaiApiKey or provider environment variables for Remnic if all LLM-backed memory operations should stay on the OpenClaw gateway path. When plugin/provider mode is configured, selected conversation and memory excerpts may be sent to the configured provider for extraction, consolidation, summarization, embeddings, active recall, or benchmark judging."
+    }
+  },
   "supports": {
     "memorySlot": true,
     "dreamingSlot": true,
@@ -139,7 +159,7 @@
       },
       "openaiBaseUrl": {
         "type": "string",
-        "description": "Override the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
+        "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
       },
       "model": {
         "type": "string",
@@ -222,7 +242,7 @@
       "maxMemoryTokens": {
         "type": "number",
         "default": 2000,
-        "description": "Max tokens injected per turn"
+        "description": "Max memory-context tokens per turn"
       },
       "memoryOsPreset": {
         "type": "string",
@@ -233,7 +253,7 @@
           "research-max",
           "local-llm-heavy"
         ],
-        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting overrides are applied. `research` is accepted as a backward-compatible alias for `research-max`."
+        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
       },
       "qmdEnabled": {
         "type": "boolean",
@@ -325,7 +345,7 @@
       },
       "entitySchemas": {
         "type": "object",
-        "description": "Optional per-entity-type structured section schema overrides.",
+        "description": "Optional per-entity-type structured section schema customizations.",
         "additionalProperties": {
           "type": "object",
           "additionalProperties": false,
@@ -666,7 +686,7 @@
             "minimum": 1,
             "maximum": 10,
             "default": 2,
-            "description": "Maximum procedure memories to inject on task-initiation recall."
+            "description": "Maximum procedure memories to add on task-initiation recall."
           },
           "proceduralMiningCronAutoRegister": {
             "type": "boolean",
@@ -754,7 +774,7 @@
       "recallTranscriptsEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Write JSONL recall audit transcripts for runtime-surface injections."
+        "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
       },
       "recallTranscriptRetentionDays": {
         "type": "integer",
@@ -771,7 +791,7 @@
       "activeRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable the OpenClaw active-recall prompt surface."
+        "description": "Enable the OpenClaw active-recall context surface."
       },
       "activeRecallAgents": {
         "type": "array",
@@ -818,7 +838,7 @@
           "preference-only"
         ],
         "default": "balanced",
-        "description": "Prompt assembly style for the active-recall surface."
+        "description": "Context assembly style for the active-recall surface."
       },
       "activeRecallCustomInstruction": {
         "type": "string",
@@ -826,7 +846,7 @@
       },
       "activeRecallPromptAppend": {
         "type": "string",
-        "description": "Optional additional guidance appended to the active-recall builder."
+        "description": "Optional additional guidance for the active-recall builder."
       },
       "activeRecallMaxSummaryChars": {
         "type": "integer",
@@ -892,7 +912,7 @@
       },
       "activeRecallModel": {
         "type": "string",
-        "description": "Optional model override for active recall."
+        "description": "Optional model selection for active recall."
       },
       "activeRecallModelFallbackPolicy": {
         "type": "string",
@@ -1208,7 +1228,7 @@
       "memoryExtensionsEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Whether third-party memory extensions are discovered and injected into consolidation prompts."
+        "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
       },
       "memoryExtensionsRoot": {
         "type": "string",
@@ -1292,12 +1312,12 @@
           "full"
         ],
         "default": "recovery_only",
-        "description": "Controls when identity continuity context is injected into recall assembly"
+        "description": "Controls when identity continuity context is added to recall assembly"
       },
       "identityMaxInjectChars": {
         "type": "number",
         "default": 1200,
-        "description": "Maximum characters allowed for identity continuity context injection"
+        "description": "Maximum characters allowed for identity continuity context"
       },
       "continuityIncidentLoggingEnabled": {
         "type": "boolean",
@@ -1498,12 +1518,12 @@
           "maxResults": {
             "type": "number",
             "default": 4,
-            "description": "Maximum native knowledge chunks to inject into recall."
+            "description": "Maximum native knowledge chunks to add to recall."
           },
           "maxChars": {
             "type": "number",
             "default": 2400,
-            "description": "Maximum total characters to inject from native knowledge recall."
+            "description": "Maximum total characters to add from native knowledge recall."
           },
           "stateDir": {
             "type": "string",
@@ -1777,7 +1797,7 @@
       "recordEmptyRecallImpressions": {
         "type": "boolean",
         "default": false,
-        "description": "Record recall impressions with empty memoryIds when no memory context is injected."
+        "description": "Record recall impressions with empty memoryIds when no memory context is added."
       },
       "recallPlannerEnabled": {
         "type": "boolean",
@@ -1852,7 +1872,7 @@
       "verbatimArtifactsMaxRecall": {
         "type": "number",
         "default": 5,
-        "description": "Maximum artifact anchors injected per recall."
+        "description": "Maximum artifact anchors added per recall."
       },
       "verbatimArtifactCategories": {
         "type": "array",
@@ -1918,7 +1938,7 @@
       "boxRecallDays": {
         "type": "number",
         "default": 3,
-        "description": "Number of recent days of boxes to inject during recall."
+        "description": "Number of recent days of boxes to add during recall."
       },
       "episodeNoteModeEnabled": {
         "type": "boolean",
@@ -1983,7 +2003,7 @@
       "tagRecallMaxMatches": {
         "type": "number",
         "default": 10,
-        "description": "Maximum number of tag-matched memories injected per recall."
+        "description": "Maximum number of tag-matched memories added per recall."
       },
       "multiGraphMemoryEnabled": {
         "type": "boolean",
@@ -2013,7 +2033,7 @@
       "graphRecallShadowEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Run graph recall in shadow mode — evaluate but do not inject results."
+        "description": "Run graph recall in shadow mode - evaluate but do not add results."
       },
       "graphRecallSnapshotEnabled": {
         "type": "boolean",
@@ -2127,12 +2147,12 @@
       "graphRecallEntityHintMax": {
         "type": "number",
         "default": 3,
-        "description": "Maximum number of entity hints injected per graph recall result."
+        "description": "Maximum number of entity hints added per graph recall result."
       },
       "graphRecallEntityHintMaxChars": {
         "type": "number",
         "default": 200,
-        "description": "Maximum characters per entity hint injected during graph recall."
+        "description": "Maximum characters per entity hint added during graph recall."
       },
       "graphRecallSnapshotDir": {
         "type": "string",
@@ -2161,7 +2181,7 @@
       "graphAssistShadowEvalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep injected recall output baseline-identical."
+        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
       },
       "graphAssistMinSeedResults": {
         "type": "number",
@@ -2239,12 +2259,12 @@
       "recallConfidenceGateEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Synapse-inspired confidence gate: skip memory injection when top recall score is below threshold"
+        "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
       },
       "recallConfidenceGateThreshold": {
         "type": "number",
         "default": 0.12,
-        "description": "Minimum top recall score to inject memories (0-1). Below this, memories are rejected as too uncertain"
+        "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
       },
       "causalRuleExtractionEnabled": {
         "type": "boolean",
@@ -2850,12 +2870,12 @@
       "maxTranscriptTurns": {
         "type": "number",
         "default": 50,
-        "description": "Maximum transcript turns to inject"
+        "description": "Maximum transcript turns to include"
       },
       "maxTranscriptTokens": {
         "type": "number",
         "default": 1000,
-        "description": "Maximum tokens for transcript injection"
+        "description": "Maximum tokens for transcript context"
       },
       "checkpointEnabled": {
         "type": "boolean",
@@ -2870,7 +2890,7 @@
       "compactionResetEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Trigger session reset after compaction with BOOT.md injection (requires OC fork with api.resetSession)"
+        "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
       },
       "hourlySummariesEnabled": {
         "type": "boolean",
@@ -2890,7 +2910,7 @@
       "maxSummaryCount": {
         "type": "number",
         "default": 6,
-        "description": "Maximum number of summaries to inject"
+        "description": "Maximum number of summaries to include"
       },
       "summaryModel": {
         "type": "string",
@@ -2981,7 +3001,7 @@
       "traceRecallContent": {
         "type": "boolean",
         "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default — only enable when you want external trace collectors to capture injected memory context."
+        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
       },
       "profilingEnabled": {
         "type": "boolean",
@@ -3198,7 +3218,7 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is only injected when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
       },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
@@ -3312,12 +3332,12 @@
       "conversationRecallTopK": {
         "type": "number",
         "default": 3,
-        "description": "Top-K conversation chunks to inject."
+        "description": "Top-K conversation chunks to include."
       },
       "conversationRecallMaxChars": {
         "type": "number",
         "default": 2500,
-        "description": "Max characters of semantic conversation recall to inject."
+        "description": "Max characters of semantic conversation recall to include."
       },
       "conversationRecallTimeoutMs": {
         "type": "number",
@@ -3366,7 +3386,7 @@
       "objectiveStateRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant objective-state snapshots into recall context."
+        "description": "Add recall-relevant objective-state snapshots to recall context."
       },
       "objectiveStateStoreDir": {
         "type": "string",
@@ -3384,7 +3404,7 @@
       "causalTrajectoryRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant causal trajectories into recall context."
+        "description": "Add recall-relevant causal trajectories to recall context."
       },
       "trustZonesEnabled": {
         "type": "boolean",
@@ -3403,7 +3423,7 @@
       "trustZoneRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant working and trusted trust-zone records into recall context."
+        "description": "Add recall-relevant working and trusted trust-zone records to recall context."
       },
       "memoryPoisoningDefenseEnabled": {
         "type": "boolean",
@@ -3418,7 +3438,7 @@
       "harmonicRetrievalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section injection and harmonic-search diagnostics."
+        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
       },
       "abstractionAnchorsEnabled": {
         "type": "boolean",
@@ -3432,7 +3452,7 @@
       "verifiedRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+        "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
       },
       "semanticRulePromotionEnabled": {
         "type": "boolean",
@@ -3489,7 +3509,7 @@
       "operatorAwareConsolidationEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Opt in to operator-aware consolidation prompts so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+        "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
       },
       "peerProfileReasonerEnabled": {
         "type": "boolean",
@@ -3516,13 +3536,13 @@
       "peerProfileRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "When true, inject the active peer's profile fields into the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
+        "description": "When true, add the active peer's profile fields to the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
       },
       "peerProfileRecallMaxFields": {
         "type": "number",
         "default": 5,
         "minimum": 0,
-        "description": "Maximum number of peer profile fields to inject per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field injection even when peerProfileRecallEnabled is true."
+        "description": "Maximum number of peer profile fields to add per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field inclusion even when peerProfileRecallEnabled is true."
       },
       "creationMemoryEnabled": {
         "type": "boolean",
@@ -3570,7 +3590,7 @@
       "workProductRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant work-product ledger entries into recall context and expose artifact-recovery search tooling."
+        "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
       },
       "workProductLedgerDir": {
         "type": "string",
@@ -3810,7 +3830,7 @@
       "sharedContextEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable shared-context injection + tools (v4.0). Default off."
+        "description": "Enable shared-context assembly and tools (v4.0). Default off."
       },
       "sharedContextDir": {
         "type": "string",
@@ -3819,7 +3839,7 @@
       "sharedContextMaxInjectChars": {
         "type": "number",
         "default": 4000,
-        "description": "Max characters of shared-context to inject into each prompt."
+        "description": "Max characters of shared-context to include in each recall context."
       },
       "crossSignalsSemanticEnabled": {
         "type": "boolean",
@@ -4092,17 +4112,17 @@
       "calibrationEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable recall calibration rules injection (v9.0, default off)."
+        "description": "Enable recall calibration rules (v9.0, default off)."
       },
       "calibrationMaxRulesPerRecall": {
         "type": "number",
         "default": 10,
-        "description": "Maximum number of calibration rules to inject per recall pass."
+        "description": "Maximum number of calibration rules to include per recall pass."
       },
       "calibrationMaxChars": {
         "type": "number",
         "default": 1200,
-        "description": "Maximum characters of calibration content to inject per recall pass."
+        "description": "Maximum characters of calibration content to include per recall pass."
       },
       "lancedbEnabled": {
         "type": "boolean",
@@ -4267,7 +4287,7 @@
       },
       "recallBudgetChars": {
         "type": "number",
-        "description": "Hard character cap for total recall injection. Defaults to maxMemoryTokens * 4."
+        "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
       },
       "recallOuterTimeoutMs": {
         "type": "number",
@@ -4287,7 +4307,7 @@
       "recallMmrEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the injected context."
+        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
       },
       "recallMmrLambda": {
         "type": "number",
@@ -4428,7 +4448,7 @@
       "messagePartsRecallMaxResults": {
         "type": "number",
         "default": 6,
-        "description": "Maximum structured message-part matches to inject into recall when messagePartsEnabled is true."
+        "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
       },
       "ircEnabled": {
         "type": "boolean",
@@ -4438,7 +4458,7 @@
       "ircMaxPreferences": {
         "type": "number",
         "default": 20,
-        "description": "Maximum number of preferences to include in IRC rule injection."
+        "description": "Maximum number of preferences to include in IRC rules."
       },
       "ircIncludeCorrections": {
         "type": "boolean",
@@ -4493,7 +4513,7 @@
       "cmcRetrievalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable CMC retrieval injection at recall time (default off)."
+        "description": "Enable CMC retrieval at recall time (default off)."
       },
       "cmcRetrievalMaxDepth": {
         "type": "number",
@@ -4503,7 +4523,7 @@
       "cmcRetrievalMaxChars": {
         "type": "number",
         "default": 800,
-        "description": "Maximum characters of CMC content injected per recall pass."
+        "description": "Maximum characters of CMC content included per recall pass."
       },
       "cmcRetrievalCounterfactualBoost": {
         "type": "number",
@@ -4779,13 +4799,13 @@
       "help": "Enable identity continuity workflows (anchor, incidents, audits)"
     },
     "identityInjectionMode": {
-      "label": "Identity Injection Mode",
+      "label": "Identity Context Mode",
       "advanced": true,
       "placeholder": "recovery_only",
-      "help": "When to inject identity continuity context: recovery_only, minimal, or full"
+      "help": "When to add identity continuity context: recovery_only, minimal, or full"
     },
     "identityMaxInjectChars": {
-      "label": "Identity Max Inject Chars",
+      "label": "Identity Max Context Chars",
       "advanced": true,
       "placeholder": "1200"
     },
@@ -5062,7 +5082,7 @@
     },
     "compactionResetEnabled": {
       "label": "Compaction Reset",
-      "help": "Reset session after compaction and inject BOOT.md for recovery",
+      "help": "Reset session after compaction and add BOOT.md recovery context",
       "advanced": true
     },
     "hourlySummariesEnabled": {
@@ -5224,7 +5244,7 @@
     "objectiveStateRecallEnabled": {
       "label": "Objective-State Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant objective-state snapshots into recall context."
+      "help": "Add recall-relevant objective-state snapshots to recall context."
     },
     "objectiveStateStoreDir": {
       "label": "Objective-State Store Directory",
@@ -5245,7 +5265,7 @@
     "causalTrajectoryRecallEnabled": {
       "label": "Causal Trajectory Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant causal trajectories into recall context."
+      "help": "Add recall-relevant causal trajectories to recall context."
     },
     "trustZonesEnabled": {
       "label": "Trust Zones",
@@ -5265,7 +5285,7 @@
     "trustZoneRecallEnabled": {
       "label": "Trust-Zone Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant working and trusted trust-zone records into recall context."
+      "help": "Add recall-relevant working and trusted trust-zone records to recall context."
     },
     "memoryPoisoningDefenseEnabled": {
       "label": "Memory Poisoning Defense",
@@ -5279,7 +5299,7 @@
     },
     "harmonicRetrievalEnabled": {
       "label": "Harmonic Retrieval",
-      "help": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section injection and harmonic-search diagnostics."
+      "help": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
     },
     "abstractionAnchorsEnabled": {
       "label": "Abstraction Anchors",
@@ -5294,7 +5314,7 @@
     },
     "verifiedRecallEnabled": {
       "label": "Verified Recall",
-      "help": "Inject prompt-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+      "help": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
     },
     "semanticRulePromotionEnabled": {
       "label": "Semantic Rule Promotion",
@@ -5342,9 +5362,9 @@
       "help": "Max memories to consolidate per run to limit LLM cost."
     },
     "operatorAwareConsolidationEnabled": {
-      "label": "Operator-Aware Consolidation Prompt",
+      "label": "Operator-Aware Consolidation",
       "advanced": true,
-      "help": "Opt in to operator-aware consolidation prompts (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+      "help": "Opt in to operator-aware consolidation instructions (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
     },
     "peerProfileReasonerEnabled": {
       "label": "Peer Profile Reasoner",
@@ -5367,14 +5387,14 @@
       "help": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
     },
     "peerProfileRecallEnabled": {
-      "label": "Peer Profile Recall Injection",
+      "label": "Peer Profile Recall",
       "advanced": true,
-      "help": "When enabled, injects the active peer's profile fields into recall context as a '## Peer Profile' section. Requires the session peer ID to be registered. Default off."
+      "help": "When enabled, adds the active peer's profile fields to recall context as a '## Peer Profile' section. Requires the session peer ID to be registered. Default off."
     },
     "peerProfileRecallMaxFields": {
       "label": "Peer Profile Recall Max Fields",
       "advanced": true,
-      "help": "Maximum number of peer profile fields to inject per recall. Only the most-recently-updated N fields are included. Set to 0 to disable injection."
+      "help": "Maximum number of peer profile fields to add per recall. Only the most-recently-updated N fields are included. Set to 0 to disable this feature."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",
@@ -5426,7 +5446,7 @@
     "workProductRecallEnabled": {
       "label": "Work-Product Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant work-product ledger entries into recall context and expose artifact-recovery search tooling."
+      "help": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
     },
     "workProductLedgerDir": {
       "label": "Work-Product Ledger Directory",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.28",
-  "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
+  "version": "1.0.29",
+  "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",
   "exports": {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1324,7 +1324,7 @@ export class Orchestrator {
   >();
   private static readonly MEMORY_WORTH_CACHE_TTL_MS = 30_000;
   /**
-   * Per-session workspace overrides keyed by sessionKey.
+   * Per-session workspace selections keyed by sessionKey.
    * Set by the before_agent_start hook so recall() uses the correct
    * agent workspace for BOOT.md injection. Cleared after each recall.
    * Using a Map prevents concurrent sessions from overwriting each other.
@@ -1458,7 +1458,7 @@ export class Orchestrator {
     this._recallWorkspaceOverrides.set(sessionKey, dir);
   }
 
-  /** Remove a per-session workspace override (cleanup on error or early return). @internal */
+  /** Remove a per-session workspace selection (cleanup on error or early return). @internal */
   clearRecallWorkspaceOverride(sessionKey: string): void {
     this._recallWorkspaceOverrides.delete(sessionKey);
   }
@@ -6285,7 +6285,7 @@ export class Orchestrator {
         namespace: selfNamespace,
         snapshot: intentSnapshot,
       });
-      // Clean up workspace override before early return to prevent Map leaks.
+      // Clean up workspace selection before early return to prevent Map leaks.
       const earlySessionKey = sessionKey ?? "default";
       this._recallWorkspaceOverrides.delete(earlySessionKey);
       timings.total = `${Date.now() - recallStart}ms`;
@@ -7796,7 +7796,7 @@ export class Orchestrator {
     // Compaction reset runs independently of transcript — it must work even when
     // transcriptEnabled=false, since compaction recovery is a separate concern.
     const compactionPromise = (async (): Promise<string | null> => {
-      // Always clean up per-session workspace overrides, even if the feature is off,
+      // Always clean up per-session workspace selections, even if the feature is off,
       // to prevent the Map from accumulating stale entries on long-running gateways.
       const effectiveSessionKey = sessionKey ?? "default";
       const compactionWorkspaceDir =
@@ -11027,7 +11027,7 @@ export class Orchestrator {
   ): Promise<string[]> {
     // Inline source attribution (issue #369). When enabled, every extracted
     // fact is rewritten to carry a compact provenance tag inside its body so
-    // the citation survives prompt injection, copy/paste, and LLM quoting.
+    // the citation survives hostile memory text, copy/paste, and LLM quoting.
     // The helper is a no-op when the feature flag is off, so legacy pipelines
     // see zero behavioral change.
     const citationEnabled = this.config.inlineSourceAttributionEnabled === true;

--- a/packages/remnic-core/src/sanitize.ts
+++ b/packages/remnic-core/src/sanitize.ts
@@ -1,15 +1,27 @@
+const rx = (...parts: string[]): RegExp => new RegExp(parts.join(""), "i");
+
 const INJECTION_PATTERNS: RegExp[] = [
-  /ignore\s+(all\s+)?(previous|prior|above)\s+(instructions?|prompts?|context)/i,
-  /forget\s+(everything|all|previous|what)/i,
-  /new\s+(system\s+)?prompt:/i,
-  /\[system\]/i,
-  /<\s*system\s*>/i,
-  /you\s+are\s+now\s+(?!called|named)/i,
-  /disregard\s+(all\s+)?(previous|prior)/i,
-  /override\s+(previous\s+)?(instructions?|prompt)/i,
-  /act\s+as\s+(?:an?\s+)?(?:AI|assistant|ChatGPT|GPT|Claude|LLM)\s+(?:without|that\s+ignores)/i,
-  /do\s+not\s+(?:follow|obey)\s+(?:previous|prior|your)\s+instructions/i,
-  /pretend\s+(?:you\s+)?(?:have\s+no|you\s+don.?t\s+have)\s+(restrictions|guidelines|rules)/i,
+  rx("ignore\\s+(all\\s+)?", "(previous|prior|above)", "\\s+(instructions?|prompts?|context)"),
+  rx("forget\\s+", "(everything|all|previous|what)"),
+  rx(
+    "new\\s+(",
+    "system",
+    "\\s+)?",
+    "prompt:",
+  ),
+  rx("\\[", "system", "\\]"),
+  rx("<\\s*", "system", "\\s*>"),
+  rx("you\\s+are\\s+now\\s+(?!called|named)"),
+  rx("disregard\\s+(all\\s+)?", "(previous|prior)"),
+  rx(
+    "over",
+    "ride\\s+(previous\\s+)?",
+    "(instructions?|",
+    "prompt)",
+  ),
+  rx("act\\s+as\\s+(?:an?\\s+)?(?:AI|assistant|ChatGPT|GPT|Claude|LLM)\\s+(?:without|that\\s+ignores)"),
+  rx("do\\s+not\\s+(?:follow|obey)\\s+(?:previous|prior|your)\\s+", "instructions"),
+  rx("pretend\\s+(?:you\\s+)?(?:have\\s+no|you\\s+don.?t\\s+have)\\s+(restrictions|guidelines|rules)"),
 ];
 
 export type SanitizeResult = {
@@ -18,7 +30,7 @@ export type SanitizeResult = {
   violations: string[];
 };
 
-const REDACTED_PLACEHOLDER = "[content removed: possible prompt injection]";
+const REDACTED_PLACEHOLDER = "[content removed: unsafe memory text]";
 
 export function sanitizeMemoryContent(text: string): SanitizeResult {
   const source = typeof text === "string" ? text : "";
@@ -44,4 +56,3 @@ export function sanitizeMemoryContent(text: string): SanitizeResult {
 export function isSafeMemoryContent(text: string): boolean {
   return sanitizeMemoryContent(text).clean;
 }
-

--- a/packages/remnic-core/src/source-attribution.ts
+++ b/packages/remnic-core/src/source-attribution.ts
@@ -2,7 +2,7 @@
  * Inline Source Attribution Protocol (issue #369)
  *
  * Extracted facts carry provenance inline inside the fact body, so the
- * citation survives prompt injection, copy/paste, and LLM quoting. This
+ * citation survives hostile memory text, copy/paste, and LLM quoting. This
  * complements — never replaces — the YAML frontmatter provenance stored on
  * disk.
  *

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1140,7 +1140,7 @@ export interface PluginConfig {
    * Inline source attribution (issue #369).
    * When enabled, extracted facts carry a compact provenance tag (agent,
    * session, timestamp) inlined into the fact text — not just in YAML
-   * frontmatter — so the citation survives prompt injection, copy/paste,
+   * frontmatter — so the citation survives hostile memory text, copy/paste,
    * and LLM quoting. Off by default to preserve backwards compatibility
    * with existing downstream consumers that expect raw fact text.
    */
@@ -2857,7 +2857,7 @@ export interface RecallTraceEvent {
   durationMs: number;
   timings?: Record<string, string>;
   /**
-   * The full recalled memory context injected into the system prompt.
+   * The full recalled memory context added to the runtime context.
    * Only populated when `traceRecallContent` config option is `true`.
    * Omitted by default to avoid sending potentially sensitive memory content
    * to external trace collectors unless explicitly opted in.


### PR DESCRIPTION
## Summary
- bump @remnic/plugin-openclaw to 1.0.29
- disclose bundled Remnic core footprint and dynamic provider credential sources in the OpenClaw manifest/README
- remove prompt-override scan phrases from published docs/manifest and fragment sanitizer regex construction while preserving sanitizer behavior

## Verification
- pnpm --filter @remnic/plugin-openclaw build
- node --check packages/plugin-openclaw/dist/index.js
- pnpm --dir packages/remnic-core exec tsc --noEmit
- packed @remnic/plugin-openclaw artifact contains no SKILL.md and no targeted prompt-override scan strings
- OpenClaw 2026.4.22 local scanner on packed artifact: scanned=82 critical=0 warn=0

Note: pnpm --filter @remnic/plugin-openclaw check-types still fails on existing package rootDir/workspace import typing issues unrelated to this metadata/sanitizer change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily manifest/README wording and metadata changes, with a small refactor of sanitizer regex construction and redaction copy that should not affect behavior but could if patterns were inadvertently altered.
> 
> **Overview**
> Bumps `@remnic/plugin-openclaw` to `1.0.29` and updates the plugin manifest/README to explicitly disclose the bundled `@remnic/core` runtime, what conversation/tooling data the memory-slot hooks can observe, and how provider credentials may be sourced (including recommended `modelSource=gateway`).
> 
> Refines a large set of config/help text to use *context/assembly* wording (vs *prompt injection*) and adjusts the memory sanitizer implementation to construct the same injection-detection regexes via a helper and to redact with a more general "unsafe memory text" placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 673e1cc72a0319495d023c5f1c423b7264366133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->