### PR TITLE
Ensure Remnic OpenClaw installs grant conversation hook access

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ After installation, add the Remnic bridge plugin to your `openclaw.json`:
     "entries": {
       "openclaw-remnic": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           // Recommended for OpenClaw: use the gateway model chain.
           "modelSource": "gateway",

--- a/docs/guides/openclaw-engram-to-remnic.md
+++ b/docs/guides/openclaw-engram-to-remnic.md
@@ -54,6 +54,9 @@ Use this key after migration:
     },
     "entries": {
       "openclaw-remnic": {
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "memoryDir": "~/.openclaw/workspace/memory/local"
         }

--- a/docs/integration/sample-openclaw-config.json
+++ b/docs/integration/sample-openclaw-config.json
@@ -22,11 +22,11 @@
             "port": 4318,
             "authToken": "your-secret-token-here"
           }
+        },
+        "hooks": {
+          "allowConversationAccess": true
         }
       }
-    },
-    "slots": {
-      "memory": "openclaw-remnic"
     }
   }
 }

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -74,7 +74,10 @@ Minimal configuration:
     "slots": { "memory": "openclaw-remnic" },
     "entries": {
       "openclaw-remnic": {
-        "package": "@remnic/plugin-openclaw"
+        "package": "@remnic/plugin-openclaw",
+        "hooks": {
+          "allowConversationAccess": true
+        }
       }
     }
   }

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -25,7 +25,10 @@ Add the plugin to your `openclaw.json`:
     "slots": { "memory": "openclaw-remnic" },
     "entries": {
       "openclaw-remnic": {
-        "package": "@remnic/plugin-openclaw"
+        "package": "@remnic/plugin-openclaw",
+        "hooks": {
+          "allowConversationAccess": true
+        }
       }
     }
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2916,6 +2916,23 @@ function parseOpenclawPluginState(
   return { plugins, entries, slots };
 }
 
+function readOpenclawHooksPolicy(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function buildRemnicOpenclawHooksPolicy(
+  legacyHooks: unknown,
+  existingHooks: unknown,
+): Record<string, unknown> {
+  return {
+    ...readOpenclawHooksPolicy(legacyHooks),
+    ...readOpenclawHooksPolicy(existingHooks),
+    allowConversationAccess: true,
+  };
+}
+
 function resolveOpenclawInstallMemoryDir(args: {
   requestedMemoryDir?: string;
   existingNewEntryConfig: Record<string, unknown>;
@@ -6456,6 +6473,10 @@ async function cmdOpenclawInstall(opts: OpenclawInstallOptions): Promise<void> {
   const newEntry: Record<string, unknown> = {
     ...legacyNonConfigFields,
     ...existingNewEntryFields,
+    hooks: buildRemnicOpenclawHooksPolicy(
+      legacyNonConfigFields.hooks,
+      existingNewEntryFields.hooks,
+    ),
     config: {
       modelSource: defaultModelSource,
       ...legacyConfigToMerge,
@@ -6497,6 +6518,7 @@ async function cmdOpenclawInstall(opts: OpenclawInstallOptions): Promise<void> {
   const changes: string[] = [];
   if (!hasNew) changes.push(`+ Added plugins.entries["${REMNIC_OPENCLAW_PLUGIN_ID}"]`);
   else changes.push(`~ Updated plugins.entries["${REMNIC_OPENCLAW_PLUGIN_ID}"].config.memoryDir`);
+  changes.push(`~ Set plugins.entries["${REMNIC_OPENCLAW_PLUGIN_ID}"].hooks.allowConversationAccess = true`);
   if (!slotIsActiveLegacy && currentSlot !== REMNIC_OPENCLAW_PLUGIN_ID) {
     changes.push(`~ Set plugins.slots.memory = "${REMNIC_OPENCLAW_PLUGIN_ID}" (was: ${currentSlot ?? "(unset)"})`);
   } else if (slotIsActiveLegacy) {
@@ -6517,7 +6539,8 @@ async function cmdOpenclawInstall(opts: OpenclawInstallOptions): Promise<void> {
     const entrySummary = dryRunEntries
       ? Object.keys(dryRunEntries).map((k) => {
           const cfg = (dryRunEntries[k] as Record<string, unknown>)?.config as Record<string, unknown> | undefined;
-          return `  ${k}: { config: { memoryDir: ${cfg?.memoryDir ?? "(unset)"}, ... } }`;
+          const hooks = (dryRunEntries[k] as Record<string, unknown>)?.hooks as Record<string, unknown> | undefined;
+          return `  ${k}: { hooks: { allowConversationAccess: ${hooks?.allowConversationAccess ?? "(unset)"} }, config: { memoryDir: ${cfg?.memoryDir ?? "(unset)"}, ... } }`;
         }).join("\n")
       : "  (none)";
     console.log("\nResulting plugins.entries:");

--- a/tests/openclaw-install-cli.test.ts
+++ b/tests/openclaw-install-cli.test.ts
@@ -135,6 +135,15 @@ test("CLI openclaw install defaults Remnic to gateway model source", async () =>
   );
 });
 
+test("CLI openclaw install grants required conversation hook access", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes("buildRemnicOpenclawHooksPolicy") &&
+      src.includes("allowConversationAccess: true"),
+    "OpenClaw 2026.5 requires non-bundled plugins using agent_end/llm_output hooks to set hooks.allowConversationAccess",
+  );
+});
+
 test("CLI query does not wait for deferred QMD startup maintenance", async () => {
   const src = await readCli();
   const queryStart = src.indexOf("async function cmdQuery");

--- a/tests/openclaw-install-logic.test.ts
+++ b/tests/openclaw-install-logic.test.ts
@@ -59,7 +59,7 @@ function buildUpdatedOpenclawConfig(
   const defaultModelSource = !existingNewEntry && !migrateLegacy ? "gateway" : "plugin";
 
   const legacyHooks =
-    legacyEntry?.hooks && typeof legacyEntry.hooks === "object" && !Array.isArray(legacyEntry.hooks)
+    migrateLegacy && legacyEntry?.hooks && typeof legacyEntry.hooks === "object" && !Array.isArray(legacyEntry.hooks)
       ? (legacyEntry.hooks as Record<string, unknown>)
       : {};
   const existingHooks =
@@ -156,6 +156,26 @@ test("migration: preserves hook policy fields while enabling conversation access
     customFlag: "legacy",
     allowConversationAccess: true,
   });
+});
+
+test("declined migration: does not merge legacy hook policy fields", () => {
+  const existing: OpenclawConfig = {
+    plugins: {
+      entries: {
+        "openclaw-engram": {
+          hooks: { allowPromptInjection: false, customFlag: "legacy" },
+          config: { memoryDir: "/old/path" },
+        },
+      },
+      slots: { memory: "openclaw-engram" },
+    },
+  };
+  const result = buildUpdatedOpenclawConfig(existing, "/new/path", false);
+
+  assert.deepEqual(result.plugins!.entries!["openclaw-remnic"].hooks, {
+    allowConversationAccess: true,
+  });
+  assert.equal(result.plugins?.slots?.memory, "openclaw-engram");
 });
 
 test("reinstall: keeps existing hook fields while repairing conversation access", () => {

--- a/tests/openclaw-install-logic.test.ts
+++ b/tests/openclaw-install-logic.test.ts
@@ -58,7 +58,21 @@ function buildUpdatedOpenclawConfig(
       : {};
   const defaultModelSource = !existingNewEntry && !migrateLegacy ? "gateway" : "plugin";
 
+  const legacyHooks =
+    legacyEntry?.hooks && typeof legacyEntry.hooks === "object" && !Array.isArray(legacyEntry.hooks)
+      ? (legacyEntry.hooks as Record<string, unknown>)
+      : {};
+  const existingHooks =
+    existingNewEntry?.hooks && typeof existingNewEntry.hooks === "object" && !Array.isArray(existingNewEntry.hooks)
+      ? (existingNewEntry.hooks as Record<string, unknown>)
+      : {};
+
   const newEntry: OpenclawPluginEntry = {
+    hooks: {
+      ...legacyHooks,
+      ...existingHooks,
+      allowConversationAccess: true,
+    },
     config: {
       modelSource: defaultModelSource,
       ...legacyConfigToMerge,
@@ -112,6 +126,55 @@ test("fresh install: creates openclaw-remnic entry and slot", () => {
     "gateway",
     "fresh OpenClaw installs should route Remnic LLM calls through the gateway by default",
   );
+});
+
+test("fresh install: enables OpenClaw conversation-access hooks", () => {
+  const result = buildUpdatedOpenclawConfig({}, "/tmp/test-memory", false);
+
+  assert.deepEqual(
+    result.plugins!.entries!["openclaw-remnic"].hooks,
+    { allowConversationAccess: true },
+    "OpenClaw 2026.5 requires explicit conversation access for agent_end/llm_output hooks",
+  );
+});
+
+test("migration: preserves hook policy fields while enabling conversation access", () => {
+  const existing: OpenclawConfig = {
+    plugins: {
+      entries: {
+        "openclaw-engram": {
+          hooks: { allowPromptInjection: false, customFlag: "legacy" },
+          config: { memoryDir: "/old/path" },
+        },
+      },
+    },
+  };
+  const result = buildUpdatedOpenclawConfig(existing, "/new/path", true);
+
+  assert.deepEqual(result.plugins!.entries!["openclaw-remnic"].hooks, {
+    allowPromptInjection: false,
+    customFlag: "legacy",
+    allowConversationAccess: true,
+  });
+});
+
+test("reinstall: keeps existing hook fields while repairing conversation access", () => {
+  const existing: OpenclawConfig = {
+    plugins: {
+      entries: {
+        "openclaw-remnic": {
+          hooks: { allowConversationAccess: false, allowPromptInjection: false },
+          config: { memoryDir: "/old/path" },
+        },
+      },
+    },
+  };
+  const result = buildUpdatedOpenclawConfig(existing, "/new/path", false);
+
+  assert.deepEqual(result.plugins!.entries!["openclaw-remnic"].hooks, {
+    allowConversationAccess: true,
+    allowPromptInjection: false,
+  });
 });
 
 test("fresh install: preserves existing top-level config keys", () => {


### PR DESCRIPTION
### Motivation
- OpenClaw 2026.5 requires non-bundled plugins that observe conversation lifecycle hooks to explicitly declare conversation access in their manifest/hook policy so lifecycle hooks like `agent_end`, `llm_output`, and `before_agent_finalize` are allowed to observe conversation content.

### Description
- Preserve existing legacy/new `hooks` fields when building the `openclaw-remnic` entry and always set `hooks.allowConversationAccess = true` during `remnic openclaw install` and config mutation paths (`cmdOpenclawInstall` and `buildUpdatedOpenclawConfig`).
- Added small helpers `readOpenclawHooksPolicy()` and `buildRemnicOpenclawHooksPolicy()` to merge legacy and existing hook policy fields while enabling conversation access.
- Surface the hook change in dry-run/summary output and keep other hook fields intact (no overwrite of unrelated hook flags).
- Updated documentation and examples (`README.md`, `docs/plugins/openclaw.md`, `docs/guides/openclaw-engram-to-remnic.md`, `docs/integration/sample-openclaw-config.json`, `packages/plugin-openclaw/README.md`) to include the new `hooks.allowConversationAccess` example, and added/updated unit tests to cover fresh install, migration, reinstall, and CLI source checks.

### Testing
- Ran `npm run check-types` which completed successfully (type-check passed).
- Ran targeted unit tests with `npm exec -- tsx --test tests/openclaw-install-logic.test.ts tests/openclaw-install-cli.test.ts tests/openclaw-plugin-runtime-surfaces.test.ts` and all tests passed (69 tests, 0 failures).
- Ran the local preflight quick path `npm run preflight:quick`; it progressed through type/config checks but the `plugin-inspector` step could not run in this environment and caused the preflight to stop (environment lacked `plugin-inspector`), so preflight finished with a partial failure at that optional inspection step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94f02cc50832eab5ad752683d7244)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `remnic openclaw install` config-mutation behavior and hook policy handling, which affects what conversation data the plugin is permitted to observe. The logic is small and covered by new unit tests, but mis-merges could alter user hook policies or install output.
> 
> **Overview**
> Ensures OpenClaw installs/migrations for `openclaw-remnic` explicitly grant required lifecycle-hook access by always writing `plugins.entries["openclaw-remnic"].hooks.allowConversationAccess = true`.
> 
> The CLI now merges any existing/legacy `hooks` policy fields (without clobbering unrelated flags), surfaces the hook change in dry-run output, and adds tests covering fresh install, reinstall, and legacy migration/declined-migration behavior.
> 
> Documentation and sample configs are updated to include the new `hooks.allowConversationAccess` block in OpenClaw setup examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70838a8708ade83ad65568577e76ba82facf9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->