### PR TITLE
Abort fallback LLM calls on timeout

### DIFF
--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -77,6 +77,7 @@ export interface ResolvedBenchRuntimeProfile {
 const REDACTED_CONFIG_VALUE = "[redacted]";
 const INTERNAL_GATEWAY_AGENT_ID = "remnic-bench-internal";
 let codexCliFallbackRegistered = false;
+let codexCliFallbackChain: Promise<void> = Promise.resolve();
 
 export async function resolveBenchRuntimeProfile(
   options: ResolveBenchRuntimeProfileOptions,
@@ -557,52 +558,71 @@ function registerCodexCliFallbackRunnerIfNeeded(config: ProviderConfig | null): 
     return;
   }
 
-  const runner: CodexCliFallbackRunner = async (request) => {
-    const reasoningEffort = asCodexReasoningEffort(
-      request.config.codexCliReasoningEffort ?? request.config.reasoningEffort,
-    );
-    const provider = createProvider({
-      provider: "codex-cli",
-      model: request.modelId,
-      ...(typeof request.config.apiKey === "string"
-        ? { apiKey: request.config.apiKey }
-        : {}),
-      ...(reasoningEffort ? { reasoningEffort } : {}),
-      ...(typeof request.config.codexCliExecutable === "string"
-        ? { executable: request.config.codexCliExecutable }
-        : typeof request.config.executable === "string"
-          ? { executable: request.config.executable }
+  const runner: CodexCliFallbackRunner = async (request) =>
+    enqueueCodexCliFallback(async () => {
+      if (request.options.signal?.aborted) {
+        throw abortReason(request.options.signal);
+      }
+      const reasoningEffort = asCodexReasoningEffort(
+        request.config.codexCliReasoningEffort ?? request.config.reasoningEffort,
+      );
+      const provider = createProvider({
+        provider: "codex-cli",
+        model: request.modelId,
+        ...(typeof request.config.apiKey === "string"
+          ? { apiKey: request.config.apiKey }
           : {}),
-      ...(typeof request.config.retryOptions?.timeoutMs === "number" ||
-        typeof request.options.timeoutMs === "number"
-        ? {
-            retryOptions: {
-              timeoutMs:
-                typeof request.config.retryOptions?.timeoutMs === "number"
-                  ? request.config.retryOptions.timeoutMs
-                  : request.options.timeoutMs,
-            },
-          }
-        : {}),
+        ...(reasoningEffort ? { reasoningEffort } : {}),
+        ...(typeof request.config.codexCliExecutable === "string"
+          ? { executable: request.config.codexCliExecutable }
+          : typeof request.config.executable === "string"
+            ? { executable: request.config.executable }
+            : {}),
+        ...(typeof request.config.retryOptions?.timeoutMs === "number" ||
+          typeof request.options.timeoutMs === "number"
+          ? {
+              retryOptions: {
+                timeoutMs:
+                  typeof request.config.retryOptions?.timeoutMs === "number"
+                    ? request.config.retryOptions.timeoutMs
+                    : request.options.timeoutMs,
+              },
+            }
+          : {}),
+      });
+      const split = splitCodexFallbackMessages(request.messages);
+      const completion = await provider.complete(split.prompt, {
+        systemPrompt: split.systemPrompt,
+        temperature: 0.3,
+        maxTokens: 4096,
+        signal: request.options.signal,
+      });
+      return {
+        content: completion.text,
+        usage: {
+          inputTokens: completion.tokens.input,
+          outputTokens: completion.tokens.output,
+          totalTokens: completion.tokens.input + completion.tokens.output,
+        },
+      };
     });
-    const split = splitCodexFallbackMessages(request.messages);
-    const completion = await provider.complete(split.prompt, {
-      systemPrompt: split.systemPrompt,
-      temperature: 0.3,
-      maxTokens: 4096,
-    });
-    return {
-      content: completion.text,
-      usage: {
-        inputTokens: completion.tokens.input,
-        outputTokens: completion.tokens.output,
-        totalTokens: completion.tokens.input + completion.tokens.output,
-      },
-    };
-  };
 
   setCodexCliFallbackRunnerForProcess(runner);
   codexCliFallbackRegistered = true;
+}
+
+function enqueueCodexCliFallback<T>(task: () => Promise<T>): Promise<T> {
+  const run = codexCliFallbackChain.then(task, task);
+  codexCliFallbackChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+function abortReason(signal: AbortSignal | undefined): Error {
+  const reason = signal?.reason;
+  return reason instanceof Error ? reason : new Error("codex-cli fallback aborted");
 }
 
 function asCodexReasoningEffort(

--- a/packages/remnic-core/src/codex-cli-fallback.ts
+++ b/packages/remnic-core/src/codex-cli-fallback.ts
@@ -18,6 +18,7 @@ export interface CodexCliFallbackConfig {
 
 export interface CodexCliFallbackOptions {
   timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 export interface CodexCliFallbackResult {
@@ -114,6 +115,7 @@ function normalizeCodexCliFallbackOptions(
     ...(options.timeoutMs !== undefined
       ? { timeoutMs: normalizeCodexCliTimeoutMs(options.timeoutMs) }
       : {}),
+    ...(options.signal ? { signal: options.signal } : {}),
   };
 }
 

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -7,6 +7,7 @@ import { __codexCliFallbackTestHooks } from "./codex-cli-fallback.js";
 import { clearModelsJsonCache, __setModelsJsonForTest } from "./models-json.js";
 import {
   __setGatewayRuntimeAuthForModelForTest,
+  __setGatewayResolverForTest,
   clearSecretCache,
 } from "./resolve-provider-secret.js";
 
@@ -478,6 +479,65 @@ test("fallback llm invokes registered codex-cli fallback runner", { concurrency:
   }
 });
 
+test("fallback llm aborts codex-cli fallback requests when timeout wins", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  let capturedSignal: AbortSignal | undefined;
+  let sawAbort = false;
+  const restoreRunner = __codexCliFallbackTestHooks.setRunCodexCliForTest(
+    async (request) => {
+      capturedSignal = request.options.signal;
+      return await new Promise<never>((_resolve, reject) => {
+        const onAbort = (): void => {
+          sawAbort = true;
+          reject(request.options.signal?.reason ?? new Error("aborted"));
+        };
+        if (request.options.signal?.aborted) {
+          onAbort();
+          return;
+        }
+        request.options.signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+  );
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "codex-cli/gpt-custom",
+        },
+      },
+    },
+    models: {
+      providers: {
+        "codex-cli": {
+          baseUrl: "",
+          api: "codex-cli",
+          apiKey: "codex-test-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Say OK" }],
+      { temperature: 0, maxTokens: 16, timeoutMs: 10 },
+    );
+
+    assert.equal(response, null);
+    assert.equal(capturedSignal?.aborted, true);
+    assert.equal(sawAbort, true);
+  } finally {
+    restoreRunner();
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 test("fallback llm can call Ollama native chat and suppress thinking", { concurrency: false }, async () => {
   clearModelsJsonCache();
   clearSecretCache();
@@ -552,6 +612,7 @@ test("fallback llm can call Ollama native chat and suppress thinking", { concurr
 test("fallback llm has built-in anthropic defaults when the gateway provider catalog is unavailable", { concurrency: false }, async () => {
   clearModelsJsonCache();
   clearSecretCache();
+  disableGatewaySecretResolverForTest();
 
   const previousAnthropicKey = process.env.ANTHROPIC_API_KEY;
   process.env.ANTHROPIC_API_KEY = "anthropic-test-key";
@@ -618,6 +679,7 @@ test("fallback llm prefers configured alias providers before built-in defaults",
     },
   });
   clearSecretCache();
+  disableGatewaySecretResolverForTest();
 
   const llm = new FallbackLlmClient({
     agents: {
@@ -683,6 +745,7 @@ test("fallback llm resolves claude-cli refs through the anthropic built-in fallb
     },
   });
   clearSecretCache();
+  disableGatewaySecretResolverForTest();
 
   const previousAnthropicKey = process.env.ANTHROPIC_API_KEY;
   process.env.ANTHROPIC_API_KEY = "anthropic-test-key";
@@ -934,3 +997,7 @@ test("fallback llm normalizes anthropic-compatible base URLs that omit /v1", { c
     clearSecretCache();
   }
 });
+
+function disableGatewaySecretResolverForTest(): void {
+  __setGatewayResolverForTest(async () => null);
+}

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -17,6 +17,7 @@ export interface FallbackLlmOptions {
   temperature?: number;
   maxTokens?: number;
   timeoutMs?: number;
+  signal?: AbortSignal;
   /** Override which agent persona's model chain to use (by ID from agents.list[]). */
   agentId?: string;
 }
@@ -109,14 +110,19 @@ export class FallbackLlmClient {
       return null;
     }
 
-    const runChain = async (): Promise<FallbackLlmResponse | null> => {
+    const runChain = async (
+      runOptions: FallbackLlmOptions,
+    ): Promise<FallbackLlmResponse | null> => {
       // Try each model in the chain
       for (let i = 0; i < models.length; i++) {
+        if (runOptions.signal?.aborted) {
+          throw abortReason(runOptions.signal);
+        }
         const model = models[i];
         const isFallback = i > 0;
 
         try {
-          const result = await this.tryModel(model, messages, options);
+          const result = await this.tryModel(model, messages, runOptions);
           if (result) {
             if (isFallback) {
               log.debug(`fallback LLM: succeeded using ${model.modelString} (fallback ${i})`);
@@ -128,6 +134,9 @@ export class FallbackLlmClient {
             };
           }
         } catch (err) {
+          if (runOptions.signal?.aborted) {
+            throw abortReason(runOptions.signal);
+          }
           const errorMsg = err instanceof Error ? err.message : String(err);
           log.debug(`fallback LLM: ${model.modelString} failed (${errorMsg}), trying next...`);
           // Continue to next model in chain
@@ -144,22 +153,37 @@ export class FallbackLlmClient {
         return null;
       }
       let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      const controller = new AbortController();
+      const onCallerAbort = (): void => {
+        controller.abort(abortReason(options.signal));
+      };
+      options.signal?.addEventListener("abort", onCallerAbort, { once: true });
+      if (options.signal?.aborted) {
+        onCallerAbort();
+      }
+      const timedOptions = { ...options, signal: controller.signal };
+      const chain = runChain(timedOptions);
+      chain.catch(() => {});
       try {
         return await Promise.race([
-          runChain(),
+          chain,
           new Promise<null>((resolve) => {
             timeoutHandle = setTimeout(() => {
               log.warn(`fallback LLM: timed out after ${options.timeoutMs}ms`);
+              controller.abort(
+                new Error(`fallback LLM timed out after ${options.timeoutMs}ms`),
+              );
               resolve(null);
             }, options.timeoutMs);
           }),
         ]);
       } finally {
         if (timeoutHandle) clearTimeout(timeoutHandle);
+        options.signal?.removeEventListener("abort", onCallerAbort);
       }
     }
 
-    return await runChain();
+    return await runChain(options);
   }
 
   /**
@@ -413,7 +437,7 @@ export class FallbackLlmClient {
         effectiveConfig,
         model.modelId,
         messages,
-        { timeoutMs: options.timeoutMs },
+        { timeoutMs: options.timeoutMs, signal: options.signal },
       );
     }
 
@@ -538,6 +562,7 @@ export class FallbackLlmClient {
     const response = await fetch(url, {
       method: "POST",
       headers,
+      signal: options.signal,
       body: JSON.stringify(body),
     });
 
@@ -600,6 +625,7 @@ export class FallbackLlmClient {
     const response = await fetch(url, {
       method: "POST",
       headers,
+      signal: options.signal,
       body: JSON.stringify({
         model: modelId,
         messages,
@@ -693,6 +719,7 @@ export class FallbackLlmClient {
     const response = await fetch(url, {
       method: "POST",
       headers,
+      signal: options.signal,
       body: JSON.stringify(body),
     });
 
@@ -784,6 +811,7 @@ export class FallbackLlmClient {
     const response = await fetch(url, {
       method: "POST",
       headers,
+      signal: options.signal,
       body: JSON.stringify(body),
     });
 
@@ -819,6 +847,11 @@ export class FallbackLlmClient {
         : undefined,
     };
   }
+}
+
+function abortReason(signal: AbortSignal | undefined): Error {
+  const reason = signal?.reason;
+  return reason instanceof Error ? reason : new Error("fallback LLM request aborted");
 }
 
 function normalizeRuntimePath(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- propagate abort signals through Remnic fallback LLM requests
- abort registered codex-cli fallback transports when fallback timeouts win
- serialize benchmark-internal codex-cli fallback calls to prevent process buildup

## Verification
- pnpm exec tsx --test packages/remnic-core/src/fallback-llm.test.ts
- pnpm exec tsx --test packages/bench/src/providers/codex-cli.test.ts
- pnpm exec tsx --test packages/bench/src/adapters/timeout-guard.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request execution/cancellation semantics across all fallback LLM transports (fetch-based and `codex-cli`), which could surface new abort-related errors or alter timing/cleanup behavior under load.
> 
> **Overview**
> **Adds end-to-end abort support for fallback LLM requests.** `FallbackLlmClient` now accepts an optional `signal`, passes it through to all HTTP `fetch` calls, and wires timeouts to an `AbortController` so in-flight model attempts are actively cancelled when the timeout (or caller abort) wins.
> 
> **Improves `codex-cli` fallback behavior under cancellation and load.** The codex-cli fallback options now carry an abort `signal`, benchmark runtime’s process-local codex-cli runner forwards the signal into provider calls, and benchmark-internal codex-cli fallback executions are serialized via a promise chain to avoid piling up concurrent CLI processes.
> 
> **Tests updated/added** to cover codex-cli abort-on-timeout behavior and to make gateway secret resolution deterministic in scenarios relying on built-in provider defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c52d48d5a4f3b83adeb5a8493b5a2aaf0d170006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->