### PR TITLE
Publish ClawHub release to existing Remnic package

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -450,8 +450,7 @@ jobs:
       - name: Publish OpenClaw plugin to ClawHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-          CLAWHUB_PACKAGE_NAME: "@joshuaswarren/plugin-openclaw"
-          CLAWHUB_OWNER: "joshuaswarren"
+          CLAWHUB_PACKAGE_NAME: "@remnic/plugin-openclaw"
           NPM_PACKAGE_NAME: "@remnic/plugin-openclaw"
           NPM_PACKAGE_PATH: "packages/plugin-openclaw"
         run: |
@@ -479,44 +478,11 @@ jobs:
             exit 1
           fi
 
-          # ClawHub requires package.json name to match the marketplace package name.
-          # Keep npm published as @remnic/plugin-openclaw, then repack for ClawHub.
-          unpack_dir="${pack_dir}/clawhub-package"
-          rm -rf "${unpack_dir}"
-          mkdir -p "${unpack_dir}"
-          tar -xzf "${tarball}" -C "${unpack_dir}"
-          UNPACK_DIR="${unpack_dir}" CLAWHUB_PACKAGE_NAME="${CLAWHUB_PACKAGE_NAME}" node - <<'NODE'
-          const fs = require("fs");
-          const path = require("path");
-
-          const packageJsonPath = path.join(process.env.UNPACK_DIR, "package", "package.json");
-          const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-          pkg.name = process.env.CLAWHUB_PACKAGE_NAME;
-          fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
-          NODE
-          clawhub_pack_json="$(cd "${unpack_dir}/package" && npm pack --pack-destination "${pack_dir}" --ignore-scripts --json)"
-          clawhub_tarball="$(PACK_DIR="${pack_dir}" PACK_JSON="${clawhub_pack_json}" node - <<'NODE'
-          const path = require("path");
-
-          const pack = JSON.parse(process.env.PACK_JSON);
-          const filename = pack?.[0]?.filename;
-          if (!filename) {
-            throw new Error("npm pack did not report a tarball filename");
-          }
-          console.log(path.join(process.env.PACK_DIR, filename));
-          NODE
-          )"
-          if [ ! -f "${clawhub_tarball}" ]; then
-            echo "No ${CLAWHUB_PACKAGE_NAME} tarball produced" >&2
-            exit 1
-          fi
-
           source_commit="$(git rev-parse HEAD)"
           publish_log="$(mktemp)"
-          if clawhub package publish "${clawhub_tarball}" \
+          if clawhub package publish "${tarball}" \
             --family code-plugin \
             --name "${CLAWHUB_PACKAGE_NAME}" \
-            --owner "${CLAWHUB_OWNER}" \
             --display-name "Remnic OpenClaw Plugin" \
             --version "${package_version}" \
             --host-targets openclaw \
@@ -532,7 +498,7 @@ jobs:
             publish_status=$?
             cat "${publish_log}"
             if grep -q "publisher does not exist on ClawHub" "${publish_log}"; then
-              echo "::notice title=ClawHub publish skipped::${CLAWHUB_OWNER} is not provisioned as a ClawHub publisher yet; create that publisher before enabling marketplace publishing."
+              echo "::notice title=ClawHub publish skipped::The authenticated ClawHub account is not provisioned as a package publisher yet."
               rm -f "${publish_log}"
               exit 0
             fi

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@
 ### Option A: npm (recommended)
 
 ```bash
-openclaw plugins install clawhub:@joshuaswarren/plugin-openclaw
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 ```
 
 ### Option B: Developer install (from Git)

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -17,14 +17,15 @@ Canonical upstream references for this adapter:
 ## Install
 
 ```bash
-openclaw plugins install clawhub:@joshuaswarren/plugin-openclaw
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 ```
 
 OpenClaw 2026.5.2+ resolves bare plugin package names through ClawHub first and
 then falls back to npm. Remnic is published on ClawHub as
-`@joshuaswarren/plugin-openclaw`, so the explicit `clawhub:` prefix keeps fresh
-installs deterministic. For npm-only fallback or rollback versions, use the
-explicit `npm:` source prefix, such as `npm:@remnic/plugin-openclaw@<version>`.
+`@remnic/plugin-openclaw` under the `joshuaswarren` account, so the explicit
+`clawhub:` prefix keeps fresh installs deterministic. For npm-only fallback or
+rollback versions, use the explicit `npm:` source prefix, such as
+`npm:@remnic/plugin-openclaw@<version>`.
 
 Or use the Remnic installer:
 
@@ -47,9 +48,9 @@ for config-key behavior, backup behavior, and local patch preservation notes.
 Publish ClawHub releases from the built npm/ClawPack tarball, not from the raw
 GitHub source folder. Source-folder publishing does not run the package build,
 so ClawHub can scan an incomplete three-file artifact with no `dist/index.js`.
-The npm package remains `@remnic/plugin-openclaw`; the ClawHub listing is
-published as `@joshuaswarren/plugin-openclaw` because ClawHub package scopes must
-match their owner.
+The ClawHub listing is `@remnic/plugin-openclaw` and is owned by the
+`joshuaswarren` account. Publish it with the authenticated owner account and do
+not pass `--owner` unless deliberately transferring ownership.
 
 ```bash
 pnpm --filter @remnic/plugin-openclaw build
@@ -57,8 +58,7 @@ pnpm run verify:openclaw-clawpack
 clawhub package pack packages/plugin-openclaw --pack-destination /tmp/remnic-clawpack
 clawhub package publish /tmp/remnic-clawpack/remnic-plugin-openclaw-<version>.tgz \
   --family code-plugin \
-  --name @joshuaswarren/plugin-openclaw \
-  --owner joshuaswarren \
+  --name @remnic/plugin-openclaw \
   --display-name "Remnic OpenClaw Plugin" \
   --version <version> \
   --source-repo joshuaswarren/remnic \

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -7,12 +7,12 @@ Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory 
 ## Install
 
 ```bash
-openclaw plugins install clawhub:@joshuaswarren/plugin-openclaw
+openclaw plugins install clawhub:@remnic/plugin-openclaw
 ```
 
 Or ask your OpenClaw agent:
 
-> Install the @joshuaswarren/plugin-openclaw ClawHub plugin and configure it as my memory system.
+> Install the @remnic/plugin-openclaw ClawHub plugin and configure it as my memory system.
 
 ## Configure
 


### PR DESCRIPTION
## Summary
- publish ClawHub releases to the existing @remnic/plugin-openclaw package owned by the authenticated joshuaswarren account
- remove the explicit --owner flag that caused ClawHub scope/owner validation failures
- restore install docs to the existing ClawHub package slug and document that the listing is owned by joshuaswarren

## Verification
- git diff --check
- local ClawHub dry-run publish succeeds for @remnic/plugin-openclaw@1.0.34 with 86 files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow’s ClawHub publish mechanics (package name/ownership and tarball handling), which could break automated marketplace publishing if misconfigured. No runtime/product code is affected.
> 
> **Overview**
> Updates the release workflow to publish the OpenClaw plugin to ClawHub as `@remnic/plugin-openclaw`, **dropping the explicit `--owner` flag** and publishing the existing `pnpm pack` tarball directly (removing the previous repack step that rewrote `package.json` for a different ClawHub slug).
> 
> Refreshes installation and publishing docs to consistently reference `clawhub:@remnic/plugin-openclaw`, and clarifies that the ClawHub listing is owned by the authenticated `joshuaswarren` account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23930081c650088e56fcaa91332672843aa10d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->