### PR TITLE
Capture Codex CLI benchmark diagnostics

### DIFF
--- a/packages/bench/src/providers/codex-cli.test.ts
+++ b/packages/bench/src/providers/codex-cli.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -194,6 +194,99 @@ test("codex-cli provider surfaces non-zero CLI exits", async () => {
     provider.complete("hello"),
     /Codex CLI completion failed \(exit 2\): invalid model/,
   );
+});
+
+test("codex-cli provider writes metadata diagnostics without full prompt text", async () => {
+  const diagnosticsDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-codex-cli-diag-"),
+  );
+
+  try {
+    const provider = createCodexCliProvider(
+      {
+        provider: "codex-cli",
+        model: "gpt-5.5",
+        diagnosticsDir,
+        reasoningEffort: "xhigh",
+        retryOptions: { timeoutMs: 1234 },
+      },
+      {
+        async runCodexCli() {
+          return {
+            status: 0,
+            signal: null,
+            stdout: "tokens used 44",
+            stderr: "ok",
+            outputText: "final answer",
+          };
+        },
+      },
+    );
+
+    await provider.complete("What is remembered?", {
+      systemPrompt: "Answer using only benchmark context.",
+    });
+
+    const files = await readdir(diagnosticsDir);
+    assert.equal(files.length, 1);
+    const diagnostic = JSON.parse(
+      await readFile(path.join(diagnosticsDir, files[0]!), "utf8"),
+    ) as Record<string, unknown>;
+
+    assert.equal(diagnostic.provider, "codex-cli");
+    assert.equal(diagnostic.model, "gpt-5.5");
+    assert.equal(diagnostic.reasoningEffort, "xhigh");
+    assert.equal(diagnostic.timeoutMs, 1234);
+    assert.equal("fullPrompt" in diagnostic, false);
+    assert.equal((diagnostic.prompt as { userPromptChars: number }).userPromptChars, 19);
+    assert.equal((diagnostic.result as { status: number }).status, 0);
+  } finally {
+    await rm(diagnosticsDir, { force: true, recursive: true });
+  }
+});
+
+test("codex-cli provider writes full diagnostics only when explicitly requested", async () => {
+  const diagnosticsDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-codex-cli-diag-"),
+  );
+
+  try {
+    const provider = createCodexCliProvider(
+      {
+        provider: "codex-cli",
+        model: "gpt-5.5",
+        diagnosticsDir,
+        diagnosticsMode: "full",
+      },
+      {
+        async runCodexCli() {
+          return {
+            status: 124,
+            signal: "SIGTERM",
+            stdout: "",
+            stderr: "timed out",
+            outputText: "",
+          };
+        },
+      },
+    );
+
+    await assert.rejects(
+      provider.complete("diagnostic prompt"),
+      /Codex CLI completion failed \(signal SIGTERM\): timed out/,
+    );
+
+    const [file] = await readdir(diagnosticsDir);
+    const diagnostic = JSON.parse(
+      await readFile(path.join(diagnosticsDir, file!), "utf8"),
+    ) as Record<string, unknown>;
+
+    assert.match(String(diagnostic.fullPrompt), /diagnostic prompt/);
+    assert.equal((diagnostic.result as { status: number }).status, 124);
+    assert.match(String(diagnostic.error), /Codex CLI completion failed/);
+  } finally {
+    await rm(diagnosticsDir, { force: true, recursive: true });
+  }
 });
 
 test("codex-cli command terminates subprocess when aborted", async () => {

--- a/packages/bench/src/providers/codex-cli.test.ts
+++ b/packages/bench/src/providers/codex-cli.test.ts
@@ -289,6 +289,17 @@ test("codex-cli provider writes full diagnostics only when explicitly requested"
   }
 });
 
+test("codex-cli diagnostics dir expands home-relative tilde paths", () => {
+  assert.equal(
+    __codexCliProviderTestHooks.resolveCodexCliDiagnosticsDir({
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      diagnosticsDir: "~/codex-diag",
+    }),
+    path.join(os.homedir(), "codex-diag"),
+  );
+});
+
 test("codex-cli command terminates subprocess when aborted", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-codex-cli-test-"));
   const controller = new AbortController();

--- a/packages/bench/src/providers/codex-cli.ts
+++ b/packages/bench/src/providers/codex-cli.ts
@@ -411,9 +411,20 @@ function resolveCodexCliDiagnosticsDir(
   config: CodexCliProviderConfig,
 ): string | undefined {
   const dir = config.diagnosticsDir ?? process.env[CODEX_CLI_DIAGNOSTICS_DIR_ENV];
-  return typeof dir === "string" && dir.trim().length > 0
-    ? path.resolve(dir)
+  const trimmed = typeof dir === "string" ? dir.trim() : "";
+  return trimmed.length > 0
+    ? path.resolve(expandHomeRelativePath(trimmed))
     : undefined;
+}
+
+function expandHomeRelativePath(value: string): string {
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
 }
 
 function resolveCodexCliDiagnosticsMode(
@@ -774,6 +785,7 @@ export const __codexCliProviderTestHooks = {
   buildIsolatedCodexEnv,
   getActiveCodexCliChildCount: () => activeCodexCliChildPids.size,
   parseCodexTokenUsage,
+  resolveCodexCliDiagnosticsDir,
   runCodexCliCommand,
   terminateActiveCodexCliChildren,
 };

--- a/packages/bench/src/providers/codex-cli.ts
+++ b/packages/bench/src/providers/codex-cli.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -39,6 +40,47 @@ interface CodexCliProviderDeps {
   ) => Promise<{ status: number | null; stderr: string }>;
 }
 
+interface CodexCliDiagnosticRecord {
+  schemaVersion: 1;
+  id: string;
+  startedAt: string;
+  finishedAt?: string;
+  durationMs?: number;
+  provider: "codex-cli";
+  model: string;
+  reasoningEffort: string;
+  executable: string;
+  timeoutMs?: number;
+  workspaceBasename: string;
+  outputBasename: string;
+  prompt: {
+    sha256: string;
+    chars: number;
+    lines: number;
+    systemPromptChars?: number;
+    userPromptChars?: number;
+  };
+  command: {
+    args: string[];
+  };
+  result?: {
+    status: number | null;
+    signal: NodeJS.Signals | null;
+    stdoutChars: number;
+    stderrChars: number;
+    outputChars: number;
+    stdoutTail: string;
+    stderrTail: string;
+  };
+  error?: string;
+  fullPrompt?: string;
+}
+
+interface CodexCliDiagnosticHandle {
+  path: string;
+  record: CodexCliDiagnosticRecord;
+}
+
 const DEFAULT_REASONING_EFFORT = "xhigh";
 const CODEX_CLI_STDIO_LIMIT = 64_000;
 const CODEX_CLI_PARENT_SIGNALS: NodeJS.Signals[] = [
@@ -47,6 +89,8 @@ const CODEX_CLI_PARENT_SIGNALS: NodeJS.Signals[] = [
   "SIGTERM",
 ];
 const CODEX_CLI_FORCED_PARENT_EXIT_MS = 1_000;
+const CODEX_CLI_DIAGNOSTICS_DIR_ENV = "REMNIC_BENCH_CODEX_CLI_DIAGNOSTICS_DIR";
+const CODEX_CLI_DIAGNOSTICS_MODE_ENV = "REMNIC_BENCH_CODEX_CLI_DIAGNOSTICS_MODE";
 
 const activeCodexCliChildPids = new Set<number>();
 let codexCliParentCleanupInstalled = false;
@@ -84,11 +128,18 @@ class CodexCliProvider implements LlmProvider {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-codex-cli-"));
     const workspacePath = path.join(tempDir, "workspace");
     const outputPath = path.join(tempDir, "last-message.txt");
+    let diagnostics: CodexCliDiagnosticHandle | undefined;
 
     try {
       await mkdir(workspacePath, { recursive: true });
       const request = this.buildRunRequest(prompt, opts, workspacePath, outputPath);
+      diagnostics = await startCodexCliDiagnostics({
+        config: this.config,
+        request,
+        reasoningEffort: this.config.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+      });
       const result = await this.runCodexCli(request);
+      await finishCodexCliDiagnostics(diagnostics, startedAt, { result });
       if (result.status !== 0) {
         const exitLabel = result.signal
           ? `signal ${result.signal}`
@@ -116,6 +167,9 @@ class CodexCliProvider implements LlmProvider {
         latencyMs: Math.round(performance.now() - startedAt),
         model: this.config.model,
       };
+    } catch (error) {
+      await finishCodexCliDiagnostics(diagnostics, startedAt, { error });
+      throw error;
     } finally {
       await rm(tempDir, { force: true, recursive: true });
     }
@@ -265,6 +319,164 @@ function buildIsolatedCodexEnv(apiKey?: string): NodeJS.ProcessEnv {
     env.OPENAI_API_KEY = apiKey;
   }
   return env;
+}
+
+async function startCodexCliDiagnostics(args: {
+  config: CodexCliProviderConfig;
+  request: CodexCliRunRequest;
+  reasoningEffort: string;
+}): Promise<CodexCliDiagnosticHandle | undefined> {
+  const diagnosticsDir = resolveCodexCliDiagnosticsDir(args.config);
+  if (!diagnosticsDir) {
+    return undefined;
+  }
+
+  try {
+    await mkdir(diagnosticsDir, { recursive: true });
+    const id = `${Date.now()}-${process.pid}-${randomUUID()}`;
+    const promptStats = inspectCodexCompletionPrompt(args.request.input);
+    const mode = resolveCodexCliDiagnosticsMode(args.config);
+    const record: CodexCliDiagnosticRecord = {
+      schemaVersion: 1,
+      id,
+      startedAt: new Date().toISOString(),
+      provider: "codex-cli",
+      model: args.config.model,
+      reasoningEffort: args.reasoningEffort,
+      executable: path.basename(args.request.executable),
+      ...(args.request.timeoutMs ? { timeoutMs: args.request.timeoutMs } : {}),
+      workspaceBasename: path.basename(args.request.workspacePath),
+      outputBasename: path.basename(args.request.outputPath),
+      prompt: promptStats,
+      command: {
+        args: redactCodexCliArgs(args.request.args),
+      },
+      ...(mode === "full" ? { fullPrompt: args.request.input } : {}),
+    };
+    const filePath = path.join(diagnosticsDir, `${id}.json`);
+    await writeCodexCliDiagnosticRecord(filePath, record);
+    return { path: filePath, record };
+  } catch {
+    return undefined;
+  }
+}
+
+async function finishCodexCliDiagnostics(
+  handle: CodexCliDiagnosticHandle | undefined,
+  startedAt: number,
+  outcome: { result?: CodexCliRunResult; error?: unknown },
+): Promise<void> {
+  if (!handle) {
+    return;
+  }
+
+  const result = outcome.result;
+  const error = outcome.error;
+  const record: CodexCliDiagnosticRecord = {
+    ...handle.record,
+    finishedAt: new Date().toISOString(),
+    durationMs: Math.round(performance.now() - startedAt),
+    ...(result
+      ? {
+          result: {
+            status: result.status,
+            signal: result.signal,
+            stdoutChars: result.stdout.length,
+            stderrChars: result.stderr.length,
+            outputChars: result.outputText.length,
+            stdoutTail: result.stdout.slice(-2_000),
+            stderrTail: result.stderr.slice(-2_000),
+          },
+        }
+      : {}),
+    ...(error ? { error: error instanceof Error ? error.message : String(error) } : {}),
+  };
+  handle.record = record;
+
+  try {
+    await writeCodexCliDiagnosticRecord(handle.path, record);
+  } catch {
+    // Diagnostics must never change benchmark behavior.
+  }
+}
+
+async function writeCodexCliDiagnosticRecord(
+  filePath: string,
+  record: CodexCliDiagnosticRecord,
+): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+}
+
+function resolveCodexCliDiagnosticsDir(
+  config: CodexCliProviderConfig,
+): string | undefined {
+  const dir = config.diagnosticsDir ?? process.env[CODEX_CLI_DIAGNOSTICS_DIR_ENV];
+  return typeof dir === "string" && dir.trim().length > 0
+    ? path.resolve(dir)
+    : undefined;
+}
+
+function resolveCodexCliDiagnosticsMode(
+  config: CodexCliProviderConfig,
+): "metadata" | "full" {
+  const raw = config.diagnosticsMode ?? process.env[CODEX_CLI_DIAGNOSTICS_MODE_ENV];
+  return raw === "full" ? "full" : "metadata";
+}
+
+function inspectCodexCompletionPrompt(
+  prompt: string,
+): CodexCliDiagnosticRecord["prompt"] {
+  const stats: CodexCliDiagnosticRecord["prompt"] = {
+    sha256: createHash("sha256").update(prompt).digest("hex"),
+    chars: prompt.length,
+    lines: prompt.length === 0 ? 0 : prompt.split("\n").length,
+  };
+  const marker = "BENCHMARK_REQUEST_JSON:";
+  const markerIndex = prompt.indexOf(marker);
+  if (markerIndex < 0) {
+    return stats;
+  }
+
+  try {
+    const parsed = JSON.parse(prompt.slice(markerIndex + marker.length).trim()) as {
+      systemPrompt?: unknown;
+      userPrompt?: unknown;
+    };
+    return {
+      ...stats,
+      ...(typeof parsed.systemPrompt === "string"
+        ? { systemPromptChars: parsed.systemPrompt.length }
+        : {}),
+      ...(typeof parsed.userPrompt === "string"
+        ? { userPromptChars: parsed.userPrompt.length }
+        : {}),
+    };
+  } catch {
+    return stats;
+  }
+}
+
+function redactCodexCliArgs(args: string[]): string[] {
+  const redacted = [...args];
+  for (let index = 0; index < redacted.length; index += 1) {
+    const value = redacted[index];
+    const lowered = value.toLowerCase();
+    if (value === "--cd" || value === "--output-last-message") {
+      if (index + 1 < redacted.length) {
+        redacted[index + 1] = "[redacted]";
+      }
+      continue;
+    }
+    if (
+      lowered.includes("api_key") ||
+      lowered.includes("apikey") ||
+      lowered.includes("token") ||
+      lowered.includes("secret")
+    ) {
+      redacted[index] = "[redacted]";
+    }
+  }
+  return redacted;
 }
 
 function runCodexCliCommand(request: CodexCliRunRequest): Promise<CodexCliRunResult> {

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -73,6 +73,17 @@ export interface CodexCliProviderConfig extends ProviderBaseConfig {
   reasoningEffort?: BenchReasoningEffort;
   /** Optional executable override for tests or non-standard Codex CLI installs. */
   executable?: string;
+  /**
+   * Optional diagnostics artifact directory. When set, the provider writes
+   * per-call metadata that helps debug slow benchmark completions without
+   * depending on transient temp workspaces.
+   */
+  diagnosticsDir?: string;
+  /**
+   * `metadata` stores hashes/counts only. `full` additionally stores the full
+   * benchmark prompt and should only be used for isolated benchmark datasets.
+   */
+  diagnosticsMode?: "metadata" | "full";
 }
 
 export type ProviderFactoryConfig =

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2319,6 +2319,19 @@ async function runBenchViaPackage(
   const benchStartTime = Date.now();
   const partialTasks: import("@remnic/bench").TaskResult[] = [];
   let system: Awaited<ReturnType<PackageBenchExecutionPlan["createAdapter"]>> | undefined;
+  const previousCodexDiagnosticsDir =
+    process.env[CODEX_CLI_BENCH_DIAGNOSTICS_DIR_ENV];
+  const previousCodexDiagnosticsMode =
+    process.env[CODEX_CLI_BENCH_DIAGNOSTICS_MODE_ENV];
+  if (!previousCodexDiagnosticsDir) {
+    process.env[CODEX_CLI_BENCH_DIAGNOSTICS_DIR_ENV] = path.join(
+      outputDir,
+      "codex-cli-diagnostics",
+    );
+  }
+  if (!previousCodexDiagnosticsMode) {
+    process.env[CODEX_CLI_BENCH_DIAGNOSTICS_MODE_ENV] = "metadata";
+  }
 
   try {
     const amaBenchProtocol = buildAmaBenchProtocolOptions(
@@ -2413,8 +2426,27 @@ async function runBenchViaPackage(
     }
     throw err;
   } finally {
-    await system?.destroy();
+    try {
+      await system?.destroy();
+    } finally {
+      restoreOptionalEnv(
+        CODEX_CLI_BENCH_DIAGNOSTICS_DIR_ENV,
+        previousCodexDiagnosticsDir,
+      );
+      restoreOptionalEnv(
+        CODEX_CLI_BENCH_DIAGNOSTICS_MODE_ENV,
+        previousCodexDiagnosticsMode,
+      );
+    }
   }
+}
+
+function restoreOptionalEnv(key: string, previousValue: string | undefined): void {
+  if (previousValue === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = previousValue;
 }
 
 function buildAmaBenchProtocolOptions(
@@ -2651,6 +2683,10 @@ const BENCH_REPRO_ENV_KEYS = [
   "REMNIC_BENCH_REQUEST_TIMEOUT_MS",
   "XDG_CACHE_HOME",
 ] as const;
+const CODEX_CLI_BENCH_DIAGNOSTICS_DIR_ENV =
+  "REMNIC_BENCH_CODEX_CLI_DIAGNOSTICS_DIR";
+const CODEX_CLI_BENCH_DIAGNOSTICS_MODE_ENV =
+  "REMNIC_BENCH_CODEX_CLI_DIAGNOSTICS_MODE";
 
 function resolveBenchReproEnvKeys(): string[] {
   return BENCH_REPRO_ENV_KEYS.filter((key) => process.env[key] !== undefined);


### PR DESCRIPTION
## Summary
- write per-call Codex CLI diagnostics for benchmark provider calls
- auto-store metadata diagnostics under the benchmark results directory
- keep full prompts out of artifacts unless explicitly requested with full diagnostics mode

## Verification
- pnpm exec tsx --test packages/bench/src/providers/codex-cli.test.ts
- pnpm --filter @remnic/bench check-types
- pnpm --filter @remnic/bench build
- npm run check-types
- node scripts/run-bench-cli.mjs list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new on-disk diagnostics and environment-driven defaults for Codex CLI benchmark executions, which can affect filesystem writes and artifact contents. Prompt capture is gated behind an explicit `full` mode, reducing data-leak risk but still warrants review of redaction and paths.
> 
> **Overview**
> Adds **per-call diagnostics artifacts** for the `codex-cli` provider, writing a JSON record (timings, model/reasoning settings, redacted CLI args, prompt hash/size, and result/errored outcome with stdout/stderr tails) when a diagnostics directory is configured via `CodexCliProviderConfig` or `REMNIC_BENCH_CODEX_CLI_DIAGNOSTICS_DIR`.
> 
> Introduces a `diagnosticsMode` switch (`metadata` default vs `full`) that **keeps full prompt text out of artifacts unless explicitly requested**, plus tilde/home expansion for diagnostics paths and basic argument redaction.
> 
> Updates the bench CLI to **default Codex CLI diagnostics** under the benchmark output directory (`codex-cli-diagnostics`) in `metadata` mode for runs that don’t already set the env vars, and restores prior env values afterward. Adds tests covering metadata vs full diagnostics behavior and tilde path resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee75e45995b1c8ded093c778686de2fbe1b145c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->