### PR TITLE
Publish OpenClaw compatibility package versions

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-engram",
   "name": "Remnic OpenClaw Plugin",
-  "version": "9.3.19",
+  "version": "9.3.20",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.19",
+  "version": "9.3.20",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `@remnic/core` to `1.1.11` so the merged OpenClaw 2026.5.7 compatibility fix is published as a new core package version.
- Bump `@remnic/plugin-openclaw` to `1.0.34` and sync `openclaw.plugin.json` so OpenClaw/ClawHub installs resolve the new plugin package.
- Bump the legacy `@joshuaswarren/openclaw-engram` shim to `9.3.20` and sync its manifest.

## Why
PR #944 merged the OpenClaw 2026.5.7 registration/manifest compatibility fix, but the release workflow only published the root `v9.3.355` release because the package versions were still already-published versions. This PR gives npm/ClawHub a new package version to publish and install.

## Verification
- `npm run check:openclaw-plugin-sync`
- `pnpm --filter @remnic/plugin-openclaw run plugin:inspect`
- `git diff --check`
- `npm run check-types`
- `npm run check:openclaw-sdk-surface -- --package-root /tmp/openclaw-2026.5.7-beta.1 --require`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps package and plugin manifest versions to force publishing new releases; no runtime logic changes.
> 
> **Overview**
> Publishes new OpenClaw compatibility releases by bumping versions across `@remnic/core` (to `1.1.11`), `@remnic/plugin-openclaw` (to `1.0.34`), and the legacy `@joshuaswarren/openclaw-engram` shim (to `9.3.20`).
> 
> Synchronizes the corresponding `openclaw.plugin.json` manifests (root and package-local copies) to match the new plugin/shim versions so OpenClaw/ClawHub resolves the updated packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d776f7dd4b30d2a92da3fec349adb899e24372c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->