### PR TITLE
fix(bench): fail AMA-Bench on drain errors

### DIFF
--- a/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
@@ -97,6 +97,48 @@ test("AMA-Bench normalizes sparse null trajectory fields from the official datas
   }
 });
 
+test("AMA-Bench fails fast when trajectory drain fails before scoring", async () => {
+  let completedTasks = 0;
+  let recallCalls = 0;
+
+  await assert.rejects(
+    () =>
+      runAmaBenchBenchmark({
+        benchmark: amaBenchDefinition,
+        mode: "quick",
+        onTaskComplete() {
+          completedTasks += 1;
+        },
+        system: {
+          async store() {},
+          async recall() {
+            recallCalls += 1;
+            return "Spanish";
+          },
+          async search() {
+            return [];
+          },
+          async reset() {},
+          async getStats() {
+            return {
+              totalMessages: 4,
+              totalSummaryNodes: 0,
+              maxDepth: 0,
+            };
+          },
+          async drain() {
+            throw new Error("drain timed out");
+          },
+          async destroy() {},
+        },
+      }),
+    /AMA-Bench drain failed for episode 1: drain timed out/,
+  );
+
+  assert.equal(recallCalls, 0);
+  assert.equal(completedTasks, 0);
+});
+
 test("AMA-Bench records recommended and cross-judge protocol metrics", async () => {
   const result = await runAmaBenchBenchmark({
     benchmark: amaBenchDefinition,

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -76,7 +76,10 @@ export async function runAmaBenchBenchmark(
     try {
       await options.system.drain?.();
     } catch (drainErr) {
-      console.error(`  [WARN] ama-bench drain failed for episode ${episode.episode_id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+      const message = drainErr instanceof Error ? drainErr.message : String(drainErr);
+      throw new Error(
+        `AMA-Bench drain failed for episode ${episode.episode_id}: ${message}`,
+      );
     }
 
     for (const qa of episode.qa_pairs) {


### PR DESCRIPTION
## Summary
- make AMA-Bench trajectory drain failures fatal instead of warning and continuing
- add a regression test proving no recall/scoring/progress is emitted after failed drain

## Verification
- pnpm exec tsx --test packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check

This prevents leaderboard-style AMA artifacts from silently mixing fully drained and partially indexed episodes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AMA-Bench execution flow to throw on `system.drain()` failures, which can cause benchmark runs that previously completed (with warnings) to now abort early. Risk is limited to benchmarking/metrics correctness but affects CI/leaderboard pipelines that depend on this runner.
> 
> **Overview**
> AMA-Bench now treats `system.drain()` failures as **fatal**: the runner throws `AMA-Bench drain failed for episode …` instead of logging a warning and continuing into recall/scoring.
> 
> Adds a regression test asserting that when drain fails, the run rejects immediately and does **not** call `recall()` or emit `onTaskComplete` progress events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d40032fe81bd713106cb488637ec8a4277a37c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->