### PR TITLE
Publish OpenClaw plugin under ClawHub account scope

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -450,8 +450,10 @@ jobs:
       - name: Publish OpenClaw plugin to ClawHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-          CLAWHUB_PACKAGE_NAME: "@remnic/plugin-openclaw"
+          CLAWHUB_PACKAGE_NAME: "@joshuaswarren/plugin-openclaw"
           CLAWHUB_OWNER: "joshuaswarren"
+          NPM_PACKAGE_NAME: "@remnic/plugin-openclaw"
+          NPM_PACKAGE_PATH: "packages/plugin-openclaw"
         run: |
           if [ -z "${CLAWHUB_TOKEN:-}" ]; then
             echo "::notice title=ClawHub publish skipped::CLAWHUB_TOKEN secret is not configured."
@@ -461,7 +463,7 @@ jobs:
           npm install -g clawhub@0.12.2
           clawhub login --token "${CLAWHUB_TOKEN}" --no-browser
 
-          package_version="$(node -p "require('./packages/plugin-openclaw/package.json').version")"
+          package_version="$(node -p "require('./${NPM_PACKAGE_PATH}/package.json').version")"
           if clawhub package inspect "${CLAWHUB_PACKAGE_NAME}" --version "${package_version}" --json >/dev/null 2>&1; then
             echo "::notice title=ClawHub publish skipped::${CLAWHUB_PACKAGE_NAME}@${package_version} is already published."
             exit 0
@@ -470,10 +472,10 @@ jobs:
           pack_dir="${RUNNER_TEMP}/clawhub-openclaw-pack"
           rm -rf "${pack_dir}"
           mkdir -p "${pack_dir}"
-          pnpm --filter "${CLAWHUB_PACKAGE_NAME}" pack --pack-destination "${pack_dir}"
+          pnpm --filter "${NPM_PACKAGE_NAME}" pack --pack-destination "${pack_dir}"
           tarball="$(find "${pack_dir}" -maxdepth 1 -name '*.tgz' -print -quit)"
           if [ -z "${tarball}" ]; then
-            echo "No ${CLAWHUB_PACKAGE_NAME} tarball produced" >&2
+            echo "No ${NPM_PACKAGE_NAME} tarball produced" >&2
             exit 1
           fi
 
@@ -489,7 +491,7 @@ jobs:
             --source-repo "${GITHUB_REPOSITORY}" \
             --source-ref "${{ steps.version.outputs.tag_name }}" \
             --source-commit "${source_commit}" \
-            --source-path packages/plugin-openclaw \
+            --source-path "${NPM_PACKAGE_PATH}" \
             --changelog "Publish ${CLAWHUB_PACKAGE_NAME}@${package_version} from the GitHub release workflow." \
             --json >"${publish_log}" 2>&1; then
             cat "${publish_log}"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@
 ### Option A: npm (recommended)
 
 ```bash
-openclaw plugins install clawhub:@remnic/plugin-openclaw
+openclaw plugins install clawhub:@joshuaswarren/plugin-openclaw
 ```
 
 ### Option B: Developer install (from Git)

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -17,14 +17,14 @@ Canonical upstream references for this adapter:
 ## Install
 
 ```bash
-openclaw plugins install clawhub:@remnic/plugin-openclaw
+openclaw plugins install clawhub:@joshuaswarren/plugin-openclaw
 ```
 
 OpenClaw 2026.5.2+ resolves bare plugin package names through ClawHub first and
 then falls back to npm. Remnic is published on ClawHub as
-`@remnic/plugin-openclaw`, so the explicit `clawhub:` prefix keeps fresh installs
-deterministic. For npm-only fallback or rollback versions, use the explicit
-`npm:` source prefix, such as `npm:@remnic/plugin-openclaw@<version>`.
+`@joshuaswarren/plugin-openclaw`, so the explicit `clawhub:` prefix keeps fresh
+installs deterministic. For npm-only fallback or rollback versions, use the
+explicit `npm:` source prefix, such as `npm:@remnic/plugin-openclaw@<version>`.
 
 Or use the Remnic installer:
 
@@ -47,8 +47,9 @@ for config-key behavior, backup behavior, and local patch preservation notes.
 Publish ClawHub releases from the built npm/ClawPack tarball, not from the raw
 GitHub source folder. Source-folder publishing does not run the package build,
 so ClawHub can scan an incomplete three-file artifact with no `dist/index.js`.
-The package is named `@remnic/plugin-openclaw`, but the current ClawHub owner is
-the `joshuaswarren` account.
+The npm package remains `@remnic/plugin-openclaw`; the ClawHub listing is
+published as `@joshuaswarren/plugin-openclaw` because ClawHub package scopes must
+match their owner.
 
 ```bash
 pnpm --filter @remnic/plugin-openclaw build
@@ -56,7 +57,7 @@ pnpm run verify:openclaw-clawpack
 clawhub package pack packages/plugin-openclaw --pack-destination /tmp/remnic-clawpack
 clawhub package publish /tmp/remnic-clawpack/remnic-plugin-openclaw-<version>.tgz \
   --family code-plugin \
-  --name @remnic/plugin-openclaw \
+  --name @joshuaswarren/plugin-openclaw \
   --owner joshuaswarren \
   --display-name "Remnic OpenClaw Plugin" \
   --version <version> \

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -7,12 +7,12 @@ Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory 
 ## Install
 
 ```bash
-openclaw plugins install clawhub:@remnic/plugin-openclaw
+openclaw plugins install clawhub:@joshuaswarren/plugin-openclaw
 ```
 
 Or ask your OpenClaw agent:
 
-> Install the @remnic/plugin-openclaw plugin and configure it as my memory system.
+> Install the @joshuaswarren/plugin-openclaw ClawHub plugin and configure it as my memory system.
 
 ## Configure
 


### PR DESCRIPTION
## Summary
- publish the ClawHub listing as @joshuaswarren/plugin-openclaw so package scope matches owner
- keep packing the npm workspace package @remnic/plugin-openclaw
- update ClawHub install and publishing docs

## Verification
- git diff --check
- package version lookup via NPM_PACKAGE_PATH returns 1.0.34
- clawhub package publish dry-run succeeds for @joshuaswarren/plugin-openclaw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release workflow publish step; misconfiguration could break ClawHub publishing or publish under the wrong listing, but runtime code is unchanged.
> 
> **Overview**
> Updates the GitHub release workflow to **publish the OpenClaw plugin to ClawHub as `@joshuaswarren/plugin-openclaw`** (matching the ClawHub owner scope) while still packing the npm workspace package `@remnic/plugin-openclaw` from `packages/plugin-openclaw`.
> 
> Refreshes OpenClaw install/publish docs and the plugin README to reference the new ClawHub install target and clarify that npm remains `@remnic/plugin-openclaw` (including updated sample `clawhub package publish --name`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2fa1bc65c3fb3af42d3593186d1ceee976baf8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->