### PR TITLE
fix(bench): avoid duplicate LCM archival in adapter

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -231,6 +231,7 @@ test("direct adapter recall expands search hits with adjacent stored results", a
 test("direct adapter archives stored messages into LCM once", async () => {
   const adapter = await createRemnicAdapter({
     configOverrides: {
+      transcriptEnabled: true,
       extractionMinUserTurns: 999,
     },
   });

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -228,6 +228,35 @@ test("direct adapter recall expands search hits with adjacent stored results", a
   }
 });
 
+test("direct adapter archives stored messages into LCM once", async () => {
+  const adapter = await createRemnicAdapter({
+    configOverrides: {
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("archive-once-session", [
+      {
+        role: "user",
+        content: "First archived turn.",
+      },
+      {
+        role: "assistant",
+        content: "Second archived turn.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    const stats = await adapter.getStats("archive-once-session");
+
+    assert.equal(stats.totalMessages, 2);
+    assert.equal(stats.maxTurnIndex, 1);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
 test("adapter recall front-loads exact step references from the session trace", async () => {
   const adapter = await createRemnicAdapter();
 

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -118,6 +118,19 @@ type OrchestratorTeardownView = {
   qmdMaintenanceInFlight?: boolean;
 };
 
+type OrchestratorDrainDiagnosticsView = {
+  lcmEngine: {
+    observeQueueDepth: number;
+    observeQueueInFlightCount: number;
+  } | null;
+  extractionQueue?: unknown[];
+  queueProcessing?: boolean;
+  consolidationInFlight?: boolean;
+  qmdMaintenancePending?: boolean;
+  qmdMaintenanceInFlight?: boolean;
+  tierMigrationInFlight?: boolean;
+};
+
 const BENCH_TEARDOWN_DEFERRED_READY_WAIT_MS = 500;
 const DEFAULT_BENCH_DRAIN_TIMEOUT_MS = 5 * 60_000;
 const CORE_EXPLICIT_CUE_MAX_CHARS = 18_000;
@@ -448,7 +461,9 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           });
         }
 
-        await state.orchestrator.ingestReplayBatch(replayTurns);
+        await state.orchestrator.ingestReplayBatch(replayTurns, {
+          archiveLcm: false,
+        });
       },
 
       async recall(sessionId: string, query: string, budgetChars?: number): Promise<string> {
@@ -681,7 +696,11 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         const timeout = new Promise<void>((_, reject) => {
           timer = setTimeout(() => {
             abortController.abort();
-            reject(new Error(`drain() timed out after ${drainTimeoutMs}ms`));
+            reject(
+              new Error(
+                `drain() timed out after ${drainTimeoutMs}ms (${describeDrainState(state.orchestrator)})`,
+              ),
+            );
           }, drainTimeoutMs);
         });
         try {
@@ -693,10 +712,14 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
                 state.orchestrator.waitForConsolidationIdle(drainTimeoutMs),
               ]);
               if (!extractionIdle) {
-                throw new Error("drain() timed out waiting for extraction idle");
+                throw new Error(
+                  `drain() timed out waiting for extraction idle (${describeDrainState(state.orchestrator)})`,
+                );
               }
               if (!consolidationIdle) {
-                throw new Error("drain() timed out waiting for consolidation idle");
+                throw new Error(
+                  `drain() timed out waiting for consolidation idle (${describeDrainState(state.orchestrator)})`,
+                );
               }
             })().catch((err: unknown) => {
               if (abortController.signal.aborted) return;
@@ -725,6 +748,25 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
 
 export const createLightweightAdapter = createAdapterFactory("lightweight");
 export const createRemnicAdapter = createAdapterFactory("direct");
+
+function describeDrainState(orchestrator: Orchestrator): string {
+  const view = orchestrator as unknown as OrchestratorDrainDiagnosticsView;
+  const lcmDepth = view.lcmEngine?.observeQueueDepth ?? 0;
+  const lcmInFlight = view.lcmEngine?.observeQueueInFlightCount ?? 0;
+  const extractionQueueDepth = Array.isArray(view.extractionQueue)
+    ? view.extractionQueue.length
+    : 0;
+  return [
+    `lcmDepth=${lcmDepth}`,
+    `lcmInFlight=${lcmInFlight}`,
+    `extractionProcessing=${view.queueProcessing === true}`,
+    `extractionQueueDepth=${extractionQueueDepth}`,
+    `consolidationInFlight=${view.consolidationInFlight === true}`,
+    `qmdMaintenancePending=${view.qmdMaintenancePending === true}`,
+    `qmdMaintenanceInFlight=${view.qmdMaintenanceInFlight === true}`,
+    `tierMigrationInFlight=${view.tierMigrationInFlight === true}`,
+  ].join(", ");
+}
 
 function shouldUseCoreMemoryPipeline(
   mode: BenchAdapterMode,


### PR DESCRIPTION
## Summary
- avoid double-archiving benchmark batches into LCM when the direct adapter also invokes the Remnic replay ingestion path
- add drain timeout diagnostics that report LCM, extraction, consolidation, QMD maintenance, and tier migration state
- add a regression test that a two-message stored batch remains two LCM archive messages

## Verification
- pnpm exec tsx --test packages/bench/src/adapters/remnic-adapter.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark adapter ingestion and drain behavior; while scoped to bench tooling, mistakes could skew memory stats/recall behavior or mask real pipeline issues.
> 
> **Overview**
> Prevents the direct bench adapter from double-archiving turns into LCM by calling `orchestrator.ingestReplayBatch` with `archiveLcm: false` after `observeMessages` already persists the batch.
> 
> Improves `drain()` timeout errors by appending a snapshot of orchestrator state (LCM queue depth/in-flight, extraction queue/processing, consolidation, QMD maintenance, tier migration) to help debug stalls.
> 
> Adds a regression test ensuring a stored two-message batch results in exactly two archived LCM messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9504e1c005b7f035176131ad3d7931ef6923fb41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->