### PR TITLE
docs(import-supermemory): add npm README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ remnic status              # Daemon status and local endpoint summary
 ## Bring your memory
 
 Remnic can import existing memory from the platforms you already use.
-Four optional importer packages ship alongside the CLI — install only the
+Five optional importer packages ship alongside the CLI — install only the
 ones you need:
 
 ```bash
@@ -323,6 +323,11 @@ remnic import --adapter gemini --file "~/Takeout/Gemini/My Activity.json"
 npm install -g @remnic/import-mem0
 export MEM0_API_KEY=...
 remnic import --adapter mem0 --rate-limit 2
+
+# Supermemory (JSON export)
+npm install -g @remnic/import-supermemory
+remnic import --adapter supermemory --file ./supermemory-memories.json --dry-run
+remnic import --adapter supermemory --file ./supermemory-memories.json
 ```
 
 Each importer is an **optional runtime companion** — the base CLI
@@ -557,6 +562,7 @@ Remnic is organized as a monorepo with a core engine, standalone server/CLI, and
 | `@remnic/import-claude` | [![npm](https://img.shields.io/npm/v/@remnic/import-claude)](https://www.npmjs.com/package/@remnic/import-claude) | Claude project docs and prompt-template importer — optional `remnic import --adapter claude` surface |
 | `@remnic/import-gemini` | [![npm](https://img.shields.io/npm/v/@remnic/import-gemini)](https://www.npmjs.com/package/@remnic/import-gemini) | Google Takeout Gemini Apps Activity importer — optional `remnic import --adapter gemini` surface |
 | `@remnic/import-mem0` | [![npm](https://img.shields.io/npm/v/@remnic/import-mem0)](https://www.npmjs.com/package/@remnic/import-mem0) | mem0 REST and JSON importer — optional `remnic import --adapter mem0` surface |
+| `@remnic/import-supermemory` | [![npm](https://img.shields.io/npm/v/@remnic/import-supermemory)](https://www.npmjs.com/package/@remnic/import-supermemory) | Supermemory JSON importer — optional `remnic import --adapter supermemory` surface |
 | `@remnic/plugin-openclaw` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-openclaw)](https://www.npmjs.com/package/@remnic/plugin-openclaw) | OpenClaw adapter — thin bridge (embedded or delegate mode) |
 | `@remnic/plugin-claude-code` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-claude-code)](https://www.npmjs.com/package/@remnic/plugin-claude-code) | Native Claude Code plugin — hooks, skills, MCP |
 | `@remnic/plugin-codex` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-codex)](https://www.npmjs.com/package/@remnic/plugin-codex) | Native Codex CLI plugin — hooks, skills, MCP |
@@ -1037,7 +1043,7 @@ OpenClaw plugin settings live in `openclaw.json` under `plugins.entries.openclaw
 - [Recall X-ray](docs/xray.md) — `remnic xray` CLI, HTTP endpoint, MCP tool for per-result retrieval attribution (issue #570)
 - [Connectors](docs/connectors.md) — `remnic connectors list/status/run` CLI reference, OAuth setup, config keys, env vars, and troubleshooting for Google Drive and Notion (issue #683 PR 6/N)
 - [Live connectors framework](docs/live-connectors.md) — Connector framework contract, registry, state store API, and how to write a connector
-- [Memory importers](docs/importers.md) — Bring memory from ChatGPT, Claude, Gemini, and mem0 (issue #568)
+- [Memory importers](docs/importers.md) — Bring memory from ChatGPT, Claude, Gemini, mem0, and Supermemory (issue #568)
 - [Memory Extraction Threat Model](docs/security/memory-extraction-threat-model.md) — ADAM attack analysis, attacker tiers, and mitigation wiring (issue #565)
 - [ADAM Baseline 2026-04](docs/security/adam-baseline-2026-04.md) — Reproducible ASR measurements per attacker tier
 

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,8 @@ Packages:
   @remnic/plugin-openclaw OpenClaw adapter (embedded or delegate mode).
   @remnic/plugin-codex    Codex CLI adapter (hooks + MCP + memory extension).
   @remnic/hermes-provider TypeScript HTTP client for remote Remnic instances.
+  @remnic/import-supermemory Optional Supermemory JSON importer for
+                          `remnic import --adapter supermemory`.
   remnic-hermes           Python PyPI package, MemoryProvider for Hermes Agent.
 
 OpenClaw adapter note:

--- a/packages/import-supermemory/README.md
+++ b/packages/import-supermemory/README.md
@@ -1,0 +1,94 @@
+# @remnic/import-supermemory
+
+Import a Supermemory JSON export into Remnic.
+
+This package is an optional companion for `@remnic/cli`. Install it only when
+you want to migrate memories out of Supermemory and into Remnic's local memory
+store.
+
+## Install
+
+```bash
+npm install -g @remnic/cli
+npm install -g @remnic/import-supermemory
+```
+
+If you use Remnic from a project instead of globally, add both packages to the
+same project:
+
+```bash
+pnpm add @remnic/cli @remnic/import-supermemory
+```
+
+## Export From Supermemory
+
+Export or collect your Supermemory memories as JSON. The importer accepts:
+
+- A flat JSON array of memory objects.
+- An object with one of these array keys: `memoryEntries`, `memories`,
+  `results`, or `data`.
+
+Each memory can provide content in `content`, `memory`, `summary`, or `title`.
+Remnic keeps Supermemory IDs, timestamps, container tags, source metadata, and
+the source file path when they are present.
+
+If your Supermemory export is paginated, combine the pages into one flat array
+or into an object like this:
+
+```json
+{
+  "memories": [
+    {
+      "id": "mem_123",
+      "content": "The user prefers short release notes.",
+      "updatedAt": "2026-05-05T12:00:00Z",
+      "containerTags": ["product"]
+    }
+  ]
+}
+```
+
+## Dry Run First
+
+Run a dry run before writing anything:
+
+```bash
+remnic import --adapter supermemory --file ./supermemory-memories.json --dry-run
+```
+
+When the count and warnings look right, run the import:
+
+```bash
+remnic import --adapter supermemory --file ./supermemory-memories.json
+```
+
+The importer writes records with `sourceLabel: "supermemory"` and
+`metadata.kind: "supermemory_memory"` so you can audit where imported memories
+came from later.
+
+## Privacy
+
+Parsing and writing run locally. If your Remnic extraction or consolidation
+pipeline is configured to use a remote model provider, imported content may be
+sent to that provider during normal Remnic processing. Use local model routing
+or gateway settings if you need the full migration path to stay local.
+
+## API
+
+```ts
+import { adapter, supermemoryAdapter } from "@remnic/import-supermemory";
+```
+
+Both exports expose the same Remnic importer adapter:
+
+- `name: "supermemory"`
+- `sourceLabel: "supermemory"`
+- `parse(input, options)`
+- `transform(parsed)`
+- `writeTo(target, memories)`
+
+## More Documentation
+
+- Remnic importer docs: https://github.com/joshuaswarren/remnic/blob/main/docs/importers.md
+- Supermemory migration guide: https://remnic.ai/guides/import-supermemory/
+- Package source: https://github.com/joshuaswarren/remnic/tree/main/packages/import-supermemory

--- a/packages/import-supermemory/package.json
+++ b/packages/import-supermemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/import-supermemory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Import Supermemory exports into Remnic",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- add a package README for @remnic/import-supermemory so npm shows installation and migration instructions
- bump @remnic/import-supermemory to 0.1.2 for trusted publishing
- surface the importer from the root README and llms.txt

## Verification
- pnpm --filter @remnic/core build
- pnpm --filter @remnic/import-supermemory build
- pnpm --filter @remnic/import-supermemory test
- pnpm --filter @remnic/import-supermemory pack --pack-destination <tmp>
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation-only plus a patch version bump for `@remnic/import-supermemory`, with no runtime behavior modifications.
> 
> **Overview**
> Documents the new `@remnic/import-supermemory` optional importer by adding a dedicated package `README.md` (install/export/dry-run guidance) and surfacing it in the root `README.md` and `llms.txt` package lists.
> 
> Bumps `@remnic/import-supermemory` from `0.1.1` to `0.1.2` to publish the documentation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd583fe1d025bddae3c2df2270f2954ddd3c61f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->