### PR TITLE
Route benchmark Remnic internal LLM providers

### DIFF
--- a/packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
@@ -387,6 +387,11 @@ test("diagnostic matrix artifact records sanitized run metadata", () => {
         model: "gemma4:31b",
         baseUrl: "https://ollama.com/api",
       },
+      internalProvider: {
+        provider: "codex-cli",
+        model: "gpt-5.5",
+        baseUrl: "codex-cli://local",
+      },
     },
     variants: [],
   });
@@ -398,6 +403,9 @@ test("diagnostic matrix artifact records sanitized run metadata", () => {
     artifact.config.amaBenchCrossJudgeProvider?.baseUrl,
     "https://ollama.com/api",
   );
+  assert.equal(artifact.config.internalProvider?.provider, "codex-cli");
+  assert.equal(artifact.config.internalProvider?.model, "gpt-5.5");
+  assert.equal(artifact.config.internalProvider?.baseUrl, "codex-cli://local");
   assert.equal(artifact.config.limit, 2);
 });
 

--- a/packages/bench/src/benchmarks/published/ama-bench/diagnostics.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/diagnostics.ts
@@ -325,6 +325,7 @@ export interface AmaBenchDiagnosticMatrixArtifact {
     seed?: number;
     systemProvider?: SanitizedDiagnosticProvider | null;
     judgeProvider?: SanitizedDiagnosticProvider | null;
+    internalProvider?: SanitizedDiagnosticProvider | null;
     amaBenchCrossJudgeProvider?: SanitizedDiagnosticProvider | null;
     strongSystemProvider?: SanitizedDiagnosticProvider | null;
     variantIds?: string[];

--- a/packages/bench/src/reporter.test.ts
+++ b/packages/bench/src/reporter.test.ts
@@ -39,6 +39,12 @@ function buildResult(): BenchmarkResult {
         baseUrl: "https://ollama.com/api",
         apiKey: "judge-secret-key",
       },
+      internalProvider: {
+        provider: "ollama",
+        model: "gemma4:31b-cloud",
+        baseUrl: "https://ollama.com/api",
+        apiKey: "internal-secret-key",
+      },
       adapterMode: "direct",
       remnicConfig: {
         nested: {
@@ -78,6 +84,7 @@ test("redactBenchmarkResultSecrets redacts provider and nested secret fields", (
 
   assert.equal(redacted.config.systemProvider?.apiKey, "[REDACTED]");
   assert.equal(redacted.config.judgeProvider?.apiKey, "[REDACTED]");
+  assert.equal(redacted.config.internalProvider?.apiKey, "[REDACTED]");
   assert.equal(
     (redacted.config.remnicConfig.nested as { authToken?: string }).authToken,
     "[REDACTED]",
@@ -127,7 +134,7 @@ test("writeBenchmarkResult does not persist secret values", async () => {
 
     assert.doesNotMatch(
       raw,
-      /system-secret-key|judge-secret-key|nested-token|bearer-token|private-key|session-token|auth-header|plain-token/,
+      /system-secret-key|judge-secret-key|internal-secret-key|nested-token|bearer-token|private-key|session-token|auth-header|plain-token/,
     );
     assert.match(raw, /"apiKey": "\[REDACTED\]"/);
     assert.match(raw, /"provider": "ollama"/);

--- a/packages/bench/src/result-config.test.ts
+++ b/packages/bench/src/result-config.test.ts
@@ -71,3 +71,21 @@ test("finalizeBenchmarkResultConfig normalizes omitted runtime profile to null",
 
   assert.equal(finalized.config.runtimeProfile, null);
 });
+
+test("finalizeBenchmarkResultConfig records internal provider when missing", () => {
+  const result = buildResult();
+
+  const finalized = finalizeBenchmarkResultConfig(result, {
+    internalProvider: {
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+    },
+  });
+
+  assert.deepEqual(finalized.config.internalProvider, {
+    provider: "codex-cli",
+    model: "gpt-5.5",
+    reasoningEffort: "xhigh",
+  });
+});

--- a/packages/bench/src/result-config.ts
+++ b/packages/bench/src/result-config.ts
@@ -6,8 +6,9 @@ import type { BenchmarkResult, RunBenchmarkOptions } from "./types.js";
 
 export function finalizeBenchmarkResultConfig(
   result: BenchmarkResult,
-  options: Pick<RunBenchmarkOptions, "runtimeProfile">,
+  options: Pick<RunBenchmarkOptions, "runtimeProfile" | "internalProvider">,
 ): BenchmarkResult {
   result.config.runtimeProfile ??= options.runtimeProfile ?? null;
+  result.config.internalProvider ??= options.internalProvider ?? null;
   return result;
 }

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -666,6 +666,7 @@ function renderBenchmarkResultHtml(result: BenchmarkResult): string {
   const renderedConfig = {
     systemProvider: result.config.systemProvider,
     judgeProvider: result.config.judgeProvider,
+    internalProvider: result.config.internalProvider,
     remnicConfig:
       remnicConfigKeyCount === 0
         ? "[empty]"

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -331,3 +331,113 @@ test("provider-backed runtime resolution configures codex-cli with xhigh reasoni
   assert.equal(typeof resolved.adapterOptions.responder?.respond, "function");
   assert.equal(typeof resolved.adapterOptions.judge?.score, "function");
 });
+
+test("runtime profile can route Remnic internal LLM calls through codex-cli", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    internalProvider: "codex-cli",
+    internalModel: "gpt-5.5",
+    internalCodexReasoningEffort: "xhigh",
+  });
+
+  assert.deepEqual(resolved.internalProvider, {
+    provider: "codex-cli",
+    model: "gpt-5.5",
+    baseUrl: "codex-cli://local",
+    reasoningEffort: "xhigh",
+  });
+  assert.equal(resolved.remnicConfig.modelSource, "gateway");
+  assert.equal(resolved.effectiveRemnicConfig.modelSource, "gateway");
+  assert.equal(resolved.remnicConfig.gatewayAgentId, "remnic-bench-internal");
+  const gatewayConfig = resolved.effectiveRemnicConfig.gatewayConfig as {
+    agents?: { defaults?: { model?: { primary?: string } } };
+    models?: { providers?: Record<string, { api?: string; codexCliReasoningEffort?: string }> };
+  };
+  assert.equal(
+    gatewayConfig.agents?.defaults?.model?.primary,
+    "remnic-bench-internal/gpt-5.5",
+  );
+  assert.equal(
+    gatewayConfig.models?.providers?.["remnic-bench-internal"]?.api,
+    "codex-cli",
+  );
+  assert.equal(
+    gatewayConfig.models?.providers?.["remnic-bench-internal"]?.codexCliReasoningEffort,
+    "xhigh",
+  );
+});
+
+test("runtime profile can route Remnic internal LLM calls through Ollama native chat", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    internalProvider: "ollama",
+    internalModel: "gemma4:31b-cloud",
+    internalBaseUrl: "https://ollama.example/api",
+    internalApiKey: "secret-ollama-key",
+    internalDisableThinking: true,
+  });
+
+  assert.deepEqual(resolved.internalProvider, {
+    provider: "ollama",
+    model: "gemma4:31b-cloud",
+    baseUrl: "https://ollama.example/api",
+    apiKey: "[redacted]",
+    disableThinking: true,
+  });
+  const persistedGateway = resolved.remnicConfig.gatewayConfig as {
+    models?: { providers?: Record<string, { apiKey?: string; api?: string; disableThinking?: boolean }> };
+  };
+  assert.equal(
+    persistedGateway.models?.providers?.["remnic-bench-internal"]?.apiKey,
+    "[redacted]",
+  );
+  const effectiveGateway = resolved.effectiveRemnicConfig.gatewayConfig as {
+    models?: { providers?: Record<string, { apiKey?: string; api?: string; disableThinking?: boolean }> };
+  };
+  assert.equal(
+    effectiveGateway.models?.providers?.["remnic-bench-internal"]?.api,
+    "ollama-chat",
+  );
+  assert.equal(
+    effectiveGateway.models?.providers?.["remnic-bench-internal"]?.apiKey,
+    "secret-ollama-key",
+  );
+  assert.equal(
+    effectiveGateway.models?.providers?.["remnic-bench-internal"]?.disableThinking,
+    true,
+  );
+});
+
+test("runtime profile routes OpenAI internal LLM calls through Responses API", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    internalProvider: "openai",
+    internalModel: "gpt-5.5",
+    internalApiKey: "secret-openai-key",
+  });
+
+  assert.deepEqual(resolved.internalProvider, {
+    provider: "openai",
+    model: "gpt-5.5",
+    baseUrl: "https://api.openai.com/v1",
+    apiKey: "[redacted]",
+  });
+  const persistedGateway = resolved.remnicConfig.gatewayConfig as {
+    models?: { providers?: Record<string, { apiKey?: string; api?: string }> };
+  };
+  assert.equal(
+    persistedGateway.models?.providers?.["remnic-bench-internal"]?.apiKey,
+    "[redacted]",
+  );
+  const effectiveGateway = resolved.effectiveRemnicConfig.gatewayConfig as {
+    models?: { providers?: Record<string, { apiKey?: string; api?: string }> };
+  };
+  assert.equal(
+    effectiveGateway.models?.providers?.["remnic-bench-internal"]?.api,
+    "openai-responses",
+  );
+  assert.equal(
+    effectiveGateway.models?.providers?.["remnic-bench-internal"]?.apiKey,
+    "secret-openai-key",
+  );
+});

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -4,7 +4,9 @@ import { readFile } from "node:fs/promises";
 import {
   type FallbackLlmRuntimeContext,
   resolveRemnicPluginEntry,
+  setCodexCliFallbackRunnerForProcess,
   type GatewayConfig,
+  type CodexCliFallbackRunner,
 } from "@remnic/core";
 import type {
   BenchJudge,
@@ -43,6 +45,12 @@ export interface ResolveBenchRuntimeProfileOptions {
   judgeModel?: string;
   judgeBaseUrl?: string;
   judgeApiKey?: string;
+  internalProvider?: BuiltInProvider;
+  internalModel?: string;
+  internalBaseUrl?: string;
+  internalApiKey?: string;
+  internalDisableThinking?: boolean;
+  internalCodexReasoningEffort?: ProviderConfig["reasoningEffort"];
   requestTimeout?: number;
   max429WaitMs?: number;
   disableThinking?: boolean;
@@ -60,9 +68,12 @@ export interface ResolvedBenchRuntimeProfile {
   };
   systemProvider: ProviderConfig | null;
   judgeProvider: ProviderConfig | null;
+  internalProvider: ProviderConfig | null;
 }
 
 const REDACTED_CONFIG_VALUE = "[redacted]";
+const INTERNAL_GATEWAY_AGENT_ID = "remnic-bench-internal";
+let codexCliFallbackRegistered = false;
 
 export async function resolveBenchRuntimeProfile(
   options: ResolveBenchRuntimeProfileOptions,
@@ -90,6 +101,24 @@ export async function resolveBenchRuntimeProfile(
     options.judgeApiKey,
     options.max429WaitMs,
   );
+  const internalProvider = applyInternalProviderDefaults(
+    resolveProviderConfig(
+      "internal",
+      options.internalProvider,
+      options.internalModel,
+      options.internalBaseUrl,
+      options.requestTimeout,
+      options.internalDisableThinking,
+      options.internalApiKey,
+      options.max429WaitMs,
+      options.internalCodexReasoningEffort,
+    ),
+  );
+  const internalConfigOverrides = buildInternalRemnicConfigOverrides(
+    internalProvider,
+    { disableThinking: options.internalDisableThinking === true },
+  );
+  registerCodexCliFallbackRunnerIfNeeded(internalProvider);
   const responderFactoryConfig = systemProvider
     ? asProviderFactoryConfig(systemProvider)
     : undefined;
@@ -111,15 +140,18 @@ export async function resolveBenchRuntimeProfile(
       ? createProviderBackedResponder(responderFactoryConfig)
       : undefined;
     const baselineConfig = buildBenchBaselineRemnicConfig();
-    const persistedRemnicConfig = sanitizePersistedConfig(baselineConfig);
+    const baselineWithInternalLlm = {
+      ...baselineConfig,
+      ...internalConfigOverrides,
+    };
     const effectiveRemnicConfig = withAssistantHooks(
-      { ...baselineConfig },
+      baselineWithInternalLlm,
       responder,
       structuredJudge,
     );
     return {
       profile,
-      remnicConfig: persistedRemnicConfig,
+      remnicConfig: sanitizePersistedConfig(baselineWithInternalLlm),
       effectiveRemnicConfig,
       adapterOptions: {
         configOverrides: effectiveRemnicConfig,
@@ -128,6 +160,7 @@ export async function resolveBenchRuntimeProfile(
       },
       systemProvider,
       judgeProvider,
+      internalProvider: internalProvider ? sanitizeProviderConfig(internalProvider) : null,
     };
   }
 
@@ -138,24 +171,23 @@ export async function resolveBenchRuntimeProfile(
     const fileConfig = options.remnicConfigPath
       ? await loadRemnicConfigFile(options.remnicConfigPath)
       : {};
-    const persistedRemnicConfig = sanitizePersistedConfig({
-      ...fileConfig,
+    const realProfileOverrides = {
       lcmEnabled: true,
       ...(options.modelSource ? { modelSource: options.modelSource } : {}),
       ...(options.gatewayAgentId ? { gatewayAgentId: options.gatewayAgentId } : {}),
       ...(options.fastGatewayAgentId
         ? { fastGatewayAgentId: options.fastGatewayAgentId }
         : {}),
+      ...internalConfigOverrides,
+    };
+    const persistedRemnicConfig = sanitizePersistedConfig({
+      ...fileConfig,
+      ...realProfileOverrides,
     });
     const effectiveRemnicConfig = withAssistantHooks(
       {
         ...fileConfig,
-        lcmEnabled: true,
-        ...(options.modelSource ? { modelSource: options.modelSource } : {}),
-        ...(options.gatewayAgentId ? { gatewayAgentId: options.gatewayAgentId } : {}),
-        ...(options.fastGatewayAgentId
-          ? { fastGatewayAgentId: options.fastGatewayAgentId }
-          : {}),
+        ...realProfileOverrides,
       },
       responder,
       structuredJudge,
@@ -172,6 +204,7 @@ export async function resolveBenchRuntimeProfile(
       },
       systemProvider,
       judgeProvider,
+      internalProvider: internalProvider ? sanitizeProviderConfig(internalProvider) : null,
     };
   }
 
@@ -196,6 +229,7 @@ export async function resolveBenchRuntimeProfile(
       modelSource: "gateway",
       ...(gatewayAgentId ? { gatewayAgentId } : {}),
       ...(fastGatewayAgentId ? { fastGatewayAgentId } : {}),
+      ...internalConfigOverrides,
     },
   );
   const effectiveRemnicConfig = withAssistantHooks(
@@ -206,6 +240,7 @@ export async function resolveBenchRuntimeProfile(
       modelSource: "gateway",
       ...(gatewayAgentId ? { gatewayAgentId } : {}),
       ...(fastGatewayAgentId ? { fastGatewayAgentId } : {}),
+      ...internalConfigOverrides,
     },
     gatewayResponder,
     structuredJudge,
@@ -223,6 +258,7 @@ export async function resolveBenchRuntimeProfile(
     },
     systemProvider: null,
     judgeProvider,
+    internalProvider: internalProvider ? sanitizeProviderConfig(internalProvider) : null,
   };
 }
 
@@ -305,7 +341,7 @@ async function loadJsonObject(
 }
 
 function resolveProviderConfig(
-  kind: "system" | "judge",
+  kind: "system" | "judge" | "internal",
   provider: BuiltInProvider | undefined,
   model: string | undefined,
   baseUrl: string | undefined,
@@ -313,12 +349,15 @@ function resolveProviderConfig(
   disableThinking?: boolean,
   apiKey?: string,
   max429WaitMs?: number,
+  reasoningEffort?: ProviderConfig["reasoningEffort"],
 ): ProviderConfig | null {
   const hasProvider = typeof provider === "string";
   const hasModel = typeof model === "string" && model.trim().length > 0;
   const hasBaseUrl = typeof baseUrl === "string" && baseUrl.trim().length > 0;
+  const hasApiKey = typeof apiKey === "string" && apiKey.trim().length > 0;
+  const hasReasoningEffort = reasoningEffort !== undefined;
 
-  if (!hasProvider && !hasModel && !hasBaseUrl) {
+  if (!hasProvider && !hasModel && !hasBaseUrl && !hasApiKey && !hasReasoningEffort) {
     return null;
   }
 
@@ -337,12 +376,17 @@ function resolveProviderConfig(
         "(e.g. http://localhost:8080/v1 for llama.cpp).",
     );
   }
+  if (reasoningEffort !== undefined && provider !== "codex-cli") {
+    throw new Error(
+      `${kind} Codex reasoning effort requires provider "codex-cli"`,
+    );
+  }
 
   return {
     provider,
     model: model.trim(),
     ...(hasBaseUrl ? { baseUrl: baseUrl!.trim() } : {}),
-    ...(apiKey ? { apiKey } : {}),
+    ...(hasApiKey ? { apiKey: apiKey!.trim() } : {}),
     ...(requestTimeout != null || max429WaitMs != null
       ? { retryOptions: {
           ...(requestTimeout != null ? { timeoutMs: requestTimeout } : {}),
@@ -350,7 +394,223 @@ function resolveProviderConfig(
         } }
       : {}),
     ...(disableThinking ? { disableThinking: true } : {}),
-    ...(provider === "codex-cli" ? { reasoningEffort: "xhigh" as const } : {}),
+    ...(provider === "codex-cli" ? { reasoningEffort: reasoningEffort ?? "xhigh" } : {}),
+  };
+}
+
+function applyInternalProviderDefaults(
+  config: ProviderConfig | null,
+): ProviderConfig | null {
+  if (!config || config.baseUrl) {
+    return config;
+  }
+
+  const baseUrl = defaultInternalBaseUrl(config.provider);
+  return baseUrl ? { ...config, baseUrl } : config;
+}
+
+function buildInternalRemnicConfigOverrides(
+  config: ProviderConfig | null,
+  options: { disableThinking: boolean },
+): Record<string, unknown> {
+  const thinkingOverrides = options.disableThinking
+    ? {
+        localLlmDisableThinking: true,
+        reasoningEffort: "none",
+      }
+    : {};
+
+  if (!config) {
+    return thinkingOverrides;
+  }
+
+  if (config.provider === "local-llm") {
+    return {
+      ...thinkingOverrides,
+      modelSource: "plugin",
+      localLlmEnabled: true,
+      localLlmFallback: false,
+      localLlmUrl: config.baseUrl,
+      localLlmModel: config.model,
+      ...(config.apiKey ? { localLlmApiKey: config.apiKey } : {}),
+      ...(config.retryOptions?.timeoutMs
+        ? { localLlmTimeoutMs: config.retryOptions.timeoutMs }
+        : {}),
+    };
+  }
+
+  return {
+    ...thinkingOverrides,
+    modelSource: "gateway",
+    localLlmEnabled: false,
+    gatewayConfig: buildInternalGatewayConfig(config, options),
+    gatewayAgentId: INTERNAL_GATEWAY_AGENT_ID,
+    fastGatewayAgentId: INTERNAL_GATEWAY_AGENT_ID,
+  };
+}
+
+function buildInternalGatewayConfig(
+  config: ProviderConfig,
+  options: { disableThinking: boolean },
+): GatewayConfig {
+  const providerId = INTERNAL_GATEWAY_AGENT_ID;
+  const modelRef = `${providerId}/${config.model}`;
+  const timeoutMs = config.retryOptions?.timeoutMs;
+
+  return {
+    agents: {
+      defaults: {
+        model: { primary: modelRef },
+        ...(options.disableThinking ? { thinking: { mode: "off" as const } } : {}),
+      },
+      list: [
+        {
+          id: INTERNAL_GATEWAY_AGENT_ID,
+          name: "Remnic bench internal provider",
+          model: { primary: modelRef },
+        },
+      ],
+    },
+    models: {
+      providers: {
+        [providerId]: {
+          baseUrl: config.baseUrl ?? defaultInternalBaseUrl(config.provider) ?? "",
+          api: gatewayProviderApi(config.provider),
+          ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+          ...(config.disableThinking || options.disableThinking ? { disableThinking: true } : {}),
+          ...(config.reasoningEffort ? { codexCliReasoningEffort: config.reasoningEffort } : {}),
+          ...(timeoutMs ? { retryOptions: { timeoutMs } } : {}),
+          models: [{ id: config.model, name: config.model }],
+        },
+      },
+    },
+  };
+}
+
+function gatewayProviderApi(provider: BuiltInProvider): string {
+  if (provider === "anthropic") {
+    return "anthropic-messages";
+  }
+  if (provider === "codex-cli") {
+    return "codex-cli";
+  }
+  if (provider === "ollama") {
+    return "ollama-chat";
+  }
+  if (provider === "openai") {
+    return "openai-responses";
+  }
+  return "openai-completions";
+}
+
+function defaultInternalBaseUrl(provider: BuiltInProvider): string | undefined {
+  switch (provider) {
+    case "openai":
+      return "https://api.openai.com/v1";
+    case "anthropic":
+      return "https://api.anthropic.com/v1";
+    case "litellm":
+      return "http://localhost:4000";
+    case "ollama":
+      return "http://localhost:11434/api";
+    case "codex-cli":
+      return "codex-cli://local";
+    case "local-llm":
+      return undefined;
+    default: {
+      const exhaustive: never = provider;
+      return exhaustive;
+    }
+  }
+}
+
+function sanitizeProviderConfig(config: ProviderConfig): ProviderConfig {
+  return {
+    ...config,
+    ...(config.apiKey ? { apiKey: REDACTED_CONFIG_VALUE } : {}),
+  };
+}
+
+function registerCodexCliFallbackRunnerIfNeeded(config: ProviderConfig | null): void {
+  if (!config || config.provider !== "codex-cli" || codexCliFallbackRegistered) {
+    return;
+  }
+
+  const runner: CodexCliFallbackRunner = async (request) => {
+    const reasoningEffort = asCodexReasoningEffort(
+      request.config.codexCliReasoningEffort ?? request.config.reasoningEffort,
+    );
+    const provider = createProvider({
+      provider: "codex-cli",
+      model: request.modelId,
+      ...(typeof request.config.apiKey === "string"
+        ? { apiKey: request.config.apiKey }
+        : {}),
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+      ...(typeof request.config.codexCliExecutable === "string"
+        ? { executable: request.config.codexCliExecutable }
+        : typeof request.config.executable === "string"
+          ? { executable: request.config.executable }
+          : {}),
+      ...(typeof request.config.retryOptions?.timeoutMs === "number" ||
+        typeof request.options.timeoutMs === "number"
+        ? {
+            retryOptions: {
+              timeoutMs:
+                typeof request.config.retryOptions?.timeoutMs === "number"
+                  ? request.config.retryOptions.timeoutMs
+                  : request.options.timeoutMs,
+            },
+          }
+        : {}),
+    });
+    const split = splitCodexFallbackMessages(request.messages);
+    const completion = await provider.complete(split.prompt, {
+      systemPrompt: split.systemPrompt,
+      temperature: 0.3,
+      maxTokens: 4096,
+    });
+    return {
+      content: completion.text,
+      usage: {
+        inputTokens: completion.tokens.input,
+        outputTokens: completion.tokens.output,
+        totalTokens: completion.tokens.input + completion.tokens.output,
+      },
+    };
+  };
+
+  setCodexCliFallbackRunnerForProcess(runner);
+  codexCliFallbackRegistered = true;
+}
+
+function asCodexReasoningEffort(
+  value: unknown,
+): ProviderConfig["reasoningEffort"] | undefined {
+  return value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "xhigh"
+    ? value
+    : undefined;
+}
+
+function splitCodexFallbackMessages(
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
+): { systemPrompt?: string; prompt: string } {
+  const systemPrompt = messages
+    .filter((message) => message.role === "system")
+    .map((message) => message.content)
+    .join("\n\n")
+    .trim();
+  const prompt = messages
+    .filter((message) => message.role !== "system")
+    .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
+    .join("\n\n")
+    .trim();
+  return {
+    ...(systemPrompt ? { systemPrompt } : {}),
+    prompt: prompt || messages.map((message) => message.content).join("\n\n"),
   };
 }
 

--- a/packages/bench/src/schema.ts
+++ b/packages/bench/src/schema.ts
@@ -95,6 +95,20 @@ export const BENCHMARK_RESULT_SCHEMA = {
             },
           ],
         },
+        internalProvider: {
+          anyOf: [
+            { type: "null" },
+            {
+              type: "object",
+              required: ["provider", "model"],
+              properties: {
+                provider: { type: "string" },
+                model: { type: "string" },
+                baseUrl: { type: "string" },
+              },
+            },
+          ],
+        },
         adapterMode: { type: "string" },
         remnicConfig: { type: "object" },
       },

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -158,6 +158,7 @@ export interface BenchmarkResult {
     runtimeProfile?: BenchRuntimeProfile | null;
     systemProvider: ProviderConfig | null;
     judgeProvider: ProviderConfig | null;
+    internalProvider?: ProviderConfig | null;
     adapterMode: string;
     remnicConfig: Record<string, unknown>;
     benchmarkOptions?: Record<string, unknown>;
@@ -219,6 +220,7 @@ export interface RunBenchmarkOptions {
   ingestionAdapter?: import("./ingestion-types.js").IngestionBenchAdapter;
   systemProvider?: ProviderConfig | null;
   judgeProvider?: ProviderConfig | null;
+  internalProvider?: ProviderConfig | null;
   remnicConfig?: Record<string, unknown>;
   amaBenchJudgeProtocol?: AmaBenchJudgeProtocol;
   amaBenchCrossJudge?: import("./adapters/types.js").BenchJudge;

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -174,6 +174,42 @@ test("parseBenchArgs accepts codex-cli as a system and judge provider", () => {
   assert.equal(parsed.judgeModel, "gpt-5.5");
 });
 
+test("parseBenchArgs accepts internal Remnic LLM provider flags", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "ama-bench",
+    "--internal-provider",
+    "codex-cli",
+    "--internal-model",
+    "gpt-5.5",
+    "--internal-disable-thinking",
+    "--internal-codex-reasoning-effort",
+    "xhigh",
+  ]);
+
+  assert.equal(parsed.internalProvider, "codex-cli");
+  assert.equal(parsed.internalModel, "gpt-5.5");
+  assert.equal(parsed.internalDisableThinking, true);
+  assert.equal(parsed.internalCodexReasoningEffort, "xhigh");
+});
+
+test("parseBenchArgs rejects internal Codex reasoning effort for non-Codex providers", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--internal-provider",
+        "ollama",
+        "--internal-model",
+        "gemma4:31b-cloud",
+        "--internal-codex-reasoning-effort",
+        "xhigh",
+      ]),
+    /--internal-codex-reasoning-effort requires --internal-provider codex-cli/,
+  );
+});
+
 test("parseBenchArgs accepts AMA-Bench recommended judge and cross-judge flags", () => {
   const parsed = parseBenchArgs([
     "run",

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -54,6 +54,12 @@ export interface ParsedBenchArgs {
   judgeModel?: string;
   judgeBaseUrl?: string;
   judgeApiKey?: string;
+  internalProvider?: BuiltInProvider;
+  internalModel?: string;
+  internalBaseUrl?: string;
+  internalApiKey?: string;
+  internalDisableThinking?: boolean;
+  internalCodexReasoningEffort?: "low" | "medium" | "high" | "xhigh";
   threshold?: number;
   baselineAction?: BenchBaselineAction;
   datasetAction?: BenchDatasetAction;
@@ -188,6 +194,11 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--judge-model" ||
       arg === "--judge-base-url" ||
       arg === "--judge-api-key" ||
+      arg === "--internal-provider" ||
+      arg === "--internal-model" ||
+      arg === "--internal-base-url" ||
+      arg === "--internal-api-key" ||
+      arg === "--internal-codex-reasoning-effort" ||
       arg === "--threshold" ||
       arg === "--custom" ||
       arg === "--format" ||
@@ -322,6 +333,14 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const judgeModel = readBenchOptionValue(args, "--judge-model");
   const judgeBaseUrl = readBenchOptionValue(args, "--judge-base-url");
   const judgeApiKey = readBenchOptionValue(args, "--judge-api-key");
+  const internalProviderRaw = readBenchOptionValue(args, "--internal-provider");
+  const internalModel = readBenchOptionValue(args, "--internal-model");
+  const internalBaseUrl = readBenchOptionValue(args, "--internal-base-url");
+  const internalApiKey = readBenchOptionValue(args, "--internal-api-key");
+  const internalCodexReasoningEffortRaw = readBenchOptionValue(
+    args,
+    "--internal-codex-reasoning-effort",
+  );
   const thresholdRaw = readBenchOptionValue(args, "--threshold");
   const customRaw = readBenchOptionValue(args, "--custom");
   const formatRaw = readBenchOptionValue(args, "--format");
@@ -374,6 +393,26 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   let judgeProvider: BuiltInProvider | undefined;
   if (judgeProviderRaw !== undefined) {
     judgeProvider = parseBenchProvider(judgeProviderRaw, "--judge-provider");
+  }
+
+  let internalProvider: BuiltInProvider | undefined;
+  if (internalProviderRaw !== undefined) {
+    internalProvider = parseBenchProvider(internalProviderRaw, "--internal-provider");
+  }
+
+  let internalCodexReasoningEffort: ParsedBenchArgs["internalCodexReasoningEffort"];
+  if (internalCodexReasoningEffortRaw !== undefined) {
+    if (
+      internalCodexReasoningEffortRaw !== "low" &&
+      internalCodexReasoningEffortRaw !== "medium" &&
+      internalCodexReasoningEffortRaw !== "high" &&
+      internalCodexReasoningEffortRaw !== "xhigh"
+    ) {
+      throw new Error(
+        'ERROR: --internal-codex-reasoning-effort must be "low", "medium", "high", or "xhigh".',
+      );
+    }
+    internalCodexReasoningEffort = internalCodexReasoningEffortRaw;
   }
 
   let amaBenchJudgeProtocol: AmaBenchJudgeProtocol | undefined;
@@ -540,6 +579,21 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         "vLLM (http://localhost:8000/v1), LM Studio (http://localhost:1234/v1).",
     );
   }
+  if (internalProvider === "local-llm" && !internalBaseUrl) {
+    throw new Error(
+      "ERROR: --internal-provider local-llm requires --internal-base-url. " +
+        "Examples: llama.cpp (http://localhost:8080/v1), " +
+        "vLLM (http://localhost:8000/v1), LM Studio (http://localhost:1234/v1).",
+    );
+  }
+  if (
+    internalCodexReasoningEffort !== undefined &&
+    internalProvider !== "codex-cli"
+  ) {
+    throw new Error(
+      "ERROR: --internal-codex-reasoning-effort requires --internal-provider codex-cli.",
+    );
+  }
   if (
     amaBenchCrossJudgeProvider === "local-llm" &&
     !(amaBenchCrossJudgeBaseUrl ?? judgeBaseUrl)
@@ -594,6 +648,12 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     judgeModel,
     judgeBaseUrl,
     judgeApiKey,
+    internalProvider,
+    internalModel,
+    internalBaseUrl,
+    internalApiKey,
+    internalDisableThinking: args.includes("--internal-disable-thinking"),
+    internalCodexReasoningEffort,
     threshold,
     custom: customRaw ? path.resolve(expandTilde(customRaw)) : undefined,
     baselineAction,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -337,6 +337,7 @@ type PackageBenchModule = {
     runtimeProfile?: BenchRuntimeProfile | null;
     systemProvider?: PackageBenchProviderConfig | null;
     judgeProvider?: PackageBenchProviderConfig | null;
+    internalProvider?: PackageBenchProviderConfig | null;
     remnicConfig?: Record<string, unknown>;
     amaBenchJudgeProtocol?: "default" | "recommended";
     amaBenchCrossJudge?: unknown;
@@ -352,6 +353,7 @@ type PackageBenchModule = {
       runtimeProfile?: BenchRuntimeProfile | null;
       systemProvider?: PackageBenchProviderConfig | null;
       judgeProvider?: PackageBenchProviderConfig | null;
+      internalProvider?: PackageBenchProviderConfig | null;
       adapterMode: string;
       remnicConfig: Record<string, unknown>;
       benchmarkOptions?: Record<string, unknown>;
@@ -370,11 +372,25 @@ type PackageBenchModule = {
       provider: string;
       model: string;
       baseUrl?: string;
+      apiKey?: string;
+      disableThinking?: boolean;
+      reasoningEffort?: "low" | "medium" | "high" | "xhigh";
     } | null;
     judgeProvider?: {
       provider: string;
       model: string;
       baseUrl?: string;
+      apiKey?: string;
+      disableThinking?: boolean;
+      reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+    } | null;
+    internalProvider?: {
+      provider: string;
+      model: string;
+      baseUrl?: string;
+      apiKey?: string;
+      disableThinking?: boolean;
+      reasoningEffort?: "low" | "medium" | "high" | "xhigh";
     } | null;
     remnicConfig?: Record<string, unknown>;
     system: {
@@ -393,6 +409,17 @@ type PackageBenchModule = {
         provider: string;
         model: string;
         baseUrl?: string;
+        apiKey?: string;
+        disableThinking?: boolean;
+        reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+      } | null;
+      internalProvider?: {
+        provider: string;
+        model: string;
+        baseUrl?: string;
+        apiKey?: string;
+        disableThinking?: boolean;
+        reasoningEffort?: "low" | "medium" | "high" | "xhigh";
       } | null;
       adapterMode: string;
       remnicConfig: Record<string, unknown>;
@@ -413,6 +440,17 @@ type PackageBenchModule = {
         provider: string;
         model: string;
         baseUrl?: string;
+        apiKey?: string;
+        disableThinking?: boolean;
+        reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+      } | null;
+      internalProvider?: {
+        provider: string;
+        model: string;
+        baseUrl?: string;
+        apiKey?: string;
+        disableThinking?: boolean;
+        reasoningEffort?: "low" | "medium" | "high" | "xhigh";
       } | null;
       adapterMode: string;
       remnicConfig: Record<string, unknown>;
@@ -552,6 +590,12 @@ interface ResolveBenchRuntimeProfileOptions {
   judgeModel?: string;
   judgeBaseUrl?: string;
   judgeApiKey?: string;
+  internalProvider?: string;
+  internalModel?: string;
+  internalBaseUrl?: string;
+  internalApiKey?: string;
+  internalDisableThinking?: boolean;
+  internalCodexReasoningEffort?: "low" | "medium" | "high" | "xhigh";
   amaBenchJudgeProtocol?: "default" | "recommended";
   amaBenchCrossJudgeProvider?: string;
   amaBenchCrossJudgeModel?: string;
@@ -574,6 +618,7 @@ interface ResolvedBenchRuntimeProfile {
   };
   systemProvider: BenchProviderConfig | null;
   judgeProvider: BenchProviderConfig | null;
+  internalProvider: BenchProviderConfig | null;
 }
 
 interface BenchSummaryResult {
@@ -657,6 +702,16 @@ Options:
                            Use a direct provider-backed judge
   --judge-model <model>    Model name for the judge provider
   --judge-base-url <url>   Base URL for the judge provider
+  --internal-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli>
+                           Provider for Remnic's internal extraction/summarization LLM
+  --internal-model <model> Model name for Remnic's internal LLM provider
+  --internal-base-url <url>
+                           Base URL for Remnic's internal LLM provider
+  --internal-api-key <key> API key for Remnic's internal LLM provider
+  --internal-disable-thinking
+                           Suppress thinking for Remnic's internal LLM when supported
+  --internal-codex-reasoning-effort <low|medium|high|xhigh>
+                           Codex CLI reasoning effort for Remnic's internal LLM
   --ama-bench-judge-protocol <default|recommended>
                            For ama-bench, use the recommended binary LLM-judge protocol
   --ama-bench-cross-judge-model <model>
@@ -743,6 +798,12 @@ export function buildBenchRuntimeProfileRequest(
     judgeModel: parsed.judgeModel,
     judgeBaseUrl: parsed.judgeBaseUrl,
     judgeApiKey: parsed.judgeApiKey,
+    internalProvider: parsed.internalProvider,
+    internalModel: parsed.internalModel,
+    internalBaseUrl: parsed.internalBaseUrl,
+    internalApiKey: parsed.internalApiKey,
+    internalDisableThinking: parsed.internalDisableThinking,
+    internalCodexReasoningEffort: parsed.internalCodexReasoningEffort,
     requestTimeout: parsed.requestTimeout,
     max429WaitMs: parsed.max429WaitMs,
     disableThinking: parsed.disableThinking,
@@ -926,6 +987,12 @@ async function runBenchViaFallback(
     parsed.judgeProvider !== undefined ||
     parsed.judgeModel !== undefined ||
     parsed.judgeBaseUrl !== undefined ||
+    parsed.internalProvider !== undefined ||
+    parsed.internalModel !== undefined ||
+    parsed.internalBaseUrl !== undefined ||
+    parsed.internalApiKey !== undefined ||
+    parsed.internalDisableThinking === true ||
+    parsed.internalCodexReasoningEffort !== undefined ||
     parsed.amaBenchJudgeProtocol !== undefined ||
     parsed.amaBenchCrossJudgeProvider !== undefined ||
     parsed.amaBenchCrossJudgeModel !== undefined ||
@@ -2272,6 +2339,7 @@ async function runBenchViaPackage(
       runtimeProfile: plan.runtime.profile,
       systemProvider: plan.runtime.systemProvider,
       judgeProvider: plan.runtime.judgeProvider,
+      internalProvider: plan.runtime.internalProvider,
       remnicConfig: plan.runtime.effectiveRemnicConfig,
       ...(amaBenchProtocol.judgeProtocol
         ? { amaBenchJudgeProtocol: amaBenchProtocol.judgeProtocol }
@@ -2302,6 +2370,7 @@ async function runBenchViaPackage(
       },
     });
     result.config.remnicConfig = plan.runtime.remnicConfig;
+    result.config.internalProvider = plan.runtime.internalProvider;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
       console.log(JSON.stringify(redactBenchResultForStdout(benchModule, result), null, 2));
@@ -2462,6 +2531,7 @@ function buildPartialBenchmarkResult(
     config: {
       systemProvider: plan.runtime.systemProvider ?? null,
       judgeProvider: plan.runtime.judgeProvider ?? null,
+      internalProvider: plan.runtime.internalProvider ?? null,
       adapterMode: plan.adapterMode,
       remnicConfig: plan.runtime.remnicConfig ?? {},
     },
@@ -2519,10 +2589,12 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
         runtimeProfile: plan.runtime.profile,
         systemProvider: plan.runtime.systemProvider,
         judgeProvider: plan.runtime.judgeProvider,
+        internalProvider: plan.runtime.internalProvider,
         remnicConfig: plan.runtime.effectiveRemnicConfig,
         system,
       });
       result.config.remnicConfig = plan.runtime.remnicConfig;
+      result.config.internalProvider = plan.runtime.internalProvider;
       customBenchmarkIds.push(result.meta.benchmark);
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       writtenPaths.push(writtenPath);

--- a/packages/remnic-core/src/codex-cli-fallback.ts
+++ b/packages/remnic-core/src/codex-cli-fallback.ts
@@ -1,0 +1,160 @@
+import type { CodexCliReasoningEffort } from "./types.js";
+
+export interface CodexCliFallbackMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface CodexCliFallbackConfig {
+  apiKey?: string | Record<string, unknown>;
+  executable?: unknown;
+  codexCliExecutable?: unknown;
+  reasoningEffort?: unknown;
+  codexCliReasoningEffort?: unknown;
+  retryOptions?: {
+    timeoutMs?: unknown;
+  };
+}
+
+export interface CodexCliFallbackOptions {
+  timeoutMs?: number;
+}
+
+export interface CodexCliFallbackResult {
+  content: string;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+export interface CodexCliFallbackRequest {
+  config: CodexCliFallbackConfig;
+  modelId: string;
+  messages: CodexCliFallbackMessage[];
+  options: CodexCliFallbackOptions;
+}
+
+export type CodexCliFallbackRunner = (
+  request: CodexCliFallbackRequest,
+) => Promise<CodexCliFallbackResult>;
+
+const VALID_CODEX_CLI_REASONING_EFFORTS = new Set<CodexCliReasoningEffort>([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+]);
+
+let processRunner: CodexCliFallbackRunner | undefined;
+
+/**
+ * Registers the process-local Codex CLI transport. Core deliberately does not
+ * import child_process so host adapters such as OpenClaw do not ship shell
+ * execution in their plugin bundle; benchmark/standalone runtimes opt in.
+ */
+export function setCodexCliFallbackRunnerForProcess(
+  runner: CodexCliFallbackRunner | undefined,
+): () => void {
+  const previous = processRunner;
+  processRunner = runner;
+  return () => {
+    processRunner = previous;
+  };
+}
+
+export async function callCodexCliFallback(
+  config: CodexCliFallbackConfig,
+  modelId: string,
+  messages: CodexCliFallbackMessage[],
+  options: CodexCliFallbackOptions = {},
+): Promise<CodexCliFallbackResult> {
+  if (!processRunner) {
+    throw new Error(
+      'codex-cli fallback transport is not registered; install a runner with setCodexCliFallbackRunnerForProcess() before using api: "codex-cli"',
+    );
+  }
+
+  return await processRunner({
+    config: normalizeCodexCliFallbackConfig(config),
+    modelId: normalizeCodexCliModel(modelId),
+    messages,
+    options: normalizeCodexCliFallbackOptions(options),
+  });
+}
+
+function normalizeCodexCliFallbackConfig(
+  config: CodexCliFallbackConfig,
+): CodexCliFallbackConfig {
+  return {
+    ...config,
+    ...(config.executable !== undefined
+      ? { executable: normalizeOptionalString(config.executable, "codex-cli executable") }
+      : {}),
+    ...(config.codexCliExecutable !== undefined
+      ? { codexCliExecutable: normalizeOptionalString(config.codexCliExecutable, "codex-cli executable") }
+      : {}),
+    ...(config.reasoningEffort !== undefined
+      ? { reasoningEffort: normalizeCodexCliReasoningEffort(config.reasoningEffort) }
+      : {}),
+    ...(config.codexCliReasoningEffort !== undefined
+      ? { codexCliReasoningEffort: normalizeCodexCliReasoningEffort(config.codexCliReasoningEffort) }
+      : {}),
+    ...(config.retryOptions?.timeoutMs !== undefined
+      ? { retryOptions: { timeoutMs: normalizeCodexCliTimeoutMs(config.retryOptions.timeoutMs) } }
+      : {}),
+  };
+}
+
+function normalizeCodexCliFallbackOptions(
+  options: CodexCliFallbackOptions,
+): CodexCliFallbackOptions {
+  return {
+    ...(options.timeoutMs !== undefined
+      ? { timeoutMs: normalizeCodexCliTimeoutMs(options.timeoutMs) }
+      : {}),
+  };
+}
+
+function normalizeOptionalString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function normalizeCodexCliModel(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error("codex-cli model must be a non-empty string");
+  }
+  return trimmed;
+}
+
+function normalizeCodexCliReasoningEffort(value: unknown): CodexCliReasoningEffort {
+  if (typeof value !== "string") {
+    throw new Error("codex-cli reasoningEffort must be one of low, medium, high, xhigh");
+  }
+  const normalized = value.trim().toLowerCase();
+  if (VALID_CODEX_CLI_REASONING_EFFORTS.has(normalized as CodexCliReasoningEffort)) {
+    return normalized as CodexCliReasoningEffort;
+  }
+  throw new Error("codex-cli reasoningEffort must be one of low, medium, high, xhigh");
+}
+
+function normalizeCodexCliTimeoutMs(value: unknown): number {
+  const parsed = typeof value === "number"
+    ? value
+    : typeof value === "string" && value.trim().length > 0
+      ? Number(value)
+      : NaN;
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("codex-cli timeoutMs must be a positive integer");
+  }
+  return parsed;
+}
+
+export const __codexCliFallbackTestHooks = {
+  setRunCodexCliForTest: setCodexCliFallbackRunnerForProcess,
+};

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { FallbackLlmClient } from "./fallback-llm.js";
+import { __codexCliFallbackTestHooks } from "./codex-cli-fallback.js";
 import { clearModelsJsonCache, __setModelsJsonForTest } from "./models-json.js";
 import { clearSecretCache } from "./resolve-provider-secret.js";
 
@@ -232,6 +233,159 @@ test("fallback llm prefers requested canonical models.json provider before legac
 
     assert.equal(response?.content, "ok from canonical codex");
     assert.equal(capturedUrl, "https://codex.example/v1/responses");
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm invokes registered codex-cli fallback runner", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const captured: {
+    modelId?: string;
+    messages?: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+    apiKey?: string | Record<string, unknown>;
+    executable?: unknown;
+    reasoningEffort?: unknown;
+    timeoutMs?: number;
+  } = {};
+  const restoreRunner = __codexCliFallbackTestHooks.setRunCodexCliForTest(
+    async (request) => {
+      captured.modelId = request.modelId;
+      captured.messages = request.messages;
+      captured.apiKey = request.config.apiKey;
+      captured.executable = request.config.executable;
+      captured.reasoningEffort = request.config.reasoningEffort;
+      captured.timeoutMs = request.config.retryOptions?.timeoutMs as number | undefined;
+      return {
+        content: "final codex answer",
+        usage: {
+          inputTokens: 40,
+          outputTokens: 4,
+          totalTokens: 44,
+        },
+      };
+    },
+  );
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "codex-cli/gpt-custom",
+        },
+      },
+    },
+    models: {
+      providers: {
+        "codex-cli": {
+          baseUrl: "",
+          api: "codex-cli",
+          apiKey: "codex-test-key",
+          executable: "codex-test-bin",
+          reasoningEffort: "high",
+          retryOptions: { timeoutMs: 1234 },
+          models: [],
+        },
+      },
+    },
+  });
+
+  try {
+    const response = await llm.chatCompletion(
+      [
+        { role: "system", content: "Return concise JSON." },
+        { role: "user", content: "Say OK" },
+      ],
+      { temperature: 0, maxTokens: 16, timeoutMs: 5000 },
+    );
+
+    assert.equal(response?.content, "final codex answer");
+    assert.equal(response?.modelUsed, "codex-cli/gpt-custom");
+    assert.equal(response?.usage?.totalTokens, 44);
+    assert.equal(captured.modelId, "gpt-custom");
+    assert.deepEqual(captured.messages, [
+      { role: "system", content: "Return concise JSON." },
+      { role: "user", content: "Say OK" },
+    ]);
+    assert.equal(captured.apiKey, "codex-test-key");
+    assert.equal(captured.executable, "codex-test-bin");
+    assert.equal(captured.reasoningEffort, "high");
+    assert.equal(captured.timeoutMs, 1234);
+  } finally {
+    restoreRunner();
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm can call Ollama native chat and suppress thinking", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "ollama-internal/gemma4:31b-cloud",
+        },
+      },
+    },
+    models: {
+      providers: {
+        "ollama-internal": {
+          baseUrl: "https://ollama.example/api",
+          api: "ollama-chat",
+          apiKey: "ollama-key",
+          disableThinking: true,
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  let capturedAuth = "";
+  let capturedBody = "";
+  globalThis.fetch = (async (url, init) => {
+    capturedUrl = String(url);
+    capturedAuth = String((init?.headers as Record<string, string> | undefined)?.Authorization ?? "");
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        message: { content: "ok from ollama" },
+        prompt_eval_count: 7,
+        eval_count: 3,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    assert.equal(response?.content, "ok from ollama");
+    assert.equal(response?.usage?.totalTokens, 10);
+    assert.equal(capturedUrl, "https://ollama.example/api/chat");
+    assert.equal(capturedAuth, "Bearer ollama-key");
+    const parsedBody = JSON.parse(capturedBody) as {
+      model?: string;
+      think?: boolean;
+      options?: { num_predict?: number };
+    };
+    assert.equal(parsedBody.model, "gemma4:31b-cloud");
+    assert.equal(parsedBody.think, false);
+    assert.equal(parsedBody.options?.num_predict, 16);
   } finally {
     globalThis.fetch = originalFetch;
     clearModelsJsonCache();

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -8,6 +8,7 @@ import {
 } from "./openai-chat-compat.js";
 import { resolveProviderApiKey, getGatewayRuntimeAuthForModel } from "./resolve-provider-secret.js";
 import { loadModelsJsonProviders } from "./models-json.js";
+import { callCodexCliFallback } from "./codex-cli-fallback.js";
 
 export interface FallbackLlmOptions {
   temperature?: number;
@@ -368,9 +369,16 @@ export class FallbackLlmClient {
   ): Promise<{ content: string; usage?: FallbackLlmResponse["usage"] } | null> {
     // Try the gateway's native runtime auth first — it handles all provider-
     // specific transforms (OAuth exchange, base URL rewrite, etc.)
-    const runtimeAuth = await this.resolveRuntimeAuth(model);
+    const runtimeAuth = model.providerConfig.api === "codex-cli"
+      ? null
+      : await this.resolveRuntimeAuth(model);
     const effectiveBaseUrl = runtimeAuth?.baseUrl ?? model.providerConfig.baseUrl;
-    const resolvedApiKey = runtimeAuth?.apiKey ?? await this.resolveFallbackApiKey(model);
+    const resolvedApiKey = runtimeAuth?.apiKey
+      ?? (
+        model.providerConfig.api === "codex-cli" && model.providerConfig.apiKey === undefined
+          ? undefined
+          : await this.resolveFallbackApiKey(model)
+      );
 
     // If the raw key looks like an unresolved secret ref and resolution fails,
     // skip this provider entirely so the chain falls through to the next.
@@ -389,6 +397,19 @@ export class FallbackLlmClient {
 
     if (model.providerConfig.api === "anthropic-messages") {
       return await this.callAnthropic(effectiveConfig, model.modelId, messages, options);
+    }
+
+    if (model.providerConfig.api === "codex-cli") {
+      return await callCodexCliFallback(
+        effectiveConfig,
+        model.modelId,
+        messages,
+        { timeoutMs: options.timeoutMs },
+      );
+    }
+
+    if (model.providerConfig.api === "ollama-chat") {
+      return await this.callOllamaChat(effectiveConfig, model.modelId, messages, options);
     }
 
     if (
@@ -543,6 +564,70 @@ export class FallbackLlmClient {
             totalTokens: data.usage.total_tokens,
           }
         : undefined,
+    };
+  }
+
+  /**
+   * Call Ollama's native /api/chat transport. This lets benchmark-isolated
+   * gateway configs route Remnic's own internal LLM calls to Ollama Cloud
+   * without requiring an OpenAI-compatible shim.
+   */
+  private async callOllamaChat(
+    config: ModelProviderConfig,
+    modelId: string,
+    messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
+    options: FallbackLlmOptions,
+  ): Promise<{ content: string; usage?: FallbackLlmResponse["usage"] } | null> {
+    const base = config.baseUrl.replace(/\/$/, "");
+    const url = base.endsWith("/api") ? `${base}/chat` : `${base}/api/chat`;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...config.headers,
+    };
+    if (config.apiKey && typeof config.apiKey === "string" && config.authHeader !== false) {
+      headers.Authorization = `Bearer ${config.apiKey}`;
+    }
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: modelId,
+        messages,
+        stream: false,
+        ...(config.disableThinking ? { think: false } : {}),
+        options: {
+          temperature: options.temperature ?? 0.3,
+          num_predict: options.maxTokens ?? 4096,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Ollama API error: ${response.status} ${error}`);
+    }
+
+    const data = (await response.json()) as {
+      message?: { content?: string };
+      response?: string;
+      prompt_eval_count?: number;
+      eval_count?: number;
+    };
+    const content = data.message?.content ?? data.response;
+    if (!content) {
+      throw new Error("Empty response from Ollama API");
+    }
+
+    const inputTokens = data.prompt_eval_count ?? 0;
+    const outputTokens = data.eval_count ?? 0;
+    return {
+      content,
+      usage: {
+        inputTokens,
+        outputTokens,
+        totalTokens: inputTokens + outputTokens,
+      },
     };
   }
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -74,6 +74,15 @@ export { StorageManager } from "./storage.js";
 // ---------------------------------------------------------------------------
 
 export { ExtractionEngine } from "./extraction.js";
+export {
+  setCodexCliFallbackRunnerForProcess,
+  type CodexCliFallbackConfig,
+  type CodexCliFallbackMessage,
+  type CodexCliFallbackOptions,
+  type CodexCliFallbackRequest,
+  type CodexCliFallbackResult,
+  type CodexCliFallbackRunner,
+} from "./codex-cli-fallback.js";
 
 // ---------------------------------------------------------------------------
 // Smart buffer (issue #563)

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -2872,7 +2872,13 @@ export type LlmTraceCallback = (event: EngramTraceEvent) => void;
 // Gateway Configuration Types (for fallback AI)
 // ============================================================================
 
-export type ModelApi = "openai-completions" | "anthropic-messages" | "google-generative" | string;
+export type ModelApi =
+  | "openai-completions"
+  | "anthropic-messages"
+  | "google-generative"
+  | "codex-cli"
+  | string;
+export type CodexCliReasoningEffort = "low" | "medium" | "high" | "xhigh";
 
 export type ModelProviderAuthMode = "bearer" | "header" | "query";
 
@@ -2893,6 +2899,14 @@ export interface ModelProviderConfig {
   api?: ModelApi;
   headers?: Record<string, string>;
   authHeader?: boolean;
+  disableThinking?: boolean;
+  executable?: string;
+  reasoningEffort?: CodexCliReasoningEffort;
+  codexCliExecutable?: string;
+  codexCliReasoningEffort?: CodexCliReasoningEffort;
+  retryOptions?: {
+    timeoutMs?: number;
+  };
   models: ModelDefinitionConfig[];
 }
 

--- a/scripts/bench/ama-diagnostic-matrix.ts
+++ b/scripts/bench/ama-diagnostic-matrix.ts
@@ -66,6 +66,12 @@ interface ParsedArgs {
   judgeModel?: string;
   judgeBaseUrl?: string;
   judgeApiKey?: string;
+  internalProvider?: BuiltInProvider;
+  internalModel?: string;
+  internalBaseUrl?: string;
+  internalApiKey?: string;
+  internalDisableThinking: boolean;
+  internalCodexReasoningEffort?: ProviderConfig["reasoningEffort"];
   strongSystemProvider?: BuiltInProvider;
   strongSystemModel?: string;
   strongSystemBaseUrl?: string;
@@ -134,6 +140,12 @@ export async function runAmaBenchDiagnosticMatrix(
     judgeModel: parsed.judgeModel,
     judgeBaseUrl: parsed.judgeBaseUrl,
     judgeApiKey: parsed.judgeApiKey,
+    internalProvider: parsed.internalProvider,
+    internalModel: parsed.internalModel,
+    internalBaseUrl: parsed.internalBaseUrl,
+    internalApiKey: parsed.internalApiKey,
+    internalDisableThinking: parsed.internalDisableThinking,
+    internalCodexReasoningEffort: parsed.internalCodexReasoningEffort,
     requestTimeout: parsed.requestTimeout,
     max429WaitMs: parsed.max429WaitMs,
     disableThinking: parsed.disableThinking,
@@ -168,6 +180,7 @@ export async function runAmaBenchDiagnosticMatrix(
         runtimeProfile: runtime.profile,
         systemProvider: runtime.systemProvider,
         judgeProvider: runtime.judgeProvider,
+        internalProvider: runtime.internalProvider,
         remnicConfig: runtime.remnicConfig,
         amaBenchJudgeProtocol: parsed.amaBenchJudgeProtocol,
         ...(crossJudge.judge ? { amaBenchCrossJudge: crossJudge.judge } : {}),
@@ -197,6 +210,7 @@ export async function runAmaBenchDiagnosticMatrix(
       ...(parsed.seed !== undefined ? { seed: parsed.seed } : {}),
       systemProvider: sanitizeProvider(runtime.systemProvider),
       judgeProvider: sanitizeProvider(runtime.judgeProvider),
+      internalProvider: sanitizeProvider(runtime.internalProvider),
       amaBenchCrossJudgeProvider: sanitizeProvider(crossJudge.provider),
       strongSystemProvider: sanitizeProvider(strongProviderConfig(parsed)),
       variantIds: variants.map((variant) => variant.id),
@@ -356,22 +370,31 @@ function validatePrimaryProviderConfigs(parsed: ParsedArgs): void {
     baseUrl: parsed.judgeBaseUrl,
     apiKey: parsed.judgeApiKey,
   });
+  validateProviderFlagGroup("internal", {
+    provider: parsed.internalProvider,
+    model: parsed.internalModel,
+    baseUrl: parsed.internalBaseUrl,
+    apiKey: parsed.internalApiKey,
+    codexReasoningEffort: parsed.internalCodexReasoningEffort,
+  });
 }
 
 function validateProviderFlagGroup(
-  label: "system" | "judge",
+  label: "system" | "judge" | "internal",
   config: {
     provider?: BuiltInProvider;
     model?: string;
     baseUrl?: string;
     apiKey?: string;
+    codexReasoningEffort?: ProviderConfig["reasoningEffort"];
   },
 ): void {
   const hasAny =
     config.provider !== undefined ||
     config.model !== undefined ||
     config.baseUrl !== undefined ||
-    config.apiKey !== undefined;
+    config.apiKey !== undefined ||
+    config.codexReasoningEffort !== undefined;
   if (!hasAny) {
     return;
   }
@@ -383,6 +406,14 @@ function validateProviderFlagGroup(
   if (config.provider === "local-llm" && !config.baseUrl) {
     throw new Error(
       `--${label}-provider local-llm requires --${label}-base-url.`,
+    );
+  }
+  if (
+    config.codexReasoningEffort !== undefined &&
+    config.provider !== "codex-cli"
+  ) {
+    throw new Error(
+      `--${label}-codex-reasoning-effort requires --${label}-provider codex-cli.`,
     );
   }
 }
@@ -436,6 +467,7 @@ function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig 
     ...(config.apiKey ? { apiKey: config.apiKey } : {}),
     ...(config.retryOptions ? { retryOptions: config.retryOptions } : {}),
     ...(config.disableThinking ? { disableThinking: config.disableThinking } : {}),
+    ...(config.reasoningEffort ? { reasoningEffort: config.reasoningEffort } : {}),
   } as ProviderFactoryConfig;
 }
 
@@ -458,6 +490,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     runtimeProfile: "real",
     strongDisableThinking: false,
     disableThinking: false,
+    internalDisableThinking: false,
     amaBenchJudgeProtocol: "default",
     includeStrong: false,
   };
@@ -551,6 +584,32 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--judge-api-key":
         parsed.judgeApiKey = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--internal-provider":
+        parsed.internalProvider = parseProvider(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--internal-model":
+        parsed.internalModel = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--internal-base-url":
+        parsed.internalBaseUrl = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--internal-api-key":
+        parsed.internalApiKey = parseNonEmptyValue(takeValue(index, arg), arg);
+        index += 1;
+        break;
+      case "--internal-disable-thinking":
+        parsed.internalDisableThinking = true;
+        break;
+      case "--internal-codex-reasoning-effort":
+        parsed.internalCodexReasoningEffort = parseReasoningEffort(
+          takeValue(index, arg),
+          arg,
+        );
         index += 1;
         break;
       case "--strong-system-provider":
@@ -679,6 +738,21 @@ function parseAmaProtocol(value: string): "default" | "recommended" {
   throw new Error('--ama-bench-judge-protocol must be "default" or "recommended".');
 }
 
+function parseReasoningEffort(
+  value: string,
+  flag: string,
+): NonNullable<ProviderConfig["reasoningEffort"]> {
+  if (
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "xhigh"
+  ) {
+    return value;
+  }
+  throw new Error(`${flag} must be "low", "medium", "high", or "xhigh".`);
+}
+
 function parseNonEmptyValue(value: string, flag: string): string {
   if (value.trim().length === 0) {
     throw new Error(`${flag} must not be empty.`);
@@ -748,6 +822,14 @@ Normal answerer / judge:
   --judge-model <model>
   --judge-base-url <url>
   --ama-bench-judge-protocol <default|recommended>
+
+Remnic internal LLM:
+  --internal-provider <provider>     Provider for Remnic extraction/summarization.
+  --internal-model <model>
+  --internal-base-url <url>
+  --internal-api-key <key>
+  --internal-disable-thinking
+  --internal-codex-reasoning-effort <low|medium|high|xhigh>
 
 Strong-answerer ablations:
   --strong-system-provider <provider>


### PR DESCRIPTION
## Summary
- add a core codex-cli fallback transport for Remnic internal LLM calls without depending on @remnic/bench
- add native Ollama /api/chat support for gateway-routed internal Remnic LLM calls
- add benchmark/CLI --internal-* provider flags and persist sanitized internal-provider metadata in results and AMA diagnostics

## Verification
- pnpm exec tsx --test --test-name-pattern "codex-cli|Ollama native|runtime profile can route|internal Remnic LLM|finalizeBenchmarkResultConfig" packages/remnic-core/src/fallback-llm.test.ts packages/bench/src/runtime-profiles.test.ts packages/remnic-cli/src/bench-args.test.ts packages/bench/src/result-config.test.ts
- pnpm exec tsx --test packages/bench/src/reporter.test.ts packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
- pnpm --filter @remnic/core run check-types
- pnpm --filter @remnic/bench run check-types
- pnpm --filter @remnic/core run build
- pnpm --filter @remnic/bench run build
- git diff --check

## Smoke run
- AMA diagnostic quick run: runtimeProfile=real, adapterMode=direct, remnic-full-normal, Codex CLI for system/judge/cross-judge/internal, score=1.0 on 2 quick tasks

## Known unrelated local issue
- Full fallback-llm.test.ts still hits the existing Anthropic runtime-auth fixture issue when local OpenClaw runtime auth is present; the focused Codex/Ollama tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new internal-provider configuration path that affects how Remnic’s internal extraction/summarization LLM calls are routed, including new transport behaviors (`codex-cli` runner, native Ollama chat). Moderate risk due to new provider selection/secret-handling logic and expanded CLI/config surfaces, but changes are covered by targeted tests and keep persisted secrets redacted.
> 
> **Overview**
> Benchmarks can now specify a separate **internal LLM provider** (used for Remnic extraction/summarization calls) via new `--internal-*` CLI flags, and benchmark artifacts/results now persist this provider metadata in a sanitized form (`internalProvider`).
> 
> `@remnic/bench` runtime profile resolution is extended to build internal-provider Remnic gateway/plugin overrides (including default base URLs, optional thinking suppression, and Codex reasoning effort), and registers a process-local `codex-cli` fallback runner when needed.
> 
> `@remnic/core` adds a `codex-cli` fallback transport API and extends `FallbackLlmClient` to support `api: "codex-cli"` via the registered runner and `api: "ollama-chat"` via native Ollama `/api/chat`. Secret redaction and schemas/tests are updated to include the new `internalProvider` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0bb7cf1294f138727e53cc392cbff8536b73142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->