### PR TITLE
Bump OpenClaw publish packages

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-engram",
   "name": "Remnic OpenClaw Plugin",
-  "version": "9.3.18",
+  "version": "9.3.19",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.18",
+  "version": "9.3.19",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs
+++ b/packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs
@@ -17,4 +17,32 @@ const packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8"));
 const manifest = JSON.parse(raw);
 manifest.id = "openclaw-engram";
 manifest.version = packageJson.version;
+manifest.contracts = {
+  ...manifest.contracts,
+  memoryCapabilities: [manifest.id],
+  services: [manifest.id],
+};
+manifest.providerAuthChoices = [
+  {
+    provider: "openai",
+    method: "api-key",
+    choiceId: "remnic-openai-api-key",
+    choiceLabel: "OpenAI API key for Remnic memory extraction",
+    choiceHint:
+      "Remnic sends memory extraction, consolidation, and embedding requests to OpenAI or the configured OpenAI-compatible endpoint unless you route those tasks through OpenClaw gateway/local LLM settings.",
+    groupId: "remnic-memory",
+    groupLabel: "Remnic memory",
+    optionKey: "openaiApiKey",
+    cliFlag: "--openai-api-key",
+    cliOption: "--openai-api-key <key>",
+    cliDescription:
+      "OpenAI API key used by Remnic memory extraction, consolidation, and embedding flows.",
+    onboardingScopes: ["text-inference"],
+  },
+];
+if (manifest.configSchema?.properties?.modelSource) {
+  manifest.configSchema.properties.modelSource.default = "plugin";
+  manifest.configSchema.properties.modelSource.description =
+    "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[]).";
+}
 await writeFile(target, JSON.stringify(manifest, null, 2) + "\n");

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -3,17 +3,20 @@ import test from "node:test";
 import { readFile } from "node:fs/promises";
 
 const shimPackageJsonPath = new URL("../packages/shim-openclaw-engram/package.json", import.meta.url);
+const shimManifestPath = new URL("../packages/shim-openclaw-engram/openclaw.plugin.json", import.meta.url);
 const bannerScriptPath = new URL("../packages/shim-openclaw-engram/scripts/postinstall-banner.mjs", import.meta.url);
 
 test("Phase C shim package keeps a workspace-linked source manifest", async () => {
   const raw = await readFile(shimPackageJsonPath, "utf8");
+  const manifestRaw = await readFile(shimManifestPath, "utf8");
   const pkg = JSON.parse(raw) as Record<string, unknown>;
+  const manifest = JSON.parse(manifestRaw) as Record<string, unknown>;
   const bin = pkg.bin as Record<string, string>;
   const exportsMap = pkg.exports as Record<string, { import: string }>;
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.18");
+  assert.equal(pkg.version, manifest.version);
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary
- bump @remnic/core to 1.1.10 for the OpenClaw runtime-auth compatibility fix
- bump @remnic/plugin-openclaw to 1.0.33 and sync OpenClaw manifests
- bump the legacy @joshuaswarren/openclaw-engram shim to 9.3.19 and resync its manifest

## Test plan
- git diff --check
- pnpm run check:openclaw-plugin-sync
- pnpm run verify:openclaw-clawpack
- npm run preflight:quick

## Publish intent
After merge, the release-and-publish workflow should publish @remnic/core@1.1.10, @remnic/plugin-openclaw@1.0.33, @joshuaswarren/openclaw-engram@9.3.19, and the ClawHub @remnic/plugin-openclaw@1.0.33 package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly release/version and manifest-sync changes, but it also tweaks the legacy shim’s generated `openclaw.plugin.json` contracts/auth choices and defaults (e.g. `modelSource`), which can affect OpenClaw runtime configuration behavior.
> 
> **Overview**
> Bumps publish versions for the OpenClaw artifacts: `@remnic/plugin-openclaw` to `1.0.33`, `@remnic/core` to `1.1.10`, and the legacy `@joshuaswarren/openclaw-engram` shim to `9.3.19`, along with matching `openclaw.plugin.json` manifest version updates.
> 
> Updates the shim’s `sync-openclaw-plugin.mjs` manifest patching to explicitly set `contracts.memoryCapabilities/services` to the shim id, add a standardized `providerAuthChoices` entry for the OpenAI API key, and force the shim’s `modelSource` default/description to plugin mode. The shim package test now asserts the manifest version is kept in sync with `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19d7579606b08a8b1a6ac1a24ee383137739275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->