### PR TITLE
Align OpenClaw 2026.5 compatibility

### DIFF
--- a/.changeset/openclaw-2026-5-6-compat.md
+++ b/.changeset/openclaw-2026-5-6-compat.md
@@ -1,0 +1,9 @@
+---
+"@remnic/core": patch
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Refresh OpenClaw adapter compatibility metadata for OpenClaw 2026.5.6 and pass
+workspace context into gateway-backed runtime auth resolution so Remnic follows
+OpenClaw's workspace-scoped provider/auth path on recent 2026.5 releases.

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -164,6 +164,13 @@ CI jobs that provision OpenClaw should use
 `npm run check:openclaw-sdk-surface:required` or pass
 `-- --require --package-root <path>` so a missing SDK fails instead of skipping.
 
+Last compatibility sweep: May 7, 2026. The SDK surface check passed against
+`openclaw@2026.5.3`, `openclaw@2026.5.3-1`, `openclaw@2026.5.4-beta.1`,
+`openclaw@2026.5.4-beta.2`, `openclaw@2026.5.4-beta.3`,
+`openclaw@2026.5.4`, `openclaw@2026.5.5`, and `openclaw@2026.5.6`.
+Keep the peer range broad unless an upstream release removes a runtime surface
+Remnic actively uses.
+
 Native memory registrars are tracked separately in
 [`docs/plugins/openclaw-native-memory-registrars.md`](../../docs/plugins/openclaw-native-memory-registrars.md).
 That spike explains why Remnic currently uses `registerMemoryCapability()` as

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -26,8 +26,8 @@
       "pluginApi": ">=2026.4.8"
     },
     "build": {
-      "openclawVersion": "2026.5.2",
-      "pluginSdkVersion": "2026.5.2"
+      "openclawVersion": "2026.5.6",
+      "pluginSdkVersion": "2026.5.6"
     },
     "install": {
       "minHostVersion": ">=2026.4.8"

--- a/packages/remnic-core/src/calibration.ts
+++ b/packages/remnic-core/src/calibration.ts
@@ -305,9 +305,12 @@ export async function runCalibrationConsolidation(options: {
   memoryDir: string;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  workspaceDir?: string;
 }): Promise<CalibrationRule[]> {
   try {
-    const llm = new FallbackLlmClient(options.gatewayConfig);
+    const llm = new FallbackLlmClient(options.gatewayConfig, {
+      workspaceDir: options.workspaceDir,
+    });
     if (!llm.isAvailable(options.gatewayAgentId)) {
       log.debug("[calibration] no LLM available — skipping consolidation");
       return [];
@@ -367,6 +370,7 @@ export async function runCalibrationIfEnabled(options: {
   memoryDir: string;
   calibrationEnabled: boolean;
   gatewayConfig?: GatewayConfig;
+  workspaceDir?: string;
 }): Promise<CalibrationRule[]> {
   if (!options.calibrationEnabled) {
     return [];
@@ -374,6 +378,7 @@ export async function runCalibrationIfEnabled(options: {
   return runCalibrationConsolidation({
     memoryDir: options.memoryDir,
     gatewayConfig: options.gatewayConfig,
+    workspaceDir: options.workspaceDir,
   });
 }
 

--- a/packages/remnic-core/src/causal-consolidation.ts
+++ b/packages/remnic-core/src/causal-consolidation.ts
@@ -260,6 +260,7 @@ export async function deriveCausalPromotionCandidates(options: {
   config: ConsolidationConfig;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  workspaceDir?: string;
   pluginConfig?: PluginConfig;
 }): Promise<CausalPatternCandidate[]> {
   try {
@@ -281,7 +282,9 @@ export async function deriveCausalPromotionCandidates(options: {
     }
 
     // If no LLM available, fall back to empty (no deterministic fallback)
-    const llm = new FallbackLlmClient(options.gatewayConfig);
+    const llm = new FallbackLlmClient(options.gatewayConfig, {
+      workspaceDir: options.pluginConfig?.workspaceDir ?? options.workspaceDir,
+    });
     if (!llm.isAvailable(options.gatewayAgentId)) {
       log.debug("[cmc] no LLM available for consolidation — skipping");
       return [];
@@ -308,6 +311,7 @@ export async function synthesizeCausalPreferencesViaLlm(options: {
   causalTrajectoryStoreDir?: string;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  workspaceDir?: string;
   minTrajectories?: number;
 }): Promise<string | null> {
   try {
@@ -318,7 +322,9 @@ export async function synthesizeCausalPreferencesViaLlm(options: {
     const chainIndex = await readChainIndex(chainsDir);
     const context = formatCausalContext(trajectories, chainIndex);
 
-    const llm = new FallbackLlmClient(options.gatewayConfig);
+    const llm = new FallbackLlmClient(options.gatewayConfig, {
+      workspaceDir: options.workspaceDir,
+    });
     if (!llm.isAvailable(options.gatewayAgentId)) return null;
 
     const result = await consolidateWithLlm(context, llm, options.gatewayAgentId);

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -492,6 +492,7 @@ export class CompoundingEngine {
           causalTrajectoryStoreDir: this.config.causalTrajectoryStoreDir,
           gatewayConfig: this.config.gatewayConfig,
           gatewayAgentId: this.config.modelSource === "gateway" ? (this.config.gatewayAgentId || undefined) : undefined,
+          workspaceDir: this.config.workspaceDir,
           pluginConfig: this.config,
           config: {
             minRecurrence: this.config.cmcConsolidationMinRecurrence,
@@ -533,6 +534,7 @@ export class CompoundingEngine {
           memoryDir: this.config.memoryDir,
           gatewayConfig: this.config.gatewayConfig,
           gatewayAgentId: this.config.modelSource === "gateway" ? (this.config.gatewayAgentId || undefined) : undefined,
+          workspaceDir: this.config.workspaceDir,
         });
         log.debug(`[calibration] weekly synthesis produced ${calRules.length} calibration rule(s)`);
       } catch (error) {

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -114,7 +114,9 @@ export class ExtractionEngine {
       log.warn("no OpenAI API key — direct OpenAI client disabled; local and gateway fallback paths remain available");
     }
     this.localLlm = localLlm ?? new LocalLlmClient(config, modelRegistry);
-    this.fallbackLlm = new FallbackLlmClient(gatewayConfig);
+    this.fallbackLlm = new FallbackLlmClient(gatewayConfig, {
+      workspaceDir: config.workspaceDir,
+    });
     this.modelRegistry = modelRegistry ?? new ModelRegistry(config.memoryDir);
     if (config.modelSource === "gateway") {
       log.debug(

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
 
 import { FallbackLlmClient } from "./fallback-llm.js";
 import { __codexCliFallbackTestHooks } from "./codex-cli-fallback.js";
 import { clearModelsJsonCache, __setModelsJsonForTest } from "./models-json.js";
-import { clearSecretCache } from "./resolve-provider-secret.js";
+import {
+  __setGatewayRuntimeAuthForModelForTest,
+  clearSecretCache,
+} from "./resolve-provider-secret.js";
 
 test("fallback llm prefers the active gateway provider config over models.json", { concurrency: false }, async () => {
   __setModelsJsonForTest({
@@ -64,6 +68,158 @@ test("fallback llm prefers the active gateway provider config over models.json",
   } finally {
     globalThis.fetch = originalFetch;
     clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm passes the OpenClaw workspace to runtime auth", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const previousHome = process.env.HOME;
+  process.env.HOME = "/tmp/remnic-openclaw-home";
+  let capturedWorkspaceDir: string | undefined;
+  __setGatewayRuntimeAuthForModelForTest(async ({ workspaceDir }) => {
+    capturedWorkspaceDir = workspaceDir;
+    return {
+      apiKey: "runtime-key",
+      baseUrl: "https://runtime.example/v1",
+      source: "test-runtime",
+      mode: "oauth",
+    };
+  });
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/gpt-5.5",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://raw.example/v1",
+          api: "openai-completions",
+          apiKey: "secretref-managed",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+  let capturedAuth = "";
+  globalThis.fetch = (async (url, init) => {
+    capturedUrl = String(url);
+    capturedAuth = String((init?.headers as Record<string, string> | undefined)?.Authorization ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    assert.equal(response?.content, "ok");
+    assert.equal(capturedUrl, "https://runtime.example/v1/chat/completions");
+    assert.equal(capturedAuth, "Bearer runtime-key");
+    assert.equal(
+      capturedWorkspaceDir,
+      path.join("/tmp/remnic-openclaw-home", ".openclaw", "workspace"),
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    clearSecretCache();
+  }
+});
+
+test("fallback llm prefers a configured workspace for runtime auth", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const previousHome = process.env.HOME;
+  process.env.HOME = "/tmp/remnic-configured-home";
+  let capturedWorkspaceDir: string | undefined;
+  __setGatewayRuntimeAuthForModelForTest(async ({ workspaceDir }) => {
+    capturedWorkspaceDir = workspaceDir;
+    return {
+      apiKey: "runtime-key",
+      baseUrl: "https://runtime.example/v1",
+      source: "test-runtime",
+      mode: "oauth",
+    };
+  });
+
+  const llm = new FallbackLlmClient(
+    {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://raw.example/v1",
+            api: "openai-completions",
+            apiKey: "secretref-managed",
+            models: [],
+          },
+        },
+      },
+    },
+    { workspaceDir: "~/custom-openclaw-workspace" },
+  );
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    )) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    assert.equal(response?.content, "ok");
+    assert.equal(
+      capturedWorkspaceDir,
+      path.join("/tmp/remnic-configured-home", "custom-openclaw-workspace"),
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
     clearSecretCache();
   }
 });

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -1,4 +1,5 @@
 import { log } from "./logger.js";
+import path from "node:path";
 import type { GatewayConfig, ModelProviderConfig, AgentPersona } from "./types.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import {
@@ -9,6 +10,8 @@ import {
 import { resolveProviderApiKey, getGatewayRuntimeAuthForModel } from "./resolve-provider-secret.js";
 import { loadModelsJsonProviders } from "./models-json.js";
 import { callCodexCliFallback } from "./codex-cli-fallback.js";
+import { resolveHomeDir } from "./runtime/env.js";
+import { expandTildePath } from "./utils/path.js";
 
 export interface FallbackLlmOptions {
   temperature?: number;
@@ -74,7 +77,13 @@ export class FallbackLlmClient {
     runtimeContext: FallbackLlmRuntimeContext = {},
   ) {
     this.gatewayConfig = gatewayConfig;
-    this.runtimeContext = runtimeContext;
+    this.runtimeContext = {
+      ...runtimeContext,
+      workspaceDir:
+        normalizeRuntimePath(runtimeContext.workspaceDir) ??
+        readGatewayWorkspaceDir(gatewayConfig) ??
+        defaultOpenClawWorkspaceDir(),
+    };
   }
 
   /**
@@ -810,6 +819,26 @@ export class FallbackLlmClient {
         : undefined,
     };
   }
+}
+
+function normalizeRuntimePath(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? expandTildePath(trimmed) : undefined;
+}
+
+function readGatewayWorkspaceDir(gatewayConfig: GatewayConfig | undefined): string | undefined {
+  if (!gatewayConfig || typeof gatewayConfig !== "object") return undefined;
+  const raw = gatewayConfig as Record<string, unknown>;
+  return (
+    normalizeRuntimePath(raw.workspaceDir) ??
+    normalizeRuntimePath(raw.workspacePath) ??
+    normalizeRuntimePath(raw.workspace)
+  );
+}
+
+function defaultOpenClawWorkspaceDir(): string {
+  return path.join(resolveHomeDir(), ".openclaw", "workspace");
 }
 
 function extractResponsesOutputText(data: {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1846,7 +1846,9 @@ export class Orchestrator {
       : this.localLlm;
     // Initialize gateway fast LLM for fast-tier ops when modelSource is "gateway"
     this._fastGatewayLlm = config.modelSource === "gateway"
-      ? new FallbackLlmClient(config.gatewayConfig)
+      ? new FallbackLlmClient(config.gatewayConfig, {
+          workspaceDir: config.workspaceDir,
+        })
       : null;
     if (config.modelSource === "gateway") {
       log.debug(
@@ -3158,7 +3160,9 @@ export class Orchestrator {
           ? this.config.fastGatewayAgentId
           : this.config.gatewayAgentId || undefined)
       : undefined;
-    const llm = new FallbackLlmClient(this.config.gatewayConfig);
+    const llm = new FallbackLlmClient(this.config.gatewayConfig, {
+      workspaceDir: this.config.workspaceDir,
+    });
     if (!llm.isAvailable(gatewayAgentId) && !(modelSetting === "fast" && this.fastLlm && !useGateway)) {
       log.warn(
         "[semantic-consolidation] no LLM available — skipping synthesis",
@@ -3402,7 +3406,9 @@ export class Orchestrator {
     if (this.config.peerProfileReasonerEnabled) {
       try {
         const { runPeerProfileReasoner } = await import("./peers/index.js");
-        const llm = new FallbackLlmClient(this.config.gatewayConfig);
+        const llm = new FallbackLlmClient(this.config.gatewayConfig, {
+          workspaceDir: this.config.workspaceDir,
+        });
         const peerResult = await runPeerProfileReasoner({
           memoryDir: targetStorage.dir,
           enabled: true,
@@ -11711,7 +11717,9 @@ export class Orchestrator {
           judgeCandidates,
           this.config,
           this.localLlm,
-          new FallbackLlmClient(this.config.gatewayConfig),
+          new FallbackLlmClient(this.config.gatewayConfig, {
+            workspaceDir: this.config.workspaceDir,
+          }),
           this.judgeVerdictCache,
           this.judgeDeferCounts,
           judgeTelemetryHandler,

--- a/packages/remnic-core/src/resolve-provider-secret.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.ts
@@ -348,3 +348,11 @@ export function __setGatewayResolverForTest(resolver: ResolveApiKeyFn | null): v
   _resolverLoaded = resolver !== null;
   _resolverNextRetryAt = 0;
 }
+
+export function __setGatewayRuntimeAuthForModelForTest(
+  resolver: GetRuntimeAuthForModelFn | null,
+): void {
+  _getRuntimeAuthForModel = resolver;
+  _resolverLoaded = resolver !== null || _resolveApiKeyForProvider !== null;
+  _resolverNextRetryAt = 0;
+}

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -53,7 +53,9 @@ export class HourlySummarizer {
     this.localLlm = new LocalLlmClient(config, this.modelRegistry);
 
     // Initialize fallback client with gateway config
-    this.fallbackLlm = new FallbackLlmClient(gatewayConfig);
+    this.fallbackLlm = new FallbackLlmClient(gatewayConfig, {
+      workspaceDir: config.workspaceDir,
+    });
 
     if (!gatewayConfig?.agents?.defaults?.model?.primary && !config.localLlmEnabled && config.modelSource !== "gateway") {
       log.warn("no gateway default AI and local LLM disabled — hourly summarization disabled");


### PR DESCRIPTION
## Summary
- Refresh the OpenClaw adapter metadata/docs to record compatibility through `openclaw@2026.5.6` while keeping the peer range at `>=2026.4.8`.
- Pass a workspace directory into gateway-backed runtime auth resolution so Remnic follows OpenClaw's newer workspace-scoped provider/auth path for recent 2026.5 hosts.
- Add focused coverage for the workspace passed to the runtime auth resolver.

## OpenClaw Releases Reviewed
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.6
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.5
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.4
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.4-beta.3
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.4-beta.2
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.4-beta.1
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.3-1
- https://github.com/openclaw/openclaw/releases/tag/v2026.5.3

## Compatibility Matrix
SDK surface check passed against:
- `openclaw@2026.5.6`
- `openclaw@2026.5.5`
- `openclaw@2026.5.4`
- `openclaw@2026.5.4-beta.3`
- `openclaw@2026.5.4-beta.2`
- `openclaw@2026.5.4-beta.1`
- `openclaw@2026.5.3-1`
- `openclaw@2026.5.3`

## Test Plan
- [x] `pnpm exec tsx --test packages/remnic-core/src/fallback-llm.test.ts packages/remnic-core/src/resolve-provider-secret.test.ts`
- [x] `pnpm exec tsx --test tests/openclaw-sdk-surface-check.test.ts`
- [x] `pnpm run check:openclaw-plugin-sync`
- [x] OpenClaw SDK surface matrix for the eight releases above
- [x] `npm run preflight:quick`
- [x] `npm run review:cursor` attempted; local cursor-agent rejected the script's `--trust` option, so the review gate reported unavailable/skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how gateway-backed LLM requests resolve provider runtime auth/base URLs by introducing workspace-scoped context, which can affect all gateway model calls if miscomputed. Scoped and covered by new unit tests, but impacts credential resolution and request routing.
> 
> **Overview**
> Updates OpenClaw plugin compatibility metadata to record validation through `openclaw@2026.5.6` (including bumping the plugin build SDK/version pins) while keeping the declared peer range unchanged.
> 
> Routes an OpenClaw *workspace directory* through `FallbackLlmClient` into gateway runtime-auth resolution, defaulting to `~/.openclaw/workspace` (and supporting config overrides / legacy gateway config fields), and threads this through consolidation/extraction/summarization/orchestrator call sites.
> 
> Adds targeted tests and test hooks to ensure runtime auth receives the resolved workspace path and that an explicitly configured workspace overrides the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f37d376e52dd332f54308c5100d0188a970f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->