### PR TITLE
Fix extraction fallback timeout for benchmark internal LLMs

### DIFF
--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -124,6 +124,16 @@ test("parseConfig modelSource=gateway still honors an explicit openaiApiKey over
   }
 });
 
+test("parseConfig localLlmTimeoutMs accepts CLI-style numeric strings for gateway fallback", () => {
+  const cfg = parseConfig({ localLlmTimeoutMs: "600000" });
+  assert.equal(cfg.localLlmTimeoutMs, 600_000);
+});
+
+test("parseConfig localLlmTimeoutMs clamps invalid values to a positive timeout", () => {
+  assert.equal(parseConfig({ localLlmTimeoutMs: 0 }).localLlmTimeoutMs, 1);
+  assert.equal(parseConfig({ localLlmTimeoutMs: Number.NaN }).localLlmTimeoutMs, 180_000);
+});
+
 test("parseConfig keeps explicit cue recall opt-in and budgets configurable", () => {
   const defaults = parseConfig({});
   assert.equal(defaults.explicitCueRecallEnabled, false);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2011,7 +2011,7 @@ export function parseConfig(raw: unknown): PluginConfig {
         ? cfg.localLmsBinDir
         : undefined,
     localLlmTimeoutMs:
-      typeof cfg.localLlmTimeoutMs === "number" ? cfg.localLlmTimeoutMs : 180_000,
+      parseBoundedIntegerMs(cfg.localLlmTimeoutMs, 180_000, 1, 86_400_000),
     localLlmMaxContext:
       typeof cfg.localLlmMaxContext === "number" ? cfg.localLlmMaxContext : undefined,
     // Observability (disabled by default to avoid log spam)

--- a/packages/remnic-core/src/extraction-timeout.test.ts
+++ b/packages/remnic-core/src/extraction-timeout.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { ExtractionEngine } from "./extraction.js";
+import type { BufferTurn } from "./types.js";
+
+test("gateway extraction fallback honors configured timeout and output budget", async () => {
+  const config = parseConfig({
+    modelSource: "gateway",
+    localLlmTimeoutMs: 600_000,
+    extractionMaxOutputTokens: 32_768,
+    gatewayConfig: {
+      agents: {
+        defaults: { model: { primary: "bench-internal/gpt-5.5" } },
+        list: [],
+      },
+      models: {
+        providers: {
+          "bench-internal": {
+            api: "codex-cli",
+            baseUrl: "codex-cli://local",
+            models: [{ id: "gpt-5.5", name: "gpt-5.5" }],
+          },
+        },
+      },
+    },
+  });
+  const engine = new ExtractionEngine(config);
+  let capturedOptions: { timeoutMs?: number; maxTokens?: number } | undefined;
+
+  (engine as unknown as {
+    fallbackLlm: {
+      parseWithSchemaDetailed(
+        messages: unknown,
+        schema: unknown,
+        options: { timeoutMs?: number; maxTokens?: number },
+      ): Promise<unknown>;
+    };
+  }).fallbackLlm = {
+    async parseWithSchemaDetailed(_messages, _schema, options) {
+      capturedOptions = options;
+      return {
+        modelUsed: "bench-internal/gpt-5.5",
+        result: {
+          facts: [],
+          profileUpdates: [],
+          entities: [],
+          questions: [],
+        },
+      };
+    },
+  };
+
+  const turns: BufferTurn[] = [
+    {
+      role: "user",
+      content: "Remember that the analytics database is PostgreSQL.",
+      timestamp: "2026-05-08T00:00:00.000Z",
+    },
+  ];
+
+  await engine.extract(turns);
+
+  assert.equal(capturedOptions?.timeoutMs, 600_000);
+  assert.equal(capturedOptions?.maxTokens, 32_768);
+});

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1089,7 +1089,11 @@ export class ExtractionEngine {
       const detailed = await this.fallbackLlm.parseWithSchemaDetailed(
         messages,
         ExtractionResultSchema,
-        this.withGatewayAgent({ temperature: 0.3, maxTokens: 4096, timeoutMs: 30_000 }),
+        this.withGatewayAgent({
+          temperature: 0.3,
+          maxTokens: this.config.extractionMaxOutputTokens,
+          timeoutMs: this.config.localLlmTimeoutMs,
+        }),
       );
 
       const fallbackDurationMs = Date.now() - fallbackStartTime;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1095,7 +1095,7 @@ export interface PluginConfig {
   localLmsCliPath?: string;
   /** Optional bin directory prepended to PATH for LMS CLI execution. */
   localLmsBinDir?: string;
-  /** Hard timeout for local LLM requests (ms). */
+  /** Hard timeout for local LLM and gateway fallback requests (ms). */
   localLlmTimeoutMs: number;
   /** Max context window for local LLM (override auto-detection). Set lower if your LLM server defaults to smaller contexts. */
   localLlmMaxContext?: number;


### PR DESCRIPTION
## Summary
- Make gateway-backed extraction honor `localLlmTimeoutMs` and `extractionMaxOutputTokens` instead of forcing a 30s / 4096-token fallback budget.
- Parse `localLlmTimeoutMs` through the bounded numeric config parser so CLI-style numeric strings work in benchmark config.
- Add regression coverage for extraction fallback options and timeout parsing.

## Why
A diagnostic AMA-Bench run with Codex CLI as the internal Remnic LLM showed extraction fallback calls aborting after 30s even though the benchmark request timeout was configured at 600s. That meant full-feature benchmark runs could fail inside Remnic extraction before the benchmark-level timeout was reached.

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/config.test.ts packages/remnic-core/src/extraction-timeout.test.ts`
- `git diff --check`
- `pnpm --filter @remnic/core check-types`
- `pnpm --filter @remnic/core build`
- `npm run check-types`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes extraction’s gateway fallback request limits (timeout and max tokens), which can affect latency/cost and extraction completion behavior under gateway mode.
> 
> **Overview**
> Extraction’s gateway fallback path now uses the configured `localLlmTimeoutMs` and `extractionMaxOutputTokens` instead of a hardcoded 30s/4096-token budget.
> 
> Config parsing for `localLlmTimeoutMs` is updated to accept CLI-style numeric strings and clamp invalid values, and new tests cover both the parsing behavior and the fallback options passed into the gateway-backed extraction call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b189aa6c5703319b46d5d0c2140989df7916c3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->