### PR TITLE
Fix ClawHub owner for OpenClaw plugin

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -451,7 +451,7 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           CLAWHUB_PACKAGE_NAME: "@remnic/plugin-openclaw"
-          CLAWHUB_OWNER: "remnic"
+          CLAWHUB_OWNER: "joshuaswarren"
         run: |
           if [ -z "${CLAWHUB_TOKEN:-}" ]; then
             echo "::notice title=ClawHub publish skipped::CLAWHUB_TOKEN secret is not configured."

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -47,6 +47,8 @@ for config-key behavior, backup behavior, and local patch preservation notes.
 Publish ClawHub releases from the built npm/ClawPack tarball, not from the raw
 GitHub source folder. Source-folder publishing does not run the package build,
 so ClawHub can scan an incomplete three-file artifact with no `dist/index.js`.
+The package is named `@remnic/plugin-openclaw`, but the current ClawHub owner is
+the `joshuaswarren` account.
 
 ```bash
 pnpm --filter @remnic/plugin-openclaw build
@@ -55,6 +57,7 @@ clawhub package pack packages/plugin-openclaw --pack-destination /tmp/remnic-cla
 clawhub package publish /tmp/remnic-clawpack/remnic-plugin-openclaw-<version>.tgz \
   --family code-plugin \
   --name @remnic/plugin-openclaw \
+  --owner joshuaswarren \
   --display-name "Remnic OpenClaw Plugin" \
   --version <version> \
   --source-repo joshuaswarren/remnic \


### PR DESCRIPTION
## Summary
- publish the existing ClawHub package under the current joshuaswarren owner
- document the package-name/owner split for manual ClawHub publishes

## Verification
- git diff --check
- clawhub package inspect @remnic/plugin-openclaw confirms owner joshuaswarren
- clawhub package publish dry-run succeeds for @remnic/plugin-openclaw with owner joshuaswarren

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates ClawHub publishing metadata in the GitHub Actions release workflow and aligns documentation; no runtime or package code changes.
> 
> **Overview**
> Updates the release workflow to publish the existing `@remnic/plugin-openclaw` package to ClawHub under the correct owner (`joshuaswarren`) instead of `remnic`.
> 
> Documentation is updated to clarify the package-name/owner split and to include the `--owner joshuaswarren` flag for manual ClawHub publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a7f11bacb8877314885d06f31277c2f2d1d549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->