### PR TITLE
Skip semantic extraction for mechanical telemetry transcripts

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3017,6 +3017,11 @@
         "default": "low",
         "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
       },
+      "extractionTelemetryPrefilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Skip semantic durable-memory extraction for mechanical action/state telemetry transcripts that contain no durable-memory cue. Raw transcript storage and recall still run. Disable this if you intentionally want fact extraction from action logs."
+      },
       "extractionScopeClassificationEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3017,6 +3017,11 @@
         "default": "low",
         "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
       },
+      "extractionTelemetryPrefilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Skip semantic durable-memory extraction for mechanical action/state telemetry transcripts that contain no durable-memory cue. Raw transcript storage and recall still run. Disable this if you intentionally want fact extraction from action logs."
+      },
       "extractionScopeClassificationEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -133,6 +133,10 @@ test("parseConfig localLlmTimeoutMs clamps invalid values to a positive timeout"
   assert.equal(parseConfig({ localLlmTimeoutMs: 0 }).localLlmTimeoutMs, 1);
   assert.equal(parseConfig({ localLlmTimeoutMs: Number.NaN }).localLlmTimeoutMs, 180_000);
 });
+test("parseConfig extractionTelemetryPrefilterEnabled defaults on and accepts string false", () => {
+  assert.equal(parseConfig({}).extractionTelemetryPrefilterEnabled, true);
+  assert.equal(parseConfig({ extractionTelemetryPrefilterEnabled: "false" }).extractionTelemetryPrefilterEnabled, false);
+});
 
 test("parseConfig keeps explicit cue recall opt-in and budgets configurable", () => {
   const defaults = parseConfig({});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2038,6 +2038,8 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.extractionMinChars === "number" ? cfg.extractionMinChars : 40,
     extractionMinUserTurns:
       typeof cfg.extractionMinUserTurns === "number" ? cfg.extractionMinUserTurns : 1,
+    extractionTelemetryPrefilterEnabled:
+      coerceBool(cfg.extractionTelemetryPrefilterEnabled) !== false,
     extractionMaxTurnChars:
       typeof cfg.extractionMaxTurnChars === "number" ? cfg.extractionMaxTurnChars : 4000,
     extractionMaxFactsPerRun:

--- a/packages/remnic-core/src/extraction-timeout.test.ts
+++ b/packages/remnic-core/src/extraction-timeout.test.ts
@@ -65,3 +65,126 @@ test("gateway extraction fallback honors configured timeout and output budget", 
   assert.equal(capturedOptions?.timeoutMs, 600_000);
   assert.equal(capturedOptions?.maxTokens, 32_768);
 });
+
+test("extraction skips mechanical action telemetry without durable memory cues", async () => {
+  const config = parseConfig({
+    modelSource: "gateway",
+    gatewayConfig: {
+      agents: {
+        defaults: { model: { primary: "bench-internal/gpt-5.5" } },
+        list: [],
+      },
+      models: {
+        providers: {
+          "bench-internal": {
+            api: "codex-cli",
+            baseUrl: "codex-cli://local",
+            models: [{ id: "gpt-5.5", name: "gpt-5.5" }],
+          },
+        },
+      },
+    },
+  });
+  const engine = new ExtractionEngine(config);
+  let fallbackCalls = 0;
+
+  (engine as unknown as {
+    fallbackLlm: {
+      parseWithSchemaDetailed(): Promise<unknown>;
+    };
+  }).fallbackLlm = {
+    async parseWithSchemaDetailed() {
+      fallbackCalls += 1;
+      return {
+        modelUsed: "bench-internal/gpt-5.5",
+        result: {
+          facts: [],
+          profileUpdates: [],
+          entities: [],
+          questions: [],
+        },
+      };
+    },
+  };
+
+  const turns: BufferTurn[] = [
+    { role: "user", content: "[Action 0]: left", timestamp: "2026-05-08T00:00:00.000Z" },
+    {
+      role: "assistant",
+      content: "[Observation 0]: Active rules:\nbaba is you\n\nObjects on the map:\nrule `is` 3 step to the left and 3 step up\nball 2 step up",
+      timestamp: "2026-05-08T00:00:01.000Z",
+    },
+    { role: "user", content: "[Action 1]: up", timestamp: "2026-05-08T00:00:02.000Z" },
+    {
+      role: "assistant",
+      content: "[Observation 1]: Active rules:\nbaba is you\n\nObjects on the map:\nrule `win` 1 step to the left and 2 step up\nball 1 step to the right",
+      timestamp: "2026-05-08T00:00:03.000Z",
+    },
+  ];
+
+  const result = await engine.extract(turns);
+
+  assert.equal(fallbackCalls, 0);
+  assert.deepEqual(result, { facts: [], profileUpdates: [], entities: [], questions: [] });
+});
+
+test("extraction keeps action transcripts with durable memory cues", async () => {
+  const config = parseConfig({
+    modelSource: "gateway",
+    gatewayConfig: {
+      agents: {
+        defaults: { model: { primary: "bench-internal/gpt-5.5" } },
+        list: [],
+      },
+      models: {
+        providers: {
+          "bench-internal": {
+            api: "codex-cli",
+            baseUrl: "codex-cli://local",
+            models: [{ id: "gpt-5.5", name: "gpt-5.5" }],
+          },
+        },
+      },
+    },
+  });
+  const engine = new ExtractionEngine(config);
+  let fallbackCalls = 0;
+
+  (engine as unknown as {
+    fallbackLlm: {
+      parseWithSchemaDetailed(): Promise<unknown>;
+    };
+  }).fallbackLlm = {
+    async parseWithSchemaDetailed() {
+      fallbackCalls += 1;
+      return {
+        modelUsed: "bench-internal/gpt-5.5",
+        result: {
+          facts: [],
+          profileUpdates: [],
+          entities: [],
+          questions: [],
+        },
+      };
+    },
+  };
+
+  const turns: BufferTurn[] = [
+    { role: "user", content: "[Action 0]: left", timestamp: "2026-05-08T00:00:00.000Z" },
+    {
+      role: "assistant",
+      content: "[Observation 0]: Active rules:\nbaba is you\n\nObjects on the map:\nrule `is` 3 step to the left and 3 step up\nball 2 step up",
+      timestamp: "2026-05-08T00:00:01.000Z",
+    },
+    { role: "user", content: "Remember that this puzzle needs ball is win.", timestamp: "2026-05-08T00:00:02.000Z" },
+    {
+      role: "assistant",
+      content: "[Observation 1]: Active rules:\nbaba is you\n\nObjects on the map:\nrule `win` 1 step to the left and 2 step up\nball 1 step to the right",
+      timestamp: "2026-05-08T00:00:03.000Z",
+    },
+  ];
+
+  await engine.extract(turns);
+
+  assert.equal(fallbackCalls, 1);
+});

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -56,6 +56,47 @@ const CONSOLIDATION_RESPONSE_SCHEMA = `{
   "entityUpdates": [{"name": "person-jane-doe", "type": "person", "facts": ["Now leads the backend team", "Recently migrated the user service to TypeScript"]}]
 }`;
 
+const TELEMETRY_TURN_MARKER = /^\[(?:user|assistant|system)\]\s+\[(?:action|observation|state|reward|step|turn|frame)\s+\d+\]:/i;
+const BARE_TELEMETRY_MARKER = /^\[(?:action|observation|state|reward|step|turn|frame)\s+\d+\]:/i;
+const DURABLE_MEMORY_CUE =
+  /\b(?:remember|don't forget|prefer|preference|decided|decision|deadline|commit(?:ment)?|promise|my name|i am|i work|we use|correction|actually|always|never|when you|if\s+.+\s+then)\b/i;
+
+function stripRolePrefix(line: string): string {
+  return line.replace(/^\[(?:user|assistant|system)\]\s+/i, "").trim();
+}
+
+function isTelemetryMarkerLine(line: string): boolean {
+  return TELEMETRY_TURN_MARKER.test(line) || BARE_TELEMETRY_MARKER.test(stripRolePrefix(line));
+}
+
+function isMechanicalTelemetryLine(line: string): boolean {
+  const stripped = stripRolePrefix(line);
+  return (
+    isTelemetryMarkerLine(line) ||
+    /^(?:left|right|up|down|wait|noop|stop|start|forward|backward)$/i.test(stripped) ||
+    /^(?:active rules|objects on (?:the )?map|inventory|score|reward|position|location):?$/i.test(stripped) ||
+    /^rule `[^`]+`/i.test(stripped) ||
+    /^(?:[a-z][\w-]*|\w+ `[^`]+`)\s+\d+\s+steps?\s+(?:to\s+the\s+)?(?:left|right|up|down)\b/i.test(stripped)
+  );
+}
+
+function looksLikeMechanicalTelemetryTranscript(conversation: string): boolean {
+  if (DURABLE_MEMORY_CUE.test(conversation)) return false;
+
+  const lines = conversation
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length < 8) return false;
+
+  const markerLines = lines.filter((line) => isTelemetryMarkerLine(line)).length;
+  if (markerLines < 4) return false;
+
+  const mechanicalLines = lines.filter((line) => isMechanicalTelemetryLine(line)).length;
+  const mechanicalRatio = mechanicalLines / lines.length;
+  return mechanicalRatio >= 0.45;
+}
+
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -959,6 +1000,13 @@ export class ExtractionEngine {
       .join("\n\n");
     if (conversation.trim().length === 0) {
       log.debug("extraction skipped — conversation only contained non-memory work-layer context");
+      return { facts: [], profileUpdates: [], entities: [], questions: [] };
+    }
+    if (
+      this.config.extractionTelemetryPrefilterEnabled &&
+      looksLikeMechanicalTelemetryTranscript(conversation)
+    ) {
+      log.debug("extraction skipped — mechanical action/state telemetry without durable-memory cues");
       return { facts: [], profileUpdates: [], entities: [], questions: [] };
     }
 

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -58,8 +58,26 @@ const CONSOLIDATION_RESPONSE_SCHEMA = `{
 
 const TELEMETRY_TURN_MARKER = /^\[(?:user|assistant|system)\]\s+\[(?:action|observation|state|reward|step|turn|frame)\s+\d+\]:/i;
 const BARE_TELEMETRY_MARKER = /^\[(?:action|observation|state|reward|step|turn|frame)\s+\d+\]:/i;
-const DURABLE_MEMORY_CUE =
-  /\b(?:remember|don't forget|prefer|preference|decided|decision|deadline|commit(?:ment)?|promise|my name|i am|i work|we use|correction|actually|always|never|when you|if\s+.+\s+then)\b/i;
+const DURABLE_MEMORY_CUE_PHRASES = [
+  "remember",
+  "don't forget",
+  "prefer",
+  "preference",
+  "decided",
+  "decision",
+  "deadline",
+  "commitment",
+  "promise",
+  "my name",
+  "i am",
+  "i work",
+  "we use",
+  "correction",
+  "actually",
+  "always",
+  "never",
+  "when you",
+];
 
 function stripRolePrefix(line: string): string {
   return line.replace(/^\[(?:user|assistant|system)\]\s+/i, "").trim();
@@ -80,8 +98,17 @@ function isMechanicalTelemetryLine(line: string): boolean {
   );
 }
 
+function hasDurableMemoryCue(conversation: string): boolean {
+  const lower = conversation.toLowerCase();
+  if (DURABLE_MEMORY_CUE_PHRASES.some((phrase) => lower.includes(phrase))) {
+    return true;
+  }
+  const ifIndex = lower.indexOf("if ");
+  return ifIndex >= 0 && lower.indexOf(" then", ifIndex + 3) >= 0;
+}
+
 function looksLikeMechanicalTelemetryTranscript(conversation: string): boolean {
-  if (DURABLE_MEMORY_CUE.test(conversation)) return false;
+  if (hasDurableMemoryCue(conversation)) return false;
 
   const lines = conversation
     .split(/\n+/)

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1123,6 +1123,13 @@ export interface PluginConfig {
   extractionDedupeWindowMs: number;
   extractionMinChars: number;
   extractionMinUserTurns: number;
+  /**
+   * When true, skip semantic memory extraction for mechanical action/state
+   * telemetry transcripts that have no durable-memory cue. Raw transcript
+   * storage/recall still runs; this only prevents expensive low-value fact
+   * extraction over state logs. Default true.
+   */
+  extractionTelemetryPrefilterEnabled: boolean;
   extractionMaxTurnChars: number;
   extractionMaxFactsPerRun: number;
   extractionMaxEntitiesPerRun: number;


### PR DESCRIPTION
## Summary
- Add a conservative `extractionTelemetryPrefilterEnabled` config gate, enabled by default and string-false aware.
- Skip semantic durable-memory extraction when a buffer is clearly mechanical action/state telemetry and contains no durable-memory cue.
- Preserve normal extraction when the same transcript includes explicit durable-memory cues such as `Remember ...`.

## Why
The isolated AMA diagnostic showed Remnic correctly using the full internal Codex timeout after #956, but spending that budget on generic durable-memory extraction over Baba-is-You action/observation traces. Those transcripts are useful as raw task history for benchmark recall, but they do not contain durable user memories and should not trigger expensive semantic fact extraction.

This keeps the full Remnic pipeline active while avoiding low-value internal LLM work on telemetry-shaped buffers.

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/config.test.ts packages/remnic-core/src/extraction-timeout.test.ts`
- `git diff --check`
- `pnpm --filter @remnic/core check-types`
- `pnpm --filter @remnic/core build`
- `npm run check-types`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes extraction behavior by default to skip LLM-based fact extraction for transcripts that look like action/observation telemetry, which could unintentionally suppress extraction in edge cases; mitigated by an explicit config flag to disable.
> 
> **Overview**
> Adds a new `extractionTelemetryPrefilterEnabled` config (default **true**, supports string `"false"`) to skip *semantic durable-memory extraction* when the buffered conversation appears to be mechanical action/state telemetry and contains no durable-memory cues.
> 
> Implements a conservative heuristic prefilter in `ExtractionEngine.extract` and adds tests covering both the skip path (no LLM call) and the keep path when cues like “Remember …” are present, plus updates the OpenClaw plugin config schemas to expose the new knob.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562585da316943dfada46be16d2d7ecab8b0ee0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->