### PR TITLE
Expose OpenClaw split memory surfaces

### DIFF
--- a/docs/plugins/openclaw-native-memory-registrars.md
+++ b/docs/plugins/openclaw-native-memory-registrars.md
@@ -2,7 +2,7 @@
 
 Checked on 2026-05-04 against:
 
-- `openclaw/openclaw` `358cd87ff300fd515bf35f9725dd59198fb9c416`
+- `openclaw/openclaw` `9eed48fde5a9e742b69803b4895bd6f3f45ca821`
 - `openclaw/kitchen-sink` `f57a0fc7c430c928bbe8049e5d69e6c7b806ed12`
 
 The OpenClaw kitchen-sink plugin exercises three native memory-related
@@ -14,28 +14,38 @@ registrars that are adjacent to Remnic:
 
 ## Decision
 
-Keep Remnic on `registerMemoryCapability()` as the primary OpenClaw integration
-point for now. Do not register OpenClaw embedding, corpus supplement, or
-compaction providers until a product need requires one of those host-native
-surfaces directly.
+Keep `registerMemoryCapability()` as Remnic's primary OpenClaw integration
+point, but also register the compatible split memory surfaces that map directly
+to Remnic's existing adapter:
+
+- `registerMemoryRuntime()` receives the same runtime object exposed through
+  `registerMemoryCapability({ runtime })`.
+- `registerMemoryFlushPlan()` receives the same resolver exposed through
+  `registerMemoryCapability({ flushPlanResolver })`.
+- `registerMemoryCorpusSupplement()` exposes read-only Remnic search/get access
+  as an additive corpus surface.
+
+Do not register OpenClaw embedding or compaction providers yet. Those surfaces
+make OpenClaw call Remnic as an embedding backend or transcript summarizer,
+which reverses the current ownership model and needs a separate product
+decision.
 
 ## Surface Map
 
 | OpenClaw surface | Current upstream contract | Remnic mapping | Decision |
 |---|---|---|---|
 | `registerMemoryEmbeddingProvider()` | Registers an embedding-provider adapter with `create()`, `embedQuery()`, `embedBatch()`, optional multimodal support, and runtime batch metadata. | Remnic already owns embedding and index lifecycle inside `@remnic/core` and its QMD/runtime manager. Registering here would make OpenClaw call Remnic as an embedding backend for OpenClaw-owned memory, which is the wrong ownership direction. | Not a fit yet. Keep embeddings behind Remnic's runtime manager. |
-| `registerMemoryCorpusSupplement()` | Registers an additive corpus supplement with `search({ query, maxResults, agentSessionKey })` and `get({ lookup, fromLine, lineCount, agentSessionKey })`. Supplements live alongside, not instead of, the active memory capability. | Remnic can already expose search/read through `registerMemoryCapability({ runtime })`, `memory_search`, `memory_get`, and public artifacts. As a supplement, Remnic could duplicate results when it owns the memory slot and would need explicit passive-mode ranking/citation semantics when another plugin owns the slot. | Defer. Revisit only for a read-only passive bridge alongside another memory-slot owner. |
+| `registerMemoryCorpusSupplement()` | Registers an additive corpus supplement with `search({ query, maxResults, agentSessionKey })` and `get({ lookup, fromLine, lineCount, agentSessionKey })`. Supplements live alongside, not instead of, the active memory capability. | Remnic maps this to a read-only corpus over Remnic memory search/read results, with Remnic provenance and artifact/private-state filtering. | Implemented as a service-scoped corpus ID: `<serviceId>:remnic-memory-corpus`. |
 | `registerCompactionProvider()` | Registers a provider with `summarize({ messages, signal, compressionRatio, customInstructions, summarizationInstructions, previousSummary })` that can replace OpenClaw's built-in transcript compaction summarizer. | Remnic observes compaction/reset boundaries, saves checkpoints, and flushes memory around lifecycle events. It does not own the user-facing transcript summary OpenClaw needs for context management. | Not applicable. Keep compaction hooks and checkpointing, not summary replacement. |
+| `registerMemoryRuntime()` | Deprecated split runtime registration that patches the active memory capability with runtime search/read/status/sync behavior. | Remnic already builds a runtime object for `registerMemoryCapability({ runtime })`. | Implemented with the same runtime object for split-surface SDK consumers. |
+| `registerMemoryFlushPlan()` | Deprecated split flush-plan registration that patches the active memory capability with pre-compaction flush thresholds and prompts. | Remnic can provide a conservative flush plan aligned with its extraction ownership and credential/privacy policy. | Implemented with the same resolver included in `registerMemoryCapability({ flushPlanResolver })`. |
 
 ## Why `registerMemoryCapability()` Still Fits
 
 `registerMemoryCapability()` matches Remnic's shape as a complete memory adapter:
-prompt building, runtime search/read, backend status, flush planning, and public
-artifacts can live under one exclusive memory-slot capability. That keeps
-OpenClaw-specific code thin while preserving Remnic core ownership of storage,
-retrieval, extraction, consolidation, and QMD behavior.
-
-Future work can revisit `registerMemoryCorpusSupplement()` if Remnic needs an
-explicit passive-mode, read-only bridge. That should be implemented as a
-separate PR with ranking, citation, and duplicate-result expectations documented
-before code changes.
+prompt building, runtime search/read, backend status, flush planning, and
+public artifacts can live under one exclusive memory-slot capability. The split
+surface registrations now mirror the same objects for SDK/runtime paths that
+still consume them directly. That keeps OpenClaw-specific code thin while
+preserving Remnic core ownership of storage, retrieval, extraction,
+consolidation, and QMD behavior.

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -205,6 +205,15 @@ Remnic supports the following OpenClaw memory integration points:
 | `before_prompt_build` hook (new SDK) | Supported | 2026.3.22 |
 | `registerMemoryPromptSection()` (structured builder) | Supported | 2026.3.22 |
 | `registerMemoryCapability()` (unified capability) | Supported | 2026.4.5 |
+| `registerMemoryRuntime()` (split runtime surface) | Supported | 2026.4.x |
+| `registerMemoryFlushPlan()` (split flush-plan surface) | Supported | 2026.4.x |
+| `registerMemoryCorpusSupplement()` (read-only corpus supplement) | Supported | 2026.4.x |
+
+On current OpenClaw SDKs, Remnic registers both the unified memory capability
+and the compatible split surfaces. That lets OpenClaw consume Remnic through
+the active memory runtime, the explicit flush-plan resolver, and additive
+corpus search/read APIs without changing Remnic's ownership of storage,
+retrieval, extraction, and QMD behavior.
 
 ### Public Artifacts (memory-wiki bridge)
 
@@ -223,6 +232,10 @@ When `registerMemoryCapability` is available, Remnic registers a `publicArtifact
 Private runtime state (state/, questions/, transcripts/, archive/, buffers) is never exposed.
 
 With this feature, `openclaw wiki status` reports Remnic artifacts, and `memory-wiki` bridge mode can discover and ingest them.
+
+The corpus supplement exposes read-only search/get access to Remnic memories as
+the `remnic` corpus under a service-scoped supplement ID. It does not expose
+private plugin state, transcript buffers, auth metadata, or artifact paths.
 
 ### Session Lifecycle
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,10 @@ const NODE_FS_PROMISES_MODULE_ID = ["node", "fs/promises"].join(":");
 const READ_FILE_SYNC_FIELD = ["read", "File", "Sync"].join("");
 const EXISTS_SYNC_FIELD = ["exists", "Sync"].join("");
 
+function isMemoryArtifactPath(p: string): boolean {
+  return /(?:^|[\\/])artifacts(?:[\\/]|$)/i.test(p);
+}
+
 function readTextFileNow(filePath: string): string {
   const nodeRequire = createRequire(import.meta.url);
   const fs = nodeRequire(NODE_FS_MODULE_ID) as typeof import("node:fs");
@@ -2341,19 +2345,21 @@ const pluginDefinition = {
     }
 
     // ========================================================================
-    // registerMemoryCapability — unified memory plugin registration (new SDK)
+    // Native memory surfaces — unified capability plus split legacy surfaces
     // ========================================================================
     // When registerMemoryCapability is available (>=2026.4.5), register the
     // full capability object including publicArtifacts so memory-wiki bridge
     // mode can discover and ingest Remnic artifacts.
     //
     // This does NOT replace the existing registerMemoryPromptSection / hook
-    // paths above — those handle recall injection. registerMemoryCapability
-    // adds the publicArtifacts provider and establishes Remnic as the active
-    // memory plugin for the gateway.
+    // paths above — those handle recall injection. Split-only SDKs can still
+    // consume the same runtime and flush-plan objects through their direct
+    // registration functions.
     if (
-      sdkCaps.hasRegisterMemoryCapability &&
-      typeof (api as any).registerMemoryCapability === "function"
+      (sdkCaps.hasRegisterMemoryCapability &&
+        typeof (api as any).registerMemoryCapability === "function") ||
+      typeof (api as any).registerMemoryRuntime === "function" ||
+      typeof (api as any).registerMemoryFlushPlan === "function"
     ) {
       // Build a promptBuilder for the capability. When registerMemoryPromptSection
       // was also registered, the section builder already does a destructive read
@@ -2639,8 +2645,6 @@ const pluginDefinition = {
                 // surfaces (see recallForActiveMemory in @remnic/core),
                 // so exclude them here too — otherwise this runtime path
                 // would bypass the isolation every other reader honors.
-                const isArtifactPath = (p: string): boolean =>
-                  /(?:^|[\\/])artifacts(?:[\\/]|$)/i.test(p);
                 return rawResults
                   .filter((result) => {
                     const candidate = result as unknown as {
@@ -2653,7 +2657,7 @@ const pluginDefinition = {
                         : typeof candidate.id === "string"
                           ? candidate.id
                           : "";
-                    return !isArtifactPath(p);
+                    return !isMemoryArtifactPath(p);
                   })
                   .map((result, index): RuntimeSearchResult => {
                   const candidate = result as unknown as {
@@ -2824,6 +2828,26 @@ const pluginDefinition = {
         },
         async closeAllMemorySearchManagers() {},
       };
+      const remnicMemoryFlushPlanResolver = () => {
+        const maxTurnChars =
+          typeof cfg.extractionMaxTurnChars === "number" && Number.isFinite(cfg.extractionMaxTurnChars)
+            ? Math.max(1_000, Math.floor(cfg.extractionMaxTurnChars))
+            : 8_000;
+        return {
+          softThresholdTokens: 24_000,
+          forceFlushTranscriptBytes: Math.max(16_384, maxTurnChars * 4),
+          reserveTokensFloor: 2_000,
+          model:
+            typeof cfg.summaryModel === "string" && cfg.summaryModel.length > 0
+              ? cfg.summaryModel
+              : cfg.model,
+          prompt:
+            "Flush the recent OpenClaw transcript into Remnic memory. Preserve durable user preferences, project facts, decisions, corrections, and commitments. Ignore runtime metadata, credentials, and transient command noise.",
+          systemPrompt:
+            "You are Remnic's memory flush planner. Produce concise durable memory candidates only when the transcript contains information worth remembering.",
+          relativePath: ["state", "plugins", serviceId, "flush-plan.md"].join("/"),
+        };
+      };
 
       const memoryCapability: import("openclaw/plugin-sdk").MemoryPluginCapability = {
         // Include the promptBuilder so runtimes that treat unified capability
@@ -2832,6 +2856,7 @@ const pluginDefinition = {
         // Respect promptInjectionAllowed policy — omit promptBuilder if injection
         // is disabled, so the capability only provides publicArtifacts.
         ...(promptInjectionAllowed ? { promptBuilder: capabilityPromptBuilder } : {}),
+        flushPlanResolver: remnicMemoryFlushPlanResolver,
         runtime: remnicMemoryRuntime,
         publicArtifacts: {
           listArtifacts: async (_params: { cfg: unknown }) => {
@@ -2848,13 +2873,25 @@ const pluginDefinition = {
           },
         },
       };
-      (api as any).registerMemoryCapability(memoryCapability);
+      if (typeof (api as any).registerMemoryCapability === "function") {
+        (api as any).registerMemoryCapability(memoryCapability);
+      }
+      if (typeof (api as any).registerMemoryRuntime === "function") {
+        (api as any).registerMemoryRuntime(remnicMemoryRuntime);
+      }
+      if (typeof (api as any).registerMemoryFlushPlan === "function") {
+        (api as any).registerMemoryFlushPlan(remnicMemoryFlushPlanResolver);
+      }
       const builderDesc = !promptInjectionAllowed
         ? " (promptBuilder omitted — injection disabled by policy)"
         : memoryPromptBuilder
           ? " and promptBuilder (from registerMemoryPromptSection)"
           : " and promptBuilder (capability-only fallback)";
-      log.info(`registered memory capability with runtime and publicArtifacts provider${builderDesc}`);
+      const capabilityDesc =
+        typeof (api as any).registerMemoryCapability === "function"
+          ? `memory capability with publicArtifacts provider${builderDesc}`
+          : "split memory runtime/flush-plan surfaces";
+      log.info(`registered ${capabilityDesc}`);
     }
 
     // ========================================================================
@@ -3725,6 +3762,243 @@ const pluginDefinition = {
       } catch (err) {
         log.error("failed to auto-register hourly summary cron job:", err);
       }
+    }
+
+    if (typeof (api as any).registerMemoryCorpusSupplement === "function") {
+      const normalizeCorpusLookup = (lookup: unknown): string | null =>
+        typeof lookup === "string" && lookup.trim().length > 0
+          ? lookup.trim()
+          : null;
+      const resolveCorpusStorage = async (agentSessionKey?: string) => {
+        const namespace =
+          typeof orchestrator.resolveSelfNamespace === "function"
+            ? orchestrator.resolveSelfNamespace(agentSessionKey)
+            : undefined;
+        return typeof orchestrator.getStorageForNamespace === "function"
+          ? await orchestrator.getStorageForNamespace(namespace)
+          : orchestrator.storage;
+      };
+      const normalizeCorpusPath = (value: string): string =>
+        value.trim().replace(/\\/g, "/").replace(/^\.\//, "");
+      const pathIsInside = (root: string, candidate: string): boolean => {
+        const relative = path.relative(root, candidate);
+        return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+      };
+      const corpusPathCandidates = (
+        rawPath: string,
+        storageDir: string,
+      ): string[] => {
+        const candidates = new Set<string>();
+        const trimmed = rawPath.trim();
+        if (!trimmed) return [];
+        candidates.add(normalizeCorpusPath(trimmed));
+        if (path.isAbsolute(trimmed)) {
+          const absolutePath = path.resolve(trimmed);
+          const absoluteStorageDir = path.resolve(storageDir);
+          if (pathIsInside(absoluteStorageDir, absolutePath)) {
+            candidates.add(normalizeCorpusPath(path.relative(absoluteStorageDir, absolutePath)));
+          }
+        }
+        candidates.add(path.basename(trimmed));
+        return [...candidates].filter((candidate) => candidate.length > 0);
+      };
+      const displayCorpusPath = (rawPath: string, storageDir: string): string => {
+        const trimmed = rawPath.trim();
+        if (!trimmed) return "";
+        if (path.isAbsolute(trimmed)) {
+          const absolutePath = path.resolve(trimmed);
+          const absoluteStorageDir = path.resolve(storageDir);
+          if (pathIsInside(absoluteStorageDir, absolutePath)) {
+            return normalizeCorpusPath(path.relative(absoluteStorageDir, absolutePath));
+          }
+        }
+        return normalizeCorpusPath(trimmed);
+      };
+      const readMemoryByLookup = async (
+        lookup: string,
+        agentSessionKey?: string,
+      ) => {
+        const storage = await resolveCorpusStorage(agentSessionKey);
+        const storageDir =
+          typeof storage.dir === "string" && storage.dir.length > 0
+            ? storage.dir
+            : orchestrator.config.memoryDir;
+        const memories = await storage.readAllMemories();
+        const normalizedLookup = normalizeCorpusPath(lookup);
+        const matched =
+          memories.find((memory) => memory.frontmatter.id === lookup) ??
+          memories.find((memory) =>
+            corpusPathCandidates(memory.path, storageDir).includes(normalizedLookup),
+          ) ??
+          null;
+        if (!matched) return null;
+        const displayPath = displayCorpusPath(matched.path, storageDir);
+        return { memory: matched, displayPath };
+      };
+      const corpusBackendError = (operation: "search" | "get", err: unknown): Error => {
+        const message = err instanceof Error ? err.message : String(err);
+        const error = new Error(`Remnic corpus ${operation} failed: ${message}`);
+        (error as Error & { cause?: unknown }).cause = err;
+        return error;
+      };
+      const remnicCorpusSupplement = {
+        id: `${serviceId}:remnic-memory-corpus`,
+        label: "Remnic Memory Corpus",
+        async search(params: string | {
+          query?: string;
+          maxResults?: number;
+          agentSessionKey?: string;
+        }) {
+          const query = normalizeCorpusLookup(
+            typeof params === "string" ? params : params?.query,
+          );
+          if (!query) return [];
+          const maxResults =
+            typeof params === "object" &&
+            typeof params.maxResults === "number" &&
+            Number.isFinite(params.maxResults)
+              ? Math.max(1, Math.floor(params.maxResults))
+              : 8;
+          const agentSessionKey =
+            typeof params === "object" ? params.agentSessionKey : undefined;
+          const namespace =
+            typeof orchestrator.resolveSelfNamespace === "function"
+              ? orchestrator.resolveSelfNamespace(agentSessionKey)
+              : undefined;
+          try {
+            const rawResults = await orchestrator.searchAcrossNamespaces({
+              query,
+              maxResults,
+              namespaces: namespace ? [namespace] : undefined,
+              mode: "search",
+            });
+            return rawResults
+              .filter((result) => {
+                const candidate = result as unknown as { path?: string; id?: string };
+                const p =
+                  typeof candidate.path === "string"
+                    ? candidate.path
+                    : typeof candidate.id === "string"
+                      ? candidate.id
+                      : "";
+                return !isMemoryArtifactPath(p);
+              })
+              .map((result, index) => {
+                const candidate = result as unknown as {
+                  path?: string;
+                  id?: string;
+                  startLine?: number;
+                  endLine?: number;
+                  score?: number;
+                  snippet?: string;
+                  text?: string;
+                  metadata?: Record<string, unknown>;
+                };
+                const lookupPath =
+                  typeof candidate.path === "string"
+                    ? candidate.path
+                    : typeof candidate.id === "string"
+                      ? candidate.id
+                      : `remnic-memory-${index + 1}`;
+                const startLine =
+                  typeof candidate.startLine === "number" && Number.isFinite(candidate.startLine)
+                    ? Math.max(1, Math.floor(candidate.startLine))
+                    : 1;
+                const endLine =
+                  typeof candidate.endLine === "number" && Number.isFinite(candidate.endLine)
+                    ? Math.max(startLine, Math.floor(candidate.endLine))
+                    : startLine;
+                return {
+                  corpus: "remnic",
+                  path: lookupPath,
+                  title:
+                    typeof candidate.id === "string" && candidate.id.length > 0
+                      ? candidate.id
+                      : lookupPath,
+                  kind: "memory",
+                  score:
+                    typeof candidate.score === "number" && Number.isFinite(candidate.score)
+                      ? candidate.score
+                      : 0,
+                  snippet:
+                    typeof candidate.snippet === "string"
+                      ? candidate.snippet
+                      : typeof candidate.text === "string"
+                        ? candidate.text
+                        : "",
+                  id: typeof candidate.id === "string" ? candidate.id : lookupPath,
+                  startLine,
+                  endLine,
+                  citation: lookupPath,
+                  source: "remnic",
+                  provenanceLabel: "Remnic",
+                  sourceType: "memory",
+                  sourcePath: lookupPath,
+                  updatedAt:
+                    typeof candidate.metadata?.updatedAt === "string"
+                      ? candidate.metadata.updatedAt
+                      : undefined,
+                };
+              });
+          } catch (err) {
+            log.warn(`memory corpus search failed: ${err}`);
+            throw corpusBackendError("search", err);
+          }
+        },
+        async get(params: string | {
+          lookup?: string;
+          fromLine?: number;
+          lineCount?: number;
+          agentSessionKey?: string;
+        }) {
+          const lookup = normalizeCorpusLookup(
+            typeof params === "string" ? params : params?.lookup,
+          );
+          if (!lookup || isMemoryArtifactPath(lookup)) return null;
+          const agentSessionKey =
+            typeof params === "object" ? params.agentSessionKey : undefined;
+          try {
+            const resolved = await readMemoryByLookup(lookup, agentSessionKey);
+            if (!resolved) return null;
+            const { memory, displayPath } = resolved;
+            if (isMemoryArtifactPath(displayPath) || isMemoryArtifactPath(memory.path)) {
+              return null;
+            }
+            const allLines = memory.content.split(/\r?\n/);
+            const fromLine =
+              typeof params === "object" &&
+              typeof params.fromLine === "number" &&
+              Number.isFinite(params.fromLine)
+                ? Math.max(1, Math.floor(params.fromLine))
+                : 1;
+            const lineCount =
+              typeof params === "object" &&
+              typeof params.lineCount === "number" &&
+              Number.isFinite(params.lineCount)
+                ? Math.max(1, Math.floor(params.lineCount))
+                : allLines.length;
+            const selected = allLines.slice(fromLine - 1, fromLine - 1 + lineCount);
+            return {
+              corpus: "remnic",
+              path: displayPath,
+              title: memory.frontmatter.id,
+              kind: memory.frontmatter.category,
+              content: selected.join("\n"),
+              fromLine,
+              lineCount: selected.length,
+              id: memory.frontmatter.id,
+              provenanceLabel: "Remnic",
+              sourceType: "memory",
+              sourcePath: displayPath,
+              updatedAt: memory.frontmatter.updated,
+            };
+          } catch (err) {
+            log.warn(`memory corpus get failed: ${err}`);
+            throw corpusBackendError("get", err);
+          }
+        },
+      };
+      (api as any).registerMemoryCorpusSupplement(remnicCorpusSupplement);
     }
 
     // ========================================================================

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -151,6 +151,55 @@ declare module "openclaw/plugin-sdk" {
     publicArtifacts?: MemoryPluginPublicArtifactsProvider;
   }
 
+  export interface MemoryCorpusSearchResult {
+    corpus: string;
+    path: string;
+    title?: string;
+    kind?: string;
+    score: number;
+    snippet: string;
+    id?: string;
+    startLine?: number;
+    endLine?: number;
+    citation?: string;
+    source?: string;
+    provenanceLabel?: string;
+    sourceType?: string;
+    sourcePath?: string;
+    updatedAt?: string;
+  }
+
+  export interface MemoryCorpusGetResult {
+    corpus: string;
+    path: string;
+    title?: string;
+    kind?: string;
+    content: string;
+    fromLine: number;
+    lineCount: number;
+    id?: string;
+    provenanceLabel?: string;
+    sourceType?: string;
+    sourcePath?: string;
+    updatedAt?: string;
+  }
+
+  export interface MemoryCorpusSupplement {
+    id?: string;
+    label?: string;
+    search(params: {
+      query: string;
+      maxResults?: number;
+      agentSessionKey?: string;
+    }): Promise<MemoryCorpusSearchResult[]>;
+    get(params: {
+      lookup: string;
+      fromLine?: number;
+      lineCount?: number;
+      agentSessionKey?: string;
+    }): Promise<MemoryCorpusGetResult | null>;
+  }
+
   // ---- Runtime namespace (new SDK) ----
 
   export interface OpenClawRuntime {
@@ -227,6 +276,18 @@ declare module "openclaw/plugin-sdk" {
      *  New SDK >=2026.4.5. Replaces the deprecated split registration methods
      *  (registerMemoryPromptSection, registerMemoryFlushPlan, registerMemoryRuntime). */
     registerMemoryCapability?: (capability: MemoryPluginCapability) => void;
+
+    /** Register the active memory runtime adapter on split-surface SDKs. */
+    registerMemoryRuntime?: (runtime: Record<string, unknown>) => void;
+
+    /** Register the pre-compaction memory flush plan on split-surface SDKs. */
+    registerMemoryFlushPlan?: (resolver: (...args: any[]) => any) => void;
+
+    /** Register an additive memory corpus supplement. */
+    registerMemoryCorpusSupplement?: (supplement: MemoryCorpusSupplement | Record<string, unknown>) => void;
+
+    /** Register an additive memory prompt supplement. */
+    registerMemoryPromptSupplement?: (builder: MemoryPromptSectionBuilder["build"] | ((...args: any[]) => any)) => void;
 
     /** Registration mode: "full" | "setup-only" | "setup-runtime" (new SDK >=2026.3.22) */
     registrationMode?: "full" | "setup-only" | "setup-runtime";

--- a/tests/helpers/openclaw-registration-harness.ts
+++ b/tests/helpers/openclaw-registration-harness.ts
@@ -8,6 +8,7 @@ export interface CapturedOpenClawApi {
 }
 
 const SERVICE_ID = "openclaw-remnic";
+const LEGACY_SERVICE_ID = "openclaw-engram";
 const GLOBAL_KEYS = [
   `__openclawEngramRegistered::${SERVICE_ID}`,
   `__openclawEngramHookApis::${SERVICE_ID}`,
@@ -17,6 +18,14 @@ const GLOBAL_KEYS = [
   `__openclawEngramAccessHttpAuthState::${SERVICE_ID}`,
   `__openclawEngramServiceStarted::${SERVICE_ID}`,
   `__openclawEngramInitPromise::${SERVICE_ID}`,
+  `__openclawEngramRegistered::${LEGACY_SERVICE_ID}`,
+  `__openclawEngramHookApis::${LEGACY_SERVICE_ID}`,
+  `__openclawEngramOrchestrator::${LEGACY_SERVICE_ID}`,
+  `__openclawEngramAccessService::${LEGACY_SERVICE_ID}`,
+  `__openclawEngramAccessHttpServer::${LEGACY_SERVICE_ID}`,
+  `__openclawEngramAccessHttpAuthState::${LEGACY_SERVICE_ID}`,
+  `__openclawEngramServiceStarted::${LEGACY_SERVICE_ID}`,
+  `__openclawEngramInitPromise::${LEGACY_SERVICE_ID}`,
   "__openclawEngramOrchestrator",
   "__openclawEngramCliRegistered",
   "__openclawEngramCliActiveServiceCount",
@@ -32,11 +41,13 @@ export function captureOpenClawRegistrationApi(options: {
   config?: Record<string, unknown>;
   registrationMode?: "full" | "setup-only" | "setup-runtime";
   runtime?: Record<string, unknown>;
+  disabledMethods?: string[];
   logger?: Record<"debug" | "info" | "warn" | "error", (...args: unknown[]) => void>;
 } = {}): CapturedOpenClawApi {
   const captured: Record<string, RegistrationArgs[]> = {};
   const pluginConfig = options.pluginConfig ?? {};
   const config = buildGatewayConfig(options.config, pluginConfig);
+  const disabledMethods = new Set(options.disabledMethods ?? []);
   const target: Record<string, unknown> = {
     id: SERVICE_ID,
     pluginId: SERVICE_ID,
@@ -68,6 +79,9 @@ export function captureOpenClawRegistrationApi(options: {
     get(currentTarget, property) {
       if (property in currentTarget) {
         return currentTarget[property as keyof typeof currentTarget];
+      }
+      if (typeof property === "string" && disabledMethods.has(property)) {
+        return undefined;
       }
       if (property === "on") {
         return (...args: RegistrationArgs) => capture("on", args);

--- a/tests/openclaw-adapter-scenarios.test.ts
+++ b/tests/openclaw-adapter-scenarios.test.ts
@@ -106,6 +106,129 @@ test("scenario: memory_store writes through the registered tool and memory_searc
   });
 });
 
+test("scenario: native corpus supplement searches and reads Remnic memory", async () => {
+  await withScenarioRegistration(async ({ capture, orchestrator, memoryDir }) => {
+    const corpus = capture.registrations("registerMemoryCorpusSupplement")[0]?.[0] as
+      | {
+          search(params: {
+            query: string;
+            maxResults?: number;
+            agentSessionKey?: string;
+          }): Promise<Array<Record<string, unknown>>>;
+          get(params: {
+            lookup: string;
+            fromLine?: number;
+            lineCount?: number;
+          }): Promise<Record<string, unknown> | null>;
+        }
+      | undefined;
+    assert.equal(typeof corpus?.search, "function");
+    assert.equal(typeof corpus?.get, "function");
+
+    orchestrator.searchAcrossNamespaces = async (params: Record<string, unknown>) => {
+      assert.equal(params.query, "compact dashboards");
+      assert.equal(params.maxResults, 2);
+      assert.deepEqual(params.namespaces, ["default"]);
+      return [
+        {
+          id: "memory-dashboard-preference",
+          path: "facts/dashboard.md",
+          score: 0.91,
+          snippet: "Dashboards should stay compact.",
+          metadata: { updatedAt: "2026-05-04T12:00:00.000Z" },
+        },
+      ];
+    };
+
+    const searchResults = await corpus!.search({
+      query: "compact dashboards",
+      maxResults: 2,
+      agentSessionKey: "corpus-session",
+    });
+
+    assert.deepEqual(searchResults[0], {
+      corpus: "remnic",
+      path: "facts/dashboard.md",
+      title: "memory-dashboard-preference",
+      kind: "memory",
+      score: 0.91,
+      snippet: "Dashboards should stay compact.",
+      id: "memory-dashboard-preference",
+      startLine: 1,
+      endLine: 1,
+      citation: "facts/dashboard.md",
+      source: "remnic",
+      provenanceLabel: "Remnic",
+      sourceType: "memory",
+      sourcePath: "facts/dashboard.md",
+      updatedAt: "2026-05-04T12:00:00.000Z",
+    });
+
+    orchestrator.storage.readAllMemories = async () => [
+      {
+        path: path.join(memoryDir, "facts", "dashboard.md"),
+        frontmatter: {
+          id: "memory-dashboard-preference",
+          category: "preference",
+          updated: "2026-05-04T12:00:00.000Z",
+        },
+        content: "first line\nsecond line\nthird line",
+      },
+    ];
+    orchestrator.getStorageForNamespace = async () => orchestrator.storage;
+
+    const readResult = await corpus!.get({
+      lookup: String(searchResults[0].path),
+      fromLine: 2,
+      lineCount: 1,
+    });
+
+    assert.deepEqual(readResult, {
+      corpus: "remnic",
+      path: "facts/dashboard.md",
+      title: "memory-dashboard-preference",
+      kind: "preference",
+      content: "second line",
+      fromLine: 2,
+      lineCount: 1,
+      id: "memory-dashboard-preference",
+      provenanceLabel: "Remnic",
+      sourceType: "memory",
+      sourcePath: "facts/dashboard.md",
+      updatedAt: "2026-05-04T12:00:00.000Z",
+    });
+
+    orchestrator.storage.readAllMemories = async () => [
+      {
+        path: path.join(memoryDir, "artifacts", "private.md"),
+        frontmatter: {
+          id: "artifact-by-id",
+          category: "preference",
+          updated: "2026-05-04T12:00:00.000Z",
+        },
+        content: "private artifact content",
+      },
+    ];
+    assert.equal(await corpus!.get({ lookup: "artifact-by-id" }), null);
+
+    orchestrator.searchAcrossNamespaces = async () => {
+      throw new Error("search unavailable");
+    };
+    await assert.rejects(
+      corpus!.search({ query: "compact dashboards" }),
+      /Remnic corpus search failed: search unavailable/,
+    );
+
+    orchestrator.storage.readAllMemories = async () => {
+      throw new Error("store locked");
+    };
+    await assert.rejects(
+      corpus!.get({ lookup: "facts/dashboard.md" }),
+      /Remnic corpus get failed: store locked/,
+    );
+  });
+});
+
 test("scenario: prompt injection precomputes recall and serves the cached prompt-section builder", async () => {
   await withScenarioRegistration(async ({ capture, orchestrator }) => {
     let recallCount = 0;

--- a/tests/openclaw-registration-capture.test.ts
+++ b/tests/openclaw-registration-capture.test.ts
@@ -57,6 +57,7 @@ test("full modern registration captures hooks, commands, tools, memory capabilit
     assert.ok(memoryCapability, "registerMemoryCapability should be called");
     const capability = memoryCapability[0] as Record<string, unknown>;
     assert.equal(typeof capability.promptBuilder, "function");
+    assert.equal(typeof capability.flushPlanResolver, "function");
     assert.equal(typeof capability.runtime, "object");
     assert.equal(typeof capability.publicArtifacts, "object");
 
@@ -65,10 +66,62 @@ test("full modern registration captures hooks, commands, tools, memory capabilit
       1,
       "modern SDKs should still receive the prompt-section registration",
     );
+    assert.equal(
+      capture.registrations("registerMemoryRuntime").length,
+      1,
+      "split SDKs should receive the same Remnic runtime surface",
+    );
+    assert.equal(
+      capture.registrations("registerMemoryFlushPlan").length,
+      1,
+      "split SDKs should receive the same Remnic flush-plan surface",
+    );
+    const [flushPlanResolver] = capture.registrations("registerMemoryFlushPlan")[0] as [
+      () => Record<string, unknown>,
+    ];
+    assert.equal(
+      flushPlanResolver().relativePath,
+      "state/plugins/openclaw-remnic/flush-plan.md",
+    );
+    assert.deepEqual(capture.registrationNames("registerMemoryCorpusSupplement"), [
+      "openclaw-remnic:remnic-memory-corpus",
+    ]);
 
     assert.equal(capture.registrations("registerMemoryEmbeddingProvider").length, 0);
-    assert.equal(capture.registrations("registerMemoryCorpusSupplement").length, 0);
     assert.equal(capture.registrations("registerCompactionProvider").length, 0);
+  });
+});
+
+test("shim plugin ids keep flush-plan artifacts in their own plugin state namespace", async () => {
+  await withCapturedRegistration((plugin) => {
+    const capture = captureOpenClawRegistrationApi();
+
+    plugin.register.call({ id: "openclaw-engram" }, capture.api);
+
+    const [flushPlanResolver] = capture.registrations("registerMemoryFlushPlan")[0] as [
+      () => Record<string, unknown>,
+    ];
+    assert.equal(
+      flushPlanResolver().relativePath,
+      "state/plugins/openclaw-engram/flush-plan.md",
+    );
+    assert.deepEqual(capture.registrationNames("registerMemoryCorpusSupplement"), [
+      "openclaw-engram:remnic-memory-corpus",
+    ]);
+  });
+});
+
+test("split-only SDKs receive runtime and flush-plan registrations without unified capability", async () => {
+  await withCapturedRegistration((plugin) => {
+    const capture = captureOpenClawRegistrationApi({
+      disabledMethods: ["registerMemoryCapability"],
+    });
+
+    plugin.register(capture.api);
+
+    assert.equal(capture.registrations("registerMemoryCapability").length, 0);
+    assert.equal(capture.registrations("registerMemoryRuntime").length, 1);
+    assert.equal(capture.registrations("registerMemoryFlushPlan").length, 1);
   });
 });
 
@@ -112,6 +165,9 @@ test("passive slot mode suppresses active memory hooks and capability surfaces",
     assert.equal(capture.registrations("registerMemoryCapability").length, 0);
     assert.equal(capture.registrations("registerMemoryPromptSection").length, 0);
     assert.equal(capture.registrations("registerCommand").length, 0);
+    assert.deepEqual(capture.registrationNames("registerMemoryCorpusSupplement"), [
+      "openclaw-remnic:remnic-memory-corpus",
+    ]);
 
     assert.ok(
       capture.registrationNames("registerTool").includes("memory_search"),


### PR DESCRIPTION
Closes #912.

References #891 and #906.

## Summary
- Register the Remnic memory runtime and flush-plan resolver through OpenClaw split memory surfaces alongside the unified capability.
- Register a read-only Remnic corpus supplement so OpenClaw can search and read Remnic memories as a native corpus.
- Extend the OpenClaw SDK shim plus deterministic registration/scenario tests for the new surfaces.
- Refresh OpenClaw plugin docs/native registrar notes against current OpenClaw and kitchen-sink commits.

## Verification
- `npm run test:openclaw-scenarios`
- `pnpm exec tsx --test tests/openclaw-registration-capture.test.ts`
- `npm run check-types`
- `npm run check-config-contract`
- `npm run preflight:quick`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new OpenClaw memory registration paths (runtime/flush-plan/corpus supplement) and new lookup/path handling logic, which could affect what memory content is exposed or how legacy SDKs integrate, though it is guarded by feature detection and includes artifact filtering.
> 
> **Overview**
> Remnic’s OpenClaw adapter now registers **split legacy memory surfaces** alongside the unified `registerMemoryCapability()`: it exposes the same `runtime` via `registerMemoryRuntime()` and adds a concrete `flushPlanResolver` that is also registered via `registerMemoryFlushPlan()` when available.
> 
> It also registers a **read-only `registerMemoryCorpusSupplement()`** (`<serviceId>:remnic-memory-corpus`) that lets OpenClaw search/get Remnic memories as a native corpus, with explicit filtering to exclude `artifacts/` paths and guard against path/lookup edge cases.
> 
> Type shim and tests were extended to cover the new SDK methods/types (corpus search/get results, supplement interface), add capture harness support for disabling missing methods, and validate split-only SDK behavior and legacy plugin id namespacing; docs were updated to reflect the new registrar decisions and supported surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf155a7ba10521821497e003808d58d1592721c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->