### PR TITLE
docs(readme): position Remnic for user-aware agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Remnic
 
-**Persistent, private memory for AI agents.** Your agents forget everything between sessions — Remnic fixes that.
+Open-source memory and context for user-aware agents.
+
+Remnic helps AI agents understand the people they work with: their preferences, projects, constraints, decisions, patterns, and definition of good. The goal is simple: agents that remember responsibly, retrieve the right context, and ask fewer unnecessary questions.
+
+Remnic is not just a memory store. It is an exploration of the systems layer around user-aware agents: scoped memory, provenance, retrieval quality, correction, boundaries, and evals.
 
 **The trace is noise. The primitive is the product.** Remnic's job is the pipeline that distills hours of agent conversation into compressed, searchable, durable memory primitives. ([How it works →](docs/trace-to-primitive.md))
-
-Remnic gives AI agents long-term memory that survives across conversations. Decisions, preferences, project context, personal details, past mistakes — everything your agent learns persists and resurfaces exactly when it's needed. All data stays on your machine as plain markdown files. No cloud services, no subscriptions, no sharing your data with third parties.
 
 [![npm version](https://img.shields.io/npm/v/@remnic/cli)](https://www.npmjs.com/package/@remnic/cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink)](https://github.com/sponsors/joshuaswarren)
+
+Creator and maintainer of Remnic: [Joshua Warren](https://github.com/joshuaswarren).
 
 > **Engram is now Remnic.** Canonical packages live under the `@remnic/*` scope:
 > [`@remnic/core`](https://www.npmjs.com/package/@remnic/core),
@@ -36,9 +40,11 @@ OpenClaw's built-in memory works for simple cases, but it doesn't scale. It lack
 
 ## The Solution
 
-Remnic is an open-source, local-first memory system that replaces OpenClaw's default memory with something much more capable — while keeping everything on your machine. It watches your agent conversations, extracts durable knowledge, and injects the right memories back at the start of every session. Route extraction through the OpenClaw gateway model chain, OpenAI, or a **local LLM** (Ollama, LM Studio, etc.) — your choice.
+Remnic is an open-source memory and context layer for user-aware agents. It watches agent conversations, extracts durable knowledge, and injects the right context back when it is needed. Route extraction through the OpenClaw gateway model chain, OpenAI, or a **local LLM** (Ollama, LM Studio, etc.) -- your choice.
 
-Remnic is the **universal memory layer for AI agents**. It works natively with **[OpenClaw](https://github.com/openclaw/openclaw)**, **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[Codex CLI](https://github.com/openai/codex)**, **[Hermes Agent](https://github.com/NousResearch/hermes-agent)**, and any **MCP-compatible client** (Replit, Cursor, etc.). When you tell any agent a preference, every agent knows it — they share one memory store.
+Remnic helps agents understand the people they work with: preferences, projects, constraints, decisions, patterns, and definitions of good. It works natively with **[OpenClaw](https://github.com/openclaw/openclaw)**, **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[Codex CLI](https://github.com/openai/codex)**, **[Hermes Agent](https://github.com/NousResearch/hermes-agent)**, and any **MCP-compatible client** (Replit, Cursor, etc.). When you tell any agent a preference, every agent can use the same governed memory store.
+
+Local-first storage is a trust feature. All data can stay on your machine as plain markdown files: no cloud dependency, no subscription, and no third-party memory service required.
 
 Architecture rule: standalone Remnic is first-class. `@remnic/core`, `@remnic/server`, and `@remnic/cli` own the memory engine and must stay host-agnostic. OpenClaw, Hermes, Codex, Claude Code, and future integrations are thin adapters over that shared core, and adapter work should always follow the host's current upstream SDK and documentation instead of recreating host-native behavior inside Remnic.
 
@@ -581,7 +587,7 @@ All memory lives on your filesystem as plain markdown files. No cloud dependency
 
 ### A real upgrade from default OpenClaw memory
 
-OpenClaw's built-in memory is basic — it works for getting started, but lacks semantic search, entity tracking, lifecycle management, governance, and multi-agent isolation. Remnic is a drop-in replacement that brings all of those capabilities while keeping the same local-first philosophy.
+OpenClaw's built-in memory is basic — it works for getting started, but lacks semantic search, entity tracking, lifecycle management, governance, and multi-agent isolation. Remnic is a drop-in replacement that brings all of those capabilities while keeping the same inspectable local trust model.
 
 ### Smart recall, not keyword search
 

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -1,8 +1,8 @@
 # @remnic/plugin-openclaw
 
-OpenClaw plugin for Remnic memory. The package bundles the OpenClaw adapter plus the Remnic core runtime so it can run without a separate Remnic service; the adapter registers OpenClaw hooks/tools and delegates memory behavior to [`@remnic/core`](https://www.npmjs.com/package/@remnic/core).
+OpenClaw plugin for Remnic memory and context. The package bundles the OpenClaw adapter plus the Remnic core runtime so it can run without a separate Remnic service; the adapter registers OpenClaw hooks/tools and delegates memory behavior to [`@remnic/core`](https://www.npmjs.com/package/@remnic/core).
 
-Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory layer for AI agents.
+Part of [Remnic](https://github.com/joshuaswarren/remnic), open-source memory and context for user-aware agents.
 
 ## Install
 

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -1,8 +1,8 @@
 # @remnic/cli
 
-CLI for Remnic memory -- init, query, daemon management, connectors, curation, and more.
+CLI for Remnic memory and context -- init, query, daemon management, connectors, curation, and more.
 
-Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory layer for AI agents.
+Part of [Remnic](https://github.com/joshuaswarren/remnic), open-source memory and context for user-aware agents.
 
 ## Install
 

--- a/packages/remnic-core/README.md
+++ b/packages/remnic-core/README.md
@@ -1,8 +1,8 @@
 # @remnic/core
 
-Framework-agnostic memory engine for AI agents. Orchestration, storage, extraction, search, and trust zones -- all local, all private.
+Framework-agnostic memory and context engine for user-aware agents. Orchestration, storage, extraction, search, and trust zones -- inspectable and local by default.
 
-Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory layer for AI agents.
+Part of [Remnic](https://github.com/joshuaswarren/remnic), open-source memory and context for user-aware agents.
 
 ## Install
 
@@ -12,7 +12,7 @@ npm install @remnic/core
 
 ## What it does
 
-Remnic Core is the engine that powers persistent memory across AI agent sessions. It handles:
+Remnic Core is the engine that powers scoped memory and context across AI agent sessions. It handles:
 
 - **Memory orchestration** -- three-phase flow: recall before sessions, buffer during, extract after
 - **Storage** -- plain markdown files with YAML frontmatter on your local filesystem

--- a/packages/remnic-server/README.md
+++ b/packages/remnic-server/README.md
@@ -1,8 +1,8 @@
 # @remnic/server
 
-Standalone Remnic memory server -- HTTP and MCP interfaces without requiring OpenClaw.
+Standalone Remnic memory and context server -- HTTP and MCP interfaces without requiring OpenClaw.
 
-Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory layer for AI agents.
+Part of [Remnic](https://github.com/joshuaswarren/remnic), open-source memory and context for user-aware agents.
 
 ## Install
 

--- a/packages/shim-openclaw-engram/README.md
+++ b/packages/shim-openclaw-engram/README.md
@@ -16,7 +16,7 @@ For full migration details, see the [Rename Guide](https://github.com/joshuaswar
 
 ## What is Remnic?
 
-Remnic is persistent, private memory for AI agents. Your agents forget everything between sessions -- Remnic fixes that. All data stays on your machine as plain markdown files.
+Remnic is open-source memory and context for user-aware agents. It helps agents understand preferences, projects, constraints, decisions, patterns, and definitions of good while keeping memory inspectable as plain markdown files.
 
 - **Repository**: [github.com/joshuaswarren/remnic](https://github.com/joshuaswarren/remnic)
 - **Core package**: [`@remnic/core`](https://www.npmjs.com/package/@remnic/core)


### PR DESCRIPTION
## Summary
- update the README opening to frame Remnic as open-source memory and context for user-aware agents
- add the requested creator/maintainer title
- update package README taglines away from universal-memory-layer wording and keep local-first as a trust feature

## Verification
- rg -n "Persistent, private|persistent, private|universal memory layer|building a company|Remnic is where|Creator and maintainer|local-first|local first" README.md packages/*/README.md docs/README.md docs/getting-started.md docs/architecture/overview.md docs/ARCHITECTURE.md docs/plugins/*.md
- git diff --check
- gtimeout 900 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that update product positioning and terminology without affecting runtime behavior.
> 
> **Overview**
> Updates the main `README.md` messaging to position Remnic as an open-source *memory and context* layer for **user-aware agents**, emphasizing local-first storage as a trust feature and adding explicit creator/maintainer attribution.
> 
> Aligns package READMEs (`@remnic/core`, `@remnic/server`, `@remnic/cli`, `@remnic/plugin-openclaw`, and the `openclaw-engram` shim) to the same terminology, replacing the prior “universal memory layer” framing and tweaking a few taglines for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c94b0733f342e1ddc474107a80dda678f1fe771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->