### PR TITLE
feat(core): capture observed objective state

### DIFF
--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -423,6 +423,30 @@ test("runtime profile can route Remnic internal LLM calls through Ollama native 
   );
 });
 
+test("runtime profile can route Remnic internal LLM calls through plugin local-llm", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    internalProvider: "local-llm",
+    internalModel: "qwen3:32b",
+    internalBaseUrl: "http://localhost:1234/v1",
+    internalApiKey: "local-secret",
+  });
+
+  assert.deepEqual(resolved.internalProvider, {
+    provider: "local-llm",
+    model: "qwen3:32b",
+    baseUrl: "http://localhost:1234/v1",
+    apiKey: "[redacted]",
+  });
+  assert.equal(resolved.remnicConfig.modelSource, "plugin");
+  assert.equal(resolved.effectiveRemnicConfig.modelSource, "plugin");
+  assert.equal(resolved.effectiveRemnicConfig.localLlmEnabled, true);
+  assert.equal(resolved.effectiveRemnicConfig.localLlmFallback, false);
+  assert.equal(resolved.effectiveRemnicConfig.localLlmUrl, "http://localhost:1234/v1");
+  assert.equal(resolved.effectiveRemnicConfig.localLlmModel, "qwen3:32b");
+  assert.equal(resolved.effectiveRemnicConfig.localLlmApiKey, "local-secret");
+});
+
 test("runtime profile routes OpenAI internal LLM calls through Responses API", async () => {
   const resolved = await resolveBenchRuntimeProfile({
     runtimeProfile: "baseline",

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3355,6 +3355,13 @@ export class EngramAccessService {
     // Validate namespace authorization BEFORE attaching coding context so
     // a failed auth check doesn't leave orphaned context on the session
     // (Codex review P2).
+    const hasExplicitNamespace =
+      typeof request.namespace === "string" &&
+      request.namespace.trim().length > 0;
+    const principal = this.resolveWritePrincipal(
+      request.sessionKey,
+      request.authenticatedPrincipal,
+    );
     const namespace = this.resolveWritableNamespace(
       request.namespace,
       request.sessionKey,
@@ -3369,14 +3376,14 @@ export class EngramAccessService {
       projectTag: request.projectTag,
     });
 
-    const hasExplicitNamespace =
-      typeof request.namespace === "string" &&
-      request.namespace.trim().length > 0;
+    const objectiveStateBaseNamespace = hasExplicitNamespace
+      ? namespace
+      : defaultNamespaceForPrincipal(principal, this.orchestrator.config);
     const objectiveStateNamespace = hasExplicitNamespace
       ? namespace
       : this.orchestrator.applyCodingNamespaceOverlay(
           request.sessionKey,
-          namespace,
+          objectiveStateBaseNamespace,
         );
     const objectiveStateSessionKey =
       objectiveStateNamespace !== this.orchestrator.config.defaultNamespace

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3364,10 +3364,14 @@ export class EngramAccessService {
       request.sessionKey,
       request.authenticatedPrincipal,
     );
+    const shouldWriteObjectiveState =
+      this.orchestrator.config.objectiveStateMemoryEnabled === true &&
+      this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true;
     const objectiveStateBaseNamespace = hasExplicitNamespace
       ? namespace
       : defaultNamespaceForPrincipal(principal, this.orchestrator.config);
     if (
+      shouldWriteObjectiveState &&
       !hasExplicitNamespace &&
       !canWriteNamespace(
         principal,
@@ -3405,10 +3409,7 @@ export class EngramAccessService {
       ? `${namespace}:${request.sessionKey}`
       : request.sessionKey;
 
-    if (
-      this.orchestrator.config.objectiveStateMemoryEnabled === true &&
-      this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true
-    ) {
+    if (shouldWriteObjectiveState) {
       try {
         const objectiveStateLocation =
           await this.objectiveStateStoreLocationForNamespace(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -119,6 +119,7 @@ import {
   type MemoryOutcomeKind,
   type RecordMemoryOutcomeResult,
 } from "./memory-worth-outcomes.js";
+import { objectiveStateStoreOverrideForNamespace } from "./objective-state.js";
 import { recordObjectiveStateSnapshotsFromObservedMessages } from "./objective-state-writers.js";
 import {
   importCapsule as importCapsuleFn,
@@ -988,7 +989,15 @@ export class EngramAccessService {
       };
     }
     const storage = await this.orchestrator.getStorage(namespace);
-    return { memoryDir: storage.dir };
+    return {
+      memoryDir: storage.dir,
+      objectiveStateStoreDir: objectiveStateStoreOverrideForNamespace({
+        memoryDir: this.orchestrator.config.memoryDir,
+        configuredStoreDir: this.orchestrator.config.objectiveStateStoreDir,
+        namespacesEnabled: this.orchestrator.config.namespacesEnabled,
+        namespace,
+      }),
+    };
   }
 
   private resolveReadableNamespace(namespace: string | undefined, principal?: string): string {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3364,6 +3364,21 @@ export class EngramAccessService {
       request.sessionKey,
       request.authenticatedPrincipal,
     );
+    const objectiveStateBaseNamespace = hasExplicitNamespace
+      ? namespace
+      : defaultNamespaceForPrincipal(principal, this.orchestrator.config);
+    if (
+      !hasExplicitNamespace &&
+      !canWriteNamespace(
+        principal,
+        objectiveStateBaseNamespace,
+        this.orchestrator.config,
+      )
+    ) {
+      throw new EngramAccessInputError(
+        `namespace is not writable: ${objectiveStateBaseNamespace}`,
+      );
+    }
 
     // Auto-resolve coding context from cwd/projectTag so observe writes
     // route to the correct project namespace (rule 42: same namespace layer
@@ -3373,9 +3388,6 @@ export class EngramAccessService {
       projectTag: request.projectTag,
     });
 
-    const objectiveStateBaseNamespace = hasExplicitNamespace
-      ? namespace
-      : defaultNamespaceForPrincipal(principal, this.orchestrator.config);
     const objectiveStateNamespace = hasExplicitNamespace
       ? namespace
       : this.orchestrator.applyCodingNamespaceOverlay(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -119,6 +119,7 @@ import {
   type MemoryOutcomeKind,
   type RecordMemoryOutcomeResult,
 } from "./memory-worth-outcomes.js";
+import { recordObjectiveStateSnapshotsFromObservedMessages } from "./objective-state-writers.js";
 import {
   importCapsule as importCapsuleFn,
   type ImportCapsuleOptions,
@@ -3356,6 +3357,26 @@ export class EngramAccessService {
     const lcmSessionKey = namespace !== this.orchestrator.config.defaultNamespace
       ? `${namespace}:${request.sessionKey}`
       : request.sessionKey;
+
+    if (
+      this.orchestrator.config.objectiveStateMemoryEnabled === true &&
+      this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true
+    ) {
+      try {
+        await recordObjectiveStateSnapshotsFromObservedMessages({
+          memoryDir: this.orchestrator.config.memoryDir,
+          objectiveStateStoreDir: this.orchestrator.config.objectiveStateStoreDir,
+          objectiveStateMemoryEnabled: this.orchestrator.config.objectiveStateMemoryEnabled,
+          objectiveStateSnapshotWritesEnabled:
+            this.orchestrator.config.objectiveStateSnapshotWritesEnabled,
+          sessionKey: lcmSessionKey,
+          recordedAt: new Date().toISOString(),
+          messages: request.messages,
+        });
+      } catch (err) {
+        log.error(`access-observe objective-state snapshot write failed: ${err}`);
+      }
+    }
 
     // lcmArchived in the response means "LCM archival was queued" (not
     // "completed"), matching extractionQueued semantics.  Both run async.

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3407,10 +3407,6 @@ export class EngramAccessService {
           request.sessionKey,
           objectiveStateBaseNamespace,
         );
-    const objectiveStateSessionKey =
-      objectiveStateNamespace !== this.orchestrator.config.defaultNamespace
-        ? `${objectiveStateNamespace}:${request.sessionKey}`
-        : request.sessionKey;
 
     // Prefix sessionKey with namespace for LCM archival so turns are namespace-scoped.
     // This ensures multi-tenant isolation in the LCM archive.
@@ -3430,7 +3426,7 @@ export class EngramAccessService {
           objectiveStateMemoryEnabled: this.orchestrator.config.objectiveStateMemoryEnabled,
           objectiveStateSnapshotWritesEnabled:
             this.orchestrator.config.objectiveStateSnapshotWritesEnabled,
-          sessionKey: objectiveStateSessionKey,
+          sessionKey: request.sessionKey,
           recordedAt: new Date().toISOString(),
           messages: request.messages,
         });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -981,10 +981,7 @@ export class EngramAccessService {
     memoryDir: string;
     objectiveStateStoreDir?: string;
   }> {
-    if (
-      !this.orchestrator.config.namespacesEnabled ||
-      namespace === this.orchestrator.config.defaultNamespace
-    ) {
+    if (!this.orchestrator.config.namespacesEnabled) {
       return {
         memoryDir: this.orchestrator.config.memoryDir,
         objectiveStateStoreDir: this.orchestrator.config.objectiveStateStoreDir,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3369,6 +3369,20 @@ export class EngramAccessService {
       projectTag: request.projectTag,
     });
 
+    const hasExplicitNamespace =
+      typeof request.namespace === "string" &&
+      request.namespace.trim().length > 0;
+    const objectiveStateNamespace = hasExplicitNamespace
+      ? namespace
+      : this.orchestrator.applyCodingNamespaceOverlay(
+          request.sessionKey,
+          namespace,
+        );
+    const objectiveStateSessionKey =
+      objectiveStateNamespace !== this.orchestrator.config.defaultNamespace
+        ? `${objectiveStateNamespace}:${request.sessionKey}`
+        : request.sessionKey;
+
     // Prefix sessionKey with namespace for LCM archival so turns are namespace-scoped.
     // This ensures multi-tenant isolation in the LCM archive.
     const lcmSessionKey = namespace !== this.orchestrator.config.defaultNamespace
@@ -3381,14 +3395,16 @@ export class EngramAccessService {
     ) {
       try {
         const objectiveStateLocation =
-          await this.objectiveStateStoreLocationForNamespace(namespace);
+          await this.objectiveStateStoreLocationForNamespace(
+            objectiveStateNamespace,
+          );
         await recordObjectiveStateSnapshotsFromObservedMessages({
           memoryDir: objectiveStateLocation.memoryDir,
           objectiveStateStoreDir: objectiveStateLocation.objectiveStateStoreDir,
           objectiveStateMemoryEnabled: this.orchestrator.config.objectiveStateMemoryEnabled,
           objectiveStateSnapshotWritesEnabled:
             this.orchestrator.config.objectiveStateSnapshotWritesEnabled,
-          sessionKey: lcmSessionKey,
+          sessionKey: objectiveStateSessionKey,
           recordedAt: new Date().toISOString(),
           messages: request.messages,
         });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -977,6 +977,23 @@ export class EngramAccessService {
     return resolved;
   }
 
+  private async objectiveStateStoreLocationForNamespace(namespace: string): Promise<{
+    memoryDir: string;
+    objectiveStateStoreDir?: string;
+  }> {
+    if (
+      !this.orchestrator.config.namespacesEnabled ||
+      namespace === this.orchestrator.config.defaultNamespace
+    ) {
+      return {
+        memoryDir: this.orchestrator.config.memoryDir,
+        objectiveStateStoreDir: this.orchestrator.config.objectiveStateStoreDir,
+      };
+    }
+    const storage = await this.orchestrator.getStorage(namespace);
+    return { memoryDir: storage.dir };
+  }
+
   private resolveReadableNamespace(namespace: string | undefined, principal?: string): string {
     const resolved = this.resolveNamespace(namespace);
     const namespacesEnabled = this.orchestrator.config.namespacesEnabled;
@@ -3363,9 +3380,11 @@ export class EngramAccessService {
       this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true
     ) {
       try {
+        const objectiveStateLocation =
+          await this.objectiveStateStoreLocationForNamespace(namespace);
         await recordObjectiveStateSnapshotsFromObservedMessages({
-          memoryDir: this.orchestrator.config.memoryDir,
-          objectiveStateStoreDir: this.orchestrator.config.objectiveStateStoreDir,
+          memoryDir: objectiveStateLocation.memoryDir,
+          objectiveStateStoreDir: objectiveStateLocation.objectiveStateStoreDir,
           objectiveStateMemoryEnabled: this.orchestrator.config.objectiveStateMemoryEnabled,
           objectiveStateSnapshotWritesEnabled:
             this.orchestrator.config.objectiveStateSnapshotWritesEnabled,

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -252,6 +252,30 @@ test("buildExplicitCueRecallSection does not leak the next action into step wind
   assert.doesNotMatch(section, /Action 24/);
 });
 
+test("buildExplicitCueRecallSection includes successor trajectory evidence when requested", async () => {
+  const messages = Array.from({ length: 54 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  messages[46] = { role: "user", content: "[Action 23] left" };
+  messages[47] = { role: "assistant", content: "[Observation 23] loop still continued" };
+  messages[48] = { role: "user", content: "[Action 24] down" };
+  messages[49] = { role: "assistant", content: "[Observation 24] the loop was broken" };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "After step 23, what did the next action accomplish?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /Action 23/);
+  assert.match(section, /Observation 23/);
+  assert.match(section, /Action 24/);
+  assert.match(section, /Observation 24/);
+});
+
 test("buildExplicitCueRecallSection resolves action and observation labels when transcript turns are offset", async () => {
   const messages = Array.from({ length: 130 }, (_, index) => ({
     role: index % 2 === 0 ? "user" : "assistant",

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -276,6 +276,30 @@ test("buildExplicitCueRecallSection includes successor trajectory evidence when 
   assert.match(section, /Observation 24/);
 });
 
+test("buildExplicitCueRecallSection does not treat broad break wording as successor intent", async () => {
+  const messages = Array.from({ length: 54 }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant",
+    content: `filler turn ${index}`,
+  }));
+  messages[46] = { role: "user", content: "[Action 23] left" };
+  messages[47] = { role: "assistant", content: "[Observation 23] the rule broke" };
+  messages[48] = { role: "user", content: "[Action 24] down" };
+  messages[49] = { role: "assistant", content: "[Observation 24] successor state" };
+  const engine = new FakeCueEngine({ "bench-session": messages });
+
+  const section = await buildExplicitCueRecallSection({
+    engine,
+    sessionId: "bench-session",
+    query: "What broke in step 23?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /Action 23/);
+  assert.match(section, /Observation 23/);
+  assert.doesNotMatch(section, /Action 24/);
+  assert.doesNotMatch(section, /Observation 24/);
+});
+
 test("buildExplicitCueRecallSection resolves action and observation labels when transcript turns are offset", async () => {
   const messages = Array.from({ length: 130 }, (_, index) => ({
     role: index % 2 === 0 ? "user" : "assistant",

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -509,7 +509,12 @@ function contentLabelEvidenceWindow(hit: {
 
 function hasSuccessorTrajectoryIntent(query: string): boolean {
   const normalized = query.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
-  return /\b(?:after|next|following|subsequent|successor|later|breaking|breaks?|broke|interrupts?|interrupted)\b/.test(normalized);
+  return [
+    /\bafter\s+(?:step|action|observation|turn)\s+\d+\b/,
+    /\b(?:next|following|subsequent|successor)\s+(?:step|action|observation|turn)\b/,
+    /\b(?:step|action|observation|turn)\s+\d+\s+(?:then|and then)\b/,
+    /\bwhat\s+(?:happened|came|occurred)\s+next\b/,
+  ].some((pattern) => pattern.test(normalized));
 }
 
 function contentHasReferenceLabel(

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -304,6 +304,7 @@ async function collectTurnReferenceEvidence(options: {
   await collectContentLabelReferenceEvidence({
     engine: options.engine,
     sessionId: options.sessionId,
+    query: options.query,
     references,
     evidenceItems: options.evidenceItems,
     seenTurns: options.seenTurns,
@@ -343,6 +344,7 @@ async function collectTurnReferenceEvidence(options: {
 async function collectContentLabelReferenceEvidence(options: {
   engine: ExplicitCueRecallEngine;
   sessionId?: string;
+  query: string;
   references: ExplicitTurnReference[];
   evidenceItems: Array<{
     id: string;
@@ -376,7 +378,9 @@ async function collectContentLabelReferenceEvidence(options: {
         break;
       }
 
-      const { fromTurn, toTurn } = contentLabelEvidenceWindow(hit);
+      const { fromTurn, toTurn } = contentLabelEvidenceWindow(hit, {
+        includeSuccessor: hasSuccessorTrajectoryIntent(options.query),
+      });
       const expanded = await options.engine.expandContext(
         hit.session_id,
         fromTurn,
@@ -488,18 +492,24 @@ function nearestTurnDistance(turnIndex: number, candidates: readonly number[]): 
 function contentLabelEvidenceWindow(hit: {
   turn_index: number;
   labelKind: "action" | "observation";
-}): { fromTurn: number; toTurn: number } {
+}, options: { includeSuccessor?: boolean } = {}): { fromTurn: number; toTurn: number } {
+  const successorTurns = options.includeSuccessor === true ? 2 : 0;
   if (hit.labelKind === "action") {
     return {
       fromTurn: Math.max(0, hit.turn_index - 1),
-      toTurn: hit.turn_index + 1,
+      toTurn: hit.turn_index + 1 + successorTurns,
     };
   }
 
   return {
     fromTurn: Math.max(0, hit.turn_index - 1),
-    toTurn: hit.turn_index,
+    toTurn: hit.turn_index + successorTurns,
   };
+}
+
+function hasSuccessorTrajectoryIntent(query: string): boolean {
+  const normalized = query.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+  return /\b(?:after|next|following|subsequent|successor|later|breaking|breaks?|broke|interrupts?|interrupted)\b/.test(normalized);
 }
 
 function contentHasReferenceLabel(

--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -146,8 +146,12 @@ export function parseOpenAiMessageParts(
     }
     if (type === "function_call") {
       const toolName = asNonEmptyString(item.name ?? item.tool_name);
+      const callId = asNonEmptyString(item.call_id ?? item.callId);
+      const itemId = asNonEmptyString(item.id);
       const payload = {
-        id: item.id ?? item.call_id,
+        id: callId ?? itemId,
+        ...(callId ? { call_id: callId } : {}),
+        ...(itemId && itemId !== callId ? { response_item_id: itemId } : {}),
         name: toolName,
         arguments: parseMaybeJson(item.arguments),
       };
@@ -156,7 +160,14 @@ export function parseOpenAiMessageParts(
     }
     if (type === "function_call_output") {
       const output = asNonEmptyString(item.output) ?? JSON.stringify(sanitizePayload(item.output ?? item));
-      parts.push(makePart("tool_result", { id: item.id ?? item.call_id, output }, {
+      const callId = asNonEmptyString(item.call_id ?? item.callId);
+      const itemId = asNonEmptyString(item.id);
+      parts.push(makePart("tool_result", {
+        id: callId ?? itemId,
+        ...(callId ? { call_id: callId } : {}),
+        ...(itemId && itemId !== callId ? { response_item_id: itemId } : {}),
+        output,
+      }, {
         filePath: firstFilePath(output),
       }));
       continue;

--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -210,7 +210,12 @@ export function parseAnthropicMessageParts(
     if (type === "tool_result") {
       const content = block.content;
       const rendered = renderUnknownContent(content);
-      parts.push(makePart("tool_result", { id: block.tool_use_id, content: sanitizePayload(content) }, {
+      parts.push(makePart("tool_result", {
+        id: block.tool_use_id,
+        content: sanitizePayload(content),
+        ...(typeof block.is_error === "boolean" ? { is_error: block.is_error } : {}),
+        ...(typeof block.isError === "boolean" ? { isError: block.isError } : {}),
+      }, {
         filePath: firstFilePath(rendered),
       }));
       continue;

--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -53,6 +53,7 @@ export interface LcmMessagePartRow extends LcmMessagePartInput {
 export interface ParseMessagePartsOptions {
   sourceFormat?: MessagePartSourceFormat;
   renderedContent?: string;
+  allowRenderedFallback?: boolean;
 }
 
 const SECRET_KEY_RE = /(api[_-]?key|authorization|bearer|credential|password|secret|token)/i;
@@ -268,7 +269,9 @@ export function parseOpenClawMessageParts(
     ]);
   }
 
-  const rendered = options.renderedContent ?? asNonEmptyString(obj.content);
+  const rendered = options.allowRenderedFallback === false
+    ? null
+    : options.renderedContent ?? asNonEmptyString(obj.content);
   return rendered ? withOrdinals(partsFromRenderedText(rendered)) : [];
 }
 
@@ -393,6 +396,9 @@ function withRenderedFallback(
 }
 
 function renderedFallbackParts(options: ParseMessagePartsOptions): LcmMessagePartInput[] {
+  if (options.allowRenderedFallback === false) {
+    return [];
+  }
   const rendered = asNonEmptyString(options.renderedContent);
   return rendered ? partsFromRenderedText(rendered) : [];
 }

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -155,4 +155,25 @@ describe("message-parts parsers", () => {
       url: "https://example.test",
     });
   });
+
+  it("can disable rendered text fallback for structured-only callers", () => {
+    const parts = parseMessageParts(
+      {
+        role: "assistant",
+        content: [
+          "Suggested patch:",
+          "*** Begin Patch",
+          "*** Update File: src/suggested.ts",
+          "+not executed",
+          "*** End Patch",
+        ].join("\n"),
+      },
+      {
+        sourceFormat: "openclaw",
+        allowRenderedFallback: false,
+      },
+    );
+
+    assert.deepEqual(parts, []);
+  });
 });

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -120,6 +120,24 @@ describe("message-parts parsers", () => {
     assert.equal(parts[1]!.filePath, "packages/core/src/config.ts");
   });
 
+  it("preserves Anthropic tool_result error flags", () => {
+    const parts = parseAnthropicMessageParts({
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_failed",
+          is_error: true,
+          content: [{ type: "text", text: "exit code 1" }],
+        },
+      ],
+    });
+
+    assert.equal(parts.length, 1);
+    assert.equal(parts[0]!.kind, "tool_result");
+    assert.equal(parts[0]!.payload.id, "toolu_failed");
+    assert.equal(parts[0]!.payload.is_error, true);
+  });
+
   it("normalizes explicit Remnic parts and redacts secrets", () => {
     const parts = parseMessageParts({
       parts: [

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -424,9 +424,9 @@ function partPayload(part: LcmMessagePartInput): Record<string, unknown> {
 function partToolCallId(part: LcmMessagePartInput): string | undefined {
   const payload = partPayload(part);
   return (
-    optionalString(payload.id) ??
     optionalString(payload.call_id) ??
     optionalString(payload.callId) ??
+    optionalString(payload.id) ??
     optionalString(payload.tool_call_id) ??
     optionalString(payload.toolCallId) ??
     optionalString(payload.tool_use_id) ??

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -36,6 +36,19 @@ interface ObservedPartEntry {
   part: LcmMessagePartInput;
 }
 
+const rawProviderParts = new WeakSet<LcmMessagePartInput>();
+
+function markRawProviderParts(parts: LcmMessagePartInput[]): LcmMessagePartInput[] {
+  for (const part of parts) {
+    rawProviderParts.add(part);
+  }
+  return parts;
+}
+
+function isRawProviderPart(part: LcmMessagePartInput): boolean {
+  return rawProviderParts.has(part);
+}
+
 function hashSha256(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
@@ -421,20 +434,22 @@ function userRawToolResultParts(message: ObservedMessageWithParts): LcmMessagePa
   if (!containsProviderToolResultBlock(rawContent)) {
     return [];
   }
-  return sanitizeUserRoleToolResultParts(parseMessageParts(rawContent, {
-    sourceFormat: message.sourceFormat,
-    allowRenderedFallback: false,
-  }));
+  return markRawProviderParts(
+    sanitizeUserRoleToolResultParts(parseMessageParts(rawContent, {
+      sourceFormat: message.sourceFormat,
+      allowRenderedFallback: false,
+    })),
+  );
 }
 
 function assistantRawObjectiveStateParts(message: ObservedMessageWithParts): LcmMessagePartInput[] {
   if (message.rawContent === undefined || message.rawContent === null) {
     return [];
   }
-  return parseMessageParts(message.rawContent, {
+  return markRawProviderParts(parseMessageParts(message.rawContent, {
     sourceFormat: message.sourceFormat,
     allowRenderedFallback: false,
-  });
+  }));
 }
 
 function mergeObservedEvidenceParts(
@@ -746,7 +761,8 @@ function observedPartsToAgentMessages(options: {
         (part.kind === "file_write" || part.kind === "patch") &&
         !observedToolCallId &&
         !nextIsIdlessToolResult &&
-        !resultIds.has(id)
+        !resultIds.has(id) &&
+        !isRawProviderPart(part)
       ) {
         synthetic.push({
           role: "tool",

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -555,7 +555,8 @@ function observedPartsToAgentMessages(options: {
     ) {
       const toolName = partToolName(part);
       if (!toolName) continue;
-      const id = partToolCallId(part) ??
+      const observedToolCallId = partToolCallId(part);
+      const id = observedToolCallId ??
         syntheticPartId({
           sessionKey: options.sessionKey,
           messageIndex: entry.messageIndex,
@@ -565,7 +566,11 @@ function observedPartsToAgentMessages(options: {
       const args = toolArgumentsFromPart(part);
       synthetic.push(buildSyntheticAssistantToolCall(id, toolName, args));
 
-      if ((part.kind === "file_write" || part.kind === "patch") && !resultIds.has(id)) {
+      if (
+        (part.kind === "file_write" || part.kind === "patch") &&
+        !observedToolCallId &&
+        !resultIds.has(id)
+      ) {
         synthetic.push({
           role: "tool",
           tool_call_id: id,

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -658,7 +658,7 @@ function observedPartsToAgentMessages(options: {
         nextEntry?.messageIndex === entry.messageIndex &&
         nextEntry?.part.kind === "tool_result" &&
         partToolCallId(nextEntry.part) === undefined;
-      pendingIdlessToolCallId = !observedToolCallId && nextIsIdlessToolResult
+      pendingIdlessToolCallId = nextIsIdlessToolResult
         ? id
         : undefined;
 

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -388,6 +388,16 @@ function snapshotIdFor(
 function objectiveStatePartsForObservedMessage(
   message: ObservedMessageWithParts,
 ): LcmMessagePartInput[] {
+  if (message.role === "user") {
+    const rawContent = message.rawContent ?? message.content;
+    if (!containsProviderToolResultBlock(rawContent)) {
+      return [];
+    }
+    return parseMessageParts(rawContent, {
+      sourceFormat: message.sourceFormat,
+      renderedContent: message.content,
+    }).filter((part) => part.kind === "tool_result");
+  }
   if (message.role !== "assistant") {
     return [];
   }
@@ -415,6 +425,25 @@ function flattenObservedParts(messages: readonly ObservedMessageWithParts[]): Ob
     if (aOrdinal !== bOrdinal) return aOrdinal - bOrdinal;
     return a.partIndex - b.partIndex;
   });
+}
+
+function containsProviderToolResultBlock(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(containsProviderToolResultBlock);
+  }
+  if (!isRecord(value)) return false;
+  const type = optionalString(value.type ?? value.kind);
+  if (
+    type === "tool_result" ||
+    type === "function_call_output"
+  ) {
+    return true;
+  }
+  return (
+    containsProviderToolResultBlock(value.content) ||
+    containsProviderToolResultBlock(value.output) ||
+    containsProviderToolResultBlock(value.items)
+  );
 }
 
 function partPayload(part: LcmMessagePartInput): Record<string, unknown> {
@@ -507,6 +536,21 @@ function toolResultContentFromPart(part: LcmMessagePartInput): unknown {
   if ("result" in payload) return payload.result;
   if ("value" in payload) return payload.value;
   return payload;
+}
+
+function inlineToolResultContentFromPart(part: LcmMessagePartInput): unknown {
+  const payload = partPayload(part);
+  if (hasDefinedPayloadKey(payload, "output")) return payload.output;
+  if (hasDefinedPayloadKey(payload, "result")) return payload.result;
+  if (hasDefinedPayloadKey(payload, "value")) return payload.value;
+
+  const statusPayload: Record<string, unknown> = {};
+  for (const key of ["exitCode", "ok", "success", "error", "status", "stdout", "stderr"]) {
+    if (hasDefinedPayloadKey(payload, key)) {
+      statusPayload[key] = payload[key];
+    }
+  }
+  return Object.keys(statusPayload).length > 0 ? statusPayload : payload;
 }
 
 function hasDefinedPayloadKey(payload: Record<string, unknown>, key: string): boolean {
@@ -603,7 +647,7 @@ function observedPartsToAgentMessages(options: {
           role: "tool",
           tool_call_id: id,
           name: toolName,
-          content: toolResultContentFromPart(part),
+          content: inlineToolResultContentFromPart(part),
           ...(toolResultIsError(part) ? { isError: true } : {}),
         });
         pendingIdlessToolCallId = undefined;

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -723,7 +723,6 @@ function observedPartsToAgentMessages(options: {
       synthetic.push(buildSyntheticAssistantToolCall(id, toolName, args));
       const nextEntry = entries[entryIndex + 1];
       const nextIsIdlessToolResult =
-        nextEntry?.messageIndex === entry.messageIndex &&
         nextEntry?.part.kind === "tool_result" &&
         partToolCallId(nextEntry.part) === undefined;
       pendingIdlessToolCallId = nextIsIdlessToolResult

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -545,8 +545,10 @@ function observedPartsToAgentMessages(options: {
       .filter((id): id is string => id !== undefined),
   );
   const synthetic: Array<Record<string, unknown>> = [];
+  let pendingIdlessToolCallId: string | undefined;
 
-  for (const entry of entries) {
+  for (let entryIndex = 0; entryIndex < entries.length; entryIndex += 1) {
+    const entry = entries[entryIndex]!;
     const { part } = entry;
     if (
       part.kind === "tool_call" ||
@@ -565,10 +567,16 @@ function observedPartsToAgentMessages(options: {
         });
       const args = toolArgumentsFromPart(part);
       synthetic.push(buildSyntheticAssistantToolCall(id, toolName, args));
+      const nextEntry = entries[entryIndex + 1];
+      const nextIsIdlessToolResult =
+        nextEntry?.part.kind === "tool_result" &&
+        partToolCallId(nextEntry.part) === undefined;
+      pendingIdlessToolCallId = observedToolCallId ? undefined : id;
 
       if (
         (part.kind === "file_write" || part.kind === "patch") &&
         !observedToolCallId &&
+        !nextIsIdlessToolResult &&
         !resultIds.has(id)
       ) {
         synthetic.push({
@@ -577,12 +585,13 @@ function observedPartsToAgentMessages(options: {
           name: toolName,
           content: { ok: true, source: "message_part" },
         });
+        pendingIdlessToolCallId = undefined;
       }
       continue;
     }
 
     if (part.kind === "tool_result") {
-      const id = partToolCallId(part);
+      const id = partToolCallId(part) ?? pendingIdlessToolCallId;
       const toolName = partToolName(part);
       synthetic.push({
         role: "tool",
@@ -591,6 +600,7 @@ function observedPartsToAgentMessages(options: {
         content: toolResultContentFromPart(part),
         ...(toolResultIsError(part) ? { isError: true } : {}),
       });
+      pendingIdlessToolCallId = undefined;
     }
   }
 

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -5,6 +5,11 @@ import {
   type ObjectiveStateSnapshot,
   recordObjectiveStateSnapshot,
 } from "./objective-state.js";
+import {
+  parseMessageParts,
+  type LcmMessagePartInput,
+  type MessagePartSourceFormat,
+} from "./message-parts/index.js";
 
 interface ToolCallContext {
   toolName?: string;
@@ -15,6 +20,20 @@ interface ToolCallContext {
 interface DerivedObjectiveStateResult {
   snapshots: ObjectiveStateSnapshot[];
   filePaths: string[];
+}
+
+interface ObservedMessageWithParts {
+  role?: string;
+  content?: string;
+  parts?: LcmMessagePartInput[] | null;
+  rawContent?: unknown;
+  sourceFormat?: MessagePartSourceFormat;
+}
+
+interface ObservedPartEntry {
+  messageIndex: number;
+  partIndex: number;
+  part: LcmMessagePartInput;
 }
 
 function hashSha256(value: string): string {
@@ -55,6 +74,19 @@ function parseToolArguments(value: unknown): Record<string, unknown> | undefined
   }
 }
 
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? String(value);
+}
+
 function extractTextContent(value: unknown): string {
   if (typeof value === "string") return value.trim();
   if (Array.isArray(value)) {
@@ -88,7 +120,7 @@ function parseToolResultPayload(content: unknown): unknown {
 function resultHash(value: unknown): string | undefined {
   if (value === undefined) return undefined;
   const canonical =
-    typeof value === "string" ? value : JSON.stringify(value);
+    typeof value === "string" ? value : stableStringify(value);
   if (!canonical || canonical.length === 0) return undefined;
   return `sha256:${hashSha256(canonical)}`;
 }
@@ -339,13 +371,225 @@ function snapshotIdFor(
   index: number,
   toolName: string,
   scope: string,
+  stableKey?: string,
 ): string {
   const digest = crypto
     .createHash("sha256")
-    .update(`${sessionKey}|${recordedAt}|${index}|${toolName}|${scope}`)
+    .update(
+      stableKey
+        ? `${sessionKey}|stable|${stableKey}`
+        : `${sessionKey}|${recordedAt}|${index}|${toolName}|${scope}`,
+    )
     .digest("hex")
     .slice(0, 12);
   return `obj-${digest}`;
+}
+
+function objectiveStatePartsForObservedMessage(
+  message: ObservedMessageWithParts,
+): LcmMessagePartInput[] {
+  if (message.role !== "assistant") {
+    return [];
+  }
+  if (Array.isArray(message.parts) && message.parts.length > 0) {
+    return message.parts;
+  }
+  return parseMessageParts(message.rawContent ?? message.content, {
+    sourceFormat: message.sourceFormat,
+    renderedContent: message.content,
+  });
+}
+
+function flattenObservedParts(messages: readonly ObservedMessageWithParts[]): ObservedPartEntry[] {
+  const entries: ObservedPartEntry[] = [];
+  messages.forEach((message, messageIndex) => {
+    const parts = objectiveStatePartsForObservedMessage(message);
+    parts.forEach((part, partIndex) => {
+      entries.push({ messageIndex, partIndex, part });
+    });
+  });
+  return entries.sort((a, b) => {
+    if (a.messageIndex !== b.messageIndex) return a.messageIndex - b.messageIndex;
+    const aOrdinal = typeof a.part.ordinal === "number" ? a.part.ordinal : a.partIndex;
+    const bOrdinal = typeof b.part.ordinal === "number" ? b.part.ordinal : b.partIndex;
+    if (aOrdinal !== bOrdinal) return aOrdinal - bOrdinal;
+    return a.partIndex - b.partIndex;
+  });
+}
+
+function partPayload(part: LcmMessagePartInput): Record<string, unknown> {
+  return isRecord(part.payload) ? part.payload : {};
+}
+
+function partToolCallId(part: LcmMessagePartInput): string | undefined {
+  const payload = partPayload(part);
+  return (
+    optionalString(payload.id) ??
+    optionalString(payload.call_id) ??
+    optionalString(payload.callId) ??
+    optionalString(payload.tool_call_id) ??
+    optionalString(payload.toolCallId) ??
+    optionalString(payload.tool_use_id) ??
+    optionalString(payload.toolUseId)
+  );
+}
+
+function partToolName(part: LcmMessagePartInput): string | undefined {
+  const payload = partPayload(part);
+  return (
+    optionalString(part.toolName) ??
+    optionalString(part.tool_name) ??
+    optionalString(payload.name) ??
+    optionalString(payload.toolName) ??
+    optionalString(payload.tool_name) ??
+    (part.kind === "patch" ? "apply_patch" : undefined) ??
+    (part.kind === "file_write" ? "file_write" : undefined)
+  );
+}
+
+function partFilePath(part: LcmMessagePartInput): string | undefined {
+  const payload = partPayload(part);
+  return (
+    optionalString(part.filePath) ??
+    optionalString(part.file_path) ??
+    optionalString(payload.path) ??
+    optionalString(payload.filePath) ??
+    optionalString(payload.file_path)
+  );
+}
+
+function syntheticPartId(options: {
+  sessionKey: string;
+  messageIndex: number;
+  partIndex: number;
+  part: LcmMessagePartInput;
+}): string {
+  const digest = hashSha256(
+    [
+      options.sessionKey,
+      String(options.messageIndex),
+      String(options.part.ordinal ?? options.partIndex),
+      options.part.kind,
+      stableStringify(options.part.payload),
+    ].join("|"),
+  ).slice(0, 12);
+  return `part-${digest}`;
+}
+
+function toolArgumentsFromPart(part: LcmMessagePartInput): Record<string, unknown> {
+  const payload = partPayload(part);
+  const parsedArgs =
+    parseToolArguments(payload.arguments) ??
+    parseToolArguments(payload.input) ??
+    parseToolArguments(payload.args) ??
+    parseToolArguments(payload.params) ??
+    payload;
+  const args = { ...parsedArgs };
+  const filePath = partFilePath(part);
+  if (filePath && !pickString(args, ["path", "filePath", "file_path"])) {
+    args.path = filePath;
+  }
+  if (part.kind === "patch" && !pickString(args, ["patch", "diff", "text"])) {
+    const text = optionalString(payload.text) ?? optionalString(payload.patch);
+    if (text) args.patch = text;
+  }
+  return args;
+}
+
+function toolResultContentFromPart(part: LcmMessagePartInput): unknown {
+  const payload = partPayload(part);
+  if ("output" in payload) return payload.output;
+  if ("content" in payload) return payload.content;
+  if ("result" in payload) return payload.result;
+  if ("value" in payload) return payload.value;
+  return payload;
+}
+
+function toolResultIsError(part: LcmMessagePartInput): boolean {
+  const payload = partPayload(part);
+  return payload.isError === true ||
+    payload.is_error === true ||
+    payload.ok === false ||
+    payload.success === false ||
+    optionalString(payload.error) !== undefined;
+}
+
+function buildSyntheticAssistantToolCall(
+  id: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    role: "assistant",
+    tool_calls: [
+      {
+        id,
+        function: {
+          name: toolName,
+          arguments: JSON.stringify(args),
+        },
+      },
+    ],
+  };
+}
+
+function observedPartsToAgentMessages(options: {
+  sessionKey: string;
+  messages: readonly ObservedMessageWithParts[];
+}): Array<Record<string, unknown>> {
+  const entries = flattenObservedParts(options.messages);
+  const resultIds = new Set(
+    entries
+      .filter((entry) => entry.part.kind === "tool_result")
+      .map((entry) => partToolCallId(entry.part))
+      .filter((id): id is string => id !== undefined),
+  );
+  const synthetic: Array<Record<string, unknown>> = [];
+
+  for (const entry of entries) {
+    const { part } = entry;
+    if (
+      part.kind === "tool_call" ||
+      part.kind === "file_write" ||
+      part.kind === "patch"
+    ) {
+      const toolName = partToolName(part);
+      if (!toolName) continue;
+      const id = partToolCallId(part) ??
+        syntheticPartId({
+          sessionKey: options.sessionKey,
+          messageIndex: entry.messageIndex,
+          partIndex: entry.partIndex,
+          part,
+        });
+      const args = toolArgumentsFromPart(part);
+      synthetic.push(buildSyntheticAssistantToolCall(id, toolName, args));
+
+      if ((part.kind === "file_write" || part.kind === "patch") && !resultIds.has(id)) {
+        synthetic.push({
+          role: "tool",
+          tool_call_id: id,
+          name: toolName,
+          content: { ok: true, source: "message_part" },
+        });
+      }
+      continue;
+    }
+
+    if (part.kind === "tool_result") {
+      const id = partToolCallId(part);
+      const toolName = partToolName(part);
+      synthetic.push({
+        role: "tool",
+        ...(id ? { tool_call_id: id } : {}),
+        ...(toolName ? { name: toolName } : {}),
+        content: toolResultContentFromPart(part),
+        ...(toolResultIsError(part) ? { isError: true } : {}),
+      });
+    }
+  }
+
+  return synthetic;
 }
 
 export function deriveObjectiveStateSnapshotsFromAgentMessages(options: {
@@ -393,7 +637,14 @@ export function deriveObjectiveStateSnapshotsFromAgentMessages(options: {
 
     snapshots.push({
       schemaVersion: 1,
-      snapshotId: snapshotIdFor(options.sessionKey, options.recordedAt, snapshots.length, toolName, scope),
+      snapshotId: snapshotIdFor(
+        options.sessionKey,
+        options.recordedAt,
+        snapshots.length,
+        toolName,
+        scope,
+        toolCallId,
+      ),
       recordedAt: options.recordedAt,
       sessionKey: options.sessionKey,
       source: "tool_result",
@@ -414,6 +665,24 @@ export function deriveObjectiveStateSnapshotsFromAgentMessages(options: {
   return snapshots;
 }
 
+export function deriveObjectiveStateSnapshotsFromObservedMessages(options: {
+  sessionKey: string;
+  recordedAt: string;
+  messages: readonly ObservedMessageWithParts[];
+}): ObjectiveStateSnapshot[] {
+  const syntheticMessages = observedPartsToAgentMessages({
+    sessionKey: options.sessionKey,
+    messages: options.messages,
+  });
+  if (syntheticMessages.length === 0) return [];
+
+  return deriveObjectiveStateSnapshotsFromAgentMessages({
+    sessionKey: options.sessionKey,
+    recordedAt: options.recordedAt,
+    messages: syntheticMessages,
+  });
+}
+
 export async function recordObjectiveStateSnapshotsFromAgentMessages(options: {
   memoryDir: string;
   objectiveStateStoreDir?: string;
@@ -428,6 +697,39 @@ export async function recordObjectiveStateSnapshotsFromAgentMessages(options: {
   }
 
   const snapshots = deriveObjectiveStateSnapshotsFromAgentMessages({
+    sessionKey: options.sessionKey,
+    recordedAt: options.recordedAt,
+    messages: options.messages,
+  });
+
+  const filePaths: string[] = [];
+  for (const snapshot of snapshots) {
+    filePaths.push(
+      await recordObjectiveStateSnapshot({
+        memoryDir: options.memoryDir,
+        objectiveStateStoreDir: options.objectiveStateStoreDir,
+        snapshot,
+      }),
+    );
+  }
+
+  return { snapshots, filePaths };
+}
+
+export async function recordObjectiveStateSnapshotsFromObservedMessages(options: {
+  memoryDir: string;
+  objectiveStateStoreDir?: string;
+  objectiveStateMemoryEnabled: boolean;
+  objectiveStateSnapshotWritesEnabled: boolean;
+  sessionKey: string;
+  recordedAt: string;
+  messages: readonly ObservedMessageWithParts[];
+}): Promise<DerivedObjectiveStateResult> {
+  if (!options.objectiveStateMemoryEnabled || !options.objectiveStateSnapshotWritesEnabled) {
+    return { snapshots: [], filePaths: [] };
+  }
+
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: options.sessionKey,
     recordedAt: options.recordedAt,
     messages: options.messages,

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -644,7 +644,9 @@ function inlineToolResultContentFromPart(part: LcmMessagePartInput): unknown {
   const payload = partPayload(part);
   if (hasDefinedPayloadKey(payload, "output")) return payload.output;
   if (hasDefinedPayloadKey(payload, "result")) return payload.result;
-  if (hasDefinedPayloadKey(payload, "value")) return payload.value;
+  if (part.kind === "tool_result" && hasDefinedPayloadKey(payload, "value")) {
+    return payload.value;
+  }
 
   const statusPayload: Record<string, unknown> = {};
   for (const key of ["exitCode", "ok", "success", "error", "stdout", "stderr"]) {
@@ -664,7 +666,7 @@ function partHasInlineToolResult(part: LcmMessagePartInput): boolean {
   return (
     hasDefinedPayloadKey(payload, "output") ||
     hasDefinedPayloadKey(payload, "result") ||
-    hasDefinedPayloadKey(payload, "value") ||
+    (part.kind === "tool_result" && hasDefinedPayloadKey(payload, "value")) ||
     hasDefinedPayloadKey(payload, "exitCode") ||
     hasDefinedPayloadKey(payload, "ok") ||
     hasDefinedPayloadKey(payload, "success") ||
@@ -759,7 +761,6 @@ function observedPartsToAgentMessages(options: {
 
       if (
         (part.kind === "file_write" || part.kind === "patch") &&
-        !observedToolCallId &&
         !nextIsIdlessToolResult &&
         !resultIds.has(id) &&
         !isRawProviderPart(part)

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -470,6 +470,10 @@ function syntheticPartId(options: {
       String(options.messageIndex),
       String(options.part.ordinal ?? options.partIndex),
       options.part.kind,
+      optionalString(options.part.toolName) ?? "",
+      optionalString(options.part.tool_name) ?? "",
+      optionalString(options.part.filePath) ?? "",
+      optionalString(options.part.file_path) ?? "",
       stableStringify(options.part.payload),
     ].join("|"),
   ).slice(0, 12);

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -221,6 +221,14 @@ function inferOutcome(message: Record<string, unknown>, parsedPayload: unknown):
     if (optionalString(parsedPayload.error)) return "failure";
     if (parsedPayload.status === "error" || parsedPayload.status === "failed") return "failure";
     if (parsedPayload.status === "ok" || parsedPayload.status === "success") return "success";
+    const outputText = [
+      optionalString(parsedPayload.stdout),
+      optionalString(parsedPayload.stderr),
+    ].filter((entry): entry is string => entry !== undefined).join("\n");
+    if (outputText) {
+      const outputOutcome = inferOutcome({}, outputText);
+      if (outputOutcome !== "unknown") return outputOutcome;
+    }
   }
   if (typeof parsedPayload === "string") {
     const lowered = parsedPayload.toLowerCase();
@@ -645,7 +653,9 @@ function partHasInlineToolResult(part: LcmMessagePartInput): boolean {
     hasDefinedPayloadKey(payload, "exitCode") ||
     hasDefinedPayloadKey(payload, "ok") ||
     hasDefinedPayloadKey(payload, "success") ||
-    hasDefinedPayloadKey(payload, "error")
+    hasDefinedPayloadKey(payload, "error") ||
+    hasDefinedPayloadKey(payload, "stdout") ||
+    hasDefinedPayloadKey(payload, "stderr")
   );
 }
 

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -398,7 +398,7 @@ function objectiveStatePartsForObservedMessage(
     }
     return sanitizeUserRoleToolResultParts(parseMessageParts(rawContent, {
       sourceFormat: message.sourceFormat,
-      renderedContent: message.content,
+      allowRenderedFallback: false,
     }));
   }
   if (message.role !== "assistant") {
@@ -412,7 +412,7 @@ function objectiveStatePartsForObservedMessage(
   }
   return parseMessageParts(message.rawContent, {
     sourceFormat: message.sourceFormat,
-    renderedContent: message.content,
+    allowRenderedFallback: false,
   });
 }
 

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -377,7 +377,7 @@ function snapshotIdFor(
     .createHash("sha256")
     .update(
       stableKey
-        ? `${sessionKey}|stable|${stableKey}`
+        ? `${sessionKey}|${recordedAt}|${index}|${toolName}|${scope}|stable|${stableKey}`
         : `${sessionKey}|${recordedAt}|${index}|${toolName}|${scope}`,
     )
     .digest("hex")
@@ -509,6 +509,24 @@ function toolResultContentFromPart(part: LcmMessagePartInput): unknown {
   return payload;
 }
 
+function hasDefinedPayloadKey(payload: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(payload, key) && payload[key] !== undefined;
+}
+
+function partHasInlineToolResult(part: LcmMessagePartInput): boolean {
+  const payload = partPayload(part);
+  return (
+    hasDefinedPayloadKey(payload, "output") ||
+    hasDefinedPayloadKey(payload, "result") ||
+    hasDefinedPayloadKey(payload, "value") ||
+    hasDefinedPayloadKey(payload, "exitCode") ||
+    hasDefinedPayloadKey(payload, "ok") ||
+    hasDefinedPayloadKey(payload, "success") ||
+    hasDefinedPayloadKey(payload, "error") ||
+    hasDefinedPayloadKey(payload, "status")
+  );
+}
+
 function toolResultIsError(part: LcmMessagePartInput): boolean {
   const payload = partPayload(part);
   return payload.isError === true ||
@@ -573,9 +591,24 @@ function observedPartsToAgentMessages(options: {
       synthetic.push(buildSyntheticAssistantToolCall(id, toolName, args));
       const nextEntry = entries[entryIndex + 1];
       const nextIsIdlessToolResult =
+        nextEntry?.messageIndex === entry.messageIndex &&
         nextEntry?.part.kind === "tool_result" &&
         partToolCallId(nextEntry.part) === undefined;
-      pendingIdlessToolCallId = observedToolCallId ? undefined : id;
+      pendingIdlessToolCallId = !observedToolCallId && nextIsIdlessToolResult
+        ? id
+        : undefined;
+
+      if (partHasInlineToolResult(part)) {
+        synthetic.push({
+          role: "tool",
+          tool_call_id: id,
+          name: toolName,
+          content: toolResultContentFromPart(part),
+          ...(toolResultIsError(part) ? { isError: true } : {}),
+        });
+        pendingIdlessToolCallId = undefined;
+        continue;
+      }
 
       if (
         (part.kind === "file_write" || part.kind === "patch") &&

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -566,7 +566,7 @@ function inlineToolResultContentFromPart(part: LcmMessagePartInput): unknown {
   if (hasDefinedPayloadKey(payload, "value")) return payload.value;
 
   const statusPayload: Record<string, unknown> = {};
-  for (const key of ["exitCode", "ok", "success", "error", "status", "stdout", "stderr"]) {
+  for (const key of ["exitCode", "ok", "success", "error", "stdout", "stderr"]) {
     if (hasDefinedPayloadKey(payload, key)) {
       statusPayload[key] = payload[key];
     }
@@ -587,8 +587,7 @@ function partHasInlineToolResult(part: LcmMessagePartInput): boolean {
     hasDefinedPayloadKey(payload, "exitCode") ||
     hasDefinedPayloadKey(payload, "ok") ||
     hasDefinedPayloadKey(payload, "success") ||
-    hasDefinedPayloadKey(payload, "error") ||
-    hasDefinedPayloadKey(payload, "status")
+    hasDefinedPayloadKey(payload, "error")
   );
 }
 

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -389,14 +389,17 @@ function objectiveStatePartsForObservedMessage(
   message: ObservedMessageWithParts,
 ): LcmMessagePartInput[] {
   if (message.role === "user") {
+    if (Array.isArray(message.parts) && message.parts.length > 0) {
+      return sanitizeUserRoleToolResultParts(message.parts);
+    }
     const rawContent = message.rawContent ?? message.content;
     if (!containsProviderToolResultBlock(rawContent)) {
       return [];
     }
-    return parseMessageParts(rawContent, {
+    return sanitizeUserRoleToolResultParts(parseMessageParts(rawContent, {
       sourceFormat: message.sourceFormat,
       renderedContent: message.content,
-    }).filter((part) => part.kind === "tool_result");
+    }));
   }
   if (message.role !== "assistant") {
     return [];
@@ -425,6 +428,24 @@ function flattenObservedParts(messages: readonly ObservedMessageWithParts[]): Ob
     if (aOrdinal !== bOrdinal) return aOrdinal - bOrdinal;
     return a.partIndex - b.partIndex;
   });
+}
+
+function sanitizeUserRoleToolResultParts(parts: LcmMessagePartInput[]): LcmMessagePartInput[] {
+  return parts
+    .filter((part) => part.kind === "tool_result")
+    .map((part) => {
+      const payload = { ...partPayload(part) };
+      delete payload.name;
+      delete payload.tool;
+      delete payload.toolName;
+      delete payload.tool_name;
+      return {
+        ...part,
+        toolName: null,
+        tool_name: null,
+        payload,
+      };
+    });
 }
 
 function containsProviderToolResultBlock(value: unknown): boolean {
@@ -642,7 +663,8 @@ function observedPartsToAgentMessages(options: {
         ? id
         : undefined;
 
-      if (partHasInlineToolResult(part)) {
+      const hasSeparateToolResult = resultIds.has(id) || nextIsIdlessToolResult;
+      if (partHasInlineToolResult(part) && !hasSeparateToolResult) {
         synthetic.push({
           role: "tool",
           tool_call_id: id,

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -389,24 +389,37 @@ function objectiveStatePartsForObservedMessage(
   message: ObservedMessageWithParts,
 ): LcmMessagePartInput[] {
   if (message.role === "user") {
+    const explicitParts = Array.isArray(message.parts) && message.parts.length > 0
+      ? sanitizeUserRoleToolResultParts(message.parts)
+      : [];
     if (Array.isArray(message.parts) && message.parts.length > 0) {
-      return sanitizeUserRoleToolResultParts(message.parts);
+      const rawParts = userRawToolResultParts(message);
+      return mergeObservedEvidenceParts(explicitParts, rawParts);
     }
-    const rawContent = message.rawContent ?? message.content;
-    if (!containsProviderToolResultBlock(rawContent)) {
-      return [];
-    }
-    return sanitizeUserRoleToolResultParts(parseMessageParts(rawContent, {
-      sourceFormat: message.sourceFormat,
-      allowRenderedFallback: false,
-    }));
+    return userRawToolResultParts(message);
   }
   if (message.role !== "assistant") {
     return [];
   }
-  if (Array.isArray(message.parts) && message.parts.length > 0) {
-    return message.parts;
+  const explicitParts = Array.isArray(message.parts) && message.parts.length > 0
+    ? message.parts
+    : [];
+  const rawParts = assistantRawObjectiveStateParts(message);
+  return mergeObservedEvidenceParts(explicitParts, rawParts);
+}
+
+function userRawToolResultParts(message: ObservedMessageWithParts): LcmMessagePartInput[] {
+  const rawContent = message.rawContent ?? message.content;
+  if (!containsProviderToolResultBlock(rawContent)) {
+    return [];
   }
+  return sanitizeUserRoleToolResultParts(parseMessageParts(rawContent, {
+    sourceFormat: message.sourceFormat,
+    allowRenderedFallback: false,
+  }));
+}
+
+function assistantRawObjectiveStateParts(message: ObservedMessageWithParts): LcmMessagePartInput[] {
   if (message.rawContent === undefined || message.rawContent === null) {
     return [];
   }
@@ -414,6 +427,48 @@ function objectiveStatePartsForObservedMessage(
     sourceFormat: message.sourceFormat,
     allowRenderedFallback: false,
   });
+}
+
+function mergeObservedEvidenceParts(
+  explicitParts: LcmMessagePartInput[],
+  rawParts: LcmMessagePartInput[],
+): LcmMessagePartInput[] {
+  if (explicitParts.length === 0) return rawParts;
+  if (rawParts.length === 0) return explicitParts;
+
+  const merged = [...explicitParts];
+  const seen = new Set(
+    explicitParts
+      .filter(isObjectiveStateEvidencePart)
+      .map(objectiveStateEvidencePartKey),
+  );
+
+  for (const part of rawParts) {
+    if (!isObjectiveStateEvidencePart(part)) continue;
+    const key = objectiveStateEvidencePartKey(part);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(part);
+  }
+
+  return merged;
+}
+
+function isObjectiveStateEvidencePart(part: LcmMessagePartInput): boolean {
+  return (
+    part.kind === "tool_call" ||
+    part.kind === "tool_result" ||
+    part.kind === "file_write" ||
+    part.kind === "patch"
+  );
+}
+
+function objectiveStateEvidencePartKey(part: LcmMessagePartInput): string {
+  const id = partToolCallId(part);
+  if (id) return `${part.kind}:id:${id}`;
+  const toolName = partToolName(part) ?? "";
+  const filePath = partFilePath(part) ?? "";
+  return `${part.kind}:shape:${toolName}:${filePath}:${stableStringify(partPayload(part))}`;
 }
 
 function flattenObservedParts(messages: readonly ObservedMessageWithParts[]): ObservedPartEntry[] {

--- a/packages/remnic-core/src/objective-state-writers.ts
+++ b/packages/remnic-core/src/objective-state-writers.ts
@@ -407,7 +407,10 @@ function objectiveStatePartsForObservedMessage(
   if (Array.isArray(message.parts) && message.parts.length > 0) {
     return message.parts;
   }
-  return parseMessageParts(message.rawContent ?? message.content, {
+  if (message.rawContent === undefined || message.rawContent === null) {
+    return [];
+  }
+  return parseMessageParts(message.rawContent, {
     sourceFormat: message.sourceFormat,
     renderedContent: message.content,
   });

--- a/packages/remnic-core/src/objective-state.ts
+++ b/packages/remnic-core/src/objective-state.ts
@@ -93,6 +93,23 @@ export function resolveObjectiveStateStoreDir(memoryDir: string, overrideDir?: s
   return path.join(memoryDir, "state", "objective-state");
 }
 
+export function objectiveStateStoreOverrideForNamespace(options: {
+  memoryDir: string;
+  configuredStoreDir?: string;
+  namespacesEnabled: boolean;
+  namespace: string;
+}): string | undefined {
+  const configured = options.configuredStoreDir?.trim();
+  if (!configured) return undefined;
+  if (!options.namespacesEnabled) return configured;
+
+  const defaultStoreDir = path.join(options.memoryDir, "state", "objective-state");
+  if (path.resolve(configured) === path.resolve(defaultStoreDir)) {
+    return undefined;
+  }
+  return path.join(configured, "namespaces", options.namespace);
+}
+
 export function validateObjectiveStateSnapshot(raw: unknown): ObjectiveStateSnapshot {
   if (!isRecord(raw)) throw new Error("objective-state snapshot must be an object");
   if (raw.schemaVersion !== 1) throw new Error("schemaVersion must be 1");

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1885,17 +1885,23 @@ export class Orchestrator {
           ? `Compress the following into bullet points. One bullet per distinct fact or decision. Maximum ${targetTokens} tokens total. No prose.`
           : `Compress the following conversation segment into a dense summary. Preserve: decisions made, code artifacts mentioned, errors encountered, open questions, and any commitments or next-steps. Omit: pleasantries, restatements, and anything the agent would not need to recall later. Output a single paragraph, maximum ${targetTokens} tokens.`;
         try {
-          const result = await this.localLlm.chatCompletion(
-            [
-              { role: "system", content: instructionText },
-              { role: "user", content: text.slice(0, 12000) },
-            ],
-            {
-              maxTokens: targetTokens * 2,
-              operation: "lcm-summarize",
-              priority: "background",
-            },
-          );
+          const messages = [
+            { role: "system" as const, content: instructionText },
+            { role: "user" as const, content: text.slice(0, 12000) },
+          ];
+          const result = this.config.modelSource === "gateway" && this._fastGatewayLlm
+            ? await this._fastGatewayLlm.chatCompletion(messages, {
+                maxTokens: targetTokens * 2,
+                agentId:
+                  this.config.fastGatewayAgentId ||
+                  this.config.gatewayAgentId ||
+                  undefined,
+              })
+            : await this.localLlm.chatCompletion(messages, {
+                maxTokens: targetTokens * 2,
+                operation: "lcm-summarize",
+                priority: "background",
+              });
           return result?.content ?? null;
         } catch {
           return null;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1892,6 +1892,7 @@ export class Orchestrator {
           const result = this.config.modelSource === "gateway" && this._fastGatewayLlm
             ? await this._fastGatewayLlm.chatCompletion(messages, {
                 maxTokens: targetTokens * 2,
+                timeoutMs: this.config.localLlmFastTimeoutMs,
                 agentId:
                   this.config.fastGatewayAgentId ||
                   this.config.gatewayAgentId ||

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -207,6 +207,7 @@ import {
   type CausalTrajectorySearchResult,
 } from "./causal-trajectory.js";
 import {
+  objectiveStateStoreOverrideForNamespace,
   searchObjectiveStateSnapshots,
   type ObjectiveStateSearchResult,
 } from "./objective-state.js";
@@ -6866,9 +6867,12 @@ export class Orchestrator {
             memoryDir: this.config.namespacesEnabled
               ? storage!.dir
               : this.config.memoryDir,
-            objectiveStateStoreDir: !this.config.namespacesEnabled
-              ? this.config.objectiveStateStoreDir
-              : undefined,
+            objectiveStateStoreDir: objectiveStateStoreOverrideForNamespace({
+              memoryDir: this.config.memoryDir,
+              configuredStoreDir: this.config.objectiveStateStoreDir,
+              namespacesEnabled: this.config.namespacesEnabled,
+              namespace,
+            }),
             query: retrievalQuery,
             maxResults,
             sessionKey: namespace !== this.config.defaultNamespace && sessionKey

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6857,13 +6857,30 @@ export class Orchestrator {
         return null;
       }
 
-      const results = await searchObjectiveStateSnapshots({
-        memoryDir: this.config.memoryDir,
-        objectiveStateStoreDir: this.config.objectiveStateStoreDir,
-        query: retrievalQuery,
-        maxResults,
-        sessionKey,
-      });
+      const objectiveStateSearches = await Promise.all(
+        recallNamespaces.map(async (namespace) => {
+          const isDefaultNamespace = namespace === this.config.defaultNamespace;
+          const storage = isDefaultNamespace ? null : await this.getStorage(namespace);
+          return searchObjectiveStateSnapshots({
+            memoryDir: isDefaultNamespace ? this.config.memoryDir : storage!.dir,
+            objectiveStateStoreDir: isDefaultNamespace
+              ? this.config.objectiveStateStoreDir
+              : undefined,
+            query: retrievalQuery,
+            maxResults,
+            sessionKey: !isDefaultNamespace && sessionKey
+              ? `${namespace}:${sessionKey}`
+              : sessionKey,
+          });
+        }),
+      );
+      const results = objectiveStateSearches
+        .flat()
+        .sort((left, right) => {
+          if (right.score !== left.score) return right.score - left.score;
+          return right.snapshot.recordedAt.localeCompare(left.snapshot.recordedAt);
+        })
+        .slice(0, maxResults);
 
       recordRecallSectionMetric({
         section: "objectiveState",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6875,9 +6875,7 @@ export class Orchestrator {
             }),
             query: retrievalQuery,
             maxResults,
-            sessionKey: namespace !== this.config.defaultNamespace && sessionKey
-              ? `${namespace}:${sessionKey}`
-              : sessionKey,
+            sessionKey,
           });
         }),
       );

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6859,16 +6859,19 @@ export class Orchestrator {
 
       const objectiveStateSearches = await Promise.all(
         recallNamespaces.map(async (namespace) => {
-          const isDefaultNamespace = namespace === this.config.defaultNamespace;
-          const storage = isDefaultNamespace ? null : await this.getStorage(namespace);
+          const storage = this.config.namespacesEnabled
+            ? await this.getStorage(namespace)
+            : null;
           return searchObjectiveStateSnapshots({
-            memoryDir: isDefaultNamespace ? this.config.memoryDir : storage!.dir,
-            objectiveStateStoreDir: isDefaultNamespace
+            memoryDir: this.config.namespacesEnabled
+              ? storage!.dir
+              : this.config.memoryDir,
+            objectiveStateStoreDir: !this.config.namespacesEnabled
               ? this.config.objectiveStateStoreDir
               : undefined,
             query: retrievalQuery,
             maxResults,
-            sessionKey: !isDefaultNamespace && sessionKey
+            sessionKey: namespace !== this.config.defaultNamespace && sessionKey
               ? `${namespace}:${sessionKey}`
               : sessionKey,
           });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { registerTools } from "./tools.js";
 import { registerLcmTools } from "./lcm/index.js";
 import { estimateTokens as estimateLcmTokens } from "./lcm/archive.js";
 import { registerCli } from "./cli.js";
+import { objectiveStateStoreOverrideForNamespace } from "./objective-state.js";
 import { recordObjectiveStateSnapshotsFromAgentMessages } from "./objective-state-writers.js";
 import { probeQmdAvailability } from "./qmd-availability-probe.js";
 import { EngramAccessService } from "./access-service.js";
@@ -2972,15 +2973,33 @@ const pluginDefinition = {
           }
 
           try {
+            const objectiveStateNamespace =
+              orchestrator.config.namespacesEnabled &&
+              typeof orchestrator.resolveSelfNamespace === "function"
+                ? orchestrator.resolveSelfNamespace(sessionKey)
+                : orchestrator.config.defaultNamespace;
+            const objectiveStateStorage =
+              orchestrator.config.namespacesEnabled &&
+              typeof orchestrator.getStorageForNamespace === "function"
+                ? await orchestrator.getStorageForNamespace(objectiveStateNamespace)
+                : null;
             await recordObjectiveStateSnapshotsFromAgentMessages({
-              memoryDir: orchestrator.config.memoryDir,
-              objectiveStateStoreDir:
-                orchestrator.config.objectiveStateStoreDir,
+              memoryDir:
+                objectiveStateStorage?.dir ?? orchestrator.config.memoryDir,
+              objectiveStateStoreDir: objectiveStateStoreOverrideForNamespace({
+                memoryDir: orchestrator.config.memoryDir,
+                configuredStoreDir: orchestrator.config.objectiveStateStoreDir,
+                namespacesEnabled: orchestrator.config.namespacesEnabled,
+                namespace: objectiveStateNamespace,
+              }),
               objectiveStateMemoryEnabled:
                 orchestrator.config.objectiveStateMemoryEnabled,
               objectiveStateSnapshotWritesEnabled:
                 orchestrator.config.objectiveStateSnapshotWritesEnabled,
-              sessionKey,
+              sessionKey: orchestrator.config.namespacesEnabled &&
+                objectiveStateNamespace !== orchestrator.config.defaultNamespace
+                ? `${objectiveStateNamespace}:${sessionKey}`
+                : sessionKey,
               recordedAt: eventTimestamp,
               messages,
             });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2996,10 +2996,7 @@ const pluginDefinition = {
                 orchestrator.config.objectiveStateMemoryEnabled,
               objectiveStateSnapshotWritesEnabled:
                 orchestrator.config.objectiveStateSnapshotWritesEnabled,
-              sessionKey: orchestrator.config.namespacesEnabled &&
-                objectiveStateNamespace !== orchestrator.config.defaultNamespace
-                ? `${objectiveStateNamespace}:${sessionKey}`
-                : sessionKey,
+              sessionKey,
               recordedAt: eventTimestamp,
               messages,
             });

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -278,3 +278,91 @@ test("observe writes objective-state snapshots into the coding namespace overlay
     await rm(projectDir, { recursive: true, force: true });
   }
 });
+
+test("observe bases implicit objective-state snapshots on the principal namespace", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-global-"));
+  const projectDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-principal-"));
+  const service = createObjectiveStateObserveService(memoryDir, {
+    namespacesEnabled: true,
+    storageDirs: { "alice-project-a": projectDir },
+    namespacePolicies: [
+      {
+        name: "alice",
+        readPrincipals: ["alice"],
+        writePrincipals: ["alice"],
+      },
+    ],
+    codingMode: {
+      projectScope: true,
+      branchScope: false,
+      globalFallback: false,
+    },
+    applyCodingNamespaceOverlay: (sessionKey, baseNamespace, codingContext) => {
+      assert.equal(sessionKey, "agent:main");
+      assert.equal(baseNamespace, "alice");
+      assert.deepEqual(codingContext, {
+        projectId: "tag:project-a",
+        branch: null,
+        rootPath: "tag:project-a",
+        defaultBranch: null,
+      });
+      return "alice-project-a";
+    },
+  });
+
+  try {
+    const response = await service.observe({
+      sessionKey: "agent:main",
+      authenticatedPrincipal: "alice",
+      projectTag: "project-a",
+      skipExtraction: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Ran the principal project validation command.",
+          parts: [
+            {
+              ordinal: 0,
+              kind: "tool_call",
+              toolName: "exec_command",
+              payload: {
+                id: "call-principal-project-validate",
+                name: "exec_command",
+                arguments: { cmd: "npm run principal-project-validate" },
+              },
+            },
+            {
+              ordinal: 1,
+              kind: "tool_result",
+              payload: {
+                id: "call-principal-project-validate",
+                output: { exitCode: 0, stdout: "all checks passed" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(response.accepted, 1);
+
+    const globalStatus = await getObjectiveStateStoreStatus({
+      memoryDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+    const projectStatus = await getObjectiveStateStoreStatus({
+      memoryDir: projectDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+
+    assert.equal(globalStatus.snapshots.total, 0);
+    assert.equal(projectStatus.snapshots.total, 1);
+    assert.equal(projectStatus.latestSnapshot?.sessionKey, "alice-project-a:agent:main");
+    assert.equal(projectStatus.latestSnapshot?.scope, "npm run principal-project-validate");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(projectDir, { recursive: true, force: true });
+  }
+});

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -428,3 +428,64 @@ test("observe bases implicit objective-state snapshots on the principal namespac
     await rm(projectDir, { recursive: true, force: true });
   }
 });
+
+test("observe rejects implicit objective-state writes to unauthorized principal namespace", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-denied-"));
+  const service = createObjectiveStateObserveService(memoryDir, {
+    namespacesEnabled: true,
+    namespacePolicies: [
+      {
+        name: "alice",
+        readPrincipals: ["alice"],
+        writePrincipals: ["bob"],
+      },
+    ],
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        service.observe({
+          sessionKey: "agent:main",
+          authenticatedPrincipal: "alice",
+          skipExtraction: true,
+          messages: [
+            {
+              role: "assistant",
+              content: "Ran a denied validation command.",
+              parts: [
+                {
+                  ordinal: 0,
+                  kind: "tool_call",
+                  toolName: "exec_command",
+                  payload: {
+                    id: "call-denied-validate",
+                    name: "exec_command",
+                    arguments: { cmd: "npm run denied-validate" },
+                  },
+                },
+                {
+                  ordinal: 1,
+                  kind: "tool_result",
+                  payload: {
+                    id: "call-denied-validate",
+                    output: { exitCode: 0, stdout: "all checks passed" },
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      /namespace is not writable: alice/,
+    );
+
+    const status = await getObjectiveStateStoreStatus({
+      memoryDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+    assert.equal(status.snapshots.total, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { EngramAccessService } from "../src/access-service.js";
+import { getObjectiveStateStoreStatus } from "../src/objective-state.js";
+
+function createObjectiveStateObserveService(memoryDir: string): EngramAccessService {
+  return new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [],
+      defaultRecallNamespaces: ["self"],
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+      objectiveStateMemoryEnabled: true,
+      objectiveStateSnapshotWritesEnabled: true,
+    },
+    lcmEngine: null,
+  } as never);
+}
+
+test("observe persists objective-state snapshots from structured message parts", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-"));
+  const service = createObjectiveStateObserveService(memoryDir);
+
+  try {
+    const response = await service.observe({
+      sessionKey: "agent:main",
+      skipExtraction: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Ran the validation command.",
+          parts: [
+            {
+              ordinal: 0,
+              kind: "tool_call",
+              toolName: "exec_command",
+              payload: {
+                id: "call-validate",
+                name: "exec_command",
+                arguments: { cmd: "npm run validate" },
+              },
+            },
+            {
+              ordinal: 1,
+              kind: "tool_result",
+              payload: {
+                id: "call-validate",
+                output: { exitCode: 0, stdout: "all checks passed" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(response.accepted, 1);
+    assert.equal(response.extractionQueued, false);
+
+    const status = await getObjectiveStateStoreStatus({
+      memoryDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+    assert.equal(status.snapshots.total, 1);
+    assert.equal(status.latestSnapshot?.kind, "process");
+    assert.equal(status.latestSnapshot?.changeKind, "executed");
+    assert.equal(status.latestSnapshot?.scope, "npm run validate");
+    assert.equal(status.latestSnapshot?.outcome, "success");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -29,6 +29,7 @@ function createObjectiveStateObserveService(
     ) => string;
     objectiveStateMemoryEnabled?: boolean;
     objectiveStateSnapshotWritesEnabled?: boolean;
+    objectiveStateStoreDir?: string;
   } = {},
 ): EngramAccessService {
   const codingContexts = new Map<string, unknown>();
@@ -55,6 +56,9 @@ function createObjectiveStateObserveService(
         options.objectiveStateMemoryEnabled ?? true,
       objectiveStateSnapshotWritesEnabled:
         options.objectiveStateSnapshotWritesEnabled ?? true,
+      ...(options.objectiveStateStoreDir
+        ? { objectiveStateStoreDir: options.objectiveStateStoreDir }
+        : {}),
     },
     lcmEngine: null,
     getStorage: async (namespace?: string) => ({
@@ -262,6 +266,72 @@ test("observe writes default namespace snapshots through routed storage", async 
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
     await rm(routedDir, { recursive: true, force: true });
+  }
+});
+
+test("observe preserves configured objective-state store override with namespaces", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-root-"));
+  const routedDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-routed-"));
+  const overrideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-override-"));
+  const service = createObjectiveStateObserveService(memoryDir, {
+    namespacesEnabled: true,
+    storageDirs: { global: routedDir },
+    objectiveStateStoreDir: overrideDir,
+  });
+
+  try {
+    const response = await service.observe({
+      sessionKey: "agent:main",
+      skipExtraction: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Ran the override validation command.",
+          parts: [
+            {
+              ordinal: 0,
+              kind: "tool_call",
+              toolName: "exec_command",
+              payload: {
+                id: "call-override-validate",
+                name: "exec_command",
+                arguments: { cmd: "npm run override-validate" },
+              },
+            },
+            {
+              ordinal: 1,
+              kind: "tool_result",
+              payload: {
+                id: "call-override-validate",
+                output: { exitCode: 0, stdout: "all checks passed" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(response.accepted, 1);
+
+    const routedStatus = await getObjectiveStateStoreStatus({
+      memoryDir: routedDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+    const overrideStatus = await getObjectiveStateStoreStatus({
+      memoryDir: routedDir,
+      objectiveStateStoreDir: path.join(overrideDir, "namespaces", "global"),
+      enabled: true,
+      writesEnabled: true,
+    });
+
+    assert.equal(routedStatus.snapshots.total, 0);
+    assert.equal(overrideStatus.snapshots.total, 1);
+    assert.equal(overrideStatus.latestSnapshot?.scope, "npm run override-validate");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(routedDir, { recursive: true, force: true });
+    await rm(overrideDir, { recursive: true, force: true });
   }
 });
 

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -27,6 +27,8 @@ function createObjectiveStateObserveService(
       baseNamespace: string,
       codingContext: unknown,
     ) => string;
+    objectiveStateMemoryEnabled?: boolean;
+    objectiveStateSnapshotWritesEnabled?: boolean;
   } = {},
 ): EngramAccessService {
   const codingContexts = new Map<string, unknown>();
@@ -49,8 +51,10 @@ function createObjectiveStateObserveService(
         branchScope: false,
         globalFallback: false,
       },
-      objectiveStateMemoryEnabled: true,
-      objectiveStateSnapshotWritesEnabled: true,
+      objectiveStateMemoryEnabled:
+        options.objectiveStateMemoryEnabled ?? true,
+      objectiveStateSnapshotWritesEnabled:
+        options.objectiveStateSnapshotWritesEnabled ?? true,
     },
     lcmEngine: null,
     getStorage: async (namespace?: string) => ({
@@ -478,6 +482,66 @@ test("observe rejects implicit objective-state writes to unauthorized principal 
         }),
       /namespace is not writable: alice/,
     );
+
+    const status = await getObjectiveStateStoreStatus({
+      memoryDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+    assert.equal(status.snapshots.total, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("observe skips objective-state namespace authorization when writes are disabled", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-disabled-"));
+  const service = createObjectiveStateObserveService(memoryDir, {
+    namespacesEnabled: true,
+    objectiveStateSnapshotWritesEnabled: false,
+    namespacePolicies: [
+      {
+        name: "alice",
+        readPrincipals: ["alice"],
+        writePrincipals: ["bob"],
+      },
+    ],
+  });
+
+  try {
+    const response = await service.observe({
+      sessionKey: "agent:main",
+      authenticatedPrincipal: "alice",
+      skipExtraction: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Observed a command while objective-state writes are off.",
+          parts: [
+            {
+              ordinal: 0,
+              kind: "tool_call",
+              toolName: "exec_command",
+              payload: {
+                id: "call-disabled-objective-state",
+                name: "exec_command",
+                arguments: { cmd: "npm run disabled-objective-state" },
+              },
+            },
+            {
+              ordinal: 1,
+              kind: "tool_result",
+              payload: {
+                id: "call-disabled-objective-state",
+                output: { exitCode: 0, stdout: "all checks passed" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(response.accepted, 1);
 
     const status = await getObjectiveStateStoreStatus({
       memoryDir,

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -199,6 +199,68 @@ test("observe writes objective-state snapshots into the resolved namespace store
   }
 });
 
+test("observe writes default namespace snapshots through routed storage", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-root-"));
+  const routedDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-routed-"));
+  const service = createObjectiveStateObserveService(memoryDir, {
+    namespacesEnabled: true,
+    storageDirs: { global: routedDir },
+  });
+
+  try {
+    const response = await service.observe({
+      sessionKey: "agent:main",
+      skipExtraction: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Ran the routed default validation command.",
+          parts: [
+            {
+              ordinal: 0,
+              kind: "tool_call",
+              toolName: "exec_command",
+              payload: {
+                id: "call-routed-default-validate",
+                name: "exec_command",
+                arguments: { cmd: "npm run routed-default-validate" },
+              },
+            },
+            {
+              ordinal: 1,
+              kind: "tool_result",
+              payload: {
+                id: "call-routed-default-validate",
+                output: { exitCode: 0, stdout: "all checks passed" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(response.accepted, 1);
+
+    const rootStatus = await getObjectiveStateStoreStatus({
+      memoryDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+    const routedStatus = await getObjectiveStateStoreStatus({
+      memoryDir: routedDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+
+    assert.equal(rootStatus.snapshots.total, 0);
+    assert.equal(routedStatus.snapshots.total, 1);
+    assert.equal(routedStatus.latestSnapshot?.scope, "npm run routed-default-validate");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(routedDir, { recursive: true, force: true });
+  }
+});
+
 test("observe writes objective-state snapshots into the coding namespace overlay", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-global-"));
   const projectDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-project-"));

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -17,8 +17,19 @@ function createObjectiveStateObserveService(
       includeInRecallByDefault?: boolean;
     }>;
     storageDirs?: Record<string, string>;
+    codingMode?: {
+      projectScope?: boolean;
+      branchScope?: boolean;
+      globalFallback?: boolean;
+    };
+    applyCodingNamespaceOverlay?: (
+      sessionKey: string | undefined,
+      baseNamespace: string,
+      codingContext: unknown,
+    ) => string;
   } = {},
 ): EngramAccessService {
+  const codingContexts = new Map<string, unknown>();
   return new EngramAccessService({
     config: {
       memoryDir,
@@ -33,6 +44,11 @@ function createObjectiveStateObserveService(
       recallCrossNamespaceBudgetWindowMs: 60_000,
       recallCrossNamespaceBudgetSoftLimit: 10,
       recallCrossNamespaceBudgetHardLimit: 30,
+      codingMode: options.codingMode ?? {
+        projectScope: false,
+        branchScope: false,
+        globalFallback: false,
+      },
       objectiveStateMemoryEnabled: true,
       objectiveStateSnapshotWritesEnabled: true,
     },
@@ -40,6 +56,20 @@ function createObjectiveStateObserveService(
     getStorage: async (namespace?: string) => ({
       dir: options.storageDirs?.[namespace ?? "global"] ?? memoryDir,
     }),
+    getCodingContextForSession: (sessionKey?: string) =>
+      sessionKey ? codingContexts.get(sessionKey) ?? null : null,
+    setCodingContextForSession: (sessionKey: string, codingContext: unknown) => {
+      codingContexts.set(sessionKey, codingContext);
+    },
+    applyCodingNamespaceOverlay: (
+      sessionKey: string | undefined,
+      baseNamespace: string,
+    ) =>
+      options.applyCodingNamespaceOverlay?.(
+        sessionKey,
+        baseNamespace,
+        sessionKey ? codingContexts.get(sessionKey) : null,
+      ) ?? baseNamespace,
   } as never);
 }
 
@@ -166,5 +196,85 @@ test("observe writes objective-state snapshots into the resolved namespace store
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
     await rm(teamDir, { recursive: true, force: true });
+  }
+});
+
+test("observe writes objective-state snapshots into the coding namespace overlay", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-global-"));
+  const projectDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-project-"));
+  const service = createObjectiveStateObserveService(memoryDir, {
+    namespacesEnabled: true,
+    storageDirs: { "global-project-a": projectDir },
+    codingMode: {
+      projectScope: true,
+      branchScope: false,
+      globalFallback: false,
+    },
+    applyCodingNamespaceOverlay: (sessionKey, baseNamespace, codingContext) => {
+      assert.equal(sessionKey, "agent:main");
+      assert.equal(baseNamespace, "global");
+      assert.deepEqual(codingContext, {
+        projectId: "tag:project-a",
+        branch: null,
+        rootPath: "tag:project-a",
+        defaultBranch: null,
+      });
+      return "global-project-a";
+    },
+  });
+
+  try {
+    const response = await service.observe({
+      sessionKey: "agent:main",
+      projectTag: "project-a",
+      skipExtraction: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Ran the project validation command.",
+          parts: [
+            {
+              ordinal: 0,
+              kind: "tool_call",
+              toolName: "exec_command",
+              payload: {
+                id: "call-project-validate",
+                name: "exec_command",
+                arguments: { cmd: "npm run project-validate" },
+              },
+            },
+            {
+              ordinal: 1,
+              kind: "tool_result",
+              payload: {
+                id: "call-project-validate",
+                output: { exitCode: 0, stdout: "all checks passed" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(response.accepted, 1);
+
+    const globalStatus = await getObjectiveStateStoreStatus({
+      memoryDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+    const projectStatus = await getObjectiveStateStoreStatus({
+      memoryDir: projectDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+
+    assert.equal(globalStatus.snapshots.total, 0);
+    assert.equal(projectStatus.snapshots.total, 1);
+    assert.equal(projectStatus.latestSnapshot?.sessionKey, "global-project-a:agent:main");
+    assert.equal(projectStatus.latestSnapshot?.scope, "npm run project-validate");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(projectDir, { recursive: true, force: true });
   }
 });

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -199,7 +199,7 @@ test("observe writes objective-state snapshots into the resolved namespace store
 
     assert.equal(globalStatus.snapshots.total, 0);
     assert.equal(teamStatus.snapshots.total, 1);
-    assert.equal(teamStatus.latestSnapshot?.sessionKey, "team-a:agent:main");
+    assert.equal(teamStatus.latestSnapshot?.sessionKey, "agent:main");
     assert.equal(teamStatus.latestSnapshot?.scope, "npm run team-validate");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
@@ -407,7 +407,7 @@ test("observe writes objective-state snapshots into the coding namespace overlay
 
     assert.equal(globalStatus.snapshots.total, 0);
     assert.equal(projectStatus.snapshots.total, 1);
-    assert.equal(projectStatus.latestSnapshot?.sessionKey, "global-project-a:agent:main");
+    assert.equal(projectStatus.latestSnapshot?.sessionKey, "agent:main");
     assert.equal(projectStatus.latestSnapshot?.scope, "npm run project-validate");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
@@ -495,7 +495,7 @@ test("observe bases implicit objective-state snapshots on the principal namespac
 
     assert.equal(globalStatus.snapshots.total, 0);
     assert.equal(projectStatus.snapshots.total, 1);
-    assert.equal(projectStatus.latestSnapshot?.sessionKey, "alice-project-a:agent:main");
+    assert.equal(projectStatus.latestSnapshot?.sessionKey, "agent:main");
     assert.equal(projectStatus.latestSnapshot?.scope, "npm run principal-project-validate");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });

--- a/tests/access-service-objective-state.test.ts
+++ b/tests/access-service-objective-state.test.ts
@@ -6,16 +6,28 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { EngramAccessService } from "../src/access-service.js";
 import { getObjectiveStateStoreStatus } from "../src/objective-state.js";
 
-function createObjectiveStateObserveService(memoryDir: string): EngramAccessService {
+function createObjectiveStateObserveService(
+  memoryDir: string,
+  options: {
+    namespacesEnabled?: boolean;
+    namespacePolicies?: Array<{
+      name: string;
+      readPrincipals: string[];
+      writePrincipals: string[];
+      includeInRecallByDefault?: boolean;
+    }>;
+    storageDirs?: Record<string, string>;
+  } = {},
+): EngramAccessService {
   return new EngramAccessService({
     config: {
       memoryDir,
-      namespacesEnabled: false,
+      namespacesEnabled: options.namespacesEnabled === true,
       defaultNamespace: "global",
       sharedNamespace: "shared",
       principalFromSessionKeyMode: "prefix",
       principalFromSessionKeyRules: [],
-      namespacePolicies: [],
+      namespacePolicies: options.namespacePolicies ?? [],
       defaultRecallNamespaces: ["self"],
       recallCrossNamespaceBudgetEnabled: false,
       recallCrossNamespaceBudgetWindowMs: 60_000,
@@ -25,6 +37,9 @@ function createObjectiveStateObserveService(memoryDir: string): EngramAccessServ
       objectiveStateSnapshotWritesEnabled: true,
     },
     lcmEngine: null,
+    getStorage: async (namespace?: string) => ({
+      dir: options.storageDirs?.[namespace ?? "global"] ?? memoryDir,
+    }),
   } as never);
 }
 
@@ -79,5 +94,77 @@ test("observe persists objective-state snapshots from structured message parts",
     assert.equal(status.latestSnapshot?.outcome, "success");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("observe writes objective-state snapshots into the resolved namespace store", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-global-"));
+  const teamDir = await mkdtemp(path.join(os.tmpdir(), "remnic-access-objective-state-team-"));
+  const service = createObjectiveStateObserveService(memoryDir, {
+    namespacesEnabled: true,
+    storageDirs: { "team-a": teamDir },
+    namespacePolicies: [
+      {
+        name: "team-a",
+        readPrincipals: ["alice"],
+        writePrincipals: ["alice"],
+      },
+    ],
+  });
+
+  try {
+    const response = await service.observe({
+      sessionKey: "agent:main",
+      namespace: "team-a",
+      authenticatedPrincipal: "alice",
+      skipExtraction: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Ran the validation command.",
+          parts: [
+            {
+              ordinal: 0,
+              kind: "tool_call",
+              toolName: "exec_command",
+              payload: {
+                id: "call-team-validate",
+                name: "exec_command",
+                arguments: { cmd: "npm run team-validate" },
+              },
+            },
+            {
+              ordinal: 1,
+              kind: "tool_result",
+              payload: {
+                id: "call-team-validate",
+                output: { exitCode: 0, stdout: "all checks passed" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(response.accepted, 1);
+
+    const globalStatus = await getObjectiveStateStoreStatus({
+      memoryDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+    const teamStatus = await getObjectiveStateStoreStatus({
+      memoryDir: teamDir,
+      enabled: true,
+      writesEnabled: true,
+    });
+
+    assert.equal(globalStatus.snapshots.total, 0);
+    assert.equal(teamStatus.snapshots.total, 1);
+    assert.equal(teamStatus.latestSnapshot?.sessionKey, "team-a:agent:main");
+    assert.equal(teamStatus.latestSnapshot?.scope, "npm run team-validate");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(teamDir, { recursive: true, force: true });
   }
 });

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -8,6 +8,7 @@ import { EngramAccessInputError, EngramAccessService } from "../src/access-servi
 import { runMemoryGovernance } from "../src/maintenance/memory-governance.ts";
 import { rebuildMemoryProjection } from "../src/maintenance/rebuild-memory-projection.ts";
 import { getMemoryProjectionPath } from "../src/memory-projection-store.js";
+import { getObjectiveStateStoreStatus } from "../src/objective-state.js";
 import {
   keyring,
   runSecureStoreInit,
@@ -105,6 +106,85 @@ function createService(dreamsPhases = dreamsPhasesConfig()) {
   };
   return new EngramAccessService(orchestrator as any);
 }
+
+test("observe writes raw session keys to namespaced objective-state stores", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-observe-obj-ns-"));
+  const namespace = "project-x";
+  const namespaceDir = path.join(memoryDir, "namespaces", namespace);
+  const objectiveStateStoreDir = path.join(memoryDir, "objective-state-override");
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: namespace,
+          readPrincipals: [namespace],
+          writePrincipals: [namespace],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      objectiveStateMemoryEnabled: true,
+      objectiveStateSnapshotWritesEnabled: true,
+      objectiveStateStoreDir,
+    },
+    getStorage: async (requestedNamespace: string) => {
+      assert.equal(requestedNamespace, namespace);
+      return { dir: namespaceDir };
+    },
+  } as any);
+
+  try {
+    await service.observe({
+      sessionKey: "agent-session",
+      namespace,
+      authenticatedPrincipal: namespace,
+      skipExtraction: true,
+      messages: [
+        {
+          role: "assistant",
+          content: "Ran verification.",
+          parts: [
+            {
+              ordinal: 0,
+              kind: "tool_call",
+              toolName: "exec_command",
+              payload: {
+                id: "call-access-observe",
+                name: "exec_command",
+                arguments: { cmd: "npm test" },
+              },
+            },
+            {
+              ordinal: 1,
+              kind: "tool_result",
+              payload: {
+                id: "call-access-observe",
+                output: { exitCode: 0, stdout: "ok" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const status = await getObjectiveStateStoreStatus({
+      memoryDir: namespaceDir,
+      objectiveStateStoreDir: path.join(objectiveStateStoreDir, "namespaces", namespace),
+      enabled: true,
+      writesEnabled: true,
+    });
+    assert.equal(status.snapshots.total, 1);
+    assert.equal(status.latestSnapshot?.sessionKey, "agent-session");
+    assert.equal(status.latestSnapshot?.kind, "process");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
 
 function createMemoryActionService(contextCompressionActionsEnabled: boolean) {
   const capturedEvents: any[] = [];

--- a/tests/lcm-gateway-summarizer.test.ts
+++ b/tests/lcm-gateway-summarizer.test.ts
@@ -4,18 +4,20 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
 
+import { setCodexCliFallbackRunnerForProcess } from "@remnic/core";
+
 import { Orchestrator } from "../src/orchestrator.js";
 import { parseConfig } from "../src/config.js";
-import { __codexCliFallbackTestHooks } from "../packages/remnic-core/src/codex-cli-fallback.js";
 
 test("LCM summarization uses gateway internal LLM when modelSource is gateway", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lcm-gateway-"));
-  const calls: Array<{ modelId: string; agentPrompt: string }> = [];
-  const restoreRunner = __codexCliFallbackTestHooks.setRunCodexCliForTest(
+  const calls: Array<{ modelId: string; agentPrompt: string; timeoutMs?: number }> = [];
+  const restoreRunner = setCodexCliFallbackRunnerForProcess(
     async (request) => {
       calls.push({
         modelId: request.modelId,
         agentPrompt: request.messages.map((message) => message.content).join("\n"),
+        timeoutMs: request.options.timeoutMs,
       });
       return {
         content: "Codex gateway summary.",
@@ -30,6 +32,7 @@ test("LCM summarization uses gateway internal LLM when modelSource is gateway", 
       lcmLeafBatchSize: 2,
       lcmRollupFanIn: 100,
       localLlmEnabled: false,
+      localLlmFastTimeoutMs: 1234,
       modelSource: "gateway",
       gatewayAgentId: "remnic-bench-internal",
       fastGatewayAgentId: "remnic-bench-internal",
@@ -80,6 +83,7 @@ test("LCM summarization uses gateway internal LLM when modelSource is gateway", 
     assert.equal(stats.totalSummaryNodes, 1);
     assert.equal(calls.length, 1);
     assert.equal(calls[0]?.modelId, "gpt-5.5");
+    assert.equal(calls[0]?.timeoutMs, 1234);
     assert.match(calls[0]?.agentPrompt ?? "", /gateway too/);
   } finally {
     restoreRunner();

--- a/tests/lcm-gateway-summarizer.test.ts
+++ b/tests/lcm-gateway-summarizer.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { Orchestrator } from "../src/orchestrator.js";
+import { parseConfig } from "../src/config.js";
+import { __codexCliFallbackTestHooks } from "../packages/remnic-core/src/codex-cli-fallback.js";
+
+test("LCM summarization uses gateway internal LLM when modelSource is gateway", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lcm-gateway-"));
+  const calls: Array<{ modelId: string; agentPrompt: string }> = [];
+  const restoreRunner = __codexCliFallbackTestHooks.setRunCodexCliForTest(
+    async (request) => {
+      calls.push({
+        modelId: request.modelId,
+        agentPrompt: request.messages.map((message) => message.content).join("\n"),
+      });
+      return {
+        content: "Codex gateway summary.",
+        usage: { inputTokens: 10, outputTokens: 4, totalTokens: 14 },
+      };
+    },
+  );
+  const orchestrator = new Orchestrator(
+    parseConfig({
+      memoryDir,
+      lcmEnabled: true,
+      lcmLeafBatchSize: 2,
+      lcmRollupFanIn: 100,
+      localLlmEnabled: false,
+      modelSource: "gateway",
+      gatewayAgentId: "remnic-bench-internal",
+      fastGatewayAgentId: "remnic-bench-internal",
+      gatewayConfig: {
+        agents: {
+          defaults: {
+            model: { primary: "remnic-bench-internal/gpt-5.5" },
+          },
+          list: [
+            {
+              id: "remnic-bench-internal",
+              name: "Remnic bench internal provider",
+              model: { primary: "remnic-bench-internal/gpt-5.5" },
+            },
+          ],
+        },
+        models: {
+          providers: {
+            "remnic-bench-internal": {
+              baseUrl: "codex-cli://local",
+              api: "codex-cli",
+              codexCliReasoningEffort: "xhigh",
+              models: [{ id: "gpt-5.5", name: "gpt-5.5" }],
+            },
+          },
+        },
+      },
+    }),
+  );
+
+  try {
+    await orchestrator.initialize();
+    assert.ok(orchestrator.lcmEngine, "LCM engine should be enabled");
+
+    orchestrator.lcmEngine!.enqueueObserveMessages("session-1", [
+      {
+        role: "user",
+        content: "The benchmark answerer used Codex CLI as the primary model.",
+      },
+      {
+        role: "assistant",
+        content: "The internal Remnic summarizer should use the gateway too.",
+      },
+    ]);
+    await orchestrator.lcmEngine!.waitForObserveQueueIdle();
+
+    const stats = await orchestrator.lcmEngine!.getStats("session-1");
+    assert.equal(stats.totalSummaryNodes, 1);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.modelId, "gpt-5.5");
+    assert.match(calls[0]?.agentPrompt ?? "", /gateway too/);
+  } finally {
+    restoreRunner();
+    const teardown = orchestrator as unknown as {
+      abortDeferredInit(): void;
+      deferredReady: Promise<void>;
+      qmd: { dispose?(): void | Promise<void> };
+      qmdMaintenanceTimer?: NodeJS.Timeout | null;
+    };
+    teardown.abortDeferredInit();
+    if (teardown.qmdMaintenanceTimer) {
+      clearTimeout(teardown.qmdMaintenanceTimer);
+      teardown.qmdMaintenanceTimer = null;
+    }
+    await Promise.race([
+      teardown.deferredReady.catch(() => undefined),
+      new Promise((resolve) => setTimeout(resolve, 500)),
+    ]);
+    await teardown.qmd.dispose?.();
+    orchestrator.lcmEngine?.close();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/objective-state-recall.test.ts
+++ b/tests/objective-state-recall.test.ts
@@ -269,3 +269,70 @@ test("recall searches objective-state snapshots from routed default namespace st
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("recall searches namespaced objective-state snapshots from configured store override", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-objective-state-recall-override-ns-"));
+  const overrideDir = await mkdtemp(path.join(os.tmpdir(), "engram-objective-state-recall-override-store-"));
+  await mkdir(path.join(memoryDir, "namespaces", "global"), { recursive: true });
+  const cfg = parseConfig({
+    openaiApiKey: "test-openai-key",
+    memoryDir,
+    qmdEnabled: false,
+    transcriptEnabled: false,
+    sharedContextEnabled: false,
+    conversationIndexEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    namespacesEnabled: true,
+    defaultNamespace: "global",
+    sharedNamespace: "shared",
+    defaultRecallNamespaces: ["self"],
+    objectiveStateMemoryEnabled: true,
+    objectiveStateSnapshotWritesEnabled: true,
+    objectiveStateRecallEnabled: true,
+    objectiveStateStoreDir: overrideDir,
+    recallPipeline: [
+      {
+        id: "objective-state",
+        enabled: true,
+        maxResults: 2,
+        maxChars: 1200,
+      },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  try {
+    const defaultStorage = await orchestrator.getStorage("global");
+    await recordObjectiveStateSnapshot({
+      memoryDir: defaultStorage.dir,
+      objectiveStateStoreDir: path.join(overrideDir, "namespaces", "global"),
+      snapshot: {
+        schemaVersion: 1,
+        snapshotId: "snap-override-default-validation",
+        recordedAt: "2026-03-07T10:01:00.000Z",
+        sessionKey: "agent:main",
+        source: "tool_result",
+        kind: "process",
+        changeKind: "failed",
+        scope: "npm run validation",
+        summary: "Override default validation failed in the configured store.",
+        toolName: "exec_command",
+        command: "npm run validation",
+        outcome: "failure",
+        tags: ["validation"],
+      },
+    });
+
+    const context = await (orchestrator as any).recallInternal(
+      "Why did validation fail?",
+      "agent:main",
+    );
+
+    assert.match(context, /## Objective State/);
+    assert.match(context, /configured store/i);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(overrideDir, { recursive: true, force: true });
+  }
+});

--- a/tests/objective-state-recall.test.ts
+++ b/tests/objective-state-recall.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 import { recordObjectiveStateSnapshot } from "../src/objective-state.js";
@@ -183,6 +183,88 @@ test("recall searches objective-state snapshots from the requested namespace sto
     assert.match(context, /## Objective State/);
     assert.match(context, /namespace-scoped error/i);
     assert.equal(context.includes("default-namespace error"), false);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("recall searches objective-state snapshots from routed default namespace storage", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-objective-state-recall-default-ns-"));
+  await mkdir(path.join(memoryDir, "namespaces", "global"), { recursive: true });
+  const cfg = parseConfig({
+    openaiApiKey: "test-openai-key",
+    memoryDir,
+    qmdEnabled: false,
+    transcriptEnabled: false,
+    sharedContextEnabled: false,
+    conversationIndexEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    namespacesEnabled: true,
+    defaultNamespace: "global",
+    sharedNamespace: "shared",
+    defaultRecallNamespaces: ["self"],
+    objectiveStateMemoryEnabled: true,
+    objectiveStateSnapshotWritesEnabled: true,
+    objectiveStateRecallEnabled: true,
+    recallPipeline: [
+      {
+        id: "objective-state",
+        enabled: true,
+        maxResults: 2,
+        maxChars: 1200,
+      },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  try {
+    await recordObjectiveStateSnapshot({
+      memoryDir,
+      snapshot: {
+        schemaVersion: 1,
+        snapshotId: "snap-legacy-default-validation",
+        recordedAt: "2026-03-07T10:00:00.000Z",
+        sessionKey: "agent:main",
+        source: "tool_result",
+        kind: "process",
+        changeKind: "failed",
+        scope: "npm run validation",
+        summary: "Legacy root validation failed in the old default store.",
+        toolName: "exec_command",
+        command: "npm run validation",
+        outcome: "failure",
+        tags: ["validation"],
+      },
+    });
+    const defaultStorage = await orchestrator.getStorage("global");
+    await recordObjectiveStateSnapshot({
+      memoryDir: defaultStorage.dir,
+      snapshot: {
+        schemaVersion: 1,
+        snapshotId: "snap-routed-default-validation",
+        recordedAt: "2026-03-07T10:01:00.000Z",
+        sessionKey: "agent:main",
+        source: "tool_result",
+        kind: "process",
+        changeKind: "failed",
+        scope: "npm run validation",
+        summary: "Routed default validation failed in the namespace store.",
+        toolName: "exec_command",
+        command: "npm run validation",
+        outcome: "failure",
+        tags: ["validation"],
+      },
+    });
+
+    const context = await (orchestrator as any).recallInternal(
+      "Why did validation fail?",
+      "agent:main",
+    );
+
+    assert.match(context, /## Objective State/);
+    assert.match(context, /namespace store/i);
+    assert.equal(context.includes("old default store"), false);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/tests/objective-state-recall.test.ts
+++ b/tests/objective-state-recall.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 import { recordObjectiveStateSnapshot } from "../src/objective-state.js";
@@ -96,4 +96,94 @@ test("recall omits objective-state section when pipeline section is disabled", a
   );
 
   assert.equal(context.includes("## Objective State"), false);
+});
+
+test("recall searches objective-state snapshots from the requested namespace store", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-objective-state-recall-ns-"));
+  const cfg = parseConfig({
+    openaiApiKey: "test-openai-key",
+    memoryDir,
+    qmdEnabled: false,
+    transcriptEnabled: false,
+    sharedContextEnabled: false,
+    conversationIndexEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    namespacesEnabled: true,
+    defaultNamespace: "global",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      {
+        name: "team-a",
+        readPrincipals: ["alice"],
+        writePrincipals: ["alice"],
+        includeInRecallByDefault: false,
+      },
+    ],
+    defaultRecallNamespaces: ["self"],
+    objectiveStateMemoryEnabled: true,
+    objectiveStateSnapshotWritesEnabled: true,
+    objectiveStateRecallEnabled: true,
+    recallPipeline: [
+      {
+        id: "objective-state",
+        enabled: true,
+        maxResults: 2,
+        maxChars: 1200,
+      },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  try {
+    await recordObjectiveStateSnapshot({
+      memoryDir,
+      snapshot: {
+        schemaVersion: 1,
+        snapshotId: "snap-global-validation",
+        recordedAt: "2026-03-07T10:00:00.000Z",
+        sessionKey: "agent:main",
+        source: "tool_result",
+        kind: "process",
+        changeKind: "failed",
+        scope: "npm run validation",
+        summary: "Global validation failed with a default-namespace error.",
+        toolName: "exec_command",
+        command: "npm run validation",
+        outcome: "failure",
+        tags: ["validation"],
+      },
+    });
+    const teamStorage = await orchestrator.getStorage("team-a");
+    await recordObjectiveStateSnapshot({
+      memoryDir: teamStorage.dir,
+      snapshot: {
+        schemaVersion: 1,
+        snapshotId: "snap-team-validation",
+        recordedAt: "2026-03-07T10:01:00.000Z",
+        sessionKey: "team-a:agent:main",
+        source: "tool_result",
+        kind: "process",
+        changeKind: "failed",
+        scope: "npm run team-validation",
+        summary: "Team validation failed with a namespace-scoped error.",
+        toolName: "exec_command",
+        command: "npm run team-validation",
+        outcome: "failure",
+        tags: ["validation"],
+      },
+    });
+
+    const context = await (orchestrator as any).recallInternal(
+      "Why did validation fail?",
+      "agent:main",
+      { namespace: "team-a", principalOverride: "alice" },
+    );
+
+    assert.match(context, /## Objective State/);
+    assert.match(context, /namespace-scoped error/i);
+    assert.equal(context.includes("default-namespace error"), false);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });

--- a/tests/objective-state-recall.test.ts
+++ b/tests/objective-state-recall.test.ts
@@ -161,12 +161,30 @@ test("recall searches objective-state snapshots from the requested namespace sto
         schemaVersion: 1,
         snapshotId: "snap-team-validation",
         recordedAt: "2026-03-07T10:01:00.000Z",
-        sessionKey: "team-a:agent:main",
+        sessionKey: "agent:main",
         source: "tool_result",
         kind: "process",
         changeKind: "failed",
         scope: "npm run team-validation",
         summary: "Team validation failed with a namespace-scoped error.",
+        toolName: "exec_command",
+        command: "npm run team-validation",
+        outcome: "failure",
+        tags: ["validation"],
+      },
+    });
+    await recordObjectiveStateSnapshot({
+      memoryDir: teamStorage.dir,
+      snapshot: {
+        schemaVersion: 1,
+        snapshotId: "snap-team-other-validation",
+        recordedAt: "2026-03-07T10:02:00.000Z",
+        sessionKey: "agent:other",
+        source: "tool_result",
+        kind: "process",
+        changeKind: "failed",
+        scope: "npm run team-validation",
+        summary: "Other validation failed with a namespace-scoped error.",
         toolName: "exec_command",
         command: "npm run team-validation",
         outcome: "failure",
@@ -183,6 +201,11 @@ test("recall searches objective-state snapshots from the requested namespace sto
     assert.match(context, /## Objective State/);
     assert.match(context, /namespace-scoped error/i);
     assert.equal(context.includes("default-namespace error"), false);
+    assert.ok(
+      context.indexOf("Team validation failed") <
+        context.indexOf("Other validation failed"),
+      "raw session-key boost should rank the current session first",
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -953,7 +953,49 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages ignores status-only tool
   assert.equal(snapshots.length, 0);
 });
 
-test("deriveObjectiveStateSnapshotsFromObservedMessages pairs idless results only when adjacent in the same message", () => {
+test("deriveObjectiveStateSnapshotsFromObservedMessages pairs adjacent idless results across observed messages", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:58.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Running tests.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              name: "exec_command",
+              arguments: { cmd: "npm test" },
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: "Tool result: tests passed.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_result",
+            payload: {
+              output: { exitCode: 0, stdout: "ok" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.scope, "npm test");
+  assert.equal(snapshots[0]?.outcome, "success");
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages pairs idless results only when adjacent", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",
     recordedAt: "2026-03-07T12:07:00.000Z",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -236,6 +236,36 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages correlates OpenAI respon
   assert.equal(snapshots[0]?.metadata?.toolCallId, "call-openai-raw");
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages does not synthesize provider file-call success without output", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:44.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Attempted to write a file.",
+        sourceFormat: "openai",
+        rawContent: {
+          output: [
+            {
+              type: "function_call",
+              id: "fc-response-item",
+              call_id: "call-write-raw",
+              name: "write_file",
+              arguments: JSON.stringify({
+                path: "workspace/pending.txt",
+                content: "pending write",
+              }),
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 0);
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages uses stable ids for observed parts", () => {
   const input = {
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -200,6 +200,42 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages parses raw provider cont
   assert.equal(snapshots[0]?.metadata?.toolCallId, "raw-call");
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages correlates OpenAI response item ids by call_id", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:42.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran validation.",
+        sourceFormat: "openai",
+        rawContent: {
+          output: [
+            {
+              type: "function_call",
+              id: "fc-response-item",
+              call_id: "call-openai-raw",
+              name: "exec_command",
+              arguments: JSON.stringify({ cmd: "npm run validate" }),
+            },
+            {
+              type: "function_call_output",
+              call_id: "call-openai-raw",
+              output: JSON.stringify({ exitCode: 0, stdout: "ok" }),
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "executed");
+  assert.equal(snapshots[0]?.scope, "npm run validate");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "call-openai-raw");
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages uses stable ids for observed parts", () => {
   const input = {
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -266,6 +266,81 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages does not synthesize prov
   assert.equal(snapshots.length, 0);
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages pairs adjacent idless structured tool results", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:46.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran tests.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              name: "exec_command",
+              arguments: { cmd: "npm test" },
+            },
+          },
+          {
+            ordinal: 1,
+            kind: "tool_result",
+            payload: {
+              output: { exitCode: 0, stdout: "ok" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "executed");
+  assert.equal(snapshots[0]?.scope, "npm test");
+  assert.equal(snapshots[0]?.command, "npm test");
+  assert.ok(snapshots[0]?.metadata?.toolCallId);
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages uses adjacent idless file results instead of optimistic success", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:48.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Tried to write a file.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/failure.txt",
+            payload: {
+              content: "never landed",
+            },
+          },
+          {
+            ordinal: 1,
+            kind: "tool_result",
+            payload: {
+              output: { ok: false, error: "disk full" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "file");
+  assert.equal(snapshots[0]?.changeKind, "failed");
+  assert.equal(snapshots[0]?.outcome, "failure");
+  assert.deepEqual(snapshots[0]?.after, { ref: "workspace/failure.txt" });
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages uses stable ids for observed parts", () => {
   const input = {
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -346,6 +346,30 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages parses raw provider cont
   assert.equal(snapshots[0]?.metadata?.toolCallId, "raw-call");
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages does not fabricate success for raw idless file calls", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:41.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Writing a file.",
+        sourceFormat: "openclaw",
+        rawContent: {
+          role: "assistant",
+          toolName: "write_file",
+          input: {
+            path: "workspace/raw.txt",
+            content: "raw provider call without result",
+          },
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 0);
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages reads raw provider content when rendered parts are present", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -400,6 +400,44 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages pairs adjacent idless st
   assert.ok(snapshots[0]?.metadata?.toolCallId);
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages pairs idless results after identified tool calls", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:47.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran tests.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              id: "call-known-id",
+              name: "exec_command",
+              arguments: { cmd: "npm test" },
+            },
+          },
+          {
+            ordinal: 1,
+            kind: "tool_result",
+            payload: {
+              output: { exitCode: 0, stdout: "ok" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "executed");
+  assert.equal(snapshots[0]?.scope, "npm test");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "call-known-id");
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages uses adjacent idless file results instead of optimistic success", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -165,6 +165,55 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages ignores user-authored st
   assert.equal(snapshots.length, 0);
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages preserves Anthropic user-role tool results", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:38.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "I'll run validation.",
+        sourceFormat: "anthropic",
+        rawContent: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu-validate",
+              name: "exec_command",
+              input: { cmd: "npm run validate" },
+            },
+          ],
+        },
+      },
+      {
+        role: "user",
+        content: "Tool result",
+        sourceFormat: "anthropic",
+        rawContent: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu-validate",
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ exitCode: 0, stdout: "ok" }),
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "executed");
+  assert.equal(snapshots[0]?.scope, "npm run validate");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "toolu-validate");
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages parses raw provider content", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",
@@ -497,6 +546,38 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages uses inline file result 
   assert.equal(snapshots[0]?.changeKind, "failed");
   assert.equal(snapshots[0]?.outcome, "failure");
   assert.deepEqual(snapshots[0]?.after, { ref: "workspace/inline-failure.txt" });
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages does not treat file body content as inline result", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:50.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Observed a completed write.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/content.txt",
+            payload: {
+              path: "workspace/content.txt",
+              content: "Error: this text is the file body, not a tool failure.",
+              ok: true,
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "file");
+  assert.equal(snapshots[0]?.changeKind, "updated");
+  assert.equal(snapshots[0]?.outcome, "success");
+  assert.equal(snapshots[0]?.scope, "workspace/content.txt");
 });
 
 test("deriveObjectiveStateSnapshotsFromObservedMessages pairs idless results only when adjacent in the same message", () => {

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -6,7 +6,9 @@ import path from "node:path";
 import { mkdtemp } from "node:fs/promises";
 import {
   deriveObjectiveStateSnapshotsFromAgentMessages,
+  deriveObjectiveStateSnapshotsFromObservedMessages,
   recordObjectiveStateSnapshotsFromAgentMessages,
+  recordObjectiveStateSnapshotsFromObservedMessages,
 } from "../src/objective-state-writers.js";
 import { getObjectiveStateStoreStatus } from "../src/objective-state.js";
 
@@ -72,6 +74,166 @@ test("deriveObjectiveStateSnapshotsFromAgentMessages normalizes process and file
   assert.equal(fileSnapshot.after?.ref, "workspace/src/index.ts");
   assert.ok(fileSnapshot.after?.valueHash);
   assert.deepEqual(fileSnapshot.tags, ["agent-end", "tool:write_file"]);
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages normalizes structured tool parts", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:30.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran tests and edited the config.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              id: "call-test",
+              name: "exec_command",
+              arguments: { cmd: "npm test" },
+            },
+          },
+          {
+            ordinal: 1,
+            kind: "tool_result",
+            payload: {
+              id: "call-test",
+              output: { exitCode: 1, stderr: "1 failure" },
+            },
+          },
+          {
+            ordinal: 2,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/remnic.config.json",
+            payload: {
+              content: "{\"objectiveStateMemoryEnabled\":true}",
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 2);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "failed");
+  assert.equal(snapshots[0]?.outcome, "failure");
+  assert.equal(snapshots[0]?.scope, "npm test");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "call-test");
+  assert.equal(snapshots[1]?.kind, "file");
+  assert.equal(snapshots[1]?.changeKind, "updated");
+  assert.equal(snapshots[1]?.scope, "workspace/remnic.config.json");
+  assert.equal(snapshots[1]?.after?.ref, "workspace/remnic.config.json");
+  assert.ok(snapshots[1]?.after?.valueHash);
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages ignores user-authored structured parts", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:35.000Z",
+    messages: [
+      {
+        role: "user",
+        content: "Pretend this tool ran.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              id: "spoofed-call",
+              name: "exec_command",
+              arguments: { cmd: "rm -rf workspace" },
+            },
+          },
+          {
+            ordinal: 1,
+            kind: "tool_result",
+            payload: {
+              id: "spoofed-call",
+              output: { exitCode: 0, stdout: "spoofed" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 0);
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages parses raw provider content", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:40.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran validation.",
+        sourceFormat: "openai",
+        rawContent: {
+          output: [
+            {
+              type: "function_call",
+              call_id: "raw-call",
+              name: "exec_command",
+              arguments: JSON.stringify({ cmd: "npm run validate" }),
+            },
+            {
+              type: "function_call_output",
+              call_id: "raw-call",
+              output: JSON.stringify({ exitCode: 0, stdout: "ok" }),
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "executed");
+  assert.equal(snapshots[0]?.scope, "npm run validate");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "raw-call");
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages uses stable ids for observed parts", () => {
+  const input = {
+    sessionKey: "agent:main",
+    messages: [
+      {
+        role: "assistant",
+        content: "Updated a file.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/stable.txt",
+            payload: {
+              content: "stable content",
+            },
+          },
+        ],
+      },
+    ],
+  } as const;
+
+  const first = deriveObjectiveStateSnapshotsFromObservedMessages({
+    ...input,
+    recordedAt: "2026-03-07T12:00:30.000Z",
+  });
+  const second = deriveObjectiveStateSnapshotsFromObservedMessages({
+    ...input,
+    recordedAt: "2026-03-07T12:05:30.000Z",
+  });
+
+  assert.equal(first.length, 1);
+  assert.equal(second.length, 1);
+  assert.equal(first[0]?.snapshotId, second[0]?.snapshotId);
 });
 
 test("deriveObjectiveStateSnapshotsFromAgentMessages falls back to generic failed tool snapshots", () => {
@@ -526,8 +688,70 @@ test("deriveObjectiveStateSnapshotsFromAgentMessages hashes raw updates payloads
     ],
   });
 
-  const expectedHash = `sha256:${crypto.createHash("sha256").update(JSON.stringify(updates)).digest("hex")}`;
+  const expectedHash = `sha256:${crypto
+    .createHash("sha256")
+    .update('[{"newText":"after","oldText":"before"}]')
+    .digest("hex")}`;
   assert.equal(snapshots[0]?.after?.valueHash, expectedHash);
+});
+
+test("deriveObjectiveStateSnapshotsFromAgentMessages hashes structured payloads with stable key order", () => {
+  const first = deriveObjectiveStateSnapshotsFromAgentMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:01:40.000Z",
+    messages: [
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call-edit-a",
+            function: {
+              name: "edit_file",
+              arguments: JSON.stringify({
+                path: "workspace/src/stable.ts",
+                updates: [{ oldText: "before", newText: "after" }],
+              }),
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-edit-a",
+        name: "edit_file",
+        content: JSON.stringify({ ok: true }),
+      },
+    ],
+  });
+  const second = deriveObjectiveStateSnapshotsFromAgentMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:01:41.000Z",
+    messages: [
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call-edit-b",
+            function: {
+              name: "edit_file",
+              arguments: JSON.stringify({
+                path: "workspace/src/stable.ts",
+                updates: [{ newText: "after", oldText: "before" }],
+              }),
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-edit-b",
+        name: "edit_file",
+        content: JSON.stringify({ ok: true }),
+      },
+    ],
+  });
+
+  assert.equal(first[0]?.after?.valueHash, second[0]?.after?.valueHash);
 });
 
 test("recordObjectiveStateSnapshotsFromAgentMessages respects flags and persists derived snapshots", async () => {
@@ -589,4 +813,57 @@ test("recordObjectiveStateSnapshotsFromAgentMessages respects flags and persists
   });
   assert.equal(status.snapshots.total, 1);
   assert.equal(status.latestSnapshot?.scope, "workspace/archive/tmp.txt");
+});
+
+test("recordObjectiveStateSnapshotsFromObservedMessages respects flags and persists structured parts", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-objective-state-observed-"));
+  const input = {
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:02:30.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Created a note.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/observed.txt",
+            payload: {
+              content: "observed",
+            },
+          },
+        ],
+      },
+    ],
+  } as const;
+
+  const skipped = await recordObjectiveStateSnapshotsFromObservedMessages({
+    memoryDir,
+    objectiveStateMemoryEnabled: false,
+    objectiveStateSnapshotWritesEnabled: true,
+    ...input,
+  });
+  assert.equal(skipped.snapshots.length, 0);
+  assert.equal(skipped.filePaths.length, 0);
+
+  const written = await recordObjectiveStateSnapshotsFromObservedMessages({
+    memoryDir,
+    objectiveStateMemoryEnabled: true,
+    objectiveStateSnapshotWritesEnabled: true,
+    ...input,
+  });
+  assert.equal(written.snapshots.length, 1);
+  assert.equal(written.filePaths.length, 1);
+  assert.equal(written.snapshots[0]?.kind, "file");
+  assert.equal(written.snapshots[0]?.scope, "workspace/observed.txt");
+
+  const status = await getObjectiveStateStoreStatus({
+    memoryDir,
+    enabled: true,
+    writesEnabled: true,
+  });
+  assert.equal(status.snapshots.total, 1);
+  assert.equal(status.latestSnapshot?.scope, "workspace/observed.txt");
 });

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -214,6 +214,53 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages preserves Anthropic user
   assert.equal(snapshots[0]?.metadata?.toolCallId, "toolu-validate");
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages preserves normalized user-role tool result parts", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:39.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "I'll run validation.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              id: "toolu-normalized",
+              name: "exec_command",
+              arguments: { cmd: "npm run validate" },
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: "Tool result",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_result",
+            toolName: "untrusted_user_supplied_name",
+            payload: {
+              id: "toolu-normalized",
+              name: "untrusted_user_supplied_name",
+              output: { exitCode: 0, stdout: "ok" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.toolName, "exec_command");
+  assert.equal(snapshots[0]?.scope, "npm run validate");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "toolu-normalized");
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages parses raw provider content", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",
@@ -578,6 +625,45 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages does not treat file body
   assert.equal(snapshots[0]?.changeKind, "updated");
   assert.equal(snapshots[0]?.outcome, "success");
   assert.equal(snapshots[0]?.scope, "workspace/content.txt");
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages prefers separate result over tool-call status", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:55.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran tests.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              id: "call-status-then-result",
+              name: "exec_command",
+              arguments: { cmd: "npm test" },
+              status: "started",
+            },
+          },
+          {
+            ordinal: 1,
+            kind: "tool_result",
+            payload: {
+              id: "call-status-then-result",
+              output: { exitCode: 1, stderr: "failed" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "failed");
+  assert.equal(snapshots[0]?.outcome, "failure");
 });
 
 test("deriveObjectiveStateSnapshotsFromObservedMessages pairs idless results only when adjacent in the same message", () => {

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -666,6 +666,34 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages prefers separate result 
   assert.equal(snapshots[0]?.outcome, "failure");
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages ignores status-only tool calls", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:57.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Tool call lifecycle status changed.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              id: "call-status-only",
+              name: "exec_command",
+              arguments: { cmd: "npm test" },
+              status: "completed",
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 0);
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages pairs idless results only when adjacent in the same message", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -377,6 +377,55 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages uses stable ids for obse
   assert.equal(first[0]?.snapshotId, second[0]?.snapshotId);
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages includes top-level part scope in stable ids", () => {
+  const first = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:05:30.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Updated a file.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/first.txt",
+            payload: {
+              content: "same content",
+            },
+          },
+        ],
+      },
+    ],
+  });
+  const second = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:30.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Updated a file.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/second.txt",
+            payload: {
+              content: "same content",
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(first.length, 1);
+  assert.equal(second.length, 1);
+  assert.notEqual(first[0]?.snapshotId, second[0]?.snapshotId);
+});
+
 test("deriveObjectiveStateSnapshotsFromAgentMessages falls back to generic failed tool snapshots", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromAgentMessages({
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -370,6 +370,31 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages does not fabricate succe
   assert.equal(snapshots.length, 0);
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages ignores shorthand raw calls without results", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:42.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Running tests.",
+        sourceFormat: "remnic",
+        rawContent: {
+          parts: [
+            {
+              kind: "tool_call",
+              toolName: "exec_command",
+              arguments: { cmd: "npm test" },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 0);
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages reads raw provider content when rendered parts are present", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",
@@ -859,6 +884,39 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages does not treat file body
   assert.equal(snapshots[0]?.changeKind, "updated");
   assert.equal(snapshots[0]?.outcome, "success");
   assert.equal(snapshots[0]?.scope, "workspace/content.txt");
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages records identified explicit file writes without separate results", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:51.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Observed a completed write.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/identified.txt",
+            payload: {
+              id: "call-write-identified",
+              path: "workspace/identified.txt",
+              content: "identified write",
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "file");
+  assert.equal(snapshots[0]?.changeKind, "updated");
+  assert.equal(snapshots[0]?.outcome, "success");
+  assert.equal(snapshots[0]?.scope, "workspace/identified.txt");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "call-write-identified");
 });
 
 test("deriveObjectiveStateSnapshotsFromObservedMessages ignores rendered patch prose without provider evidence", () => {

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -214,6 +214,56 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages preserves Anthropic user
   assert.equal(snapshots[0]?.metadata?.toolCallId, "toolu-validate");
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages preserves Anthropic tool result failures", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:38.500Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "I'll run validation.",
+        sourceFormat: "anthropic",
+        rawContent: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu-failed-validate",
+              name: "exec_command",
+              input: { cmd: "npm run validate" },
+            },
+          ],
+        },
+      },
+      {
+        role: "user",
+        content: "Tool result",
+        sourceFormat: "anthropic",
+        rawContent: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu-failed-validate",
+              is_error: true,
+              content: [
+                {
+                  type: "text",
+                  text: "exit code 1",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "failed");
+  assert.equal(snapshots[0]?.outcome, "failure");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "toolu-failed-validate");
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages preserves normalized user-role tool result parts", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -346,6 +346,97 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages parses raw provider cont
   assert.equal(snapshots[0]?.metadata?.toolCallId, "raw-call");
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages reads raw provider content when rendered parts are present", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:41.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran validation.",
+        parts: [
+          {
+            kind: "text",
+            payload: { text: "Ran validation." },
+          },
+        ],
+        sourceFormat: "openai",
+        rawContent: {
+          output: [
+            {
+              type: "function_call",
+              call_id: "raw-call-with-rendered-parts",
+              name: "exec_command",
+              arguments: JSON.stringify({ cmd: "npm run validate" }),
+            },
+            {
+              type: "function_call_output",
+              call_id: "raw-call-with-rendered-parts",
+              output: JSON.stringify({ exitCode: 0, stdout: "ok" }),
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "executed");
+  assert.equal(snapshots[0]?.scope, "npm run validate");
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "raw-call-with-rendered-parts");
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages deduplicates explicit and raw provider parts", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:00:41.500Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran validation.",
+        parts: [
+          {
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              id: "raw-call-duplicated",
+              name: "exec_command",
+              arguments: { cmd: "npm run validate" },
+            },
+          },
+          {
+            kind: "tool_result",
+            payload: {
+              id: "raw-call-duplicated",
+              output: { exitCode: 0, stdout: "ok" },
+            },
+          },
+        ],
+        sourceFormat: "openai",
+        rawContent: {
+          output: [
+            {
+              type: "function_call",
+              call_id: "raw-call-duplicated",
+              name: "exec_command",
+              arguments: JSON.stringify({ cmd: "npm run validate" }),
+            },
+            {
+              type: "function_call_output",
+              call_id: "raw-call-duplicated",
+              output: JSON.stringify({ exitCode: 0, stdout: "ok" }),
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.metadata?.toolCallId, "raw-call-duplicated");
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages correlates OpenAI response item ids by call_id", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -369,12 +369,48 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages uses stable ids for obse
   });
   const second = deriveObjectiveStateSnapshotsFromObservedMessages({
     ...input,
-    recordedAt: "2026-03-07T12:05:30.000Z",
+    recordedAt: "2026-03-07T12:00:30.000Z",
   });
 
   assert.equal(first.length, 1);
   assert.equal(second.length, 1);
   assert.equal(first[0]?.snapshotId, second[0]?.snapshotId);
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages does not reuse stable ids across times", () => {
+  const input = {
+    sessionKey: "agent:main",
+    messages: [
+      {
+        role: "assistant",
+        content: "Updated a file.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/stable-time.txt",
+            payload: {
+              content: "stable content",
+            },
+          },
+        ],
+      },
+    ],
+  } as const;
+
+  const first = deriveObjectiveStateSnapshotsFromObservedMessages({
+    ...input,
+    recordedAt: "2026-03-07T12:00:30.000Z",
+  });
+  const second = deriveObjectiveStateSnapshotsFromObservedMessages({
+    ...input,
+    recordedAt: "2026-03-07T12:05:30.000Z",
+  });
+
+  assert.equal(first.length, 1);
+  assert.equal(second.length, 1);
+  assert.notEqual(first[0]?.snapshotId, second[0]?.snapshotId);
 });
 
 test("deriveObjectiveStateSnapshotsFromObservedMessages includes top-level part scope in stable ids", () => {
@@ -424,6 +460,84 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages includes top-level part 
   assert.equal(first.length, 1);
   assert.equal(second.length, 1);
   assert.notEqual(first[0]?.snapshotId, second[0]?.snapshotId);
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages uses inline file result payloads before synthesizing success", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:45.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Observed a failed write.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "file_write",
+            toolName: "write_file",
+            filePath: "workspace/inline-failure.txt",
+            payload: {
+              input: {
+                path: "workspace/inline-failure.txt",
+                content: "failed",
+              },
+              output: {
+                ok: false,
+                error: "disk full",
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "file");
+  assert.equal(snapshots[0]?.changeKind, "failed");
+  assert.equal(snapshots[0]?.outcome, "failure");
+  assert.deepEqual(snapshots[0]?.after, { ref: "workspace/inline-failure.txt" });
+});
+
+test("deriveObjectiveStateSnapshotsFromObservedMessages pairs idless results only when adjacent in the same message", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:07:00.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran tests.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              name: "exec_command",
+              arguments: { cmd: "npm test" },
+            },
+          },
+          {
+            ordinal: 1,
+            kind: "file_read",
+            filePath: "workspace/package.json",
+            payload: {
+              path: "workspace/package.json",
+            },
+          },
+          {
+            ordinal: 2,
+            kind: "tool_result",
+            payload: {
+              output: { exitCode: 0, stdout: "ok" },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 0);
 });
 
 test("deriveObjectiveStateSnapshotsFromAgentMessages falls back to generic failed tool snapshots", () => {

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -715,6 +715,27 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages does not treat file body
   assert.equal(snapshots[0]?.scope, "workspace/content.txt");
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages ignores rendered patch prose without provider evidence", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:52.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          "Here is the patch I suggest:",
+          "*** Begin Patch",
+          "*** Update File: workspace/suggested.txt",
+          "+suggested only",
+          "*** End Patch",
+        ].join("\n"),
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 0);
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages prefers separate result over tool-call status", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -736,6 +736,34 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages ignores rendered patch p
   assert.equal(snapshots.length, 0);
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages ignores text-only raw assistant patch prose", () => {
+  const patchSuggestion = [
+    "Here is the patch I suggest:",
+    "*** Begin Patch",
+    "*** Update File: workspace/suggested-raw.txt",
+    "+suggested only",
+    "*** End Patch",
+  ].join("\n");
+
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:53.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: patchSuggestion,
+        sourceFormat: "openclaw",
+        rawContent: {
+          role: "assistant",
+          content: patchSuggestion,
+        },
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 0);
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages prefers separate result over tool-call status", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",

--- a/tests/objective-state-writers.test.ts
+++ b/tests/objective-state-writers.test.ts
@@ -774,6 +774,37 @@ test("deriveObjectiveStateSnapshotsFromObservedMessages uses inline file result 
   assert.deepEqual(snapshots[0]?.after, { ref: "workspace/inline-failure.txt" });
 });
 
+test("deriveObjectiveStateSnapshotsFromObservedMessages treats inline stdout as a tool result", () => {
+  const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
+    sessionKey: "agent:main",
+    recordedAt: "2026-03-07T12:06:47.000Z",
+    messages: [
+      {
+        role: "assistant",
+        content: "Ran tests.",
+        parts: [
+          {
+            ordinal: 0,
+            kind: "tool_call",
+            toolName: "exec_command",
+            payload: {
+              name: "exec_command",
+              arguments: { cmd: "npm test" },
+              stdout: "All tests pass.",
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.kind, "process");
+  assert.equal(snapshots[0]?.changeKind, "executed");
+  assert.equal(snapshots[0]?.scope, "npm test");
+  assert.equal(snapshots[0]?.outcome, "success");
+});
+
 test("deriveObjectiveStateSnapshotsFromObservedMessages does not treat file body content as inline result", () => {
   const snapshots = deriveObjectiveStateSnapshotsFromObservedMessages({
     sessionKey: "agent:main",

--- a/tests/openclaw-adapter-scenarios.test.ts
+++ b/tests/openclaw-adapter-scenarios.test.ts
@@ -373,7 +373,7 @@ test("scenario: agent_end objective-state snapshots use namespaced configured st
     const snapshot = JSON.parse(
       fs.readFileSync(snapshotFiles[0]!, "utf8"),
     ) as { sessionKey?: string; kind?: string; scope?: string };
-    assert.equal(snapshot.sessionKey, `${namespace}:agent-session`);
+    assert.equal(snapshot.sessionKey, "agent-session");
     assert.equal(snapshot.kind, "process");
     assert.equal(snapshot.scope, "npm test");
     assert.equal(fs.existsSync(path.join(overrideDir, "snapshots")), false);

--- a/tests/openclaw-adapter-scenarios.test.ts
+++ b/tests/openclaw-adapter-scenarios.test.ts
@@ -65,6 +65,20 @@ async function withScenarioRegistration(
   }
 }
 
+function listJsonFiles(root: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listJsonFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort((left, right) => left.localeCompare(right));
+}
+
 test("scenario: memory_store writes through the registered tool and memory_search routes through active memory search", async () => {
   await withScenarioRegistration(async ({ capture, orchestrator }) => {
     const store = registeredTool(capture, "memory_store");
@@ -299,6 +313,70 @@ test("scenario: agent_end buffers the last user and assistant turns without live
     assert.match(processed[0].content, /compact dashboard preference/);
     assert.equal(processed[0].options.logicalSessionKey, "agent-session");
     assert.equal(processed[0].options.bufferKey, "agent-session");
+  });
+});
+
+test("scenario: agent_end objective-state snapshots use namespaced configured store overrides", async () => {
+  await withScenarioRegistration(async ({ capture, orchestrator, memoryDir }) => {
+    const namespace = "project-a";
+    const namespaceDir = path.join(memoryDir, "namespaces", namespace);
+    const overrideDir = path.join(memoryDir, "objective-override");
+    orchestrator.config.namespacesEnabled = true;
+    orchestrator.config.objectiveStateMemoryEnabled = true;
+    orchestrator.config.objectiveStateSnapshotWritesEnabled = true;
+    orchestrator.config.objectiveStateStoreDir = overrideDir;
+    orchestrator.resolveSelfNamespace = () => namespace;
+    orchestrator.getStorageForNamespace = async (requestedNamespace: string) => {
+      assert.equal(requestedNamespace, namespace);
+      return { dir: namespaceDir };
+    };
+    orchestrator.processTurn = async () => {};
+
+    const agentEnd = registeredHook(capture, "agent_end");
+    await agentEnd(
+      {
+        success: true,
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call-agent-end-test",
+                function: {
+                  name: "exec_command",
+                  arguments: JSON.stringify({ cmd: "npm test" }),
+                },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "call-agent-end-test",
+            name: "exec_command",
+            content: JSON.stringify({ exitCode: 0, stdout: "ok" }),
+          },
+          { role: "user", content: "Please remember that tests passed." },
+          { role: "assistant", content: "Tests passed." },
+        ],
+      },
+      { sessionKey: "agent-session" },
+    );
+
+    const snapshotsRoot = path.join(
+      overrideDir,
+      "namespaces",
+      namespace,
+      "snapshots",
+    );
+    const snapshotFiles = listJsonFiles(snapshotsRoot);
+    assert.equal(snapshotFiles.length, 1);
+    const snapshot = JSON.parse(
+      fs.readFileSync(snapshotFiles[0]!, "utf8"),
+    ) as { sessionKey?: string; kind?: string; scope?: string };
+    assert.equal(snapshot.sessionKey, `${namespace}:agent-session`);
+    assert.equal(snapshot.kind, "process");
+    assert.equal(snapshot.scope, "npm test");
+    assert.equal(fs.existsSync(path.join(overrideDir, "snapshots")), false);
   });
 });
 

--- a/tests/resume-bundles.test.ts
+++ b/tests/resume-bundles.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import {
   buildResumeBundleFromState,
   getResumeBundleStatus,
@@ -438,6 +438,73 @@ test("buildResumeBundleFromState assembles transcript, objective-state, work-pro
   assert.deepEqual(bundle.nextActions, ["Open the PR once builder verification passes."]);
   assert.equal(bundle.riskFlags?.some((flag) => /Verification failed in the resume-bundle builder tests\./.test(flag)), true);
   assert.equal(bundle.riskFlags?.some((flag) => /checkpoint/i.test(flag)), true);
+});
+
+test("buildResumeBundleFromState finds raw session snapshots in namespaced objective-state override stores", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-resume-bundle-ns-"));
+  const objectiveStateStoreDir = await mkdtemp(path.join(os.tmpdir(), "engram-resume-bundle-ns-override-"));
+  const namespace = "team-a";
+  const namespaceDir = path.join(memoryDir, "namespaces", namespace);
+  const namespaceObjectiveStateStoreDir = path.join(objectiveStateStoreDir, "namespaces", namespace);
+  const sessionKey = "agent:main";
+  await mkdir(namespaceDir, { recursive: true });
+
+  try {
+    await recordObjectiveStateSnapshot({
+      memoryDir: namespaceDir,
+      objectiveStateStoreDir: namespaceObjectiveStateStoreDir,
+      snapshot: {
+        schemaVersion: 1,
+        snapshotId: "snap-team-raw-session",
+        recordedAt: "2026-03-08T04:11:00.000Z",
+        sessionKey,
+        source: "tool_result",
+        kind: "process",
+        changeKind: "executed",
+        scope: "npm test",
+        summary: "Team namespace verification passed.",
+        command: "npm test",
+        outcome: "success",
+        tags: ["verification"],
+      },
+    });
+    await recordObjectiveStateSnapshot({
+      memoryDir: namespaceDir,
+      objectiveStateStoreDir: namespaceObjectiveStateStoreDir,
+      snapshot: {
+        schemaVersion: 1,
+        snapshotId: "snap-team-prefixed-session",
+        recordedAt: "2026-03-08T04:12:00.000Z",
+        sessionKey: `${namespace}:${sessionKey}`,
+        source: "tool_result",
+        kind: "process",
+        changeKind: "failed",
+        scope: "npm run stale",
+        summary: "Legacy prefixed session key should not match raw session lookups.",
+        command: "npm run stale",
+        outcome: "failure",
+      },
+    });
+
+    const bundle = await buildResumeBundleFromState({
+      memoryDir: namespaceDir,
+      objectiveStateStoreDir: namespaceObjectiveStateStoreDir,
+      sessionKey,
+      bundleId: "resume-ns-raw-session",
+      recordedAt: "2026-03-08T04:13:00.000Z",
+      scope: "namespaced objective-state",
+      objectiveStateMemoryEnabled: true,
+    });
+
+    assert.deepEqual(bundle.objectiveStateSnapshotRefs, ["snap-team-raw-session"]);
+    assert.equal(
+      bundle.objectiveStateSnapshotRefs?.includes("snap-team-prefixed-session"),
+      false,
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(objectiveStateStoreDir, { recursive: true, force: true });
+  }
 });
 
 test("buildResumeBundleFromState filters commitments to open entries before applying the recency cap", async () => {


### PR DESCRIPTION
## Summary
- capture objective-state snapshots from assistant observed structured parts and raw provider content
- route LCM summarization through the configured gateway internal LLM in benchmark/internal-provider mode
- tighten explicit trajectory cue recall for successor/next-action questions while preserving non-successor step boundaries

## Verification
- npm run check-types
- npm run check-config-contract
- npm run plugin:inspect
- bash scripts/check-review-patterns.sh
- npm run test:entity-hardening
- pnpm --filter @remnic/core run check-types
- pnpm --filter @remnic/bench run check-types
- node node_modules/tsx/dist/cli.mjs --test tests/objective-state-writers.test.ts tests/access-service-objective-state.test.ts packages/remnic-core/src/message-parts/message-parts.test.ts packages/remnic-core/src/explicit-cue-recall.test.ts tests/lcm-gateway-summarizer.test.ts
- node node_modules/tsx/dist/cli.mjs --test packages/bench/src/runtime-profiles.test.ts
- pnpm exec tsx --test tests/openclaw-registration-capture.test.ts tests/openclaw-sdk-surface-check.test.ts tests/openclaw-adapter-scenarios.test.ts tests/openclaw-hook-privacy.test.ts tests/intent.test.ts tests/runtime-input-guards.test.ts tests/artifact-recall-limit.test.ts tests/artifact-status-snapshot.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts

Note: the standalone register-multi-registry assertions completed, but the process timed out under a 180s wrapper because an existing QMD MCP handle stayed open after tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persist and query objective-state snapshots across namespaces and multiple message-part formats, plus adjusts LCM summarization routing; mistakes could lead to missing/incorrect snapshots or cross-namespace leakage despite added ACL checks and tests.
> 
> **Overview**
> Adds objective-state snapshot capture to `EngramAccessService.observe()` by deriving snapshots from *observed* structured `parts` and raw provider payloads, writing them to the correct namespace/coding-overlay store (including configured store overrides) with best-effort error handling.
> 
> Extends objective-state recall and resume-bundle collection to search across namespaced storage/override directories, and updates snapshot hashing/IDs for stability and better tool-call correlation.
> 
> Improves interoperability and recall quality: message-part parsing now preserves tool-result error flags, supports OpenAI response `call_id`/item-id mapping, and allows disabling rendered-text fallback; explicit cue recall can optionally include the immediate successor action/observation when the query asks “what happened next”; LCM summarization can route through the gateway internal LLM when `modelSource` is `gateway`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ca762f761dad5b260cd0e24f3828e7ac5e7590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->