### PR TITLE
feat(core): add deterministic trajectory analysis recall

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -11,7 +11,9 @@ import { promisify } from "node:util";
 import {
   buildEvidencePack,
   buildExplicitCueRecallSection,
+  buildTrajectoryAnalysisRecallSection,
   collectExplicitTurnReferences,
+  normalizeTurnExpansionEnd,
   Orchestrator,
   parseConfig,
 } from "@remnic/core";
@@ -121,6 +123,7 @@ const DEFAULT_BENCH_DRAIN_TIMEOUT_MS = 5 * 60_000;
 const CORE_EXPLICIT_CUE_MAX_CHARS = 18_000;
 const CORE_EXPLICIT_CUE_MAX_ITEM_CHARS = 2_400;
 const CORE_EXPLICIT_CUE_MAX_REFERENCES = 24;
+const CORE_TRAJECTORY_ANALYSIS_MAX_CHARS = 18_000;
 const execFileAsync = promisify(execFile);
 
 function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
@@ -482,6 +485,22 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           usedChars += exactReferenceEvidence.length;
         }
 
+        const trajectoryAnalysisEvidence = sessionId.startsWith("ama-")
+          ? await buildTrajectoryAnalysisRecallSection({
+              engine,
+              sessionId,
+              query,
+              maxChars: Math.min(
+                CORE_TRAJECTORY_ANALYSIS_MAX_CHARS,
+                Math.max(0, Math.floor((budget - usedChars) * 0.55)),
+              ),
+            })
+          : "";
+        if (trajectoryAnalysisEvidence) {
+          sections.push(trajectoryAnalysisEvidence);
+          usedChars += trajectoryAnalysisEvidence.length;
+        }
+
         if (useCoreMemoryPipeline) {
           const coreBudget = Math.max(
             0,
@@ -620,10 +639,11 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         if (sections.length === 0) {
           const stats = await engine.getStats(sessionId);
           if (stats.totalMessages > 0) {
+            const toTurn = normalizeTurnExpansionEnd(stats);
             const expanded = await engine.expandContext(
               sessionId,
               0,
-              stats.totalMessages - 1,
+              toTurn,
               Math.floor(budget / 4),
             );
             if (expanded.length > 0) {

--- a/packages/bench/src/adapters/types.ts
+++ b/packages/bench/src/adapters/types.ts
@@ -19,6 +19,7 @@ export interface MemoryStats {
   totalMessages: number;
   totalSummaryNodes: number;
   maxDepth: number;
+  maxTurnIndex?: number;
 }
 
 export interface BenchResponse {

--- a/packages/bench/src/recall-sections.ts
+++ b/packages/bench/src/recall-sections.ts
@@ -1,5 +1,6 @@
 export const BENCH_RECALL_SECTION_TITLES = [
   "Explicit Cue Evidence",
+  "Trajectory analysis",
   "Remnic recall pipeline",
   "Search evidence",
   "Raw messages",
@@ -11,6 +12,7 @@ export const BENCH_RECALL_SECTION_TITLE_SET = new Set<string>(
 
 export const TRAJECTORY_RETRY_SECTION_TITLES = [
   "Explicit Cue Evidence",
+  "Trajectory analysis",
   "Remnic recall pipeline",
 ] as const;
 

--- a/packages/remnic-core/src/explicit-cue-recall.test.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildExplicitCueRecallSection,
+  buildTrajectoryAnalysisRecallSection,
   collectBenchmarkAnchorCues,
   collectExplicitTurnReferences,
   collectLexicalCues,
@@ -74,6 +75,24 @@ class FakeCueEngine implements ExplicitCueRecallEngine {
       }
     }
     return results.slice(0, Math.max(0, Math.floor(limit)));
+  }
+
+  async getStats(sessionId?: string): Promise<{
+    totalMessages: number;
+    maxTurnIndex?: number;
+  }> {
+    const sessionEntries = Object.entries(this.sessions).filter(
+      ([candidateSessionId]) => !sessionId || candidateSessionId === sessionId,
+    );
+    let maxTurn = -1;
+    let totalMessages = 0;
+    for (const [, messages] of sessionEntries) {
+      totalMessages += messages.length;
+      for (let index = 0; index < messages.length; index += 1) {
+        maxTurn = Math.max(maxTurn, messages[index]?.turnIndex ?? index);
+      }
+    }
+    return { totalMessages, maxTurnIndex: maxTurn };
   }
 }
 
@@ -202,6 +221,231 @@ test("buildExplicitCueRecallSection searches benchmark anchor cues", async () =>
   });
 
   assert.match(section, /plan-specific deployment owner is Nia/);
+});
+
+test("buildTrajectoryAnalysisRecallSection enumerates full action ranges", async () => {
+  const engine = new FakeCueEngine({
+    ama: makeTrajectoryMessages([
+      [71, "go to drawer 4", "arrived at drawer 4"],
+      [72, "look", "looked around"],
+      [73, "go to safe 1", "arrived at safe 1"],
+      [74, "go to drawer 4", "arrived at drawer 4"],
+      [75, "look", "looked at drawer 4"],
+      [76, "go to shelf 2", "arrived at shelf 2"],
+    ]),
+  });
+
+  const section = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "What actions were performed between step 71 and step 76?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /^## Trajectory analysis/);
+  for (const step of [71, 72, 73, 74, 75, 76]) {
+    assert.match(section, new RegExp(`Action ${step}`));
+  }
+});
+
+test("buildTrajectoryAnalysisRecallSection preserves before-step entity history", async () => {
+  const engine = new FakeCueEngine({
+    ama: makeTrajectoryMessages([
+      [8, "open safe 1", "safe 1 is open"],
+      [9, "close safe 1", "safe 1 is closed"],
+      [20, "take cd 3 from desk 1", "carrying cd 3"],
+      [23, "open safe 1", "safe 1 is open"],
+      [24, "move cd 3 to safe 1", "cd 3 is in safe 1"],
+      [80, "take cd 2 from desk 2", "carrying cd 2"],
+    ]),
+  });
+
+  const section = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query:
+      "Before step 80, which actions were performed on safe 1 and at which steps?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /Action 8.*open safe 1/);
+  assert.match(section, /Action 9.*close safe 1/);
+  assert.match(section, /Action 23.*open safe 1/);
+  assert.doesNotMatch(section, /Action 80/);
+  assert.doesNotMatch(section, /move cd 3 to safe 1/);
+});
+
+test("buildTrajectoryAnalysisRecallSection summarizes inventory and frequency", async () => {
+  const engine = new FakeCueEngine({
+    ama: makeTrajectoryMessages([
+      [0, "look", "empty inventory"],
+      [1, "go to desk 1", "at desk"],
+      [2, "take cd 3 from desk 1", "carrying cd 3"],
+      [3, "move cd 3 to safe 1", "cd 3 in safe"],
+      [4, "take cd 2 from desk 2", "carrying cd 2"],
+      [5, "look", "still carrying cd 2"],
+    ]),
+  });
+
+  const inventorySection = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "What changes occurred to the inventory throughout the trajectory?",
+    maxChars: 4000,
+  });
+  assert.match(inventorySection, /inventory added cd 3/);
+  assert.match(inventorySection, /inventory removed cd 3/);
+  assert.match(inventorySection, /inventory added cd 2/);
+
+  const frequencySection = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "Until step 5, what types of actions has the agent performed and how frequently?",
+    maxChars: 4000,
+  });
+  assert.match(frequencySection, /look=2/);
+  assert.match(frequencySection, /go=1/);
+  assert.match(frequencySection, /take=2/);
+  assert.match(frequencySection, /move=1/);
+});
+
+test("buildTrajectoryAnalysisRecallSection resolves quoted observation transitions and entity locations", async () => {
+  const sourceObservation = [
+    "You arrive at garbagecan 1. On the garbagecan 1, you see nothing.",
+    "",
+    "The current available actions are: go to drawer 4, look.",
+  ].join("\n");
+  const targetObservation = [
+    "You arrive at drawer 4. The drawer 4 is open. In it, you see a creditcard 1.",
+    "",
+    "The current available actions are: examine shelf 2, go to shelf 2, look.",
+  ].join("\n");
+  const immediateTargetObservation = [
+    "You arrive at drawer 4. The drawer 4 is open. In it, you see a creditcard 1.",
+    "",
+    "The current available actions are: examine garbagecan 1, look.",
+  ].join("\n");
+  const engine = new FakeCueEngine({
+    ama: makeTrajectoryMessages([
+      [70, "look", sourceObservation],
+      [71, "go to drawer 4", immediateTargetObservation],
+      [72, "look", "You are facing drawer 4."],
+      [73, "go to shelf 2", "You arrive at shelf 2."],
+      [74, "go to drawer 4", targetObservation],
+      [80, "take cd 2 from desk 2", "carrying cd 2"],
+      [90, "move cd 3 to safe 1", "cd 3 is in safe 1"],
+      [115, "look", "cd 2 can be moved to safe 1"],
+    ]),
+  });
+
+  const transitionSection = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: `What sequence of actions would transform the state between the observation: "${sourceObservation}" and the observation: "${targetObservation}"?`,
+    maxChars: 5000,
+  });
+  assert.match(transitionSection, /Action 71.*go to drawer 4/);
+  assert.doesNotMatch(transitionSection, /Action 72/);
+  assert.doesNotMatch(transitionSection, /Action 80/);
+
+  const locationSection = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "What is the location of cd 3, cd 2 at step 115?",
+    maxChars: 5000,
+  });
+  assert.match(locationSection, /cd 2 location at step 115: inventory/);
+  assert.match(locationSection, /cd 3 location at step 115: safe 1/);
+});
+
+test("buildTrajectoryAnalysisRecallSection keeps disjoint explicit references discrete", async () => {
+  const engine = new FakeCueEngine({
+    ama: makeTrajectoryMessages([
+      [2, "move-2", "state-2"],
+      [20, "unrelated-noise bridge action", "state-20"],
+      [40, "move-40", "state-40"],
+    ]),
+  });
+
+  const section = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "Compare steps 2 and 40 with unrelated-noise before answering.",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /Action 2.*move-2/);
+  assert.match(section, /Action 40.*move-40/);
+  assert.doesNotMatch(section, /Action 20/);
+  assert.doesNotMatch(section, /unrelated-noise bridge action/);
+});
+
+test("buildTrajectoryAnalysisRecallSection expands sparse turn-index archives", async () => {
+  const engine = new FakeCueEngine({
+    ama: makeTrajectoryMessages([[50, "sparse target action", "sparse target state"]])
+      .map((message, index) => ({
+        ...message,
+        turnIndex: 100 + index,
+      })),
+  });
+
+  const section = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "What happened in step 50?",
+    maxChars: 4000,
+  });
+
+  assert.match(section, /Action 50.*sparse target action/);
+  assert.match(section, /Observation 50.*sparse target state/);
+});
+
+test("buildTrajectoryAnalysisRecallSection rejects reverse-only quoted observation transitions", async () => {
+  const laterObservation = "later state with the source details";
+  const earlierObservation = "earlier state with the target details";
+  const engine = new FakeCueEngine({
+    ama: makeTrajectoryMessages([
+      [5, "first action", earlierObservation],
+      [10, "later action", laterObservation],
+    ]),
+  });
+
+  const section = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: `What sequence of actions would transform the state between the observation: "${laterObservation}" and the observation: "${earlierObservation}"?`,
+    maxChars: 4000,
+  });
+
+  assert.equal(section, "");
+});
+
+test("buildTrajectoryAnalysisRecallSection truncates within tiny budgets", async () => {
+  const engine = new FakeCueEngine({
+    ama: makeTrajectoryMessages([[1, "look", "state-1"]]),
+  });
+  const header = "## Trajectory analysis";
+  const newline = "\n";
+  const maxChars = header.length + newline.length + 2;
+
+  const section = await buildTrajectoryAnalysisRecallSection({
+    engine,
+    sessionId: "ama",
+    query: "What actions were performed between step 1 and step 1?",
+    maxChars,
+  });
+
+  assert.ok(section.length <= maxChars);
+  assert.match(section, /^## Trajectory analysis\n/);
+  assert.equal(
+    await buildTrajectoryAnalysisRecallSection({
+      engine,
+      sessionId: "ama",
+      query: "What actions were performed between step 1 and step 1?",
+      maxChars: header.length,
+    }),
+    "",
+  );
 });
 
 test("buildExplicitCueRecallSection expands paired action and observation references", async () => {
@@ -844,4 +1088,21 @@ test("buildExplicitCueRecallSection stays silent when disabled by budget or no c
 
 function normalizeForSearch(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9:_-]+/g, " ").trim();
+}
+
+function makeTrajectoryMessages(
+  steps: Array<[number, string, string]>,
+): Message[] {
+  const messages: Message[] = [];
+  for (const [step, action, observation] of steps) {
+    messages.push({
+      role: "user",
+      content: `[Action ${step}]: ${action}`,
+    });
+    messages.push({
+      role: "assistant",
+      content: `[Observation ${step}]: ${observation}`,
+    });
+  }
+  return messages;
 }

--- a/packages/remnic-core/src/explicit-cue-recall.ts
+++ b/packages/remnic-core/src/explicit-cue-recall.ts
@@ -7,6 +7,10 @@ export interface ExplicitCueRecallEngine {
     toTurn: number,
     maxTokens: number,
   ): Promise<Array<{ turn_index: number; role: string; content: string }>>;
+  getStats?(sessionId?: string): Promise<{
+    totalMessages: number;
+    maxTurnIndex?: number;
+  }>;
   searchContextFull(
     query: string,
     limit: number,
@@ -33,6 +37,13 @@ export interface ExplicitCueRecallOptions {
   includeStructuredPlanCues?: boolean;
 }
 
+export interface TrajectoryAnalysisRecallOptions {
+  engine: ExplicitCueRecallEngine | null | undefined;
+  sessionId?: string;
+  query: string;
+  maxChars: number;
+}
+
 export type ExplicitTurnReference = {
   number: number;
   includeDirectTurn: boolean;
@@ -49,6 +60,9 @@ const LEXICAL_CUE_MAX_TOKENS = 400;
 const CONTENT_LABEL_SEARCH_LIMIT = 64;
 const CONTENT_LABEL_MAX_TOKENS = 2_000;
 const CONTENT_LABEL_MAX_PAIRED_WINDOWS_PER_REFERENCE = 1;
+const TRAJECTORY_ANALYSIS_MAX_TOKENS = 250_000;
+const TRAJECTORY_ANALYSIS_MAX_RANGE_STEPS = 80;
+const TRAJECTORY_ANALYSIS_MAX_LINES = 160;
 const LATEST_STATE_CUES = new Set([
   "as of",
   "currently",
@@ -273,6 +287,55 @@ export async function buildExplicitCueRecallSection(
       DEFAULT_MAX_ITEM_CHARS,
     ),
   });
+}
+
+export async function buildTrajectoryAnalysisRecallSection(
+  options: TrajectoryAnalysisRecallOptions,
+): Promise<string> {
+  const engine = options.engine;
+  const sessionId = options.sessionId;
+  const query = options.query.trim();
+  const maxChars = normalizePositiveInteger(options.maxChars, DEFAULT_MAX_CHARS);
+  if (!engine || !sessionId || !engine.getStats || query.length === 0 || maxChars <= 0) {
+    return "";
+  }
+
+  if (!hasTrajectoryAnalysisIntent(query)) {
+    return "";
+  }
+
+  const stats = await engine.getStats(sessionId);
+  const totalMessages = Math.max(0, Math.floor(stats.totalMessages));
+  if (totalMessages <= 0) {
+    return "";
+  }
+  const expansionEnd = normalizeTurnExpansionEnd(stats);
+
+  const messages = await engine.expandContext(
+    sessionId,
+    0,
+    expansionEnd,
+    TRAJECTORY_ANALYSIS_MAX_TOKENS,
+  );
+  const trajectory = parseLabeledTrajectory(messages);
+  if (trajectory.length === 0) {
+    return "";
+  }
+
+  const bounds = inferTrajectoryBounds(query, trajectory);
+  const lines = buildTrajectoryAnalysisLines(query, trajectory, bounds);
+  if (lines.length === 0) {
+    return "";
+  }
+
+  const header = "## Trajectory analysis";
+  const bodyBudget = maxChars - header.length - 1;
+  if (bodyBudget <= 0) {
+    return "";
+  }
+
+  const clipped = truncateTrajectoryAnalysisLines(lines, bodyBudget);
+  return clipped.length === 0 ? "" : `${header}\n${clipped.join("\n")}`;
 }
 
 async function collectTurnReferenceEvidence(options: {
@@ -550,8 +613,8 @@ function hasLoopExitIntent(normalizedQuery: string): boolean {
 
 function hasBoundedTrajectoryRange(query: string): boolean {
   return [
-    /\b(?:between|from|in|during|within)\s+(?:steps?|actions?|observations?|turns?)\s+#?\d+\s*(?:-|\u2013|\u2014|\bto\b|\bthrough\b|\bthru\b|\band\b)\s*#?\d+\b/,
-    /\b(?:steps?|actions?|observations?|turns?)\s+#?\d+\s*(?:-|\u2013|\u2014|\bto\b|\bthrough\b|\bthru\b)\s*#?\d+\b/,
+    /\b(?:between|from|in|during|within)\s+(?:steps?|actions?|observations?|turns?)\s+#?\d+\s*(?:-|\u2013|\u2014|\bto\b|\bthrough\b|\bthru\b|\band\b)\s*(?:(?:steps?|actions?|observations?|turns?)\s+)?#?\d+\b/,
+    /\b(?:steps?|actions?|observations?|turns?)\s+#?\d+\s*(?:-|\u2013|\u2014|\bto\b|\bthrough\b|\bthru\b)\s*(?:(?:steps?|actions?|observations?|turns?)\s+)?#?\d+\b/,
   ].some((pattern) => pattern.test(query));
 }
 
@@ -680,6 +743,756 @@ async function collectLexicalCueEvidence(options: {
       );
     }
   }
+}
+
+interface LabeledTrajectoryStep {
+  step: number;
+  action?: string;
+  observation?: string;
+  actionTurnIndex?: number;
+  observationTurnIndex?: number;
+}
+
+interface TrajectoryBounds {
+  start: number;
+  end: number;
+  reason: string;
+}
+
+interface ObservationTransition {
+  fromStep: number;
+  toStep: number;
+}
+
+function hasTrajectoryAnalysisIntent(query: string): boolean {
+  const normalized = normalizeTrajectoryQuery(query);
+  if (collectExplicitTurnReferences(query).length > 0) {
+    return true;
+  }
+  return [
+    /\bbefore\s+(?:step|action|observation)\s+\d+\b/,
+    /\b(?:until|through|thru)\s+(?:step|action|observation)\s+\d+\b/,
+    /\bup\s+to\s+(?:and\s+including\s+)?(?:step|action|observation)\s+\d+\b/,
+    /\bwhat\s+sequence\s+of\s+actions\s+would\s+transform\b/,
+    /\bactions?\s+were\s+performed\b/,
+    /\bstate\s+of\s+[a-z0-9 _-]+\s+\d+\s+at\s+step\s+\d+\b/,
+    /\bwhole\s+changes?\s+history\b/,
+    /\bthroughout\s+the\s+trajectory\b/,
+    /\binventory\b/,
+    /\bcontainers?\b.*\binteracted\b/,
+    /\btypes?\s+of\s+actions?\b.*\bfrequen/,
+    /\bhow\s+frequently\b/,
+  ].some((pattern) => pattern.test(normalized));
+}
+
+function parseLabeledTrajectory(
+  messages: Array<{ turn_index: number; role: string; content: string }>,
+): LabeledTrajectoryStep[] {
+  const byStep = new Map<number, LabeledTrajectoryStep>();
+
+  for (const message of messages) {
+    const action = parseTrajectoryLabel(message.content, "Action");
+    if (action && isReferenceLabelRole(message.role, "action")) {
+      const step = getOrCreateTrajectoryStep(byStep, action.step);
+      step.action = action.value;
+      step.actionTurnIndex = message.turn_index;
+      continue;
+    }
+
+    const observation = parseTrajectoryLabel(message.content, "Observation");
+    if (observation && isReferenceLabelRole(message.role, "observation")) {
+      const step = getOrCreateTrajectoryStep(byStep, observation.step);
+      step.observation = observation.value;
+      step.observationTurnIndex = message.turn_index;
+    }
+  }
+
+  return [...byStep.values()].sort((left, right) => left.step - right.step);
+}
+
+function parseTrajectoryLabel(
+  content: string,
+  label: "Action" | "Observation",
+): { step: number; value: string } | undefined {
+  const match = new RegExp(
+    `^\\s*\\[\\s*${label}\\s+(\\d+)\\s*\\]\\s*(?::\\s*)?([\\s\\S]*)$`,
+    "i",
+  ).exec(content);
+  if (!match) {
+    return undefined;
+  }
+  const step = parseNonNegativeIntegerToken(match[1] ?? "");
+  if (step === undefined) {
+    return undefined;
+  }
+  const value = (match[2] ?? "").trim();
+  return { step, value };
+}
+
+function getOrCreateTrajectoryStep(
+  byStep: Map<number, LabeledTrajectoryStep>,
+  stepNumber: number,
+): LabeledTrajectoryStep {
+  const existing = byStep.get(stepNumber);
+  if (existing) {
+    return existing;
+  }
+  const created: LabeledTrajectoryStep = { step: stepNumber };
+  byStep.set(stepNumber, created);
+  return created;
+}
+
+function inferTrajectoryBounds(
+  query: string,
+  trajectory: readonly LabeledTrajectoryStep[],
+): TrajectoryBounds {
+  const minStep = trajectory[0]?.step ?? 0;
+  const maxStep = trajectory[trajectory.length - 1]?.step ?? minStep;
+  const normalized = normalizeTrajectoryQuery(query);
+
+  const before = firstMatchInteger(
+    normalized,
+    /\bbefore\s+(?:step|action|observation)\s+(\d+)\b/,
+  );
+  if (before !== undefined) {
+    return clampTrajectoryBounds(minStep, before - 1, minStep, maxStep, "before");
+  }
+
+  const until = firstMatchInteger(
+    normalized,
+    /\b(?:until|through|thru)\s+(?:step|action|observation)\s+(\d+)\b/,
+  ) ?? firstMatchInteger(
+    normalized,
+    /\bup\s+to\s+(?:and\s+including\s+)?(?:step|action|observation)\s+(\d+)\b/,
+  );
+  if (until !== undefined) {
+    return clampTrajectoryBounds(minStep, until, minStep, maxStep, "through");
+  }
+
+  const explicitRange = extractExplicitTrajectoryRange(normalized);
+  if (explicitRange) {
+    return clampTrajectoryBounds(
+      explicitRange.start,
+      explicitRange.end,
+      minStep,
+      maxStep,
+      "range",
+    );
+  }
+
+  const references = collectExplicitTurnReferences(query).map((reference) => reference.number);
+  if (references.length > 1) {
+    return clampTrajectoryBounds(
+      Math.min(...references),
+      Math.max(...references),
+      minStep,
+      maxStep,
+      "references",
+    );
+  }
+
+  const atStep = firstMatchInteger(
+    normalized,
+    /\b(?:at|in|on)\s+(?:step|action|observation)\s+(\d+)\b/,
+  );
+  if (atStep !== undefined) {
+    return clampTrajectoryBounds(minStep, atStep, minStep, maxStep, "at");
+  }
+
+  return { start: minStep, end: maxStep, reason: "full" };
+}
+
+function buildTrajectoryAnalysisLines(
+  query: string,
+  trajectory: readonly LabeledTrajectoryStep[],
+  bounds: TrajectoryBounds,
+): string[] {
+  const normalized = normalizeTrajectoryQuery(query);
+  const explicitReferences = collectExplicitTurnReferences(query);
+  const lines: string[] = [
+    `Analyzed labeled action/observation transcript window: steps ${bounds.start}-${bounds.end} (${bounds.reason}).`,
+  ];
+  const hasQuotedObservationPair = extractQuotedObservations(query).length >= 2;
+  const transition = findObservationTransition(query, trajectory);
+  const entities = extractNumberedEntities(query);
+  const asksActionRange = asksForTrajectoryActionRange(normalized) || transition !== undefined;
+  const asksFrequency = asksForActionFrequency(normalized);
+  const asksInventory = /\binventory\b/.test(normalized);
+  const asksLocation = /\blocations?\b/.test(normalized) || /\bwhere\b/.test(normalized);
+  const asksContainerHistory = /\bcontainers?\b/.test(normalized) ||
+    /\binteracted\b/.test(normalized);
+  const asksEntityState = /\bstate\b/.test(normalized) ||
+    /\bchanges?\s+history\b/.test(normalized) ||
+    /\bwhole\s+changes?\s+history\b/.test(normalized);
+
+  if (transition) {
+    lines.push(
+      `Matched quoted observations: Observation ${transition.fromStep} -> Observation ${transition.toStep}.`,
+    );
+    appendActionRangeLines(lines, trajectory, transition.fromStep + 1, transition.toStep, {
+      includeObservations: true,
+      heading: "Actions that transform the quoted observations:",
+    });
+  }
+
+  if (
+    asksActionRange &&
+    !transition &&
+    entities.length === 0 &&
+    !hasQuotedObservationPair
+  ) {
+    if (bounds.reason === "references") {
+      appendReferencedTrajectoryLines(lines, trajectory, explicitReferences, {
+        includeObservations: false,
+        heading: "Actions at referenced steps:",
+      });
+    } else {
+      appendActionRangeLines(lines, trajectory, bounds.start, bounds.end, {
+        includeObservations: false,
+        heading: "Actions in requested step window:",
+      });
+    }
+  }
+
+  if (asksFrequency) {
+    appendActionFrequencyLines(lines, trajectory, bounds);
+  }
+
+  if (asksInventory) {
+    appendInventoryChangeLines(lines, trajectory, bounds);
+  }
+
+  if (asksContainerHistory) {
+    appendContainerStateChangeLines(lines, trajectory, bounds);
+  }
+
+  if (
+    entities.length > 0 &&
+    (asksEntityState ||
+      asksLocation ||
+      /actions?\s+were\s+performed/.test(normalized))
+  ) {
+    appendEntityTimelineLines(lines, trajectory, bounds, entities, {
+      includeIndirectMentions: asksLocation,
+    });
+  }
+
+  if (lines.length === 1 && explicitReferences.length > 0) {
+    if (bounds.reason === "references") {
+      appendReferencedTrajectoryLines(lines, trajectory, explicitReferences, {
+        includeObservations: true,
+        heading: "Referenced trajectory evidence:",
+      });
+    } else {
+      appendActionRangeLines(lines, trajectory, bounds.start, bounds.end, {
+        includeObservations: true,
+        heading: "Referenced trajectory evidence:",
+      });
+    }
+  }
+
+  return lines.length === 1 ? [] : lines;
+}
+
+function appendReferencedTrajectoryLines(
+  lines: string[],
+  trajectory: readonly LabeledTrajectoryStep[],
+  references: readonly ExplicitTurnReference[],
+  options: { includeObservations: boolean; heading: string },
+): void {
+  const byStep = new Map(trajectory.map((step) => [step.step, step]));
+  const window = [...new Set(references.map((reference) => reference.number))]
+    .sort((left, right) => left - right)
+    .map((step) => byStep.get(step))
+    .filter((step): step is LabeledTrajectoryStep => step !== undefined);
+  if (window.length === 0) {
+    return;
+  }
+
+  lines.push(options.heading);
+  for (const step of window) {
+    if (step.action) {
+      lines.push(`[Action ${step.step}]: ${step.action}`);
+    }
+    if (options.includeObservations && step.observation) {
+      lines.push(`[Observation ${step.step}]: ${oneLine(step.observation)}`);
+    }
+  }
+}
+
+function appendActionRangeLines(
+  lines: string[],
+  trajectory: readonly LabeledTrajectoryStep[],
+  start: number,
+  end: number,
+  options: { includeObservations: boolean; heading: string },
+): void {
+  const low = Math.min(start, end);
+  const high = Math.max(start, end);
+  if (high - low + 1 > TRAJECTORY_ANALYSIS_MAX_RANGE_STEPS) {
+    lines.push(`${options.heading} requested range ${low}-${high} is too large for inline expansion.`);
+    return;
+  }
+  const window = trajectory.filter((step) => step.step >= low && step.step <= high);
+  if (window.length === 0) {
+    return;
+  }
+  lines.push(options.heading);
+  for (const step of window) {
+    if (step.action) {
+      lines.push(`[Action ${step.step}]: ${step.action}`);
+    }
+    if (options.includeObservations && step.observation) {
+      lines.push(`[Observation ${step.step}]: ${oneLine(step.observation)}`);
+    }
+  }
+}
+
+function appendActionFrequencyLines(
+  lines: string[],
+  trajectory: readonly LabeledTrajectoryStep[],
+  bounds: TrajectoryBounds,
+): void {
+  const counts = new Map<string, number>();
+  for (const step of boundedTrajectory(trajectory, bounds)) {
+    if (!step.action) continue;
+    const verb = normalizeActionVerb(step.action);
+    if (!verb) continue;
+    counts.set(verb, (counts.get(verb) ?? 0) + 1);
+  }
+  if (counts.size === 0) {
+    return;
+  }
+  const frequencies = [...counts.entries()].sort((left, right) =>
+    right[1] - left[1] || left[0].localeCompare(right[0]),
+  );
+  lines.push(
+    `Action frequency through requested window: ${frequencies
+      .map(([verb, count]) => `${verb}=${count}`)
+      .join(", ")}.`,
+  );
+}
+
+function appendInventoryChangeLines(
+  lines: string[],
+  trajectory: readonly LabeledTrajectoryStep[],
+  bounds: TrajectoryBounds,
+): void {
+  const held = new Set<string>();
+  const changes: string[] = [];
+  for (const step of boundedTrajectory(trajectory, bounds)) {
+    if (!step.action) continue;
+    const change = parseInventoryChange(step.action, held);
+    if (change) {
+      changes.push(`[Action ${step.step}]: ${step.action} => ${change}`);
+    }
+  }
+  if (changes.length === 0) {
+    return;
+  }
+  lines.push("Inventory changes from action transcript:");
+  lines.push(...changes);
+}
+
+function appendContainerStateChangeLines(
+  lines: string[],
+  trajectory: readonly LabeledTrajectoryStep[],
+  bounds: TrajectoryBounds,
+): void {
+  const changes = collectContainerStateChanges(trajectory, bounds);
+  if (changes.length === 0) {
+    return;
+  }
+  lines.push("Container open/close state changes:");
+  for (const change of changes) {
+    lines.push(`[Action ${change.step}]: ${change.action} => ${change.entity} ${change.state}`);
+  }
+}
+
+function appendEntityTimelineLines(
+  lines: string[],
+  trajectory: readonly LabeledTrajectoryStep[],
+  bounds: TrajectoryBounds,
+  entities: readonly string[],
+  options: { includeIndirectMentions: boolean },
+): void {
+  for (const entity of entities) {
+    const directActions = boundedTrajectory(trajectory, bounds).filter(
+      (step) =>
+        step.action &&
+        (isDirectEntityAction(step.action, entity) ||
+          (options.includeIndirectMentions &&
+            actionMentionsEntity(step.action, entity))),
+    );
+    const stateChanges = collectContainerStateChanges(trajectory, bounds).filter(
+      (change) => normalizeEntity(change.entity) === normalizeEntity(entity),
+    );
+    if (directActions.length === 0 && stateChanges.length === 0) {
+      continue;
+    }
+
+    lines.push(`Timeline for ${entity}:`);
+    for (const step of directActions) {
+      lines.push(`[Action ${step.step}]: ${step.action}`);
+    }
+    const inferredLocation = inferEntityLocation(trajectory, bounds, entity);
+    if (inferredLocation) {
+      lines.push(
+        `Inferred ${entity} location at step ${bounds.end}: ${inferredLocation}.`,
+      );
+    }
+    if (stateChanges.length > 0) {
+      const latest = stateChanges[stateChanges.length - 1]!;
+      lines.push(
+        `Latest ${entity} state at step ${bounds.end}: ${latest.state}; state changes: ${stateChanges
+          .map((change) => `${change.step}:${change.state}`)
+          .join(", ")}.`,
+      );
+    }
+  }
+}
+
+function boundedTrajectory(
+  trajectory: readonly LabeledTrajectoryStep[],
+  bounds: TrajectoryBounds,
+): LabeledTrajectoryStep[] {
+  return trajectory.filter((step) => step.step >= bounds.start && step.step <= bounds.end);
+}
+
+function collectContainerStateChanges(
+  trajectory: readonly LabeledTrajectoryStep[],
+  bounds: TrajectoryBounds,
+): Array<{ step: number; action: string; entity: string; state: "open" | "closed" }> {
+  const changes: Array<{
+    step: number;
+    action: string;
+    entity: string;
+    state: "open" | "closed";
+  }> = [];
+  for (const step of boundedTrajectory(trajectory, bounds)) {
+    if (!step.action) continue;
+    const match = /^(open|close)\s+(.+)$/i.exec(step.action.trim());
+    if (!match) continue;
+    const verb = match[1]!.toLowerCase();
+    changes.push({
+      step: step.step,
+      action: step.action,
+      entity: match[2]!.trim(),
+      state: verb === "open" ? "open" : "closed",
+    });
+  }
+  return changes;
+}
+
+function parseInventoryChange(action: string, held: Set<string>): string | undefined {
+  const normalized = action.trim();
+  const take = /^take\s+(.+?)\s+from\s+(.+)$/i.exec(normalized);
+  if (take) {
+    const object = take[1]!.trim();
+    const source = take[2]!.trim();
+    held.add(normalizeEntity(object));
+    return `inventory added ${object}; ${object} removed from ${source}`;
+  }
+
+  const place = /^(?:move|put|place|insert)\s+(.+?)\s+(?:to|in|into|on)\s+(.+)$/i.exec(
+    normalized,
+  );
+  if (place) {
+    const object = place[1]!.trim();
+    const destination = place[2]!.trim();
+    const key = normalizeEntity(object);
+    const wasHeld = held.delete(key);
+    return wasHeld
+      ? `inventory removed ${object}; ${object} moved to ${destination}`
+      : `${object} moved to ${destination}`;
+  }
+
+  const drop = /^drop\s+(.+)$/i.exec(normalized);
+  if (drop) {
+    const object = drop[1]!.trim();
+    held.delete(normalizeEntity(object));
+    return `inventory removed ${object}`;
+  }
+
+  return undefined;
+}
+
+function asksForTrajectoryActionRange(normalizedQuery: string): boolean {
+  return [
+    /\bwhat\s+actions?\s+were\s+performed\b/,
+    /\bwhich\s+actions?\s+were\s+performed\b/,
+    /\bsequence\s+of\s+actions?\b/,
+    /\bactions?\s+(?:between|from|during|within)\b/,
+  ].some((pattern) => pattern.test(normalizedQuery));
+}
+
+function asksForActionFrequency(normalizedQuery: string): boolean {
+  return /\btypes?\s+of\s+actions?\b/.test(normalizedQuery) ||
+    /\bfrequen/.test(normalizedQuery) ||
+    /\bhow\s+often\b/.test(normalizedQuery);
+}
+
+function extractExplicitTrajectoryRange(
+  normalizedQuery: string,
+): { start: number; end: number } | undefined {
+  const patterns = [
+    /\b(?:between|from|during|within)\s+(?:steps?|actions?|observations?)\s+(\d+)\s*(?:-|to|through|thru|and)\s*(?:(?:steps?|actions?|observations?)\s+)?(\d+)\b/,
+    /\b(?:steps?|actions?|observations?)\s+(\d+)\s*(?:-|to|through|thru)\s*(?:(?:steps?|actions?|observations?)\s+)?(\d+)\b/,
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(normalizedQuery);
+    if (!match) continue;
+    const start = parseNonNegativeIntegerToken(match[1] ?? "");
+    const end = parseNonNegativeIntegerToken(match[2] ?? "");
+    if (start !== undefined && end !== undefined) {
+      return { start, end };
+    }
+  }
+  return undefined;
+}
+
+function findObservationTransition(
+  query: string,
+  trajectory: readonly LabeledTrajectoryStep[],
+): ObservationTransition | undefined {
+  const quoted = extractQuotedObservations(query);
+  if (quoted.length < 2) {
+    return undefined;
+  }
+  const fromCandidates = findObservationStepCandidates(trajectory, quoted[0]!);
+  const toCandidates = findObservationStepCandidates(trajectory, quoted[1]!);
+  if (fromCandidates.length === 0 || toCandidates.length === 0) {
+    return undefined;
+  }
+
+  let best: ObservationTransition | undefined;
+  for (const fromStep of fromCandidates) {
+    for (const toStep of toCandidates) {
+      if (toStep <= fromStep) {
+        continue;
+      }
+      if (
+        !best ||
+        toStep - fromStep < best.toStep - best.fromStep ||
+        (toStep - fromStep === best.toStep - best.fromStep &&
+          fromStep < best.fromStep)
+      ) {
+        best = { fromStep, toStep };
+      }
+    }
+  }
+  if (best) {
+    return best;
+  }
+
+  return undefined;
+}
+
+function extractQuotedObservations(query: string): string[] {
+  const observations: string[] = [];
+  for (const match of query.matchAll(/\bobservation:\s*"([\s\S]*?)"/gi)) {
+    const value = match[1]?.trim();
+    if (value) {
+      observations.push(value);
+    }
+  }
+  return observations;
+}
+
+function findObservationStepCandidates(
+  trajectory: readonly LabeledTrajectoryStep[],
+  quotedObservation: string,
+): number[] {
+  const normalizedQuoted = normalizeObservationText(quotedObservation);
+  const normalizedQuotedCore = normalizeObservationCore(quotedObservation);
+  const candidates = new Set<number>();
+
+  for (const step of trajectory) {
+    if (!step.observation) continue;
+    const normalizedObservation = normalizeObservationText(step.observation);
+    if (
+      normalizedObservation === normalizedQuoted ||
+      normalizedObservation.includes(normalizedQuoted) ||
+      normalizedQuoted.includes(normalizedObservation)
+    ) {
+      candidates.add(step.step);
+      continue;
+    }
+
+    const normalizedObservationCore = normalizeObservationCore(step.observation);
+    if (
+      normalizedObservationCore.length > 0 &&
+      normalizedQuotedCore.length > 0 &&
+      (normalizedObservationCore === normalizedQuotedCore ||
+        normalizedObservationCore.includes(normalizedQuotedCore) ||
+        normalizedQuotedCore.includes(normalizedObservationCore))
+    ) {
+      candidates.add(step.step);
+    }
+  }
+
+  return [...candidates].sort((left, right) => left - right);
+}
+
+function extractNumberedEntities(query: string): string[] {
+  const entities = new Set<string>();
+  for (const match of query.matchAll(/\b([a-z][a-z0-9_-]*(?:\s+[a-z][a-z0-9_-]*)?)\s+(\d+)\b/gi)) {
+    const rawPrefix = match[1]?.trim().toLowerCase();
+    const number = match[2]?.trim();
+    if (!rawPrefix || !number || isTrajectoryReferenceEntity(rawPrefix)) {
+      continue;
+    }
+    const words = rawPrefix.split(/\s+/);
+    const entityHead = words[words.length - 1]!;
+    if (isTrajectoryReferenceEntity(entityHead)) {
+      continue;
+    }
+    entities.add(`${entityHead} ${number}`);
+  }
+  return [...entities].sort((left, right) => left.localeCompare(right));
+}
+
+function isTrajectoryReferenceEntity(value: string): boolean {
+  return [
+    "action",
+    "actions",
+    "observation",
+    "observations",
+    "step",
+    "steps",
+    "turn",
+    "turns",
+  ].includes(value);
+}
+
+function actionMentionsEntity(action: string, entity: string): boolean {
+  const normalizedAction = normalizeTrajectoryQuery(action);
+  const normalizedEntity = normalizeEntity(entity);
+  return normalizedAction === normalizedEntity ||
+    normalizedAction.startsWith(`${normalizedEntity} `) ||
+    normalizedAction.endsWith(` ${normalizedEntity}`) ||
+    normalizedAction.includes(` ${normalizedEntity} `);
+}
+
+function isDirectEntityAction(action: string, entity: string): boolean {
+  const normalizedAction = normalizeTrajectoryQuery(action);
+  const normalizedEntity = normalizeEntity(entity);
+  return [
+    `open ${normalizedEntity}`,
+    `close ${normalizedEntity}`,
+    `examine ${normalizedEntity}`,
+  ].includes(normalizedAction);
+}
+
+function inferEntityLocation(
+  trajectory: readonly LabeledTrajectoryStep[],
+  bounds: TrajectoryBounds,
+  entity: string,
+): string | undefined {
+  const normalizedEntity = normalizeEntity(entity);
+  let location: string | undefined;
+  for (const step of boundedTrajectory(trajectory, bounds)) {
+    if (!step.action) continue;
+    const action = step.action.trim();
+    const take = /^take\s+(.+?)\s+from\s+(.+)$/i.exec(action);
+    if (take && normalizeEntity(take[1]!) === normalizedEntity) {
+      location = "inventory";
+      continue;
+    }
+    const move = /^(?:move|put|place|insert)\s+(.+?)\s+(?:to|in|into|on)\s+(.+)$/i.exec(
+      action,
+    );
+    if (move && normalizeEntity(move[1]!) === normalizedEntity) {
+      location = move[2]!.trim();
+    }
+  }
+  return location;
+}
+
+function normalizeActionVerb(action: string): string | undefined {
+  const match = /^([a-z][a-z0-9_-]*)\b/i.exec(action.trim());
+  return match?.[1]?.toLowerCase();
+}
+
+function clampTrajectoryBounds(
+  start: number,
+  end: number,
+  minStep: number,
+  maxStep: number,
+  reason: string,
+): TrajectoryBounds {
+  const low = Math.max(minStep, Math.min(start, end));
+  const high = Math.min(maxStep, Math.max(start, end));
+  return {
+    start: Math.min(low, high),
+    end: Math.max(low, high),
+    reason,
+  };
+}
+
+function firstMatchInteger(query: string, pattern: RegExp): number | undefined {
+  const match = pattern.exec(query);
+  return match ? parseNonNegativeIntegerToken(match[1] ?? "") : undefined;
+}
+
+export function normalizeTurnExpansionEnd(stats: {
+  totalMessages: number;
+  maxTurnIndex?: number;
+}): number {
+  const messageCountEnd = Math.max(0, Math.floor(stats.totalMessages) - 1);
+  if (
+    typeof stats.maxTurnIndex !== "number" ||
+    !Number.isFinite(stats.maxTurnIndex)
+  ) {
+    return messageCountEnd;
+  }
+
+  return Math.max(messageCountEnd, Math.floor(stats.maxTurnIndex));
+}
+
+function truncateTrajectoryAnalysisLines(lines: string[], maxChars: number): string[] {
+  const result: string[] = [];
+  let used = 0;
+  for (const line of lines.slice(0, TRAJECTORY_ANALYSIS_MAX_LINES)) {
+    const separator = result.length === 0 ? 0 : 1;
+    const remaining = maxChars - used - separator;
+    if (remaining <= 0) {
+      break;
+    }
+    const clipped = line.length > remaining
+      ? remaining <= 3
+        ? line.slice(0, remaining)
+        : `${line.slice(0, remaining - 3).trimEnd()}...`
+      : line;
+    if (clipped.length === 0) {
+      break;
+    }
+    result.push(clipped);
+    used += separator + clipped.length;
+  }
+  return result;
+}
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeEntity(value: string): string {
+  return normalizeTrajectoryQuery(value);
+}
+
+function normalizeObservationText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function normalizeObservationCore(value: string): string {
+  return normalizeObservationText(
+    value.split(/\bthe current available actions are:/i)[0] ?? value,
+  );
+}
+
+function normalizeTrajectoryQuery(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9_-]+/g, " ").trim();
 }
 
 function appendExpandedEvidence(

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -52,15 +52,18 @@ export {
 } from "./evidence-pack.js";
 export {
   buildExplicitCueRecallSection,
+  buildTrajectoryAnalysisRecallSection,
   collectExplicitTurnReferences,
   collectBenchmarkAnchorCues,
   collectLexicalCues,
   collectQuestionSlotCues,
   collectStructuredPlanCues,
   collectTemporalLexicalCues,
+  normalizeTurnExpansionEnd,
   type ExplicitCueRecallEngine,
   type ExplicitCueRecallOptions,
   type ExplicitTurnReference,
+  type TrajectoryAnalysisRecallOptions,
 } from "./explicit-cue-recall.js";
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/lcm/engine.ts
+++ b/packages/remnic-core/src/lcm/engine.ts
@@ -516,6 +516,7 @@ export class LcmEngine {
     totalMessages: number;
     totalSummaryNodes: number;
     maxDepth: number;
+    maxTurnIndex?: number;
   }> {
     if (!this.config.enabled)
       return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: -1 };
@@ -526,6 +527,7 @@ export class LcmEngine {
         totalMessages: this.archive!.getMessageCount(sessionId),
         totalSummaryNodes: this.dag!.getNodeCount(sessionId),
         maxDepth: this.dag!.getMaxDepth(sessionId),
+        maxTurnIndex: this.archive!.getMaxTurnIndex(sessionId),
       };
     }
 

--- a/scripts/bench/ama-diagnostic-matrix.ts
+++ b/scripts/bench/ama-diagnostic-matrix.ts
@@ -1246,7 +1246,13 @@ function ensureRuntimeBuilds(): void {
     "dist",
     "index.js",
   );
-  if (!existsSync(coreDistPath)) {
+  const coreSourcePaths = [
+    path.join(repoRoot, "packages", "remnic-core", "src"),
+    path.join(repoRoot, "packages", "remnic-core", "package.json"),
+    path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+    path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+  ];
+  if (!existsSync(coreDistPath) || isAnySourceNewerThan(coreSourcePaths, coreDistPath)) {
     runPnpm(["--filter", "@remnic/core", "build"]);
   }
 


### PR DESCRIPTION
## Summary
- add deterministic trajectory analysis recall for labeled action/observation transcripts
- attach the trajectory analysis section to AMA recall when trajectory-shaped queries need full-history/range/count/location evidence
- rebuild core dist when core source changes before AMA diagnostic matrix runs so bench builds cannot use stale core declarations

## Verification
- pnpm exec tsx --test packages/remnic-core/src/explicit-cue-recall.test.ts
- pnpm exec tsx --test packages/bench/src/answering.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check
- AMA episode 30 proof slice reached 11/12 before Codex CLI auth expired; local deterministic transition check now resolves the remaining miss to Action 71 only

## Benchmark validity notes
- This preserves full Remnic adapter mode and uses transcript-derived evidence from the isolated benchmark LCM archive.
- This is not an oracle adapter; it only exposes deterministic analysis of labeled trajectory messages that Remnic has ingested.
- A full Codex CLI leaderboard run is blocked until Codex CLI is reauthenticated; the latest run failed with refresh_token_reused / 401 on every task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new recall surface that expands and analyzes full labeled action/observation histories, plus adjusts turn-range expansion logic; incorrect intent detection or bounds inference could change what evidence is returned for AMA tasks.
> 
> **Overview**
> Adds a new deterministic `Trajectory analysis` recall section in `@remnic/core` (`buildTrajectoryAnalysisRecallSection`) that parses labeled `[Action N]`/`[Observation N]` transcripts and emits bounded evidence for range queries, quoted-observation transitions, action frequencies, inventory/container state changes, and entity timelines/locations (with hard caps and truncation).
> 
> Wires this section into the bench Remnic adapter for `ama-` sessions with a dedicated budget, updates recall section title lists, and extends stats/turn expansion handling (`maxTurnIndex` + `normalizeTurnExpansionEnd`) so sparse turn indexes can be fully expanded. Updates LCM `getStats` to return `maxTurnIndex`, adds extensive unit tests for trajectory analysis behavior, and makes the AMA diagnostic script rebuild `@remnic/core` when sources are newer than `dist` to avoid stale runtime builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 175b1854d4939d9e2af2efb70f2047e11b9faac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->