### PR TITLE
fix(bench): strengthen AMA trajectory history answers

### DIFF
--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -95,6 +95,10 @@ test("agentic-memory answering asks responders to synthesize grounded trajectory
         assert.match(question, /step numbers, action names, object names/);
         assert.match(question, /anchor the answer to those exact numbers/);
         assert.match(question, /state at the start of Step N is the prior observation/);
+        assert.match(question, /enumerate each action in that inclusive range/);
+        assert.match(question, /scan the whole recalled trajectory evidence up to that boundary/);
+        assert.match(question, /count all matching action verbs/);
+        assert.match(question, /container, inventory, and object-location histories/);
         assert.match(question, /adjacent trajectory evidence contains the named action/);
         assert.match(question, /next concrete maneuver it enables/);
         assert.match(question, /treat an object on the direct path as a blocker/);
@@ -177,7 +181,7 @@ test("agentic-memory answering retries one unknown answer when explicit trajecto
           };
         }
         assert.match(question, /prior answer was only "unknown"/);
-        assert.match(question, /explicit trajectory evidence/);
+        assert.match(question, /trajectory evidence/);
         return {
           text: "It moved right, making the wall shift to the left relative to the agent.",
           tokens: { input: 13, output: 12 },
@@ -196,6 +200,51 @@ test("agentic-memory answering retries one unknown answer when explicit trajecto
   assert.deepEqual(result.tokens, { input: 24, output: 13 });
   assert.equal(result.latencyMs, 16);
   assert.equal(result.model, "retry-model");
+});
+
+test("agentic-memory answering retries unknown when trajectory markers appear outside explicit cue sections", async () => {
+  const questions: string[] = [];
+  const result = await answerBenchmarkQuestion({
+    question: "What inventory changes occurred before step 80?",
+    recalledText: [
+      "## Remnic recall pipeline",
+      "[Action 20]: take cd 3",
+      "[Observation 20]: Inventory: cd 3.",
+      "[Action 24]: move cd 3 to safe 1",
+      "[Observation 24]: Inventory: empty.",
+      "[Action 80]: take cd 2",
+      "[Observation 80]: Inventory: cd 2.",
+    ].join("\n"),
+    answerMode: "agentic-memory",
+    retryUnknownWithEvidence: true,
+    responder: {
+      async respond(question) {
+        questions.push(question);
+        if (questions.length === 1) {
+          return {
+            text: "unknown",
+            tokens: { input: 11, output: 1 },
+            latencyMs: 7,
+            model: "first-model",
+          };
+        }
+        assert.match(question, /prior answer was only "unknown"/);
+        assert.match(question, /trajectory evidence/);
+        return {
+          text: "cd 3 was added at step 20, removed at step 24, and cd 2 was added at step 80.",
+          tokens: { input: 13, output: 12 },
+          latencyMs: 9,
+          model: "retry-model",
+        };
+      },
+    },
+  });
+
+  assert.equal(questions.length, 2);
+  assert.equal(
+    result.finalAnswer,
+    "cd 3 was added at step 20, removed at step 24, and cd 2 was added at step 80.",
+  );
 });
 
 test("agentic-memory answering does not retry unknown without explicit trajectory evidence", async () => {
@@ -322,13 +371,13 @@ test("unknown and explicit trajectory evidence helpers are conservative", () => 
     hasExplicitTrajectoryEvidence(
       "## Remnic recall pipeline\n[Action 3]: up\n[Observation 3]: the key moved closer",
     ),
-    false,
+    true,
   );
   assert.equal(
     hasExplicitTrajectoryEvidence(
       "##Explicit Cue Evidence\n[Action 3]: up",
     ),
-    false,
+    true,
   );
   assert.equal(
     hasExplicitTrajectoryEvidence(

--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -388,6 +388,16 @@ test("unknown and explicit trajectory evidence helpers are conservative", () => 
   );
   assert.equal(
     hasExplicitTrajectoryEvidence(
+      [
+        "## Search evidence",
+        "[ama-ep-1, turn 6, user]: The note quoted an example.",
+        "[Action 3]: up",
+      ].join("\n"),
+    ),
+    false,
+  );
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
       "##\tExplicit Cue Evidence\r\n[Observation 12]: the key moved closer",
     ),
     true,

--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -96,7 +96,8 @@ test("agentic-memory answering asks responders to synthesize grounded trajectory
         assert.match(question, /anchor the answer to those exact numbers/);
         assert.match(question, /state at the start of Step N is the prior observation/);
         assert.match(question, /enumerate each action in that inclusive range/);
-        assert.match(question, /scan the whole recalled trajectory evidence up to that boundary/);
+        assert.match(question, /exclude Action\/Observation N/);
+        assert.match(question, /include Action\/Observation N/);
         assert.match(question, /count all matching action verbs/);
         assert.match(question, /container, inventory, and object-location histories/);
         assert.match(question, /adjacent trajectory evidence contains the named action/);
@@ -377,7 +378,13 @@ test("unknown and explicit trajectory evidence helpers are conservative", () => 
     hasExplicitTrajectoryEvidence(
       "##Explicit Cue Evidence\n[Action 3]: up",
     ),
-    true,
+    false,
+  );
+  assert.equal(
+    hasExplicitTrajectoryEvidence(
+      '## Search evidence\nThe note quoted "[Action 3]: up" as an example label.',
+    ),
+    false,
   );
   assert.equal(
     hasExplicitTrajectoryEvidence(

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -120,7 +120,8 @@ export function buildAgenticMemoryBenchmarkQuestion(
     "- In action/observation trajectories, Action N causes Observation N. The state at the start of Step N is the prior observation, usually Observation N-1; use that prior state when the question asks what an alternative action at the start of a step would do.",
     "- For cited step ranges, identify the action or state change inside that range; do not name a later action outside the range as the answer.",
     "- When the question asks for actions between step X and step Y, enumerate each action in that inclusive range in step order; do not collapse the range to only the first, last, or most semantically relevant actions.",
-    "- When the question asks for actions, state changes, inventory changes, container interactions, or object locations before/until a step, scan the whole recalled trajectory evidence up to that boundary and include every matching event with its step number.",
+    "- When the question asks for actions, state changes, inventory changes, container interactions, or object locations before step N, exclude Action/Observation N and scan only earlier trajectory evidence through step N-1.",
+    "- When the question asks for actions, state changes, inventory changes, container interactions, or object locations until step N, through step N, or up to and including step N, include Action/Observation N and scan the whole recalled trajectory evidence through that boundary.",
     "- For action-frequency questions, count all matching action verbs across the requested span and report the full frequency table; do not count only the most recent recalled excerpt.",
     "- For container, inventory, and object-location histories, maintain a state timeline from actions such as open, close, take, move, put, remove, and inventory observations; preserve earlier changes even if later recall excerpts also mention the object.",
     "- If the question names a specific action but the cited step label shows a different action and adjacent trajectory evidence contains the named action, reconcile the mismatch from the adjacent evidence instead of ignoring the named action.",
@@ -231,16 +232,7 @@ export function isUnknownOnlyAnswer(answer: string): boolean {
 }
 
 export function hasExplicitTrajectoryEvidence(recalledText: string): boolean {
-  if (
-    hasStepMarker(recalledText, "Action") ||
-    hasStepMarker(recalledText, "Observation")
-  ) {
-    return true;
-  }
-
-  return hasExplicitCueEvidenceHeading(recalledText) &&
-    (hasStepMarker(recalledText, "Step") ||
-      hasStepMarker(recalledText, "Turn"));
+  return hasTrajectoryMarkerInStructuredSection(recalledText);
 }
 
 function stripWrappingQuotes(value: string): string {
@@ -271,64 +263,79 @@ function isSentencePunctuation(code: number): boolean {
   return code === 33 || code === 46 || code === 63;
 }
 
-function hasExplicitCueEvidenceHeading(text: string): boolean {
+const STRUCTURED_TRAJECTORY_SECTION_TITLES = new Set([
+  "Explicit Cue Evidence",
+  "Remnic recall pipeline",
+  "Search evidence",
+  "Raw messages",
+]);
+
+function hasTrajectoryMarkerInStructuredSection(text: string): boolean {
   const lines = text
     .replaceAll("\r\n", "\n")
     .replaceAll("\r", "\n")
     .split("\n");
+  let inStructuredSection = false;
+
   for (const line of lines) {
-    if (!line.startsWith("##") || line.startsWith("###")) {
+    const heading = parseLevelTwoHeading(line);
+    if (heading !== undefined) {
+      inStructuredSection = STRUCTURED_TRAJECTORY_SECTION_TITLES.has(heading);
       continue;
     }
-    const rawTitle = line.slice(2);
-    if (
-      rawTitle.length === 0 ||
-      !isAsciiWhitespace(rawTitle.charCodeAt(0))
-    ) {
+    if (!inStructuredSection) {
       continue;
     }
-    const title = rawTitle.trimStart();
     if (
-      title === "Explicit Cue Evidence" ||
-      title.startsWith("Explicit Cue Evidence ") ||
-      title.startsWith("Explicit Cue Evidence\t")
+      isStepMarkerLine(line, "Action") ||
+      isStepMarkerLine(line, "Observation") ||
+      isStepMarkerLine(line, "Step") ||
+      isStepMarkerLine(line, "Turn")
     ) {
       return true;
     }
   }
+
   return false;
 }
 
-function hasStepMarker(
-  text: string,
+function parseLevelTwoHeading(line: string): string | undefined {
+  if (!line.startsWith("##") || line.startsWith("###")) {
+    return undefined;
+  }
+  const rawTitle = line.slice(2);
+  if (
+    rawTitle.length === 0 ||
+    !isAsciiWhitespace(rawTitle.charCodeAt(0))
+  ) {
+    return undefined;
+  }
+  return rawTitle.trim();
+}
+
+function isStepMarkerLine(
+  line: string,
   label: "Action" | "Observation" | "Step" | "Turn",
 ): boolean {
+  const trimmed = line.trimStart();
   const prefix = `[${label}`;
-  let offset = 0;
-  while (offset < text.length) {
-    const start = text.indexOf(prefix, offset);
-    if (start === -1) {
-      return false;
-    }
-    let index = start + prefix.length;
-    if (!isAsciiWhitespace(text.charCodeAt(index))) {
-      offset = start + 1;
-      continue;
-    }
-    while (index < text.length && isAsciiWhitespace(text.charCodeAt(index))) {
-      index += 1;
-    }
-    let sawDigit = false;
-    while (index < text.length && isAsciiDigit(text.charCodeAt(index))) {
-      sawDigit = true;
-      index += 1;
-    }
-    if (sawDigit && text[index] === "]") {
-      return true;
-    }
-    offset = start + 1;
+  if (!trimmed.startsWith(prefix)) {
+    return false;
   }
-  return false;
+
+  let index = prefix.length;
+  if (!isAsciiWhitespace(trimmed.charCodeAt(index))) {
+    return false;
+  }
+  while (index < trimmed.length && isAsciiWhitespace(trimmed.charCodeAt(index))) {
+    index += 1;
+  }
+  let sawDigit = false;
+  while (index < trimmed.length && isAsciiDigit(trimmed.charCodeAt(index))) {
+    sawDigit = true;
+    index += 1;
+  }
+  return sawDigit && trimmed[index] === "]";
 }
 
 function isAsciiDigit(code: number): boolean {

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -1,4 +1,5 @@
 import type { BenchResponder } from "./adapters/types.js";
+import { TRAJECTORY_RETRY_SECTION_TITLE_SET } from "./recall-sections.js";
 
 export type BenchmarkAnswerMode = "default" | "strict" | "agentic-memory";
 
@@ -263,13 +264,6 @@ function isSentencePunctuation(code: number): boolean {
   return code === 33 || code === 46 || code === 63;
 }
 
-const STRUCTURED_TRAJECTORY_SECTION_TITLES = new Set([
-  "Explicit Cue Evidence",
-  "Remnic recall pipeline",
-  "Search evidence",
-  "Raw messages",
-]);
-
 function hasTrajectoryMarkerInStructuredSection(text: string): boolean {
   const lines = text
     .replaceAll("\r\n", "\n")
@@ -280,7 +274,7 @@ function hasTrajectoryMarkerInStructuredSection(text: string): boolean {
   for (const line of lines) {
     const heading = parseLevelTwoHeading(line);
     if (heading !== undefined) {
-      inStructuredSection = STRUCTURED_TRAJECTORY_SECTION_TITLES.has(heading);
+      inStructuredSection = TRAJECTORY_RETRY_SECTION_TITLE_SET.has(heading);
       continue;
     }
     if (!inStructuredSection) {

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -119,6 +119,10 @@ export function buildAgenticMemoryBenchmarkQuestion(
     "- For explicit step, action, observation, or turn references, anchor the answer to those exact numbers. Do not shift the answer to a neighboring step unless the question explicitly asks for the next or previous step.",
     "- In action/observation trajectories, Action N causes Observation N. The state at the start of Step N is the prior observation, usually Observation N-1; use that prior state when the question asks what an alternative action at the start of a step would do.",
     "- For cited step ranges, identify the action or state change inside that range; do not name a later action outside the range as the answer.",
+    "- When the question asks for actions between step X and step Y, enumerate each action in that inclusive range in step order; do not collapse the range to only the first, last, or most semantically relevant actions.",
+    "- When the question asks for actions, state changes, inventory changes, container interactions, or object locations before/until a step, scan the whole recalled trajectory evidence up to that boundary and include every matching event with its step number.",
+    "- For action-frequency questions, count all matching action verbs across the requested span and report the full frequency table; do not count only the most recent recalled excerpt.",
+    "- For container, inventory, and object-location histories, maintain a state timeline from actions such as open, close, take, move, put, remove, and inventory observations; preserve earlier changes even if later recall excerpts also mention the object.",
     "- If the question names a specific action but the cited step label shows a different action and adjacent trajectory evidence contains the named action, reconcile the mismatch from the adjacent evidence instead of ignoring the named action.",
     "- If a game or tool trajectory requires a strategic abstraction, name the concrete mechanism being prepared or avoided, such as pushing a rule block, breaking a rule, opening a path, satisfying a tool requirement, aligning with an object, or undoing a loop.",
     "- When a maneuver makes an object vanish from relative observations or changes its offset, answer both the immediate relation and the next concrete maneuver it enables, such as pushing from a new side, bypassing a blocker, or aligning with rule text.",
@@ -209,9 +213,9 @@ export function buildUnknownRetryQuestion(
   return [
     question,
     "",
-    "The prior answer was only \"unknown\", but the supplied Remnic context includes explicit trajectory evidence.",
+    "The prior answer was only \"unknown\", but the supplied Remnic context includes trajectory evidence.",
     "Retry once by deriving the best-supported answer from that evidence.",
-    "Use \"unknown\" only if the explicit evidence is absent, contradictory, or lacks the exact value requested.",
+    "Use \"unknown\" only if the trajectory evidence is absent, contradictory, or lacks the exact value requested.",
     "For causal or strategic questions, answer with the concrete action/state change and the implication it supports.",
     ...(answerFormat === "structured"
       ? ["Preserve the requested structured output format exactly."]
@@ -227,9 +231,16 @@ export function isUnknownOnlyAnswer(answer: string): boolean {
 }
 
 export function hasExplicitTrajectoryEvidence(recalledText: string): boolean {
+  if (
+    hasStepMarker(recalledText, "Action") ||
+    hasStepMarker(recalledText, "Observation")
+  ) {
+    return true;
+  }
+
   return hasExplicitCueEvidenceHeading(recalledText) &&
-    (hasStepMarker(recalledText, "Action") ||
-      hasStepMarker(recalledText, "Observation"));
+    (hasStepMarker(recalledText, "Step") ||
+      hasStepMarker(recalledText, "Turn"));
 }
 
 function stripWrappingQuotes(value: string): string {
@@ -288,7 +299,10 @@ function hasExplicitCueEvidenceHeading(text: string): boolean {
   return false;
 }
 
-function hasStepMarker(text: string, label: "Action" | "Observation"): boolean {
+function hasStepMarker(
+  text: string,
+  label: "Action" | "Observation" | "Step" | "Turn",
+): boolean {
   const prefix = `[${label}`;
   let offset = 0;
   while (offset < text.length) {

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -25,13 +25,7 @@ import {
   timed,
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
-
-const RECALL_SECTION_TITLES = new Set([
-  "Explicit Cue Evidence",
-  "Remnic recall pipeline",
-  "Search evidence",
-  "Raw messages",
-]);
+import { BENCH_RECALL_SECTION_TITLE_SET } from "../../../recall-sections.js";
 
 export const amaBenchDefinition: BenchmarkDefinition = {
   id: "ama-bench",
@@ -338,7 +332,7 @@ function extractRecallSectionTitles(recalledText: string): string[] {
   const titles = new Set<string>();
   for (const match of recalledText.matchAll(/^##\s+(.+)$/gm)) {
     const title = match[1]?.trim();
-    if (title && RECALL_SECTION_TITLES.has(title)) {
+    if (title && BENCH_RECALL_SECTION_TITLE_SET.has(title)) {
       titles.add(title);
     }
   }

--- a/packages/bench/src/recall-sections.ts
+++ b/packages/bench/src/recall-sections.ts
@@ -1,0 +1,19 @@
+export const BENCH_RECALL_SECTION_TITLES = [
+  "Explicit Cue Evidence",
+  "Remnic recall pipeline",
+  "Search evidence",
+  "Raw messages",
+] as const;
+
+export const BENCH_RECALL_SECTION_TITLE_SET = new Set<string>(
+  BENCH_RECALL_SECTION_TITLES,
+);
+
+export const TRAJECTORY_RETRY_SECTION_TITLES = [
+  "Explicit Cue Evidence",
+  "Remnic recall pipeline",
+] as const;
+
+export const TRAJECTORY_RETRY_SECTION_TITLE_SET = new Set<string>(
+  TRAJECTORY_RETRY_SECTION_TITLES,
+);


### PR DESCRIPTION
## Summary
- add AMA answerer guidance for inclusive step ranges, whole-history state scans, action frequencies, and container/inventory/object timelines
- retry unknown answers when trajectory markers appear in any recalled section, not only the explicit cue section
- add regression coverage for raw trajectory-marker retries and the new prompt requirements

## Verification
- pnpm exec tsx --test packages/bench/src/answering.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check

This is a general answer-synthesis improvement motivated by AMA-Bench history/state failures, not task-ID-specific tuning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `agentic-memory` prompt contract and the logic that decides when to retry `unknown`, which can materially shift benchmark outputs and token/latency accounting. Risk is contained to bench answering/runner behavior but may affect published score comparability.
> 
> **Overview**
> Improves `agentic-memory` answering guidance to better handle long-horizon AMA-style questions, adding explicit instructions for *inclusive step ranges*, *before vs through step boundaries*, *action-frequency counting*, and *inventory/container/object-location timelines*.
> 
> Broadens `unknown` retry triggering by redefining “explicit trajectory evidence” as step/turn markers found within specific structured recall sections (not just `## Explicit Cue Evidence`), while avoiding false positives from sections like `Search evidence`. Centralizes recall section title constants in new `recall-sections.ts`, updates the AMA runner to use them, and adds regression tests covering the new prompt requirements and retry/evidence-detection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 631d938ddade16b9228c6dac552f6678872dad5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->