### PR TITLE
Fix Codex CLI child cleanup on benchmark shutdown

### DIFF
--- a/packages/bench/src/providers/codex-cli.test.ts
+++ b/packages/bench/src/providers/codex-cli.test.ts
@@ -220,7 +220,39 @@ test("codex-cli command terminates subprocess when aborted", async () => {
 
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /Codex CLI aborted by benchmark timeout/);
+    assert.equal(__codexCliProviderTestHooks.getActiveCodexCliChildCount(), 0);
   } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("codex-cli parent cleanup terminates active subprocesses", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-codex-cli-test-"));
+
+  try {
+    const run = __codexCliProviderTestHooks.runCodexCliCommand({
+      executable: process.execPath,
+      args: [
+        "-e",
+        "process.stdin.resume(); setInterval(() => {}, 1000);",
+      ],
+      input: "hello",
+      outputPath: path.join(tempDir, "last-message.txt"),
+      workspacePath: tempDir,
+      timeoutMs: 60_000,
+      env: process.env,
+    });
+
+    assert.equal(__codexCliProviderTestHooks.getActiveCodexCliChildCount(), 1);
+    __codexCliProviderTestHooks.terminateActiveCodexCliChildren("SIGTERM");
+
+    const result = await run;
+
+    assert.equal(result.status, null);
+    assert.equal(result.signal, "SIGTERM");
+    assert.equal(__codexCliProviderTestHooks.getActiveCodexCliChildCount(), 0);
+  } finally {
+    __codexCliProviderTestHooks.terminateActiveCodexCliChildren("SIGKILL");
     await rm(tempDir, { force: true, recursive: true });
   }
 });

--- a/packages/bench/src/providers/codex-cli.ts
+++ b/packages/bench/src/providers/codex-cli.ts
@@ -41,6 +41,15 @@ interface CodexCliProviderDeps {
 
 const DEFAULT_REASONING_EFFORT = "xhigh";
 const CODEX_CLI_STDIO_LIMIT = 64_000;
+const CODEX_CLI_PARENT_SIGNALS: NodeJS.Signals[] = [
+  "SIGHUP",
+  "SIGINT",
+  "SIGTERM",
+];
+const CODEX_CLI_FORCED_PARENT_EXIT_MS = 1_000;
+
+const activeCodexCliChildPids = new Set<number>();
+let codexCliParentCleanupInstalled = false;
 
 class CodexCliProvider implements LlmProvider {
   readonly provider = "codex-cli" as const;
@@ -278,6 +287,9 @@ function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunRes
       detached: process.platform !== "win32",
       windowsHide: true,
     });
+    if (child.pid) {
+      registerActiveCodexCliChild(child.pid);
+    }
     let stdout = "";
     let stderr = "";
     let timedOut = false;
@@ -348,6 +360,9 @@ function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunRes
         clearTimeout(timeout);
       }
       clearKillTimeout();
+      if (child.pid) {
+        unregisterActiveCodexCliChild(child.pid);
+      }
       request.signal?.removeEventListener("abort", onAbort);
       reject(error);
     });
@@ -356,6 +371,9 @@ function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunRes
         clearTimeout(timeout);
       }
       clearKillTimeout();
+      if (child.pid) {
+        unregisterActiveCodexCliChild(child.pid);
+      }
       request.signal?.removeEventListener("abort", onAbort);
       if (timedOut) {
         resolve({
@@ -397,6 +415,78 @@ function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunRes
       );
     }
   });
+}
+
+function registerActiveCodexCliChild(pid: number): void {
+  installCodexCliParentCleanup();
+  activeCodexCliChildPids.add(pid);
+}
+
+function unregisterActiveCodexCliChild(pid: number): void {
+  activeCodexCliChildPids.delete(pid);
+}
+
+function installCodexCliParentCleanup(): void {
+  if (codexCliParentCleanupInstalled) {
+    return;
+  }
+  codexCliParentCleanupInstalled = true;
+
+  process.once("exit", () => {
+    terminateActiveCodexCliChildren("SIGTERM");
+  });
+
+  for (const signal of CODEX_CLI_PARENT_SIGNALS) {
+    process.once(signal, () => {
+      const activeChildren = activeCodexCliChildPids.size;
+      terminateActiveCodexCliChildren(signal === "SIGINT" ? "SIGINT" : "SIGTERM");
+      process.exitCode = signalExitCode(signal);
+
+      setTimeout(
+        () => {
+          terminateActiveCodexCliChildren("SIGKILL");
+          process.exit(signalExitCode(signal));
+        },
+        activeChildren > 0 ? CODEX_CLI_FORCED_PARENT_EXIT_MS : 0,
+      );
+    });
+  }
+}
+
+function terminateActiveCodexCliChildren(signal: NodeJS.Signals): void {
+  for (const pid of activeCodexCliChildPids) {
+    terminateCodexCliChildPid(pid, signal);
+  }
+}
+
+function terminateCodexCliChildPid(pid: number, signal: NodeJS.Signals): void {
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-pid, signal);
+      return;
+    } catch {
+      // Fall back to killing the direct child below.
+    }
+  }
+
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // The child may already have exited.
+  }
+}
+
+function signalExitCode(signal: NodeJS.Signals): number {
+  switch (signal) {
+    case "SIGHUP":
+      return 129;
+    case "SIGINT":
+      return 130;
+    case "SIGTERM":
+      return 143;
+    default:
+      return 1;
+  }
 }
 
 async function readCodexOutput(
@@ -470,6 +560,8 @@ export function createCodexCliProvider(
 export const __codexCliProviderTestHooks = {
   buildCodexCompletionPrompt,
   buildIsolatedCodexEnv,
+  getActiveCodexCliChildCount: () => activeCodexCliChildPids.size,
   parseCodexTokenUsage,
   runCodexCliCommand,
+  terminateActiveCodexCliChildren,
 };


### PR DESCRIPTION
## Summary
- track active Codex CLI subprocess groups while benchmark completions are running
- clean up active Codex CLI children on parent SIGTERM/SIGINT/SIGHUP/exit
- add regression coverage for parent cleanup and active-child registry reset

## Verification
- pnpm exec tsx --test packages/bench/src/providers/codex-cli.test.ts
- pnpm --filter @remnic/bench check-types
- pnpm --filter @remnic/bench build
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process/signal handling and subprocess termination logic; mistakes could cause hanging benchmarks or unintended process exits, but changes are scoped to the Codex CLI benchmark runner.
> 
> **Overview**
> Ensures Codex CLI benchmark runs don’t leak subprocesses by **tracking active spawned child PIDs** and adding a one-time **parent shutdown handler** that terminates remaining children on `exit` and on `SIGHUP`/`SIGINT`/`SIGTERM` (with a delayed `SIGKILL` fallback).
> 
> Updates `runCodexCliCommand` to register/unregister children on spawn/close/error, exports test hooks for active-child counting/termination, and adds regression tests covering abort cleanup and parent-triggered termination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddff75b9e7cb327019ab9a6852f30cf6356566ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->