### PR TITLE
feat(import): add Supermemory migration importer and quickstart guide

### DIFF
--- a/docs/importers.md
+++ b/docs/importers.md
@@ -4,7 +4,7 @@ Issue [#568](https://github.com/joshuaswarren/remnic/issues/568) ships a
 family of optional importer packages that pull personal memory out of
 external platforms and land it in Remnic as first-class memories.
 
-Four sources are supported today:
+Five sources are supported today:
 
 | Source  | Package                   | Source label | Input                                     |
 |---------|---------------------------|--------------|-------------------------------------------|
@@ -12,6 +12,7 @@ Four sources are supported today:
 | Claude  | `@remnic/import-claude`   | `claude`     | Data-export JSON (projects + conversations) |
 | Gemini  | `@remnic/import-gemini`   | `gemini`     | Google Takeout `My Activity.json`            |
 | mem0    | `@remnic/import-mem0`     | `mem0`       | REST API (paginated) or offline JSON dump    |
+| Supermemory | `@remnic/import-supermemory` | `supermemory` | JSON export from Supermemory Memories API |
 
 Each importer is an **à-la-carte optional runtime companion** of the
 `@remnic/cli` package. They are never bundled into the base CLI install,
@@ -33,7 +34,7 @@ npm install -g @remnic/cli
 
 # Add the importer you actually need
 npm install -g @remnic/import-chatgpt
-# or any mix of: @remnic/import-claude, @remnic/import-gemini, @remnic/import-mem0
+# or any mix of: @remnic/import-claude, @remnic/import-gemini, @remnic/import-mem0, @remnic/import-supermemory
 ```
 
 If you run `remnic import --adapter <name>` without the matching package
@@ -50,7 +51,7 @@ remnic import --adapter <name> [options]
 
 | Flag                        | Applies to      | Description                                                             |
 |-----------------------------|-----------------|-------------------------------------------------------------------------|
-| `--adapter <name>`          | all             | Required. One of `chatgpt`, `claude`, `gemini`, `mem0`.                 |
+| `--adapter <name>`          | all             | Required. One of `chatgpt`, `claude`, `gemini`, `mem0`, `supermemory`.                 |
 | `--file <path>`             | file-based      | Path to the export file (leading `~` is expanded).                      |
 | `--dry-run`                 | all             | Parse + transform only; print a plan and never write.                   |
 | `--batch-size <n>`          | all             | How many memories per orchestrator batch. Default 25, range 1–500.     |
@@ -158,3 +159,37 @@ Per-path behavior:
   endpoint (which may be self-hosted or hosted).
 - **Dry-run** (`--dry-run`) never writes or extracts, so it is the
   safest way to preview what an importer would pick up.
+
+
+### Supermemory (`@remnic/import-supermemory`)
+
+- Accepts JSON exports produced from Supermemory memories list endpoints.
+- Works with both direct array payloads and object payloads containing `memories`, `results`, or `data`.
+- Imports `content` first; falls back to `summary` or `title` when `content` is missing.
+- Preserves `containerTags` and source metadata under `metadata.sourceMetadata`.
+
+#### Supermemory → Remnic quick migration
+
+1. Export your Supermemory memories to JSON (example uses the current API hostname):
+
+```bash
+curl -sS https://api.supermemory.ai/v3/memories/list \
+  -H "Authorization: Bearer $SUPERMEMORY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"page":1,"limit":1000}' > supermemory-memories.json
+```
+
+2. Install the Remnic importer package:
+
+```bash
+npm install -g @remnic/import-supermemory
+```
+
+3. Preview import first, then commit:
+
+```bash
+remnic import --adapter supermemory --file ./supermemory-memories.json --dry-run
+remnic import --adapter supermemory --file ./supermemory-memories.json
+```
+
+If your export spans multiple pages, concatenate them into one object `{ "memories": [...] }` (or one flat array) before import.

--- a/packages/import-supermemory/package.json
+++ b/packages/import-supermemory/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@remnic/import-supermemory",
+  "version": "0.1.0",
+  "description": "Import Supermemory exports into Remnic",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "tsx --test src/parser.test.ts src/transform.test.ts src/adapter.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "dependencies": {
+    "@remnic/core": "workspace:^"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/import-supermemory"
+  },
+  "keywords": ["remnic", "memory", "supermemory", "import"]
+}

--- a/packages/import-supermemory/src/adapter.test.ts
+++ b/packages/import-supermemory/src/adapter.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { adapter } from "./adapter.js";
+
+describe("adapter", () => {
+  it("parses and transforms", async () => {
+    const parsed = await adapter.parse({ memories: [{ id: "x", content: "y" }] });
+    const out = adapter.transform(parsed);
+    assert.equal(out.length, 1);
+  });
+});

--- a/packages/import-supermemory/src/adapter.ts
+++ b/packages/import-supermemory/src/adapter.ts
@@ -1,0 +1,21 @@
+import type { ImporterAdapter } from "@remnic/core";
+import { defaultWriteMemoriesToOrchestrator } from "@remnic/core";
+
+import { parseSupermemoryExport, type ParsedSupermemoryExport } from "./parser.js";
+import { SUPERMEMORY_SOURCE_LABEL, transformSupermemoryExport } from "./transform.js";
+
+export const adapter: ImporterAdapter<ParsedSupermemoryExport> = {
+  name: "supermemory",
+  sourceLabel: SUPERMEMORY_SOURCE_LABEL,
+  parse(input, options) {
+    return parseSupermemoryExport(input, options?.filePath);
+  },
+  transform(parsed) {
+    return transformSupermemoryExport(parsed);
+  },
+  writeTo(target, memories) {
+    return defaultWriteMemoriesToOrchestrator(target, memories);
+  },
+};
+
+export const supermemoryAdapter = adapter;

--- a/packages/import-supermemory/src/index.ts
+++ b/packages/import-supermemory/src/index.ts
@@ -1,0 +1,3 @@
+export { adapter, supermemoryAdapter } from "./adapter.js";
+export { parseSupermemoryExport } from "./parser.js";
+export { transformSupermemoryExport } from "./transform.js";

--- a/packages/import-supermemory/src/parser.test.ts
+++ b/packages/import-supermemory/src/parser.test.ts
@@ -9,6 +9,13 @@ describe("parseSupermemoryExport", () => {
     assert.equal(parsed.importedFromPath, "bundle.json");
   });
 
+  it("reads v4 memoryEntries array from object", () => {
+    const parsed = parseSupermemoryExport({ memoryEntries: [{ id: "m1", content: "hello" }] });
+
+    assert.equal(parsed.memories.length, 1);
+    assert.equal(parsed.memories[0]?.id, "m1");
+  });
+
   it("throws when input is missing", () => {
     assert.throws(
       () => parseSupermemoryExport(undefined),
@@ -47,10 +54,11 @@ describe("parseSupermemoryExport", () => {
   it("consumes only first matching key to avoid duplicates", () => {
     const parsed = parseSupermemoryExport({
       memories: [{ id: "m1", content: "hello" }],
+      memoryEntries: [{ id: "m2", content: "newer" }],
       data: [{ id: "m1", content: "hello" }],
     });
 
     assert.equal(parsed.memories.length, 1);
-    assert.equal(parsed.memories[0]?.id, "m1");
+    assert.equal(parsed.memories[0]?.id, "m2");
   });
 });

--- a/packages/import-supermemory/src/parser.test.ts
+++ b/packages/import-supermemory/src/parser.test.ts
@@ -8,4 +8,21 @@ describe("parseSupermemoryExport", () => {
     assert.equal(parsed.memories.length, 1);
     assert.equal(parsed.importedFromPath, "bundle.json");
   });
+
+  it("throws when input is missing", () => {
+    assert.throws(
+      () => parseSupermemoryExport(undefined),
+      /Supermemory import requires JSON input\. Pass --file <supermemory-export\.json>\./,
+    );
+  });
+
+  it("consumes only first matching key to avoid duplicates", () => {
+    const parsed = parseSupermemoryExport({
+      memories: [{ id: "m1", content: "hello" }],
+      data: [{ id: "m1", content: "hello" }],
+    });
+
+    assert.equal(parsed.memories.length, 1);
+    assert.equal(parsed.memories[0]?.id, "m1");
+  });
 });

--- a/packages/import-supermemory/src/parser.test.ts
+++ b/packages/import-supermemory/src/parser.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseSupermemoryExport } from "./parser.js";
+
+describe("parseSupermemoryExport", () => {
+  it("reads memories array from object", () => {
+    const parsed = parseSupermemoryExport({ memories: [{ id: "m1", content: "hello" }] }, "bundle.json");
+    assert.equal(parsed.memories.length, 1);
+    assert.equal(parsed.importedFromPath, "bundle.json");
+  });
+});

--- a/packages/import-supermemory/src/parser.test.ts
+++ b/packages/import-supermemory/src/parser.test.ts
@@ -16,6 +16,34 @@ describe("parseSupermemoryExport", () => {
     );
   });
 
+  it("throws when JSON input is null", () => {
+    assert.throws(
+      () => parseSupermemoryExport("null"),
+      /Supermemory export must be a JSON array or object; received null/,
+    );
+  });
+
+  it("throws when JSON input is a primitive", () => {
+    assert.throws(
+      () => parseSupermemoryExport("123"),
+      /Supermemory export must be a JSON array or object; received number/,
+    );
+  });
+
+  it("throws when an object has no recognized memory key", () => {
+    assert.throws(
+      () => parseSupermemoryExport({ foo: [] }),
+      /Supermemory export object has no recognized memory key/,
+    );
+  });
+
+  it("throws when a recognized memory key is not an array", () => {
+    assert.throws(
+      () => parseSupermemoryExport({ memories: {} }),
+      /Supermemory export key 'memories' must be an array/,
+    );
+  });
+
   it("consumes only first matching key to avoid duplicates", () => {
     const parsed = parseSupermemoryExport({
       memories: [{ id: "m1", content: "hello" }],

--- a/packages/import-supermemory/src/parser.ts
+++ b/packages/import-supermemory/src/parser.ts
@@ -29,7 +29,7 @@ export function parseSupermemoryExport(input: unknown, filePath?: string): Parse
   } else if (raw && typeof raw === "object") {
     const obj = raw as Record<string, unknown>;
     let sawKnownKey = false;
-    for (const key of ["memories", "results", "data"] as const) {
+    for (const key of ["memoryEntries", "memories", "results", "data"] as const) {
       if (key in obj) {
         sawKnownKey = true;
         if (!Array.isArray(obj[key])) {
@@ -41,7 +41,7 @@ export function parseSupermemoryExport(input: unknown, filePath?: string): Parse
     }
     if (!sawKnownKey) {
       throw new Error(
-        "Supermemory export object has no recognized memory key. Expected one of 'memories', 'results', or 'data'.",
+        "Supermemory export object has no recognized memory key. Expected one of 'memoryEntries', 'memories', 'results', or 'data'.",
       );
     }
   }

--- a/packages/import-supermemory/src/parser.ts
+++ b/packages/import-supermemory/src/parser.ts
@@ -1,0 +1,36 @@
+export interface SupermemoryRecord {
+  id?: string;
+  content?: string;
+  summary?: string;
+  title?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  containerTags?: string[];
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ParsedSupermemoryExport {
+  memories: SupermemoryRecord[];
+  importedFromPath?: string;
+}
+
+export function parseSupermemoryExport(input: unknown, filePath?: string): ParsedSupermemoryExport {
+  const raw = typeof input === "string" ? JSON.parse(input) : input;
+  const memories: SupermemoryRecord[] = [];
+  if (Array.isArray(raw)) {
+    append(memories, raw);
+  } else if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    for (const key of ["memories", "results", "data"] as const) {
+      if (Array.isArray(obj[key])) append(memories, obj[key] as unknown[]);
+    }
+  }
+  return { memories, ...(filePath ? { importedFromPath: filePath } : {}) };
+}
+
+function append(dest: SupermemoryRecord[], src: unknown[]): void {
+  for (const item of src) {
+    if (item && typeof item === "object") dest.push(item as SupermemoryRecord);
+  }
+}

--- a/packages/import-supermemory/src/parser.ts
+++ b/packages/import-supermemory/src/parser.ts
@@ -1,5 +1,6 @@
 export interface SupermemoryRecord {
   id?: string;
+  memory?: string;
   content?: string;
   summary?: string;
   title?: string;

--- a/packages/import-supermemory/src/parser.ts
+++ b/packages/import-supermemory/src/parser.ts
@@ -16,16 +16,25 @@ export interface ParsedSupermemoryExport {
 }
 
 export function parseSupermemoryExport(input: unknown, filePath?: string): ParsedSupermemoryExport {
+  if (input == null) {
+    throw new Error("Supermemory import requires JSON input. Pass --file <supermemory-export.json>.");
+  }
+
   const raw = typeof input === "string" ? JSON.parse(input) : input;
   const memories: SupermemoryRecord[] = [];
+
   if (Array.isArray(raw)) {
     append(memories, raw);
   } else if (raw && typeof raw === "object") {
     const obj = raw as Record<string, unknown>;
     for (const key of ["memories", "results", "data"] as const) {
-      if (Array.isArray(obj[key])) append(memories, obj[key] as unknown[]);
+      if (Array.isArray(obj[key])) {
+        append(memories, obj[key] as unknown[]);
+        break;
+      }
     }
   }
+
   return { memories, ...(filePath ? { importedFromPath: filePath } : {}) };
 }
 

--- a/packages/import-supermemory/src/parser.ts
+++ b/packages/import-supermemory/src/parser.ts
@@ -20,26 +20,54 @@ export function parseSupermemoryExport(input: unknown, filePath?: string): Parse
     throw new Error("Supermemory import requires JSON input. Pass --file <supermemory-export.json>.");
   }
 
-  const raw = typeof input === "string" ? JSON.parse(input) : input;
+  const raw = coerceJson(input);
   const memories: SupermemoryRecord[] = [];
 
   if (Array.isArray(raw)) {
     append(memories, raw);
+    return { memories, ...(filePath ? { importedFromPath: filePath } : {}) };
   } else if (raw && typeof raw === "object") {
     const obj = raw as Record<string, unknown>;
+    let sawKnownKey = false;
     for (const key of ["memories", "results", "data"] as const) {
-      if (Array.isArray(obj[key])) {
+      if (key in obj) {
+        sawKnownKey = true;
+        if (!Array.isArray(obj[key])) {
+          throw new Error(`Supermemory export key '${key}' must be an array.`);
+        }
         append(memories, obj[key] as unknown[]);
-        break;
+        return { memories, ...(filePath ? { importedFromPath: filePath } : {}) };
       }
+    }
+    if (!sawKnownKey) {
+      throw new Error(
+        "Supermemory export object has no recognized memory key. Expected one of 'memories', 'results', or 'data'.",
+      );
     }
   }
 
-  return { memories, ...(filePath ? { importedFromPath: filePath } : {}) };
+  throw new Error(`Supermemory export must be a JSON array or object; received ${describeType(raw)}.`);
 }
 
 function append(dest: SupermemoryRecord[], src: unknown[]): void {
   for (const item of src) {
     if (item && typeof item === "object") dest.push(item as SupermemoryRecord);
   }
+}
+
+function coerceJson(input: unknown): unknown {
+  if (typeof input !== "string") return input;
+
+  try {
+    return JSON.parse(input);
+  } catch (err) {
+    throw new Error(
+      `Supermemory export is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function describeType(value: unknown): string {
+  if (value === null) return "null";
+  return typeof value;
 }

--- a/packages/import-supermemory/src/transform.test.ts
+++ b/packages/import-supermemory/src/transform.test.ts
@@ -17,4 +17,13 @@ describe("transformSupermemoryExport", () => {
     assert.equal(out.length, 1);
     assert.equal(out[0]?.sourceTimestamp, undefined);
   });
+
+  it("falls back to createdAt when updatedAt is blank", () => {
+    const out = transformSupermemoryExport({
+      memories: [{ id: "a", content: "memo", updatedAt: " ", createdAt: "2026-05-05T00:00:00.000Z" }],
+    });
+
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.sourceTimestamp, "2026-05-05T00:00:00.000Z");
+  });
 });

--- a/packages/import-supermemory/src/transform.test.ts
+++ b/packages/import-supermemory/src/transform.test.ts
@@ -18,6 +18,15 @@ describe("transformSupermemoryExport", () => {
     assert.equal(out[0]?.sourceId, "12345");
   });
 
+  it("reads v4 memory text as imported content", () => {
+    const out = transformSupermemoryExport({
+      memories: [{ id: "a", memory: "remember this" }],
+    });
+
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.content, "remember this");
+  });
+
   it("does not emit non-string sourceTimestamp", () => {
     const out = transformSupermemoryExport({
       memories: [{ id: "a", content: "memo", createdAt: 1700000000 as unknown as string }],

--- a/packages/import-supermemory/src/transform.test.ts
+++ b/packages/import-supermemory/src/transform.test.ts
@@ -8,4 +8,13 @@ describe("transformSupermemoryExport", () => {
     assert.equal(out.length, 1);
     assert.equal(out[0]?.sourceLabel, "supermemory");
   });
+
+  it("does not emit non-string sourceTimestamp", () => {
+    const out = transformSupermemoryExport({
+      memories: [{ id: "a", content: "memo", createdAt: 1700000000 as unknown as string }],
+    });
+
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.sourceTimestamp, undefined);
+  });
 });

--- a/packages/import-supermemory/src/transform.test.ts
+++ b/packages/import-supermemory/src/transform.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { transformSupermemoryExport } from "./transform.js";
+
+describe("transformSupermemoryExport", () => {
+  it("maps record into ImportedMemory", () => {
+    const out = transformSupermemoryExport({ memories: [{ id: "a", content: "memo", containerTags: ["user_1"] }] });
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.sourceLabel, "supermemory");
+  });
+});

--- a/packages/import-supermemory/src/transform.test.ts
+++ b/packages/import-supermemory/src/transform.test.ts
@@ -9,6 +9,15 @@ describe("transformSupermemoryExport", () => {
     assert.equal(out[0]?.sourceLabel, "supermemory");
   });
 
+  it("preserves numeric source IDs", () => {
+    const out = transformSupermemoryExport({
+      memories: [{ id: 12345 as unknown as string, content: "memo" }],
+    });
+
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.sourceId, "12345");
+  });
+
   it("does not emit non-string sourceTimestamp", () => {
     const out = transformSupermemoryExport({
       memories: [{ id: "a", content: "memo", createdAt: 1700000000 as unknown as string }],

--- a/packages/import-supermemory/src/transform.ts
+++ b/packages/import-supermemory/src/transform.ts
@@ -54,7 +54,7 @@ function pickSourceId(value: unknown): string | undefined {
 }
 
 function pickContent(row: SupermemoryRecord): string | undefined {
-  for (const c of [row.content, row.summary, row.title]) {
+  for (const c of [row.content, row.memory, row.summary, row.title]) {
     if (typeof c === "string" && c.trim().length > 0) return c.trim();
   }
   return undefined;

--- a/packages/import-supermemory/src/transform.ts
+++ b/packages/import-supermemory/src/transform.ts
@@ -1,0 +1,41 @@
+import type { ImportedMemory } from "@remnic/core";
+import type { ParsedSupermemoryExport, SupermemoryRecord } from "./parser.js";
+
+export const SUPERMEMORY_SOURCE_LABEL = "supermemory";
+
+export function transformSupermemoryExport(parsed: ParsedSupermemoryExport): ImportedMemory[] {
+  const out: ImportedMemory[] = [];
+  for (const row of parsed.memories) {
+    const m = toImported(row, parsed.importedFromPath);
+    if (m) out.push(m);
+  }
+  return out;
+}
+
+function toImported(row: SupermemoryRecord, importedFromPath?: string): ImportedMemory | undefined {
+  const content = pickContent(row);
+  if (!content) return undefined;
+  const sourceId = typeof row.id === "string" && row.id.length > 0 ? row.id : content.slice(0, 64);
+  const sourceTimestamp = typeof row.updatedAt === "string" ? row.updatedAt : row.createdAt;
+  return {
+    content,
+    sourceLabel: SUPERMEMORY_SOURCE_LABEL,
+    sourceId,
+    ...(sourceTimestamp ? { sourceTimestamp } : {}),
+    ...(importedFromPath ? { importedFromPath } : {}),
+    metadata: {
+      kind: "supermemory_memory",
+      ...(Array.isArray(row.containerTags) && row.containerTags.length > 0
+        ? { containerTags: [...row.containerTags] }
+        : {}),
+      ...(row.metadata && typeof row.metadata === "object" ? { sourceMetadata: row.metadata } : {}),
+    },
+  };
+}
+
+function pickContent(row: SupermemoryRecord): string | undefined {
+  for (const c of [row.content, row.summary, row.title]) {
+    if (typeof c === "string" && c.trim().length > 0) return c.trim();
+  }
+  return undefined;
+}

--- a/packages/import-supermemory/src/transform.ts
+++ b/packages/import-supermemory/src/transform.ts
@@ -16,7 +16,12 @@ function toImported(row: SupermemoryRecord, importedFromPath?: string): Imported
   const content = pickContent(row);
   if (!content) return undefined;
   const sourceId = typeof row.id === "string" && row.id.length > 0 ? row.id : content.slice(0, 64);
-  const sourceTimestamp = typeof row.updatedAt === "string" ? row.updatedAt : row.createdAt;
+  const sourceTimestamp =
+    typeof row.updatedAt === "string"
+      ? row.updatedAt
+      : typeof row.createdAt === "string"
+        ? row.createdAt
+        : undefined;
   return {
     content,
     sourceLabel: SUPERMEMORY_SOURCE_LABEL,

--- a/packages/import-supermemory/src/transform.ts
+++ b/packages/import-supermemory/src/transform.ts
@@ -15,7 +15,7 @@ export function transformSupermemoryExport(parsed: ParsedSupermemoryExport): Imp
 function toImported(row: SupermemoryRecord, importedFromPath?: string): ImportedMemory | undefined {
   const content = pickContent(row);
   if (!content) return undefined;
-  const sourceId = typeof row.id === "string" && row.id.length > 0 ? row.id : content.slice(0, 64);
+  const sourceId = pickSourceId(row.id) ?? content.slice(0, 64);
   const sourceTimestamp = pickTimestamp(row);
   return {
     content,
@@ -38,6 +38,17 @@ function pickTimestamp(row: SupermemoryRecord): string | undefined {
     if (typeof timestamp === "string" && timestamp.trim().length > 0) {
       return timestamp.trim();
     }
+  }
+  return undefined;
+}
+
+function pickSourceId(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
   }
   return undefined;
 }

--- a/packages/import-supermemory/src/transform.ts
+++ b/packages/import-supermemory/src/transform.ts
@@ -16,12 +16,7 @@ function toImported(row: SupermemoryRecord, importedFromPath?: string): Imported
   const content = pickContent(row);
   if (!content) return undefined;
   const sourceId = typeof row.id === "string" && row.id.length > 0 ? row.id : content.slice(0, 64);
-  const sourceTimestamp =
-    typeof row.updatedAt === "string"
-      ? row.updatedAt
-      : typeof row.createdAt === "string"
-        ? row.createdAt
-        : undefined;
+  const sourceTimestamp = pickTimestamp(row);
   return {
     content,
     sourceLabel: SUPERMEMORY_SOURCE_LABEL,
@@ -36,6 +31,15 @@ function toImported(row: SupermemoryRecord, importedFromPath?: string): Imported
       ...(row.metadata && typeof row.metadata === "object" ? { sourceMetadata: row.metadata } : {}),
     },
   };
+}
+
+function pickTimestamp(row: SupermemoryRecord): string | undefined {
+  for (const timestamp of [row.updatedAt, row.createdAt]) {
+    if (typeof timestamp === "string" && timestamp.trim().length > 0) {
+      return timestamp.trim();
+    }
+  }
+  return undefined;
 }
 
 function pickContent(row: SupermemoryRecord): string | undefined {

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -42,7 +42,8 @@
     "@remnic/import-claude": "^0.1.0",
     "@remnic/import-gemini": "^0.1.0",
     "@remnic/import-lossless-claw": "^0.1.1",
-    "@remnic/import-mem0": "^0.1.0"
+    "@remnic/import-mem0": "^0.1.0",
+    "@remnic/import-supermemory": "^0.1.0"
   },
   "peerDependenciesMeta": {
     "@remnic/bench": { "optional": true },
@@ -52,7 +53,8 @@
     "@remnic/import-claude": { "optional": true },
     "@remnic/import-gemini": { "optional": true },
     "@remnic/import-lossless-claw": { "optional": true },
-    "@remnic/import-mem0": { "optional": true }
+    "@remnic/import-mem0": { "optional": true },
+    "@remnic/import-supermemory": { "optional": true }
   },
   "devDependencies": {
     "@remnic/bench": "workspace:*",
@@ -63,6 +65,7 @@
     "@remnic/import-gemini": "workspace:*",
     "@remnic/import-lossless-claw": "workspace:*",
     "@remnic/import-mem0": "workspace:*",
+    "@remnic/import-supermemory": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/remnic-cli/src/optional-importer.test.ts
+++ b/packages/remnic-cli/src/optional-importer.test.ts
@@ -13,12 +13,13 @@ describe("optional-importer loader", () => {
     clearImporterModuleCacheForTesting();
   });
 
-  it("SUPPORTED_IMPORTERS lists the four canonical sources in a stable order", () => {
+  it("SUPPORTED_IMPORTERS lists the five canonical sources in a stable order", () => {
     assert.deepEqual([...SUPPORTED_IMPORTERS], [
       "chatgpt",
       "claude",
       "gemini",
       "mem0",
+      "supermemory",
     ]);
   });
 
@@ -43,12 +44,12 @@ describe("optional-importer loader", () => {
   // destabilizes, flip it to another not-yet-shipped adapter.
   it("loading a missing importer throws a user-facing install hint", async () => {
     await assert.rejects(
-      () => loadImporterModule("gemini"),
+      () => loadImporterModule("supermemory"),
       (err: Error) => {
         // Install hint must include the package name and an install
         // command the user can actually run — not a raw MODULE_NOT_FOUND.
         assert.ok(
-          err.message.includes("@remnic/import-gemini"),
+          err.message.includes("@remnic/import-supermemory"),
           `expected package name in message, got: ${err.message}`,
         );
         assert.ok(

--- a/packages/remnic-cli/src/optional-importer.test.ts
+++ b/packages/remnic-cli/src/optional-importer.test.ts
@@ -7,6 +7,7 @@ import {
   isSupportedImporterName,
   loadImporterModule,
 } from "./optional-importer.js";
+import type { SupportedImporterName } from "./optional-importer.js";
 
 describe("optional-importer loader", () => {
   beforeEach(() => {
@@ -30,26 +31,16 @@ describe("optional-importer loader", () => {
     assert.equal(isSupportedImporterName("chatgpt "), false);
   });
 
-  // All four slice packages (chatgpt, claude, gemini, mem0) are installed
-  // alongside the CLI once the import series lands, so no durable
-  // "missing package" fixture remains inside the `remnic/import-*`
-  // family. The loader still raises a clear install hint when the user
-  // asks for an importer whose package is absent at runtime; we
-  // exercise that branch via a non-existent name that satisfies the
-  // SupportedImporterName type at the call site.
-  //
-  // Keeping "claude" here is still valid during the rollout window
-  // because PR 3 has not yet been merged from this branch's POV — the
-  // merged `main` will only see this once PR 3 lands. If this test
-  // destabilizes, flip it to another not-yet-shipped adapter.
   it("loading a missing importer throws a user-facing install hint", async () => {
+    const missing = "missing-fixture" as SupportedImporterName;
+
     await assert.rejects(
-      () => loadImporterModule("supermemory"),
+      () => loadImporterModule(missing),
       (err: Error) => {
         // Install hint must include the package name and an install
         // command the user can actually run — not a raw MODULE_NOT_FOUND.
         assert.ok(
-          err.message.includes("@remnic/import-supermemory"),
+          err.message.includes("@remnic/import-missing-fixture"),
           `expected package name in message, got: ${err.message}`,
         );
         assert.ok(
@@ -63,10 +54,12 @@ describe("optional-importer loader", () => {
   });
 
   it("loader caches negative results so repeated calls do not re-import", async () => {
+    const missing = "missing-fixture" as SupportedImporterName;
+
     // First call populates the cache with a null.
-    await assert.rejects(() => loadImporterModule("claude"));
+    await assert.rejects(() => loadImporterModule(missing));
     // Second call must still throw — but the cache hit path is covered
     // exclusively by the branch that rejects from cached null.
-    await assert.rejects(() => loadImporterModule("claude"));
+    await assert.rejects(() => loadImporterModule(missing));
   });
 });

--- a/packages/remnic-cli/src/optional-importer.ts
+++ b/packages/remnic-cli/src/optional-importer.ts
@@ -41,6 +41,7 @@ export const SUPPORTED_IMPORTERS = [
   "claude",
   "gemini",
   "mem0",
+  "supermemory",
 ] as const;
 export type SupportedImporterName = (typeof SUPPORTED_IMPORTERS)[number];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -85,7 +85,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -110,19 +110,19 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.1.0
-        version: 5.2.0(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^7.1.12
-        version: 7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/connector-replit:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -131,7 +131,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -147,7 +147,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -159,7 +159,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -171,7 +171,7 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -186,7 +186,7 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -202,7 +202,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -224,7 +224,7 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -239,7 +239,23 @@ importers:
         version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/import-supermemory:
+    dependencies:
+      '@remnic/core':
+        specifier: workspace:^
+        version: link:../remnic-core
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -255,7 +271,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -278,14 +294,14 @@ importers:
         version: link:../remnic-core
       openai:
         specifier: ^6.0.0
-        version: 6.33.0(ws@8.20.0)(zod@4.4.3)
+        version: 6.33.0(zod@4.0.0)
     devDependencies:
       '@openclaw/plugin-inspector':
         specifier: 0.3.10
         version: 0.3.10
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -325,7 +341,7 @@ importers:
         version: link:../import-weclone
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -364,7 +380,7 @@ importers:
         version: 12.3.0
       openai:
         specifier: ^6.0.0
-        version: 6.33.0(ws@8.20.0)(zod@3.25.76)
+        version: 6.33.0(zod@3.25.76)
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -374,7 +390,7 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -397,7 +413,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -413,7 +429,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -702,28 +718,24 @@ packages:
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@lancedb/lancedb-linux-arm64-musl@0.26.2':
     resolution: {integrity: sha512-pR6Hs/0iphItrJYYLf/yrqCC+scPcHpCGl6rHqcU2GHxo5RFpzlMzqW1DiXScGiBRuCcD9HIMec+kBsOgXv4GQ==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@lancedb/lancedb-linux-x64-gnu@0.26.2':
     resolution: {integrity: sha512-u4UUSPwd2YecgGqWjh9W0MHKgsVwB2Ch2ROpF8AY+IA7kpGsbB18R1/t7v2B0q7pahRy20dgsaku5LH1zuzMRQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@lancedb/lancedb-linux-x64-musl@0.26.2':
     resolution: {integrity: sha512-XIS4qkVfGlzmsUPqAG2iKt8ykuz28GfemGC0ijXwu04kC1pYiCFzTpB3UIZjm5oM7OTync1aQ3mGTj1oCciSPA==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@lancedb/lancedb-win32-arm64-msvc@0.26.2':
     resolution: {integrity: sha512-//tZDPitm2PxNvalHP+m+Pf6VvFAeQgcht1+HJnutjH4gp6xYW6ynQlWWFDBmz9WRkUT+mXu2O4FUIhbdNaJSQ==}
@@ -793,28 +805,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@node-rs/argon2-linux-arm64-musl@2.0.2':
     resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@node-rs/argon2-linux-x64-gnu@2.0.2':
     resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@node-rs/argon2-linux-x64-musl@2.0.2':
     resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@node-rs/argon2-wasm32-wasi@2.0.2':
     resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
@@ -892,79 +900,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1280,10 +1275,6 @@ packages:
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
-
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
-    hasBin: true
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1714,18 +1705,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -1743,9 +1722,6 @@ packages:
 
   zod@4.0.0:
     resolution: {integrity: sha512-9diLdTPc/L7w/5jI4C3gHYNiGHDV9IZYxo1e5LSD8cabi65WVTWWb+g2BGPEpUUCOxR4D+6O5B0AzyMdUAXwrw==}
-
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -2232,7 +2208,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2240,7 +2216,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -2460,9 +2436,6 @@ snapshots:
 
   isexe@4.0.0: {}
 
-  jiti@2.6.1:
-    optional: true
-
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -2551,19 +2524,13 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@6.33.0(ws@8.20.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.20.0
-      zod: 3.25.76
-
-  openai@6.33.0(ws@8.20.0)(zod@4.4.3):
-    optionalDependencies:
-      ws: 8.20.0
-      zod: 4.4.3
-
   openai@6.33.0(zod@3.25.76):
     optionalDependencies:
       zod: 3.25.76
+
+  openai@6.33.0(zod@4.0.0):
+    optionalDependencies:
+      zod: 4.0.0
 
   pathe@2.0.3: {}
 
@@ -2579,20 +2546,13 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.6.1
       postcss: 8.5.10
       tsx: 4.21.0
       yaml: 2.8.3
-
-  postcss-load-config@6.0.1(tsx@4.21.0):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      tsx: 4.21.0
 
   postcss@8.5.10:
     dependencies:
@@ -2790,7 +2750,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -2801,7 +2761,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -2811,33 +2771,6 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.10
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.7)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3
-      esbuild: 0.27.7
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(tsx@4.21.0)
-      resolve-from: 5.0.0
-      rollup: 4.60.1
-      source-map: 0.7.6
-      sucrase: 3.35.1
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -2878,7 +2811,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2889,7 +2822,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.2
       fsevents: 2.3.3
-      jiti: 2.6.1
       tsx: 4.21.0
       yaml: 2.8.3
 
@@ -2901,9 +2833,6 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0:
-    optional: true
-
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
@@ -2913,6 +2842,3 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.0.0: {}
-
-  zod@4.4.3:
-    optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,9 @@ importers:
       '@remnic/import-mem0':
         specifier: workspace:*
         version: link:../import-mem0
+      '@remnic/import-supermemory':
+        specifier: workspace:*
+        version: link:../import-supermemory
       '@remnic/import-weclone':
         specifier: workspace:*
         version: link:../import-weclone
@@ -718,24 +721,28 @@ packages:
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@lancedb/lancedb-linux-arm64-musl@0.26.2':
     resolution: {integrity: sha512-pR6Hs/0iphItrJYYLf/yrqCC+scPcHpCGl6rHqcU2GHxo5RFpzlMzqW1DiXScGiBRuCcD9HIMec+kBsOgXv4GQ==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@lancedb/lancedb-linux-x64-gnu@0.26.2':
     resolution: {integrity: sha512-u4UUSPwd2YecgGqWjh9W0MHKgsVwB2Ch2ROpF8AY+IA7kpGsbB18R1/t7v2B0q7pahRy20dgsaku5LH1zuzMRQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@lancedb/lancedb-linux-x64-musl@0.26.2':
     resolution: {integrity: sha512-XIS4qkVfGlzmsUPqAG2iKt8ykuz28GfemGC0ijXwu04kC1pYiCFzTpB3UIZjm5oM7OTync1aQ3mGTj1oCciSPA==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@lancedb/lancedb-win32-arm64-msvc@0.26.2':
     resolution: {integrity: sha512-//tZDPitm2PxNvalHP+m+Pf6VvFAeQgcht1+HJnutjH4gp6xYW6ynQlWWFDBmz9WRkUT+mXu2O4FUIhbdNaJSQ==}
@@ -805,24 +812,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/argon2-linux-arm64-musl@2.0.2':
     resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/argon2-linux-x64-gnu@2.0.2':
     resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/argon2-linux-x64-musl@2.0.2':
     resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/argon2-wasm32-wasi@2.0.2':
     resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
@@ -900,66 +911,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}


### PR DESCRIPTION
### Motivation

- Provide a clear, supported migration path for operators to move memories from the Supermemory SaaS into Remnic via a first-class importer and docs. 
- Avoid ad-hoc one-off instructions by shipping a reusable `@remnic/import-supermemory` adapter that fits the existing importer framework and provenance model.

### Description

- Add a new optional importer package `packages/import-supermemory` with `parser.ts`, `transform.ts`, `adapter.ts`, `index.ts`, tests, and a `package.json` so Supermemory exports can be parsed, transformed into `ImportedMemory`, and written using `defaultWriteMemoriesToOrchestrator`. 
- Map Supermemory records to Remnic memories by preferring `content` then `summary`/`title`, preserve `containerTags` and `metadata` under `metadata.sourceMetadata`, and populate `sourceLabel`, `sourceId`, and `sourceTimestamp` for provenance. 
- Wire `supermemory` into the CLI loader by adding it to `SUPPORTED_IMPORTERS` and update the optional-importer tests to validate the new entry and the missing-package install-hint behavior. 
- Expand `docs/importers.md` with a concise `Supermemory → Remnic quick migration` walkthrough showing an example export `curl`, `npm install -g @remnic/import-supermemory`, and the recommended `remnic import --adapter supermemory --file <file> [--dry-run]` flow.

### Testing

- Ran `npm test --workspace packages/import-supermemory` and the package unit tests (parser/transform/adapter) passed. 
- Ran the updated importer loader unit test `npx tsx --test packages/remnic-cli/src/optional-importer.test.ts` which passed after the test was updated for the new `supermemory` entry. 
- Attempted the full preflight `npm run preflight:quick`, which failed in this environment due to a missing `plugin-inspector` binary used by the `plugin-openclaw` preflight step and unrelated module resolution issues in the sandbox; these are environmental and not caused by the importer changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95f0bf6ac832eb6748535291129cb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new optional importer package plus new parsing/transform logic for third-party exports, which could impact import correctness and provenance metadata. CLI support changes are small but expand supported adapter names and dependency wiring.
> 
> **Overview**
> Adds a new optional `@remnic/import-supermemory` importer package with a tested `parser`/`transform`/`adapter` pipeline that accepts multiple Supermemory export shapes and maps them into `ImportedMemory` with provenance and preserved `containerTags`/source metadata.
> 
> Updates the CLI to recognize `supermemory` in `SUPPORTED_IMPORTERS`, adds the package as an optional peer/dev dependency, adjusts loader tests to cover the new supported list and missing-package install-hint behavior, and expands `docs/importers.md` with a Supermemory migration quickstart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acc7972a85f524237669db0444036a00ae3ceb10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->