### PR TITLE
fix(release): publish Supermemory importer

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -366,6 +366,7 @@ jobs:
             packages/import-gemini
             packages/import-mem0
             packages/import-lossless-claw
+            packages/import-supermemory
             packages/connector-weclone
             packages/connector-replit
             packages/hermes-provider
@@ -407,9 +408,9 @@ jobs:
               publish_status=$?
               cat "$publish_log"
               if [ "$pkg_exists" != "true" ] && grep -q "npm error code E404" "$publish_log"; then
-                echo "::warning::${pkg_name}@${pkg_version} is not provisioned for first-time npm publish from this automation yet; skipping so existing package updates can still ship."
+                echo "::error::${pkg_name}@${pkg_version} is not provisioned for first-time npm publish from this automation. Set up trusted publishing for this package, then rerun the release workflow."
                 rm -f "$publish_log"
-                continue
+                exit $publish_status
               fi
               rm -f "$publish_log"
               exit $publish_status

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/import-supermemory/package.json
+++ b/packages/import-supermemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/import-supermemory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Import Supermemory exports into Remnic",
   "type": "module",
   "main": "dist/index.js",
@@ -22,10 +22,11 @@
     "access": "public",
     "provenance": true
   },
-  "dependencies": {
+  "peerDependencies": {
     "@remnic/core": "workspace:^"
   },
   "devDependencies": {
+    "@remnic/core": "workspace:*",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0"

--- a/packages/import-supermemory/tsconfig.json
+++ b/packages/import-supermemory/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/cli",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "CLI for Remnic memory — init, query, doctor, daemon management",
   "type": "module",
   "main": "dist/index.js",
@@ -43,7 +43,7 @@
     "@remnic/import-gemini": "^0.1.0",
     "@remnic/import-lossless-claw": "^0.1.1",
     "@remnic/import-mem0": "^0.1.0",
-    "@remnic/import-supermemory": "^0.1.0"
+    "@remnic/import-supermemory": "^0.1.1"
   },
   "peerDependenciesMeta": {
     "@remnic/bench": { "optional": true },

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,9 +1,9 @@
 {
   "id": "openclaw-engram",
   "name": "Remnic OpenClaw Plugin",
-  "version": "9.3.17",
+  "version": "9.3.18",
   "kind": "memory",
-  "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+  "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {
     "providers": [
       {
@@ -28,19 +28,39 @@
       "provider": "openai",
       "method": "api-key",
       "choiceId": "remnic-openai-api-key",
-      "choiceLabel": "OpenAI API key for Remnic memory extraction",
-      "choiceHint": "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
+      "choiceLabel": "Optional OpenAI API key for Remnic plugin-mode extraction",
+      "choiceHint": "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
       "groupId": "remnic-memory",
       "groupLabel": "Remnic memory",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",
-      "cliDescription": "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
+      "cliDescription": "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
       "onboardingScopes": [
         "text-inference"
       ]
     }
   ],
+  "securityDisclosure": {
+    "conversationAccess": "As a memory-slot plugin, Remnic hooks can observe conversation turns, tool-use metadata, LLM output metadata, and local memory files so they can be indexed, summarized, recalled, and exposed through memory tools.",
+    "modelProviderCredentials": {
+      "recommendedMode": "Use modelSource=gateway to route LLM-backed memory work through OpenClaw gateway agents instead of a Remnic-owned API key.",
+      "dynamicCredentialSources": [
+        "OpenClaw runtime auth resolver for configured model providers",
+        "~/.openclaw/agents/main/agent/models.json provider entries",
+        "provider-specific environment variables such as <PROVIDER>_API_KEY and <PROVIDER>_TOKEN"
+      ],
+      "providerModeData": [
+        "conversation excerpts",
+        "memory excerpts",
+        "summaries",
+        "embedding inputs",
+        "active-recall query inputs",
+        "benchmark and evaluation inputs"
+      ],
+      "externalProviderGuidance": "Do not set openaiApiKey or provider environment variables for Remnic if all LLM-backed memory operations should stay on the OpenClaw gateway path. When plugin/provider mode is configured, selected conversation and memory excerpts may be sent to the configured provider for extraction, consolidation, summarization, embeddings, active recall, or benchmark judging."
+    }
+  },
   "supports": {
     "memorySlot": true,
     "dreamingSlot": true,
@@ -70,13 +90,13 @@
       "commands.list"
     ],
     "memoryCapabilities": [
-      "openclaw-engram"
+      "openclaw-remnic"
     ],
     "memoryPromptSections": [
       "engram-memory"
     ],
     "services": [
-      "openclaw-engram"
+      "openclaw-remnic"
     ],
     "tools": [
       "compounding_promote_candidate",
@@ -135,11 +155,11 @@
     "properties": {
       "openaiApiKey": {
         "type": "string",
-        "description": "OpenAI API key (or set OPENAI_API_KEY env var). Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
+        "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
       },
       "openaiBaseUrl": {
         "type": "string",
-        "description": "Override the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
+        "description": "Set the OpenAI API base URL for OpenAI-compatible providers (Scryr, Together, OpenRouter, etc.)"
       },
       "model": {
         "type": "string",
@@ -222,7 +242,7 @@
       "maxMemoryTokens": {
         "type": "number",
         "default": 2000,
-        "description": "Max tokens injected per turn"
+        "description": "Max memory-context tokens per turn"
       },
       "memoryOsPreset": {
         "type": "string",
@@ -233,7 +253,7 @@
           "research-max",
           "local-llm-heavy"
         ],
-        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting overrides are applied. `research` is accepted as a backward-compatible alias for `research-max`."
+        "description": "Optional named preset that seeds Engram's advanced config surface before explicit per-setting settings are applied. `research` is accepted as a backward-compatible alias for `research-max`."
       },
       "qmdEnabled": {
         "type": "boolean",
@@ -325,7 +345,7 @@
       },
       "entitySchemas": {
         "type": "object",
-        "description": "Optional per-entity-type structured section schema overrides.",
+        "description": "Optional per-entity-type structured section schema customizations.",
         "additionalProperties": {
           "type": "object",
           "additionalProperties": false,
@@ -666,7 +686,7 @@
             "minimum": 1,
             "maximum": 10,
             "default": 2,
-            "description": "Maximum procedure memories to inject on task-initiation recall."
+            "description": "Maximum procedure memories to add on task-initiation recall."
           },
           "proceduralMiningCronAutoRegister": {
             "type": "boolean",
@@ -754,7 +774,7 @@
       "recallTranscriptsEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Write JSONL recall audit transcripts for runtime-surface injections."
+        "description": "Write JSONL recall audit transcripts for runtime recall-context assembly."
       },
       "recallTranscriptRetentionDays": {
         "type": "integer",
@@ -771,7 +791,7 @@
       "activeRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable the OpenClaw active-recall prompt surface."
+        "description": "Enable the OpenClaw active-recall context surface."
       },
       "activeRecallAgents": {
         "type": "array",
@@ -818,7 +838,7 @@
           "preference-only"
         ],
         "default": "balanced",
-        "description": "Prompt assembly style for the active-recall surface."
+        "description": "Context assembly style for the active-recall surface."
       },
       "activeRecallCustomInstruction": {
         "type": "string",
@@ -826,7 +846,7 @@
       },
       "activeRecallPromptAppend": {
         "type": "string",
-        "description": "Optional additional guidance appended to the active-recall builder."
+        "description": "Optional additional guidance for the active-recall builder."
       },
       "activeRecallMaxSummaryChars": {
         "type": "integer",
@@ -892,7 +912,7 @@
       },
       "activeRecallModel": {
         "type": "string",
-        "description": "Optional model override for active recall."
+        "description": "Optional model selection for active recall."
       },
       "activeRecallModelFallbackPolicy": {
         "type": "string",
@@ -1208,7 +1228,7 @@
       "memoryExtensionsEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Whether third-party memory extensions are discovered and injected into consolidation prompts."
+        "description": "Whether third-party memory extensions are discovered and included in consolidation instructions."
       },
       "memoryExtensionsRoot": {
         "type": "string",
@@ -1292,12 +1312,12 @@
           "full"
         ],
         "default": "recovery_only",
-        "description": "Controls when identity continuity context is injected into recall assembly"
+        "description": "Controls when identity continuity context is added to recall assembly"
       },
       "identityMaxInjectChars": {
         "type": "number",
         "default": 1200,
-        "description": "Maximum characters allowed for identity continuity context injection"
+        "description": "Maximum characters allowed for identity continuity context"
       },
       "continuityIncidentLoggingEnabled": {
         "type": "boolean",
@@ -1498,12 +1518,12 @@
           "maxResults": {
             "type": "number",
             "default": 4,
-            "description": "Maximum native knowledge chunks to inject into recall."
+            "description": "Maximum native knowledge chunks to add to recall."
           },
           "maxChars": {
             "type": "number",
             "default": 2400,
-            "description": "Maximum total characters to inject from native knowledge recall."
+            "description": "Maximum total characters to add from native knowledge recall."
           },
           "stateDir": {
             "type": "string",
@@ -1777,7 +1797,7 @@
       "recordEmptyRecallImpressions": {
         "type": "boolean",
         "default": false,
-        "description": "Record recall impressions with empty memoryIds when no memory context is injected."
+        "description": "Record recall impressions with empty memoryIds when no memory context is added."
       },
       "recallPlannerEnabled": {
         "type": "boolean",
@@ -1852,7 +1872,7 @@
       "verbatimArtifactsMaxRecall": {
         "type": "number",
         "default": 5,
-        "description": "Maximum artifact anchors injected per recall."
+        "description": "Maximum artifact anchors added per recall."
       },
       "verbatimArtifactCategories": {
         "type": "array",
@@ -1918,7 +1938,7 @@
       "boxRecallDays": {
         "type": "number",
         "default": 3,
-        "description": "Number of recent days of boxes to inject during recall."
+        "description": "Number of recent days of boxes to add during recall."
       },
       "episodeNoteModeEnabled": {
         "type": "boolean",
@@ -1983,7 +2003,7 @@
       "tagRecallMaxMatches": {
         "type": "number",
         "default": 10,
-        "description": "Maximum number of tag-matched memories injected per recall."
+        "description": "Maximum number of tag-matched memories added per recall."
       },
       "multiGraphMemoryEnabled": {
         "type": "boolean",
@@ -2013,7 +2033,7 @@
       "graphRecallShadowEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Run graph recall in shadow mode — evaluate but do not inject results."
+        "description": "Run graph recall in shadow mode - evaluate but do not add results."
       },
       "graphRecallSnapshotEnabled": {
         "type": "boolean",
@@ -2127,12 +2147,12 @@
       "graphRecallEntityHintMax": {
         "type": "number",
         "default": 3,
-        "description": "Maximum number of entity hints injected per graph recall result."
+        "description": "Maximum number of entity hints added per graph recall result."
       },
       "graphRecallEntityHintMaxChars": {
         "type": "number",
         "default": 200,
-        "description": "Maximum characters per entity hint injected during graph recall."
+        "description": "Maximum characters per entity hint added during graph recall."
       },
       "graphRecallSnapshotDir": {
         "type": "string",
@@ -2161,7 +2181,7 @@
       "graphAssistShadowEvalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep injected recall output baseline-identical."
+        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep recall output baseline-identical."
       },
       "graphAssistMinSeedResults": {
         "type": "number",
@@ -2239,12 +2259,12 @@
       "recallConfidenceGateEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Synapse-inspired confidence gate: skip memory injection when top recall score is below threshold"
+        "description": "Synapse-inspired confidence gate: skip memory context when top recall score is below threshold"
       },
       "recallConfidenceGateThreshold": {
         "type": "number",
         "default": 0.12,
-        "description": "Minimum top recall score to inject memories (0-1). Below this, memories are rejected as too uncertain"
+        "description": "Minimum top recall score to include memories (0-1). Below this, memories are rejected as too uncertain"
       },
       "causalRuleExtractionEnabled": {
         "type": "boolean",
@@ -2850,12 +2870,12 @@
       "maxTranscriptTurns": {
         "type": "number",
         "default": 50,
-        "description": "Maximum transcript turns to inject"
+        "description": "Maximum transcript turns to include"
       },
       "maxTranscriptTokens": {
         "type": "number",
         "default": 1000,
-        "description": "Maximum tokens for transcript injection"
+        "description": "Maximum tokens for transcript context"
       },
       "checkpointEnabled": {
         "type": "boolean",
@@ -2870,7 +2890,7 @@
       "compactionResetEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Trigger session reset after compaction with BOOT.md injection (requires OC fork with api.resetSession)"
+        "description": "Trigger session reset after compaction with BOOT.md recovery context (requires OC fork with api.resetSession)"
       },
       "hourlySummariesEnabled": {
         "type": "boolean",
@@ -2890,7 +2910,7 @@
       "maxSummaryCount": {
         "type": "number",
         "default": 6,
-        "description": "Maximum number of summaries to inject"
+        "description": "Maximum number of summaries to include"
       },
       "summaryModel": {
         "type": "string",
@@ -2902,8 +2922,8 @@
           "plugin",
           "gateway"
         ],
-        "default": "plugin",
-        "description": "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[])."
+        "default": "gateway",
+        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
       },
       "gatewayAgentId": {
         "type": "string",
@@ -2981,7 +3001,7 @@
       "traceRecallContent": {
         "type": "boolean",
         "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default — only enable when you want external trace collectors to capture injected memory context."
+        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default - only enable when you want external trace collectors to capture memory context."
       },
       "profilingEnabled": {
         "type": "boolean",
@@ -3198,7 +3218,7 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is only injected when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is sent only when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
       },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
@@ -3312,12 +3332,12 @@
       "conversationRecallTopK": {
         "type": "number",
         "default": 3,
-        "description": "Top-K conversation chunks to inject."
+        "description": "Top-K conversation chunks to include."
       },
       "conversationRecallMaxChars": {
         "type": "number",
         "default": 2500,
-        "description": "Max characters of semantic conversation recall to inject."
+        "description": "Max characters of semantic conversation recall to include."
       },
       "conversationRecallTimeoutMs": {
         "type": "number",
@@ -3366,7 +3386,7 @@
       "objectiveStateRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant objective-state snapshots into recall context."
+        "description": "Add recall-relevant objective-state snapshots to recall context."
       },
       "objectiveStateStoreDir": {
         "type": "string",
@@ -3384,7 +3404,7 @@
       "causalTrajectoryRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant causal trajectories into recall context."
+        "description": "Add recall-relevant causal trajectories to recall context."
       },
       "trustZonesEnabled": {
         "type": "boolean",
@@ -3403,7 +3423,7 @@
       "trustZoneRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant working and trusted trust-zone records into recall context."
+        "description": "Add recall-relevant working and trusted trust-zone records to recall context."
       },
       "memoryPoisoningDefenseEnabled": {
         "type": "boolean",
@@ -3418,7 +3438,7 @@
       "harmonicRetrievalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section injection and harmonic-search diagnostics."
+        "description": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
       },
       "abstractionAnchorsEnabled": {
         "type": "boolean",
@@ -3432,7 +3452,7 @@
       "verifiedRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+        "description": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
       },
       "semanticRulePromotionEnabled": {
         "type": "boolean",
@@ -3489,7 +3509,7 @@
       "operatorAwareConsolidationEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Opt in to operator-aware consolidation prompts so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+        "description": "Opt in to operator-aware consolidation instructions so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
       },
       "peerProfileReasonerEnabled": {
         "type": "boolean",
@@ -3516,13 +3536,13 @@
       "peerProfileRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "When true, inject the active peer's profile fields into the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
+        "description": "When true, add the active peer's profile fields to the recall context as a '## Peer Profile' section (issue #679 PR 3/5). Requires the session's peer ID to be registered before recall. Default off (opt-in)."
       },
       "peerProfileRecallMaxFields": {
         "type": "number",
         "default": 5,
         "minimum": 0,
-        "description": "Maximum number of peer profile fields to inject per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field injection even when peerProfileRecallEnabled is true."
+        "description": "Maximum number of peer profile fields to add per recall call. Only the most-recently-updated N fields are included. Set to 0 to disable field inclusion even when peerProfileRecallEnabled is true."
       },
       "creationMemoryEnabled": {
         "type": "boolean",
@@ -3570,7 +3590,7 @@
       "workProductRecallEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Inject prompt-relevant work-product ledger entries into recall context and expose artifact-recovery search tooling."
+        "description": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
       },
       "workProductLedgerDir": {
         "type": "string",
@@ -3810,7 +3830,7 @@
       "sharedContextEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable shared-context injection + tools (v4.0). Default off."
+        "description": "Enable shared-context assembly and tools (v4.0). Default off."
       },
       "sharedContextDir": {
         "type": "string",
@@ -3819,7 +3839,7 @@
       "sharedContextMaxInjectChars": {
         "type": "number",
         "default": 4000,
-        "description": "Max characters of shared-context to inject into each prompt."
+        "description": "Max characters of shared-context to include in each recall context."
       },
       "crossSignalsSemanticEnabled": {
         "type": "boolean",
@@ -4092,17 +4112,17 @@
       "calibrationEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable recall calibration rules injection (v9.0, default off)."
+        "description": "Enable recall calibration rules (v9.0, default off)."
       },
       "calibrationMaxRulesPerRecall": {
         "type": "number",
         "default": 10,
-        "description": "Maximum number of calibration rules to inject per recall pass."
+        "description": "Maximum number of calibration rules to include per recall pass."
       },
       "calibrationMaxChars": {
         "type": "number",
         "default": 1200,
-        "description": "Maximum characters of calibration content to inject per recall pass."
+        "description": "Maximum characters of calibration content to include per recall pass."
       },
       "lancedbEnabled": {
         "type": "boolean",
@@ -4267,7 +4287,7 @@
       },
       "recallBudgetChars": {
         "type": "number",
-        "description": "Hard character cap for total recall injection. Defaults to maxMemoryTokens * 4."
+        "description": "Hard character cap for total recall context. Defaults to maxMemoryTokens * 4."
       },
       "recallOuterTimeoutMs": {
         "type": "number",
@@ -4287,7 +4307,7 @@
       "recallMmrEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the injected context."
+        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the included context."
       },
       "recallMmrLambda": {
         "type": "number",
@@ -4428,7 +4448,7 @@
       "messagePartsRecallMaxResults": {
         "type": "number",
         "default": 6,
-        "description": "Maximum structured message-part matches to inject into recall when messagePartsEnabled is true."
+        "description": "Maximum structured message-part matches to include in recall when messagePartsEnabled is true."
       },
       "ircEnabled": {
         "type": "boolean",
@@ -4438,7 +4458,7 @@
       "ircMaxPreferences": {
         "type": "number",
         "default": 20,
-        "description": "Maximum number of preferences to include in IRC rule injection."
+        "description": "Maximum number of preferences to include in IRC rules."
       },
       "ircIncludeCorrections": {
         "type": "boolean",
@@ -4493,7 +4513,7 @@
       "cmcRetrievalEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Enable CMC retrieval injection at recall time (default off)."
+        "description": "Enable CMC retrieval at recall time (default off)."
       },
       "cmcRetrievalMaxDepth": {
         "type": "number",
@@ -4503,7 +4523,7 @@
       "cmcRetrievalMaxChars": {
         "type": "number",
         "default": 800,
-        "description": "Maximum characters of CMC content injected per recall pass."
+        "description": "Maximum characters of CMC content included per recall pass."
       },
       "cmcRetrievalCounterfactualBoost": {
         "type": "number",
@@ -4638,7 +4658,7 @@
       "label": "OpenAI API Key",
       "sensitive": true,
       "placeholder": "sk-...",
-      "help": "API key for OpenAI (or use ${OPENAI_API_KEY})"
+      "help": "Optional API key for plugin mode only. Not needed when Model Source is gateway."
     },
     "openaiBaseUrl": {
       "label": "OpenAI Base URL",
@@ -4779,13 +4799,13 @@
       "help": "Enable identity continuity workflows (anchor, incidents, audits)"
     },
     "identityInjectionMode": {
-      "label": "Identity Injection Mode",
+      "label": "Identity Context Mode",
       "advanced": true,
       "placeholder": "recovery_only",
-      "help": "When to inject identity continuity context: recovery_only, minimal, or full"
+      "help": "When to add identity continuity context: recovery_only, minimal, or full"
     },
     "identityMaxInjectChars": {
-      "label": "Identity Max Inject Chars",
+      "label": "Identity Max Context Chars",
       "advanced": true,
       "placeholder": "1200"
     },
@@ -5062,7 +5082,7 @@
     },
     "compactionResetEnabled": {
       "label": "Compaction Reset",
-      "help": "Reset session after compaction and inject BOOT.md for recovery",
+      "help": "Reset session after compaction and add BOOT.md recovery context",
       "advanced": true
     },
     "hourlySummariesEnabled": {
@@ -5086,7 +5106,7 @@
     },
     "modelSource": {
       "label": "Model Source",
-      "help": "Route LLM calls through the gateway's agent model chain instead of Engram's own config. When set to 'gateway', localLlm and openai settings are ignored."
+      "help": "Route LLM calls through the gateway's agent model chain instead of Engram's own config. Default for OpenClaw installs. When set to 'gateway', localLlm and openai settings are ignored."
     },
     "gatewayAgentId": {
       "label": "Gateway Agent ID",
@@ -5224,7 +5244,7 @@
     "objectiveStateRecallEnabled": {
       "label": "Objective-State Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant objective-state snapshots into recall context."
+      "help": "Add recall-relevant objective-state snapshots to recall context."
     },
     "objectiveStateStoreDir": {
       "label": "Objective-State Store Directory",
@@ -5245,7 +5265,7 @@
     "causalTrajectoryRecallEnabled": {
       "label": "Causal Trajectory Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant causal trajectories into recall context."
+      "help": "Add recall-relevant causal trajectories to recall context."
     },
     "trustZonesEnabled": {
       "label": "Trust Zones",
@@ -5265,7 +5285,7 @@
     "trustZoneRecallEnabled": {
       "label": "Trust-Zone Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant working and trusted trust-zone records into recall context."
+      "help": "Add recall-relevant working and trusted trust-zone records to recall context."
     },
     "memoryPoisoningDefenseEnabled": {
       "label": "Memory Poisoning Defense",
@@ -5279,7 +5299,7 @@
     },
     "harmonicRetrievalEnabled": {
       "label": "Harmonic Retrieval",
-      "help": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section injection and harmonic-search diagnostics."
+      "help": "Enable harmonic retrieval blending over abstraction nodes and cue anchors, including recall-section assembly and harmonic-search diagnostics."
     },
     "abstractionAnchorsEnabled": {
       "label": "Abstraction Anchors",
@@ -5294,7 +5314,7 @@
     },
     "verifiedRecallEnabled": {
       "label": "Verified Recall",
-      "help": "Inject prompt-relevant memory boxes only when their cited source memories verify as non-archived episodes."
+      "help": "Add recall-relevant memory boxes only when their cited source memories verify as non-archived episodes."
     },
     "semanticRulePromotionEnabled": {
       "label": "Semantic Rule Promotion",
@@ -5342,9 +5362,9 @@
       "help": "Max memories to consolidate per run to limit LLM cost."
     },
     "operatorAwareConsolidationEnabled": {
-      "label": "Operator-Aware Consolidation Prompt",
+      "label": "Operator-Aware Consolidation",
       "advanced": true,
-      "help": "Opt in to operator-aware consolidation prompts (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+      "help": "Opt in to operator-aware consolidation instructions (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
     },
     "peerProfileReasonerEnabled": {
       "label": "Peer Profile Reasoner",
@@ -5367,14 +5387,14 @@
       "help": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
     },
     "peerProfileRecallEnabled": {
-      "label": "Peer Profile Recall Injection",
+      "label": "Peer Profile Recall",
       "advanced": true,
-      "help": "When enabled, injects the active peer's profile fields into recall context as a '## Peer Profile' section. Requires the session peer ID to be registered. Default off."
+      "help": "When enabled, adds the active peer's profile fields to recall context as a '## Peer Profile' section. Requires the session peer ID to be registered. Default off."
     },
     "peerProfileRecallMaxFields": {
       "label": "Peer Profile Recall Max Fields",
       "advanced": true,
-      "help": "Maximum number of peer profile fields to inject per recall. Only the most-recently-updated N fields are included. Set to 0 to disable injection."
+      "help": "Maximum number of peer profile fields to add per recall. Only the most-recently-updated N fields are included. Set to 0 to disable this feature."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",
@@ -5426,7 +5446,7 @@
     "workProductRecallEnabled": {
       "label": "Work-Product Recall",
       "advanced": true,
-      "help": "Inject prompt-relevant work-product ledger entries into recall context and expose artifact-recovery search tooling."
+      "help": "Add recall-relevant work-product ledger entries to recall context and expose artifact-recovery search tooling."
     },
     "workProductLedgerDir": {
       "label": "Work-Product Ledger Directory",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -28,14 +28,14 @@
       "provider": "openai",
       "method": "api-key",
       "choiceId": "remnic-openai-api-key",
-      "choiceLabel": "Optional OpenAI API key for Remnic plugin-mode extraction",
-      "choiceHint": "Not needed when Remnic uses the OpenClaw gateway model source. Set only if you intentionally use plugin mode with OpenAI or an OpenAI-compatible endpoint.",
+      "choiceLabel": "OpenAI API key for Remnic memory extraction",
+      "choiceHint": "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
       "groupId": "remnic-memory",
       "groupLabel": "Remnic memory",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",
-      "cliDescription": "Optional OpenAI API key used by Remnic plugin-mode extraction, consolidation, and embedding flows.",
+      "cliDescription": "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
       "onboardingScopes": [
         "text-inference"
       ]
@@ -90,13 +90,13 @@
       "commands.list"
     ],
     "memoryCapabilities": [
-      "openclaw-remnic"
+      "openclaw-engram"
     ],
     "memoryPromptSections": [
       "engram-memory"
     ],
     "services": [
-      "openclaw-remnic"
+      "openclaw-engram"
     ],
     "tools": [
       "compounding_promote_candidate",
@@ -2922,8 +2922,8 @@
           "plugin",
           "gateway"
         ],
-        "default": "gateway",
-        "description": "LLM source: 'gateway' delegates to a gateway agent's model chain (agents.list[]); 'plugin' uses Engram's own openai/localLlm config."
+        "default": "plugin",
+        "description": "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[])."
       },
       "gatewayAgentId": {
         "type": "string",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.17",
+  "version": "9.3.18",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,11 +248,10 @@ importers:
         version: 5.9.3
 
   packages/import-supermemory:
-    dependencies:
-      '@remnic/core':
-        specifier: workspace:^
-        version: link:../remnic-core
     devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 // Topological publish order: core first, then the à-la-carte companion
-// packages (bench, weclone family, connector-replit) that install
+// packages (bench, importer/exporter family, connector-replit) that install
 // surfaces depend on, then the depend-on-core runtimes (server, CLI) and
 // plugin bundles (openclaw + per-agent plugins), and finally the legacy
 // shim that lives at the tail. Keep in sync with PUBLISH_ORDER in
@@ -18,6 +18,7 @@ const expectedPublishDirs = [
   "packages/import-gemini",
   "packages/import-mem0",
   "packages/import-lossless-claw",
+  "packages/import-supermemory",
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/hermes-provider",

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.17");
+  assert.equal(pkg.version, "9.3.18");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary
- add a package-local tsconfig for @remnic/import-supermemory so DTS builds do not inherit the root @remnic/core source alias
- add @remnic/import-supermemory to the release publish order and fail loudly if first-time npm publishing is not provisioned
- bump @remnic/core, @remnic/cli, @remnic/plugin-openclaw, @joshuaswarren/openclaw-engram, and @remnic/import-supermemory so npm/ClawHub have fresh versions to publish
- sync OpenClaw plugin manifest versions, including the legacy shim

## Verification
- pnpm --filter @remnic/core build
- pnpm --filter @remnic/import-supermemory build
- pnpm --filter @remnic/import-supermemory test
- pnpm --filter @remnic/cli exec tsx --test src/optional-importer.test.ts
- pnpm -r build
- npm run preflight:quick

## Release intent
After merge, the release workflow should publish @remnic/core@1.1.9, @remnic/cli@1.0.8, @remnic/plugin-openclaw@1.0.32, @joshuaswarren/openclaw-engram@9.3.18, and @remnic/import-supermemory@0.1.1, then publish @remnic/plugin-openclaw@1.0.32 to ClawHub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release/publish automation behavior (now fails the workflow instead of skipping) and adjusts package dependency metadata, which can impact publishing and consumer installs.
> 
> **Overview**
> Updates the release workflow to include `packages/import-supermemory` in the npm publish order and to **fail the release job** (instead of warning+skipping) when a package hits the first-time publish `E404` trusted-publishing/provisioning case.
> 
> Fixes `@remnic/import-supermemory` packaging for publishing by adding a package-local `tsconfig.json` and switching `@remnic/core` to a `peerDependency` (with a workspace dev dep for local builds), plus lockfile updates.
> 
> Bumps versions across `@remnic/core`, `@remnic/cli`, `@remnic/plugin-openclaw`, `@joshuaswarren/openclaw-engram`, and `@remnic/import-supermemory`, and updates OpenClaw plugin manifests (including a new `securityDisclosure` block and copy tweaks) to match the new releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453763aae3976ea41121c7368674d96921870c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->