### PR TITLE
docs(openclaw): declare ClawHub environment metadata

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -99,6 +99,11 @@ Credential and model-provider behavior is explicit:
 - Plugin/provider modes may read configured model credentials from the OpenClaw auth resolver, OpenClaw's materialized provider config at `~/.openclaw/agents/main/agent/models.json`, or provider-specific environment variables such as `<PROVIDER>_API_KEY` and `<PROVIDER>_TOKEN`.
 - Do not set `openaiApiKey` or provider environment variables for Remnic if you want all LLM-backed memory work routed through the gateway.
 
+The npm package also declares this surface in `package.json` under
+`openclaw.environment` so ClawHub and other registries can show the optional
+provider env vars, config path, and external-model routing behavior before
+installation.
+
 ## Plugin Inspection
 
 Run the OpenClaw plugin inspector with:

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",
@@ -31,6 +31,34 @@
     },
     "install": {
       "minHostVersion": ">=2026.4.8"
+    },
+    "environment": {
+      "externalServices": [
+        "openclaw-gateway-models",
+        "configured-llm-providers"
+      ],
+      "optionalEnv": [
+        "OPENAI_API_KEY",
+        "<PROVIDER>_API_KEY",
+        "<PROVIDER>_TOKEN"
+      ],
+      "configPaths": [
+        "~/.openclaw/agents/main/agent/models.json"
+      ],
+      "credentialSources": [
+        "OpenClaw runtime auth resolver",
+        "OpenClaw materialized provider model config",
+        "provider-specific environment variables"
+      ],
+      "dataSentToProviders": [
+        "conversation excerpts",
+        "memory excerpts",
+        "summaries",
+        "embedding inputs",
+        "active-recall query inputs",
+        "benchmark and evaluation inputs"
+      ],
+      "recommendedMode": "modelSource=gateway"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- bump @remnic/plugin-openclaw to 1.0.30
- add package.json openclaw.environment metadata for ClawHub registry readiness
- document optional provider env vars, OpenClaw models.json access, credential sources, and gateway-recommended mode in registry-visible metadata

## Verification
- pnpm --filter @remnic/plugin-openclaw build
- node --check packages/plugin-openclaw/dist/index.js
- packed artifact includes openclaw.environment metadata and no targeted prompt-override scan strings
- OpenClaw 2026.4.22 local scanner on packed artifact: scanned=82 critical=0 warn=0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: version/metadata/docs-only changes with no runtime logic modifications. Main risk is registry/installer consumers interpreting the new `openclaw.environment` fields differently than expected.
> 
> **Overview**
> Bumps the OpenClaw plugin/package version to `1.0.30`.
> 
> Adds `openclaw.environment` metadata in `@remnic/plugin-openclaw` so registries (e.g. ClawHub) can display **optional provider env vars**, **relevant config paths**, **credential sources**, and the **recommended `modelSource=gateway` mode** prior to installation, and documents this in the plugin README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c0134879880630ac26a31cc5139865b63e3073f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->