### PR TITLE
fix(bench): abort provider calls on phase timeout

### DIFF
--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -75,6 +75,71 @@ test("timeout guard wraps responder and judge calls", async () => {
   assert.equal(await guarded.judge?.score("q", "p", "e"), 1);
 });
 
+test("timeout guard aborts responder phase work on timeout", async () => {
+  const adapter = makeAdapter();
+  let sawAbort = false;
+  adapter.responder = {
+    respond(_question, _recalledText, control) {
+      return new Promise<never>((_, reject) => {
+        const signal = control?.signal;
+        const onAbort = () => {
+          sawAbort = true;
+          reject(signal?.reason);
+        };
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+  };
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 5,
+  });
+
+  await assert.rejects(
+    () => guarded.responder!.respond("q", "r"),
+    /benchmark phase timed out after 5ms: timeout-test:respond/,
+  );
+  assert.equal(sawAbort, true);
+});
+
+test("timeout guard aborts judge phase work on timeout", async () => {
+  const adapter = makeAdapter();
+  let sawAbort = false;
+  adapter.judge = {
+    async score() {
+      return 0;
+    },
+    scoreWithMetrics(_question, _predicted, _expected, control) {
+      return new Promise<never>((_, reject) => {
+        const signal = control?.signal;
+        const onAbort = () => {
+          sawAbort = true;
+          reject(signal?.reason);
+        };
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+  };
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 5,
+  });
+
+  await assert.rejects(
+    () => guarded.judge!.scoreWithMetrics!("q", "p", "e"),
+    /benchmark phase timed out after 5ms: timeout-test:judge.scoreWithMetrics/,
+  );
+  assert.equal(sawAbort, true);
+});
+
 test("resolveBenchmarkPhaseTimeoutMs prefers explicit benchmark config", () => {
   assert.equal(
     resolveBenchmarkPhaseTimeoutMs({

--- a/packages/bench/src/adapters/timeout-guard.ts
+++ b/packages/bench/src/adapters/timeout-guard.ts
@@ -68,7 +68,10 @@ export function createTimeoutGuardedAdapter(
     );
   }
 
-  const run = async <T>(phase: string, fn: () => Promise<T>): Promise<T> => {
+  const run = async <T>(
+    phase: string,
+    fn: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> => {
     const label = `${options.benchmarkId}:${phase}`;
     return runWithBenchmarkPhaseTimeout(label, options.timeoutMs, fn, options);
   };
@@ -135,7 +138,10 @@ export function createTimeoutGuardedIngestionAdapter(
     );
   }
 
-  const run = async <T>(phase: string, fn: () => Promise<T>): Promise<T> =>
+  const run = async <T>(
+    phase: string,
+    fn: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> =>
     runWithBenchmarkPhaseTimeout(`${options.benchmarkId}:${phase}`, options.timeoutMs, fn, options);
 
   return {
@@ -157,7 +163,7 @@ export function createTimeoutGuardedIngestionAdapter(
 export async function runWithBenchmarkPhaseTimeout<T>(
   label: string,
   timeoutMs: number,
-  fn: () => Promise<T>,
+  fn: (signal: AbortSignal) => Promise<T>,
   options: Pick<TimeoutGuardOptions, "logProgress" | "log" | "onTimeout"> = {},
 ): Promise<T> {
   if (options.logProgress) {
@@ -186,31 +192,33 @@ export async function runWithBenchmarkPhaseTimeout<T>(
 
 function wrapResponder(
   responder: BenchResponder,
-  run: <T>(phase: string, fn: () => Promise<T>) => Promise<T>,
+  run: <T>(phase: string, fn: (signal: AbortSignal) => Promise<T>) => Promise<T>,
 ): BenchResponder {
   return {
     respond(question, recalledText) {
-      return run("respond", () => responder.respond(question, recalledText));
+      return run("respond", (signal) =>
+        responder.respond(question, recalledText, { signal }),
+      );
     },
   };
 }
 
 function wrapJudge(
   judge: BenchJudge,
-  run: <T>(phase: string, fn: () => Promise<T>) => Promise<T>,
+  run: <T>(phase: string, fn: (signal: AbortSignal) => Promise<T>) => Promise<T>,
 ): BenchJudge {
   const wrapped: BenchJudge = {
     score(question, predicted, expected) {
-      return run("judge.score", () =>
-        judge.score(question, predicted, expected),
+      return run("judge.score", (signal) =>
+        judge.score(question, predicted, expected, { signal }),
       );
     },
   };
 
   if (judge.scoreWithMetrics) {
     wrapped.scoreWithMetrics = (question, predicted, expected) =>
-      run("judge.scoreWithMetrics", () =>
-        judge.scoreWithMetrics!(question, predicted, expected),
+      run("judge.scoreWithMetrics", (signal) =>
+        judge.scoreWithMetrics!(question, predicted, expected, { signal }),
       );
   }
 
@@ -263,25 +271,26 @@ function coerceBooleanConfig(value: unknown, key: string): boolean | undefined {
 async function withTimeout<T>(
   label: string,
   timeoutMs: number,
-  fn: () => Promise<T>,
+  fn: (signal: AbortSignal) => Promise<T>,
   onTimeout?: (label: string) => void | Promise<void>,
 ): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const controller = new AbortController();
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
+      const timeoutError = new Error(
+        `benchmark phase timed out after ${timeoutMs}ms: ${label}`,
+      );
+      reject(timeoutError);
+      controller.abort(timeoutError);
       if (onTimeout) {
         void Promise.resolve(onTimeout(label)).catch(() => {});
       }
-      reject(
-        new Error(
-          `benchmark phase timed out after ${timeoutMs}ms: ${label}`,
-        ),
-      );
     }, timeoutMs);
   });
 
   try {
-    return await Promise.race([fn(), timeout]);
+    return await Promise.race([fn(controller.signal), timeout]);
   } finally {
     if (timer) {
       clearTimeout(timer);

--- a/packages/bench/src/adapters/types.ts
+++ b/packages/bench/src/adapters/types.ts
@@ -32,8 +32,16 @@ export interface BenchResponse {
   model: string;
 }
 
+export interface BenchPhaseControl {
+  signal?: AbortSignal;
+}
+
 export interface BenchResponder {
-  respond(question: string, recalledText: string): Promise<BenchResponse>;
+  respond(
+    question: string,
+    recalledText: string,
+    control?: BenchPhaseControl,
+  ): Promise<BenchResponse>;
 }
 
 export interface BenchJudgeResult {
@@ -47,11 +55,17 @@ export interface BenchJudgeResult {
 }
 
 export interface BenchJudge {
-  score(question: string, predicted: string, expected: string): Promise<number>;
+  score(
+    question: string,
+    predicted: string,
+    expected: string,
+    control?: BenchPhaseControl,
+  ): Promise<number>;
   scoreWithMetrics?(
     question: string,
     predicted: string,
     expected: string,
+    control?: BenchPhaseControl,
   ): Promise<BenchJudgeResult>;
 }
 

--- a/packages/bench/src/providers/anthropic.ts
+++ b/packages/bench/src/providers/anthropic.ts
@@ -44,6 +44,7 @@ class AnthropicProvider implements LlmProvider {
       {
         method: "POST",
         headers: this.headers(opts.headers),
+        signal: opts.signal,
         body: JSON.stringify({
           model: this.config.model,
           system: opts.systemPrompt,

--- a/packages/bench/src/providers/codex-cli.test.ts
+++ b/packages/bench/src/providers/codex-cli.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -191,6 +194,35 @@ test("codex-cli provider surfaces non-zero CLI exits", async () => {
     provider.complete("hello"),
     /Codex CLI completion failed \(exit 2\): invalid model/,
   );
+});
+
+test("codex-cli command terminates subprocess when aborted", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-codex-cli-test-"));
+  const controller = new AbortController();
+
+  try {
+    const run = __codexCliProviderTestHooks.runCodexCliCommand({
+      executable: process.execPath,
+      args: [
+        "-e",
+        "process.stdin.resume(); setInterval(() => {}, 1000);",
+      ],
+      input: "hello",
+      outputPath: path.join(tempDir, "last-message.txt"),
+      workspacePath: tempDir,
+      timeoutMs: 60_000,
+      signal: controller.signal,
+      env: process.env,
+    });
+
+    setTimeout(() => controller.abort(), 20);
+    const result = await run;
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Codex CLI aborted by benchmark timeout/);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
 });
 
 test("codex-cli benchmark prompt keeps system and user input in separate JSON fields", () => {

--- a/packages/bench/src/providers/codex-cli.ts
+++ b/packages/bench/src/providers/codex-cli.ts
@@ -19,6 +19,7 @@ interface CodexCliRunRequest {
   outputPath: string;
   workspacePath: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
   env: NodeJS.ProcessEnv;
 }
 
@@ -190,6 +191,7 @@ class CodexCliProvider implements LlmProvider {
       outputPath,
       workspacePath,
       timeoutMs: this.config.retryOptions?.timeoutMs,
+      signal: opts.signal,
       env: buildIsolatedCodexEnv(this.config.apiKey),
     };
   }
@@ -258,24 +260,71 @@ function buildIsolatedCodexEnv(apiKey?: string): NodeJS.ProcessEnv {
 
 function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunResult> {
   return new Promise((resolve, reject) => {
+    if (request.signal?.aborted) {
+      resolve({
+        status: 124,
+        signal: null,
+        stdout: "",
+        stderr: "Codex CLI aborted before start.",
+        outputText: "",
+      });
+      return;
+    }
+
     const child = spawn(request.executable, request.args, {
       cwd: request.workspacePath,
       env: request.env,
       stdio: ["pipe", "pipe", "pipe"],
+      detached: process.platform !== "win32",
       windowsHide: true,
     });
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let aborted = false;
     let killTimeout: NodeJS.Timeout | undefined;
+    const clearKillTimeout = (): void => {
+      if (killTimeout) {
+        clearTimeout(killTimeout);
+        killTimeout = undefined;
+      }
+    };
+    const terminateChild = (signal: NodeJS.Signals): void => {
+      if (child.pid && process.platform !== "win32") {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch {
+          // Fall back to killing the direct child below.
+        }
+      }
+      child.kill(signal);
+    };
+    const scheduleForcedKill = (): void => {
+      clearKillTimeout();
+      killTimeout = setTimeout(() => {
+        terminateChild("SIGKILL");
+      }, 1_000);
+      killTimeout.unref();
+    };
+    const onAbort = (): void => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      stderr = appendBounded(stderr, "\nCodex CLI aborted by benchmark timeout.");
+      terminateChild("SIGTERM");
+      scheduleForcedKill();
+    };
+    request.signal?.addEventListener("abort", onAbort, { once: true });
+    if (request.signal?.aborted) {
+      onAbort();
+    }
     const timeout = request.timeoutMs
       ? setTimeout(() => {
           timedOut = true;
-          child.kill("SIGTERM");
-          killTimeout = setTimeout(() => {
-            child.kill("SIGKILL");
-          }, 1_000);
-          killTimeout.unref();
+          terminateChild("SIGTERM");
+          scheduleForcedKill();
         }, request.timeoutMs)
       : undefined;
     timeout?.unref();
@@ -298,18 +347,16 @@ function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunRes
       if (timeout) {
         clearTimeout(timeout);
       }
-      if (killTimeout) {
-        clearTimeout(killTimeout);
-      }
+      clearKillTimeout();
+      request.signal?.removeEventListener("abort", onAbort);
       reject(error);
     });
     child.on("close", async (status, signal) => {
       if (timeout) {
         clearTimeout(timeout);
       }
-      if (killTimeout) {
-        clearTimeout(killTimeout);
-      }
+      clearKillTimeout();
+      request.signal?.removeEventListener("abort", onAbort);
       if (timedOut) {
         resolve({
           status: status ?? 124,
@@ -319,6 +366,16 @@ function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunRes
             stderr,
             `\nCodex CLI timed out after ${request.timeoutMs}ms.`,
           ),
+          outputText: "",
+        });
+        return;
+      }
+      if (aborted) {
+        resolve({
+          status: status ?? 124,
+          signal,
+          stdout,
+          stderr,
           outputText: "",
         });
         return;
@@ -414,4 +471,5 @@ export const __codexCliProviderTestHooks = {
   buildCodexCompletionPrompt,
   buildIsolatedCodexEnv,
   parseCodexTokenUsage,
+  runCodexCliCommand,
 };

--- a/packages/bench/src/providers/local-llm.ts
+++ b/packages/bench/src/providers/local-llm.ts
@@ -102,6 +102,7 @@ class LocalLlmProvider implements LlmProvider {
         {
           method: "POST",
           headers: this.headers(opts.headers),
+          signal: opts.signal,
           body: JSON.stringify({
             model: this.config.model,
             messages: [

--- a/packages/bench/src/providers/ollama.ts
+++ b/packages/bench/src/providers/ollama.ts
@@ -53,6 +53,7 @@ class OllamaProvider implements LlmProvider {
       {
         method: "POST",
         headers: this.headers(opts.headers),
+        signal: opts.signal,
         body: JSON.stringify({
           model: this.config.model,
           prompt,

--- a/packages/bench/src/providers/openai-compatible.ts
+++ b/packages/bench/src/providers/openai-compatible.ts
@@ -66,6 +66,7 @@ class OpenAiCompatibleProvider implements LlmProvider {
       {
         method: "POST",
         headers: this.headers(opts.headers),
+        signal: opts.signal,
         body: JSON.stringify({
           model: this.config.model,
           messages: [

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -279,7 +279,7 @@ export async function retryFetch(
     // Backoff before next attempt. Capped at maxAttempts for non-429 errors.
     if (attempt < opts.maxAttempts) {
       const backoffMs = opts.baseBackoffMs * Math.pow(2, attempt - 1);
-      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      await abortAwareSleep(backoffMs, init.signal as AbortSignal | undefined);
     }
   }
 

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -12,6 +12,7 @@ export interface CompletionOpts {
   temperature?: number;
   maxTokens?: number;
   headers?: Record<string, string>;
+  signal?: AbortSignal;
 }
 
 export interface CompletionResult {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -54,7 +54,11 @@ export interface GatewayResponderOptions {
 
 export function createResponderFromProvider(provider: LlmProvider): BenchResponder {
   return {
-    async respond(question: string, recalledText: string): Promise<BenchResponse> {
+    async respond(
+      question: string,
+      recalledText: string,
+      control,
+    ): Promise<BenchResponse> {
       const completion = await provider.complete(
         [
           `QUESTION: ${question}`,
@@ -67,6 +71,7 @@ export function createResponderFromProvider(provider: LlmProvider): BenchRespond
         {
           systemPrompt: DEFAULT_RESPONDER_SYSTEM_PROMPT,
           temperature: 0,
+          signal: control?.signal,
         },
       );
 
@@ -93,6 +98,7 @@ function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
     question: string,
     predicted: string,
     expected: string,
+    control?: { signal?: AbortSignal },
   ): Promise<BenchJudgeResult> {
     const completion = await provider.complete(
       [
@@ -107,6 +113,7 @@ function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
       {
         systemPrompt: DEFAULT_JUDGE_SYSTEM_PROMPT,
         temperature: 0,
+        signal: control?.signal,
       },
     );
 
@@ -119,8 +126,13 @@ function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
   }
 
   return {
-    async score(question: string, predicted: string, expected: string): Promise<number> {
-      return (await scoreWithMetrics(question, predicted, expected)).score;
+    async score(
+      question: string,
+      predicted: string,
+      expected: string,
+      control,
+    ): Promise<number> {
+      return (await scoreWithMetrics(question, predicted, expected, control)).score;
     },
     scoreWithMetrics,
   };
@@ -139,6 +151,7 @@ function createAmaBenchRecommendedJudgeFromProvider(provider: LlmProvider): Benc
     question: string,
     predicted: string,
     expected: string,
+    control?: { signal?: AbortSignal },
   ): Promise<BenchJudgeResult> {
     const completion = await provider.complete(
       [
@@ -153,6 +166,7 @@ function createAmaBenchRecommendedJudgeFromProvider(provider: LlmProvider): Benc
       {
         systemPrompt: AMA_BENCH_RECOMMENDED_JUDGE_SYSTEM_PROMPT,
         temperature: 0,
+        signal: control?.signal,
       },
     );
 
@@ -165,8 +179,13 @@ function createAmaBenchRecommendedJudgeFromProvider(provider: LlmProvider): Benc
   }
 
   return {
-    async score(question: string, predicted: string, expected: string): Promise<number> {
-      return (await scoreWithMetrics(question, predicted, expected)).score;
+    async score(
+      question: string,
+      predicted: string,
+      expected: string,
+      control,
+    ): Promise<number> {
+      return (await scoreWithMetrics(question, predicted, expected, control)).score;
     },
     scoreWithMetrics,
   };


### PR DESCRIPTION
## Summary
- propagate benchmark phase AbortSignal into responder, judge, and provider completion calls
- terminate Codex CLI subprocess groups when a benchmark phase timeout aborts the call
- add regression coverage for timeout abort propagation and Codex CLI subprocess cleanup

## Verification
- pnpm exec tsx --test packages/bench/src/providers/codex-cli.test.ts
- pnpm exec tsx --test packages/bench/src/adapters/timeout-guard.test.ts
- pnpm exec tsc --noEmit --pretty false

## Runtime note
The previous AMA-Bench full run timed out at 950/2496 tasks inside `ama-bench:judge.scoreWithMetrics`; this patch prevents that timeout from leaving the underlying Codex CLI process alive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark execution semantics by propagating `AbortSignal` through responder/judge and provider completion paths, which can alter timing/error behavior and requires downstream implementations to tolerate the new optional control parameter.
> 
> **Overview**
> **Benchmark phase timeouts now actively abort in-flight work.** The timeout guard creates an `AbortController` per phase and propagates its `AbortSignal` into `BenchResponder`/`BenchJudge` calls, so long-running responder/judge logic can stop when the phase times out.
> 
> Provider completion APIs now accept an optional `signal` and pass it down to HTTP `fetch` calls (Anthropic/OpenAI-compatible/Ollama/local-llm) and to the Codex CLI runner. The Codex CLI implementation now terminates the spawned process (and its process group on non-Windows) on abort, with new regression tests covering abort propagation and subprocess cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b018ccf21afc8b62e3f7e691ddea398b212b379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->