### PR TITLE
Add deterministic OpenClaw adapter scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "check-types": "tsc --noEmit",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
     "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts' 'packages/export-weclone/src/**/*.test.ts' 'packages/import-weclone/src/**/*.test.ts'",
+    "test:openclaw-scenarios": "pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",
     "plugin:inspect": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect",
     "plugin:inspect:runtime": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect:runtime",

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -108,6 +108,15 @@ guarded in the adapter, including `registerMemoryCapability`, `registerCli`,
 and `registerCommand`; keep runtime capture coverage for those surfaces in a
 separate adapter test slice.
 
+Run the deterministic OpenClaw adapter scenario suite with:
+
+```bash
+npm run test:openclaw-scenarios
+```
+
+The suite covers the registered memory tools and lifecycle hooks without live
+OpenClaw, LLM credentials, or network calls.
+
 ## SDK Surface Drift Check
 
 The adapter keeps a conservative OpenClaw SDK surface snapshot at

--- a/scripts/check-review-patterns.sh
+++ b/scripts/check-review-patterns.sh
@@ -22,6 +22,7 @@ STALE=$(grep -ri "engram" \
   --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs" --include="*.cjs" \
   --include="*.json" --include="*.md" --include="*.sh" --include="*.py" \
   --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
   --exclude="CHANGELOG.md" --exclude="RENAME.md" --exclude="package-lock.json" \
   --exclude="pnpm-lock.yaml" \
   -l . 2>/dev/null \
@@ -73,7 +74,10 @@ fi
 echo "[check] Duplicated utility functions across packages..."
 
 for helper in "toolJsonResult" "parseConfig" "formatMemory"; do
-  FILES=$(grep -rn "$helper" --include="*.ts" -l . 2>/dev/null \
+  FILES=$(grep -rn "$helper" --include="*.ts" \
+    --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+    --exclude-dir=.claude --exclude-dir=.worktrees \
+    -l . 2>/dev/null \
     | grep -v node_modules \
     | grep -v ".test." \
     | grep -v dist \
@@ -89,7 +93,10 @@ done
 # ---- 4. Test quality: vacuous empty-array assertions ----
 echo "[check] Vacuous empty-array test assertions..."
 
-VACUOUS=$(grep -rn "toEqual(\[\])" --include="*.test.ts" . 2>/dev/null \
+VACUOUS=$(grep -rn "toEqual(\[\])" --include="*.test.ts" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
+  . 2>/dev/null \
   | grep -v node_modules \
   | grep -v "// intentional" \
   || true)
@@ -118,7 +125,10 @@ fi
 echo "[check] Test teardown completeness..."
 
 # Check if any test file creates orchestrator instances but doesn't call resetGlobals
-ORCH_TEST=$(grep -rl "Orchestrator\|orchestrator" --include="*.test.ts" . 2>/dev/null \
+ORCH_TEST=$(grep -rl "Orchestrator\|orchestrator" --include="*.test.ts" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
+  . 2>/dev/null \
   | grep -v node_modules \
   || true)
 
@@ -136,6 +146,8 @@ echo "[check] Tilde path expansion consistency..."
 # Look for .replace(/^~/ or similar ad-hoc tilde expansion that isn't expandTilde
 TILDE_HACK=$(grep -rn '\.replace(/\^~/' \
   --include="*.ts" --include="*.js" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
   . 2>/dev/null \
   | grep -v node_modules \
   | grep -v dist \
@@ -152,7 +164,10 @@ fi
 echo "[check] Sort comparator stability..."
 
 # Look for comparators that return 1 for both directions (missing return 0)
-BAD_SORT=$(grep -rn 'return 1' --include="*.ts" . 2>/dev/null \
+BAD_SORT=$(grep -rn 'return 1' --include="*.ts" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
+  . 2>/dev/null \
   | grep -v node_modules \
   | grep -v dist \
   | grep -v ".test." \
@@ -175,6 +190,8 @@ echo "[check] JSON.parse result validation..."
 # Look for JSON.parse without subsequent type check
 PARSE_NO_CHECK=$(grep -rn 'JSON.parse(' \
   --include="*.ts" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
   . 2>/dev/null \
   | grep -v node_modules \
   | grep -v dist \
@@ -201,6 +218,8 @@ echo "[check] Config resolution deduplication..."
 
 SLOT_RESOLVE=$(grep -rn "slots.*memory\|slots\.memory\|LEGACY_PLUGIN_ID\|resolveRemnicPluginEntry" \
   --include="*.ts" --include="*.cjs" --include="*.mjs" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
   . 2>/dev/null \
   | grep -v node_modules \
   | grep -v dist \
@@ -239,6 +258,8 @@ echo "[check] slice(-expr) without zero/negative guard..."
 
 SLICE_NEG=$(grep -rn 'slice(-' \
   --include="*.ts" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
   . 2>/dev/null \
   | grep -v node_modules \
   | grep -v dist \
@@ -282,6 +303,8 @@ echo "[check] Explicit flush paths missing skipDedupeCheck..."
 
 FLUSH_NO_SKIP=$(grep -rn 'flushSession\|forceFlush\|queueBufferedExtraction' \
   --include="*.ts" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
   . 2>/dev/null \
   | grep -v node_modules \
   | grep -v dist \
@@ -343,6 +366,8 @@ echo "[check] Test mock signature fidelity..."
 # ignores its arguments in test files near interface implementations.
 MOCK_NO_ARGS=$(grep -rn 'fn(()\s*=>\s*{' \
   --include="*.test.ts" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
   . 2>/dev/null \
   | grep -v node_modules \
   | grep -v dist \
@@ -524,6 +549,8 @@ echo "[check] Config schema minimums vs documented zero-disable..."
 
 SCHEMA_MINIMUM_ONE=$(grep -rn '"minimum":\s*1' \
   --include="*.json" \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+  --exclude-dir=.claude --exclude-dir=.worktrees \
   . 2>/dev/null \
   | grep -v node_modules \
   | grep -v dist \

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -53,14 +53,15 @@ if [[ "$MODE" == "quick" ]]; then
   run pnpm exec tsx --test tests/openclaw-registration-capture.test.ts
   run npm run check:openclaw-sdk-surface
   run pnpm exec tsx --test tests/openclaw-sdk-surface-check.test.ts
-  run npm test -- tests/register-multi-registry.test.ts
-  run npm test -- tests/intent.test.ts
-  run npm test -- tests/runtime-input-guards.test.ts
-  run npm test -- tests/artifact-recall-limit.test.ts
-  run npm test -- tests/artifact-status-snapshot.test.ts
-  run npm test -- tests/recall-no-recall-short-circuit.test.ts
-  run npm test -- tests/orchestrator-path-filter.test.ts
-  run npm test -- tests/artifact-cache.test.ts
+  run npm run test:openclaw-scenarios
+  run pnpm exec tsx --test tests/register-multi-registry.test.ts
+  run pnpm exec tsx --test tests/intent.test.ts
+  run pnpm exec tsx --test tests/runtime-input-guards.test.ts
+  run pnpm exec tsx --test tests/artifact-recall-limit.test.ts
+  run pnpm exec tsx --test tests/artifact-status-snapshot.test.ts
+  run pnpm exec tsx --test tests/recall-no-recall-short-circuit.test.ts
+  run pnpm exec tsx --test tests/orchestrator-path-filter.test.ts
+  run pnpm exec tsx --test tests/artifact-cache.test.ts
 else
   run npm test
   run npm run build

--- a/tests/openclaw-adapter-scenarios.test.ts
+++ b/tests/openclaw-adapter-scenarios.test.ts
@@ -1,0 +1,288 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  captureOpenClawRegistrationApi,
+  disableRegisterMigrationForCaptureTest,
+  restoreOpenClawRegistrationGlobals,
+  restoreRegisterMigrationForCaptureTest,
+  saveAndResetOpenClawRegistrationGlobals,
+} from "./helpers/openclaw-registration-harness.js";
+
+const SERVICE_ID = "openclaw-remnic";
+const ORCHESTRATOR_KEY = `__openclawEngramOrchestrator::${SERVICE_ID}`;
+
+type ToolSpec = {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal?: AbortSignal,
+    ctx?: Record<string, unknown>,
+  ) => Promise<{ content: Array<{ text: string }> }>;
+};
+
+type ScenarioContext = {
+  capture: ReturnType<typeof captureOpenClawRegistrationApi>;
+  orchestrator: Record<string, any>;
+  memoryDir: string;
+};
+
+async function withScenarioRegistration(
+  fn: (context: ScenarioContext) => Promise<void> | void,
+  options: Parameters<typeof captureOpenClawRegistrationApi>[0] = {},
+) {
+  const memoryDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-openclaw-scenario-"));
+  const saved = saveAndResetOpenClawRegistrationGlobals();
+  const previousMigration = disableRegisterMigrationForCaptureTest();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+    const capture = captureOpenClawRegistrationApi({
+      ...options,
+      pluginConfig: {
+        memoryDir,
+        modelSource: "gateway",
+        qmdEnabled: false,
+        transcriptEnabled: false,
+        hourlySummariesEnabled: false,
+        ...options.pluginConfig,
+      },
+    });
+
+    (plugin as { register(api: unknown): void }).register(capture.api);
+    const orchestrator = (globalThis as Record<string, any>)[ORCHESTRATOR_KEY];
+    if (options.registrationMode !== "setup-only") {
+      assert.ok(orchestrator, "registration should expose the Remnic orchestrator");
+    }
+
+    await fn({ capture, orchestrator: orchestrator ?? {}, memoryDir });
+  } finally {
+    restoreRegisterMigrationForCaptureTest(previousMigration);
+    restoreOpenClawRegistrationGlobals(saved);
+    fs.rmSync(memoryDir, { force: true, recursive: true });
+  }
+}
+
+test("scenario: memory_store writes through the registered tool and memory_search routes through active memory search", async () => {
+  await withScenarioRegistration(async ({ capture, orchestrator }) => {
+    const store = registeredTool(capture, "memory_store");
+    const storeResult = await store.execute("store-1", {
+      content: "The user prefers compact dashboards for operational tools.",
+      category: "preference",
+      tags: ["scenario"],
+    });
+
+    assert.match(resultText(storeResult), /Memory stored:/);
+
+    let searched = false;
+    orchestrator.searchAcrossNamespaces = async (params: Record<string, unknown>) => {
+      searched = true;
+      assert.equal(params.query, "compact dashboards");
+      assert.deepEqual(params.namespaces, ["default"]);
+      return [
+        {
+          id: "memory-dashboard-preference",
+          score: 0.97,
+          snippet: "The user prefers compact dashboards for operational tools.",
+          metadata: { source: "scenario" },
+        },
+      ];
+    };
+
+    const search = registeredTool(capture, "memory_search");
+    const searchResult = await search.execute(
+      "search-1",
+      { query: "compact dashboards", limit: 1 },
+      undefined,
+      { sessionKey: "scenario-session" },
+    );
+    const payload = JSON.parse(resultText(searchResult));
+
+    assert.equal(searched, true);
+    assert.equal(payload.results[0].id, "memory-dashboard-preference");
+    assert.match(payload.results[0].text, /compact dashboards/);
+  });
+});
+
+test("scenario: prompt injection precomputes recall and serves the cached prompt-section builder", async () => {
+  await withScenarioRegistration(async ({ capture, orchestrator }) => {
+    let recallCount = 0;
+    orchestrator.recall = async (query: string, sessionKey: string) => {
+      recallCount += 1;
+      assert.match(query, /dashboard/);
+      assert.equal(sessionKey, "prompt-session");
+      return "Remember that the user prefers compact dashboards.";
+    };
+
+    const beforePromptBuild = registeredHook(capture, "before_prompt_build");
+    const hookResult = await beforePromptBuild(
+      { prompt: "Please design a dashboard for repeated operational review." },
+      { sessionKey: "prompt-session" },
+    );
+
+    const promptSectionBuilder = capture.registrations("registerMemoryPromptSection")[0]?.[0] as
+      | ((params: { availableTools: Set<string> }) => string[])
+      | undefined;
+    assert.equal(typeof promptSectionBuilder, "function");
+    const lines = promptSectionBuilder({
+      availableTools: new Set(["memory_search"]),
+      sessionKey: "prompt-session",
+    } as never);
+
+    assert.equal(recallCount, 1);
+    assert.equal(hookResult, undefined);
+    assert.match(lines.join("\n"), /Memory Context \(Remnic\)/);
+    assert.match(lines.join("\n"), /compact dashboards/);
+  });
+});
+
+test("scenario: agent_end buffers the last user and assistant turns without live extraction", async () => {
+  await withScenarioRegistration(async ({ capture, orchestrator }) => {
+    const processed: Array<{
+      role: string;
+      content: string;
+      sessionKey: string;
+      options: Record<string, unknown>;
+    }> = [];
+    orchestrator.processTurn = async (
+      role: string,
+      content: string,
+      sessionKey: string,
+      options: Record<string, unknown>,
+    ) => {
+      processed.push({ role, content, sessionKey, options });
+    };
+
+    const agentEnd = registeredHook(capture, "agent_end");
+    await agentEnd(
+      {
+        success: true,
+        messages: [
+          { role: "system", content: "system metadata should be ignored" },
+          { role: "user", content: "Please remember the compact dashboard preference." },
+          { role: "assistant", content: "I will keep the dashboard compact." },
+        ],
+      },
+      { sessionKey: "agent-session" },
+    );
+
+    assert.deepEqual(processed.map((turn) => turn.role), ["user", "assistant"]);
+    assert.deepEqual(processed.map((turn) => turn.sessionKey), [
+      "agent-session",
+      "agent-session",
+    ]);
+    assert.match(processed[0].content, /compact dashboard preference/);
+    assert.equal(processed[0].options.logicalSessionKey, "agent-session");
+    assert.equal(processed[0].options.bufferKey, "agent-session");
+  });
+});
+
+test("scenario: before_reset and session_end drain discovered buffers with explicit reasons", async () => {
+  await withScenarioRegistration(async ({ capture, orchestrator }) => {
+    const flushes: Array<{ sessionKey: string; reason: string; bufferKey: string }> = [];
+    orchestrator.buffer.findBufferKeysForSession = async () => ["lifecycle-session", "secondary-buffer"];
+    orchestrator.buffer.getTurns = (bufferKey: string) =>
+      bufferKey === "secondary-buffer" ? [{ role: "user", content: "buffered" }] : [];
+    orchestrator.flushSession = async (
+      sessionKey: string,
+      options: { reason: string; bufferKey: string },
+    ) => {
+      flushes.push({ sessionKey, reason: options.reason, bufferKey: options.bufferKey });
+    };
+
+    await registeredHook(capture, "before_reset")(
+      { sessionKey: "lifecycle-session" },
+      {},
+    );
+    await registeredHook(capture, "session_end")(
+      { sessionKey: "lifecycle-session" },
+      {},
+    );
+
+    assert.deepEqual(flushes, [
+      {
+        sessionKey: "lifecycle-session",
+        reason: "before_reset",
+        bufferKey: "lifecycle-session",
+      },
+      {
+        sessionKey: "lifecycle-session",
+        reason: "before_reset",
+        bufferKey: "secondary-buffer",
+      },
+      {
+        sessionKey: "lifecycle-session",
+        reason: "session_end",
+        bufferKey: "lifecycle-session",
+      },
+      {
+        sessionKey: "lifecycle-session",
+        reason: "session_end",
+        bufferKey: "secondary-buffer",
+      },
+    ]);
+  }, {
+    pluginConfig: {
+      flushOnResetEnabled: true,
+      beforeResetTimeoutMs: 1000,
+    },
+  });
+});
+
+test("scenario: passive slot and setup-only registrations stay inert for active memory hooks", async () => {
+  await withScenarioRegistration(({ capture }) => {
+    assert.deepEqual(capture.hooks(), []);
+    assert.equal(capture.registrations("registerMemoryCapability").length, 0);
+    assert.ok(capture.registrationNames("registerTool").includes("memory_search"));
+  }, {
+    config: {
+      plugins: {
+        slots: {
+          memory: "another-memory-plugin",
+        },
+      },
+    },
+    pluginConfig: {
+      slotBehavior: {
+        onSlotMismatch: "silent",
+      },
+    },
+  });
+
+  await withScenarioRegistration(({ capture }) => {
+    assert.deepEqual(capture.hooks(), []);
+    assert.deepEqual(capture.registrations(), []);
+  }, {
+    registrationMode: "setup-only",
+  });
+});
+
+function registeredTool(
+  capture: ReturnType<typeof captureOpenClawRegistrationApi>,
+  name: string,
+): ToolSpec {
+  const tool = capture
+    .registrations("registerTool")
+    .map(([spec]) => spec as ToolSpec)
+    .find((spec) => spec.name === name);
+  assert.ok(tool, `expected registered tool ${name}`);
+  return tool;
+}
+
+function registeredHook(
+  capture: ReturnType<typeof captureOpenClawRegistrationApi>,
+  name: string,
+) {
+  const handler = capture.hooks(name)[0]?.[1];
+  assert.equal(typeof handler, "function", `expected registered hook ${name}`);
+  return handler as (
+    event: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ) => Promise<unknown>;
+}
+
+function resultText(result: { content: Array<{ text: string }> }): string {
+  return result.content.map((part) => part.text).join("\n");
+}


### PR DESCRIPTION
Closes #892

## Summary
- add deterministic OpenClaw adapter scenarios for memory_store/search, prompt-section recall caching, agent_end buffering, lifecycle drain hooks, and passive/setup-only modes
- document the scenario suite in the OpenClaw plugin README and wire it into quick preflight
- keep quick preflight targeted by invoking tsx directly for single-file test checks and excluding historical local worktrees from broad pattern scans

## Verification
- npm run test:openclaw-scenarios
- bash scripts/check-review-patterns.sh
- git diff --check
- npm run check-types
- npm run check-config-contract
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds deterministic OpenClaw adapter scenario tests and minor CI/preflight/review-script wiring, without changing runtime behavior.
> 
> **Overview**
> Adds a deterministic OpenClaw adapter scenario test suite (`tests/openclaw-adapter-scenarios.test.ts`) that validates key tool + lifecycle behaviors (e.g., `memory_store`/`memory_search`, prompt recall caching via `before_prompt_build`, `agent_end` buffering, and `before_reset`/`session_end` draining) without requiring live OpenClaw/LLM/network.
> 
> Wires the suite into developer workflows via a new `test:openclaw-scenarios` script, runs it in `preflight:quick`, and documents it in the OpenClaw plugin README.
> 
> Hardens `scripts/check-review-patterns.sh` by excluding `.claude/` and `.worktrees/` from broad greps to avoid scanning local tooling/worktree directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb299cd4df3199c89fd819d8ae1b2d167b2b5ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->