### PR TITLE
test(openclaw): disable qmd in registration lifecycle tests

### DIFF
--- a/tests/register-multi-registry.test.ts
+++ b/tests/register-multi-registry.test.ts
@@ -65,6 +65,11 @@ const SECRET_REF_RESOLVER_TEST_KEY = "__openclawEngramSecretRefResolverForTest";
 // Helpers
 // ============================================================================
 
+const BASE_TEST_PLUGIN_CONFIG = {
+  qmdEnabled: false,
+  searchBackend: "noop",
+};
+
 function buildApi(label: string) {
   const registeredToolNames: string[] = [];
   let registeredCliCount = 0;
@@ -78,7 +83,7 @@ function buildApi(label: string) {
       warn: () => {},
       error: () => {},
     },
-    pluginConfig: {},
+    pluginConfig: { ...BASE_TEST_PLUGIN_CONFIG },
     config: {},
     registerTool(spec: { name: string }) {
       registeredToolNames.push(spec.name);
@@ -442,6 +447,7 @@ test("SecretRef auth resolution failure rejects start() and rolls back service o
     first = buildApi("secretref-failure-primary");
     second = buildApi("secretref-failure-secondary");
     const pluginConfig = {
+      ...BASE_TEST_PLUGIN_CONFIG,
       memoryDir,
       agentAccessHttp: {
         enabled: true,


### PR DESCRIPTION
## Summary
- disable QMD/search backend in register-multi-registry test API config
- keep the SecretRef lifecycle case on the same noop search path
- prevents the lifecycle test from spawning a lingering qmd mcp child during preflight

## Verification
- gtimeout 180 pnpm exec tsx --test tests/register-multi-registry.test.ts
- gtimeout 900 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test configuration, reducing external process spawning without touching production logic.
> 
> **Overview**
> Updates `register-multi-registry.test.ts` to use a shared `BASE_TEST_PLUGIN_CONFIG` that sets `qmdEnabled: false` and `searchBackend: "noop"` for all stubbed plugin `api` instances.
> 
> Also applies the same baseline config to the SecretRef lifecycle test’s explicit `pluginConfig`, preventing the test suite from spawning/keeping a QMD child process during registration/startup preflight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5adc3b85f14c74ed24ff330fa3cf4e856f0a1ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->