### PR TITLE
Guard OpenClaw hook payload privacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
     "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts' 'packages/export-weclone/src/**/*.test.ts' 'packages/import-weclone/src/**/*.test.ts'",
     "test:openclaw-scenarios": "pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
+    "test:openclaw-privacy": "pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",
     "plugin:inspect": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect",
     "plugin:inspect:runtime": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect:runtime",

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -104,6 +104,18 @@ The npm package also declares this surface in `package.json` under
 provider env vars, config path, and external-model routing behavior before
 installation.
 
+## Privacy Boundary
+
+OpenClaw hook runtime metadata such as authorization headers, API keys, provider
+credential objects, and bearer tokens is operational metadata. Remnic does not
+persist those fields to transcripts, extraction buffers, recall audit entries,
+logs, or memory content.
+
+User-authored message text is different: Remnic is a memory plugin, so message
+content can be stored, extracted, summarized, embedded, or recalled according to
+the configured memory policy. Do not paste secrets into chat when you do not
+want them treated as conversation content.
+
 ## Plugin Inspection
 
 Run the OpenClaw plugin inspector with:
@@ -127,6 +139,15 @@ npm run test:openclaw-scenarios
 
 The suite covers the registered memory tools and lifecycle hooks without live
 OpenClaw, LLM credentials, or network calls.
+
+Run the OpenClaw hook privacy suite with:
+
+```bash
+npm run test:openclaw-privacy
+```
+
+The suite guards against runtime auth metadata leaking into persisted memory,
+transcript, recall-audit, or debug-log surfaces.
 
 ## SDK Surface Drift Check
 

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -54,6 +54,7 @@ if [[ "$MODE" == "quick" ]]; then
   run npm run check:openclaw-sdk-surface
   run pnpm exec tsx --test tests/openclaw-sdk-surface-check.test.ts
   run npm run test:openclaw-scenarios
+  run npm run test:openclaw-privacy
   run pnpm exec tsx --test tests/register-multi-registry.test.ts
   run pnpm exec tsx --test tests/intent.test.ts
   run pnpm exec tsx --test tests/runtime-input-guards.test.ts

--- a/tests/openclaw-hook-privacy.test.ts
+++ b/tests/openclaw-hook-privacy.test.ts
@@ -1,0 +1,226 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  captureOpenClawRegistrationApi,
+  disableRegisterMigrationForCaptureTest,
+  restoreOpenClawRegistrationGlobals,
+  restoreRegisterMigrationForCaptureTest,
+  saveAndResetOpenClawRegistrationGlobals,
+} from "./helpers/openclaw-registration-harness.js";
+
+const SERVICE_ID = "openclaw-remnic";
+const ORCHESTRATOR_KEY = `__openclawEngramOrchestrator::${SERVICE_ID}`;
+const RUNTIME_SECRETS = [
+  "sk-runtime-openclaw-secret-893",
+  "runtime-bearer-token-893",
+  "provider-password-secret-893",
+];
+
+async function withPrivacyRegistration(
+  fn: (context: {
+    capture: ReturnType<typeof captureOpenClawRegistrationApi>;
+    orchestrator: Record<string, any>;
+    memoryDir: string;
+    logs: string[];
+  }) => Promise<void> | void,
+) {
+  const memoryDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-openclaw-privacy-"));
+  const logs: string[] = [];
+  const logger = {
+    debug: (...args: unknown[]) => logs.push(args.map(formatLogArg).join(" ")),
+    info: (...args: unknown[]) => logs.push(args.map(formatLogArg).join(" ")),
+    warn: (...args: unknown[]) => logs.push(args.map(formatLogArg).join(" ")),
+    error: (...args: unknown[]) => logs.push(args.map(formatLogArg).join(" ")),
+  };
+  const saved = saveAndResetOpenClawRegistrationGlobals();
+  const previousMigration = disableRegisterMigrationForCaptureTest();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+    const capture = captureOpenClawRegistrationApi({
+      logger,
+      pluginConfig: {
+        memoryDir,
+        modelSource: "gateway",
+        qmdEnabled: false,
+        transcriptEnabled: true,
+        recallTranscriptsEnabled: true,
+        verboseRecallVisibility: true,
+        debug: true,
+      },
+    });
+
+    (plugin as { register(api: unknown): void }).register(capture.api);
+    const orchestrator = (globalThis as Record<string, any>)[ORCHESTRATOR_KEY];
+    assert.ok(orchestrator, "registration should expose the Remnic orchestrator");
+
+    await fn({ capture, orchestrator, memoryDir, logs });
+  } finally {
+    restoreRegisterMigrationForCaptureTest(previousMigration);
+    restoreOpenClawRegistrationGlobals(saved);
+    fs.rmSync(memoryDir, { force: true, recursive: true });
+  }
+}
+
+test("before_prompt_build does not persist OpenClaw runtime auth metadata", async () => {
+  await withPrivacyRegistration(async ({ capture, orchestrator, memoryDir, logs }) => {
+    orchestrator.recall = async () => "Remember operational dashboards should stay compact.";
+
+    await registeredHook(capture, "before_prompt_build")(
+      {
+        prompt: "Please design a compact operational dashboard.",
+        apiKey: RUNTIME_SECRETS[0],
+        headers: {
+          authorization: `Bearer ${RUNTIME_SECRETS[1]}`,
+        },
+        providerCredentials: {
+          password: RUNTIME_SECRETS[2],
+        },
+      },
+      {
+        sessionKey: "privacy-before-prompt",
+        authorization: `Bearer ${RUNTIME_SECRETS[1]}`,
+        provider: {
+          apiKey: RUNTIME_SECRETS[0],
+        },
+      },
+    );
+
+    assertNoSecretsInLogs(logs);
+    assertNoSecretsInFiles(memoryDir);
+  });
+});
+
+test("agent_end stores message content but not OpenClaw runtime auth metadata", async () => {
+  await withPrivacyRegistration(async ({ capture, memoryDir, logs }) => {
+    await registeredHook(capture, "agent_end")(
+      {
+        success: true,
+        apiKey: RUNTIME_SECRETS[0],
+        headers: {
+          authorization: `Bearer ${RUNTIME_SECRETS[1]}`,
+        },
+        providerCredentials: {
+          password: RUNTIME_SECRETS[2],
+        },
+        messages: [
+          { role: "user", content: "Remember that dashboard layouts should be compact." },
+          { role: "assistant", content: "Noted: dashboard layouts should be compact." },
+        ],
+      },
+      {
+        sessionKey: "privacy-agent-end",
+        authorization: `Bearer ${RUNTIME_SECRETS[1]}`,
+        providerCredentials: {
+          apiKey: RUNTIME_SECRETS[0],
+        },
+      },
+    );
+
+    const persisted = readAllText(memoryDir);
+    assert.match(persisted, /dashboard layouts should be compact/);
+    assertNoSecretsInLogs(logs);
+    assertNoSecretsInText(persisted);
+  });
+});
+
+test("llm_output observation logs token metadata without auth payload fields", async () => {
+  await withPrivacyRegistration(async ({ capture, memoryDir, logs }) => {
+    await registeredHook(capture, "llm_output")(
+      {
+        model: "gpt-5.4-mini",
+        tokenUsage: {
+          input: 12,
+          output: 34,
+        },
+        durationMs: 56,
+        headers: {
+          authorization: `Bearer ${RUNTIME_SECRETS[1]}`,
+        },
+        providerCredentials: {
+          apiKey: RUNTIME_SECRETS[0],
+          password: RUNTIME_SECRETS[2],
+        },
+      },
+      { sessionKey: "privacy-llm-output" },
+    );
+
+    assert.match(logs.join("\n"), /llm_output: model=gpt-5\.4-mini/);
+    assertNoSecretsInLogs(logs);
+    assertNoSecretsInFiles(memoryDir);
+  });
+});
+
+test("privacy policy documents user-authored secret text as conversation content", () => {
+  const readme = fs.readFileSync(
+    path.join(import.meta.dirname, "..", "packages/plugin-openclaw/README.md"),
+    "utf-8",
+  );
+
+  assert.match(readme, /runtime metadata such as authorization headers/i);
+  assert.match(readme, /User-authored message text is different/i);
+});
+
+function registeredHook(
+  capture: ReturnType<typeof captureOpenClawRegistrationApi>,
+  name: string,
+) {
+  const handler = capture.hooks(name)[0]?.[1];
+  assert.equal(typeof handler, "function", `expected registered hook ${name}`);
+  return handler as (
+    event: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ) => Promise<unknown>;
+}
+
+function assertNoSecretsInLogs(logs: string[]) {
+  assertNoSecretsInText(logs.join("\n"));
+}
+
+function assertNoSecretsInFiles(root: string) {
+  assertNoSecretsInText(readAllText(root));
+}
+
+function assertNoSecretsInText(text: string) {
+  for (const secret of RUNTIME_SECRETS) {
+    assert.equal(
+      text.includes(secret),
+      false,
+      `runtime metadata secret leaked into persisted/logged text: ${secret}`,
+    );
+  }
+}
+
+function formatLogArg(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return `${value.name}: ${value.message}\n${value.stack ?? ""}`;
+  if (value && typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function readAllText(root: string): string {
+  const chunks: string[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (!fs.existsSync(current)) continue;
+    const stat = fs.statSync(current);
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(current)) {
+        stack.push(path.join(current, entry));
+      }
+      continue;
+    }
+    if (!stat.isFile() || stat.size > 1_000_000) continue;
+    chunks.push(fs.readFileSync(current, "utf-8"));
+  }
+  return chunks.join("\n");
+}


### PR DESCRIPTION
Closes #893

## Summary
- add OpenClaw hook privacy tests for before_prompt_build, agent_end, and llm_output runtime metadata
- assert runtime auth metadata does not land in logs, transcripts, extraction buffers, recall audit, or persisted memory content
- document the boundary between OpenClaw runtime metadata and user-authored message content
- add npm run test:openclaw-privacy and include it in quick preflight

## Verification
- npm run test:openclaw-privacy
- npm run preflight:quick
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds tests, docs, and CI/preflight wiring only, with no runtime behavior changes. Main impact is tighter gating that could surface existing secret-leak regressions as test failures.
> 
> **Overview**
> Adds a new `openclaw` privacy regression test suite that exercises `before_prompt_build`, `agent_end`, and `llm_output` hooks to ensure runtime auth metadata (API keys/headers/provider creds) never appears in logs or persisted memory artifacts, while confirming normal message content still persists.
> 
> Documents this privacy boundary in the OpenClaw plugin README, and wires the suite into `npm run test:openclaw-privacy` plus the `preflight:quick` gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baaedc2d23ace55f313052a50af6119c6d2c138e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->