### PR TITLE
feat(core): add user-model contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@
 - [Pattern Reinforcement](pattern-reinforcement.md) — Cross-session pattern detection: reinforced primitives, `remnic patterns list/explain` CLI, recall boost (issue #687)
 - [Recall X-ray](xray.md) — Per-result retrieval attribution: which tier served each memory and why (issue #570)
 - [Recall Disclosure](recall-disclosure.md) — Three-tier progressive disclosure (chunk / section / raw): cost/quality tradeoffs, auto-escalation policy, and the disclosure-vs-retrieval-tier distinction (issue #677)
+- [User-Aware Agents](user-aware-agents.md) — User-model dimensions, context scopes, and boundary principles
 - [Temporal Recall](temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and `as_of` recall filter (issue #680)
 - [Tags](tags.md) — Free-form tag filter on recall and propose; tags vs taxonomy (issue #689)
 - [Live Connectors](live-connectors.md) — Continuous-sync framework for external sources (issue #683)

--- a/docs/user-aware-agents.md
+++ b/docs/user-aware-agents.md
@@ -1,0 +1,68 @@
+# User-Aware Agents
+
+Remnic is open-source memory and context for user-aware agents. The user model
+contract in `@remnic/core` is the typed surface for answering one question:
+
+> What does the agent need to understand about this user to act well right now?
+
+## User Model Dimensions
+
+The public `USER_MODEL_DIMENSIONS` contract covers:
+
+- preferences
+- goals
+- projects
+- constraints
+- current priorities
+- communication style
+- risk tolerance
+- people and relationships
+- past decisions
+- definitions of good
+- ask-before rules
+- do-not-use-outside rules
+
+These dimensions are broader than memory storage categories. They describe the
+working context an agent needs before deciding whether to answer, ask, draft,
+act, refuse, or escalate.
+
+## Context Scopes
+
+The public `USER_CONTEXT_SCOPES` contract covers:
+
+- personal
+- work
+- client
+- project
+- repo
+- tool
+- temporary
+- private
+- do-not-use-outside-this-context
+
+The existing `MemoryScope` type still means extraction routing scope
+(`project` or `global`). User context scopes are different: they describe where
+a user-model facet is safe and useful to apply. `temporary`, `private`, and
+`do-not-use-outside-this-context` are boundary scopes and should force stricter
+ask-versus-act decisions in later planning layers.
+
+Useful principle:
+
+> Personalization without boundaries becomes surveillance. Personalization with correction and control becomes agency.
+
+## Core Exports
+
+`@remnic/core` exports:
+
+- `USER_MODEL_CORE_QUESTION`
+- `USER_MODEL_DIMENSIONS`
+- `USER_CONTEXT_SCOPES`
+- `USER_BOUNDARY_SCOPES`
+- `normalizeUserModelDimension`
+- `normalizeUserContextScope`
+- `facetHasBoundary`
+- `summarizeUserModelCoverage`
+
+This contract is intentionally host-agnostic. OpenClaw, Hermes, Codex, MCP, and
+future adapters should consume the core model rather than defining their own
+parallel user profile taxonomies.

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -177,6 +177,29 @@ export {
 } from "./direct-answer.js";
 
 // ---------------------------------------------------------------------------
+// User-aware agent model
+// ---------------------------------------------------------------------------
+
+export {
+  USER_MODEL_CORE_QUESTION,
+  USER_MODEL_DIMENSIONS,
+  USER_CONTEXT_SCOPES,
+  USER_BOUNDARY_SCOPES,
+  facetHasBoundary,
+  isUserBoundaryScope,
+  isUserContextScope,
+  isUserModelDimension,
+  normalizeUserContextScope,
+  normalizeUserModelDimension,
+  summarizeUserModelCoverage,
+  type UserBoundaryScope,
+  type UserContextScope,
+  type UserModelCoverage,
+  type UserModelDimension,
+  type UserModelFacet,
+} from "./user-model.js";
+
+// ---------------------------------------------------------------------------
 // Hot/cold tier routing (issue #686)
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/user-model.test.ts
+++ b/packages/remnic-core/src/user-model.test.ts
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  USER_MODEL_CORE_QUESTION,
+  USER_MODEL_DIMENSIONS,
+  USER_CONTEXT_SCOPES,
+  facetHasBoundary,
+  isUserBoundaryScope,
+  isUserContextScope,
+  isUserModelDimension,
+  normalizeUserContextScope,
+  normalizeUserModelDimension,
+  summarizeUserModelCoverage,
+  type UserModelFacet,
+} from "./user-model.js";
+
+test("user-model contract includes the required user-aware dimensions", () => {
+  assert.equal(
+    USER_MODEL_CORE_QUESTION,
+    "What does the agent need to understand about this user to act well right now?",
+  );
+  assert.deepEqual(USER_MODEL_DIMENSIONS, [
+    "preferences",
+    "goals",
+    "projects",
+    "constraints",
+    "current_priorities",
+    "communication_style",
+    "risk_tolerance",
+    "people_relationships",
+    "past_decisions",
+    "definitions_of_good",
+    "ask_before_rules",
+    "do_not_use_outside_rules",
+  ]);
+});
+
+test("user context scopes include trust and boundary scopes", () => {
+  assert.deepEqual(USER_CONTEXT_SCOPES, [
+    "personal",
+    "work",
+    "client",
+    "project",
+    "repo",
+    "tool",
+    "temporary",
+    "private",
+    "do-not-use-outside-this-context",
+  ]);
+  assert.equal(isUserContextScope("repo"), true);
+  assert.equal(isUserContextScope("global"), false);
+});
+
+test("dimension normalization accepts human labels and rejects unknown values", () => {
+  assert.equal(isUserModelDimension("preferences"), true);
+  assert.equal(normalizeUserModelDimension("Communication style"), "communication_style");
+  assert.equal(normalizeUserModelDimension("Ask me before"), "ask_before_rules");
+  assert.equal(normalizeUserModelDimension("people & relationships"), "people_relationships");
+  assert.equal(normalizeUserModelDimension("outside the contract"), null);
+  assert.equal(normalizeUserModelDimension("constructor"), null);
+  assert.equal(normalizeUserModelDimension(null), null);
+});
+
+test("scope normalization accepts aliases without silently accepting invalid scopes", () => {
+  assert.equal(normalizeUserContextScope("repository"), "repo");
+  assert.equal(
+    normalizeUserContextScope("do not use outside this context"),
+    "do-not-use-outside-this-context",
+  );
+  assert.equal(normalizeUserContextScope("do_not_use_outside"), "do-not-use-outside-this-context");
+  assert.equal(normalizeUserContextScope("global"), null);
+  assert.equal(normalizeUserContextScope("constructor"), null);
+  assert.equal(normalizeUserContextScope(false), null);
+  assert.equal(normalizeUserContextScope("_".repeat(10_000)), null);
+});
+
+test("boundary helper identifies scopes that require stricter use decisions", () => {
+  assert.equal(isUserBoundaryScope("private"), true);
+  assert.equal(isUserBoundaryScope("temporary"), true);
+  assert.equal(isUserBoundaryScope("work"), false);
+  assert.equal(
+    facetHasBoundary({
+      scopes: ["work", "do-not-use-outside-this-context"],
+    }),
+    true,
+  );
+  assert.equal(facetHasBoundary({ scopes: ["work", "repo"] }), false);
+});
+
+test("coverage summary reports present and missing user-model dimensions deterministically", () => {
+  const facets: UserModelFacet[] = [
+    {
+      dimension: "preferences",
+      statement: "The user prefers terse status updates.",
+      scopes: ["work"],
+    },
+    {
+      dimension: "ask_before_rules",
+      statement: "Ask before changing public APIs.",
+      scopes: ["repo"],
+    },
+  ];
+
+  const coverage = summarizeUserModelCoverage(facets, [
+    "preferences",
+    "risk_tolerance",
+    "ask_before_rules",
+  ]);
+
+  assert.deepEqual(coverage.present, ["preferences", "ask_before_rules"]);
+  assert.deepEqual(coverage.missing, ["risk_tolerance"]);
+  assert.deepEqual(coverage.byDimension.preferences, [facets[0]]);
+  assert.deepEqual(coverage.byDimension.ask_before_rules, [facets[1]]);
+  assert.deepEqual(coverage.byDimension.risk_tolerance, []);
+});

--- a/packages/remnic-core/src/user-model.ts
+++ b/packages/remnic-core/src/user-model.ts
@@ -1,0 +1,162 @@
+/**
+ * Host-agnostic user-model contract for user-aware agents.
+ *
+ * This is intentionally separate from the existing `MemoryScope` type, which
+ * still means extraction routing scope (`project` | `global`). User context
+ * scopes describe where a model facet is safe and useful to apply.
+ */
+
+export const USER_MODEL_CORE_QUESTION =
+  "What does the agent need to understand about this user to act well right now?";
+
+export const USER_MODEL_DIMENSIONS = [
+  "preferences",
+  "goals",
+  "projects",
+  "constraints",
+  "current_priorities",
+  "communication_style",
+  "risk_tolerance",
+  "people_relationships",
+  "past_decisions",
+  "definitions_of_good",
+  "ask_before_rules",
+  "do_not_use_outside_rules",
+] as const;
+
+export type UserModelDimension = (typeof USER_MODEL_DIMENSIONS)[number];
+
+export const USER_CONTEXT_SCOPES = [
+  "personal",
+  "work",
+  "client",
+  "project",
+  "repo",
+  "tool",
+  "temporary",
+  "private",
+  "do-not-use-outside-this-context",
+] as const;
+
+export type UserContextScope = (typeof USER_CONTEXT_SCOPES)[number];
+
+export const USER_BOUNDARY_SCOPES = [
+  "temporary",
+  "private",
+  "do-not-use-outside-this-context",
+] as const satisfies readonly UserContextScope[];
+
+export type UserBoundaryScope = (typeof USER_BOUNDARY_SCOPES)[number];
+
+export interface UserModelFacet {
+  dimension: UserModelDimension;
+  statement: string;
+  scopes: UserContextScope[];
+  appliesTo?: string[];
+  sourceMemoryIds?: string[];
+  confidence?: number;
+  updatedAt?: string;
+}
+
+export interface UserModelCoverage {
+  present: UserModelDimension[];
+  missing: UserModelDimension[];
+  byDimension: Record<UserModelDimension, UserModelFacet[]>;
+}
+
+const DIMENSION_ALIASES = new Map<string, UserModelDimension>([
+  ["ask_me_before", "ask_before_rules"],
+  ["ask_before", "ask_before_rules"],
+  ["do_not_use_outside", "do_not_use_outside_rules"],
+  ["dont_use_outside", "do_not_use_outside_rules"],
+  ["definition_of_good", "definitions_of_good"],
+  ["relationships", "people_relationships"],
+  ["people_and_relationships", "people_relationships"],
+  ["priorities", "current_priorities"],
+]);
+
+const SCOPE_ALIASES = new Map<string, UserContextScope>([
+  ["do_not_use_outside_this_context", "do-not-use-outside-this-context"],
+  ["do_not_use_outside", "do-not-use-outside-this-context"],
+  ["dont_use_outside", "do-not-use-outside-this-context"],
+  ["repository", "repo"],
+  ["client_work", "client"],
+]);
+
+function normalizeToken(value: string): string {
+  const parts: string[] = [];
+  let current = "";
+
+  const pushCurrent = () => {
+    if (current.length === 0) return;
+    parts.push(current);
+    current = "";
+  };
+
+  for (const char of value.trim().toLowerCase()) {
+    if ((char >= "a" && char <= "z") || (char >= "0" && char <= "9")) {
+      current += char;
+    } else if (char === "&") {
+      pushCurrent();
+      parts.push("and");
+    } else if (char === "'" || char === '"') {
+      continue;
+    } else {
+      pushCurrent();
+    }
+  }
+
+  pushCurrent();
+  return parts.join("_");
+}
+
+export function isUserModelDimension(value: unknown): value is UserModelDimension {
+  return typeof value === "string" && USER_MODEL_DIMENSIONS.includes(value as UserModelDimension);
+}
+
+export function normalizeUserModelDimension(value: unknown): UserModelDimension | null {
+  if (typeof value !== "string") return null;
+  if (isUserModelDimension(value)) return value;
+  const normalized = normalizeToken(value);
+  if (isUserModelDimension(normalized)) return normalized;
+  return DIMENSION_ALIASES.get(normalized) ?? null;
+}
+
+export function isUserContextScope(value: unknown): value is UserContextScope {
+  return typeof value === "string" && USER_CONTEXT_SCOPES.includes(value as UserContextScope);
+}
+
+export function normalizeUserContextScope(value: unknown): UserContextScope | null {
+  if (typeof value !== "string") return null;
+  if (isUserContextScope(value)) return value;
+  const normalized = normalizeToken(value);
+  const hyphenated = normalized.split("_").join("-");
+  if (isUserContextScope(hyphenated)) return hyphenated;
+  return SCOPE_ALIASES.get(normalized) ?? null;
+}
+
+export function isUserBoundaryScope(value: unknown): value is UserBoundaryScope {
+  return typeof value === "string" && USER_BOUNDARY_SCOPES.includes(value as UserBoundaryScope);
+}
+
+export function facetHasBoundary(facet: Pick<UserModelFacet, "scopes">): boolean {
+  return facet.scopes.some(isUserBoundaryScope);
+}
+
+export function summarizeUserModelCoverage(
+  facets: readonly UserModelFacet[],
+  requiredDimensions: readonly UserModelDimension[] = USER_MODEL_DIMENSIONS,
+): UserModelCoverage {
+  const byDimension = Object.fromEntries(
+    USER_MODEL_DIMENSIONS.map((dimension) => [dimension, [] as UserModelFacet[]]),
+  ) as Record<UserModelDimension, UserModelFacet[]>;
+
+  for (const facet of facets) {
+    byDimension[facet.dimension].push(facet);
+  }
+
+  const present = requiredDimensions.filter((dimension) => byDimension[dimension].length > 0);
+  const missing = requiredDimensions.filter((dimension) => byDimension[dimension].length === 0);
+
+  return { present, missing, byDimension };
+}


### PR DESCRIPTION
## Summary
- add a host-agnostic user-model contract for user-aware agents
- define user-model dimensions, context scopes, and boundary scope helpers
- document the model contract and export it from @remnic/core

## Verification
- pnpm exec tsx --test packages/remnic-core/src/user-model.test.ts
- git diff --check
- gtimeout 900 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: introduces new `@remnic/core` exports and documentation with no changes to existing runtime behavior, aside from potential downstream compile impact from the expanded public API surface.
> 
> **Overview**
> Adds a host-agnostic **user-model contract** to `@remnic/core`, defining standard user-model *dimensions* and *context/boundary scopes* plus helpers to validate/normalize tokens and summarize coverage (group facets by dimension and report missing/present).
> 
> Exports the new contract from the package entrypoint, adds unit tests for normalization and boundary detection behavior, and documents the model in a new `docs/user-aware-agents.md` page linked from the docs README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4b23089cb545f578a3f79f8216a0d810f68a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->