### PR TITLE
fix(bench): retry AMA answers with explicit evidence

### DIFF
--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -5,7 +5,10 @@ import {
   answerBenchmarkQuestion,
   buildAgenticMemoryBenchmarkQuestion,
   buildStrictBenchmarkQuestion,
+  buildUnknownRetryQuestion,
+  hasExplicitTrajectoryEvidence,
   inferAnswerFormat,
+  isUnknownOnlyAnswer,
 } from "./answering.ts";
 
 test("without a responder the benchmark answer falls back to recalled text", async () => {
@@ -91,6 +94,7 @@ test("agentic-memory answering asks responders to synthesize grounded trajectory
         assert.match(question, /requires inference/);
         assert.match(question, /step numbers, action names, object names/);
         assert.match(question, /anchor the answer to those exact numbers/);
+        assert.match(question, /Answer every clause in the question/);
         assert.match(question, /Do not assume an object disappeared/);
         assert.equal(
           recalledText,
@@ -107,6 +111,142 @@ test("agentic-memory answering asks responders to synthesize grounded trajectory
   });
 
   assert.equal(result.finalAnswer, "It repositioned around the blocking ball.");
+});
+
+test("agentic-memory answering includes benchmark context when provided", async () => {
+  const result = await answerBenchmarkQuestion({
+    question: "What did the rule manipulation accomplish?",
+    recalledText: "[Action 4]: push IS\n[Observation 4]: ROCK IS PUSH",
+    answerMode: "agentic-memory",
+    questionContext: {
+      benchmark: "AMA-Bench",
+      domain: "Games",
+      task: "Baba Is You trajectory",
+      taskType: "game",
+      qaType: "reasoning",
+    },
+    responder: {
+      async respond(question) {
+        assert.match(question, /Benchmark context:/);
+        assert.match(question, /Benchmark: AMA-Bench/);
+        assert.match(question, /Domain: Games/);
+        assert.match(question, /Task type: game/);
+        assert.match(question, /QA type: reasoning/);
+        assert.match(question, /Task setting: Baba Is You trajectory/);
+        return {
+          text: "It changed the active rock rule.",
+          tokens: { input: 10, output: 6 },
+          latencyMs: 5,
+          model: "test-model",
+        };
+      },
+    },
+  });
+
+  assert.equal(result.finalAnswer, "It changed the active rock rule.");
+});
+
+test("agentic-memory answering retries one unknown answer when explicit trajectory evidence is present", async () => {
+  const questions: string[] = [];
+  const result = await answerBenchmarkQuestion({
+    question: "Why did the agent move right after step 12?",
+    recalledText: [
+      "## Explicit Cue Evidence",
+      "[Action 12]: right",
+      "[Observation 12]: The wall is now one tile to the left.",
+    ].join("\n"),
+    answerMode: "agentic-memory",
+    retryUnknownWithEvidence: true,
+    responder: {
+      async respond(question) {
+        questions.push(question);
+        if (questions.length === 1) {
+          return {
+            text: "unknown",
+            tokens: { input: 11, output: 1 },
+            latencyMs: 7,
+            model: "first-model",
+          };
+        }
+        assert.match(question, /prior answer was only "unknown"/);
+        assert.match(question, /explicit trajectory evidence/);
+        return {
+          text: "It moved right, making the wall shift to the left relative to the agent.",
+          tokens: { input: 13, output: 12 },
+          latencyMs: 9,
+          model: "retry-model",
+        };
+      },
+    },
+  });
+
+  assert.equal(questions.length, 2);
+  assert.equal(
+    result.finalAnswer,
+    "It moved right, making the wall shift to the left relative to the agent.",
+  );
+  assert.deepEqual(result.tokens, { input: 24, output: 13 });
+  assert.equal(result.latencyMs, 16);
+  assert.equal(result.model, "retry-model");
+});
+
+test("agentic-memory answering does not retry unknown without explicit trajectory evidence", async () => {
+  let calls = 0;
+  const result = await answerBenchmarkQuestion({
+    question: "What happened?",
+    recalledText: "## Remnic recall pipeline\nNo exact trajectory cue was found.",
+    answerMode: "agentic-memory",
+    retryUnknownWithEvidence: true,
+    responder: {
+      async respond() {
+        calls += 1;
+        return {
+          text: "unknown",
+          tokens: { input: 3, output: 1 },
+          latencyMs: 4,
+          model: "test-model",
+        };
+      },
+    },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.finalAnswer, "unknown");
+  assert.deepEqual(result.tokens, { input: 3, output: 1 });
+});
+
+test("agentic-memory answering preserves the first unknown answer when the optional retry fails", async () => {
+  let calls = 0;
+  const result = await answerBenchmarkQuestion({
+    question: "Why did the agent move right after step 12?",
+    recalledText: [
+      "## Explicit Cue Evidence",
+      "[Action 12]: right",
+      "[Observation 12]: The wall is now one tile to the left.",
+    ].join("\n"),
+    answerMode: "agentic-memory",
+    retryUnknownWithEvidence: true,
+    responder: {
+      async respond() {
+        calls += 1;
+        if (calls === 2) {
+          throw new Error("retry timed out");
+        }
+        return {
+          text: "unknown",
+          tokens: { input: 5, output: 1 },
+          latencyMs: 6,
+          model: "first-model",
+        };
+      },
+    },
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(result.finalAnswer, "unknown");
+  assert.deepEqual(result.tokens, { input: 5, output: 1 });
+  assert.equal(result.latencyMs, 6);
+  assert.equal(result.model, "first-model");
 });
 
 test("strict question builder preserves structured protocols", () => {
@@ -134,6 +274,41 @@ test("agentic-memory question builder preserves strict safety while allowing tra
   assert.match(prompt, /synthesize the best-supported explanation/);
   assert.match(prompt, /do not name a later action outside the range/);
   assert.match(prompt, /Do not answer "unknown" merely because the answer requires inference/);
+});
+
+test("unknown retry helper preserves the original prompt and answer format constraints", () => {
+  const prompt = buildUnknownRetryQuestion(
+    "What happened?\n\nBenchmark answer protocol:",
+    "structured",
+  );
+
+  assert.match(prompt, /What happened\?/);
+  assert.match(prompt, /prior answer was only "unknown"/);
+  assert.match(prompt, /Preserve the requested structured output format exactly/);
+});
+
+test("unknown and explicit trajectory evidence helpers are conservative", () => {
+  assert.equal(isUnknownOnlyAnswer("unknown"), true);
+  assert.equal(isUnknownOnlyAnswer("\"The answer is unknown.\""), true);
+  assert.equal(isUnknownOnlyAnswer("unknown from the context"), false);
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
+      "## Explicit Cue Evidence\n[Action 3]: up\n[Observation 3]: the key moved closer",
+    ),
+    true,
+  );
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
+      "## Explicit Cue Evidence\nThe key moved closer without cited steps",
+    ),
+    false,
+  );
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
+      "## Remnic recall pipeline\n[Action 3]: up\n[Observation 3]: the key moved closer",
+    ),
+    false,
+  );
 });
 
 test("strict question builder preserves free-form summarization prompts", () => {

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -23,12 +23,22 @@ export interface BenchmarkAnswerResult {
   model?: string;
 }
 
+export interface BenchmarkQuestionContext {
+  benchmark?: string;
+  domain?: string;
+  task?: string;
+  taskType?: string;
+  qaType?: string;
+}
+
 export async function answerBenchmarkQuestion(options: {
   question: string;
   recalledText: string;
   responder?: BenchResponder;
   answerMode?: BenchmarkAnswerMode;
   answerFormat?: BenchmarkAnswerFormat;
+  questionContext?: BenchmarkQuestionContext;
+  retryUnknownWithEvidence?: boolean;
 }): Promise<BenchmarkAnswerResult> {
   if (!options.responder) {
     return {
@@ -52,39 +62,68 @@ export async function answerBenchmarkQuestion(options: {
     answerMode === "strict"
       ? buildStrictBenchmarkQuestion(options.question, answerFormat)
       : answerMode === "agentic-memory"
-        ? buildAgenticMemoryBenchmarkQuestion(options.question, answerFormat)
+        ? buildAgenticMemoryBenchmarkQuestion(
+            options.question,
+            answerFormat,
+            options.questionContext,
+          )
       : options.question;
   const response = await options.responder.respond(
     question,
     options.recalledText,
   );
+  const shouldRetry =
+    options.retryUnknownWithEvidence === true &&
+    answerMode === "agentic-memory" &&
+    isUnknownOnlyAnswer(response.text) &&
+    hasExplicitTrajectoryEvidence(options.recalledText);
+  const retryResponse = shouldRetry
+    ? await options.responder
+        .respond(
+          buildUnknownRetryQuestion(question, answerFormat),
+          options.recalledText,
+        )
+        .catch(() => undefined)
+    : undefined;
+  const finalResponse = retryResponse ?? response;
 
   return {
-    finalAnswer: response.text,
+    finalAnswer: finalResponse.text,
     recalledText: options.recalledText,
-    answeredText: response.text,
-    latencyMs: response.latencyMs,
-    tokens: response.tokens,
-    model: response.model,
+    answeredText: finalResponse.text,
+    latencyMs: response.latencyMs + (retryResponse?.latencyMs ?? 0),
+    tokens: retryResponse
+      ? {
+          input: response.tokens.input + retryResponse.tokens.input,
+          output: response.tokens.output + retryResponse.tokens.output,
+        }
+      : response.tokens,
+    model: finalResponse.model ?? response.model,
   };
 }
 
 export function buildAgenticMemoryBenchmarkQuestion(
   question: string,
   answerFormat: BenchmarkAnswerFormat = "auto",
+  context?: BenchmarkQuestionContext,
 ): string {
   const prompt = buildStrictBenchmarkQuestion(question, answerFormat);
   return [
     prompt,
     "",
+    ...formatQuestionContext(context),
+    ...(context ? [""] : []),
     "Agentic trajectory protocol:",
     "- Treat action and observation sequences as evidence for causal, strategic, and temporal reasoning.",
     "- When the question asks why an action mattered, what a maneuver accomplished, what would have happened, or what can be inferred, synthesize the best-supported explanation from the trajectory instead of looking only for an explicit quoted answer.",
     "- For explicit step, action, observation, or turn references, anchor the answer to those exact numbers. Do not shift the answer to a neighboring step unless the question explicitly asks for the next or previous step.",
     "- For cited step ranges, identify the action or state change inside that range; do not name a later action outside the range as the answer.",
-    "- If a game or tool trajectory requires a strategic abstraction, name the concrete mechanism being prepared or avoided, such as pushing a rule block, breaking a rule, opening a path, collecting an object, or undoing a loop.",
+    "- If a game or tool trajectory requires a strategic abstraction, name the concrete mechanism being prepared or avoided, such as pushing a rule block, breaking a rule, opening a path, satisfying a tool requirement, aligning with an object, or undoing a loop.",
+    "- Answer every clause in the question: include both the concrete state/action/value and the causal or strategic implication when the question asks for both.",
     "- Use step numbers, action names, object names, files, tools, commands, rewards, or state changes from the memory context when they support the answer.",
-    "- Do not assume an object disappeared because it was collected, pushed, or overlapped unless the before/after observations or active rules support that mechanism.",
+    "- Do not assume an object disappeared because it was collected, pushed, or overlapped unless the before/after observations, rewards, inventory, or active rules support that mechanism.",
+    "- In grid-game contexts, infer movement from relative-position changes carefully: if a static object's relative offset changes, explain the agent movement that caused that offset change.",
+    "- In rule-manipulation games, distinguish objects from rule text blocks and only claim a push/collect/win condition when active rules or observations support it.",
     "- Do not answer \"unknown\" merely because the answer requires inference; reserve \"unknown\" for cases where the trajectory evidence is absent or contradictory.",
     "- Keep the answer focused on the asked trajectory event and omit unrelated recalled history.",
   ].join("\n");
@@ -153,6 +192,53 @@ export function buildStrictBenchmarkQuestion(
   }
 
   return `${question}\n\n${instructions.join("\n")}`;
+}
+
+export function buildUnknownRetryQuestion(
+  question: string,
+  answerFormat: BenchmarkAnswerFormat = "auto",
+): string {
+  return [
+    question,
+    "",
+    "The prior answer was only \"unknown\", but the supplied Remnic context includes explicit trajectory evidence.",
+    "Retry once by deriving the best-supported answer from that evidence.",
+    "Use \"unknown\" only if the explicit evidence is absent, contradictory, or lacks the exact value requested.",
+    "For causal or strategic questions, answer with the concrete action/state change and the implication it supports.",
+    ...(answerFormat === "structured"
+      ? ["Preserve the requested structured output format exactly."]
+      : []),
+  ].join("\n");
+}
+
+export function isUnknownOnlyAnswer(answer: string): boolean {
+  const normalized = answer
+    .trim()
+    .toLowerCase()
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/[.!?]+$/g, "")
+    .trim();
+  return normalized === "unknown" || normalized === "the answer is unknown";
+}
+
+export function hasExplicitTrajectoryEvidence(recalledText: string): boolean {
+  return /^##\s+Explicit Cue Evidence\b/m.test(recalledText)
+    && /\[(?:Action|Observation)\s+\d+\]/.test(recalledText);
+}
+
+function formatQuestionContext(context: BenchmarkQuestionContext | undefined): string[] {
+  if (!context) {
+    return [];
+  }
+  const lines = [
+    "Benchmark context:",
+    ...(context.benchmark ? [`- Benchmark: ${context.benchmark}`] : []),
+    ...(context.domain ? [`- Domain: ${context.domain}`] : []),
+    ...(context.taskType ? [`- Task type: ${context.taskType}`] : []),
+    ...(context.qaType ? [`- QA type: ${context.qaType}`] : []),
+    ...(context.task ? [`- Task setting: ${context.task}`] : []),
+  ];
+  return lines.length > 1 ? lines : [];
 }
 
 export function inferAnswerFormat(question: string): BenchmarkAnswerFormat {

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -93,6 +93,14 @@ export async function runAmaBenchBenchmark(
           recalledText,
           responder: options.system.responder,
           answerMode: "agentic-memory",
+          questionContext: {
+            benchmark: "AMA-Bench",
+            domain: episode.domain,
+            task: episode.task,
+            taskType: episode.task_type,
+            qaType: qa.type,
+          },
+          retryUnknownWithEvidence: true,
         });
         const judgeResult = await llmJudgeScoreDetailed(
           options.system.judge,


### PR DESCRIPTION
## Summary
- adds AMA-Bench task/domain context to the agentic-memory answer prompt
- retries a single `unknown` answer only when explicit trajectory evidence is present
- adds focused tests for prompt context, retry gating, and helper behavior

## Why
The latest isolated AMA-Bench run retrieved useful explicit trajectory evidence but still produced too many `unknown` or under-specified answers. This keeps the AMA judge protocol unchanged and improves the answer-generation path so Remnic evidence is used more faithfully.

## Verification
- `pnpm exec tsx --test packages/bench/src/answering.test.ts`
- `pnpm exec tsx --test packages/bench/src/benchmarks/published/ama-bench/runner.test.ts`
- `pnpm --filter @remnic/bench check-types`

## Note
- `npm run preflight:quick` currently fails in this worktree because `plugin-inspector` is not installed for the OpenClaw plugin inspection step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the benchmark answering flow to conditionally issue a second LLM call and to aggregate usage across calls, which can affect benchmark results/costs but is gated to `agentic-memory` and explicit-evidence cases.
> 
> **Overview**
> Improves `agentic-memory` benchmark answering by optionally injecting **benchmark/task metadata** into the prompt and tightening the trajectory protocol instructions (e.g., answer all clauses, more conservative inferences).
> 
> Adds a **single retry** mechanism when the first response is only `"unknown"` *and* the recalled text contains `## Explicit Cue Evidence` with step-tagged `[Action N]`/`[Observation N]` entries; retry failures fall back to the original answer while **summing tokens/latency** across attempts.
> 
> Updates the AMA-Bench runner to pass `questionContext` and enable `retryUnknownWithEvidence`, and adds focused tests for context formatting, retry gating/aggregation, and helper behavior (`isUnknownOnlyAnswer`, `hasExplicitTrajectoryEvidence`, `buildUnknownRetryQuestion`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a081695c0b17bd91e20b00259f674bc2dd93fb9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->