### PR TITLE
fix(bench): isolate diagnostic QMD evidence

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { parseConfig } from "@remnic/core";
 
@@ -14,6 +17,10 @@ const BASE_CONFIG = {
   workspaceDir: "/tmp/remnic-bench-workspace",
   lcmEnabled: true as const,
 };
+
+function shellQuoteForTest(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
 
 test("direct adapter keeps its recall-friendly defaults without overrides", () => {
   const config = buildBenchAdapterConfig("direct", BASE_CONFIG);
@@ -48,6 +55,73 @@ test("adapter sandbox paths cannot be overridden by runtime config", () => {
   assert.equal(lightweight.memoryDir, BASE_CONFIG.memoryDir);
   assert.equal(lightweight.workspaceDir, BASE_CONFIG.workspaceDir);
   assert.equal(lightweight.lcmEnabled, true);
+});
+
+test("adapter sandbox QMD index settings cannot be overridden by runtime config", () => {
+  const sandboxedConfig = {
+    ...BASE_CONFIG,
+    qmdCollection: "remnic-bench-hot",
+    qmdColdCollection: "remnic-bench-cold",
+    qmdPath: "/tmp/remnic-bench-qmd",
+  };
+  const overrides = {
+    qmdCollection: "openclaw-engram",
+    qmdColdCollection: "openclaw-engram-cold",
+    qmdPath: "/usr/local/bin/qmd",
+  };
+
+  const direct = buildBenchAdapterConfig("direct", sandboxedConfig, overrides);
+  const lightweight = buildBenchAdapterConfig("lightweight", sandboxedConfig, overrides);
+
+  assert.equal(direct.qmdCollection, "remnic-bench-hot");
+  assert.equal(direct.qmdColdCollection, "remnic-bench-cold");
+  assert.equal(direct.qmdPath, "/tmp/remnic-bench-qmd");
+  assert.equal(lightweight.qmdCollection, "remnic-bench-hot");
+  assert.equal(lightweight.qmdColdCollection, "remnic-bench-cold");
+  assert.equal(lightweight.qmdPath, "/tmp/remnic-bench-qmd");
+});
+
+test("adapter QMD wrapper resolves relative binaries and isolates QMD env", async () => {
+  const fakeRoot = await mkdtemp(path.join(tmpdir(), "remnic-fake-qmd-"));
+  const fakeQmdPath = path.join(fakeRoot, "qmd");
+  const markerPath = path.join(fakeRoot, "calls.log");
+  await writeFile(
+    fakeQmdPath,
+    [
+      "#!/bin/sh",
+      `{`,
+      `  echo "PWD=$PWD"`,
+      `  echo "INDEX_PATH=$INDEX_PATH"`,
+      `  echo "XDG_CACHE_HOME=$XDG_CACHE_HOME"`,
+      `  echo "QMD_CONFIG_DIR=$QMD_CONFIG_DIR"`,
+      `  echo "XDG_CONFIG_HOME=${"$"}{XDG_CONFIG_HOME-}"`,
+      `  echo "ARGS=$*"`,
+      `} >> ${shellQuoteForTest(markerPath)}`,
+      "exit 0",
+      "",
+    ].join("\n"),
+    { mode: 0o700 },
+  );
+  await chmod(fakeQmdPath, 0o700);
+
+  const adapter = await createRemnicAdapter({
+    configOverrides: {
+      qmdPath: path.relative(process.cwd(), fakeQmdPath),
+    },
+  });
+
+  try {
+    const marker = await readFile(markerPath, "utf8");
+    assert.match(marker, /ARGS=.* collection add .* --name remnic-bench-direct-/);
+    assert.match(marker, /INDEX_PATH=.*\/qmd-cache\/remnic-bench-direct-.*\.sqlite/);
+    assert.match(marker, /XDG_CACHE_HOME=.*\/qmd-cache/);
+    assert.match(marker, /QMD_CONFIG_DIR=.*\/qmd-config/);
+    assert.match(marker, /XDG_CONFIG_HOME=\n/);
+    assert.doesNotMatch(marker, /openclaw-engram/);
+  } finally {
+    await adapter.destroy();
+    await rm(fakeRoot, { recursive: true, force: true });
+  }
 });
 
 test("lightweight adapter keeps smoke-run guardrails even when overrides conflict", () => {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -3,9 +3,11 @@
  */
 
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import {
   buildEvidencePack,
   buildExplicitCueRecallSection,
@@ -36,6 +38,18 @@ interface BenchAdapterBaseConfig {
   memoryDir: string;
   workspaceDir: string;
   lcmEnabled: true;
+  qmdCollection?: string;
+  qmdColdCollection?: string;
+  qmdPath?: string;
+}
+
+interface BenchQmdSandbox {
+  collection: string;
+  coldCollection: string;
+  cacheDir: string;
+  configDir: string;
+  indexName: string;
+  wrapperPath: string;
 }
 
 export const BENCH_ADAPTER_SHARED_CONFIG: Record<string, unknown> = {
@@ -105,6 +119,7 @@ const BENCH_TEARDOWN_DEFERRED_READY_WAIT_MS = 500;
 const CORE_EXPLICIT_CUE_MAX_CHARS = 18_000;
 const CORE_EXPLICIT_CUE_MAX_ITEM_CHARS = 2_400;
 const CORE_EXPLICIT_CUE_MAX_REFERENCES = 24;
+const execFileAsync = promisify(execFile);
 
 function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
   return cloneBenchConfigValue(config) as Record<string, unknown>;
@@ -148,6 +163,9 @@ export function buildBenchAdapterConfig(
     memoryDir: baseConfig.memoryDir,
     workspaceDir: baseConfig.workspaceDir,
     lcmEnabled: baseConfig.lcmEnabled,
+    ...(baseConfig.qmdCollection ? { qmdCollection: baseConfig.qmdCollection } : {}),
+    ...(baseConfig.qmdColdCollection ? { qmdColdCollection: baseConfig.qmdColdCollection } : {}),
+    ...(baseConfig.qmdPath ? { qmdPath: baseConfig.qmdPath } : {}),
   };
   const modeConfig = {
     ...BENCH_ADAPTER_SHARED_CONFIG,
@@ -183,14 +201,18 @@ async function createBenchOrchestrator(
   mode: BenchAdapterMode,
   overrides?: Record<string, unknown>,
   preserveRuntimeDefaults = false,
-): Promise<{ tempDir: string; orchestrator: Orchestrator }> {
+): Promise<{ tempDir: string; orchestrator: Orchestrator; qmdSandbox: BenchQmdSandbox }> {
   const tempDir = await mkdtemp(path.join(tmpdir(), `remnic-bench-${mode}-`));
   await mkdir(path.join(tempDir, "state"), { recursive: true });
+  const qmdSandbox = await createBenchQmdSandbox(tempDir, overrides);
 
   const commonConfig: BenchAdapterBaseConfig = {
     memoryDir: tempDir,
     workspaceDir: tempDir,
     lcmEnabled: true,
+    qmdCollection: qmdSandbox.collection,
+    qmdColdCollection: qmdSandbox.coldCollection,
+    qmdPath: qmdSandbox.wrapperPath,
   };
 
   const orchestrator = new Orchestrator(
@@ -206,7 +228,107 @@ async function createBenchOrchestrator(
     throw new Error("Remnic benchmark adapter requires LCM to be enabled.");
   }
 
-  return { tempDir, orchestrator };
+  return { tempDir, orchestrator, qmdSandbox };
+}
+
+async function createBenchQmdSandbox(
+  tempDir: string,
+  overrides?: Record<string, unknown>,
+): Promise<BenchQmdSandbox> {
+  const collection = safeBenchQmdName(path.basename(tempDir));
+  const coldCollection = `${collection}-cold`;
+  const indexName = collection;
+  const wrapperPath = path.join(tempDir, "qmd-bench");
+  const qmdCacheDir = path.join(tempDir, "qmd-cache");
+  const qmdConfigDir = path.join(tempDir, "qmd-config");
+  const qmdIndexPath = path.join(qmdCacheDir, `${indexName}.sqlite`);
+  const qmdBinary = typeof overrides?.qmdPath === "string" && overrides.qmdPath.trim().length > 0
+    ? resolveConfiguredQmdBinary(overrides.qmdPath)
+    : "qmd";
+  await mkdir(qmdCacheDir, { recursive: true });
+  await mkdir(qmdConfigDir, { recursive: true });
+  await writeFile(
+    wrapperPath,
+    [
+      "#!/bin/sh",
+      `cd ${shellQuote(tempDir)} || exit 1`,
+      `export INDEX_PATH=${shellQuote(qmdIndexPath)}`,
+      `export XDG_CACHE_HOME=${shellQuote(qmdCacheDir)}`,
+      `export QMD_CONFIG_DIR=${shellQuote(qmdConfigDir)}`,
+      "unset XDG_CONFIG_HOME",
+      `exec ${shellQuote(qmdBinary)} --index ${shellQuote(indexName)} "$@"`,
+      "",
+    ].join("\n"),
+    { mode: 0o700 },
+  );
+  await chmod(wrapperPath, 0o700);
+
+  await registerBenchQmdCollection(wrapperPath, tempDir, collection);
+  await registerBenchQmdCollection(wrapperPath, tempDir, coldCollection);
+
+  return {
+    collection,
+    coldCollection,
+    cacheDir: qmdCacheDir,
+    configDir: qmdConfigDir,
+    indexName,
+    wrapperPath,
+  };
+}
+
+async function registerBenchQmdCollection(
+  wrapperPath: string,
+  tempDir: string,
+  collection: string,
+): Promise<void> {
+  try {
+    await execFileAsync(wrapperPath, [
+      "collection",
+      "add",
+      tempDir,
+      "--name",
+      collection,
+    ], {
+      cwd: tempDir,
+      env: { ...process.env, NO_COLOR: "1" },
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+    });
+  } catch {
+    // QMD is optional at runtime. If the CLI is unavailable, Remnic's normal
+    // probe path will mark it unavailable and the adapter will continue with
+    // non-QMD recall surfaces.
+  }
+}
+
+function safeBenchQmdName(value: string): string {
+  const safe = value.replace(/[^a-zA-Z0-9_-]+/g, "-").slice(0, 80);
+  return safe.startsWith("remnic-bench-") ? safe : `remnic-bench-${safe}`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function resolveConfiguredQmdBinary(value: string): string {
+  const trimmed = value.trim();
+  if (
+    path.isAbsolute(trimmed) ||
+    (!trimmed.startsWith(".") && !trimmed.includes("/") && !trimmed.includes("\\"))
+  ) {
+    return trimmed;
+  }
+  return path.resolve(trimmed);
+}
+
+async function removeBenchQmdSandbox(sandbox: BenchQmdSandbox): Promise<void> {
+  if (!sandbox.indexName.startsWith("remnic-bench-")) {
+    return;
+  }
+  await Promise.all([
+    rm(sandbox.cacheDir, { recursive: true, force: true }),
+    rm(sandbox.configDir, { recursive: true, force: true }),
+  ]);
 }
 
 function createAdapterFactory(mode: "lightweight" | "direct") {
@@ -247,6 +369,12 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       ]);
       await orchestrator.qmd.dispose?.();
       orchestrator.lcmEngine?.close();
+      try {
+        await removeBenchQmdSandbox(state.qmdSandbox);
+      } catch {
+        // QMD sandbox cleanup is best-effort; the benchmark temp dir must
+        // still be removed even if a sqlite/config artifact is busy.
+      }
       await rm(state.tempDir, { recursive: true, force: true });
     };
 

--- a/packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
@@ -299,6 +299,81 @@ test("diagnostic summary groups domain and QA type without raw answer text", () 
   assert.equal(summary.tasks[0]?.crossJudgeScore, 1);
 });
 
+test("diagnostic summary can include bounded task evidence by opt-in", () => {
+  const variant = selectAmaBenchDiagnosticVariants({
+    ids: ["remnic-full-normal"],
+  })[0]!;
+  const result: BenchmarkResult = {
+    meta: {
+      id: "run-1",
+      benchmark: "ama-bench",
+      benchmarkTier: "published",
+      version: "2.0.0",
+      remnicVersion: "test",
+      gitSha: "abc",
+      timestamp: "2026-05-05T00:00:00.000Z",
+      mode: "full",
+      runCount: 1,
+      seeds: [0],
+    },
+    config: {
+      systemProvider: null,
+      judgeProvider: null,
+      adapterMode: "direct",
+      remnicConfig: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: [
+        {
+          taskId: "q1",
+          question: "Which color was the small box?",
+          expected: "red",
+          actual: "The small box was red.",
+          scores: { f1: 1 },
+          latencyMs: 0,
+          tokens: { input: 0, output: 0 },
+          details: {
+            domain: "Game",
+            qaType: "A",
+            taskType: "babaisai",
+            recalledText: "## Explicit Cue Evidence\n[Action 1]: inspect small box",
+          },
+        },
+      ],
+      aggregates: {},
+    },
+    environment: {
+      os: "test",
+      nodeVersion: "test",
+    },
+  };
+
+  const summary = buildAmaBenchDiagnosticVariantSummary(variant, result, {
+    runtimeProfile: "real",
+    hasResponder: true,
+    includeTaskEvidence: true,
+    taskEvidenceMaxChars: 12,
+  });
+
+  assert.equal(summary.tasks[0]?.evidence?.question, "Which color ");
+  assert.equal(summary.tasks[0]?.evidence?.expected, "red");
+  assert.equal(summary.tasks[0]?.evidence?.actual, "The small bo");
+  assert.equal(summary.tasks[0]?.evidence?.recalledText, "## Explicit ");
+  assert.deepEqual(summary.tasks[0]?.evidence?.truncatedFields, [
+    "question",
+    "actual",
+    "recalledText",
+  ]);
+});
+
 test("diagnostic summary only marks primary full-system scores for full real Remnic runs", () => {
   const variant = selectAmaBenchDiagnosticVariants({
     ids: ["remnic-full-normal"],

--- a/packages/bench/src/benchmarks/published/ama-bench/diagnostics.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/diagnostics.ts
@@ -282,6 +282,15 @@ export interface AmaBenchDiagnosticTaskRow {
   judgeModel?: string;
   crossJudgeModel?: string;
   crossJudgeScore?: number;
+  evidence?: AmaBenchDiagnosticTaskEvidence;
+}
+
+export interface AmaBenchDiagnosticTaskEvidence {
+  question: string;
+  expected: string;
+  actual: string;
+  recalledText: string;
+  truncatedFields?: string[];
 }
 
 export interface AmaBenchDiagnosticBreakdown {
@@ -330,6 +339,8 @@ export interface AmaBenchDiagnosticMatrixArtifact {
     amaBenchCrossJudgeProvider?: SanitizedDiagnosticProvider | null;
     strongSystemProvider?: SanitizedDiagnosticProvider | null;
     variantIds?: string[];
+    includeTaskEvidence?: boolean;
+    taskEvidenceMaxChars?: number;
   };
   variants: AmaBenchDiagnosticVariantSummary[];
 }
@@ -337,6 +348,8 @@ export interface AmaBenchDiagnosticMatrixArtifact {
 export interface AmaBenchDiagnosticRunContext {
   runtimeProfile?: string;
   hasResponder?: boolean;
+  includeTaskEvidence?: boolean;
+  taskEvidenceMaxChars?: number;
 }
 
 export function buildAmaBenchDiagnosticVariantSummary(
@@ -345,7 +358,10 @@ export function buildAmaBenchDiagnosticVariantSummary(
   context: AmaBenchDiagnosticRunContext = {},
 ): AmaBenchDiagnosticVariantSummary {
   const tasks = result.results.tasks.map((task) =>
-    taskToDiagnosticRow(variant.id, task),
+    taskToDiagnosticRow(variant.id, task, {
+      includeTaskEvidence: context.includeTaskEvidence === true,
+      maxChars: context.taskEvidenceMaxChars,
+    }),
   );
   const usesFullRemnicRecallProcess =
     context.runtimeProfile === "real" &&
@@ -405,6 +421,7 @@ export function isAmaBenchUnknownLikeAnswer(answer: string): boolean {
 function taskToDiagnosticRow(
   variantId: string,
   task: TaskResult,
+  options: { includeTaskEvidence?: boolean; maxChars?: number } = {},
 ): AmaBenchDiagnosticTaskRow {
   const details = task.details ?? {};
   return {
@@ -423,7 +440,52 @@ function taskToDiagnosticRow(
     judgeModel: asOptionalString(details.judgeModel),
     crossJudgeModel: asOptionalString(details.amaBenchCrossJudgeModel),
     crossJudgeScore: asOptionalNumber(details.amaBenchCrossJudgeScore),
+    ...(options.includeTaskEvidence === true
+      ? { evidence: buildTaskEvidence(task, options.maxChars) }
+      : {}),
   };
+}
+
+function buildTaskEvidence(
+  task: TaskResult,
+  maxChars: number | undefined,
+): AmaBenchDiagnosticTaskEvidence {
+  const budget = normalizeEvidenceMaxChars(maxChars);
+  const recalled = asOptionalString(task.details?.recalledText) ?? "";
+  const fields = {
+    question: truncateEvidenceField(task.question, budget),
+    expected: truncateEvidenceField(task.expected, budget),
+    actual: truncateEvidenceField(task.actual, budget),
+    recalledText: truncateEvidenceField(recalled, budget),
+  };
+  const truncatedFields = Object.entries(fields)
+    .filter(([, field]) => field.truncated)
+    .map(([name]) => name);
+
+  return {
+    question: fields.question.text,
+    expected: fields.expected.text,
+    actual: fields.actual.text,
+    recalledText: fields.recalledText.text,
+    ...(truncatedFields.length > 0 ? { truncatedFields } : {}),
+  };
+}
+
+function normalizeEvidenceMaxChars(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 6000;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function truncateEvidenceField(
+  value: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) {
+    return { text: value, truncated: false };
+  }
+  return { text: value.slice(0, maxChars), truncated: true };
 }
 
 function truncateToBudget(text: string, budgetChars?: number): string {

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -175,6 +175,7 @@ export type {
   AmaBenchDiagnosticMatrixArtifact,
   AmaBenchDiagnosticRecallMode,
   AmaBenchDiagnosticRunContext,
+  AmaBenchDiagnosticTaskEvidence,
   AmaBenchDiagnosticTaskRow,
   AmaBenchDiagnosticVariant,
   AmaBenchDiagnosticVariantSummary,

--- a/scripts/bench/ama-diagnostic-matrix.ts
+++ b/scripts/bench/ama-diagnostic-matrix.ts
@@ -91,6 +91,8 @@ interface ParsedArgs {
   amaBenchCrossJudgeCodexReasoningEffort?: ProviderConfig["reasoningEffort"];
   variants?: string[];
   includeStrong: boolean;
+  includeTaskEvidence: boolean;
+  taskEvidenceMaxChars: number;
 }
 
 interface MatrixRunResult {
@@ -202,6 +204,8 @@ export async function runAmaBenchDiagnosticMatrix(
         buildAmaBenchDiagnosticVariantSummary(variant, result, {
           runtimeProfile: runtime.profile,
           hasResponder: system.responder !== undefined,
+          includeTaskEvidence: parsed.includeTaskEvidence,
+          taskEvidenceMaxChars: parsed.taskEvidenceMaxChars,
         }),
       );
     } finally {
@@ -223,6 +227,12 @@ export async function runAmaBenchDiagnosticMatrix(
       amaBenchCrossJudgeProvider: sanitizeProvider(crossJudge.provider),
       strongSystemProvider: sanitizeProvider(strongProviderConfig(parsed)),
       variantIds: variants.map((variant) => variant.id),
+      ...(parsed.includeTaskEvidence
+        ? {
+            includeTaskEvidence: true,
+            taskEvidenceMaxChars: parsed.taskEvidenceMaxChars,
+          }
+        : {}),
     },
     variants: summaries,
   });
@@ -527,6 +537,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     internalDisableThinking: false,
     amaBenchJudgeProtocol: "default",
     includeStrong: false,
+    includeTaskEvidence: false,
+    taskEvidenceMaxChars: 6000,
   };
 
   const takeValue = (index: number, flag: string): string => {
@@ -749,6 +761,16 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--include-strong":
         parsed.includeStrong = true;
         break;
+      case "--include-task-evidence":
+        parsed.includeTaskEvidence = true;
+        break;
+      case "--task-evidence-max-chars":
+        parsed.taskEvidenceMaxChars = parsePositiveInteger(
+          takeValue(index, arg),
+          arg,
+        );
+        index += 1;
+        break;
       default:
         throw new Error(`Unknown argument: ${arg}`);
     }
@@ -875,6 +897,8 @@ Core options:
   --remnic-config <path>             Remnic config for --runtime-profile real.
   --openclaw-config <path>           OpenClaw config for --runtime-profile openclaw-chain.
   --variants <ids>                   Comma-separated variant ids.
+  --include-task-evidence            Include bounded raw question/answer/recall evidence for failure analysis.
+  --task-evidence-max-chars <n>       Max chars per evidence field when --include-task-evidence is set. Defaults to 6000.
 
 Normal answerer / judge:
   --system-provider <provider>       openai, anthropic, ollama, litellm, local-llm, or codex-cli.


### PR DESCRIPTION
## Summary
- give each benchmark Remnic adapter its own QMD wrapper, index, and collection rooted at the adapter temp directory
- force benchmark-owned QMD collection/path settings over runtime overrides so real-profile runs cannot read the production QMD collection
- add opt-in bounded AMA diagnostic task evidence for question/expected/actual/recalled text
- record sanitized Remnic QMD collection names in AMA diagnostic matrix metadata

## Verification
- node node_modules/tsx/dist/cli.mjs --test packages/bench/src/adapters/remnic-adapter.test.ts packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
- pnpm --filter @remnic/bench run check-types
- pnpm --filter @remnic/bench run build
- git diff --check
- live Codex-all-roles AMA evidence run after isolation fix: remnic-full-normal tasks=12 score=0.6667 unknown_like=0.0000
- artifact grep after isolation fix found no API keys, /Users/joshuawarren paths, openclaw-engram, production facts/conversation-index paths, QMD cache paths

## Notes
- npm run preflight:quick was attempted, but it hung in tests/register-multi-registry.test.ts after spawning a production qmd mcp/update child. I interrupted the stalled gate after the focused verification and live isolation run completed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes how benchmark adapters configure and invoke QMD (new wrapper script + child-process calls) and tweaks diagnostic artifact contents, which could affect isolation guarantees and benchmark behavior if misconfigured.
> 
> **Overview**
> Benchmark Remnic adapters now **sandbox QMD per run** by generating a temp-dir-scoped `qmd` wrapper that sets isolated cache/config/index paths and registers per-adapter hot/cold collections, preventing real-profile runs from reading or writing to production QMD state.
> 
> Runtime config overrides can no longer replace benchmark-owned QMD collection/path settings, adapter teardown best-effort cleans up QMD sandbox artifacts, and tests validate env isolation plus relative `qmdPath` resolution.
> 
> AMA diagnostic matrix output gains an **opt-in** `includeTaskEvidence` mode that embeds *bounded/truncated* per-task `question`/`expected`/`actual`/`recalledText` (with `truncatedFields` metadata), is plumbed through the matrix CLI via new flags, and is exported via the package index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd07a79fb75078c6f97399dc34b5744047b6b52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->