### PR TITLE
feat(bench): add Codex CLI provider

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -18,6 +18,7 @@ export type {
   BenchmarkStatus,
   BenchmarkCategory,
   BenchRuntimeProfile,
+  BenchReasoningEffort,
   BuiltInProvider,
   ProviderConfig,
   TaskTokenUsage,
@@ -95,6 +96,7 @@ export type {
 } from "./ingestion-adapters/synthetic-email-adapter.js";
 export type {
   AnthropicProviderConfig,
+  CodexCliProviderConfig,
   CompletionOpts,
   CompletionResult,
   DiscoveredModel,
@@ -142,6 +144,7 @@ export type {
   WriteBenchmarkArtifactResult,
 } from "./published-artifact.js";
 export { createAnthropicProvider } from "./providers/anthropic.js";
+export { createCodexCliProvider } from "./providers/codex-cli.js";
 export { getRemnicVersion } from "./reporter.js";
 export {
   createProvider,

--- a/packages/bench/src/providers/codex-cli.test.ts
+++ b/packages/bench/src/providers/codex-cli.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  __codexCliProviderTestHooks,
+  createCodexCliProvider,
+} from "./codex-cli.ts";
+
+test("codex-cli provider invokes codex exec in an isolated benchmark mode", async () => {
+  const captured: {
+    args?: string[];
+    input?: string;
+    env?: NodeJS.ProcessEnv;
+    workspacePath?: string;
+    outputPath?: string;
+  } = {};
+  const provider = createCodexCliProvider(
+    {
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      apiKey: "test-api-key",
+      reasoningEffort: "xhigh",
+      retryOptions: { timeoutMs: 1234 },
+    },
+    {
+      async runCodexCli(request) {
+        captured.args = request.args;
+        captured.input = request.input;
+        captured.env = request.env;
+        captured.workspacePath = request.workspacePath;
+        captured.outputPath = request.outputPath;
+        assert.equal(request.executable, "codex");
+        assert.equal(request.timeoutMs, 1234);
+        return {
+          status: 0,
+          signal: null,
+          stdout: "ignored stdout",
+          stderr: "",
+          outputText: "  final answer\n",
+        };
+      },
+    },
+  );
+
+  const result = await provider.complete("What is remembered?", {
+    systemPrompt: "Answer using only benchmark context.",
+    temperature: 0,
+  });
+
+  assert.equal(result.text, "final answer");
+  assert.equal(result.model, "gpt-5.5");
+  assert.deepEqual(result.tokens, { input: 0, output: 0 });
+  assert.deepEqual(provider.getUsage(), {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  });
+  assert.deepEqual(captured.args, [
+    "exec",
+    "--model",
+    "gpt-5.5",
+    "--config",
+    'model_reasoning_effort="xhigh"',
+    "--config",
+    'approval_policy="never"',
+    "--disable",
+    "codex_hooks",
+    "--ephemeral",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--sandbox",
+    "read-only",
+    "--cd",
+    captured.workspacePath,
+    "--skip-git-repo-check",
+    "--output-last-message",
+    captured.outputPath,
+    "-",
+  ]);
+  assert.match(captured.workspacePath ?? "", /remnic-codex-cli-/);
+  assert.ok(captured.input?.includes("BENCHMARK_REQUEST_JSON:"));
+  assert.ok(captured.input?.includes('"systemPrompt": "Answer using only benchmark context."'));
+  assert.ok(captured.input?.includes('"userPrompt": "What is remembered?"'));
+  assert.equal(captured.env?.REMNIC_MEMORY_DIR, undefined);
+  assert.equal(captured.env?.ENGRAM_MEMORY_DIR, undefined);
+  assert.equal(captured.env?.OPENCLAW_ENGRAM_ACCESS_TOKEN, undefined);
+  assert.equal(captured.env?.OPENAI_API_KEY, "test-api-key");
+});
+
+test("codex-cli provider defaults reasoning effort to xhigh", async () => {
+  let args: string[] = [];
+  const provider = createCodexCliProvider(
+    { provider: "codex-cli", model: "gpt-5.5" },
+    {
+      async runCodexCli(request) {
+        args = request.args;
+        return {
+          status: 0,
+          signal: null,
+          stdout: "",
+          stderr: "",
+          outputText: "ok",
+        };
+      },
+    },
+  );
+
+  await provider.complete("hello");
+
+  assert.equal(
+    args[args.indexOf("--config") + 1],
+    'model_reasoning_effort="xhigh"',
+  );
+});
+
+test("codex-cli provider records total token usage from CLI stderr", async () => {
+  const provider = createCodexCliProvider(
+    { provider: "codex-cli", model: "gpt-5.5" },
+    {
+      async runCodexCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: "",
+          stderr: "tokens used 1,234",
+          outputText: "final answer",
+        };
+      },
+    },
+  );
+
+  const result = await provider.complete("hello");
+
+  assert.deepEqual(result.tokens, { input: 1231, output: 3 });
+  assert.deepEqual(provider.getUsage(), {
+    inputTokens: 1231,
+    outputTokens: 3,
+    totalTokens: 1234,
+  });
+});
+
+test("codex-cli token parser uses the final tokens-used line", () => {
+  assert.deepEqual(
+    __codexCliProviderTestHooks.parseCodexTokenUsage(
+      "tokens used 100\ntokens used 2,000",
+      "ok",
+    ),
+    { input: 1999, output: 1 },
+  );
+});
+
+test("codex-cli provider records token usage when Codex writes token accounting to stdout", async () => {
+  const provider = createCodexCliProvider(
+    { provider: "codex-cli", model: "gpt-5.5" },
+    {
+      async runCodexCli() {
+        return {
+          status: 0,
+          signal: null,
+          stdout: "tokens used 44",
+          stderr: "",
+          outputText: "final answer",
+        };
+      },
+    },
+  );
+
+  const result = await provider.complete("hello");
+
+  assert.equal(result.tokens.input + result.tokens.output, 44);
+  assert.equal(provider.getUsage().totalTokens, 44);
+});
+
+test("codex-cli provider surfaces non-zero CLI exits", async () => {
+  const provider = createCodexCliProvider(
+    { provider: "codex-cli", model: "gpt-5.5" },
+    {
+      async runCodexCli() {
+        return {
+          status: 2,
+          signal: null,
+          stdout: "",
+          stderr: "invalid model",
+          outputText: "",
+        };
+      },
+    },
+  );
+
+  await assert.rejects(
+    provider.complete("hello"),
+    /Codex CLI completion failed \(exit 2\): invalid model/,
+  );
+});
+
+test("codex-cli benchmark prompt keeps system and user input in separate JSON fields", () => {
+  const prompt = __codexCliProviderTestHooks.buildCodexCompletionPrompt(
+    "USER_CONTEXT: answer this",
+    "SYSTEM_CONTEXT: judge this",
+  );
+
+  const json = prompt.slice(prompt.indexOf("{"));
+  const parsed = JSON.parse(json);
+  assert.deepEqual(parsed, {
+    systemPrompt: "SYSTEM_CONTEXT: judge this",
+    userPrompt: "USER_CONTEXT: answer this",
+  });
+});

--- a/packages/bench/src/providers/codex-cli.ts
+++ b/packages/bench/src/providers/codex-cli.ts
@@ -1,0 +1,417 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+  CodexCliProviderConfig,
+  CompletionOpts,
+  CompletionResult,
+  DiscoveredModel,
+  LlmProvider,
+  TokenUsage,
+} from "./types.js";
+
+interface CodexCliRunRequest {
+  executable: string;
+  args: string[];
+  input: string;
+  outputPath: string;
+  workspacePath: string;
+  timeoutMs?: number;
+  env: NodeJS.ProcessEnv;
+}
+
+interface CodexCliRunResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  outputText: string;
+}
+
+interface CodexCliProviderDeps {
+  runCodexCli?: (request: CodexCliRunRequest) => Promise<CodexCliRunResult>;
+  runCodexVersion?: (
+    executable: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ status: number | null; stderr: string }>;
+}
+
+const DEFAULT_REASONING_EFFORT = "xhigh";
+const CODEX_CLI_STDIO_LIMIT = 64_000;
+
+class CodexCliProvider implements LlmProvider {
+  readonly provider = "codex-cli" as const;
+  readonly id: string;
+  readonly name: string;
+
+  private readonly config: CodexCliProviderConfig;
+  private readonly runCodexCli: (request: CodexCliRunRequest) => Promise<CodexCliRunResult>;
+  private readonly runCodexVersion: (
+    executable: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<{ status: number | null; stderr: string }>;
+  private usage: TokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+
+  constructor(config: CodexCliProviderConfig, deps: CodexCliProviderDeps = {}) {
+    this.config = config;
+    this.runCodexCli = deps.runCodexCli ?? runCodexCliCommand;
+    this.runCodexVersion = deps.runCodexVersion ?? runCodexVersionCommand;
+    this.id = `codex-cli:${config.model}`;
+    this.name = config.model;
+  }
+
+  async complete(
+    prompt: string,
+    opts: CompletionOpts = {},
+  ): Promise<CompletionResult> {
+    const startedAt = performance.now();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-codex-cli-"));
+    const workspacePath = path.join(tempDir, "workspace");
+    const outputPath = path.join(tempDir, "last-message.txt");
+
+    try {
+      await mkdir(workspacePath, { recursive: true });
+      const request = this.buildRunRequest(prompt, opts, workspacePath, outputPath);
+      const result = await this.runCodexCli(request);
+      if (result.status !== 0) {
+        const exitLabel = result.signal
+          ? `signal ${result.signal}`
+          : `exit ${result.status ?? "unknown"}`;
+        throw new Error(
+          `Codex CLI completion failed (${exitLabel}): ${summarizeProcessOutput(result.stderr, result.stdout)}`,
+        );
+      }
+
+      const text = result.outputText.trim();
+      if (text.length === 0) {
+        throw new Error(
+          `Codex CLI completion returned no final message: ${summarizeProcessOutput(result.stderr, result.stdout)}`,
+        );
+      }
+      const tokens = parseCodexTokenUsage(
+        `${result.stderr}\n${result.stdout}`,
+        text,
+      );
+      this.recordUsage(tokens.input, tokens.output);
+
+      return {
+        text,
+        tokens,
+        latencyMs: Math.round(performance.now() - startedAt),
+        model: this.config.model,
+      };
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  }
+
+  async discover(): Promise<DiscoveredModel[]> {
+    const version = await this.runCodexVersion(
+      this.config.executable ?? "codex",
+      buildIsolatedCodexEnv(),
+    );
+    if (version.status !== 0) {
+      throw new Error(
+        `Codex CLI discovery failed: ${version.stderr.trim() || `exit ${version.status ?? "unknown"}`}`,
+      );
+    }
+
+    return [
+      {
+        id: this.config.model,
+        name: `${this.config.model} (Codex CLI)`,
+        contextLength: 0,
+        capabilities: ["completion"],
+      },
+    ];
+  }
+
+  getUsage(): TokenUsage {
+    return { ...this.usage };
+  }
+
+  resetUsage(): void {
+    this.usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+  }
+
+  private recordUsage(inputTokens: number, outputTokens: number): void {
+    this.usage = {
+      inputTokens: this.usage.inputTokens + inputTokens,
+      outputTokens: this.usage.outputTokens + outputTokens,
+      totalTokens: this.usage.totalTokens + inputTokens + outputTokens,
+    };
+  }
+
+  private buildRunRequest(
+    prompt: string,
+    opts: CompletionOpts,
+    workspacePath: string,
+    outputPath: string,
+  ): CodexCliRunRequest {
+    const reasoningEffort =
+      this.config.reasoningEffort ?? DEFAULT_REASONING_EFFORT;
+    const args = [
+      "exec",
+      "--model",
+      this.config.model,
+      "--config",
+      `model_reasoning_effort=${tomlString(reasoningEffort)}`,
+      "--config",
+      'approval_policy="never"',
+      "--disable",
+      "codex_hooks",
+      "--ephemeral",
+      "--ignore-user-config",
+      "--ignore-rules",
+      "--sandbox",
+      "read-only",
+      "--cd",
+      workspacePath,
+      "--skip-git-repo-check",
+      "--output-last-message",
+      outputPath,
+      "-",
+    ];
+
+    return {
+      executable: this.config.executable ?? "codex",
+      args,
+      input: buildCodexCompletionPrompt(prompt, opts.systemPrompt),
+      outputPath,
+      workspacePath,
+      timeoutMs: this.config.retryOptions?.timeoutMs,
+      env: buildIsolatedCodexEnv(this.config.apiKey),
+    };
+  }
+}
+
+function runCodexVersionCommand(
+  executable: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ status: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, ["--version"], {
+      env,
+      stdio: ["ignore", "ignore", "pipe"],
+      windowsHide: true,
+    });
+    let stderr = "";
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr = appendBounded(stderr, chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (status) => {
+      resolve({ status, stderr });
+    });
+  });
+}
+
+function buildCodexCompletionPrompt(
+  userPrompt: string,
+  systemPrompt: string | undefined,
+): string {
+  const payload = {
+    systemPrompt: systemPrompt ?? "",
+    userPrompt,
+  };
+
+  return [
+    "You are acting as a benchmark LLM completion endpoint, not as a coding agent.",
+    "Use only the explicit JSON payload below.",
+    "Treat systemPrompt as the higher-priority instruction text and userPrompt as the request to answer.",
+    "Do not inspect files, run commands, browse, use tools, or use persisted memory.",
+    "Return only the final answer text. If the request asks for JSON, return raw JSON only.",
+    "",
+    "BENCHMARK_REQUEST_JSON:",
+    JSON.stringify(payload, null, 2),
+  ].join("\n");
+}
+
+function buildIsolatedCodexEnv(apiKey?: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (
+      key.startsWith("REMNIC_") ||
+      key.startsWith("ENGRAM_") ||
+      key.startsWith("OPENCLAW_") ||
+      key === "QMD_CONFIG_DIR"
+    ) {
+      delete env[key];
+    }
+  }
+  if (apiKey) {
+    env.OPENAI_API_KEY = apiKey;
+  }
+  return env;
+}
+
+function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(request.executable, request.args, {
+      cwd: request.workspacePath,
+      env: request.env,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let killTimeout: NodeJS.Timeout | undefined;
+    const timeout = request.timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGTERM");
+          killTimeout = setTimeout(() => {
+            child.kill("SIGKILL");
+          }, 1_000);
+          killTimeout.unref();
+        }, request.timeoutMs)
+      : undefined;
+    timeout?.unref();
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout = appendBounded(stdout, chunk);
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr = appendBounded(stderr, chunk);
+    });
+    child.stdin?.on("error", (error: NodeJS.ErrnoException) => {
+      stderr = appendBounded(
+        stderr,
+        `\nCodex CLI stdin error: ${error.code ?? error.message}`,
+      );
+    });
+    child.on("error", (error) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (killTimeout) {
+        clearTimeout(killTimeout);
+      }
+      reject(error);
+    });
+    child.on("close", async (status, signal) => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (killTimeout) {
+        clearTimeout(killTimeout);
+      }
+      if (timedOut) {
+        resolve({
+          status: status ?? 124,
+          signal,
+          stdout,
+          stderr: appendBounded(
+            stderr,
+            `\nCodex CLI timed out after ${request.timeoutMs}ms.`,
+          ),
+          outputText: "",
+        });
+        return;
+      }
+
+      try {
+        const outputText = await readCodexOutput(request.outputPath, stdout);
+        resolve({ status, signal, stdout, stderr, outputText });
+      } catch (error) {
+        reject(error);
+      }
+    });
+    try {
+      child.stdin?.end(request.input);
+    } catch (error) {
+      stderr = appendBounded(
+        stderr,
+        `\nCodex CLI stdin error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  });
+}
+
+async function readCodexOutput(
+  outputPath: string,
+  stdout: string,
+): Promise<string> {
+  try {
+    return await readFile(outputPath, "utf8");
+  } catch {
+    return stdout;
+  }
+}
+
+function appendBounded(existing: string, next: string): string {
+  const combined = existing + next;
+  if (combined.length <= CODEX_CLI_STDIO_LIMIT) {
+    return combined;
+  }
+  return combined.slice(combined.length - CODEX_CLI_STDIO_LIMIT);
+}
+
+function summarizeProcessOutput(stderr: string, stdout: string): string {
+  const summary = [stderr.trim(), stdout.trim()]
+    .filter((value) => value.length > 0)
+    .join("\n")
+    .trim();
+  return summary.length > 0 ? summary.slice(-1_000) : "no process output";
+}
+
+function parseCodexTokenUsage(
+  stderr: string,
+  outputText: string,
+): { input: number; output: number } {
+  const totalTokens = parseCodexTotalTokens(stderr);
+  if (totalTokens === undefined) {
+    return { input: 0, output: 0 };
+  }
+
+  const estimatedOutputTokens = Math.min(
+    totalTokens,
+    Math.max(1, Math.ceil(outputText.length / 4)),
+  );
+  return {
+    input: totalTokens - estimatedOutputTokens,
+    output: estimatedOutputTokens,
+  };
+}
+
+function parseCodexTotalTokens(stderr: string): number | undefined {
+  const matches = [...stderr.matchAll(/\btokens used\s+([0-9][0-9,]*)\b/gi)];
+  const raw = matches.at(-1)?.[1];
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = Number(raw.replace(/,/g, ""));
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+export function createCodexCliProvider(
+  config: CodexCliProviderConfig,
+  deps?: CodexCliProviderDeps,
+): LlmProvider {
+  return new CodexCliProvider(config, deps);
+}
+
+export const __codexCliProviderTestHooks = {
+  buildCodexCompletionPrompt,
+  buildIsolatedCodexEnv,
+  parseCodexTokenUsage,
+};

--- a/packages/bench/src/providers/factory.ts
+++ b/packages/bench/src/providers/factory.ts
@@ -4,10 +4,15 @@ import type {
   ProviderFactoryConfig,
 } from "./types.js";
 import { createAnthropicProvider } from "./anthropic.js";
+import { createCodexCliProvider } from "./codex-cli.js";
 import { createLiteLlmProvider } from "./litellm.js";
 import { createLocalLlmProvider } from "./local-llm.js";
 import { createOllamaProvider } from "./ollama.js";
 import { createOpenAiCompatibleProvider } from "./openai-compatible.js";
+
+export interface DiscoverAllProvidersOptions {
+  includeCodexCli?: boolean;
+}
 
 export function createProvider(config: ProviderFactoryConfig): LlmProvider {
   switch (config.provider) {
@@ -21,6 +26,8 @@ export function createProvider(config: ProviderFactoryConfig): LlmProvider {
       return createLiteLlmProvider(config);
     case "local-llm":
       return createLocalLlmProvider(config);
+    case "codex-cli":
+      return createCodexCliProvider(config);
     default: {
       const exhaustive: never = config;
       throw new Error(`Unknown provider: ${JSON.stringify(exhaustive)}`);
@@ -28,8 +35,13 @@ export function createProvider(config: ProviderFactoryConfig): LlmProvider {
   }
 }
 
-export async function discoverAllProviders(): Promise<ProviderDiscoveryResult[]> {
-  const discoveryTargets = [
+export async function discoverAllProviders(
+  options: DiscoverAllProvidersOptions = {},
+): Promise<ProviderDiscoveryResult[]> {
+  const discoveryTargets: Array<{
+    provider: ProviderDiscoveryResult["provider"];
+    create: () => LlmProvider;
+  }> = [
     {
       provider: "ollama" as const,
       create: () => createOllamaProvider({ provider: "ollama", model: "probe" }),
@@ -52,6 +64,18 @@ export async function discoverAllProviders(): Promise<ProviderDiscoveryResult[]>
         }),
     },
   ];
+
+  if (options.includeCodexCli ?? true) {
+    discoveryTargets.push({
+      provider: "codex-cli" as const,
+      create: () =>
+        createCodexCliProvider({
+          provider: "codex-cli",
+          model: "gpt-5.5",
+          reasoningEffort: "xhigh",
+        }),
+    });
+  }
 
   const results: ProviderDiscoveryResult[] = [];
   for (const target of discoveryTargets) {

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -2,7 +2,10 @@
  * Minimal LLM provider contract for the bench engine.
  */
 
-import type { BuiltInProvider } from "../types.js";
+import type {
+  BenchReasoningEffort,
+  BuiltInProvider,
+} from "../types.js";
 
 export interface CompletionOpts {
   systemPrompt?: string;
@@ -63,11 +66,20 @@ export interface LocalLlmProviderConfig extends ProviderBaseConfig {
   baseUrl: string;
 }
 
+export interface CodexCliProviderConfig extends ProviderBaseConfig {
+  provider?: "codex-cli";
+  /** Codex CLI model reasoning effort. Bench CLI defaults this to xhigh. */
+  reasoningEffort?: BenchReasoningEffort;
+  /** Optional executable override for tests or non-standard Codex CLI installs. */
+  executable?: string;
+}
+
 export type ProviderFactoryConfig =
   | (OpenAiCompatibleProviderConfig & { provider: "openai" | "litellm" })
   | (AnthropicProviderConfig & { provider: "anthropic" })
   | (OllamaProviderConfig & { provider: "ollama" })
-  | (LocalLlmProviderConfig & { provider: "local-llm" });
+  | (LocalLlmProviderConfig & { provider: "local-llm" })
+  | (CodexCliProviderConfig & { provider: "codex-cli" });
 
 export interface ProviderDiscoveryResult {
   provider: BuiltInProvider;

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -308,3 +308,26 @@ test("provider-backed runtime resolution rejects incomplete provider configurati
     /judge provider requires both provider and model/i,
   );
 });
+
+test("provider-backed runtime resolution configures codex-cli with xhigh reasoning", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    systemProvider: "codex-cli",
+    systemModel: "gpt-5.5",
+    judgeProvider: "codex-cli",
+    judgeModel: "gpt-5.5",
+  });
+
+  assert.deepEqual(resolved.systemProvider, {
+    provider: "codex-cli",
+    model: "gpt-5.5",
+    reasoningEffort: "xhigh",
+  });
+  assert.deepEqual(resolved.judgeProvider, {
+    provider: "codex-cli",
+    model: "gpt-5.5",
+    reasoningEffort: "xhigh",
+  });
+  assert.equal(typeof resolved.adapterOptions.responder?.respond, "function");
+  assert.equal(typeof resolved.adapterOptions.judge?.score, "function");
+});

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -350,6 +350,7 @@ function resolveProviderConfig(
         } }
       : {}),
     ...(disableThinking ? { disableThinking: true } : {}),
+    ...(provider === "codex-cli" ? { reasoningEffort: "xhigh" as const } : {}),
   };
 }
 
@@ -389,6 +390,7 @@ function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig 
     ...(config.apiKey ? { apiKey: config.apiKey } : {}),
     ...(config.retryOptions ? { retryOptions: config.retryOptions } : {}),
     ...(config.disableThinking ? { disableThinking: config.disableThinking } : {}),
+    ...(config.reasoningEffort ? { reasoningEffort: config.reasoningEffort } : {}),
   } as ProviderFactoryConfig;
 }
 

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -21,13 +21,20 @@ export type AmaBenchJudgeProtocol = "default" | "recommended";
  * the `localLlm*` plugin config on the Remnic core side so that
  * `remnic bench published --provider local-llm` actually exercises
  * the same transport path as the running plugin. Issue #566 slice 5.
+ *
+ * `codex-cli` shells out to `codex exec` as an isolated benchmark-only
+ * responder/judge target. It is intentionally not routed through Remnic
+ * memory or OpenClaw gateway state.
  */
 export type BuiltInProvider =
   | "openai"
   | "anthropic"
   | "ollama"
   | "litellm"
-  | "local-llm";
+  | "local-llm"
+  | "codex-cli";
+
+export type BenchReasoningEffort = "low" | "medium" | "high" | "xhigh";
 
 export interface ProviderConfig {
   provider: BuiltInProvider;
@@ -36,6 +43,7 @@ export interface ProviderConfig {
   apiKey?: string;
   retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number; max429WaitMs?: number };
   disableThinking?: boolean;
+  reasoningEffort?: BenchReasoningEffort;
 }
 
 export interface TaskTokenUsage {

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -154,6 +154,26 @@ test("parseBenchArgs accepts --provider shorthand", () => {
   assert.equal(parsed.systemBaseUrl, "https://api.openai.com");
 });
 
+test("parseBenchArgs accepts codex-cli as a system and judge provider", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "longmemeval",
+    "--system-provider",
+    "codex-cli",
+    "--system-model",
+    "gpt-5.5",
+    "--judge-provider",
+    "codex-cli",
+    "--judge-model",
+    "gpt-5.5",
+  ]);
+
+  assert.equal(parsed.systemProvider, "codex-cli");
+  assert.equal(parsed.systemModel, "gpt-5.5");
+  assert.equal(parsed.judgeProvider, "codex-cli");
+  assert.equal(parsed.judgeModel, "gpt-5.5");
+});
+
 test("parseBenchArgs accepts AMA-Bench recommended judge and cross-judge flags", () => {
   const parsed = parseBenchArgs([
     "run",
@@ -215,7 +235,7 @@ test("parseBenchArgs rejects unknown --provider", () => {
         "--provider",
         "not-a-provider",
       ]),
-    /--provider must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"/,
+    /--provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"/,
   );
 });
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -126,7 +126,8 @@ function parseBenchRuntimeProfile(
  * `--judge-provider`. Keeping these in lockstep is a CLAUDE.md rule 52
  * concern: if one flag accepts "local-llm" but another rejects it,
  * behavior becomes path-dependent. Issue #566 slice 5 added
- * "local-llm"; the single source of truth is here.
+ * "local-llm"; Codex CLI provider wiring added "codex-cli". The
+ * single source of truth is here.
  */
 const BENCH_PROVIDER_ALLOWED: readonly BuiltInProvider[] = Object.freeze([
   "openai",
@@ -134,6 +135,7 @@ const BENCH_PROVIDER_ALLOWED: readonly BuiltInProvider[] = Object.freeze([
   "ollama",
   "litellm",
   "local-llm",
+  "codex-cli",
 ]);
 
 function isBuiltInProvider(value: string): value is BuiltInProvider {
@@ -143,7 +145,7 @@ function isBuiltInProvider(value: string): value is BuiltInProvider {
 function parseBenchProvider(raw: string, flag: string): BuiltInProvider {
   if (!isBuiltInProvider(raw)) {
     throw new Error(
-      `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm".`,
+      `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli".`,
     );
   }
   return raw;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -316,6 +316,7 @@ type PackageBenchProviderConfig = {
     max429WaitMs?: number;
   };
   disableThinking?: boolean;
+  reasoningEffort?: "low" | "medium" | "high" | "xhigh";
 };
 
 type PackageBenchModule = {
@@ -533,6 +534,7 @@ interface BenchProviderConfig {
     max429WaitMs?: number;
   };
   disableThinking?: boolean;
+  reasoningEffort?: "low" | "medium" | "high" | "xhigh";
 }
 
 interface ResolveBenchRuntimeProfileOptions {
@@ -647,11 +649,11 @@ Options:
   --gateway-agent-id <id>  OpenClaw agent persona id for gateway model routing
   --fast-gateway-agent-id <id>
                            OpenClaw fast-tier agent persona id for gateway model routing
-  --system-provider <openai|anthropic|ollama|litellm>
+  --system-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli>
                            Use a direct provider-backed answering path
   --system-model <model>   Model name for the direct answering provider
   --system-base-url <url>  Base URL for the direct answering provider
-  --judge-provider <openai|anthropic|ollama|litellm>
+  --judge-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli>
                            Use a direct provider-backed judge
   --judge-model <model>    Model name for the judge provider
   --judge-base-url <url>   Base URL for the judge provider
@@ -686,6 +688,7 @@ Examples:
   remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
   remnic bench run longmemeval --runtime-profile real --remnic-config ~/.config/remnic/config.json
   remnic bench run longmemeval --runtime-profile real --system-provider openai --system-model gpt-5.4-mini
+  remnic bench run longmemeval --quick --system-provider codex-cli --system-model gpt-5.5 --judge-provider codex-cli --judge-model gpt-5.5
   remnic bench run ama-bench --runtime-profile real --system-provider ollama --system-model gemma4:31b-cloud --judge-provider ollama --judge-model qwen3:32b --ama-bench-judge-protocol recommended
   remnic bench run longmemeval --runtime-profile openclaw-chain --openclaw-config ~/.openclaw/openclaw.json --gateway-agent-id memory-primary
   remnic bench run longmemeval --matrix baseline,real,openclaw-chain

--- a/tests/bench-providers.test.ts
+++ b/tests/bench-providers.test.ts
@@ -166,7 +166,7 @@ test("discoverAllProviders skips unavailable endpoints and returns successful di
   });
 
   try {
-    const discovered = await discoverAllProviders();
+    const discovered = await discoverAllProviders({ includeCodexCli: false });
     assert.deepEqual(
       discovered.map((entry) => entry.provider),
       ["ollama", "openai"],

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -183,9 +183,9 @@ test("bench CLI exposes runtime profile and provider-backed run surfaces", async
   assert.match(source, /--model-source <plugin\|gateway>/);
   assert.match(source, /--gateway-agent-id <id>/);
   assert.match(source, /--fast-gateway-agent-id <id>/);
-  assert.match(source, /--system-provider <openai\|anthropic\|ollama\|litellm>/);
+  assert.match(source, /--system-provider <openai\|anthropic\|ollama\|litellm\|local-llm\|codex-cli>/);
   assert.match(source, /--system-model <model>/);
-  assert.match(source, /--judge-provider <openai\|anthropic\|ollama\|litellm>/);
+  assert.match(source, /--judge-provider <openai\|anthropic\|ollama\|litellm\|local-llm\|codex-cli>/);
   assert.match(source, /--judge-model <model>/);
   assert.match(source, /remnic bench run --quick longmemeval --runtime-profile baseline/);
   assert.match(source, /remnic bench run longmemeval --runtime-profile real --remnic-config/);
@@ -977,9 +977,9 @@ test("parseBenchArgs rejects unknown bench publish targets", async () => {
   );
 });
 
-// Issue #566 slice 5 — local-llm provider parity. `--provider`,
-// `--system-provider`, and `--judge-provider` must all accept
-// "local-llm" (CLAUDE.md rule 52: allow-lists in lockstep). When
+// Issue #566 slice 5 and Codex CLI provider parity. `--provider`,
+// `--system-provider`, and `--judge-provider` must all accept the same
+// provider list (CLAUDE.md rule 52: allow-lists in lockstep). When
 // the chosen provider is local-llm, a base URL is REQUIRED at the
 // boundary — silent OpenAI fallback violates rule 51.
 test("parseBenchArgs accepts --provider local-llm with --base-url", async () => {
@@ -1073,7 +1073,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--model",
         "m",
       ]),
-    /ERROR: --provider must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"\./,
+    /ERROR: --provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
   );
   assert.throws(
     () =>
@@ -1085,7 +1085,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--system-model",
         "m",
       ]),
-    /ERROR: --system-provider must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"\./,
+    /ERROR: --system-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
   );
   assert.throws(
     () =>
@@ -1097,7 +1097,7 @@ test("parseBenchArgs rejects unknown providers across all three flags with liste
         "--judge-model",
         "m",
       ]),
-    /ERROR: --judge-provider must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"\./,
+    /ERROR: --judge-provider must be one of "openai", "anthropic", "ollama", "litellm", "local-llm", or "codex-cli"\./,
   );
 });
 


### PR DESCRIPTION
## Summary
- adds a benchmark `codex-cli` provider backed by non-interactive `codex exec`
- wires it through provider factory, runtime profile config, and bench CLI provider parsing
- defaults Codex CLI benchmark calls to `gpt-5.5`-compatible xhigh reasoning when selected

## Validity
- runs Codex CLI in an isolated temporary workspace with read-only sandboxing and benchmark-only prompts
- scrubs Remnic/OpenClaw environment variables before invoking Codex CLI
- captures only the final message for benchmark responder/judge use

## Verification
- `pnpm exec tsx --test packages/bench/src/providers/codex-cli.test.ts packages/remnic-cli/src/bench-args.test.ts packages/bench/src/runtime-profiles.test.ts`
- `pnpm run check-types`
- `pnpm --filter @remnic/bench run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `codex-cli` execution path that shells out to an external binary and threads it through provider discovery/runtime/CLI parsing, which could affect benchmark execution environments and error handling. Changes are scoped to bench/provider plumbing with tests covering prompt isolation and token accounting.
> 
> **Overview**
> Adds a new built-in benchmark provider, `codex-cli`, which runs completions/judging by invoking non-interactive `codex exec` in an ephemeral, read-only sandbox workspace with a benchmark-only JSON prompt and a scrubbed environment.
> 
> Wires `codex-cli` through the bench provider factory and optional provider discovery (`includeCodexCli`), extends shared config/types with `BenchReasoningEffort`/`reasoningEffort`, and updates runtime profile + CLI surfaces to accept `codex-cli` and default it to `xhigh` reasoning.
> 
> Includes focused tests for invocation flags/env isolation, token usage parsing from CLI output, error propagation on non-zero exits, and CLI/runtime integration expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043412117892be935eaa84bc7468ae308829f2e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->