### PR TITLE
feat(core): add retrieved memory provenance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@
 - [At-Rest Encryption](encryption.md) — AES-256-GCM transparent storage encryption, secure-store CLI, threat model (issue #690)
 - [Advanced Retrieval](advanced-retrieval.md) — Reranking, query expansion, feedback loop
 - [Pattern Reinforcement](pattern-reinforcement.md) — Cross-session pattern detection: reinforced primitives, `remnic patterns list/explain` CLI, recall boost (issue #687)
-- [Recall X-ray](xray.md) — Per-result retrieval attribution: which tier served each memory and why (issue #570)
+- [Recall X-ray](xray.md) — Per-result retrieval attribution, provenance, safety, and why each memory surfaced (issue #570)
 - [Recall Disclosure](recall-disclosure.md) — Three-tier progressive disclosure (chunk / section / raw): cost/quality tradeoffs, auto-escalation policy, and the disclosure-vs-retrieval-tier distinction (issue #677)
 - [User-Aware Agents](user-aware-agents.md) — User-model dimensions, context scopes, and boundary principles
 - [Temporal Recall](temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and `as_of` recall filter (issue #680)

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -11,9 +11,13 @@ itself is a static `index.html` + `app.js` shell shipped under
 - **Memory Browser** — paginated list of `/engram/v1/memories` with
   query / status / category / sort filters.
 - **Memory Detail** — content + timeline for a selected memory, with
-  raw-path copy.
+  raw-path copy. Memory detail is the operator home for "why did you
+  remember this?", "forget this", "correct this", and "scope this"
+  actions as those controls graduate from API/CLI surfaces.
 - **Recall Debugger** — runs `/engram/v1/recall` and
-  `/engram/v1/recall/explain` for a session key.
+  `/engram/v1/recall/explain` for a session key. Pair it with Recall
+  X-ray when auditing per-result provenance, stale/correction state,
+  and whether a memory is safe to use in the current context.
 - **Quality Dashboard** — counts + latest governance run from
   `/engram/v1/quality`.
 - **Trust Zones** — browse and (optionally) promote trust-zone

--- a/docs/user-aware-agents.md
+++ b/docs/user-aware-agents.md
@@ -50,6 +50,32 @@ Useful principle:
 
 > Personalization without boundaries becomes surveillance. Personalization with correction and control becomes agency.
 
+## Retrieved Memory Provenance
+
+`@remnic/core` also exports a `RetrievedMemoryProvenance` contract for recall
+surfaces. It answers the operational questions a user-aware agent needs before
+using a memory:
+
+- Where did this memory come from?
+- When was it created or updated?
+- What namespace or user context scope does it belong to?
+- Why was it retrieved for this request?
+- How confident is Remnic in the memory?
+- Is it stale, corrected, disputed, forgotten, or superseded?
+- Is it safe to use in the current context?
+
+Recall X-ray attaches this provenance per result when retrieval already loaded
+the memory frontmatter. The concrete scope is always present as the namespace
+or storage path. User context scopes are inferred from explicit in-memory
+metadata when provided by callers and from existing tags such as `work`, `repo`,
+`private`, and `do-not-use-outside-this-context`.
+
+Boundary scopes affect the safety decision. Forgotten, rejected, quarantined,
+and out-of-context `do-not-use-outside-this-context` memories are marked
+`blocked`; stale, pending-review, superseded, archived, disputed, private, and
+temporary memories are marked `requires-review` unless the current context
+matches the boundary.
+
 ## Core Exports
 
 `@remnic/core` exports:
@@ -62,6 +88,9 @@ Useful principle:
 - `normalizeUserContextScope`
 - `facetHasBoundary`
 - `summarizeUserModelCoverage`
+- `buildRetrievedMemoryProvenance`
+- `normalizeRetrievedMemoryProvenance`
+- `summarizeRetrievedMemoryProvenance`
 
 This contract is intentionally host-agnostic. OpenClaw, Hermes, Codex, MCP, and
 future adapters should consume the core model rather than defining their own

--- a/docs/xray.md
+++ b/docs/xray.md
@@ -5,8 +5,8 @@ unified per-result attribution snapshot for recalls. After any recall,
 an X-ray capture tells you **exactly why each memory surfaced** — which
 retrieval tier served it, how its score decomposed, every filter it
 passed (and the first filter that would have rejected it), any graph
-path traversed, the audit-log entry id, and the character budget the
-final payload consumed.
+path traversed, the audit-log entry id, memory provenance and safety
+context, and the character budget the final payload consumed.
 
 Most competitors treat retrieval as a black box. Remnic X-ray makes the
 whole ladder legible in one snapshot that is rendered identically by
@@ -73,11 +73,17 @@ budget: 5284 / 8192 chars
 [1] decisions/recall-cache-ttl — served-by=direct-answer
     path: decisions/recall-cache-ttl.md
     score: final=0.8912 importance=0.6000 tier_prior=0.3000
+    provenance: source=conversation created=2026-04-18T21:13:00.000Z scope=namespace:alice-project-origin-ab12cd34 confidence=0.94 stale=false corrected=false safe=true
+    retrieval-reason: served-by=direct-answer
+    context-scopes: repo, work
     admitted-by: namespace-scope, status-active, trust-zone, token-overlap
     audit-entry: audit-0e4a1b
 [2] decisions/recall-cache-eviction — served-by=hybrid
     path: decisions/recall-cache-eviction.md
     score: final=0.7204 vector=0.5812 bm25=0.4733 mmr_penalty=0.0400
+    provenance: source=conversation created=2026-03-28T14:02:00.000Z scope=namespace:alice-project-origin-ab12cd34 confidence=0.83 stale=true corrected=superseded safe=false
+    retrieval-reason: served-by=hybrid
+    safety: requires-review (status=superseded, stale=true)
     admitted-by: namespace-scope, status-active, trust-zone, token-overlap, mmr-diversify
     audit-entry: audit-0e4a1c
 [3] notes/perf-regression-2026-03 — served-by=graph
@@ -113,10 +119,10 @@ envelope.
 
 The canonical v1 shape lives in
 [`packages/remnic-core/src/recall-xray.ts`](../packages/remnic-core/src/recall-xray.ts).
-A stable `schemaVersion: "1"` tag on every snapshot (line 118) lets
-downstream consumers version-gate their parsers.
+A stable `schemaVersion: "1"` tag on every snapshot lets downstream
+consumers version-gate their parsers.
 
-### `RecallXraySnapshot` (lines 116-142)
+### `RecallXraySnapshot`
 
 ```ts
 interface RecallXraySnapshot {
@@ -134,7 +140,7 @@ interface RecallXraySnapshot {
 }
 ```
 
-### `RecallXrayResult` (lines 80-96)
+### `RecallXrayResult`
 
 ```ts
 interface RecallXrayResult {
@@ -153,8 +159,38 @@ interface RecallXrayResult {
   auditEntryId?: string;
   admittedBy: string[];      // filters the candidate passed
   rejectedBy?: string;       // first filter that would have rejected
+  provenance?: RetrievedMemoryProvenance;
 }
 ```
+
+### `RetrievedMemoryProvenance`
+
+```ts
+interface RetrievedMemoryProvenance {
+  source: string;                 // where the memory came from
+  created?: string;
+  updated?: string;
+  namespace?: string;
+  scope: string;                  // concrete retrieval scope
+  userContextScopes: UserContextScope[];
+  retrievalReason: string;        // why this result surfaced now
+  confidence: number;             // [0, 1]
+  stale: boolean;
+  corrected: boolean;
+  correctionState: "none" | "correction" | "superseded" | "disputed" | "forgotten";
+  safeToUse: boolean;
+  safety: "safe" | "requires-review" | "blocked";
+  safetyReasons: string[];
+}
+```
+
+Provenance is built from memory frontmatter already loaded by the retrieval
+ranking path. It records source, creation/update timestamps, namespace scope,
+retrieval reason, confidence, stale/correction state, and whether the memory is
+safe to use in the current context. User-aware scopes come from explicit
+in-memory metadata when present and from existing scope tags such as `work`,
+`repo`, `private`, or `do-not-use-outside-this-context`; the concrete namespace
+still remains the always-present retrieval scope.
 
 When the graph subsystem (`servedBy: "graph"`) produced a result, the X-ray
 optionally surfaces a `graphEdgeConfidences` array aligned with `graphPath`:

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -199,6 +199,16 @@ export {
   type UserModelFacet,
 } from "./user-model.js";
 
+export {
+  buildRetrievedMemoryProvenance,
+  normalizeRetrievedMemoryProvenance,
+  summarizeRetrievedMemoryProvenance,
+  type BuildRetrievedMemoryProvenanceOptions,
+  type RetrievedMemoryCorrectionState,
+  type RetrievedMemoryProvenance,
+  type RetrievedMemorySafety,
+} from "./memory-provenance.js";
+
 // ---------------------------------------------------------------------------
 // Hot/cold tier routing (issue #686)
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/memory-provenance.test.ts
+++ b/packages/remnic-core/src/memory-provenance.test.ts
@@ -1,0 +1,196 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildRetrievedMemoryProvenance,
+  normalizeRetrievedMemoryProvenance,
+  summarizeRetrievedMemoryProvenance,
+} from "./memory-provenance.js";
+import type { MemoryFile, MemoryFrontmatter } from "./types.js";
+
+const NOW = Date.parse("2026-05-01T00:00:00.000Z");
+
+function frontmatter(
+  overrides: Partial<MemoryFrontmatter> = {},
+): MemoryFrontmatter {
+  return {
+    id: "mem-1",
+    category: "preference",
+    created: "2026-04-20T00:00:00.000Z",
+    updated: "2026-04-21T00:00:00.000Z",
+    source: "conversation",
+    confidence: 0.91,
+    confidenceTier: "explicit",
+    tags: [],
+    ...overrides,
+  };
+}
+
+function memory(overrides: Partial<MemoryFrontmatter> = {}): MemoryFile {
+  return {
+    path: "facts/2026-04-20/mem-1.md",
+    content: "The user prefers concise status updates.",
+    frontmatter: frontmatter(overrides),
+  };
+}
+
+test("buildRetrievedMemoryProvenance records source, scope, confidence, and retrieval reason", () => {
+  const provenance = buildRetrievedMemoryProvenance(
+    memory({
+      tags: ["repo", "work", "repo"],
+      sourceMemoryId: "source-memory",
+      sourceTurnId: "turn-7",
+      derived_from: ["facts/original.md:2"],
+      derived_via: "merge",
+    }),
+    {
+      namespace: "project-alpha",
+      retrievalReason: "served-by=hybrid",
+      now: () => NOW,
+    },
+  );
+
+  assert.equal(provenance.source, "conversation");
+  assert.equal(provenance.created, "2026-04-20T00:00:00.000Z");
+  assert.equal(provenance.updated, "2026-04-21T00:00:00.000Z");
+  assert.equal(provenance.namespace, "project-alpha");
+  assert.equal(provenance.scope, "namespace:project-alpha");
+  assert.deepEqual(provenance.userContextScopes, ["repo", "work"]);
+  assert.equal(provenance.retrievalReason, "served-by=hybrid");
+  assert.equal(provenance.confidence, 0.91);
+  assert.equal(provenance.stale, false);
+  assert.equal(provenance.corrected, false);
+  assert.equal(provenance.safeToUse, true);
+  assert.equal(provenance.safety, "safe");
+  assert.deepEqual(provenance.safetyReasons, []);
+  assert.equal(provenance.sourceMemoryId, "source-memory");
+  assert.equal(provenance.sourceTurnId, "turn-7");
+  assert.deepEqual(provenance.derivedFrom, ["facts/original.md:2"]);
+  assert.equal(provenance.derivedVia, "merge");
+});
+
+test("buildRetrievedMemoryProvenance marks stale and superseded memories as requiring review", () => {
+  const provenance = buildRetrievedMemoryProvenance(
+    memory({
+      status: "superseded",
+      lifecycleState: "stale",
+      supersededBy: "newer-memory",
+      invalid_at: "2026-04-30T00:00:00.000Z",
+    }),
+    { now: () => NOW },
+  );
+
+  assert.equal(provenance.stale, true);
+  assert.equal(provenance.corrected, true);
+  assert.equal(provenance.correctionState, "superseded");
+  assert.equal(provenance.safeToUse, false);
+  assert.equal(provenance.safety, "requires-review");
+  assert.ok(provenance.safetyReasons.includes("status=superseded"));
+  assert.ok(provenance.safetyReasons.includes("stale=true"));
+});
+
+test("buildRetrievedMemoryProvenance blocks forgotten and quarantined memories", () => {
+  const forgotten = buildRetrievedMemoryProvenance(
+    memory({
+      status: "forgotten",
+      forgottenAt: "2026-04-25T00:00:00.000Z",
+      forgottenReason: "user asked to remove it",
+    }),
+    { now: () => NOW },
+  );
+  assert.equal(forgotten.safety, "blocked");
+  assert.equal(forgotten.safeToUse, false);
+  assert.equal(forgotten.correctionState, "forgotten");
+  assert.equal(forgotten.forgottenReason, "user asked to remove it");
+
+  const quarantined = buildRetrievedMemoryProvenance(
+    memory({ status: "quarantined" }),
+    { now: () => NOW },
+  );
+  assert.equal(quarantined.safety, "blocked");
+  assert.ok(quarantined.safetyReasons.includes("status=quarantined"));
+});
+
+test("buildRetrievedMemoryProvenance enforces boundary scopes against current context", () => {
+  const blocked = buildRetrievedMemoryProvenance(
+    memory({ tags: ["repo", "do not use outside this context"] }),
+    {
+      currentContextScopes: ["repo"],
+      now: () => NOW,
+    },
+  );
+
+  assert.equal(blocked.safety, "blocked");
+  assert.equal(blocked.safeToUse, false);
+  assert.ok(
+    blocked.safetyReasons.includes(
+      "boundary-blocked=do-not-use-outside-this-context",
+    ),
+  );
+
+  const inScope = buildRetrievedMemoryProvenance(
+    memory({ tags: ["repo", "do not use outside this context"] }),
+    {
+      currentContextScopes: ["do-not-use-outside-this-context"],
+      now: () => NOW,
+    },
+  );
+  assert.equal(inScope.safety, "safe");
+  assert.deepEqual(inScope.safetyReasons, []);
+});
+
+test("normalizeRetrievedMemoryProvenance clamps and drops malformed fields", () => {
+  const normalized = normalizeRetrievedMemoryProvenance({
+    source: " import ",
+    scope: "",
+    userContextScopes: ["repository", "constructor", "private"],
+    retrievalReason: "",
+    confidence: 2,
+    stale: true,
+    corrected: false,
+    correctionState: "disputed",
+    safety: "bogus",
+    safeToUse: false,
+    safetyReasons: [" stale=true ", "", 7],
+    status: "bogus",
+    lifecycleState: "archived",
+    verificationState: "disputed",
+    policyClass: "protected",
+    derivedFrom: ["a:1", "", "a:1"],
+    derivedVia: "pattern-reinforcement",
+  });
+
+  assert.ok(normalized);
+  assert.equal(normalized.source, "import");
+  assert.equal(normalized.scope, "unknown");
+  assert.deepEqual(normalized.userContextScopes, ["repo", "private"]);
+  assert.equal(normalized.retrievalReason, "retrieved");
+  assert.equal(normalized.confidence, 1);
+  assert.equal(normalized.corrected, true);
+  assert.equal(normalized.correctionState, "disputed");
+  assert.equal(normalized.safeToUse, false);
+  assert.equal(normalized.safety, "requires-review");
+  assert.deepEqual(normalized.safetyReasons, ["stale=true"]);
+  assert.equal(normalized.status, undefined);
+  assert.equal(normalized.lifecycleState, "archived");
+  assert.equal(normalized.verificationState, "disputed");
+  assert.equal(normalized.policyClass, "protected");
+  assert.deepEqual(normalized.derivedFrom, ["a:1"]);
+  assert.equal(normalized.derivedVia, "pattern-reinforcement");
+});
+
+test("summarizeRetrievedMemoryProvenance produces stable compact text", () => {
+  const provenance = buildRetrievedMemoryProvenance(
+    memory({ tags: ["work"] }),
+    {
+      namespace: "default",
+      retrievalReason: "served-by=recent-scan",
+      now: () => NOW,
+    },
+  );
+
+  assert.equal(
+    summarizeRetrievedMemoryProvenance(provenance),
+    "source=conversation created=2026-04-20T00:00:00.000Z scope=namespace:default confidence=0.91 stale=false corrected=false safe=true",
+  );
+});

--- a/packages/remnic-core/src/memory-provenance.ts
+++ b/packages/remnic-core/src/memory-provenance.ts
@@ -1,0 +1,484 @@
+import type {
+  LifecycleState,
+  MemoryFile,
+  MemoryFrontmatter,
+  MemoryStatus,
+  PolicyClass,
+  VerificationState,
+} from "./types.js";
+import {
+  isUserBoundaryScope,
+  normalizeUserContextScope,
+  type UserContextScope,
+} from "./user-model.js";
+
+export type RetrievedMemoryCorrectionState =
+  | "none"
+  | "correction"
+  | "superseded"
+  | "disputed"
+  | "forgotten";
+
+export type RetrievedMemorySafety = "safe" | "requires-review" | "blocked";
+
+export interface RetrievedMemoryProvenance {
+  /** Frontmatter source, for example conversation, artifact, import, or consolidation. */
+  source: string;
+  /** ISO timestamp the memory was created, when known. */
+  created?: string;
+  /** ISO timestamp the memory was last updated, when known. */
+  updated?: string;
+  /** Namespace that produced the result, when known. */
+  namespace?: string;
+  /** Concrete retrieval scope. Defaults to namespace:<name> or the storage path. */
+  scope: string;
+  /** User-aware context scopes inferred from explicit scope metadata or tags. */
+  userContextScopes: UserContextScope[];
+  /** Why this memory was retrieved for the current response. */
+  retrievalReason: string;
+  /** Memory confidence clamped into [0, 1]. */
+  confidence: number;
+  /** Whether lifecycle, validity, or expiry metadata says this memory is stale now. */
+  stale: boolean;
+  /** Whether this result represents, has, or is affected by a user/system correction. */
+  corrected: boolean;
+  correctionState: RetrievedMemoryCorrectionState;
+  /** Whether the memory is safe to use in the current context without asking first. */
+  safeToUse: boolean;
+  safety: RetrievedMemorySafety;
+  safetyReasons: string[];
+  status?: MemoryStatus;
+  lifecycleState?: LifecycleState;
+  verificationState?: VerificationState;
+  policyClass?: PolicyClass;
+  sourceMemoryId?: string;
+  sourceTurnId?: string;
+  derivedFrom?: string[];
+  derivedVia?: MemoryFrontmatter["derived_via"];
+  validAt?: string;
+  invalidAt?: string;
+  forgottenAt?: string;
+  forgottenReason?: string;
+}
+
+export interface BuildRetrievedMemoryProvenanceOptions {
+  namespace?: string;
+  scope?: string;
+  retrievalReason?: string;
+  currentContextScopes?: readonly unknown[];
+  now?: () => number;
+}
+
+const MEMORY_STATUS_VALUES: readonly MemoryStatus[] = [
+  "active",
+  "pending_review",
+  "rejected",
+  "quarantined",
+  "superseded",
+  "archived",
+  "forgotten",
+];
+
+const LIFECYCLE_STATE_VALUES: readonly LifecycleState[] = [
+  "candidate",
+  "validated",
+  "active",
+  "stale",
+  "archived",
+];
+
+const VERIFICATION_STATE_VALUES: readonly VerificationState[] = [
+  "unverified",
+  "user_confirmed",
+  "system_inferred",
+  "disputed",
+];
+
+const POLICY_CLASS_VALUES: readonly PolicyClass[] = [
+  "ephemeral",
+  "durable",
+  "protected",
+];
+
+const SAFETY_VALUES: readonly RetrievedMemorySafety[] = [
+  "safe",
+  "requires-review",
+  "blocked",
+];
+
+const CORRECTION_STATE_VALUES: readonly RetrievedMemoryCorrectionState[] = [
+  "none",
+  "correction",
+  "superseded",
+  "disputed",
+  "forgotten",
+];
+
+export function buildRetrievedMemoryProvenance(
+  memory: MemoryFile,
+  options: BuildRetrievedMemoryProvenanceOptions = {},
+): RetrievedMemoryProvenance {
+  const frontmatter = memory.frontmatter;
+  const nowMs = safeNow(options.now);
+  const namespace = nonEmptyString(options.namespace);
+  const scope =
+    nonEmptyString(options.scope) ??
+    (namespace ? `namespace:${namespace}` : nonEmptyString(memory.path) ?? "unknown");
+  const userContextScopes = inferUserContextScopes(frontmatter);
+  const currentContextScopes = normalizeScopeList(options.currentContextScopes);
+  const stale = isStale(frontmatter, nowMs);
+  const correctionState = inferCorrectionState(frontmatter);
+  const corrected = correctionState !== "none";
+  const safetyReasons = inferSafetyReasons({
+    frontmatter,
+    stale,
+    userContextScopes,
+    currentContextScopes,
+  });
+  const safety = inferSafety(safetyReasons);
+  const provenance: RetrievedMemoryProvenance = {
+    source: nonEmptyString(frontmatter.source) ?? "unknown",
+    scope,
+    userContextScopes,
+    retrievalReason: nonEmptyString(options.retrievalReason) ?? "retrieved",
+    confidence: clamp01(frontmatter.confidence),
+    stale,
+    corrected,
+    correctionState,
+    safeToUse: safety === "safe",
+    safety,
+    safetyReasons,
+  };
+
+  assignString(provenance, "created", frontmatter.created);
+  assignString(provenance, "updated", frontmatter.updated);
+  assignString(provenance, "namespace", namespace);
+  assignStatus(provenance, "status", frontmatter.status);
+  assignLifecycleState(provenance, "lifecycleState", frontmatter.lifecycleState);
+  assignVerificationState(provenance, "verificationState", frontmatter.verificationState);
+  assignPolicyClass(provenance, "policyClass", frontmatter.policyClass);
+  assignString(provenance, "sourceMemoryId", frontmatter.sourceMemoryId);
+  assignString(provenance, "sourceTurnId", frontmatter.sourceTurnId);
+  assignString(provenance, "validAt", frontmatter.valid_at);
+  assignString(provenance, "invalidAt", frontmatter.invalid_at);
+  assignString(provenance, "forgottenAt", frontmatter.forgottenAt);
+  assignString(provenance, "forgottenReason", frontmatter.forgottenReason);
+  if (Array.isArray(frontmatter.derived_from) && frontmatter.derived_from.length > 0) {
+    provenance.derivedFrom = stringList(frontmatter.derived_from);
+  }
+  if (frontmatter.derived_via !== undefined) {
+    provenance.derivedVia = frontmatter.derived_via;
+  }
+
+  return provenance;
+}
+
+export function normalizeRetrievedMemoryProvenance(
+  value: unknown,
+): RetrievedMemoryProvenance | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  const source = nonEmptyString(raw.source) ?? "unknown";
+  const scope = nonEmptyString(raw.scope) ?? "unknown";
+  const retrievalReason = nonEmptyString(raw.retrievalReason) ?? "retrieved";
+  let safety = isRetrievedMemorySafety(raw.safety)
+    ? raw.safety
+    : raw.safeToUse === false
+      ? "requires-review"
+      : "safe";
+  if (raw.safeToUse === false && safety === "safe") {
+    safety = "requires-review";
+  }
+  const correctionState = isRetrievedMemoryCorrectionState(raw.correctionState)
+    ? raw.correctionState
+    : raw.corrected === true
+      ? "correction"
+      : "none";
+  const safetyReasons = stringList(raw.safetyReasons);
+  const provenance: RetrievedMemoryProvenance = {
+    source,
+    scope,
+    userContextScopes: normalizeScopeList(raw.userContextScopes),
+    retrievalReason,
+    confidence: clamp01(raw.confidence),
+    stale: raw.stale === true,
+    corrected: raw.corrected === true || correctionState !== "none",
+    correctionState,
+    safeToUse: safety === "safe",
+    safety,
+    safetyReasons,
+  };
+
+  assignString(provenance, "created", raw.created);
+  assignString(provenance, "updated", raw.updated);
+  assignString(provenance, "namespace", raw.namespace);
+  assignStatus(provenance, "status", raw.status);
+  assignLifecycleState(provenance, "lifecycleState", raw.lifecycleState);
+  assignVerificationState(provenance, "verificationState", raw.verificationState);
+  assignPolicyClass(provenance, "policyClass", raw.policyClass);
+  assignString(provenance, "sourceMemoryId", raw.sourceMemoryId);
+  assignString(provenance, "sourceTurnId", raw.sourceTurnId);
+  assignString(provenance, "validAt", raw.validAt);
+  assignString(provenance, "invalidAt", raw.invalidAt);
+  assignString(provenance, "forgottenAt", raw.forgottenAt);
+  assignString(provenance, "forgottenReason", raw.forgottenReason);
+  const derivedFrom = stringList(raw.derivedFrom);
+  if (derivedFrom.length > 0) provenance.derivedFrom = derivedFrom;
+  if (
+    raw.derivedVia === "split" ||
+    raw.derivedVia === "merge" ||
+    raw.derivedVia === "update" ||
+    raw.derivedVia === "pattern-reinforcement"
+  ) {
+    provenance.derivedVia = raw.derivedVia;
+  }
+  return provenance;
+}
+
+export function summarizeRetrievedMemoryProvenance(
+  provenance: RetrievedMemoryProvenance,
+): string {
+  return [
+    `source=${provenance.source}`,
+    `created=${provenance.created ?? "unknown"}`,
+    `scope=${provenance.scope}`,
+    `confidence=${provenance.confidence.toFixed(2)}`,
+    `stale=${provenance.stale ? "true" : "false"}`,
+    `corrected=${provenance.corrected ? provenance.correctionState : "false"}`,
+    `safe=${provenance.safeToUse ? "true" : "false"}`,
+  ].join(" ");
+}
+
+function inferUserContextScopes(frontmatter: MemoryFrontmatter): UserContextScope[] {
+  const scoped = frontmatter as MemoryFrontmatter & {
+    userContextScopes?: readonly unknown[];
+  };
+  return normalizeScopeList([
+    ...(Array.isArray(scoped.userContextScopes) ? scoped.userContextScopes : []),
+    ...(Array.isArray(frontmatter.tags) ? frontmatter.tags : []),
+  ]);
+}
+
+function normalizeScopeList(values: unknown): UserContextScope[] {
+  const input = Array.isArray(values) ? values : [];
+  const seen = new Set<UserContextScope>();
+  const normalized: UserContextScope[] = [];
+  for (const value of input) {
+    const scope = normalizeUserContextScope(value);
+    if (!scope || seen.has(scope)) continue;
+    seen.add(scope);
+    normalized.push(scope);
+  }
+  return normalized;
+}
+
+function isStale(frontmatter: MemoryFrontmatter, nowMs: number): boolean {
+  if (
+    frontmatter.status === "superseded" ||
+    frontmatter.status === "archived" ||
+    frontmatter.status === "forgotten"
+  ) {
+    return true;
+  }
+  if (
+    frontmatter.lifecycleState === "stale" ||
+    frontmatter.lifecycleState === "archived"
+  ) {
+    return true;
+  }
+  const expiresAtMs = parseEpochMs(frontmatter.expiresAt);
+  if (expiresAtMs !== null && expiresAtMs <= nowMs) return true;
+  const invalidAtMs = parseEpochMs(frontmatter.invalid_at);
+  if (invalidAtMs !== null && invalidAtMs <= nowMs) return true;
+  return false;
+}
+
+function inferCorrectionState(
+  frontmatter: MemoryFrontmatter,
+): RetrievedMemoryCorrectionState {
+  if (frontmatter.status === "forgotten") return "forgotten";
+  if (
+    frontmatter.status === "superseded" ||
+    frontmatter.supersededBy ||
+    frontmatter.supersededAt
+  ) {
+    return "superseded";
+  }
+  if (frontmatter.verificationState === "disputed") return "disputed";
+  if (frontmatter.category === "correction" || frontmatter.supersedes) {
+    return "correction";
+  }
+  return "none";
+}
+
+function inferSafetyReasons(input: {
+  frontmatter: MemoryFrontmatter;
+  stale: boolean;
+  userContextScopes: UserContextScope[];
+  currentContextScopes: UserContextScope[];
+}): string[] {
+  const reasons: string[] = [];
+  const { frontmatter, stale, userContextScopes, currentContextScopes } = input;
+  if (frontmatter.status === "forgotten") reasons.push("status=forgotten");
+  if (frontmatter.status === "rejected") reasons.push("status=rejected");
+  if (frontmatter.status === "quarantined") reasons.push("status=quarantined");
+  if (frontmatter.status === "pending_review") reasons.push("status=pending_review");
+  if (frontmatter.status === "superseded") reasons.push("status=superseded");
+  if (frontmatter.status === "archived") reasons.push("status=archived");
+  if (frontmatter.verificationState === "disputed") {
+    reasons.push("verification=disputed");
+  }
+  if (stale) reasons.push("stale=true");
+
+  const boundaryScopes = userContextScopes.filter(isUserBoundaryScope);
+  if (boundaryScopes.length > 0) {
+    const current = new Set(currentContextScopes);
+    const hasMatchingBoundary = boundaryScopes.some((scope) => current.has(scope));
+    if (!hasMatchingBoundary) {
+      const joined = boundaryScopes.join(",");
+      if (boundaryScopes.includes("do-not-use-outside-this-context")) {
+        reasons.push(`boundary-blocked=${joined}`);
+      } else {
+        reasons.push(`boundary-review=${joined}`);
+      }
+    }
+  }
+  return uniqueStrings(reasons);
+}
+
+function inferSafety(reasons: readonly string[]): RetrievedMemorySafety {
+  if (
+    reasons.some((reason) =>
+      reason === "status=forgotten" ||
+      reason === "status=rejected" ||
+      reason === "status=quarantined" ||
+      reason.startsWith("boundary-blocked="),
+    )
+  ) {
+    return "blocked";
+  }
+  return reasons.length > 0 ? "requires-review" : "safe";
+}
+
+function safeNow(now: (() => number) | undefined): number {
+  const value = now ? now() : Date.now();
+  return Number.isFinite(value) ? value : Date.now();
+}
+
+function parseEpochMs(value: unknown): number | null {
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function clamp01(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return uniqueStrings(
+    value
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0),
+  );
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+type RetrievedMemoryProvenanceStringField =
+  | "created"
+  | "updated"
+  | "namespace"
+  | "sourceMemoryId"
+  | "sourceTurnId"
+  | "validAt"
+  | "invalidAt"
+  | "forgottenAt"
+  | "forgottenReason";
+
+function assignString(
+  target: RetrievedMemoryProvenance,
+  key: RetrievedMemoryProvenanceStringField,
+  value: unknown,
+): void {
+  const normalized = nonEmptyString(value);
+  if (normalized !== undefined) {
+    target[key] = normalized;
+  }
+}
+
+function assignStatus(
+  target: RetrievedMemoryProvenance,
+  key: "status",
+  value: unknown,
+): void {
+  if (isMemoryStatus(value)) target[key] = value;
+}
+
+function assignLifecycleState(
+  target: RetrievedMemoryProvenance,
+  key: "lifecycleState",
+  value: unknown,
+): void {
+  if (isLifecycleState(value)) target[key] = value;
+}
+
+function assignVerificationState(
+  target: RetrievedMemoryProvenance,
+  key: "verificationState",
+  value: unknown,
+): void {
+  if (isVerificationState(value)) target[key] = value;
+}
+
+function assignPolicyClass(
+  target: RetrievedMemoryProvenance,
+  key: "policyClass",
+  value: unknown,
+): void {
+  if (isPolicyClass(value)) target[key] = value;
+}
+
+function isMemoryStatus(value: unknown): value is MemoryStatus {
+  return typeof value === "string" && MEMORY_STATUS_VALUES.includes(value as MemoryStatus);
+}
+
+function isLifecycleState(value: unknown): value is LifecycleState {
+  return typeof value === "string" && LIFECYCLE_STATE_VALUES.includes(value as LifecycleState);
+}
+
+function isVerificationState(value: unknown): value is VerificationState {
+  return typeof value === "string" && VERIFICATION_STATE_VALUES.includes(value as VerificationState);
+}
+
+function isPolicyClass(value: unknown): value is PolicyClass {
+  return typeof value === "string" && POLICY_CLASS_VALUES.includes(value as PolicyClass);
+}
+
+function isRetrievedMemorySafety(value: unknown): value is RetrievedMemorySafety {
+  return typeof value === "string" && SAFETY_VALUES.includes(value as RetrievedMemorySafety);
+}
+
+function isRetrievedMemoryCorrectionState(
+  value: unknown,
+): value is RetrievedMemoryCorrectionState {
+  return typeof value === "string" && CORRECTION_STATE_VALUES.includes(value as RetrievedMemoryCorrectionState);
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -132,6 +132,7 @@ import {
   type RecallXraySnapshot,
   type RecallXrayServedBy,
 } from "./recall-xray.js";
+import { buildRetrievedMemoryProvenance } from "./memory-provenance.js";
 import {
   recordEvalShadowRecall,
   type EvalShadowRecallRecord,
@@ -6072,6 +6073,7 @@ export class Orchestrator {
     // per-result explain data (e.g. reinforcementBoost) from the result that
     // was actually served.
     let xrayRecalledResults: QmdSearchResult[] = [];
+    const xrayMemoryByPath = new Map<string, MemoryFile>();
     const lcmStructuredXrayResults: RecallXrayResult[] = [];
     // Per-branch pre-limit candidate pool size for the X-ray filter
     // trace (issue #570 PR 1).  `recalledMemoryCount` is assigned
@@ -8826,7 +8828,7 @@ export class Orchestrator {
         recallNamespaces,
         retrievalQuery,
         undefined,
-        { asOfMs },
+        { asOfMs, xrayMemoryByPath },
       );
 
       // Optional LLM reranking (default off). Fail-open if rerank fails/slow.
@@ -9029,7 +9031,7 @@ export class Orchestrator {
           recallNamespaces,
           retrievalQuery,
           undefined,
-          { asOfMs },
+          { asOfMs, xrayMemoryByPath },
         );
         // MMR runs on the pre-truncation pool so diverse candidates just
         // below the cutoff can be promoted into the injected set.
@@ -9079,6 +9081,7 @@ export class Orchestrator {
             queryAwarePrefilter,
             abortSignal: options.abortSignal,
             xrayPoolSizeSink: xrayColdPoolSink,
+            xrayMemoryByPath,
             asOfMs,
             ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
@@ -9174,7 +9177,7 @@ export class Orchestrator {
         recallNamespaces,
         retrievalQuery,
         undefined,
-        { asOfMs },
+        { asOfMs, xrayMemoryByPath },
       );
       // MMR runs on the pre-truncation pool so diverse candidates just
       // below the cutoff can be promoted into the injected set.
@@ -9289,6 +9292,7 @@ export class Orchestrator {
               queryAwarePrefilter,
               abortSignal: options.abortSignal,
               xrayPoolSizeSink: xrayColdPoolSink,
+              xrayMemoryByPath,
               asOfMs,
               ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
             });
@@ -9339,7 +9343,7 @@ export class Orchestrator {
                 recallNamespaces,
                 retrievalQuery,
                 preloadedMap,
-                { asOfMs },
+                { asOfMs, xrayMemoryByPath },
               )
             ).sort((a, b) => b.score - a.score);
             // MMR runs on the pre-truncation pool so diverse candidates just
@@ -9391,6 +9395,7 @@ export class Orchestrator {
                 queryAwarePrefilter,
                 abortSignal: options.abortSignal,
                 xrayPoolSizeSink: xrayColdPoolSink,
+                xrayMemoryByPath,
                 asOfMs,
                 ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
               });
@@ -9434,6 +9439,7 @@ export class Orchestrator {
             queryAwarePrefilter,
             abortSignal: options.abortSignal,
             xrayPoolSizeSink: xrayColdPoolSink,
+            xrayMemoryByPath,
             asOfMs,
             ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
@@ -9687,6 +9693,7 @@ export class Orchestrator {
           const derivedId = idFromPath(recalledPath);
           if (!derivedId) continue;
           const xrayResult = xrayResultByPath.get(recalledPath);
+          const memory = xrayMemoryByPath.get(recalledPath);
           const scoreDecomposition: RecallXrayScoreDecomposition = {
             final: xrayResult?.score ?? 0,
           };
@@ -9697,13 +9704,20 @@ export class Orchestrator {
             scoreDecomposition.reinforcementBoost =
               xrayResult.explain.reinforcementBoost;
           }
-          results.push({
+          const result: RecallXrayResult = {
             memoryId: derivedId,
             path: recalledPath,
             servedBy,
             scoreDecomposition,
             admittedBy: [],
-          });
+          };
+          if (memory) {
+            result.provenance = buildRetrievedMemoryProvenance(memory, {
+              namespace: this.namespaceFromPath(recalledPath),
+              retrievalReason: `served-by=${servedBy}`,
+            });
+          }
+          results.push(result);
         }
         // `considered` must reflect the pool size of the branch that
         // actually produced the admitted results, NOT the max across
@@ -15080,6 +15094,11 @@ export class Orchestrator {
      * Unset by default so existing call sites are unaffected.
      */
     xrayPoolSizeSink?: { size: number };
+    /**
+     * Optional out-parameter that receives memory frontmatter loaded during
+     * ranking so X-ray capture can attach provenance without a second read.
+     */
+    xrayMemoryByPath?: Map<string, MemoryFile>;
     /** Issue #681 — when true, bypass graphTraversalConfidenceFloor. */
     includeLowConfidence?: boolean;
   }): Promise<QmdSearchResult[]> {
@@ -15171,7 +15190,11 @@ export class Orchestrator {
       options.recallNamespaces,
       options.prompt,
       undefined,
-      { allowLifecycleFiltered: true, asOfMs: options.asOfMs },
+      {
+        allowLifecycleFiltered: true,
+        asOfMs: options.asOfMs,
+        xrayMemoryByPath: options.xrayMemoryByPath,
+      },
     );
 
     if (this.config.rerankEnabled && this.config.rerankProvider === "local") {
@@ -15332,6 +15355,7 @@ export class Orchestrator {
     options?: {
       allowLifecycleFiltered?: boolean;
       allowDedicatedSurface?: boolean;
+      xrayMemoryByPath?: Map<string, MemoryFile>;
       /**
        * Historical recall point in ms-since-epoch (issue #680).  When
        * set, drops candidates that were not authoritative at this
@@ -15414,6 +15438,14 @@ export class Orchestrator {
     let forgottenFilteredCount = 0;
     const boosted: QmdSearchResult[] = [];
     const recencyWeight = this.effectiveRecencyWeight();
+    const rememberXrayMemory = (
+      memory: MemoryFile | undefined,
+      candidatePath: string | undefined,
+    ): void => {
+      if (memory && candidatePath) {
+        options?.xrayMemoryByPath?.set(candidatePath, memory);
+      }
+    };
     for (const r of results) {
       const memory = memoryByPath.get(r.path);
       let score = r.score;
@@ -15613,6 +15645,7 @@ export class Orchestrator {
           score += reinforcementBoost;
         }
         if (reinforcementBoost > 0) {
+          rememberXrayMemory(memory, r.path);
           boosted.push({
             ...r,
             score,
@@ -15622,6 +15655,7 @@ export class Orchestrator {
         }
       }
 
+      rememberXrayMemory(memory, r.path);
       boosted.push({ ...r, score });
     }
     if (lifecycleFilteredCount > 0) {

--- a/packages/remnic-core/src/recall-xray-renderer.test.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.test.ts
@@ -345,6 +345,86 @@ test("renderXray formats scores deterministically to 4 decimals", () => {
   assert.ok(out.includes("final=0.1235 vector=0.0000"));
 });
 
+test("renderXrayText surfaces provenance and safety context", () => {
+  const snap: RecallXraySnapshot = {
+    ...minimalSnapshot(),
+    results: [
+      {
+        memoryId: "mem-provenance",
+        path: "facts/provenance.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.88 },
+        admittedBy: [],
+        provenance: {
+          source: "conversation",
+          created: "2026-04-20T00:00:00.000Z",
+          namespace: "default",
+          scope: "namespace:default",
+          userContextScopes: ["repo", "private"],
+          retrievalReason: "served-by=hybrid",
+          confidence: 0.9,
+          stale: true,
+          corrected: true,
+          correctionState: "disputed",
+          safeToUse: false,
+          safety: "requires-review",
+          safetyReasons: ["stale=true", "verification=disputed"],
+        },
+      },
+    ],
+  };
+
+  const out = renderXrayText(snap);
+  assert.ok(
+    out.includes(
+      "provenance: source=conversation created=2026-04-20T00:00:00.000Z scope=namespace:default confidence=0.90 stale=true corrected=disputed safe=false",
+    ),
+  );
+  assert.ok(out.includes("retrieval-reason: served-by=hybrid"));
+  assert.ok(out.includes("context-scopes: repo, private"));
+  assert.ok(out.includes("safety: requires-review (stale=true, verification=disputed)"));
+});
+
+test("renderXrayMarkdown surfaces provenance and safety context", () => {
+  const snap: RecallXraySnapshot = {
+    ...minimalSnapshot(),
+    results: [
+      {
+        memoryId: "mem-provenance",
+        path: "facts/provenance.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.88 },
+        admittedBy: [],
+        provenance: {
+          source: "conversation",
+          created: "2026-04-20T00:00:00.000Z",
+          namespace: "default",
+          scope: "namespace:default",
+          userContextScopes: ["repo"],
+          retrievalReason: "served-by=hybrid",
+          confidence: 0.9,
+          stale: false,
+          corrected: false,
+          correctionState: "none",
+          safeToUse: true,
+          safety: "safe",
+          safetyReasons: [],
+        },
+      },
+    ],
+  };
+
+  const out = renderXrayMarkdown(snap);
+  assert.ok(
+    out.includes(
+      "**Provenance:** source=conversation created=2026-04-20T00:00:00.000Z scope=namespace:default confidence=0.90 stale=false corrected=false safe=true",
+    ),
+  );
+  assert.ok(out.includes("**Retrieval reason:** `served-by=hybrid`"));
+  assert.ok(out.includes("**Context scopes:** `repo`"));
+  assert.ok(!out.includes("**Safety:**"));
+});
+
 test("renderXray formats non-finite capturedAt as (unknown)", () => {
   const snap: RecallXraySnapshot = {
     ...minimalSnapshot(),

--- a/packages/remnic-core/src/recall-xray-renderer.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.ts
@@ -24,6 +24,7 @@ import type {
 } from "./recall-xray.js";
 import { summarizeDisclosureTokens } from "./recall-xray.js";
 import { renderTierExplainTextLines } from "./recall-explain-renderer.js";
+import { summarizeRetrievedMemoryProvenance } from "./memory-provenance.js";
 
 export type RecallXrayFormat = "json" | "text" | "markdown";
 
@@ -152,6 +153,27 @@ function renderResultTextLines(
   lines.push(`[${rank}] ${result.memoryId} — ${servedByLabel(result.servedBy)}`);
   if (result.path) lines.push(`    path: ${result.path}`);
   lines.push(`    score: ${renderScoreDecomposition(result)}`);
+  if (result.provenance) {
+    lines.push(
+      `    provenance: ${summarizeRetrievedMemoryProvenance(result.provenance)}`,
+    );
+    lines.push(`    retrieval-reason: ${result.provenance.retrievalReason}`);
+    if (result.provenance.userContextScopes.length > 0) {
+      lines.push(
+        `    context-scopes: ${result.provenance.userContextScopes.join(", ")}`,
+      );
+    }
+    if (
+      result.provenance.safety !== "safe" ||
+      result.provenance.safetyReasons.length > 0
+    ) {
+      const reasonSuffix =
+        result.provenance.safetyReasons.length > 0
+          ? ` (${result.provenance.safetyReasons.join(", ")})`
+          : "";
+      lines.push(`    safety: ${result.provenance.safety}${reasonSuffix}`);
+    }
+  }
   if (result.admittedBy.length > 0) {
     lines.push(`    admitted-by: ${result.admittedBy.join(", ")}`);
   }
@@ -325,6 +347,33 @@ function renderResultMarkdownLines(
     lines.push("");
   }
   lines.push(`- **Score:** ${renderScoreDecomposition(result)}`);
+  if (result.provenance) {
+    lines.push(
+      `- **Provenance:** ${mdEscape(summarizeRetrievedMemoryProvenance(result.provenance))}`,
+    );
+    lines.push(
+      `- **Retrieval reason:** ${mdInlineCode(result.provenance.retrievalReason)}`,
+    );
+    if (result.provenance.userContextScopes.length > 0) {
+      lines.push(
+        `- **Context scopes:** ${result.provenance.userContextScopes
+          .map(mdInlineCode)
+          .join(", ")}`,
+      );
+    }
+    if (
+      result.provenance.safety !== "safe" ||
+      result.provenance.safetyReasons.length > 0
+    ) {
+      const reasonSuffix =
+        result.provenance.safetyReasons.length > 0
+          ? ` (${result.provenance.safetyReasons.map(mdInlineCode).join(", ")})`
+          : "";
+      lines.push(
+        `- **Safety:** ${mdInlineCode(result.provenance.safety)}${reasonSuffix}`,
+      );
+    }
+  }
   if (result.admittedBy.length > 0) {
     lines.push(
       `- **Admitted by:** ${result.admittedBy.map(mdInlineCode).join(", ")}`,

--- a/packages/remnic-core/src/recall-xray.test.ts
+++ b/packages/remnic-core/src/recall-xray.test.ts
@@ -308,6 +308,54 @@ test("buildXraySnapshot rejects results with an unknown servedBy tier", () => {
   );
 });
 
+test("buildXraySnapshot normalizes per-result provenance", () => {
+  const result: RecallXrayResult = {
+    memoryId: "mem-provenance",
+    path: "/notes/provenance.md",
+    servedBy: "hybrid",
+    admittedBy: [],
+    scoreDecomposition: { final: 0.7 },
+    provenance: {
+      source: "conversation",
+      created: "2026-04-20T00:00:00.000Z",
+      namespace: "default",
+      scope: "namespace:default",
+      userContextScopes: ["repo", "private"],
+      retrievalReason: "served-by=hybrid",
+      confidence: 2,
+      stale: true,
+      corrected: false,
+      correctionState: "superseded",
+      safeToUse: false,
+      safety: "requires-review",
+      safetyReasons: ["stale=true", ""],
+    },
+  };
+
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+
+  assert.deepEqual(snapshot.results[0]?.provenance, {
+    source: "conversation",
+    created: "2026-04-20T00:00:00.000Z",
+    namespace: "default",
+    scope: "namespace:default",
+    userContextScopes: ["repo", "private"],
+    retrievalReason: "served-by=hybrid",
+    confidence: 1,
+    stale: true,
+    corrected: true,
+    correctionState: "superseded",
+    safeToUse: false,
+    safety: "requires-review",
+    safetyReasons: ["stale=true"],
+  });
+});
+
 // ─── Budget accounting ────────────────────────────────────────────────────
 
 test("buildXraySnapshot clamps negative / non-finite budgets to zero", () => {

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -19,6 +19,10 @@
 
 import { randomUUID } from "node:crypto";
 
+import {
+  normalizeRetrievedMemoryProvenance,
+  type RetrievedMemoryProvenance,
+} from "./memory-provenance.js";
 import type { RecallDisclosure, RecallTierExplain } from "./types.js";
 import { isRecallDisclosure } from "./types.js";
 
@@ -162,6 +166,11 @@ export interface RecallXrayResult {
    * could not be read.
    */
   tags?: string[];
+  /**
+   * Per-result memory provenance and safety context. Populated by recall
+   * capture when the memory frontmatter was already loaded by retrieval.
+   */
+  provenance?: RetrievedMemoryProvenance;
 }
 
 /**
@@ -508,6 +517,10 @@ function cloneResult(result: RecallXrayResult): RecallXrayResult {
     if (cleanedTags.length > 0) {
       out.tags = cleanedTags;
     }
+  }
+  const provenance = normalizeRetrievedMemoryProvenance(result.provenance);
+  if (provenance !== undefined) {
+    out.provenance = provenance;
   }
   return out;
 }

--- a/tests/recall-xray-capture.test.ts
+++ b/tests/recall-xray-capture.test.ts
@@ -197,3 +197,42 @@ test("recall without xrayCapture does not overwrite a prior captured snapshot", 
   assert.ok(stillCaptured);
   assert.equal(stillCaptured.query, "first");
 });
+
+test("recall X-ray attaches provenance for surfaced memory results", async () => {
+  const orchestrator = await makeOrchestrator("engram-xray-provenance-");
+  (orchestrator as any).initPromise = null;
+
+  await (orchestrator as any).storage.writeMemory(
+    "fact",
+    "The recall cache TTL is twenty minutes.",
+    {
+      source: "test",
+      confidence: 0.92,
+      tags: ["repo", "private"],
+    },
+  );
+
+  await orchestrator.recall(
+    "recall cache TTL",
+    "agent:test:xray-provenance",
+    { xrayCapture: true, mode: "full" },
+  );
+
+  const snapshot = orchestrator.getLastXraySnapshot();
+  assert.ok(snapshot);
+  assert.equal(snapshot.results.length, 1);
+  const result = snapshot.results[0]!;
+  assert.equal(result.servedBy, "recent-scan");
+  const provenance = result.provenance;
+  assert.ok(provenance, "surfaced memory should carry provenance");
+  assert.equal(provenance.source, "test");
+  assert.equal(provenance.scope, "namespace:default");
+  assert.deepEqual(provenance.userContextScopes, ["repo", "private"]);
+  assert.equal(provenance.retrievalReason, "served-by=recent-scan");
+  assert.equal(provenance.confidence, 0.92);
+  assert.equal(provenance.stale, false);
+  assert.equal(provenance.corrected, false);
+  assert.equal(provenance.safeToUse, false);
+  assert.equal(provenance.safety, "requires-review");
+  assert.ok(provenance.safetyReasons.includes("boundary-review=private"));
+});


### PR DESCRIPTION
## Summary
- add a host-agnostic RetrievedMemoryProvenance contract for source, scope, stale/correction state, and safety decisions
- attach provenance to Recall X-ray results without adding capture-time storage reads
- document X-ray/user-aware provenance and add focused + integration coverage

## Verification
- pnpm exec tsx --test tests/recall-xray-capture.test.ts packages/remnic-core/src/memory-provenance.test.ts packages/remnic-core/src/recall-xray.test.ts packages/remnic-core/src/recall-xray-renderer.test.ts
- npm run test:entity-hardening
- gtimeout 900 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core recall/X-ray capture plumbing and adds new safety classification logic; errors could mislabel or omit provenance and change X-ray output expectations, though recall behavior is intended to remain unchanged when `xrayCapture` is off.
> 
> **Overview**
> **Recall X-ray results now optionally include per-memory provenance and safety context.** A new `RetrievedMemoryProvenance` contract (source/timestamps/scope, inferred user context scopes, stale/correction state, and `safe`/`requires-review`/`blocked` classification) is added to `@remnic/core` and exported publicly.
> 
> The orchestrator is updated to capture enough frontmatter during ranking (via an `xrayMemoryByPath` out-parameter) so X-ray capture can attach provenance to each admitted result **without extra storage reads**, and the X-ray snapshot builder normalizes/defensively clamps malformed provenance fields.
> 
> Text/markdown X-ray renderers are extended to display provenance, retrieval reason, context scopes, and safety reasons when present, with new unit + integration tests and accompanying docs updates (`xray.md`, `user-aware-agents.md`, admin console notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d929fb6c6e1cc49732f0f059dc995c9d1b9c5eac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->