### PR TITLE
fix(bench): honor slow internal LLM drain timeouts

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -30,6 +30,7 @@ export interface RemnicAdapterOptions {
   preserveRuntimeDefaults?: boolean;
   responder?: BenchResponder;
   judge?: BenchJudge;
+  drainTimeoutMs?: number;
 }
 
 type BenchAdapterMode = "lightweight" | "direct";
@@ -116,6 +117,7 @@ type OrchestratorTeardownView = {
 };
 
 const BENCH_TEARDOWN_DEFERRED_READY_WAIT_MS = 500;
+const DEFAULT_BENCH_DRAIN_TIMEOUT_MS = 5 * 60_000;
 const CORE_EXPLICIT_CUE_MAX_CHARS = 18_000;
 const CORE_EXPLICIT_CUE_MAX_ITEM_CHARS = 2_400;
 const CORE_EXPLICIT_CUE_MAX_REFERENCES = 24;
@@ -321,6 +323,18 @@ function resolveConfiguredQmdBinary(value: string): string {
   return path.resolve(trimmed);
 }
 
+function normalizeDrainTimeoutMs(value: unknown): number {
+  if (value === undefined) {
+    return DEFAULT_BENCH_DRAIN_TIMEOUT_MS;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(
+      `benchmark drain timeout must be a positive integer; received ${String(value)}`,
+    );
+  }
+  return value;
+}
+
 async function removeBenchQmdSandbox(sandbox: BenchQmdSandbox): Promise<void> {
   if (!sandbox.indexName.startsWith("remnic-bench-")) {
     return;
@@ -336,6 +350,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
     options: RemnicAdapterOptions = {},
   ): Promise<BenchMemoryAdapter> {
     const useCoreMemoryPipeline = shouldUseCoreMemoryPipeline(mode, options);
+    const drainTimeoutMs = normalizeDrainTimeoutMs(options.drainTimeoutMs);
     let state = await createBenchOrchestrator(
       mode,
       options.configOverrides,
@@ -640,23 +655,22 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       },
 
       async drain(): Promise<void> {
-        const DRAIN_TIMEOUT_MS = 5 * 60_000;
         const engine = getEngine();
         const abortController = new AbortController();
         let timer: ReturnType<typeof setTimeout> | undefined;
         const timeout = new Promise<void>((_, reject) => {
           timer = setTimeout(() => {
             abortController.abort();
-            reject(new Error("drain() timed out after 5 minutes"));
-          }, DRAIN_TIMEOUT_MS);
+            reject(new Error(`drain() timed out after ${drainTimeoutMs}ms`));
+          }, drainTimeoutMs);
         });
         try {
           await Promise.race([
             (async () => {
               const [, extractionIdle, consolidationIdle] = await Promise.all([
                 engine.waitForObserveQueueIdle(),
-                state.orchestrator.waitForExtractionIdle(DRAIN_TIMEOUT_MS),
-                state.orchestrator.waitForConsolidationIdle(DRAIN_TIMEOUT_MS),
+                state.orchestrator.waitForExtractionIdle(drainTimeoutMs),
+                state.orchestrator.waitForConsolidationIdle(drainTimeoutMs),
               ]);
               if (!extractionIdle) {
                 throw new Error("drain() timed out waiting for extraction idle");

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -353,12 +353,15 @@ test("runtime profile can route Remnic internal LLM calls through codex-cli", as
     internalProvider: "codex-cli",
     internalModel: "gpt-5.5",
     internalCodexReasoningEffort: "xhigh",
+    requestTimeout: 900_000,
   });
 
+  assert.equal(resolved.adapterOptions.drainTimeoutMs, 900_000);
   assert.deepEqual(resolved.internalProvider, {
     provider: "codex-cli",
     model: "gpt-5.5",
     baseUrl: "codex-cli://local",
+    retryOptions: { timeoutMs: 900_000 },
     reasoningEffort: "xhigh",
   });
   assert.equal(resolved.remnicConfig.modelSource, "gateway");

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -67,6 +67,7 @@ export interface ResolvedBenchRuntimeProfile {
     preserveRuntimeDefaults?: boolean;
     responder?: BenchResponder;
     judge?: BenchJudge;
+    drainTimeoutMs?: number;
   };
   systemProvider: ProviderConfig | null;
   judgeProvider: ProviderConfig | null;
@@ -122,6 +123,7 @@ export async function resolveBenchRuntimeProfile(
     internalProvider,
     { disableThinking: options.internalDisableThinking === true },
   );
+  const drainTimeoutMs = normalizeDrainTimeoutMs(options.requestTimeout);
   registerCodexCliFallbackRunnerIfNeeded(internalProvider);
   const responderFactoryConfig = systemProvider
     ? asProviderFactoryConfig(systemProvider)
@@ -161,6 +163,7 @@ export async function resolveBenchRuntimeProfile(
         configOverrides: effectiveRemnicConfig,
         responder,
         judge,
+        ...(drainTimeoutMs ? { drainTimeoutMs } : {}),
       },
       systemProvider,
       judgeProvider,
@@ -205,6 +208,7 @@ export async function resolveBenchRuntimeProfile(
         preserveRuntimeDefaults: true,
         responder,
         judge,
+        ...(drainTimeoutMs ? { drainTimeoutMs } : {}),
       },
       systemProvider,
       judgeProvider,
@@ -259,6 +263,7 @@ export async function resolveBenchRuntimeProfile(
       preserveRuntimeDefaults: true,
       responder: gatewayResponder,
       judge,
+      ...(drainTimeoutMs ? { drainTimeoutMs } : {}),
     },
     systemProvider: null,
     judgeProvider,
@@ -400,6 +405,18 @@ function resolveProviderConfig(
     ...(disableThinking ? { disableThinking: true } : {}),
     ...(provider === "codex-cli" ? { reasoningEffort: reasoningEffort ?? "xhigh" } : {}),
   };
+}
+
+function normalizeDrainTimeoutMs(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(
+      `request timeout must be a positive integer when used for benchmark drain; received ${value}`,
+    );
+  }
+  return value;
 }
 
 function applyInternalProviderDefaults(


### PR DESCRIPTION
## Summary
- add a configurable benchmark adapter drain timeout
- pass benchmark `--request-timeout` through runtime profiles into adapter drain
- cover Codex internal-provider timeout attribution in runtime profile tests

## Verification
- `pnpm exec tsx --test --test-reporter=dot packages/bench/src/runtime-profiles.test.ts packages/bench/src/adapters/remnic-adapter.test.ts tests/lcm-gateway-summarizer.test.ts`
- `npm run check-types`
- `git diff --check`
- `npm run preflight:quick` progressed through typecheck, config contract, plugin inspect, review-patterns, OpenClaw registration/surface/scenario/privacy, then stalled in `tests/register-multi-registry.test.ts`; interrupted after several minutes of no output/CPU, matching the existing local preflight hang point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark adapter shutdown/drain logic and timeout propagation, which could impact benchmark stability (hangs vs premature timeouts) if misconfigured. Changes are scoped to bench/runtime-profile plumbing with straightforward validation.
> 
> **Overview**
> **Benchmark drain is now configurable.** The Remnic bench adapter accepts `drainTimeoutMs`, validates it, and uses it for the `drain()` watchdog timer and the extraction/consolidation idle waits (replacing the hard-coded 5 minute limit).
> 
> **Runtime profiles now propagate request timeout into drain + providers.** `resolveBenchRuntimeProfile` derives `adapterOptions.drainTimeoutMs` from `requestTimeout` (with validation) and tests are updated to assert that Codex internal-provider runs set both provider `retryOptions.timeoutMs` and the adapter drain timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a44640d4babd047578c170b98e8b263c343470f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->