### PR TITLE
Skip ClawHub publish when Remnic publisher is absent

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -497,6 +497,11 @@ jobs:
           else
             publish_status=$?
             cat "${publish_log}"
+            if grep -q "publisher does not exist on ClawHub" "${publish_log}"; then
+              echo "::notice title=ClawHub publish skipped::${CLAWHUB_OWNER} is not provisioned as a ClawHub publisher yet; create that publisher before enabling marketplace publishing."
+              rm -f "${publish_log}"
+              exit 0
+            fi
             rm -f "${publish_log}"
             exit "${publish_status}"
           fi


### PR DESCRIPTION
## Summary\n- keep the ClawHub owner aligned to the @remnic package scope\n- treat the known missing ClawHub publisher provisioning state as a skip notice instead of failing releases after npm/GitHub publication has succeeded\n\n## Verification\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions release workflow error handling to treat a known ClawHub provisioning error as a non-fatal skip.
> 
> **Overview**
> Updates the release workflow to **gracefully skip** the ClawHub publish step when `clawhub package publish` fails due to a missing publisher (matches "publisher does not exist on ClawHub").
> 
> Instead of failing the entire release after npm/GitHub publication succeeds, the job now emits a notice and exits successfully for that specific error while preserving existing failure behavior for all other publish errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297074f3f188187ce886afbbd94d3617c78adc3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->