### PR TITLE
feat(bench): add AMA diagnostic matrix

### DIFF
--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -290,6 +290,10 @@ test("unknown retry helper preserves the original prompt and answer format const
 test("unknown and explicit trajectory evidence helpers are conservative", () => {
   assert.equal(isUnknownOnlyAnswer("unknown"), true);
   assert.equal(isUnknownOnlyAnswer("\"The answer is unknown.\""), true);
+  assert.equal(
+    isUnknownOnlyAnswer(`${'"'.repeat(5_000)}unknown${'"'.repeat(5_000)}`),
+    true,
+  );
   assert.equal(isUnknownOnlyAnswer("unknown from the context"), false);
   assert.equal(
     hasExplicitTrajectoryEvidence(
@@ -308,6 +312,30 @@ test("unknown and explicit trajectory evidence helpers are conservative", () => 
       "## Remnic recall pipeline\n[Action 3]: up\n[Observation 3]: the key moved closer",
     ),
     false,
+  );
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
+      "##Explicit Cue Evidence\n[Action 3]: up",
+    ),
+    false,
+  );
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
+      "##\tExplicit Cue Evidence\r\n[Observation 12]: the key moved closer",
+    ),
+    true,
+  );
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
+      "## Explicit Cue Evidence\n[Action\t12]: the key moved closer",
+    ),
+    true,
+  );
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
+      "## Explicit Cue Evidence\n[Action  12]: the key moved closer",
+    ),
+    true,
   );
 });
 

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -212,18 +212,116 @@ export function buildUnknownRetryQuestion(
 }
 
 export function isUnknownOnlyAnswer(answer: string): boolean {
-  const normalized = answer
-    .trim()
-    .toLowerCase()
-    .replace(/^["'`]+|["'`]+$/g, "")
-    .replace(/[.!?]+$/g, "")
-    .trim();
+  const normalized = stripTrailingSentencePunctuation(
+    stripWrappingQuotes(answer.trim().toLowerCase()),
+  ).trim();
   return normalized === "unknown" || normalized === "the answer is unknown";
 }
 
 export function hasExplicitTrajectoryEvidence(recalledText: string): boolean {
-  return /^##\s+Explicit Cue Evidence\b/m.test(recalledText)
-    && /\[(?:Action|Observation)\s+\d+\]/.test(recalledText);
+  return hasExplicitCueEvidenceHeading(recalledText) &&
+    (hasStepMarker(recalledText, "Action") ||
+      hasStepMarker(recalledText, "Observation"));
+}
+
+function stripWrappingQuotes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && isWrappingQuote(value.charCodeAt(start))) {
+    start += 1;
+  }
+  while (end > start && isWrappingQuote(value.charCodeAt(end - 1))) {
+    end -= 1;
+  }
+  return value.slice(start, end);
+}
+
+function stripTrailingSentencePunctuation(value: string): string {
+  let end = value.length;
+  while (end > 0 && isSentencePunctuation(value.charCodeAt(end - 1))) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+function isWrappingQuote(code: number): boolean {
+  return code === 34 || code === 39 || code === 96;
+}
+
+function isSentencePunctuation(code: number): boolean {
+  return code === 33 || code === 46 || code === 63;
+}
+
+function hasExplicitCueEvidenceHeading(text: string): boolean {
+  const lines = text
+    .replaceAll("\r\n", "\n")
+    .replaceAll("\r", "\n")
+    .split("\n");
+  for (const line of lines) {
+    if (!line.startsWith("##") || line.startsWith("###")) {
+      continue;
+    }
+    const rawTitle = line.slice(2);
+    if (
+      rawTitle.length === 0 ||
+      !isAsciiWhitespace(rawTitle.charCodeAt(0))
+    ) {
+      continue;
+    }
+    const title = rawTitle.trimStart();
+    if (
+      title === "Explicit Cue Evidence" ||
+      title.startsWith("Explicit Cue Evidence ") ||
+      title.startsWith("Explicit Cue Evidence\t")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasStepMarker(text: string, label: "Action" | "Observation"): boolean {
+  const prefix = `[${label}`;
+  let offset = 0;
+  while (offset < text.length) {
+    const start = text.indexOf(prefix, offset);
+    if (start === -1) {
+      return false;
+    }
+    let index = start + prefix.length;
+    if (!isAsciiWhitespace(text.charCodeAt(index))) {
+      offset = start + 1;
+      continue;
+    }
+    while (index < text.length && isAsciiWhitespace(text.charCodeAt(index))) {
+      index += 1;
+    }
+    let sawDigit = false;
+    while (index < text.length && isAsciiDigit(text.charCodeAt(index))) {
+      sawDigit = true;
+      index += 1;
+    }
+    if (sawDigit && text[index] === "]") {
+      return true;
+    }
+    offset = start + 1;
+  }
+  return false;
+}
+
+function isAsciiDigit(code: number): boolean {
+  return code >= 48 && code <= 57;
+}
+
+function isAsciiWhitespace(code: number): boolean {
+  return (
+    code === 9 ||
+    code === 10 ||
+    code === 11 ||
+    code === 12 ||
+    code === 13 ||
+    code === 32
+  );
 }
 
 function formatQuestionContext(context: BenchmarkQuestionContext | undefined): string[] {

--- a/packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
@@ -1,0 +1,433 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../../../adapters/types.ts";
+import type { BenchmarkResult } from "../../../types.ts";
+import {
+  buildAmaBenchDiagnosticMatrixArtifact,
+  buildAmaBenchDiagnosticVariantSummary,
+  buildOracleTrajectoryRecall,
+  createAmaBenchDiagnosticAdapter,
+  extractMarkdownSectionsByTitle,
+  isAmaBenchUnknownLikeAnswer,
+  selectAmaBenchDiagnosticVariants,
+  type AmaBenchDiagnosticVariant,
+} from "./diagnostics.ts";
+
+const DEFAULT_TEST_VARIANT_IDS = new Set([
+  "remnic-full-normal",
+  "explicit-only-normal",
+  "oracle-trajectory-normal",
+]);
+
+class FakeAdapter implements BenchMemoryAdapter {
+  recalledText = "";
+  drainCalls = 0;
+  storeCalls = 0;
+  responder = {
+    async respond() {
+      return {
+        text: "normal answer",
+        tokens: { input: 0, output: 0 },
+        latencyMs: 0,
+        model: "normal-responder",
+      };
+    },
+  };
+
+  async store(): Promise<void> {
+    this.storeCalls += 1;
+  }
+
+  async recall(): Promise<string> {
+    return this.recalledText;
+  }
+
+  async search(): Promise<SearchResult[]> {
+    return [];
+  }
+
+  async reset(): Promise<void> {}
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    return {
+      totalMessages: 0,
+      totalSummaryNodes: 0,
+      maxDepth: 0,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+
+  async drain(): Promise<void> {
+    this.drainCalls += 1;
+  }
+}
+
+const explicitOnlyVariant: AmaBenchDiagnosticVariant = {
+  id: "explicit-only-normal",
+  label: "explicit",
+  recallMode: "explicit-evidence-only",
+  answererMode: "normal",
+  description: "test",
+};
+
+test("extractMarkdownSectionsByTitle keeps only matching level-two sections", () => {
+  const filtered = extractMarkdownSectionsByTitle(
+    [
+      "# Preamble",
+      "not included",
+      "## Explicit Cue Evidence",
+      "[Action 1]: Open settings.",
+      "",
+      "## Remnic recall pipeline",
+      "This should be stripped.",
+      "",
+      "## Explicit Cue Evidence",
+      "[Observation 1]: Language was Spanish.",
+    ].join("\n"),
+    ["Explicit Cue Evidence"],
+  );
+
+  assert.match(filtered, /\[Action 1\]: Open settings/);
+  assert.match(filtered, /\[Observation 1\]: Language was Spanish/);
+  assert.doesNotMatch(filtered, /Remnic recall pipeline/);
+  assert.doesNotMatch(filtered, /should be stripped/);
+});
+
+test("extractMarkdownSectionsByTitle handles CRLF and ignores deeper headings", () => {
+  const filtered = extractMarkdownSectionsByTitle(
+    [
+      "##\tExplicit Cue Evidence",
+      "kept",
+      "### Explicit Cue Evidence",
+      "still inside the previous section",
+      "## Search evidence",
+      "stripped",
+    ].join("\r\n"),
+    ["Explicit Cue Evidence"],
+  );
+
+  assert.match(filtered, /kept/);
+  assert.match(filtered, /still inside the previous section/);
+  assert.doesNotMatch(filtered, /stripped/);
+});
+
+test("diagnostic adapter supports explicit-evidence-only recall and strong responder override", async () => {
+  const base = new FakeAdapter();
+  base.recalledText = [
+    "## Explicit Cue Evidence",
+    "[Action 1]: Open settings.",
+    "",
+    "## Search evidence",
+    "Unrelated search context.",
+  ].join("\n");
+  const strongResponder = {
+    async respond() {
+      return {
+        text: "strong answer",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 1,
+        model: "strong-responder",
+      };
+    },
+  };
+  const adapter = createAmaBenchDiagnosticAdapter(
+    base,
+    { ...explicitOnlyVariant, answererMode: "strong" },
+    { strongResponder },
+  );
+
+  assert.equal(adapter.responder, strongResponder);
+  const recalled = await adapter.recall("ama-ep-1", "What happened?");
+  assert.match(recalled, /\[Action 1\]: Open settings/);
+  assert.doesNotMatch(recalled, /Search evidence/);
+  assert.doesNotMatch(recalled, /Unrelated search context/);
+});
+
+test("oracle trajectory recall uses stored visible messages and clears on reset", async () => {
+  const base = new FakeAdapter();
+  const adapter = createAmaBenchDiagnosticAdapter(base, {
+    id: "oracle-trajectory-normal",
+    label: "oracle",
+    recallMode: "oracle-trajectory",
+    answererMode: "normal",
+    description: "test",
+  });
+  const messages: Message[] = [
+    { role: "user", content: "[Action 1]: Open settings." },
+    {
+      role: "assistant",
+      content: "[Observation 1]: The profile language is Spanish.",
+    },
+  ];
+
+  await adapter.store("ama-ep-1", messages);
+  await adapter.drain?.();
+  assert.equal(base.storeCalls, 0);
+  assert.equal(base.drainCalls, 0);
+  const recalled = await adapter.recall("ama-ep-1", "What language?");
+  assert.match(recalled, /^## Explicit Cue Evidence/);
+  assert.match(recalled, /\[Action 1\]: Open settings/);
+  assert.match(recalled, /\[Observation 1\]: The profile language is Spanish/);
+  assert.doesNotMatch(recalled, /expected answer/i);
+
+  await adapter.reset();
+  assert.equal(await adapter.recall("ama-ep-1", "What language?"), "");
+});
+
+test("oracle trajectory recall respects non-positive budgets", () => {
+  assert.equal(
+    buildOracleTrajectoryRecall(
+      [{ role: "user", content: "[Action 1]: Open settings." }],
+      0,
+    ),
+    "",
+  );
+});
+
+test("diagnostic summary groups domain and QA type without raw answer text", () => {
+  const variant = selectAmaBenchDiagnosticVariants({
+    ids: ["remnic-full-normal"],
+  })[0]!;
+  const result: BenchmarkResult = {
+    meta: {
+      id: "run-1",
+      benchmark: "ama-bench",
+      benchmarkTier: "published",
+      version: "2.0.0",
+      remnicVersion: "test",
+      gitSha: "abc",
+      timestamp: "2026-05-05T00:00:00.000Z",
+      mode: "full",
+      runCount: 1,
+      seeds: [0],
+    },
+    config: {
+      systemProvider: null,
+      judgeProvider: null,
+      adapterMode: "direct",
+      remnicConfig: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: [
+        {
+          taskId: "q1",
+          question: "redacted by summary",
+          expected: "Spanish",
+          actual: "Spanish",
+          scores: { f1: 1, ama_bench_recommended_accuracy: 1 },
+          latencyMs: 0,
+          tokens: { input: 0, output: 0 },
+          details: {
+            domain: "WEB",
+            qaType: "recall",
+            taskType: "web",
+            episodeId: 1,
+            recalledLength: 100,
+            answeredLength: 7,
+            recallSections: ["Explicit Cue Evidence"],
+            responderModel: "normal",
+            judgeModel: "judge",
+            amaBenchCrossJudgeModel: "cross-judge",
+            amaBenchCrossJudgeScore: 1,
+          },
+        },
+        {
+          taskId: "q2",
+          question: "redacted by summary",
+          expected: "disabled",
+          actual: "There is not enough information.",
+          scores: { f1: 0, ama_bench_recommended_accuracy: 0 },
+          latencyMs: 0,
+          tokens: { input: 0, output: 0 },
+          details: {
+            domain: "WEB",
+            qaType: "state_updating",
+            taskType: "web",
+          },
+        },
+      ],
+      aggregates: {},
+    },
+    environment: {
+      os: "test",
+      nodeVersion: "test",
+    },
+  };
+
+  const summary = buildAmaBenchDiagnosticVariantSummary(variant, result, {
+    runtimeProfile: "real",
+    hasResponder: true,
+  });
+  assert.equal(summary.taskCount, 2);
+  assert.equal(summary.usesFullRemnicRecallProcess, true);
+  assert.equal(summary.isPrimaryFullSystemScore, true);
+  assert.equal(summary.unknownLikeRate, 0.5);
+  assert.equal(summary.scoreMeans.f1, 0.5);
+  assert.equal(summary.scoreCounts.ama_bench_recommended_accuracy, 2);
+  assert.deepEqual(
+    summary.byDomain.map((entry) => [entry.key, entry.taskCount]),
+    [["WEB", 2]],
+  );
+  assert.deepEqual(
+    summary.byQaType.map((entry) => [entry.key, entry.taskCount]),
+    [
+      ["recall", 1],
+      ["state_updating", 1],
+    ],
+  );
+  assert.equal("question" in summary.tasks[0]!, false);
+  assert.equal("actual" in summary.tasks[0]!, false);
+  assert.equal(summary.tasks[0]?.crossJudgeModel, "cross-judge");
+  assert.equal(summary.tasks[0]?.crossJudgeScore, 1);
+});
+
+test("diagnostic summary only marks primary full-system scores for full real Remnic runs", () => {
+  const variant = selectAmaBenchDiagnosticVariants({
+    ids: ["remnic-full-normal"],
+  })[0]!;
+  const result: BenchmarkResult = {
+    meta: {
+      id: "run-1",
+      benchmark: "ama-bench",
+      benchmarkTier: "published",
+      version: "2.0.0",
+      remnicVersion: "test",
+      gitSha: "abc",
+      timestamp: "2026-05-05T00:00:00.000Z",
+      mode: "quick",
+      runCount: 1,
+      seeds: [0],
+    },
+    config: {
+      systemProvider: null,
+      judgeProvider: null,
+      adapterMode: "lightweight",
+      remnicConfig: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: [],
+      aggregates: {},
+    },
+    environment: {
+      os: "test",
+      nodeVersion: "test",
+    },
+  };
+
+  const baselineSummary = buildAmaBenchDiagnosticVariantSummary(
+    variant,
+    result,
+    { runtimeProfile: "baseline" },
+  );
+  assert.equal(baselineSummary.usesFullRemnicRecallProcess, false);
+  assert.equal(baselineSummary.isPrimaryFullSystemScore, false);
+
+  const quickRealSummary = buildAmaBenchDiagnosticVariantSummary(
+    variant,
+    result,
+    { runtimeProfile: "real", hasResponder: true },
+  );
+  assert.equal(quickRealSummary.usesFullRemnicRecallProcess, true);
+  assert.equal(quickRealSummary.isPrimaryFullSystemScore, false);
+
+  const noResponderResult: BenchmarkResult = {
+    ...result,
+    meta: {
+      ...result.meta,
+      mode: "full",
+    },
+  };
+  const noResponderSummary = buildAmaBenchDiagnosticVariantSummary(
+    variant,
+    noResponderResult,
+    { runtimeProfile: "real", hasResponder: false },
+  );
+  assert.equal(noResponderSummary.usesFullRemnicRecallProcess, true);
+  assert.equal(noResponderSummary.isPrimaryFullSystemScore, false);
+});
+
+test("diagnostic matrix artifact records sanitized run metadata", () => {
+  const artifact = buildAmaBenchDiagnosticMatrixArtifact({
+    mode: "quick",
+    generatedAt: "2026-05-05T00:00:00.000Z",
+    config: {
+      runtimeProfile: "real",
+      adapterMode: "direct",
+      datasetDir: "/tmp/ama",
+      limit: 2,
+      seed: 7,
+      amaBenchCrossJudgeProvider: {
+        provider: "ollama",
+        model: "gemma4:31b",
+        baseUrl: "https://ollama.com/api",
+      },
+    },
+    variants: [],
+  });
+
+  assert.equal(artifact.schemaVersion, 1);
+  assert.equal(artifact.benchmark, "ama-bench");
+  assert.equal(artifact.config.runtimeProfile, "real");
+  assert.equal(
+    artifact.config.amaBenchCrossJudgeProvider?.baseUrl,
+    "https://ollama.com/api",
+  );
+  assert.equal(artifact.config.limit, 2);
+});
+
+test("diagnostic variant selection rejects unknown ids and can include strong rows", () => {
+  assert.deepEqual(
+    selectAmaBenchDiagnosticVariants().map((variant) => variant.id),
+    ["remnic-full-normal", "explicit-only-normal", "oracle-trajectory-normal"],
+  );
+  assert.ok(
+    selectAmaBenchDiagnosticVariants({ includeStrong: true }).some(
+      (variant) => variant.id === "remnic-full-strong",
+    ),
+  );
+  assert.deepEqual(
+    selectAmaBenchDiagnosticVariants({ includeStrong: true })
+      .filter((variant) => !DEFAULT_TEST_VARIANT_IDS.has(variant.id))
+      .map((variant) => variant.answererMode),
+    ["strong", "strong", "strong"],
+  );
+  assert.throws(
+    () => selectAmaBenchDiagnosticVariants({ ids: ["missing"] }),
+    /Unknown AMA-Bench diagnostic variant/,
+  );
+});
+
+test("unknown-like answer detection catches underspecified answer patterns", () => {
+  assert.equal(isAmaBenchUnknownLikeAnswer("unknown"), true);
+  assert.equal(
+    isAmaBenchUnknownLikeAnswer("There is insufficient context to answer."),
+    true,
+  );
+  assert.equal(isAmaBenchUnknownLikeAnswer("Spanish"), false);
+});

--- a/packages/bench/src/benchmarks/published/ama-bench/diagnostics.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/diagnostics.ts
@@ -1,0 +1,536 @@
+import type {
+  BenchMemoryAdapter,
+  BenchResponder,
+  Message,
+} from "../../../adapters/types.js";
+import { isUnknownOnlyAnswer } from "../../../answering.js";
+import type {
+  BenchmarkMode,
+  BenchmarkResult,
+  TaskResult,
+} from "../../../types.js";
+
+export type AmaBenchDiagnosticRecallMode =
+  | "remnic-full"
+  | "explicit-evidence-only"
+  | "oracle-trajectory";
+
+export type AmaBenchDiagnosticAnswererMode = "normal" | "strong";
+
+export interface AmaBenchDiagnosticVariant {
+  id: string;
+  label: string;
+  recallMode: AmaBenchDiagnosticRecallMode;
+  answererMode: AmaBenchDiagnosticAnswererMode;
+  description: string;
+}
+
+export const AMA_BENCH_DIAGNOSTIC_VARIANTS: readonly AmaBenchDiagnosticVariant[] = Object.freeze([
+  {
+    id: "remnic-full-normal",
+    label: "Remnic full recall + normal answerer",
+    recallMode: "remnic-full",
+    answererMode: "normal",
+    description:
+      "Current Remnic recall surface, including explicit cue evidence, full recall, search evidence, and fallback context.",
+  },
+  {
+    id: "explicit-only-normal",
+    label: "Explicit evidence only + normal answerer",
+    recallMode: "explicit-evidence-only",
+    answererMode: "normal",
+    description:
+      "Keeps only the Explicit Cue Evidence section from Remnic recall to isolate exact visible trajectory cues.",
+  },
+  {
+    id: "oracle-trajectory-normal",
+    label: "Oracle trajectory recall + normal answerer",
+    recallMode: "oracle-trajectory",
+    answererMode: "normal",
+    description:
+      "Diagnostic ceiling that recalls the full stored visible action/observation trajectory without using hidden answers.",
+  },
+  {
+    id: "remnic-full-strong",
+    label: "Remnic full recall + strong answerer",
+    recallMode: "remnic-full",
+    answererMode: "strong",
+    description:
+      "Current Remnic recall surface answered by the strong diagnostic responder.",
+  },
+  {
+    id: "explicit-only-strong",
+    label: "Explicit evidence only + strong answerer",
+    recallMode: "explicit-evidence-only",
+    answererMode: "strong",
+    description:
+      "Exact visible trajectory cues answered by the strong diagnostic responder.",
+  },
+  {
+    id: "oracle-trajectory-strong",
+    label: "Oracle trajectory recall + strong answerer",
+    recallMode: "oracle-trajectory",
+    answererMode: "strong",
+    description:
+      "Full visible trajectory recall answered by the strong diagnostic responder.",
+  },
+]);
+
+const DEFAULT_NORMAL_VARIANT_IDS = new Set([
+  "remnic-full-normal",
+  "explicit-only-normal",
+  "oracle-trajectory-normal",
+]);
+
+export function selectAmaBenchDiagnosticVariants(options: {
+  ids?: string[];
+  includeStrong?: boolean;
+} = {}): AmaBenchDiagnosticVariant[] {
+  const byId = new Map(
+    AMA_BENCH_DIAGNOSTIC_VARIANTS.map((variant) => [variant.id, variant]),
+  );
+  const requested = options.ids?.map((id) => id.trim()).filter(Boolean);
+  const variants = requested && requested.length > 0
+    ? requested.map((id) => {
+        const variant = byId.get(id);
+        if (!variant) {
+          throw new Error(
+            `Unknown AMA-Bench diagnostic variant "${id}". Available variants: ${
+              [...byId.keys()].join(", ")
+            }.`,
+          );
+        }
+        return variant;
+      })
+    : AMA_BENCH_DIAGNOSTIC_VARIANTS.filter((variant) =>
+        DEFAULT_NORMAL_VARIANT_IDS.has(variant.id) ||
+        (options.includeStrong === true && variant.answererMode === "strong"),
+      );
+
+  return variants.map((variant) => ({ ...variant }));
+}
+
+export interface AmaBenchDiagnosticAdapterOptions {
+  strongResponder?: BenchResponder;
+}
+
+export function createAmaBenchDiagnosticAdapter(
+  base: BenchMemoryAdapter,
+  variant: AmaBenchDiagnosticVariant,
+  options: AmaBenchDiagnosticAdapterOptions = {},
+): BenchMemoryAdapter {
+  const sessions = new Map<string, Message[]>();
+
+  const clearCapturedSession = (sessionId?: string): void => {
+    if (sessionId) {
+      sessions.delete(sessionId);
+      return;
+    }
+    sessions.clear();
+  };
+
+  const diagnostic: BenchMemoryAdapter = {
+    async store(sessionId, messages) {
+      const existing = sessions.get(sessionId) ?? [];
+      sessions.set(sessionId, [...existing, ...messages]);
+      if (variant.recallMode !== "oracle-trajectory") {
+        await base.store(sessionId, messages);
+      }
+    },
+    async recall(sessionId, query, budgetChars) {
+      if (variant.recallMode === "oracle-trajectory") {
+        return buildOracleTrajectoryRecall(
+          sessions.get(sessionId) ?? [],
+          budgetChars,
+        );
+      }
+
+      const recalled = await base.recall(sessionId, query, budgetChars);
+      if (variant.recallMode === "explicit-evidence-only") {
+        return extractMarkdownSectionsByTitle(recalled, [
+          "Explicit Cue Evidence",
+        ]);
+      }
+
+      return recalled;
+    },
+    async search(query, limit, sessionId) {
+      return base.search(query, limit, sessionId);
+    },
+    async reset(sessionId) {
+      clearCapturedSession(sessionId);
+      await base.reset(sessionId);
+    },
+    async getStats(sessionId) {
+      return base.getStats(sessionId);
+    },
+    async drain() {
+      if (variant.recallMode !== "oracle-trajectory") {
+        await base.drain?.();
+      }
+    },
+    async destroy() {
+      await base.destroy();
+    },
+  };
+
+  Object.defineProperty(diagnostic, "responder", {
+    enumerable: true,
+    get() {
+      return variant.answererMode === "strong"
+        ? options.strongResponder ?? base.responder
+        : base.responder;
+    },
+  });
+  Object.defineProperty(diagnostic, "judge", {
+    enumerable: true,
+    get() {
+      return base.judge;
+    },
+  });
+
+  return diagnostic;
+}
+
+export function buildOracleTrajectoryRecall(
+  messages: readonly Message[],
+  budgetChars?: number,
+): string {
+  if (messages.length === 0) {
+    return "";
+  }
+
+  const body = messages
+    .map((message) => message.content.trim())
+    .filter((content) => content.length > 0)
+    .join("\n");
+  if (body.length === 0) {
+    return "";
+  }
+
+  return truncateToBudget(`## Explicit Cue Evidence\n${body}`, budgetChars);
+}
+
+export function extractMarkdownSectionsByTitle(
+  markdown: string,
+  allowedTitles: readonly string[],
+): string {
+  const allowed = new Set(allowedTitles);
+  const sections: string[] = [];
+  let currentTitle: string | undefined;
+  let currentLines: string[] = [];
+
+  const flush = (): void => {
+    if (currentTitle && allowed.has(currentTitle)) {
+      const section = [`## ${currentTitle}`, ...currentLines].join("\n").trim();
+      if (section.length > 0) {
+        sections.push(section);
+      }
+    }
+    currentTitle = undefined;
+    currentLines = [];
+  };
+
+  for (const line of splitMarkdownLines(markdown)) {
+    const headingTitle = secondLevelMarkdownHeadingTitle(line);
+    if (headingTitle) {
+      flush();
+      currentTitle = headingTitle;
+      currentLines = [];
+      continue;
+    }
+    if (currentTitle) {
+      currentLines.push(line);
+    }
+  }
+  flush();
+
+  return sections.join("\n\n");
+}
+
+function splitMarkdownLines(markdown: string): string[] {
+  return markdown.replaceAll("\r\n", "\n").replaceAll("\r", "\n").split("\n");
+}
+
+function secondLevelMarkdownHeadingTitle(line: string): string | undefined {
+  if (!line.startsWith("##") || line.startsWith("###")) {
+    return undefined;
+  }
+
+  const title = line.slice(2);
+  if (!title.startsWith(" ") && !title.startsWith("\t")) {
+    return undefined;
+  }
+
+  const trimmed = title.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export interface AmaBenchDiagnosticTaskRow {
+  variantId: string;
+  taskId: string;
+  episodeId?: string | number;
+  domain: string;
+  qaType: string;
+  taskType: string;
+  scores: Record<string, number>;
+  unknownLike: boolean;
+  recalledLength: number;
+  answeredLength: number;
+  recallSections: string[];
+  responderModel?: string;
+  judgeModel?: string;
+  crossJudgeModel?: string;
+  crossJudgeScore?: number;
+}
+
+export interface AmaBenchDiagnosticBreakdown {
+  key: string;
+  taskCount: number;
+  unknownLikeRate: number;
+  scoreMeans: Record<string, number>;
+  scoreCounts: Record<string, number>;
+}
+
+export interface AmaBenchDiagnosticVariantSummary {
+  variant: AmaBenchDiagnosticVariant;
+  usesFullRemnicRecallProcess: boolean;
+  isPrimaryFullSystemScore: boolean;
+  taskCount: number;
+  unknownLikeRate: number;
+  scoreMeans: Record<string, number>;
+  scoreCounts: Record<string, number>;
+  byDomain: AmaBenchDiagnosticBreakdown[];
+  byQaType: AmaBenchDiagnosticBreakdown[];
+  byDomainAndQaType: AmaBenchDiagnosticBreakdown[];
+  tasks: AmaBenchDiagnosticTaskRow[];
+}
+
+export interface SanitizedDiagnosticProvider {
+  provider: string;
+  model: string;
+  baseUrl?: string;
+}
+
+export interface AmaBenchDiagnosticMatrixArtifact {
+  schemaVersion: 1;
+  benchmark: "ama-bench";
+  generatedAt: string;
+  mode: BenchmarkMode;
+  config: {
+    runtimeProfile?: string;
+    adapterMode?: string;
+    datasetDir?: string;
+    limit?: number;
+    seed?: number;
+    systemProvider?: SanitizedDiagnosticProvider | null;
+    judgeProvider?: SanitizedDiagnosticProvider | null;
+    amaBenchCrossJudgeProvider?: SanitizedDiagnosticProvider | null;
+    strongSystemProvider?: SanitizedDiagnosticProvider | null;
+    variantIds?: string[];
+  };
+  variants: AmaBenchDiagnosticVariantSummary[];
+}
+
+export interface AmaBenchDiagnosticRunContext {
+  runtimeProfile?: string;
+  hasResponder?: boolean;
+}
+
+export function buildAmaBenchDiagnosticVariantSummary(
+  variant: AmaBenchDiagnosticVariant,
+  result: BenchmarkResult,
+  context: AmaBenchDiagnosticRunContext = {},
+): AmaBenchDiagnosticVariantSummary {
+  const tasks = result.results.tasks.map((task) =>
+    taskToDiagnosticRow(variant.id, task),
+  );
+  const usesFullRemnicRecallProcess =
+    context.runtimeProfile === "real" &&
+    variant.recallMode === "remnic-full";
+  const isPrimaryFullSystemScore =
+    usesFullRemnicRecallProcess &&
+    result.meta.mode === "full" &&
+    context.hasResponder === true &&
+    variant.answererMode === "normal";
+
+  return {
+    variant: { ...variant },
+    usesFullRemnicRecallProcess,
+    isPrimaryFullSystemScore,
+    taskCount: tasks.length,
+    unknownLikeRate: unknownLikeRate(tasks),
+    ...summarizeScores(tasks),
+    byDomain: groupBreakdowns(tasks, (task) => task.domain),
+    byQaType: groupBreakdowns(tasks, (task) => task.qaType),
+    byDomainAndQaType: groupBreakdowns(
+      tasks,
+      (task) => `${task.domain} / ${task.qaType}`,
+    ),
+    tasks,
+  };
+}
+
+export function buildAmaBenchDiagnosticMatrixArtifact(args: {
+  mode: BenchmarkMode;
+  config?: AmaBenchDiagnosticMatrixArtifact["config"];
+  variants: AmaBenchDiagnosticVariantSummary[];
+  generatedAt?: string;
+}): AmaBenchDiagnosticMatrixArtifact {
+  return {
+    schemaVersion: 1,
+    benchmark: "ama-bench",
+    generatedAt: args.generatedAt ?? new Date().toISOString(),
+    mode: args.mode,
+    config: args.config ?? {},
+    variants: args.variants,
+  };
+}
+
+export function isAmaBenchUnknownLikeAnswer(answer: string): boolean {
+  if (isUnknownOnlyAnswer(answer)) {
+    return true;
+  }
+
+  const normalized = answer.trim().toLowerCase();
+  return (
+    /\b(?:not enough|insufficient)\s+(?:information|context|evidence)\b/.test(normalized) ||
+    /\b(?:not specified|not provided|not mentioned|cannot determine|can't determine)\b/.test(normalized) ||
+    /\bno relevant evidence\b/.test(normalized)
+  );
+}
+
+function taskToDiagnosticRow(
+  variantId: string,
+  task: TaskResult,
+): AmaBenchDiagnosticTaskRow {
+  const details = task.details ?? {};
+  return {
+    variantId,
+    taskId: task.taskId,
+    episodeId: asStringOrNumber(details.episodeId),
+    domain: asString(details.domain, "unknown-domain"),
+    qaType: asString(details.qaType, "unknown-qa-type"),
+    taskType: asString(details.taskType, "unknown-task-type"),
+    scores: { ...task.scores },
+    unknownLike: isAmaBenchUnknownLikeAnswer(task.actual),
+    recalledLength: asNumber(details.recalledLength, 0),
+    answeredLength: asNumber(details.answeredLength, task.actual.length),
+    recallSections: asStringArray(details.recallSections),
+    responderModel: asOptionalString(details.responderModel),
+    judgeModel: asOptionalString(details.judgeModel),
+    crossJudgeModel: asOptionalString(details.amaBenchCrossJudgeModel),
+    crossJudgeScore: asOptionalNumber(details.amaBenchCrossJudgeScore),
+  };
+}
+
+function truncateToBudget(text: string, budgetChars?: number): string {
+  if (budgetChars === undefined) {
+    return text;
+  }
+  if (!Number.isFinite(budgetChars) || budgetChars <= 0) {
+    return "";
+  }
+  return text.length > budgetChars ? text.slice(0, budgetChars) : text;
+}
+
+function groupBreakdowns(
+  tasks: AmaBenchDiagnosticTaskRow[],
+  keyForTask: (task: AmaBenchDiagnosticTaskRow) => string,
+): AmaBenchDiagnosticBreakdown[] {
+  const groups = new Map<string, AmaBenchDiagnosticTaskRow[]>();
+  for (const task of tasks) {
+    const key = keyForTask(task);
+    groups.set(key, [...(groups.get(key) ?? []), task]);
+  }
+
+  return [...groups.entries()]
+    .map(([key, groupTasks]) => ({
+      key,
+      taskCount: groupTasks.length,
+      unknownLikeRate: unknownLikeRate(groupTasks),
+      ...summarizeScores(groupTasks),
+    }))
+    .sort((left, right) => {
+      if (left.taskCount !== right.taskCount) {
+        return right.taskCount - left.taskCount;
+      }
+      return left.key.localeCompare(right.key);
+    });
+}
+
+function unknownLikeRate(tasks: readonly AmaBenchDiagnosticTaskRow[]): number {
+  if (tasks.length === 0) {
+    return 0;
+  }
+  const unknownCount = tasks.filter((task) => task.unknownLike).length;
+  return unknownCount / tasks.length;
+}
+
+function summarizeScores(tasks: readonly AmaBenchDiagnosticTaskRow[]): {
+  scoreMeans: Record<string, number>;
+  scoreCounts: Record<string, number>;
+} {
+  const values = new Map<string, number[]>();
+  for (const task of tasks) {
+    for (const [metric, value] of Object.entries(task.scores)) {
+      if (Number.isFinite(value) && value >= 0) {
+        values.set(metric, [...(values.get(metric) ?? []), value]);
+      }
+    }
+  }
+
+  const scoreMeans: Record<string, number> = {};
+  const scoreCounts: Record<string, number> = {};
+  for (const [metric, metricValues] of [...values.entries()].sort()) {
+    scoreCounts[metric] = metricValues.length;
+    scoreMeans[metric] =
+      metricValues.reduce((sum, value) => sum + value, 0) /
+      metricValues.length;
+  }
+  return { scoreMeans, scoreCounts };
+}
+
+function asString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : fallback;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function asStringOrNumber(value: unknown): string | number | undefined {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : fallback;
+}
+
+function asOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (entry): entry is string =>
+      typeof entry === "string" && entry.trim().length > 0,
+  );
+}

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -158,6 +158,28 @@ export {
   serializeJsonl,
   writeLeaderboardArtifactsForResult,
 } from "./leaderboard-export.js";
+export {
+  AMA_BENCH_DIAGNOSTIC_VARIANTS,
+  buildAmaBenchDiagnosticMatrixArtifact,
+  buildAmaBenchDiagnosticVariantSummary,
+  buildOracleTrajectoryRecall,
+  createAmaBenchDiagnosticAdapter,
+  extractMarkdownSectionsByTitle,
+  isAmaBenchUnknownLikeAnswer,
+  selectAmaBenchDiagnosticVariants,
+} from "./benchmarks/published/ama-bench/diagnostics.js";
+export type {
+  AmaBenchDiagnosticAdapterOptions,
+  AmaBenchDiagnosticAnswererMode,
+  AmaBenchDiagnosticBreakdown,
+  AmaBenchDiagnosticMatrixArtifact,
+  AmaBenchDiagnosticRecallMode,
+  AmaBenchDiagnosticRunContext,
+  AmaBenchDiagnosticTaskRow,
+  AmaBenchDiagnosticVariant,
+  AmaBenchDiagnosticVariantSummary,
+  SanitizedDiagnosticProvider,
+} from "./benchmarks/published/ama-bench/diagnostics.js";
 export type {
   LeaderboardArtifactWrite,
 } from "./leaderboard-export.js";

--- a/scripts/bench/ama-diagnostic-matrix.ts
+++ b/scripts/bench/ama-diagnostic-matrix.ts
@@ -1,0 +1,917 @@
+#!/usr/bin/env tsx
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import type {
+  BenchJudge,
+  BenchMemoryAdapter,
+  BenchResponder,
+  BenchRuntimeProfile,
+  BuiltInProvider,
+  AmaBenchDiagnosticMatrixArtifact,
+  AmaBenchDiagnosticVariant,
+  ProviderConfig,
+  SanitizedDiagnosticProvider,
+  ProviderFactoryConfig,
+} from "@remnic/bench";
+
+type BenchModule = typeof import("@remnic/bench");
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+let buildAmaBenchDiagnosticMatrixArtifact: BenchModule["buildAmaBenchDiagnosticMatrixArtifact"];
+let buildAmaBenchDiagnosticVariantSummary: BenchModule["buildAmaBenchDiagnosticVariantSummary"];
+let createAmaBenchDiagnosticAdapter: BenchModule["createAmaBenchDiagnosticAdapter"];
+let createLightweightAdapter: BenchModule["createLightweightAdapter"];
+let createProviderBackedAmaBenchRecommendedJudge: BenchModule["createProviderBackedAmaBenchRecommendedJudge"];
+let createProviderBackedResponder: BenchModule["createProviderBackedResponder"];
+let createRemnicAdapter: BenchModule["createRemnicAdapter"];
+let resolveBenchRuntimeProfile: BenchModule["resolveBenchRuntimeProfile"];
+let runBenchmark: BenchModule["runBenchmark"];
+let selectAmaBenchDiagnosticVariants: BenchModule["selectAmaBenchDiagnosticVariants"];
+let expandTildePath: ((value: string) => string) | undefined;
+let runtimeDepsLoaded = false;
+
+const PROVIDERS: readonly BuiltInProvider[] = Object.freeze([
+  "openai",
+  "anthropic",
+  "ollama",
+  "litellm",
+  "local-llm",
+  "codex-cli",
+]);
+
+interface ParsedArgs {
+  quick: boolean;
+  datasetDir?: string;
+  output?: string;
+  limit?: number;
+  seed?: number;
+  runtimeProfile: BenchRuntimeProfile;
+  remnicConfigPath?: string;
+  openclawConfigPath?: string;
+  modelSource?: "plugin" | "gateway";
+  gatewayAgentId?: string;
+  fastGatewayAgentId?: string;
+  systemProvider?: BuiltInProvider;
+  systemModel?: string;
+  systemBaseUrl?: string;
+  systemApiKey?: string;
+  judgeProvider?: BuiltInProvider;
+  judgeModel?: string;
+  judgeBaseUrl?: string;
+  judgeApiKey?: string;
+  strongSystemProvider?: BuiltInProvider;
+  strongSystemModel?: string;
+  strongSystemBaseUrl?: string;
+  strongSystemApiKey?: string;
+  strongDisableThinking: boolean;
+  requestTimeout?: number;
+  max429WaitMs?: number;
+  disableThinking: boolean;
+  amaBenchJudgeProtocol: "default" | "recommended";
+  amaBenchCrossJudgeProvider?: BuiltInProvider;
+  amaBenchCrossJudgeModel?: string;
+  amaBenchCrossJudgeBaseUrl?: string;
+  amaBenchCrossJudgeApiKey?: string;
+  variants?: string[];
+  includeStrong: boolean;
+}
+
+interface MatrixRunResult {
+  artifact: AmaBenchDiagnosticMatrixArtifact;
+  outputPath?: string;
+}
+
+export async function runAmaBenchDiagnosticMatrix(
+  parsed: ParsedArgs,
+): Promise<MatrixRunResult> {
+  await loadRuntimeDeps();
+  validatePrimaryProviderConfigs(parsed);
+
+  if (!parsed.quick && !parsed.datasetDir) {
+    throw new Error(
+      "AMA diagnostic matrix full mode requires --dataset-dir. Use --quick for the smoke fixture.",
+    );
+  }
+
+  const strongResponder = createStrongResponder(parsed);
+  const variants = selectAmaBenchDiagnosticVariants({
+    ids: parsed.variants,
+    includeStrong: parsed.includeStrong,
+  });
+  validateStrongVariants(variants, strongResponder);
+
+  const runtime = await resolveBenchRuntimeProfile({
+    runtimeProfile: parsed.runtimeProfile,
+    remnicConfigPath: parsed.remnicConfigPath,
+    openclawConfigPath: parsed.openclawConfigPath,
+    modelSource: parsed.runtimeProfile === "real" ? parsed.modelSource : undefined,
+    gatewayAgentId: parsed.gatewayAgentId,
+    fastGatewayAgentId: parsed.fastGatewayAgentId,
+    systemProvider:
+      parsed.runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemProvider,
+    systemModel:
+      parsed.runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemModel,
+    systemBaseUrl:
+      parsed.runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemBaseUrl,
+    systemApiKey:
+      parsed.runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemApiKey,
+    judgeProvider: parsed.judgeProvider,
+    judgeModel: parsed.judgeModel,
+    judgeBaseUrl: parsed.judgeBaseUrl,
+    judgeApiKey: parsed.judgeApiKey,
+    requestTimeout: parsed.requestTimeout,
+    max429WaitMs: parsed.max429WaitMs,
+    disableThinking: parsed.disableThinking,
+  });
+  const primaryJudge = createPrimaryJudge(parsed, runtime.judgeProvider);
+  const crossJudge = createCrossJudge(parsed, runtime.judgeProvider);
+  const adapterMode = parsed.quick && runtime.profile === "baseline"
+    ? "lightweight"
+    : "direct";
+  const summaries = [];
+
+  for (const variant of variants) {
+    process.stderr.write(`[ama-diagnostic] running ${variant.id}\n`);
+    const adapterOptions = {
+      ...runtime.adapterOptions,
+      ...(primaryJudge ? { judge: primaryJudge } : {}),
+    };
+    const base = variant.recallMode === "oracle-trajectory"
+      ? createOracleTrajectoryBaseAdapter(adapterOptions)
+      : await createBaseAdapter(adapterMode, adapterOptions);
+    const system = createAmaBenchDiagnosticAdapter(base, variant, {
+      strongResponder,
+    });
+
+    try {
+      const result = await runBenchmark("ama-bench", {
+        mode: parsed.quick ? "quick" : "full",
+        datasetDir: parsed.datasetDir,
+        limit: parsed.limit,
+        seed: parsed.seed,
+        adapterMode,
+        runtimeProfile: runtime.profile,
+        systemProvider: runtime.systemProvider,
+        judgeProvider: runtime.judgeProvider,
+        remnicConfig: runtime.remnicConfig,
+        amaBenchJudgeProtocol: parsed.amaBenchJudgeProtocol,
+        ...(crossJudge.judge ? { amaBenchCrossJudge: crossJudge.judge } : {}),
+        ...(crossJudge.provider
+          ? { amaBenchCrossJudgeProvider: crossJudge.provider }
+          : {}),
+        system,
+      });
+      summaries.push(
+        buildAmaBenchDiagnosticVariantSummary(variant, result, {
+          runtimeProfile: runtime.profile,
+          hasResponder: system.responder !== undefined,
+        }),
+      );
+    } finally {
+      await system.destroy();
+    }
+  }
+
+  const artifact = buildAmaBenchDiagnosticMatrixArtifact({
+    mode: parsed.quick ? "quick" : "full",
+    config: {
+      runtimeProfile: runtime.profile,
+      adapterMode,
+      datasetDir: parsed.datasetDir ? "[provided]" : undefined,
+      ...(parsed.limit !== undefined ? { limit: parsed.limit } : {}),
+      ...(parsed.seed !== undefined ? { seed: parsed.seed } : {}),
+      systemProvider: sanitizeProvider(runtime.systemProvider),
+      judgeProvider: sanitizeProvider(runtime.judgeProvider),
+      amaBenchCrossJudgeProvider: sanitizeProvider(crossJudge.provider),
+      strongSystemProvider: sanitizeProvider(strongProviderConfig(parsed)),
+      variantIds: variants.map((variant) => variant.id),
+    },
+    variants: summaries,
+  });
+
+  if (parsed.output) {
+    const outputPath = path.resolve(parsed.output);
+    await mkdir(path.dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+    return { artifact, outputPath };
+  }
+
+  return { artifact };
+}
+
+function createStrongResponder(parsed: ParsedArgs): BenchResponder | undefined {
+  const config = strongProviderConfig(parsed);
+  return config ? createProviderBackedResponder(asProviderFactoryConfig(config)) : undefined;
+}
+
+function createPrimaryJudge(
+  parsed: ParsedArgs,
+  judgeProvider: ProviderConfig | null,
+): BenchJudge | undefined {
+  if (parsed.amaBenchJudgeProtocol !== "recommended") {
+    return undefined;
+  }
+  if (!judgeProvider) {
+    throw new Error(
+      "--ama-bench-judge-protocol recommended requires --judge-provider and --judge-model.",
+    );
+  }
+  return createProviderBackedAmaBenchRecommendedJudge(
+    asProviderFactoryConfig(judgeProvider),
+  );
+}
+
+function createCrossJudge(
+  parsed: ParsedArgs,
+  primaryJudgeProvider: ProviderConfig | null,
+): { judge?: BenchJudge; provider?: ProviderConfig } {
+  const hasAnyCrossJudgeConfig =
+    parsed.amaBenchCrossJudgeProvider !== undefined ||
+    parsed.amaBenchCrossJudgeModel !== undefined ||
+    parsed.amaBenchCrossJudgeBaseUrl !== undefined ||
+    parsed.amaBenchCrossJudgeApiKey !== undefined;
+  if (!hasAnyCrossJudgeConfig) {
+    return {};
+  }
+  if (!parsed.amaBenchCrossJudgeModel) {
+    throw new Error(
+      "Cross-judge config requires --ama-bench-cross-judge-model.",
+    );
+  }
+
+  const provider = parsed.amaBenchCrossJudgeProvider ?? primaryJudgeProvider?.provider;
+  if (!provider) {
+    throw new Error(
+      "--ama-bench-cross-judge-model requires --ama-bench-cross-judge-provider or --judge-provider.",
+    );
+  }
+  const inheritPrimary =
+    parsed.amaBenchCrossJudgeProvider === undefined ||
+    parsed.amaBenchCrossJudgeProvider === primaryJudgeProvider?.provider;
+  const baseUrl = parsed.amaBenchCrossJudgeBaseUrl ??
+    (inheritPrimary ? primaryJudgeProvider?.baseUrl : undefined);
+  const apiKey = parsed.amaBenchCrossJudgeApiKey ??
+    (inheritPrimary ? primaryJudgeProvider?.apiKey : undefined);
+
+  const config: ProviderConfig = {
+    provider,
+    model: parsed.amaBenchCrossJudgeModel,
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(apiKey ? { apiKey } : {}),
+    ...(inheritPrimary && primaryJudgeProvider?.retryOptions
+      ? { retryOptions: primaryJudgeProvider.retryOptions }
+      : {}),
+    ...(inheritPrimary && primaryJudgeProvider?.disableThinking
+      ? { disableThinking: primaryJudgeProvider.disableThinking }
+      : {}),
+  };
+  if (config.provider === "local-llm" && !config.baseUrl) {
+    throw new Error(
+      "--ama-bench-cross-judge-provider local-llm requires --ama-bench-cross-judge-base-url or --judge-base-url.",
+    );
+  }
+
+  return {
+    judge: createProviderBackedAmaBenchRecommendedJudge(
+      asProviderFactoryConfig(config),
+    ),
+    provider: config,
+  };
+}
+
+async function createBaseAdapter(
+  adapterMode: "lightweight" | "direct",
+  options: Parameters<typeof createRemnicAdapter>[0],
+): Promise<BenchMemoryAdapter> {
+  return adapterMode === "lightweight"
+    ? createLightweightAdapter(options)
+    : createRemnicAdapter(options);
+}
+
+function createOracleTrajectoryBaseAdapter(
+  options: Parameters<typeof createRemnicAdapter>[0],
+): BenchMemoryAdapter {
+  return {
+    responder: options.responder,
+    judge: options.judge,
+    async store() {},
+    async recall() {
+      return "";
+    },
+    async search() {
+      return [];
+    },
+    async reset() {},
+    async getStats() {
+      return {
+        totalMessages: 0,
+        totalSummaryNodes: 0,
+        maxDepth: 0,
+      };
+    },
+    async drain() {},
+    async destroy() {},
+  };
+}
+
+function validateStrongVariants(
+  variants: readonly AmaBenchDiagnosticVariant[],
+  strongResponder: BenchResponder | undefined,
+): void {
+  if (
+    !strongResponder &&
+    variants.some((variant) => variant.answererMode === "strong")
+  ) {
+    throw new Error(
+      "Strong AMA diagnostic variants require --strong-system-provider and --strong-system-model.",
+    );
+  }
+}
+
+function validatePrimaryProviderConfigs(parsed: ParsedArgs): void {
+  validateProviderFlagGroup("system", {
+    provider: parsed.systemProvider,
+    model: parsed.systemModel,
+    baseUrl: parsed.systemBaseUrl,
+    apiKey: parsed.systemApiKey,
+  });
+  validateProviderFlagGroup("judge", {
+    provider: parsed.judgeProvider,
+    model: parsed.judgeModel,
+    baseUrl: parsed.judgeBaseUrl,
+    apiKey: parsed.judgeApiKey,
+  });
+}
+
+function validateProviderFlagGroup(
+  label: "system" | "judge",
+  config: {
+    provider?: BuiltInProvider;
+    model?: string;
+    baseUrl?: string;
+    apiKey?: string;
+  },
+): void {
+  const hasAny =
+    config.provider !== undefined ||
+    config.model !== undefined ||
+    config.baseUrl !== undefined ||
+    config.apiKey !== undefined;
+  if (!hasAny) {
+    return;
+  }
+  if (!config.provider || !config.model) {
+    throw new Error(
+      `${label} provider config requires both --${label}-provider and --${label}-model.`,
+    );
+  }
+  if (config.provider === "local-llm" && !config.baseUrl) {
+    throw new Error(
+      `--${label}-provider local-llm requires --${label}-base-url.`,
+    );
+  }
+}
+
+function strongProviderConfig(parsed: ParsedArgs): ProviderConfig | undefined {
+  const hasAny =
+    parsed.strongSystemProvider !== undefined ||
+    parsed.strongSystemModel !== undefined ||
+    parsed.strongSystemBaseUrl !== undefined ||
+    parsed.strongSystemApiKey !== undefined;
+  if (!hasAny) {
+    return undefined;
+  }
+  if (!parsed.strongSystemProvider || !parsed.strongSystemModel) {
+    throw new Error(
+      "Strong answerer config requires both --strong-system-provider and --strong-system-model.",
+    );
+  }
+  if (parsed.strongSystemProvider === "local-llm" && !parsed.strongSystemBaseUrl) {
+    throw new Error(
+      "--strong-system-provider local-llm requires --strong-system-base-url.",
+    );
+  }
+
+  return {
+    provider: parsed.strongSystemProvider,
+    model: parsed.strongSystemModel,
+    ...(parsed.strongSystemBaseUrl ? { baseUrl: parsed.strongSystemBaseUrl } : {}),
+    ...(parsed.strongSystemApiKey ? { apiKey: parsed.strongSystemApiKey } : {}),
+    ...(parsed.requestTimeout !== undefined || parsed.max429WaitMs !== undefined
+      ? {
+          retryOptions: {
+            ...(parsed.requestTimeout !== undefined
+              ? { timeoutMs: parsed.requestTimeout }
+              : {}),
+            ...(parsed.max429WaitMs !== undefined
+              ? { max429WaitMs: parsed.max429WaitMs }
+              : {}),
+          },
+        }
+      : {}),
+    ...(parsed.strongDisableThinking ? { disableThinking: true } : {}),
+  };
+}
+
+function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig {
+  return {
+    provider: config.provider,
+    model: config.model,
+    ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+    ...(config.retryOptions ? { retryOptions: config.retryOptions } : {}),
+    ...(config.disableThinking ? { disableThinking: config.disableThinking } : {}),
+  } as ProviderFactoryConfig;
+}
+
+function sanitizeProvider(
+  config: ProviderConfig | undefined | null,
+): SanitizedDiagnosticProvider | null {
+  if (!config) {
+    return null;
+  }
+  return {
+    provider: config.provider,
+    model: config.model,
+    ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+  };
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    quick: false,
+    runtimeProfile: "real",
+    strongDisableThinking: false,
+    disableThinking: false,
+    amaBenchJudgeProtocol: "default",
+    includeStrong: false,
+  };
+
+  const takeValue = (index: number, flag: string): string => {
+    const value = argv[index + 1];
+    if (!value || value.startsWith("-")) {
+      throw new Error(`${flag} requires a value.`);
+    }
+    return value;
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    switch (arg) {
+      case "--help":
+      case "-h":
+        throw new UsageRequested();
+      case "--quick":
+        parsed.quick = true;
+        break;
+      case "--dataset-dir":
+      case "--dataset":
+        parsed.datasetDir = resolveUserPath(takeValue(index, arg));
+        index += 1;
+        break;
+      case "--output":
+      case "--out":
+        parsed.output = resolveUserPath(takeValue(index, arg));
+        index += 1;
+        break;
+      case "--limit":
+        parsed.limit = parseNonNegativeInteger(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--seed":
+        parsed.seed = parseNonNegativeInteger(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--runtime-profile":
+        parsed.runtimeProfile = parseRuntimeProfile(takeValue(index, arg));
+        index += 1;
+        break;
+      case "--remnic-config":
+        parsed.remnicConfigPath = resolveUserPath(takeValue(index, arg));
+        index += 1;
+        break;
+      case "--openclaw-config":
+        parsed.openclawConfigPath = resolveUserPath(takeValue(index, arg));
+        index += 1;
+        break;
+      case "--model-source":
+        parsed.modelSource = parseModelSource(takeValue(index, arg));
+        index += 1;
+        break;
+      case "--gateway-agent-id":
+        parsed.gatewayAgentId = takeValue(index, arg);
+        index += 1;
+        break;
+      case "--fast-gateway-agent-id":
+        parsed.fastGatewayAgentId = takeValue(index, arg);
+        index += 1;
+        break;
+      case "--system-provider":
+        parsed.systemProvider = parseProvider(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--system-model":
+        parsed.systemModel = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--system-base-url":
+        parsed.systemBaseUrl = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--system-api-key":
+        parsed.systemApiKey = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--judge-provider":
+        parsed.judgeProvider = parseProvider(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--judge-model":
+        parsed.judgeModel = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--judge-base-url":
+        parsed.judgeBaseUrl = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--judge-api-key":
+        parsed.judgeApiKey = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--strong-system-provider":
+        parsed.strongSystemProvider = parseProvider(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--strong-system-model":
+        parsed.strongSystemModel = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--strong-system-base-url":
+        parsed.strongSystemBaseUrl = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--strong-system-api-key":
+        parsed.strongSystemApiKey = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--strong-disable-thinking":
+        parsed.strongDisableThinking = true;
+        break;
+      case "--request-timeout":
+        parsed.requestTimeout = parsePositiveInteger(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--max-429-wait":
+        parsed.max429WaitMs = parseNonNegativeInteger(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--disable-thinking":
+        parsed.disableThinking = true;
+        break;
+      case "--ama-bench-judge-protocol":
+        parsed.amaBenchJudgeProtocol = parseAmaProtocol(takeValue(index, arg));
+        index += 1;
+        break;
+      case "--ama-bench-cross-judge-provider":
+        parsed.amaBenchCrossJudgeProvider = parseProvider(
+          takeValue(index, arg),
+          arg,
+        );
+        index += 1;
+        break;
+      case "--ama-bench-cross-judge-model":
+        parsed.amaBenchCrossJudgeModel = parseNonEmptyValue(
+          takeValue(index, arg),
+          arg,
+        );
+        index += 1;
+        break;
+      case "--ama-bench-cross-judge-base-url":
+        parsed.amaBenchCrossJudgeBaseUrl = parseNonEmptyValue(
+          takeValue(index, arg),
+          arg,
+        );
+        index += 1;
+        break;
+      case "--ama-bench-cross-judge-api-key":
+        parsed.amaBenchCrossJudgeApiKey = parseNonEmptyValue(
+          takeValue(index, arg),
+          arg,
+        );
+        index += 1;
+        break;
+      case "--variants":
+        parsed.variants = takeValue(index, arg)
+          .split(",")
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0);
+        if (parsed.variants.length === 0) {
+          throw new Error("--variants must include at least one variant id.");
+        }
+        index += 1;
+        break;
+      case "--include-strong":
+        parsed.includeStrong = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function parseProvider(value: string, flag: string): BuiltInProvider {
+  if ((PROVIDERS as readonly string[]).includes(value)) {
+    return value as BuiltInProvider;
+  }
+  throw new Error(
+    `${flag} must be one of ${PROVIDERS.map((provider) => `"${provider}"`).join(", ")}.`,
+  );
+}
+
+function resolveUserPath(value: string): string {
+  if (!expandTildePath) {
+    throw new Error("AMA diagnostic matrix runtime dependencies were not loaded.");
+  }
+  return path.resolve(expandTildePath(value));
+}
+
+function parseRuntimeProfile(value: string): BenchRuntimeProfile {
+  if (
+    value === "baseline" ||
+    value === "real" ||
+    value === "openclaw-chain"
+  ) {
+    return value;
+  }
+  throw new Error(
+    '--runtime-profile must be "baseline", "real", or "openclaw-chain".',
+  );
+}
+
+function parseModelSource(value: string): "plugin" | "gateway" {
+  if (value === "plugin" || value === "gateway") {
+    return value;
+  }
+  throw new Error('--model-source must be "plugin" or "gateway".');
+}
+
+function parseAmaProtocol(value: string): "default" | "recommended" {
+  if (value === "default" || value === "recommended") {
+    return value;
+  }
+  throw new Error('--ama-bench-judge-protocol must be "default" or "recommended".');
+}
+
+function parseNonEmptyValue(value: string, flag: string): string {
+  if (value.trim().length === 0) {
+    throw new Error(`${flag} must not be empty.`);
+  }
+  return value.trim();
+}
+
+function parseNonNegativeInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function parsePositiveInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function printSummary(
+  artifact: AmaBenchDiagnosticMatrixArtifact,
+  stream: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+): void {
+  stream.write(`AMA-Bench diagnostic matrix (${artifact.mode})\n`);
+  for (const summary of artifact.variants) {
+    const preferredMetric =
+      summary.scoreMeans.ama_bench_recommended_accuracy ??
+      summary.scoreMeans.llm_judge ??
+      summary.scoreMeans.f1;
+    const metricText = preferredMetric === undefined
+      ? "score=n/a"
+      : `score=${preferredMetric.toFixed(4)}`;
+    const processLabel = summary.isPrimaryFullSystemScore
+      ? "primary-full-system"
+      : summary.usesFullRemnicRecallProcess
+        ? "full-remnic-recall-control"
+        : "diagnostic-control";
+    stream.write(
+      `  ${summary.variant.id.padEnd(26)} ${processLabel} tasks=${summary.taskCount} ${metricText} unknown_like=${summary.unknownLikeRate.toFixed(4)}\n`,
+    );
+  }
+}
+
+function printUsage(): void {
+  console.log(`Usage:
+  pnpm exec tsx scripts/bench/ama-diagnostic-matrix.ts --dataset-dir <ama-bench-dir> [options]
+  pnpm exec tsx scripts/bench/ama-diagnostic-matrix.ts --quick [options]
+
+Core options:
+  --output <path>                    Write sanitized matrix JSON. If omitted, JSON is printed to stdout.
+  --limit <n>                        Limit episodes before expanding QA pairs.
+  --seed <n>                         Record benchmark seed metadata.
+  --runtime-profile <profile>        baseline, real, or openclaw-chain. Defaults to real.
+  --remnic-config <path>             Remnic config for --runtime-profile real.
+  --openclaw-config <path>           OpenClaw config for --runtime-profile openclaw-chain.
+  --variants <ids>                   Comma-separated variant ids.
+
+Normal answerer / judge:
+  --system-provider <provider>       openai, anthropic, ollama, litellm, local-llm, or codex-cli.
+  --system-model <model>
+  --system-base-url <url>
+  --judge-provider <provider>
+  --judge-model <model>
+  --judge-base-url <url>
+  --ama-bench-judge-protocol <default|recommended>
+
+Strong-answerer ablations:
+  --strong-system-provider <provider>
+  --strong-system-model <model>
+  --strong-system-base-url <url>
+  --include-strong                   Include all strong variants when strong config is present.
+
+Default variants:
+  remnic-full-normal, explicit-only-normal, oracle-trajectory-normal
+
+Primary full-system score:
+  remnic-full-normal with --runtime-profile real and an isolated Remnic config.
+
+Strong variants:
+  remnic-full-strong, explicit-only-strong, oracle-trajectory-strong`);
+}
+
+class UsageRequested extends Error {}
+
+function hasHelpFlag(argv: readonly string[]): boolean {
+  return argv.includes("--help") || argv.includes("-h");
+}
+
+async function main(): Promise<void> {
+  if (hasHelpFlag(process.argv.slice(2))) {
+    printUsage();
+    return;
+  }
+
+  await loadRuntimeDeps();
+
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    if (error instanceof UsageRequested) {
+      printUsage();
+      return;
+    }
+    throw error;
+  }
+
+  const { artifact, outputPath } = await runAmaBenchDiagnosticMatrix(parsed);
+  if (outputPath) {
+    printSummary(artifact);
+    console.log(`Matrix JSON: ${outputPath}`);
+  } else {
+    printSummary(artifact, process.stderr);
+    console.log(JSON.stringify(artifact, null, 2));
+  }
+}
+
+const directRunPath = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : undefined;
+
+if (directRunPath === import.meta.url) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+async function loadRuntimeDeps(): Promise<void> {
+  if (runtimeDepsLoaded) {
+    return;
+  }
+
+  ensureRuntimeBuilds();
+  const [benchModule, coreModule] = await Promise.all([
+    import("@remnic/bench"),
+    import("@remnic/core"),
+  ]);
+
+  buildAmaBenchDiagnosticMatrixArtifact =
+    benchModule.buildAmaBenchDiagnosticMatrixArtifact;
+  buildAmaBenchDiagnosticVariantSummary =
+    benchModule.buildAmaBenchDiagnosticVariantSummary;
+  createAmaBenchDiagnosticAdapter = benchModule.createAmaBenchDiagnosticAdapter;
+  createLightweightAdapter = benchModule.createLightweightAdapter;
+  createProviderBackedAmaBenchRecommendedJudge =
+    benchModule.createProviderBackedAmaBenchRecommendedJudge;
+  createProviderBackedResponder = benchModule.createProviderBackedResponder;
+  createRemnicAdapter = benchModule.createRemnicAdapter;
+  resolveBenchRuntimeProfile = benchModule.resolveBenchRuntimeProfile;
+  runBenchmark = benchModule.runBenchmark;
+  selectAmaBenchDiagnosticVariants = benchModule.selectAmaBenchDiagnosticVariants;
+  expandTildePath = coreModule.expandTildePath;
+  runtimeDepsLoaded = true;
+}
+
+function ensureRuntimeBuilds(): void {
+  const coreDistPath = path.join(
+    repoRoot,
+    "packages",
+    "remnic-core",
+    "dist",
+    "index.js",
+  );
+  if (!existsSync(coreDistPath)) {
+    runPnpm(["--filter", "@remnic/core", "build"]);
+  }
+
+  const benchDistPath = path.join(
+    repoRoot,
+    "packages",
+    "bench",
+    "dist",
+    "index.js",
+  );
+  const benchSourcePaths = [
+    path.join(repoRoot, "packages", "bench", "src"),
+    path.join(repoRoot, "packages", "bench", "package.json"),
+    path.join(repoRoot, "packages", "bench", "tsup.config.ts"),
+    path.join(repoRoot, "packages", "bench", "tsconfig.json"),
+  ];
+  if (!existsSync(benchDistPath) || isAnySourceNewerThan(benchSourcePaths, benchDistPath)) {
+    runPnpm(["--filter", "@remnic/bench", "build"]);
+  }
+}
+
+function runPnpm(args: string[]): void {
+  const result = spawnSync(pnpmCmd, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (typeof result.status === "number" && result.status !== 0) {
+    throw new Error(`pnpm ${args.join(" ")} failed with exit ${result.status}.`);
+  }
+}
+
+function isAnySourceNewerThan(sourcePaths: readonly string[], distPath: string): boolean {
+  const distMtimeMs = statSync(distPath).mtimeMs;
+  const newestSource = newestMtime(sourcePaths);
+  return newestSource !== undefined && newestSource > distMtimeMs + 1_000;
+}
+
+function newestMtime(paths: readonly string[]): number | undefined {
+  let newest: number | undefined;
+  const visit = (entryPath: string): void => {
+    if (!existsSync(entryPath)) {
+      return;
+    }
+    const stat = statSync(entryPath);
+    if (stat.isDirectory()) {
+      for (const child of readdirSync(entryPath)) {
+        visit(path.join(entryPath, child));
+      }
+      return;
+    }
+    if (stat.isFile()) {
+      newest = newest === undefined
+        ? stat.mtimeMs
+        : Math.max(newest, stat.mtimeMs);
+    }
+  };
+
+  for (const sourcePath of paths) {
+    visit(sourcePath);
+  }
+  return newest;
+}


### PR DESCRIPTION
## Summary
- adds an AMA-Bench diagnostic matrix runner with full Remnic, explicit-only, and oracle trajectory variants
- supports strong-answerer ablations for isolating answer synthesis bottlenecks
- emits sanitized per-domain and per-QA-type summaries without raw questions, answers, recalled text, paths, or secrets

## Validity
- `remnic-full-normal` is explicitly labeled as the primary full-system Remnic score
- diagnostic controls are labeled separately so ablation scores are not confused with leaderboard scores
- default runtime profile is `real`; use `--runtime-profile baseline` only for smoke/control runs

## Verification
- `pnpm exec tsx --test packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts packages/bench/src/benchmarks/published/ama-bench/runner.test.ts tests/bench-ama-bench-runner.test.ts`
- `pnpm run check-types`
- `pnpm --filter @remnic/bench run build`
- smoke: `pnpm exec tsx scripts/bench/ama-diagnostic-matrix.ts --quick --runtime-profile baseline --variants oracle-trajectory-normal --output /tmp/remnic-ama-diagnostic-matrix-smoke.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new diagnostic runner and adapter variants that change how AMA-Bench recall/answering is executed and summarized; while mostly additive, it touches benchmark answer normalization and recall filtering logic that could affect evaluation behavior.
> 
> **Overview**
> Adds an **AMA-Bench diagnostic matrix** capability: selectable variants for full Remnic recall, explicit-evidence-only recall, and oracle trajectory recall, plus optional *strong answerer* rows to isolate synthesis vs recall bottlenecks.
> 
> Introduces new utilities (`createAmaBenchDiagnosticAdapter`, `buildAmaBenchDiagnosticVariantSummary`, `buildAmaBenchDiagnosticMatrixArtifact`, `extractMarkdownSectionsByTitle`, `isAmaBenchUnknownLikeAnswer`) and exports them from `@remnic/bench`, along with a new `scripts/bench/ama-diagnostic-matrix.ts` CLI that runs each variant and emits **sanitized JSON artifacts** (no raw questions/answers/paths/secrets).
> 
> Tightens benchmark answering helpers by making `isUnknownOnlyAnswer` and `hasExplicitTrajectoryEvidence` more conservative/robust (quote/punctuation stripping, whitespace/CRLF-aware headings and step markers), with expanded tests for edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75df470f1be7c0683b320edc95e4cfa011cb16b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->