### PR TITLE
Align OpenClaw 2026.5.7 registration metadata handling

### DIFF
--- a/.changeset/openclaw-2026-5-7-registration.md
+++ b/.changeset/openclaw-2026-5-7-registration.md
@@ -1,0 +1,9 @@
+---
+"@remnic/core": patch
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Align the OpenClaw adapter with 2026.5.7 registration metadata flows by keeping
+discovery/setup/CLI metadata registration modes inert and removing deprecated
+manifest contract keys that current OpenClaw no longer accepts.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -70,34 +70,6 @@
     "beforeReset": true
   },
   "contracts": {
-    "commands": [
-      "remnic"
-    ],
-    "hooks": [
-      "before_prompt_build",
-      "before_agent_start",
-      "agent_end",
-      "before_compaction",
-      "after_compaction",
-      "before_reset",
-      "session_start",
-      "session_end",
-      "before_tool_call",
-      "after_tool_call",
-      "llm_output",
-      "subagent_spawning",
-      "subagent_ended",
-      "commands.list"
-    ],
-    "memoryCapabilities": [
-      "openclaw-remnic"
-    ],
-    "memoryPromptSections": [
-      "engram-memory"
-    ],
-    "services": [
-      "openclaw-remnic"
-    ],
     "tools": [
       "compounding_promote_candidate",
       "compounding_weekly_synthesize",

--- a/packages/plugin-openclaw/openclaw-sdk-surface.expected.json
+++ b/packages/plugin-openclaw/openclaw-sdk-surface.expected.json
@@ -40,8 +40,6 @@
     "session_start"
   ],
   "manifestContracts": [
-    "commands",
-    "hooks",
     "memoryEmbeddingProviders",
     "tools"
   ]

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -70,34 +70,6 @@
     "beforeReset": true
   },
   "contracts": {
-    "commands": [
-      "remnic"
-    ],
-    "hooks": [
-      "before_prompt_build",
-      "before_agent_start",
-      "agent_end",
-      "before_compaction",
-      "after_compaction",
-      "before_reset",
-      "session_start",
-      "session_end",
-      "before_tool_call",
-      "after_tool_call",
-      "llm_output",
-      "subagent_spawning",
-      "subagent_ended",
-      "commands.list"
-    ],
-    "memoryCapabilities": [
-      "openclaw-remnic"
-    ],
-    "memoryPromptSections": [
-      "engram-memory"
-    ],
-    "services": [
-      "openclaw-remnic"
-    ],
     "tools": [
       "compounding_promote_candidate",
       "compounding_weekly_synthesize",

--- a/packages/remnic-core/src/sdk-compat.ts
+++ b/packages/remnic-core/src/sdk-compat.ts
@@ -26,8 +26,17 @@ export interface SdkCapabilities {
   /** Detected SDK version string, or "legacy" */
   sdkVersion: string;
   /** api.registrationMode value when present */
-  registrationMode: "full" | "setup-only" | "setup-runtime" | undefined;
+  registrationMode: OpenClawRegistrationMode | undefined;
 }
+
+export type OpenClawRegistrationMode =
+  | "full"
+  | "discovery"
+  | "tool-discovery"
+  | "setup-only"
+  | "setup-runtime"
+  | "cli-metadata"
+  | (string & {});
 
 export function detectSdkCapabilities(api: Record<string, unknown>): SdkCapabilities {
   const hasRegisterMemoryPromptSection =

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -70,34 +70,6 @@
     "beforeReset": true
   },
   "contracts": {
-    "commands": [
-      "remnic"
-    ],
-    "hooks": [
-      "before_prompt_build",
-      "before_agent_start",
-      "agent_end",
-      "before_compaction",
-      "after_compaction",
-      "before_reset",
-      "session_start",
-      "session_end",
-      "before_tool_call",
-      "after_tool_call",
-      "llm_output",
-      "subagent_spawning",
-      "subagent_ended",
-      "commands.list"
-    ],
-    "memoryCapabilities": [
-      "openclaw-engram"
-    ],
-    "memoryPromptSections": [
-      "engram-memory"
-    ],
-    "services": [
-      "openclaw-engram"
-    ],
     "tools": [
       "compounding_promote_candidate",
       "compounding_weekly_synthesize",

--- a/packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs
+++ b/packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs
@@ -17,11 +17,6 @@ const packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8"));
 const manifest = JSON.parse(raw);
 manifest.id = "openclaw-engram";
 manifest.version = packageJson.version;
-manifest.contracts = {
-  ...manifest.contracts,
-  memoryCapabilities: [manifest.id],
-  services: [manifest.id],
-};
 manifest.providerAuthChoices = [
   {
     provider: "openai",

--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -21,6 +21,12 @@ const PREFERRED_SDK_SURFACE_FILES = [
   "dist/plugin-sdk/src/plugins/manifest-registry.d.ts",
   "dist/plugin-sdk/src/plugins/memory-embedding-providers.d.ts",
   "dist/plugin-sdk/src/plugins/compaction-provider.d.ts",
+  "src/plugins/types.ts",
+  "src/plugins/hook-types.ts",
+  "src/plugins/manifest.ts",
+  "src/plugins/manifest-registry.ts",
+  "src/plugins/memory-embedding-providers.ts",
+  "src/plugins/compaction-provider.ts",
 ];
 const EXPECTED_REGISTRAR_PREFIXES = [
   "registerCli",
@@ -39,13 +45,7 @@ const EXPECTED_HOOK_PREFIXES = [
   "llm_",
   "session_",
 ];
-const EXPECTED_CONTRACT_PREFIXES = [
-  "commands",
-  "hooks",
-  "memory",
-  "services",
-  "tools",
-];
+const EXPECTED_CONTRACT_PREFIXES = ["memory", "tools"];
 
 const args = parseArgs(process.argv.slice(2));
 const expectedPath = resolveUserPath(args.expected ?? defaultExpectedPath);
@@ -158,7 +158,7 @@ async function inspectOpenClawSurface(root) {
   const files = await collectFiles(root);
   if (files.length === 0) {
     throw new Error(
-      `OpenClaw SDK surface check failed: no SDK declaration files found under ${root}. Build OpenClaw or pass --package-root to a package containing dist/plugin-sdk declarations.`,
+      `OpenClaw SDK surface check failed: no SDK declaration or source files found under ${root}. Build OpenClaw or pass --package-root to a package containing dist/plugin-sdk declarations.`,
     );
   }
   const manifestFiles = files.filter((file) =>
@@ -182,7 +182,9 @@ async function inspectOpenClawSurface(root) {
 
   for (const file of contractFiles) {
     const text = await readFile(file, "utf-8").catch(() => "");
-    for (const match of text.matchAll(/\b([A-Za-z][A-Za-z0-9]+Providers|tools|commands|hooks|services|memory[A-Za-z0-9]+)\b/g)) {
+    const contractsText = extractPluginManifestContractsBlock(text);
+    if (!contractsText) continue;
+    for (const match of contractsText.matchAll(/\b([A-Za-z][A-Za-z0-9]+Providers|tools|commands|hooks|services|memory[A-Za-z0-9]+)\b/g)) {
       const value = match[1];
       if (looksLikeManifestContract(value)) manifestContracts.add(value);
     }
@@ -208,6 +210,26 @@ function looksLikeHookName(value) {
 
 function looksLikeManifestContract(value) {
   return EXPECTED_CONTRACT_PREFIXES.some((prefix) => value.startsWith(prefix));
+}
+
+function extractPluginManifestContractsBlock(text) {
+  const match =
+    /\b(?:export\s+)?(?:interface|type)\s+PluginManifestContracts\b[^={]*[={]/.exec(text);
+  if (!match) return null;
+
+  const openBraceIndex = text.indexOf("{", match.index);
+  if (openBraceIndex === -1) return null;
+
+  let depth = 0;
+  for (let index = openBraceIndex; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return text.slice(openBraceIndex + 1, index);
+    }
+  }
+  return null;
 }
 
 async function collectFiles(root) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,11 @@ import { createRequire } from "node:module";
 import { parseConfig } from "./config.js";
 import { initLogger } from "./logger.js";
 import { log } from "./logger.js";
-import { detectSdkCapabilities, type SdkCapabilities } from "./sdk-compat.js";
+import {
+  detectSdkCapabilities,
+  type OpenClawRegistrationMode,
+  type SdkCapabilities,
+} from "./sdk-compat.js";
 import {
   Orchestrator,
   sanitizeSessionKeyForFilename,
@@ -588,6 +592,20 @@ function tryDefinePluginEntry(def: {
 /** SDK capabilities detected at register() time — available to later tasks. */
 let sdkCaps: SdkCapabilities | undefined;
 
+const NON_RUNTIME_REGISTRATION_MODES = new Set<OpenClawRegistrationMode>([
+  "discovery",
+  "tool-discovery",
+  "setup-only",
+  "setup-runtime",
+  "cli-metadata",
+]);
+
+function isNonRuntimeRegistrationMode(
+  mode: SdkCapabilities["registrationMode"],
+): boolean {
+  return typeof mode === "string" && NON_RUNTIME_REGISTRATION_MODES.has(mode);
+}
+
 const pluginDefinition = {
   id: PLUGIN_ID,
   name: "Remnic (Local Memory)",
@@ -620,6 +638,21 @@ const pluginDefinition = {
     // Initialize logger early (debug off until config is parsed).
     initLogger(api.logger, false);
 
+    // Detect SDK capabilities for dual-path hook registration.
+    sdkCaps = detectSdkCapabilities(api as unknown as Record<string, unknown>);
+    log.info(
+      `SDK detection: version=${sdkCaps.sdkVersion}, beforePromptBuild=${sdkCaps.hasBeforePromptBuild}, memoryPromptSection=${sdkCaps.hasRegisterMemoryPromptSection}, memoryCapability=${sdkCaps.hasRegisterMemoryCapability}, typedHooks=${sdkCaps.hasTypedHooks}`,
+    );
+
+    // Metadata/setup loaders invoke register() to inspect static surfaces. Keep
+    // those paths inert: no migrations, config reads, hooks, services, or tools.
+    if (isNonRuntimeRegistrationMode(sdkCaps.registrationMode)) {
+      log.info(
+        `registrationMode=${sdkCaps.registrationMode} — skipping runtime initialization`,
+      );
+      return;
+    }
+
     const disableRegisterMigration =
       readEnvVar("REMNIC_DISABLE_REGISTER_MIGRATION") === "1" ||
       readEnvVar("OPENCLAW_ENGRAM_DISABLE_REGISTER_MIGRATION") === "1";
@@ -632,18 +665,6 @@ const pluginDefinition = {
           log.warn(`register migration failed: ${error}`);
         }));
       void migrationPromise;
-    }
-
-    // Detect SDK capabilities for dual-path hook registration.
-    sdkCaps = detectSdkCapabilities(api as unknown as Record<string, unknown>);
-    log.info(
-      `SDK detection: version=${sdkCaps.sdkVersion}, beforePromptBuild=${sdkCaps.hasBeforePromptBuild}, memoryPromptSection=${sdkCaps.hasRegisterMemoryPromptSection}, memoryCapability=${sdkCaps.hasRegisterMemoryCapability}, typedHooks=${sdkCaps.hasTypedHooks}`,
-    );
-
-    // Skip heavy initialization in setup-only mode (new SDK channel setup flows)
-    if (sdkCaps.registrationMode === "setup-only") {
-      log.info("registrationMode=setup-only — skipping full initialization");
-      return;
     }
 
     // Workaround: Load config from file since gateway may not pass it.

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -289,8 +289,14 @@ declare module "openclaw/plugin-sdk" {
     /** Register an additive memory prompt supplement. */
     registerMemoryPromptSupplement?: (builder: MemoryPromptSectionBuilder["build"] | ((...args: any[]) => any)) => void;
 
-    /** Registration mode: "full" | "setup-only" | "setup-runtime" (new SDK >=2026.3.22) */
-    registrationMode?: "full" | "setup-only" | "setup-runtime";
+    /** Registration mode: "full" | "discovery" | "tool-discovery" | "setup-only" | "setup-runtime" | "cli-metadata" (new SDK >=2026.3.22) */
+    registrationMode?:
+      | "full"
+      | "discovery"
+      | "tool-discovery"
+      | "setup-only"
+      | "setup-runtime"
+      | "cli-metadata";
 
     /** Runtime namespace (new SDK >=2026.3.22) */
     runtime?: OpenClawRuntime;

--- a/tests/helpers/openclaw-registration-harness.ts
+++ b/tests/helpers/openclaw-registration-harness.ts
@@ -1,4 +1,11 @@
 type RegistrationArgs = unknown[];
+type OpenClawRegistrationMode =
+  | "full"
+  | "discovery"
+  | "tool-discovery"
+  | "setup-only"
+  | "setup-runtime"
+  | "cli-metadata";
 
 export interface CapturedOpenClawApi {
   api: Record<string, unknown>;
@@ -39,7 +46,7 @@ export function captureOpenClawRegistrationApi(options: {
   label?: string;
   pluginConfig?: Record<string, unknown>;
   config?: Record<string, unknown>;
-  registrationMode?: "full" | "setup-only" | "setup-runtime";
+  registrationMode?: OpenClawRegistrationMode;
   runtime?: Record<string, unknown>;
   disabledMethods?: string[];
   logger?: Record<"debug" | "info" | "warn" | "error", (...args: unknown[]) => void>;

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -46,22 +46,6 @@ const OPENCLAW_MANIFEST_PATHS = [
   "packages/plugin-openclaw/openclaw.plugin.json",
   "packages/shim-openclaw-engram/openclaw.plugin.json",
 ];
-const EXPECTED_LIFECYCLE_HOOK_CONTRACTS = [
-  "after_compaction",
-  "after_tool_call",
-  "agent_end",
-  "before_agent_start",
-  "before_compaction",
-  "before_prompt_build",
-  "before_reset",
-  "before_tool_call",
-  "commands.list",
-  "llm_output",
-  "session_end",
-  "session_start",
-  "subagent_ended",
-  "subagent_spawning",
-];
 const TOOL_SOURCE_PATHS = [
   "src/tools.ts",
   "packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.ts",
@@ -129,7 +113,7 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
     );
   });
 
-  test(`${manifestPath} declares OpenClaw adapter command, memory, service, and hook contracts`, () => {
+  test(`${manifestPath} keeps runtime declarations on supported manifest surfaces`, () => {
     const manifest = readManifest(manifestPath);
 
     assert.deepEqual(manifest.commandAliases, [
@@ -143,14 +127,19 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
       onCommands: ["remnic"],
       onCapabilities: ["tool", "hook"],
     });
-    assert.deepEqual(manifest.contracts?.commands, ["remnic"]);
-    assert.deepEqual(
-      [...(manifest.contracts?.hooks ?? [])].sort(),
-      EXPECTED_LIFECYCLE_HOOK_CONTRACTS,
-    );
-    assert.deepEqual(manifest.contracts?.memoryCapabilities, [manifest.id]);
-    assert.deepEqual(manifest.contracts?.memoryPromptSections, ["engram-memory"]);
-    assert.deepEqual(manifest.contracts?.services, [manifest.id]);
+    for (const deprecatedKey of [
+      "commands",
+      "hooks",
+      "memoryCapabilities",
+      "memoryPromptSections",
+      "services",
+    ]) {
+      assert.equal(
+        deprecatedKey in (manifest.contracts ?? {}),
+        false,
+        `${deprecatedKey} is no longer part of OpenClaw PluginManifestContracts`,
+      );
+    }
   });
 
   test(`${manifestPath} declares pre-runtime auth metadata for OpenAI-backed memory extraction`, () => {

--- a/tests/openclaw-registration-capture.test.ts
+++ b/tests/openclaw-registration-capture.test.ts
@@ -125,16 +125,22 @@ test("split-only SDKs receive runtime and flush-plan registrations without unifi
   });
 });
 
-test("setup-only mode does not register runtime hooks or services", async () => {
+test("non-runtime registration modes do not register runtime hooks or services", async () => {
   await withCapturedRegistration((plugin) => {
-    const capture = captureOpenClawRegistrationApi({
-      registrationMode: "setup-only",
-    });
+    for (const registrationMode of [
+      "discovery",
+      "tool-discovery",
+      "setup-only",
+      "setup-runtime",
+      "cli-metadata",
+    ] as const) {
+      const capture = captureOpenClawRegistrationApi({ registrationMode });
 
-    plugin.register(capture.api);
+      plugin.register(capture.api);
 
-    assert.deepEqual(capture.hooks(), []);
-    assert.deepEqual(capture.registrations(), []);
+      assert.deepEqual(capture.hooks(), [], registrationMode);
+      assert.deepEqual(capture.registrations(), [], registrationMode);
+    }
   });
 });
 

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -120,7 +120,7 @@ test("OpenClaw SDK surface check fails clearly when SDK declarations are missing
     const result = runCheck(["--package-root", tempRoot]);
 
     assert.equal(result.status, 1);
-    assert.match(result.stderr, /no SDK declaration files found/);
+    assert.match(result.stderr, /no SDK declaration or source files found/);
     assert.doesNotMatch(result.stderr, /registerMemoryInternalHelper/);
   } finally {
     fs.rmSync(tempRoot, { force: true, recursive: true });
@@ -188,8 +188,6 @@ const expectedHooks = [
   "session_start",
 ];
 const expectedManifestContracts = [
-  "commands",
-  "hooks",
   "memoryEmbeddingProviders",
   "tools",
 ];
@@ -259,11 +257,15 @@ export type HookName =
   | "session_end"
   | "session_start";
 
-export interface PluginContracts {
+export interface PluginManifestContracts {
   commands?: string[];
   hooks?: HookName[];
   memoryEmbeddingProviders?: string[];
   tools?: string[];
+}
+
+export interface LegacyRuntimeMetadata {
+  memoryCapabilities?: string[];
 }
 `,
   );

--- a/tests/sdk-compat-hook-handlers.test.ts
+++ b/tests/sdk-compat-hook-handlers.test.ts
@@ -4544,16 +4544,24 @@ test("capability promptBuilder does not fall back to stale Codex thread cache af
   );
 });
 
-test("registrationMode setup-only registers zero handlers", async () => {
+test("non-runtime registration modes register zero handlers", async () => {
   const { default: plugin } = await import("../src/index.js");
-  const api = buildHandlerCapturingApi("setup-only-test", {
-    registrationMode: "setup-only",
-  });
-  plugin.register(api as any);
+  for (const registrationMode of [
+    "discovery",
+    "tool-discovery",
+    "setup-only",
+    "setup-runtime",
+    "cli-metadata",
+  ]) {
+    const api = buildHandlerCapturingApi(`${registrationMode}-test`, {
+      registrationMode,
+    });
+    plugin.register(api as any);
 
-  assert.equal(
-    api.handlers.size,
-    0,
-    `expected zero handlers in setup-only mode, got: ${[...api.handlers.keys()].join(", ")}`,
-  );
+    assert.equal(
+      api.handlers.size,
+      0,
+      `expected zero handlers in ${registrationMode} mode, got: ${[...api.handlers.keys()].join(", ")}`,
+    );
+  }
 });

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -7,7 +7,7 @@
  * - New SDK api: gets before_prompt_build, session/tool/llm/subagent hooks,
  *   registerMemoryPromptSection, and service registration.
  * - Legacy SDK api: gets before_agent_start and core hooks only.
- * - Setup-only mode: skips all registration entirely.
+ * - Non-runtime registration modes: skip all registration entirely.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -255,6 +255,7 @@ test("new SDK api gets all new hooks + memory section", async () => {
     const { default: plugin } = await import("../src/index.js");
 
     const api = buildNewSdkApi("new-sdk-test");
+    api.pluginConfig = { initGateTimeoutMs: 30_000 };
     plugin.register(api as any);
 
     // When registerMemoryPromptSection is available (new SDK), before_prompt_build
@@ -709,44 +710,48 @@ test("tryDefinePluginEntry: fallback produces correct plugin shape when SDK modu
 });
 
 // ============================================================================
-// Test 4: Setup-only mode skips all registration
+// Test 4: Non-runtime registration modes skip all registration
 // ============================================================================
-test("setup-only mode skips all registration", async () => {
+test("non-runtime registration modes skip all registration", async () => {
   resetGlobals();
   const previousDisableMigration = disableRegisterMigrationForTest();
   try {
     const { default: plugin } = await import("../src/index.js");
 
-    const api = buildNewSdkApi("setup-only-test");
-    api.registrationMode = "setup-only";
-    plugin.register(api as any);
+    for (const mode of [
+      "discovery",
+      "tool-discovery",
+      "setup-only",
+      "setup-runtime",
+      "cli-metadata",
+    ]) {
+      const api = buildNewSdkApi(`${mode}-test`);
+      api.registrationMode = mode;
+      plugin.register(api as any);
 
-    // No hooks should be registered
-    assert.equal(
-      api._registeredHooks.length,
-      0,
-      `expected zero hooks in setup-only mode, got: ${api._registeredHooks.join(", ")}`,
-    );
+      assert.equal(
+        api._registeredHooks.length,
+        0,
+        `expected zero hooks in ${mode} mode, got: ${api._registeredHooks.join(", ")}`,
+      );
 
-    // No tools registered
-    assert.equal(
-      api._registeredToolCount,
-      0,
-      "expected zero tools in setup-only mode",
-    );
+      assert.equal(
+        api._registeredToolCount,
+        0,
+        `expected zero tools in ${mode} mode`,
+      );
 
-    // No services registered
-    assert.equal(
-      api._registeredServiceIds.length,
-      0,
-      "expected zero services in setup-only mode",
-    );
+      assert.equal(
+        api._registeredServiceIds.length,
+        0,
+        `expected zero services in ${mode} mode`,
+      );
 
-    // registerMemoryPromptSection should not have been called
-    assert.ok(
-      !api._memoryPromptSectionRegistered,
-      "registerMemoryPromptSection should NOT be called in setup-only mode",
-    );
+      assert.ok(
+        !api._memoryPromptSectionRegistered,
+        `registerMemoryPromptSection should NOT be called in ${mode} mode`,
+      );
+    }
   } finally {
     await awaitPendingMigration();
     restoreRegisterMigrationEnv(previousDisableMigration);

--- a/tests/sdk-compat.test.ts
+++ b/tests/sdk-compat.test.ts
@@ -177,17 +177,26 @@ test("runtime namespace null does not count as hasRuntimeNamespace", () => {
   assert.equal(caps.hasRuntimeNamespace, false);
 });
 
-test("registrationMode 'setup-runtime' is passed through correctly", () => {
-  const api: Record<string, unknown> = {
-    on: () => {},
-    runtime: { version: "2026.3.22" },
-    registrationMode: "setup-runtime",
-  };
+test("modern registrationMode values are passed through correctly", () => {
+  for (const mode of [
+    "full",
+    "discovery",
+    "tool-discovery",
+    "setup-only",
+    "setup-runtime",
+    "cli-metadata",
+  ]) {
+    const api: Record<string, unknown> = {
+      on: () => {},
+      runtime: { version: "2026.3.22" },
+      registrationMode: mode,
+    };
 
-  const caps = detectSdkCapabilities(api);
+    const caps = detectSdkCapabilities(api);
 
-  assert.equal(caps.registrationMode, "setup-runtime");
-  assert.equal(caps.hasRegistrationMode, true);
+    assert.equal(caps.registrationMode, mode);
+    assert.equal(caps.hasRegistrationMode, true);
+  }
 });
 
 test("registerMemoryCapability detection when present", () => {


### PR DESCRIPTION
## Summary
- Keep OpenClaw discovery/tool-discovery/setup/setup-runtime/CLI-metadata registration modes inert before migrations, config reads, hooks, services, tools, or memory surfaces are initialized.
- Remove deprecated manifest contract keys (`commands`, `hooks`, `memoryCapabilities`, `memoryPromptSections`, `services`) from the Remnic and legacy Engram OpenClaw manifests, leaving the supported `contracts.tools` declaration.
- Tighten the SDK surface drift checker to read `PluginManifestContracts` specifically and support source checkouts such as OpenClaw `v2026.5.7-beta.1`.

Fixes #933.
Fixes #939.
Fixes #940.

## Verification
- `pnpm exec tsx --test tests/openclaw-plugin-runtime-surfaces.test.ts tests/sdk-compat.test.ts tests/openclaw-registration-capture.test.ts tests/sdk-compat-integration.test.ts`
- `pnpm exec tsx --test tests/openclaw-sdk-surface-check.test.ts`
- `pnpm exec tsx --test --test-name-pattern "non-runtime registration modes register zero handlers" tests/sdk-compat-hook-handlers.test.ts`
- `npm run check:openclaw-sdk-surface -- --package-root /tmp/openclaw-2026.5.7-beta.1 --require`
- `npm run check:openclaw-plugin-sync`
- `pnpm --filter @remnic/plugin-openclaw run plugin:inspect`
- `git diff --check`

`npm run preflight:quick` was started and passed through typecheck, config contract, plugin inspection, review-pattern scan, registration capture, SDK surface checks, OpenClaw scenarios, and privacy. It was stopped after `tests/register-multi-registry.test.ts` printed all assertions but held the process open for minutes. The remaining quick-preflight test files were run manually and passed: `tests/intent.test.ts tests/runtime-input-guards.test.ts tests/artifact-recall-limit.test.ts tests/artifact-status-snapshot.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenClaw plugin registration flow to early-exit in several new metadata/setup modes and removes manifest contract keys that OpenClaw previously accepted; mistakes could cause the plugin to not initialize or to fail manifest validation on some runtimes.
> 
> **Overview**
> Aligns the Remnic OpenClaw adapter with OpenClaw `2026.5.7` registration metadata flows by making `register()` **fully inert** (no migrations, config reads, hooks, services, tools, or memory surfaces) when `api.registrationMode` is one of `discovery`, `tool-discovery`, `setup-only`, `setup-runtime`, or `cli-metadata`.
> 
> Updates plugin manifests to drop deprecated `contracts` keys (`commands`, `hooks`, `memoryCapabilities`, `memoryPromptSections`, `services`), leaving only supported declarations (notably `contracts.tools`), and adjusts tests/snapshots accordingly.
> 
> Tightens the OpenClaw SDK surface drift checker to also inspect OpenClaw source checkouts and to extract contract names specifically from the `PluginManifestContracts` block, updating the expected surface snapshot and related error messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1424ab07436e0006d9fabffc47013aa7857cdb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
