### PR TITLE
Fix AMA Codex benchmark prompt stalls

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4412,6 +4412,11 @@
         "default": 512,
         "description": "Max tokens for deterministic (non-LLM) summaries"
       },
+      "lcmTelemetryPrefilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use deterministic LCM compression for mechanical action/state telemetry without durable-memory cues."
+      },
       "lcmArchiveRetentionDays": {
         "type": "number",
         "default": 90,

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -39,6 +39,18 @@ export interface ProviderBaseConfig {
   retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number; max429WaitMs?: number };
   /** Suppress thinking/reasoning tokens for thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek). */
   disableThinking?: boolean;
+  /**
+   * Optional answering-only memory-context budget. Benchmark artifacts keep the
+   * full recalled text, but provider-backed responders may receive this compact
+   * deterministic view to avoid transport-specific prompt stalls.
+   */
+  responderContextBudgetChars?: number;
+  /**
+   * Optional answering-only question/protocol budget. This keeps the original
+   * benchmark question and artifact unchanged while shortening repeated harness
+   * instructions for slow transport-backed responders such as Codex CLI.
+   */
+  responderPromptBudgetChars?: number;
 }
 
 export interface OpenAiCompatibleProviderConfig extends ProviderBaseConfig {

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -8,10 +8,15 @@ import {
   createProviderBackedResponder,
   createResponderFromProvider,
   createStructuredJudgeFromProvider,
+  compactResponderContext,
+  compactResponderQuestion,
 } from "./responders.ts";
 import type { LlmProvider } from "./providers/types.ts";
 
-function createFakeProvider(resultText: string): LlmProvider {
+function createFakeProvider(
+  resultText: string,
+  onPrompt?: (prompt: string) => void,
+): LlmProvider {
   let inputTokens = 0;
   let outputTokens = 0;
 
@@ -20,6 +25,7 @@ function createFakeProvider(resultText: string): LlmProvider {
     name: "test-model",
     provider: "openai",
     async complete(prompt) {
+      onPrompt?.(prompt);
       inputTokens += prompt.length;
       outputTokens += resultText.length;
       return {
@@ -76,6 +82,86 @@ test("responder wrappers adapt a provider instance into answer-generation and ju
     taskId: "task-1",
   });
   assert.match(raw, /identity_accuracy/);
+});
+
+test("responder context compaction preserves referenced trajectory evidence", async () => {
+  let capturedPrompt = "";
+  const recalledText = Array.from({ length: 80 }, (_, index) => {
+    const step = index + 1;
+    return `[Action ${step}]: move-${step}\n[Observation ${step}]: state-${step}`;
+  }).join("\n");
+  const responder = createProviderBackedResponder(
+    {
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      responderContextBudgetChars: 900,
+    },
+    createFakeProvider("answer", (prompt) => {
+      capturedPrompt = prompt;
+    }),
+  );
+
+  await responder.respond(
+    "What changed between Actions 41-42?",
+    recalledText,
+  );
+
+  assert.equal(capturedPrompt.includes("state-42"), true);
+  assert.equal(capturedPrompt.includes("move-2"), false);
+  assert.equal(capturedPrompt.length < recalledText.length, true);
+});
+
+test("compactResponderContext falls back to deterministic head/tail context without trajectory references", () => {
+  const compacted = compactResponderContext(
+    "alpha ".repeat(200) + "omega",
+    "What is the summary?",
+    320,
+  );
+
+  assert.equal(compacted.length <= 320, true);
+  assert.match(compacted, /alpha/);
+  assert.match(compacted, /omega/);
+  assert.match(compacted, /omitted unrelated recalled context/);
+});
+
+test("responder prompt compaction preserves the question and concise agentic protocol", async () => {
+  let capturedPrompt = "";
+  const longProtocolQuestion = [
+    "What did Action 42 accomplish?",
+    "",
+    "Benchmark answer protocol:",
+    "- Use only the supplied Remnic memory context as evidence.",
+    "- Return the shortest complete answer that satisfies the question.",
+    "",
+    "Agentic trajectory protocol:",
+    ...Array.from({ length: 40 }, (_, index) =>
+      `- Detailed trajectory instruction ${index + 1}.`,
+    ),
+  ].join("\n");
+  const responder = createProviderBackedResponder(
+    {
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      responderPromptBudgetChars: 1_200,
+    },
+    createFakeProvider("answer", (prompt) => {
+      capturedPrompt = prompt;
+    }),
+  );
+
+  await responder.respond(longProtocolQuestion, "[Action 42]: right");
+
+  assert.match(capturedPrompt, /What did Action 42 accomplish\?/);
+  assert.match(capturedPrompt, /Agentic trajectory protocol/);
+  assert.match(capturedPrompt, /Action N causes Observation N/);
+  assert.doesNotMatch(capturedPrompt, /Detailed trajectory instruction 40/);
+});
+
+test("compactResponderQuestion validates the prompt budget", () => {
+  assert.throws(
+    () => compactResponderQuestion("question", 0),
+    /responder prompt budget must be a positive integer/,
+  );
 });
 
 test("provider-backed responder factories reject invalid configs and produce typed wrappers", () => {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -40,6 +40,15 @@ const AMA_BENCH_RECOMMENDED_JUDGE_SYSTEM_PROMPT = [
 ].join(" ");
 
 const SCORE_CUE_REGEX = /\b(score|rated|rating|grade|graded|result|overall|final)\b/;
+const CONTEXT_COMPACTION_MARKER = "[...omitted unrelated recalled context...]";
+const COMPACTED_CONTEXT_PREFIX =
+  "[Remnic memory context compacted for the responder prompt; full recalled text is preserved in the benchmark artifact.]";
+const TRAJECTORY_LABELS = Object.freeze([
+  "action",
+  "observation",
+  "step",
+  "turn",
+]);
 
 export interface GatewayResponderOptions {
   gatewayConfig?: GatewayConfig;
@@ -52,19 +61,39 @@ export interface GatewayResponderOptions {
   ) => Pick<FallbackLlmClient, "chatCompletion">;
 }
 
-export function createResponderFromProvider(provider: LlmProvider): BenchResponder {
+export interface ProviderResponderOptions {
+  contextBudgetChars?: number;
+  promptBudgetChars?: number;
+}
+
+export function createResponderFromProvider(
+  provider: LlmProvider,
+  options: ProviderResponderOptions = {},
+): BenchResponder {
   return {
     async respond(
       question: string,
       recalledText: string,
       control,
     ): Promise<BenchResponse> {
+      const responderQuestion = options.promptBudgetChars === undefined
+        ? question
+        : compactResponderQuestion(question, options.promptBudgetChars);
+      const responderContext = options.contextBudgetChars === undefined
+        ? recalledText
+        : compactResponderContext(
+          recalledText,
+          question,
+          options.contextBudgetChars,
+        );
       const completion = await provider.complete(
         [
-          `QUESTION: ${question}`,
+          `QUESTION: ${responderQuestion}`,
           "",
           "REMNIC_MEMORY_CONTEXT:",
-          recalledText.trim().length > 0 ? recalledText : "(no memory context available)",
+          responderContext.trim().length > 0
+            ? responderContext
+            : "(no memory context available)",
           "",
           "Answer the question using only the supplied memory context.",
         ].join("\n"),
@@ -90,7 +119,373 @@ export function createProviderBackedResponder(
   providerInstance?: LlmProvider,
 ): BenchResponder {
   validateProviderConfig(config, "responder");
-  return createResponderFromProvider(providerInstance ?? createProvider(config));
+  return createResponderFromProvider(providerInstance ?? createProvider(config), {
+    contextBudgetChars: config.responderContextBudgetChars,
+    promptBudgetChars: config.responderPromptBudgetChars,
+  });
+}
+
+export function compactResponderQuestion(
+  question: string,
+  maxChars: number,
+): string {
+  if (!Number.isInteger(maxChars) || maxChars <= 0) {
+    throw new Error("responder prompt budget must be a positive integer");
+  }
+  if (question.length <= maxChars) {
+    return question;
+  }
+
+  const baseQuestion = extractBenchmarkQuestionText(question);
+  const conciseProtocol = question.includes("Agentic trajectory protocol:")
+    ? buildConciseAgenticProtocol(question)
+    : question.includes("Benchmark answer protocol:")
+      ? buildConciseStrictProtocol(question)
+      : "";
+  const compacted = [baseQuestion, conciseProtocol]
+    .filter((part) => part.trim().length > 0)
+    .join("\n\n");
+  if (compacted.length <= maxChars) {
+    return compacted;
+  }
+
+  if (baseQuestion.length >= maxChars - 40) {
+    return headTailCompact(baseQuestion, maxChars);
+  }
+
+  const separator = "\n\n";
+  const protocolBudget = maxChars - baseQuestion.length - separator.length;
+  return `${baseQuestion}${separator}${headTailCompact(
+    conciseProtocol,
+    protocolBudget,
+  )}`;
+}
+
+function extractBenchmarkQuestionText(question: string): string {
+  const strictIndex = question.indexOf("\n\nBenchmark answer protocol:");
+  if (strictIndex >= 0) {
+    return question.slice(0, strictIndex).trim();
+  }
+  const agenticIndex = question.indexOf("\n\nAgentic trajectory protocol:");
+  if (agenticIndex >= 0) {
+    return question.slice(0, agenticIndex).trim();
+  }
+  return question.trim();
+}
+
+function buildConciseStrictProtocol(question: string): string {
+  const instructions = [
+    "Benchmark answer protocol:",
+    "- Use only the supplied Remnic memory context.",
+    "- Answer directly and briefly; do not add unsupported facts.",
+    "- Say \"unknown\" only when relevant evidence is absent, contradictory, or lacks the requested value.",
+    "- Preserve any requested output format.",
+  ];
+  appendFormatSpecificInstruction(question, instructions);
+  return instructions.join("\n");
+}
+
+function buildConciseAgenticProtocol(question: string): string {
+  const instructions = [
+    buildConciseStrictProtocol(question),
+    "",
+    "Agentic trajectory protocol:",
+    "- Treat Action/Observation/Step/Turn lines as causal evidence; Action N causes Observation N and the prior state for Step N is usually Observation N-1.",
+    "- Honor exact cited numbers and boundaries; for ranges, before, until, counts, or lists, scan the requested span and include all requested actions or state changes.",
+    "- For causal or strategic questions, infer the concrete mechanism from trajectory evidence and answer every clause.",
+    "- In grid/rule games, distinguish objects from rule text; only claim passability, collection, disappearance, or win conditions when active rules or observations support it.",
+    "- Keep the answer focused on the asked event.",
+  ];
+  return instructions.join("\n");
+}
+
+function appendFormatSpecificInstruction(
+  question: string,
+  instructions: string[],
+): void {
+  if (question.includes("- Return only the selected option letter")) {
+    instructions.push("- Return only the selected option letter.");
+  } else if (question.includes("- Return only the selected option number")) {
+    instructions.push("- Return only the selected option number.");
+  } else if (question.includes("- Preserve the requested structured output format")) {
+    instructions.push("- Preserve the requested structured output format exactly.");
+  } else if (question.includes("- Return the shortest complete answer")) {
+    instructions.push("- Return the shortest complete answer that satisfies the question.");
+  }
+}
+
+export function compactResponderContext(
+  recalledText: string,
+  question: string,
+  maxChars: number,
+): string {
+  if (!Number.isInteger(maxChars) || maxChars <= 0) {
+    throw new Error("responder context budget must be a positive integer");
+  }
+
+  const normalized = recalledText.trim();
+  if (normalized.length <= maxChars) {
+    return recalledText;
+  }
+
+  const stepRefs = extractReferencedTrajectoryNumbers(question);
+  const body = stepRefs.size > 0
+    ? buildTrajectoryFocusedContext(normalized, stepRefs)
+    : "";
+  const compactedBody = body.trim().length > 0
+    ? body.trim()
+    : headTailCompact(normalized, maxChars);
+  const withPrefix = `${COMPACTED_CONTEXT_PREFIX}\n${compactedBody}`;
+  if (withPrefix.length <= maxChars) {
+    return withPrefix;
+  }
+
+  const bodyBudget = maxChars - COMPACTED_CONTEXT_PREFIX.length - 1;
+  if (bodyBudget < 40) {
+    return withPrefix.slice(0, maxChars);
+  }
+
+  return `${COMPACTED_CONTEXT_PREFIX}\n${headTailCompact(compactedBody, bodyBudget)}`;
+}
+
+function extractReferencedTrajectoryNumbers(question: string): Set<number> {
+  const refs = new Set<number>();
+  const lower = question.toLowerCase();
+  for (let index = 0; index < lower.length; index += 1) {
+    for (const label of TRAJECTORY_LABELS) {
+      const matchedLength = matchedTrajectoryLabelLength(lower, index, label);
+      if (matchedLength === 0) {
+        continue;
+      }
+      const parsed = parseNumberRangeAfterLabel(lower, index + matchedLength);
+      if (!parsed) {
+        continue;
+      }
+      addBoundedRange(refs, parsed.start, parsed.end);
+      index = Math.max(index, parsed.nextIndex - 1);
+      break;
+    }
+  }
+  return refs;
+}
+
+function matchedTrajectoryLabelLength(
+  text: string,
+  index: number,
+  label: string,
+): number {
+  if (!isWordBoundary(text[index - 1])) {
+    return 0;
+  }
+  if (text.startsWith(label, index) && isWordBoundary(text[index + label.length])) {
+    return label.length;
+  }
+  const plural = `${label}s`;
+  if (text.startsWith(plural, index) && isWordBoundary(text[index + plural.length])) {
+    return plural.length;
+  }
+  return 0;
+}
+
+function parseNumberRangeAfterLabel(
+  text: string,
+  index: number,
+): { start: number; end: number; nextIndex: number } | undefined {
+  let cursor = skipNumberLeadIn(text, index);
+  const first = parseUnsignedIntegerAt(text, cursor);
+  if (!first) {
+    return undefined;
+  }
+  cursor = skipWhitespace(text, first.nextIndex);
+
+  let end = first.value;
+  if (isRangeDash(text[cursor])) {
+    cursor = skipWhitespace(text, cursor + 1);
+    const second = parseUnsignedIntegerAt(text, cursor);
+    if (second) {
+      end = second.value;
+      cursor = second.nextIndex;
+    }
+  }
+
+  return {
+    start: first.value,
+    end,
+    nextIndex: cursor,
+  };
+}
+
+function skipNumberLeadIn(text: string, index: number): number {
+  let cursor = index;
+  while (cursor < text.length) {
+    const char = text[cursor];
+    if (char === " " || char === "\t" || char === ":" || char === "#" || char === "-") {
+      cursor += 1;
+      continue;
+    }
+    break;
+  }
+  return cursor;
+}
+
+function skipWhitespace(text: string, index: number): number {
+  let cursor = index;
+  while (cursor < text.length && (text[cursor] === " " || text[cursor] === "\t")) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function parseUnsignedIntegerAt(
+  text: string,
+  index: number,
+): { value: number; nextIndex: number } | undefined {
+  let cursor = index;
+  let raw = "";
+  while (cursor < text.length && isDigit(text[cursor])) {
+    raw += text[cursor];
+    cursor += 1;
+  }
+  if (raw.length === 0) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) {
+    return undefined;
+  }
+  return { value, nextIndex: cursor };
+}
+
+function addBoundedRange(refs: Set<number>, start: number, end: number): void {
+  const low = Math.min(start, end);
+  const high = Math.max(start, end);
+  for (let value = low; value <= high && value - low <= 50; value += 1) {
+    refs.add(value);
+  }
+}
+
+function buildTrajectoryFocusedContext(
+  recalledText: string,
+  stepRefs: Set<number>,
+): string {
+  const lines = recalledText.split("\n");
+  const include = new Set<number>();
+  for (let index = 0; index < lines.length; index += 1) {
+    if (isContextHeading(lines[index])) {
+      include.add(index);
+      continue;
+    }
+
+    const trajectoryNumber = parseTrajectoryLineNumber(lines[index]);
+    if (trajectoryNumber === undefined) {
+      continue;
+    }
+
+    if (isNearReferencedStep(stepRefs, trajectoryNumber)) {
+      include.add(index);
+      if (index > 0) {
+        include.add(index - 1);
+      }
+      if (index + 1 < lines.length) {
+        include.add(index + 1);
+      }
+    }
+  }
+
+  if (include.size === 0) {
+    return "";
+  }
+
+  const rendered: string[] = [];
+  let lastIncluded = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!include.has(index)) {
+      continue;
+    }
+    if (
+      lastIncluded >= 0 &&
+      index > lastIncluded + 1 &&
+      rendered.at(-1) !== CONTEXT_COMPACTION_MARKER
+    ) {
+      rendered.push(CONTEXT_COMPACTION_MARKER);
+    }
+    rendered.push(lines[index]);
+    lastIncluded = index;
+  }
+  return rendered.join("\n");
+}
+
+function isContextHeading(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith("#") ||
+    trimmed === "REMNIC_MEMORY_CONTEXT:" ||
+    trimmed.startsWith("Memory context") ||
+    trimmed.startsWith("Relevant");
+}
+
+function parseTrajectoryLineNumber(line: string): number | undefined {
+  const trimmed = line.trimStart();
+  const bracketStart = trimmed[0] === "[" ? 1 : 0;
+  const bracketEnd = bracketStart === 1 ? trimmed.indexOf("]") : -1;
+  const candidate = bracketEnd > bracketStart
+    ? trimmed.slice(bracketStart, bracketEnd)
+    : trimmed.slice(0, 48);
+  const lower = candidate.toLowerCase();
+  for (const label of TRAJECTORY_LABELS) {
+    if (!lower.startsWith(label)) {
+      continue;
+    }
+    const parsed = parseNumberRangeAfterLabel(lower, label.length);
+    return parsed?.start;
+  }
+  return undefined;
+}
+
+function isNearReferencedStep(stepRefs: Set<number>, value: number): boolean {
+  return stepRefs.has(value) || stepRefs.has(value - 1) || stepRefs.has(value + 1);
+}
+
+function headTailCompact(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  if (maxChars <= CONTEXT_COMPACTION_MARKER.length + 20) {
+    return text.slice(0, maxChars);
+  }
+  const marker = `\n${CONTEXT_COMPACTION_MARKER}\n`;
+  const remaining = maxChars - marker.length;
+  const headChars = Math.ceil(remaining * 0.6);
+  const tailChars = remaining - headChars;
+  return `${text.slice(0, headChars).trimEnd()}${marker}${
+    text.slice(text.length - tailChars).trimStart()
+  }`;
+}
+
+function isWordBoundary(char: string | undefined): boolean {
+  return char === undefined || !isAsciiAlnum(char);
+}
+
+function isAsciiAlnum(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122);
+}
+
+function isDigit(char: string | undefined): boolean {
+  if (char === undefined) {
+    return false;
+  }
+  const code = char.charCodeAt(0);
+  return code >= 48 && code <= 57;
+}
+
+function isRangeDash(char: string | undefined): boolean {
+  if (char === undefined) {
+    return false;
+  }
+  const code = char.charCodeAt(0);
+  return char === "-" || code === 8211 || code === 8212;
 }
 
 function createJudgeFromProvider(provider: LlmProvider): BenchJudge {

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -347,6 +347,30 @@ test("provider-backed runtime resolution can override codex-cli reasoning effort
   assert.equal(resolved.judgeProvider?.reasoningEffort, "medium");
 });
 
+test("provider-backed runtime resolution can budget direct responder context", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    systemProvider: "codex-cli",
+    systemModel: "gpt-5.5",
+    systemResponderContextBudgetChars: 8_000,
+  });
+
+  assert.equal(resolved.systemProvider?.responderContextBudgetChars, 8_000);
+  assert.equal(typeof resolved.adapterOptions.responder?.respond, "function");
+});
+
+test("provider-backed runtime resolution can budget direct responder prompt protocol", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+    systemProvider: "codex-cli",
+    systemModel: "gpt-5.5",
+    systemResponderPromptBudgetChars: 2_000,
+  });
+
+  assert.equal(resolved.systemProvider?.responderPromptBudgetChars, 2_000);
+  assert.equal(typeof resolved.adapterOptions.responder?.respond, "function");
+});
+
 test("runtime profile can route Remnic internal LLM calls through codex-cli", async () => {
   const resolved = await resolveBenchRuntimeProfile({
     runtimeProfile: "baseline",

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -42,6 +42,8 @@ export interface ResolveBenchRuntimeProfileOptions {
   systemBaseUrl?: string;
   systemApiKey?: string;
   systemCodexReasoningEffort?: ProviderConfig["reasoningEffort"];
+  systemResponderContextBudgetChars?: number;
+  systemResponderPromptBudgetChars?: number;
   judgeProvider?: BuiltInProvider;
   judgeModel?: string;
   judgeBaseUrl?: string;
@@ -95,6 +97,8 @@ export async function resolveBenchRuntimeProfile(
       options.systemApiKey,
       options.max429WaitMs,
       options.systemCodexReasoningEffort,
+      options.systemResponderContextBudgetChars,
+      options.systemResponderPromptBudgetChars,
     );
   const judgeProvider = resolveProviderConfig(
     "judge",
@@ -103,10 +107,12 @@ export async function resolveBenchRuntimeProfile(
     options.judgeBaseUrl,
     options.requestTimeout,
     options.disableThinking,
-    options.judgeApiKey,
-    options.max429WaitMs,
-    options.judgeCodexReasoningEffort,
-  );
+      options.judgeApiKey,
+      options.max429WaitMs,
+      options.judgeCodexReasoningEffort,
+      undefined,
+      undefined,
+    );
   const internalProvider = applyInternalProviderDefaults(
     resolveProviderConfig(
       "internal",
@@ -118,6 +124,8 @@ export async function resolveBenchRuntimeProfile(
       options.internalApiKey,
       options.max429WaitMs,
       options.internalCodexReasoningEffort,
+      undefined,
+      undefined,
     ),
   );
   const internalConfigOverrides = buildInternalRemnicConfigOverrides(
@@ -360,14 +368,26 @@ function resolveProviderConfig(
   apiKey?: string,
   max429WaitMs?: number,
   reasoningEffort?: ProviderConfig["reasoningEffort"],
+  responderContextBudgetChars?: number,
+  responderPromptBudgetChars?: number,
 ): ProviderConfig | null {
   const hasProvider = typeof provider === "string";
   const hasModel = typeof model === "string" && model.trim().length > 0;
   const hasBaseUrl = typeof baseUrl === "string" && baseUrl.trim().length > 0;
   const hasApiKey = typeof apiKey === "string" && apiKey.trim().length > 0;
   const hasReasoningEffort = reasoningEffort !== undefined;
+  const hasResponderContextBudget = responderContextBudgetChars !== undefined;
+  const hasResponderPromptBudget = responderPromptBudgetChars !== undefined;
 
-  if (!hasProvider && !hasModel && !hasBaseUrl && !hasApiKey && !hasReasoningEffort) {
+  if (
+    !hasProvider &&
+    !hasModel &&
+    !hasBaseUrl &&
+    !hasApiKey &&
+    !hasReasoningEffort &&
+    !hasResponderContextBudget &&
+    !hasResponderPromptBudget
+  ) {
     return null;
   }
 
@@ -405,6 +425,12 @@ function resolveProviderConfig(
       : {}),
     ...(disableThinking ? { disableThinking: true } : {}),
     ...(provider === "codex-cli" ? { reasoningEffort: reasoningEffort ?? "xhigh" } : {}),
+    ...(responderContextBudgetChars !== undefined
+      ? { responderContextBudgetChars }
+      : {}),
+    ...(responderPromptBudgetChars !== undefined
+      ? { responderPromptBudgetChars }
+      : {}),
   };
 }
 
@@ -692,6 +718,12 @@ function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig 
     ...(config.retryOptions ? { retryOptions: config.retryOptions } : {}),
     ...(config.disableThinking ? { disableThinking: config.disableThinking } : {}),
     ...(config.reasoningEffort ? { reasoningEffort: config.reasoningEffort } : {}),
+    ...(config.responderContextBudgetChars !== undefined
+      ? { responderContextBudgetChars: config.responderContextBudgetChars }
+      : {}),
+    ...(config.responderPromptBudgetChars !== undefined
+      ? { responderPromptBudgetChars: config.responderPromptBudgetChars }
+      : {}),
   } as ProviderFactoryConfig;
 }
 

--- a/packages/bench/src/schema.ts
+++ b/packages/bench/src/schema.ts
@@ -78,6 +78,8 @@ export const BENCHMARK_RESULT_SCHEMA = {
                 model: { type: "string" },
                 baseUrl: { type: "string" },
                 reasoningEffort: { type: "string" },
+                responderContextBudgetChars: { type: "number" },
+                responderPromptBudgetChars: { type: "number" },
               },
             },
           ],

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -44,6 +44,8 @@ export interface ProviderConfig {
   retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number; max429WaitMs?: number };
   disableThinking?: boolean;
   reasoningEffort?: BenchReasoningEffort;
+  responderContextBudgetChars?: number;
+  responderPromptBudgetChars?: number;
 }
 
 export interface TaskTokenUsage {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -4412,6 +4412,11 @@
         "default": 512,
         "description": "Max tokens for deterministic (non-LLM) summaries"
       },
+      "lcmTelemetryPrefilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use deterministic LCM compression for mechanical action/state telemetry without durable-memory cues."
+      },
       "lcmArchiveRetentionDays": {
         "type": "number",
         "default": 90,

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -180,6 +180,96 @@ test("parseBenchArgs accepts codex-cli as a system and judge provider", () => {
   assert.equal(parsed.judgeCodexReasoningEffort, "medium");
 });
 
+test("parseBenchArgs accepts direct responder context budgeting", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "ama-bench",
+    "--system-provider",
+    "codex-cli",
+    "--system-model",
+    "gpt-5.5",
+    "--system-responder-context-budget-chars",
+    "8000",
+  ]);
+
+  assert.equal(parsed.systemResponderContextBudgetChars, 8000);
+});
+
+test("parseBenchArgs accepts direct responder prompt budgeting", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "ama-bench",
+    "--system-provider",
+    "codex-cli",
+    "--system-model",
+    "gpt-5.5",
+    "--system-responder-prompt-budget-chars",
+    "2000",
+  ]);
+
+  assert.equal(parsed.systemResponderPromptBudgetChars, 2000);
+});
+
+test("parseBenchArgs rejects responder context budget without a direct responder", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--system-responder-context-budget-chars",
+        "8000",
+      ]),
+    /--system-responder-context-budget-chars requires --system-provider/,
+  );
+});
+
+test("parseBenchArgs rejects responder prompt budget without a direct responder", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--system-responder-prompt-budget-chars",
+        "2000",
+      ]),
+    /--system-responder-prompt-budget-chars requires --system-provider/,
+  );
+});
+
+test("parseBenchArgs rejects invalid responder context budgets", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--system-provider",
+        "codex-cli",
+        "--system-model",
+        "gpt-5.5",
+        "--system-responder-context-budget-chars",
+        "0",
+      ]),
+    /--system-responder-context-budget-chars must be a positive integer/,
+  );
+});
+
+test("parseBenchArgs rejects invalid responder prompt budgets", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--system-provider",
+        "codex-cli",
+        "--system-model",
+        "gpt-5.5",
+        "--system-responder-prompt-budget-chars",
+        "3.14",
+      ]),
+    /--system-responder-prompt-budget-chars must be a positive integer/,
+  );
+});
+
 test("parseBenchArgs rejects system Codex reasoning effort for non-Codex providers", () => {
   assert.throws(
     () =>

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -52,6 +52,8 @@ export interface ParsedBenchArgs {
   systemBaseUrl?: string;
   systemApiKey?: string;
   systemCodexReasoningEffort?: BenchCodexReasoningEffort;
+  systemResponderContextBudgetChars?: number;
+  systemResponderPromptBudgetChars?: number;
   judgeProvider?: BuiltInProvider;
   judgeModel?: string;
   judgeBaseUrl?: string;
@@ -207,6 +209,8 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--system-base-url" ||
       arg === "--system-api-key" ||
       arg === "--system-codex-reasoning-effort" ||
+      arg === "--system-responder-context-budget-chars" ||
+      arg === "--system-responder-prompt-budget-chars" ||
       arg === "--judge-provider" ||
       arg === "--judge-model" ||
       arg === "--judge-base-url" ||
@@ -351,6 +355,14 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const systemCodexReasoningEffortRaw = readBenchOptionValue(
     args,
     "--system-codex-reasoning-effort",
+  );
+  const systemResponderContextBudgetRaw = readBenchOptionValue(
+    args,
+    "--system-responder-context-budget-chars",
+  );
+  const systemResponderPromptBudgetRaw = readBenchOptionValue(
+    args,
+    "--system-responder-prompt-budget-chars",
   );
   const judgeProviderRaw = readBenchOptionValue(args, "--judge-provider");
   const judgeModel = readBenchOptionValue(args, "--judge-model");
@@ -533,6 +545,42 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     }
   }
 
+  let systemResponderContextBudgetChars: number | undefined;
+  if (systemResponderContextBudgetRaw !== undefined) {
+    systemResponderContextBudgetChars = Number(systemResponderContextBudgetRaw);
+    if (
+      !Number.isInteger(systemResponderContextBudgetChars) ||
+      systemResponderContextBudgetChars <= 0
+    ) {
+      throw new Error(
+        "ERROR: --system-responder-context-budget-chars must be a positive integer.",
+      );
+    }
+    if (systemResponderContextBudgetChars > 1_000_000) {
+      throw new Error(
+        "ERROR: --system-responder-context-budget-chars must not exceed 1,000,000.",
+      );
+    }
+  }
+
+  let systemResponderPromptBudgetChars: number | undefined;
+  if (systemResponderPromptBudgetRaw !== undefined) {
+    systemResponderPromptBudgetChars = Number(systemResponderPromptBudgetRaw);
+    if (
+      !Number.isInteger(systemResponderPromptBudgetChars) ||
+      systemResponderPromptBudgetChars <= 0
+    ) {
+      throw new Error(
+        "ERROR: --system-responder-prompt-budget-chars must be a positive integer.",
+      );
+    }
+    if (systemResponderPromptBudgetChars > 1_000_000) {
+      throw new Error(
+        "ERROR: --system-responder-prompt-budget-chars must not exceed 1,000,000.",
+      );
+    }
+  }
+
   // `bench published` flags. Parsed unconditionally so `--name`, `--model`,
   // etc. raise consistent errors even when used outside the `published`
   // action (mirrors CLAUDE.md rule 14: validate flag args at input boundaries).
@@ -631,6 +679,22 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     );
   }
   if (
+    systemResponderContextBudgetChars !== undefined &&
+    effectiveSystemProvider === undefined
+  ) {
+    throw new Error(
+      "ERROR: --system-responder-context-budget-chars requires --system-provider (or --provider).",
+    );
+  }
+  if (
+    systemResponderPromptBudgetChars !== undefined &&
+    effectiveSystemProvider === undefined
+  ) {
+    throw new Error(
+      "ERROR: --system-responder-prompt-budget-chars requires --system-provider (or --provider).",
+    );
+  }
+  if (
     judgeCodexReasoningEffort !== undefined &&
     judgeProvider !== "codex-cli"
   ) {
@@ -716,6 +780,8 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     systemBaseUrl: effectiveSystemBaseUrl,
     systemApiKey,
     systemCodexReasoningEffort,
+    systemResponderContextBudgetChars,
+    systemResponderPromptBudgetChars,
     judgeProvider,
     judgeModel,
     judgeBaseUrl,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -573,6 +573,8 @@ interface BenchProviderConfig {
   };
   disableThinking?: boolean;
   reasoningEffort?: "low" | "medium" | "high" | "xhigh";
+  responderContextBudgetChars?: number;
+  responderPromptBudgetChars?: number;
 }
 
 interface ResolveBenchRuntimeProfileOptions {
@@ -587,6 +589,8 @@ interface ResolveBenchRuntimeProfileOptions {
   systemBaseUrl?: string;
   systemApiKey?: string;
   systemCodexReasoningEffort?: "low" | "medium" | "high" | "xhigh";
+  systemResponderContextBudgetChars?: number;
+  systemResponderPromptBudgetChars?: number;
   judgeProvider?: string;
   judgeModel?: string;
   judgeBaseUrl?: string;
@@ -703,6 +707,10 @@ Options:
   --system-base-url <url>  Base URL for the direct answering provider
   --system-codex-reasoning-effort <low|medium|high|xhigh>
                            Codex CLI reasoning effort for the direct answerer
+  --system-responder-context-budget-chars <n>
+                           Compact recalled memory context before sending it to the direct answerer
+  --system-responder-prompt-budget-chars <n>
+                           Compact repeated benchmark prompt instructions before sending them to the direct answerer
   --judge-provider <openai|anthropic|ollama|litellm|local-llm|codex-cli>
                            Use a direct provider-backed judge
   --judge-model <model>    Model name for the judge provider
@@ -807,6 +815,14 @@ export function buildBenchRuntimeProfileRequest(
       runtimeProfile === "openclaw-chain"
         ? undefined
         : parsed.systemCodexReasoningEffort,
+    systemResponderContextBudgetChars:
+      runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemResponderContextBudgetChars,
+    systemResponderPromptBudgetChars:
+      runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemResponderPromptBudgetChars,
     judgeProvider: parsed.judgeProvider,
     judgeModel: parsed.judgeModel,
     judgeBaseUrl: parsed.judgeBaseUrl,

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -138,6 +138,11 @@ test("parseConfig extractionTelemetryPrefilterEnabled defaults on and accepts st
   assert.equal(parseConfig({ extractionTelemetryPrefilterEnabled: "false" }).extractionTelemetryPrefilterEnabled, false);
 });
 
+test("parseConfig lcmTelemetryPrefilterEnabled defaults on and accepts string false", () => {
+  assert.equal(parseConfig({}).lcmTelemetryPrefilterEnabled, true);
+  assert.equal(parseConfig({ lcmTelemetryPrefilterEnabled: "false" }).lcmTelemetryPrefilterEnabled, false);
+});
+
 test("parseConfig keeps explicit cue recall opt-in and budgets configurable", () => {
   const defaults = parseConfig({});
   assert.equal(defaults.explicitCueRecallEnabled, false);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2774,6 +2774,8 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.lcmDeterministicMaxTokens === "number"
         ? Math.max(64, Math.floor(cfg.lcmDeterministicMaxTokens))
         : 512,
+    lcmTelemetryPrefilterEnabled:
+      coerceBool(cfg.lcmTelemetryPrefilterEnabled) !== false,
     lcmArchiveRetentionDays:
       typeof cfg.lcmArchiveRetentionDays === "number"
         ? Math.max(1, Math.floor(cfg.lcmArchiveRetentionDays))

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -36,6 +36,7 @@ import { formatDaySummaryMemories, loadDaySummaryPrompt, buildExtensionsFooterFo
 import { ProfilingCollector } from "./profiling.js";
 import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
 import { normalizeReasoningTrace } from "./reasoning-trace-types.js";
+import { looksLikeMechanicalTelemetryTranscript } from "./telemetry-transcript.js";
 
 type ExtractionQuestion = ExtractionResult["questions"][number];
 type ExtractedFactResult = ExtractionResult["facts"][number];
@@ -55,74 +56,6 @@ const CONSOLIDATION_RESPONSE_SCHEMA = `{
   "profileUpdates": ["optional profile update"],
   "entityUpdates": [{"name": "person-jane-doe", "type": "person", "facts": ["Now leads the backend team", "Recently migrated the user service to TypeScript"]}]
 }`;
-
-const TELEMETRY_TURN_MARKER = /^\[(?:user|assistant|system)\]\s+\[(?:action|observation|state|reward|step|turn|frame)\s+\d+\]:/i;
-const BARE_TELEMETRY_MARKER = /^\[(?:action|observation|state|reward|step|turn|frame)\s+\d+\]:/i;
-const DURABLE_MEMORY_CUE_PHRASES = [
-  "remember",
-  "don't forget",
-  "prefer",
-  "preference",
-  "decided",
-  "decision",
-  "deadline",
-  "commitment",
-  "promise",
-  "my name",
-  "i am",
-  "i work",
-  "we use",
-  "correction",
-  "actually",
-  "always",
-  "never",
-  "when you",
-];
-
-function stripRolePrefix(line: string): string {
-  return line.replace(/^\[(?:user|assistant|system)\]\s+/i, "").trim();
-}
-
-function isTelemetryMarkerLine(line: string): boolean {
-  return TELEMETRY_TURN_MARKER.test(line) || BARE_TELEMETRY_MARKER.test(stripRolePrefix(line));
-}
-
-function isMechanicalTelemetryLine(line: string): boolean {
-  const stripped = stripRolePrefix(line);
-  return (
-    isTelemetryMarkerLine(line) ||
-    /^(?:left|right|up|down|wait|noop|stop|start|forward|backward)$/i.test(stripped) ||
-    /^(?:active rules|objects on (?:the )?map|inventory|score|reward|position|location):?$/i.test(stripped) ||
-    /^rule `[^`]+`/i.test(stripped) ||
-    /^(?:[a-z][\w-]*|\w+ `[^`]+`)\s+\d+\s+steps?\s+(?:to\s+the\s+)?(?:left|right|up|down)\b/i.test(stripped)
-  );
-}
-
-function hasDurableMemoryCue(conversation: string): boolean {
-  const lower = conversation.toLowerCase();
-  if (DURABLE_MEMORY_CUE_PHRASES.some((phrase) => lower.includes(phrase))) {
-    return true;
-  }
-  const ifIndex = lower.indexOf("if ");
-  return ifIndex >= 0 && lower.indexOf(" then", ifIndex + 3) >= 0;
-}
-
-function looksLikeMechanicalTelemetryTranscript(conversation: string): boolean {
-  if (hasDurableMemoryCue(conversation)) return false;
-
-  const lines = conversation
-    .split(/\n+/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-  if (lines.length < 8) return false;
-
-  const markerLines = lines.filter((line) => isTelemetryMarkerLine(line)).length;
-  if (markerLines < 4) return false;
-
-  const mechanicalLines = lines.filter((line) => isMechanicalTelemetryLine(line)).length;
-  const mechanicalRatio = mechanicalLines / lines.length;
-  return mechanicalRatio >= 0.45;
-}
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/remnic-core/src/lcm-engine.test.ts
+++ b/packages/remnic-core/src/lcm-engine.test.ts
@@ -113,6 +113,7 @@ function createPluginConfig(memoryDir: string): PluginConfig {
     lcmFreshTailTurns: 16,
     lcmMaxDepth: 5,
     lcmDeterministicMaxTokens: 128,
+    lcmTelemetryPrefilterEnabled: true,
     lcmArchiveRetentionDays: 90,
     lcmRecallBudgetShare: 0.15,
     messagePartsEnabled: true,
@@ -129,6 +130,83 @@ function deferred<T = void>() {
   });
   return { promise, resolve, reject };
 }
+
+test("LCM deterministically compresses mechanical telemetry without calling the summarizer", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-lcm-telemetry-prefilter-"),
+  );
+  let summarizeCalls = 0;
+
+  try {
+    const engine = new LcmEngine(
+      {
+        ...createPluginConfig(memoryDir),
+        lcmLeafBatchSize: 8,
+      } as PluginConfig,
+      async () => {
+        summarizeCalls += 1;
+        throw new Error("summarizer should not run for mechanical telemetry");
+      },
+    );
+
+    await engine.observeMessages("session-telemetry", [
+      { role: "user", content: "[Action 1]: right" },
+      { role: "assistant", content: "[Observation 1]: baba moved right" },
+      { role: "user", content: "[Action 2]: up" },
+      { role: "assistant", content: "[Observation 2]: wall blocks the path" },
+      { role: "user", content: "[Action 3]: left" },
+      { role: "assistant", content: "[Observation 3]: baba moved left" },
+      { role: "user", content: "[Action 4]: wait" },
+      { role: "assistant", content: "[Observation 4]: state unchanged" },
+    ]);
+    await engine.waitForSessionObserveIdle("session-telemetry");
+
+    assert.equal(summarizeCalls, 0);
+    const summary = await engine.describeContext("session-telemetry", 0, 0);
+    assert.match(summary?.summary ?? "", /\[Action 1\]/);
+    assert.equal(summary?.depth, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("LCM keeps semantic summarization when telemetry contains durable cues", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-lcm-telemetry-durable-cue-"),
+  );
+  let summarizeCalls = 0;
+
+  try {
+    const engine = new LcmEngine(
+      {
+        ...createPluginConfig(memoryDir),
+        lcmLeafBatchSize: 8,
+      } as PluginConfig,
+      async () => {
+        summarizeCalls += 1;
+        return "semantic durable summary";
+      },
+    );
+
+    await engine.observeMessages("session-telemetry", [
+      { role: "user", content: "[Action 1]: right" },
+      { role: "assistant", content: "[Observation 1]: remember this route preference" },
+      { role: "user", content: "[Action 2]: up" },
+      { role: "assistant", content: "[Observation 2]: wall blocks the path" },
+      { role: "user", content: "[Action 3]: left" },
+      { role: "assistant", content: "[Observation 3]: baba moved left" },
+      { role: "user", content: "[Action 4]: wait" },
+      { role: "assistant", content: "[Observation 4]: state unchanged" },
+    ]);
+    await engine.waitForSessionObserveIdle("session-telemetry");
+
+    assert.equal(summarizeCalls, 1);
+    const summary = await engine.describeContext("session-telemetry", 0, 0);
+    assert.equal(summary?.summary, "semantic durable summary");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
 
 test("observeMessages resolves before summarize finishes and background worker persists results", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-lcm-engine-"));

--- a/packages/remnic-core/src/lcm/engine.ts
+++ b/packages/remnic-core/src/lcm/engine.ts
@@ -17,6 +17,7 @@ export interface LcmEngineConfig {
   deterministicMaxTokens: number;
   archiveRetentionDays: number;
   recallBudgetShare: number;
+  telemetryPrefilterEnabled: boolean;
   messagePartsEnabled: boolean;
   messagePartsRecallMaxResults: number;
 }
@@ -31,6 +32,7 @@ export function extractLcmConfig(cfg: PluginConfig): LcmEngineConfig {
     deterministicMaxTokens: (cfg as any).lcmDeterministicMaxTokens ?? 512,
     archiveRetentionDays: (cfg as any).lcmArchiveRetentionDays ?? 90,
     recallBudgetShare: (cfg as any).lcmRecallBudgetShare ?? 0.15,
+    telemetryPrefilterEnabled: (cfg as any).lcmTelemetryPrefilterEnabled !== false,
     messagePartsEnabled: (cfg as any).messagePartsEnabled === true,
     messagePartsRecallMaxResults:
       typeof (cfg as any).messagePartsRecallMaxResults === "number"
@@ -95,6 +97,7 @@ export class LcmEngine {
         rollupFanIn: this.config.rollupFanIn,
         maxDepth: this.config.maxDepth,
         deterministicMaxTokens: this.config.deterministicMaxTokens,
+        telemetryPrefilterEnabled: this.config.telemetryPrefilterEnabled,
       },
     );
     const observeQueue = new LcmWorkQueue({

--- a/packages/remnic-core/src/lcm/summarizer.ts
+++ b/packages/remnic-core/src/lcm/summarizer.ts
@@ -2,6 +2,7 @@ import { log } from "../logger.js";
 import type { LcmArchive, LcmMessage } from "./archive.js";
 import { LcmDag } from "./dag.js";
 import { estimateTokens } from "./archive.js";
+import { looksLikeMechanicalTelemetryTranscript } from "../telemetry-transcript.js";
 
 /** Generate a ULID-like ID (timestamp + random). */
 function generateNodeId(): string {
@@ -21,6 +22,7 @@ export interface LcmSummarizerConfig {
   rollupFanIn: number;
   maxDepth: number;
   deterministicMaxTokens: number;
+  telemetryPrefilterEnabled: boolean;
 }
 
 export class LcmSummarizer {
@@ -151,6 +153,19 @@ export class LcmSummarizer {
     text: string,
     targetTokens: number,
   ): Promise<{ text: string; escalation: number }> {
+    if (
+      this.config.telemetryPrefilterEnabled &&
+      looksLikeMechanicalTelemetryTranscript(text)
+    ) {
+      return {
+        text: deterministicTruncate(
+          text,
+          Math.min(targetTokens, this.config.deterministicMaxTokens),
+        ),
+        escalation: 2,
+      };
+    }
+
     // Level 0: Normal LLM summary
     try {
       const result = await this.summarizeFn(text, targetTokens, false);

--- a/packages/remnic-core/src/telemetry-transcript.ts
+++ b/packages/remnic-core/src/telemetry-transcript.ts
@@ -1,0 +1,70 @@
+const TELEMETRY_TURN_MARKER = /^\[(?:user|assistant|system)\]\s+\[(?:action|observation|state|reward|step|turn|frame)\s+\d+\]:/i;
+const BARE_TELEMETRY_MARKER = /^\[(?:action|observation|state|reward|step|turn|frame)\s+\d+\]:/i;
+const DURABLE_MEMORY_CUE_PHRASES = [
+  "remember",
+  "don't forget",
+  "prefer",
+  "preference",
+  "decided",
+  "decision",
+  "deadline",
+  "commitment",
+  "promise",
+  "my name",
+  "i am",
+  "i work",
+  "we use",
+  "correction",
+  "actually",
+  "always",
+  "never",
+  "when you",
+];
+
+export function stripRolePrefix(line: string): string {
+  return line.replace(/^\[(?:user|assistant|system)\]\s+/i, "").trim();
+}
+
+export function isTelemetryMarkerLine(line: string): boolean {
+  return TELEMETRY_TURN_MARKER.test(line) ||
+    BARE_TELEMETRY_MARKER.test(stripRolePrefix(line));
+}
+
+export function isMechanicalTelemetryLine(line: string): boolean {
+  const stripped = stripRolePrefix(line);
+  return (
+    isTelemetryMarkerLine(line) ||
+    /^(?:left|right|up|down|wait|noop|stop|start|forward|backward)$/i.test(stripped) ||
+    /^(?:active rules|objects on (?:the )?map|inventory|score|reward|position|location):?$/i.test(stripped) ||
+    /^rule `[^`]+`/i.test(stripped) ||
+    /^(?:[a-z][\w-]*|\w+ `[^`]+`)\s+\d+\s+steps?\s+(?:to\s+the\s+)?(?:left|right|up|down)\b/i.test(stripped)
+  );
+}
+
+export function hasDurableMemoryCue(conversation: string): boolean {
+  const lower = conversation.toLowerCase();
+  if (DURABLE_MEMORY_CUE_PHRASES.some((phrase) => lower.includes(phrase))) {
+    return true;
+  }
+  const ifIndex = lower.indexOf("if ");
+  return ifIndex >= 0 && lower.indexOf(" then", ifIndex + 3) >= 0;
+}
+
+export function looksLikeMechanicalTelemetryTranscript(
+  conversation: string,
+): boolean {
+  if (hasDurableMemoryCue(conversation)) return false;
+
+  const lines = conversation
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length < 8) return false;
+
+  const markerLines = lines.filter((line) => isTelemetryMarkerLine(line)).length;
+  if (markerLines < 4) return false;
+
+  const mechanicalLines = lines.filter((line) => isMechanicalTelemetryLine(line)).length;
+  const mechanicalRatio = mechanicalLines / lines.length;
+  return mechanicalRatio >= 0.45;
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1130,6 +1130,12 @@ export interface PluginConfig {
    * extraction over state logs. Default true.
    */
   extractionTelemetryPrefilterEnabled: boolean;
+  /**
+   * When true, LCM uses deterministic compression instead of semantic LLM
+   * summarization for mechanical action/state telemetry transcripts with no
+   * durable-memory cue. Raw transcript storage/recall still runs. Default true.
+   */
+  lcmTelemetryPrefilterEnabled: boolean;
   extractionMaxTurnChars: number;
   extractionMaxFactsPerRun: number;
   extractionMaxEntitiesPerRun: number;


### PR DESCRIPTION
## Summary
- add deterministic telemetry classification shared by extraction and LCM
- skip LCM semantic summarization for mechanical action/state telemetry without durable-memory cues while preserving raw archive/recall
- add responder context and prompt budget knobs for direct provider-backed benchmark answerers

## Diagnostics
- real AMA-Bench limit-1 diagnostic after LCM guard: store batches completed in milliseconds, drain completed in 0ms, recall completed in ~180ms
- direct Codex CLI responder still timed out at 300s even with low reasoning and ~3k prompt; this PR fixes the Remnic-side ingestion/drain blockers and records prompt-budget controls, but Codex CLI is still not viable as the benchmark answerer until its transport behavior is addressed

## Verification
- pnpm exec tsx --test packages/remnic-core/src/lcm-engine.test.ts packages/remnic-core/src/config.test.ts packages/remnic-core/src/extraction-timeout.test.ts
- pnpm exec tsx --test packages/bench/src/responders.test.ts packages/bench/src/runtime-profiles.test.ts packages/remnic-cli/src/bench-args.test.ts
- pnpm --filter @remnic/core check-types
- pnpm --filter @remnic/bench check-types
- pnpm --filter @remnic/core build
- pnpm --filter @remnic/bench build
- npm run check:openclaw-plugin-sync
- git diff --check