### PR TITLE
Fix ClawHub package tarball name

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -479,9 +479,41 @@ jobs:
             exit 1
           fi
 
+          # ClawHub requires package.json name to match the marketplace package name.
+          # Keep npm published as @remnic/plugin-openclaw, then repack for ClawHub.
+          unpack_dir="${pack_dir}/clawhub-package"
+          rm -rf "${unpack_dir}"
+          mkdir -p "${unpack_dir}"
+          tar -xzf "${tarball}" -C "${unpack_dir}"
+          UNPACK_DIR="${unpack_dir}" CLAWHUB_PACKAGE_NAME="${CLAWHUB_PACKAGE_NAME}" node - <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+
+          const packageJsonPath = path.join(process.env.UNPACK_DIR, "package", "package.json");
+          const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+          pkg.name = process.env.CLAWHUB_PACKAGE_NAME;
+          fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
+          NODE
+          clawhub_pack_json="$(cd "${unpack_dir}/package" && npm pack --pack-destination "${pack_dir}" --ignore-scripts --json)"
+          clawhub_tarball="$(PACK_DIR="${pack_dir}" PACK_JSON="${clawhub_pack_json}" node - <<'NODE'
+          const path = require("path");
+
+          const pack = JSON.parse(process.env.PACK_JSON);
+          const filename = pack?.[0]?.filename;
+          if (!filename) {
+            throw new Error("npm pack did not report a tarball filename");
+          }
+          console.log(path.join(process.env.PACK_DIR, filename));
+          NODE
+          )"
+          if [ ! -f "${clawhub_tarball}" ]; then
+            echo "No ${CLAWHUB_PACKAGE_NAME} tarball produced" >&2
+            exit 1
+          fi
+
           source_commit="$(git rev-parse HEAD)"
           publish_log="$(mktemp)"
-          if clawhub package publish "${tarball}" \
+          if clawhub package publish "${clawhub_tarball}" \
             --family code-plugin \
             --name "${CLAWHUB_PACKAGE_NAME}" \
             --owner "${CLAWHUB_OWNER}" \


### PR DESCRIPTION
## Summary
- keep npm publishing the OpenClaw plugin as @remnic/plugin-openclaw
- repack the ClawHub artifact so package.json.name matches @joshuaswarren/plugin-openclaw
- use the repacked npm-compatible tarball for the ClawHub publish step

## Verification
- git diff --check
- local ClawHub dry-run publish succeeds for @joshuaswarren/plugin-openclaw@1.0.34 with 86 files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow’s ClawHub publish artifact generation; mistakes here could break marketplace publishing or publish an incorrectly named package, but it doesn’t touch runtime code.
> 
> **Overview**
> Fixes ClawHub publishing by **repacking** the OpenClaw plugin tarball so the embedded `package.json` `name` matches the ClawHub marketplace package (`CLAWHUB_PACKAGE_NAME`), while keeping npm publishing under `NPM_PACKAGE_NAME`.
> 
> The workflow now unpacks the `pnpm pack` output, rewrites `package.json.name`, repacks via `npm pack`, and uses the repacked tarball for `clawhub package publish`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c9b207dcbd8e8781160ecd669f14cff4020d950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->