### PR TITLE
Fix ClawHub owner for Remnic plugin release

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -451,7 +451,7 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           CLAWHUB_PACKAGE_NAME: "@remnic/plugin-openclaw"
-          CLAWHUB_OWNER: "joshuaswarren"
+          CLAWHUB_OWNER: "remnic"
         run: |
           if [ -z "${CLAWHUB_TOKEN:-}" ]; then
             echo "::notice title=ClawHub publish skipped::CLAWHUB_TOKEN secret is not configured."


### PR DESCRIPTION
## Summary\n- publish the @remnic/plugin-openclaw ClawHub package under the remnic owner so the owner matches the package scope\n\n## Verification\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that updates metadata for the ClawHub publish step; it only affects where the plugin is published, not runtime code.
> 
> **Overview**
> Fixes the release workflow’s ClawHub publish configuration by changing `CLAWHUB_OWNER` from `joshuaswarren` to `remnic`, so `@remnic/plugin-openclaw` is published under the correct owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4e4d684f6676208f177e1a4bb7ad69201dc08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->