### PR TITLE
Rebuild stale core declarations before benchmark builds

### DIFF
--- a/scripts/build-staleness.mjs
+++ b/scripts/build-staleness.mjs
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+export function runPnpm(repoRoot, args) {
+  const result = spawnSync(pnpmCmd, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === "number" && result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+export function ensurePackageBuild(repoRoot, pkgName, distPath, sourcePaths) {
+  if (
+    fs.existsSync(distPath) &&
+    !isAnySourceNewerThan(sourcePaths, distPath)
+  ) {
+    return;
+  }
+
+  runPnpm(repoRoot, ["--filter", pkgName, "build"]);
+}
+
+export function isAnySourceNewerThan(sourcePaths, distPath) {
+  const distMtimeMs = fs.statSync(distPath).mtimeMs;
+  const newestSource = newestMtime(sourcePaths);
+  return newestSource !== undefined && newestSource > distMtimeMs + 1000;
+}
+
+function newestMtime(paths) {
+  let newest;
+  const visit = (entryPath) => {
+    if (!fs.existsSync(entryPath)) {
+      return;
+    }
+    const stat = fs.statSync(entryPath);
+    if (stat.isDirectory()) {
+      for (const child of fs.readdirSync(entryPath)) {
+        visit(path.join(entryPath, child));
+      }
+      return;
+    }
+    if (stat.isFile()) {
+      newest = newest === undefined ? stat.mtimeMs : Math.max(newest, stat.mtimeMs);
+    }
+  };
+  for (const sourcePath of paths) {
+    visit(sourcePath);
+  }
+  return newest;
+}

--- a/scripts/ensure-bench-build-deps.mjs
+++ b/scripts/ensure-bench-build-deps.mjs
@@ -1,36 +1,17 @@
-import fs from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { ensurePackageBuild } from "./build-staleness.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-
-function run(args) {
-  const result = spawnSync(pnpmCmd, args, {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: process.env,
-  });
-
-  if (result.error) {
-    throw result.error;
-  }
-
-  if (typeof result.status === "number" && result.status !== 0) {
-    process.exit(result.status);
-  }
-}
-
-function ensurePackageBuild(pkgName, distPath) {
-  if (fs.existsSync(distPath)) {
-    return;
-  }
-
-  run(["--filter", pkgName, "build"]);
-}
 
 ensurePackageBuild(
+  repoRoot,
   "@remnic/core",
   path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+  [
+    path.join(repoRoot, "packages", "remnic-core", "src"),
+    path.join(repoRoot, "packages", "remnic-core", "package.json"),
+    path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+    path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+  ],
 );

--- a/scripts/ensure-cli-bench-build-deps.mjs
+++ b/scripts/ensure-cli-bench-build-deps.mjs
@@ -1,44 +1,39 @@
-import fs from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { ensurePackageBuild } from "./build-staleness.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-
-function run(args) {
-  const result = spawnSync(pnpmCmd, args, {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: process.env,
-  });
-
-  if (result.error) {
-    throw result.error;
-  }
-
-  if (typeof result.status === "number" && result.status !== 0) {
-    process.exit(result.status);
-  }
-}
-
-function ensurePackageBuild(pkgName, distPath) {
-  if (fs.existsSync(distPath)) {
-    return;
-  }
-
-  run(["--filter", pkgName, "build"]);
-}
 
 ensurePackageBuild(
+  repoRoot,
   "@remnic/core",
   path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+  [
+    path.join(repoRoot, "packages", "remnic-core", "src"),
+    path.join(repoRoot, "packages", "remnic-core", "package.json"),
+    path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+    path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+  ],
 );
 ensurePackageBuild(
+  repoRoot,
   "@remnic/bench",
   path.join(repoRoot, "packages", "bench", "dist", "index.js"),
+  [
+    path.join(repoRoot, "packages", "bench", "src"),
+    path.join(repoRoot, "packages", "bench", "package.json"),
+    path.join(repoRoot, "packages", "bench", "tsup.config.ts"),
+    path.join(repoRoot, "packages", "bench", "tsconfig.json"),
+  ],
 );
 ensurePackageBuild(
+  repoRoot,
   "@remnic/export-weclone",
   path.join(repoRoot, "packages", "export-weclone", "dist", "index.js"),
+  [
+    path.join(repoRoot, "packages", "export-weclone", "src"),
+    path.join(repoRoot, "packages", "export-weclone", "package.json"),
+    path.join(repoRoot, "packages", "export-weclone", "tsup.config.ts"),
+    path.join(repoRoot, "packages", "export-weclone", "tsconfig.json"),
+  ],
 );

--- a/scripts/run-bench-cli.mjs
+++ b/scripts/run-bench-cli.mjs
@@ -1,29 +1,19 @@
-import fs from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { ensurePackageBuild, runPnpm } from "./build-staleness.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 
 function run(args) {
-  const result = spawnSync(pnpmCmd, args, {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: process.env,
-  });
-
-  if (result.error) {
-    throw result.error;
-  }
-
-  if (typeof result.status === "number" && result.status !== 0) {
-    process.exit(result.status);
-  }
+  runPnpm(repoRoot, args);
 }
 
-const coreDistPath = path.join(repoRoot, "packages", "remnic-core", "dist", "index.js");
-const benchDistPath = path.join(repoRoot, "packages", "bench", "dist", "index.js");
+const coreSourcePaths = [
+  path.join(repoRoot, "packages", "remnic-core", "src"),
+  path.join(repoRoot, "packages", "remnic-core", "package.json"),
+  path.join(repoRoot, "packages", "remnic-core", "tsup.config.ts"),
+  path.join(repoRoot, "packages", "remnic-core", "tsconfig.json"),
+];
 const benchSourcePaths = [
   path.join(repoRoot, "packages", "bench", "src"),
   path.join(repoRoot, "packages", "bench", "package.json"),
@@ -31,41 +21,17 @@ const benchSourcePaths = [
   path.join(repoRoot, "packages", "bench", "tsconfig.json"),
 ];
 
-if (!fs.existsSync(coreDistPath)) {
-  run(["--filter", "@remnic/core", "build"]);
-}
-
-if (!fs.existsSync(benchDistPath) || isAnySourceNewerThan(benchSourcePaths, benchDistPath)) {
-  run(["--filter", "@remnic/bench", "build"]);
-}
+ensurePackageBuild(
+  repoRoot,
+  "@remnic/core",
+  path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+  coreSourcePaths,
+);
+ensurePackageBuild(
+  repoRoot,
+  "@remnic/bench",
+  path.join(repoRoot, "packages", "bench", "dist", "index.js"),
+  benchSourcePaths,
+);
 
 run(["exec", "tsx", "packages/remnic-cli/src/index.ts", "bench", ...process.argv.slice(2)]);
-
-function isAnySourceNewerThan(sourcePaths, distPath) {
-  const distMtimeMs = fs.statSync(distPath).mtimeMs;
-  const newestSource = newestMtime(sourcePaths);
-  return newestSource !== undefined && newestSource > distMtimeMs + 1000;
-}
-
-function newestMtime(paths) {
-  let newest;
-  const visit = (entryPath) => {
-    if (!fs.existsSync(entryPath)) {
-      return;
-    }
-    const stat = fs.statSync(entryPath);
-    if (stat.isDirectory()) {
-      for (const child of fs.readdirSync(entryPath)) {
-        visit(path.join(entryPath, child));
-      }
-      return;
-    }
-    if (stat.isFile()) {
-      newest = newest === undefined ? stat.mtimeMs : Math.max(newest, stat.mtimeMs);
-    }
-  };
-  for (const sourcePath of paths) {
-    visit(sourcePath);
-  }
-  return newest;
-}

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -46,29 +46,35 @@ test("workspace scripts expose bench list, bench run, and a quick smoke path", a
     scripts?: Record<string, string>;
   };
   const helper = await readFile("scripts/run-bench-cli.mjs", "utf8");
+  const buildHelper = await readFile("scripts/build-staleness.mjs", "utf8");
 
   assert.equal(pkg.scripts?.["bench:list"], "node scripts/run-bench-cli.mjs list");
   assert.equal(pkg.scripts?.["bench:run"], "node scripts/run-bench-cli.mjs run");
   assert.equal(pkg.scripts?.["bench:compare"], "node scripts/run-bench-cli.mjs compare");
   assert.equal(pkg.scripts?.["bench:quick"], "node scripts/run-bench-cli.mjs run --quick longmemeval");
 
+  assert.match(helper, /from "\.\/build-staleness\.mjs"/);
   assert.match(helper, /packages", "remnic-core", "dist", "index\.js"/);
   assert.match(helper, /packages", "bench", "dist", "index\.js"/);
-  assert.match(helper, /\["--filter", "@remnic\/core", "build"\]/);
-  assert.match(helper, /\["--filter", "@remnic\/bench", "build"\]/);
+  assert.match(helper, /ensurePackageBuild\(\s*repoRoot,\s*"@remnic\/core"/);
+  assert.match(helper, /ensurePackageBuild\(\s*repoRoot,\s*"@remnic\/bench"/);
+  assert.doesNotMatch(helper, /isAnySourceNewerThan\(/);
+  assert.match(buildHelper, /export function runPnpm\(repoRoot, args\)/);
   assert.match(helper, /\["exec", "tsx", "packages\/remnic-cli\/src\/index\.ts", "bench"/);
 });
 
 test("CLI prebuild helper hydrates the bundled export adapter before building", async () => {
   const helper = await readFile("scripts/ensure-cli-bench-build-deps.mjs", "utf8");
+  const buildHelper = await readFile("scripts/build-staleness.mjs", "utf8");
 
+  assert.match(helper, /from "\.\/build-staleness\.mjs"/);
   assert.match(helper, /packages", "remnic-core", "dist", "index\.js"/);
   assert.match(helper, /packages", "bench", "dist", "index\.js"/);
   assert.match(helper, /packages", "export-weclone", "dist", "index\.js"/);
-  assert.match(helper, /run\(\["--filter", pkgName, "build"\]\);/);
-  assert.match(helper, /ensurePackageBuild\(\s*"@remnic\/core"/);
-  assert.match(helper, /ensurePackageBuild\(\s*"@remnic\/bench"/);
-  assert.match(helper, /ensurePackageBuild\(\s*"@remnic\/export-weclone"/);
+  assert.match(buildHelper, /runPnpm\(repoRoot, \["--filter", pkgName, "build"\]\);/);
+  assert.match(helper, /ensurePackageBuild\(\s*repoRoot,\s*"@remnic\/core"/);
+  assert.match(helper, /ensurePackageBuild\(\s*repoRoot,\s*"@remnic\/bench"/);
+  assert.match(helper, /ensurePackageBuild\(\s*repoRoot,\s*"@remnic\/export-weclone"/);
 });
 
 test("CLI README documents bench list and quick-run examples", async () => {


### PR DESCRIPTION
## Summary
- share build staleness checks across benchmark build helpers
- rebuild @remnic/core when its source/config is newer than dist before building @remnic/bench
- apply the same staleness behavior to CLI benchmark/export dependency prep

## Verification
- pnpm --filter @remnic/core build
- pnpm --filter @remnic/bench build
- node scripts/run-bench-cli.mjs list
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark/CLI helper scripts that decide when to rebuild packages; incorrect staleness detection could lead to unnecessary rebuilds or running benchmarks against outdated artifacts, especially across filesystems/platforms.
> 
> **Overview**
> Adds a shared `scripts/build-staleness.mjs` helper to run `pnpm` and detect when a package’s `dist` output is missing *or older than* its source/config inputs.
> 
> Updates the benchmark and CLI prebuild scripts to use this centralized staleness check and to rebuild `@remnic/core`, `@remnic/bench`, and `@remnic/export-weclone` when their sources change, and adjusts tests to assert the new behavior and helper import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d3edb97a79b15190dc39683dbb7e94aaa7087a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->