### PR TITLE
feat(core): add action confidence advisory

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -294,7 +294,7 @@ The HTTP server also exposes an MCP JSON-RPC endpoint at `POST /mcp`, allowing r
 openclaw engram access http-serve --host 0.0.0.0 --port 4318 --token "$TOKEN"
 ```
 
-Clients send standard MCP JSON-RPC requests to `http://<host>:4318/mcp` with an `Authorization: Bearer <token>` header. All 10 MCP tools are available. Write operations (`engram.memory_store`, `engram.suggestion_submit`, `engram.observe`) are rate-limited consistently with the REST write endpoints — dry runs and idempotency replays do not count toward the limit.
+Clients send standard MCP JSON-RPC requests to `http://<host>:4318/mcp` with an `Authorization: Bearer <token>` header. Advertised MCP tools include both canonical `remnic.*` names and legacy `engram.*` aliases where supported. Write operations (`engram.memory_store`, `engram.suggestion_submit`, `engram.observe`) are rate-limited consistently with the REST write endpoints - dry runs and idempotency replays do not count toward the limit.
 
 **Namespace-enabled deployments:** If you have `namespacesEnabled: true`, pass `--principal <name>` to set the authenticated principal for all MCP connections. The principal must appear in `writePrincipals` for the target namespace. Without `--principal`, the principal resolves to `"default"`, which may not have write access:
 
@@ -429,6 +429,29 @@ Record a memory-action telemetry event with optional safe dry-run mode.
 
 ---
 
+### `action_confidence`
+
+Return a read-only interruption-budgeting decision: `ask`, `draft`, `act`,
+`refuse`, or `escalate`.
+
+**HTTP:** `POST /remnic/v1/action-confidence` or
+`POST /engram/v1/action-confidence`
+
+**MCP:** `remnic.action_confidence` or `engram.action_confidence`
+
+**Parameters:**
+- `confidence` (number, optional) - Overall confidence score 0-1.
+- `risk` (string, optional) - One of: `low`, `medium`, `high`, `irreversible`, `restricted`.
+- `contextReadiness` (string, optional) - One of: `none`, `partial`, `sufficient`.
+- `retrievedMemories` (array, optional) - Provenance/safety summaries for recalled memories.
+- `currentContextScopes` (array, optional) - Current user-context scopes.
+- `userRules` (array, optional) - Matched `ask-before`, `do-not-use-outside-this-context`, `never`, or `requires-escalation` rules.
+
+**Returns:** The decision, confidence, blockers, reasons, factor breakdown, and
+`attentionPolicy: "interruption_budgeting"`.
+
+---
+
 ### `identity_anchor_get`
 
 Read the identity continuity anchor document used for recovery-safe identity context.
@@ -539,6 +562,7 @@ Run via `openclaw engram <command>`:
 | `continuity incident-open --symptom <text> [--trigger-window <text>] [--suspected-cause <text>]` | Open a continuity incident |
 | `continuity incident-close --id <id> --fix-applied <text> --verification-result <text> [--preventive-rule <text>]` | Close a continuity incident |
 | `action-audit [--namespace <name>] [--limit N]` | Show namespace-aware memory action outcomes and policy decisions |
+| `action-confidence [--confidence N] [--risk low\|medium\|high\|irreversible\|restricted] [--context none\|partial\|sufficient]` | Evaluate ask/draft/act/refuse/escalate advisory policy |
 | `trust-zone-status` | Show trust-zone store status and aggregate counts |
 | `trust-zone-promote --record-id <id> --target-zone <zone> --reason <text> [--dry-run]` | Preview or apply a trust-zone promotion |
 | `trust-zone-demo-seed [--scenario enterprise-buyer-v1] [--recorded-at <iso>] [--dry-run]` | Explicitly preview or seed the opt-in trust-zone buyer demo dataset |

--- a/docs/user-aware-agents.md
+++ b/docs/user-aware-agents.md
@@ -76,6 +76,33 @@ and out-of-context `do-not-use-outside-this-context` memories are marked
 temporary memories are marked `requires-review` unless the current context
 matches the boundary.
 
+## Action Confidence
+
+`@remnic/core` exports an `evaluateActionConfidence` helper for read-only
+ask-versus-act decisions. It returns one of:
+
+- `ask`
+- `draft`
+- `act`
+- `refuse`
+- `escalate`
+
+The helper is an advisory interruption-budgeting surface, not an executor. It
+uses confidence, provenance strength, scope match, staleness, correction
+history, user rules, context readiness, and action risk to decide whether an
+agent has enough context to proceed.
+
+Public line:
+
+> A good agent should spend the user's attention carefully.
+
+The helper is exposed as:
+
+- core: `evaluateActionConfidence(input)`
+- HTTP: `POST /remnic/v1/action-confidence`
+- MCP: `remnic.action_confidence` and legacy `engram.action_confidence`
+- CLI: `remnic action-confidence`
+
 ## Core Exports
 
 `@remnic/core` exports:
@@ -91,6 +118,8 @@ matches the boundary.
 - `buildRetrievedMemoryProvenance`
 - `normalizeRetrievedMemoryProvenance`
 - `summarizeRetrievedMemoryProvenance`
+- `evaluateActionConfidence`
+- `renderActionConfidenceText`
 
 This contract is intentionally host-agnostic. OpenClaw, Hermes, Codex, MCP, and
 future adapters should consume the core model rather than defining their own

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -122,6 +122,9 @@ import {
   formatProcedureStatsText,
   parseXrayCliOptions,
   renderXray,
+  buildActionConfidenceInputFromOptions,
+  evaluateActionConfidence,
+  renderActionConfidenceText,
   expandTildePath,
   // capsule fork — issue #676 PR 4/6
   forkCapsule,
@@ -134,7 +137,12 @@ import { loadWecloneExportModule } from "./optional-weclone-export.js";
 import type {
   BinaryLifecycleConfig,
 } from "@remnic/core";
-import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
+import type {
+  ActionConfidenceInput,
+  MemoryCategory,
+  Taxonomy,
+  TaxonomyCategory,
+} from "@remnic/core";
 // @remnic/bench is an optional install surface. Import types only at the
 // top level (erased at compile time); runtime access goes through
 // loadBenchModule() / tryLoadBenchModule() so the CLI stays functional for
@@ -237,6 +245,7 @@ type CommandName =
   | "training:export"
   | "import"
   | "import-lossless-claw"
+  | "action-confidence"
   | "xray"
   | "capsule";
 
@@ -3465,6 +3474,82 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
     // maintenance; the daemon/gateway process performs full warmup instead.
     orchestrator.abortDeferredInit();
   }
+}
+
+// ── Action confidence ──────────────────────────────────────────────────────
+
+function parseActionConfidenceRest(rest: string[]): {
+  input: ActionConfidenceInput;
+  json: boolean;
+} {
+  const valueFlags = new Set([
+    "--action",
+    "--confidence",
+    "--risk",
+    "--context",
+    "--rule",
+    "--current-scope",
+    "--memory-scope",
+  ]);
+  const booleanFlags = new Set(["--json", "--stale", "--corrected", "--unsafe"]);
+  const options: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+
+  for (let i = 0; i < rest.length; i++) {
+    const token = rest[i];
+    if (!token.startsWith("--")) {
+      positional.push(token);
+      continue;
+    }
+    if (booleanFlags.has(token)) {
+      options[token.slice(2)] = true;
+      continue;
+    }
+    if (!valueFlags.has(token)) {
+      throw new Error(
+        `Unknown flag ${JSON.stringify(token)}. Supported flags: --action, --confidence, --risk, --context, --rule, --current-scope, --memory-scope, --stale, --corrected, --unsafe, --json.`,
+      );
+    }
+    const next = rest[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      throw new Error(`${token} requires a value.`);
+    }
+    options[token.slice(2)] = next;
+    i++;
+  }
+
+  const intendedAction =
+    typeof options.action === "string"
+      ? options.action
+      : positional.length > 0
+        ? positional.join(" ")
+        : undefined;
+
+  const input = buildActionConfidenceInputFromOptions({
+    action: intendedAction,
+    confidence: options.confidence,
+    risk: options.risk,
+    context: options.context,
+    rule: options.rule,
+    currentScope: options["current-scope"],
+    memoryScope: options["memory-scope"],
+    stale: options.stale,
+    corrected: options.corrected,
+    unsafe: options.unsafe,
+  });
+  return { input, json: options.json === true };
+}
+
+async function cmdActionConfidence(rest: string[]): Promise<void> {
+  let parsed: ReturnType<typeof parseActionConfidenceRest>;
+  try {
+    parsed = parseActionConfidenceRest(rest);
+  } catch (err) {
+    console.error(`action-confidence: ${(err as Error).message}`);
+    process.exit(1);
+  }
+  const result = evaluateActionConfidence(parsed.input);
+  console.log(parsed.json ? JSON.stringify(result, null, 2) : renderActionConfidenceText(result));
 }
 
 // ── Recall X-ray (issue #570) ──────────────────────────────────────────────
@@ -7617,6 +7702,10 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
       await cmdQuery(queryText, json, explain);
       break;
     }
+
+    case "action-confidence":
+      await cmdActionConfidence(rest);
+      break;
 
     case "xray":
       // `remnic xray "<query>"` — recall with X-ray capture and print

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -588,6 +588,15 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    if (
+      req.method === "POST" &&
+      (pathname === "/engram/v1/action-confidence" || pathname === "/remnic/v1/action-confidence")
+    ) {
+      const body = await this.readValidatedBody(req, "actionConfidence");
+      this.respondJson(res, 200, await this.service.actionConfidence(body));
+      return;
+    }
+
     // Tier-explain (issue #518): structured per-result annotation from
     // the direct-answer retrieval tier.  Orthogonal to /recall/explain
     // above, which returns a graph-path explanation document.

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import { EngramAccessInputError, type EngramAccessService, type EngramAccessRecallResponse } from "./access-service.js";
 import {
   validateRequest,
+  type ActionConfidenceRequest,
   type CapsuleExportRequest,
   type CapsuleImportRequest,
   type CapsuleListRequest,
@@ -292,6 +293,86 @@ export class EngramMcpServer {
             },
           },
           required: ["query"],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.action_confidence",
+        description:
+          "Advisory ask/draft/act/refuse/escalate decision helper for interruption budgeting. Read-only; never mutates memory.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            intendedAction: { type: "string" },
+            confidence: { type: "number", minimum: 0, maximum: 1 },
+            risk: {
+              type: "string",
+              enum: ["low", "medium", "high", "irreversible", "restricted"],
+            },
+            contextReadiness: {
+              type: "string",
+              enum: ["none", "partial", "sufficient"],
+            },
+            currentContextScopes: {
+              type: "array",
+              items: { type: "string" },
+            },
+            userRules: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  kind: {
+                    type: "string",
+                    enum: [
+                      "ask-before",
+                      "do-not-use-outside-this-context",
+                      "never",
+                      "requires-escalation",
+                    ],
+                  },
+                  description: { type: "string" },
+                  matched: { type: "boolean" },
+                },
+                required: ["kind"],
+                additionalProperties: false,
+              },
+            },
+            retrievedMemories: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  source: { type: "string" },
+                  created: { type: "string" },
+                  updated: { type: "string" },
+                  scope: { type: "string" },
+                  userContextScopes: {
+                    type: "array",
+                    items: { type: "string" },
+                  },
+                  retrievalReason: { type: "string" },
+                  confidence: { type: "number", minimum: 0, maximum: 1 },
+                  stale: { type: "boolean" },
+                  corrected: { type: "boolean" },
+                  correctionState: {
+                    type: "string",
+                    enum: ["none", "correction", "superseded", "disputed", "forgotten"],
+                  },
+                  safeToUse: { type: "boolean" },
+                  safety: {
+                    type: "string",
+                    enum: ["safe", "requires-review", "blocked"],
+                  },
+                  safetyReasons: {
+                    type: "array",
+                    items: { type: "string" },
+                  },
+                },
+                additionalProperties: false,
+              },
+            },
+          },
           additionalProperties: false,
         },
       },
@@ -1897,6 +1978,10 @@ export class EngramMcpServer {
             ? { disclosure: disclosure as import("./types.js").RecallDisclosure }
             : {}),
         });
+      }
+      case "engram.action_confidence": {
+        const body: ActionConfidenceRequest = parseMcpRequest("actionConfidence", args);
+        return this.service.actionConfidence(body);
       }
       case "engram.day_summary":
         return this.service.daySummary({

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -3,6 +3,11 @@
 // field-level detail so consumers get clear feedback on malformed requests.
 
 import { z } from "zod";
+import {
+  ACTION_CONFIDENCE_CONTEXT_READINESS,
+  ACTION_CONFIDENCE_RISK_CATEGORIES,
+  ACTION_CONFIDENCE_RULE_KINDS,
+} from "./action-confidence.js";
 import { isValidCapsuleSince } from "./transfer/capsule-export.js";
 import { CAPSULE_ID_PATTERN } from "./transfer/types.js";
 
@@ -347,6 +352,51 @@ export const capsuleListRequestSchema = z
   });
 
 // ---------------------------------------------------------------------------
+// Action confidence
+// ---------------------------------------------------------------------------
+
+const nullableOptional = <T extends z.ZodTypeAny>(schema: T) =>
+  schema.optional().nullable().transform((value) => value ?? undefined);
+
+const actionConfidenceRuleSchema = z
+  .object({
+    kind: z.enum(ACTION_CONFIDENCE_RULE_KINDS),
+    description: nullableOptional(z.string().trim().min(1).max(2000)),
+    matched: nullableOptional(z.boolean()),
+  })
+  .strict();
+
+const actionConfidenceMemorySchema = z
+  .object({
+    source: nullableOptional(z.string().trim().min(1).max(256)),
+    created: nullableOptional(z.string().trim().min(1).max(128)),
+    updated: nullableOptional(z.string().trim().min(1).max(128)),
+    scope: nullableOptional(z.string().trim().min(1).max(512)),
+    userContextScopes: nullableOptional(z.array(z.string().trim().min(1).max(128)).max(50)),
+    retrievalReason: nullableOptional(z.string().trim().min(1).max(2000)),
+    confidence: nullableOptional(z.number().min(0).max(1)),
+    stale: nullableOptional(z.boolean()),
+    corrected: nullableOptional(z.boolean()),
+    correctionState: nullableOptional(z.enum(["none", "correction", "superseded", "disputed", "forgotten"])),
+    safeToUse: nullableOptional(z.boolean()),
+    safety: nullableOptional(z.enum(["safe", "requires-review", "blocked"])),
+    safetyReasons: nullableOptional(z.array(z.string().trim().min(1).max(1000)).max(50)),
+  })
+  .strict();
+
+export const actionConfidenceRequestSchema = z
+  .object({
+    intendedAction: nullableOptional(z.string().trim().min(1).max(1000)),
+    confidence: nullableOptional(z.number().min(0).max(1)),
+    risk: nullableOptional(z.enum(ACTION_CONFIDENCE_RISK_CATEGORIES)),
+    contextReadiness: nullableOptional(z.enum(ACTION_CONFIDENCE_CONTEXT_READINESS)),
+    currentContextScopes: nullableOptional(z.array(z.string().trim().min(1).max(128)).max(50)),
+    userRules: nullableOptional(z.array(actionConfidenceRuleSchema).max(100)),
+    retrievedMemories: nullableOptional(z.array(actionConfidenceMemorySchema).max(200)),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
 // Inferred types
 // ---------------------------------------------------------------------------
 
@@ -364,6 +414,7 @@ export type DaySummaryRequest = z.infer<typeof daySummaryRequestSchema>;
 export type CapsuleExportRequest = z.infer<typeof capsuleExportRequestSchema>;
 export type CapsuleImportRequest = z.infer<typeof capsuleImportRequestSchema>;
 export type CapsuleListRequest = z.infer<typeof capsuleListRequestSchema>;
+export type ActionConfidenceRequest = z.infer<typeof actionConfidenceRequestSchema>;
 
 // ---------------------------------------------------------------------------
 // Validation helper
@@ -383,7 +434,8 @@ export type SchemaName =
   | "daySummary"
   | "capsuleExport"
   | "capsuleImport"
-  | "capsuleList";
+  | "capsuleList"
+  | "actionConfidence";
 
 export type SchemaTypeFor<N extends SchemaName> =
   N extends "recall" ? RecallRequest
@@ -400,6 +452,7 @@ export type SchemaTypeFor<N extends SchemaName> =
   : N extends "capsuleExport" ? CapsuleExportRequest
   : N extends "capsuleImport" ? CapsuleImportRequest
   : N extends "capsuleList" ? CapsuleListRequest
+  : N extends "actionConfidence" ? ActionConfidenceRequest
   : never;
 
 const schemas: Record<SchemaName, z.ZodTypeAny> = {
@@ -417,6 +470,7 @@ const schemas: Record<SchemaName, z.ZodTypeAny> = {
   capsuleExport: capsuleExportRequestSchema,
   capsuleImport: capsuleImportRequestSchema,
   capsuleList: capsuleListRequestSchema,
+  actionConfidence: actionConfidenceRequestSchema,
 };
 
 /**

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -135,6 +135,11 @@ import {
   defaultCapsulesDir,
   type CapsuleListEntry,
 } from "./capsule-cli.js";
+import {
+  evaluateActionConfidence,
+  type ActionConfidenceInput,
+  type ActionConfidenceResult,
+} from "./action-confidence.js";
 import { formatProfileTraceAscii } from "./profiling.js";
 
 export class EngramAccessInputError extends Error {}
@@ -594,6 +599,9 @@ export interface EngramAccessCapsuleListResponse {
   capsulesDir: string;
   capsules: CapsuleListEntry[];
 }
+
+export type EngramAccessActionConfidenceRequest = ActionConfidenceInput;
+export type EngramAccessActionConfidenceResponse = ActionConfidenceResult;
 
 async function buildProjectedGovernanceProposedActions(
   storage: Awaited<ReturnType<Orchestrator["getStorage"]>>,
@@ -1270,6 +1278,12 @@ export class EngramAccessService {
       nativeKnowledgeEnabled: this.orchestrator.config.nativeKnowledge?.enabled === true,
       projectionAvailable,
     };
+  }
+
+  async actionConfidence(
+    request: EngramAccessActionConfidenceRequest = {},
+  ): Promise<EngramAccessActionConfidenceResponse> {
+    return evaluateActionConfidence(request);
   }
 
   async daySummary(

--- a/packages/remnic-core/src/action-confidence.test.ts
+++ b/packages/remnic-core/src/action-confidence.test.ts
@@ -1,0 +1,206 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildActionConfidenceInputFromOptions,
+  evaluateActionConfidence,
+  renderActionConfidenceText,
+} from "./action-confidence.js";
+
+test("evaluateActionConfidence acts for sufficient low-risk context", () => {
+  const result = evaluateActionConfidence({
+    intendedAction: "update local config",
+    risk: "low",
+    contextReadiness: "sufficient",
+    retrievedMemories: [
+      {
+        source: "manual",
+        created: "2026-05-01T00:00:00.000Z",
+        scope: "namespace:repo",
+        confidence: 0.92,
+        safeToUse: true,
+      },
+    ],
+  });
+
+  assert.equal(result.decision, "act");
+  assert.equal(result.safeToAct, true);
+  assert.equal(result.usableMemoryCount, 1);
+  assert.equal(result.attentionPolicy, "interruption_budgeting");
+});
+
+test("evaluateActionConfidence asks when an ask-before rule matches", () => {
+  const result = evaluateActionConfidence({
+    risk: "low",
+    contextReadiness: "sufficient",
+    confidence: 0.97,
+    userRules: [
+      {
+        kind: "ask-before",
+        description: "Ask me before changing a public API.",
+      },
+    ],
+  });
+
+  assert.equal(result.decision, "ask");
+  assert.equal(result.safeToAct, false);
+  assert.match(result.reasons.join("\n"), /Ask me before changing a public API/);
+});
+
+test("evaluateActionConfidence refuses blocked provenance", () => {
+  const result = evaluateActionConfidence({
+    risk: "low",
+    contextReadiness: "sufficient",
+    retrievedMemories: [
+      {
+        source: "conversation",
+        created: "2026-05-01T00:00:00.000Z",
+        confidence: 0.91,
+        safety: "blocked",
+        safeToUse: false,
+        safetyReasons: ["do-not-use-outside-this-context"],
+      },
+    ],
+  });
+
+  assert.equal(result.decision, "refuse");
+  assert.equal(result.blockers.length, 1);
+  assert.equal(result.usableMemoryCount, 0);
+});
+
+test("evaluateActionConfidence excludes blocked memory from stale and corrected penalties", () => {
+  const result = evaluateActionConfidence({
+    risk: "low",
+    contextReadiness: "sufficient",
+    retrievedMemories: [
+      {
+        source: "conversation",
+        confidence: 0.9,
+        safeToUse: true,
+      },
+      {
+        source: "conversation",
+        confidence: 0.9,
+        stale: true,
+        corrected: true,
+        safety: "blocked",
+        safeToUse: false,
+      },
+    ],
+  });
+
+  assert.equal(result.decision, "refuse");
+  assert.equal(result.confidence, 0.98);
+  assert.equal(result.staleMemoryCount, 0);
+  assert.equal(result.correctedMemoryCount, 0);
+});
+
+test("evaluateActionConfidence does not refuse for requires-review memory", () => {
+  const result = evaluateActionConfidence({
+    risk: "medium",
+    contextReadiness: "partial",
+    confidence: 0.7,
+    retrievedMemories: [
+      {
+        source: "conversation",
+        confidence: 0.9,
+        safety: "requires-review",
+        safeToUse: false,
+      },
+    ],
+  });
+
+  assert.equal(result.decision, "draft");
+  assert.equal(result.blockers.length, 0);
+  assert.equal(result.safeToAct, false);
+  assert.equal(result.usableMemoryCount, 0);
+});
+
+test("evaluateActionConfidence drafts when memory is useful but stale or corrected", () => {
+  const result = evaluateActionConfidence({
+    risk: "medium",
+    contextReadiness: "sufficient",
+    retrievedMemories: [
+      {
+        source: "conversation",
+        created: "2026-01-01T00:00:00.000Z",
+        confidence: 0.88,
+        stale: true,
+        corrected: true,
+        correctionState: "superseded",
+        safeToUse: true,
+      },
+    ],
+  });
+
+  assert.equal(result.decision, "draft");
+  assert.equal(result.staleMemoryCount, 1);
+  assert.equal(result.correctedMemoryCount, 1);
+  assert.equal(result.safeToAct, false);
+});
+
+test("evaluateActionConfidence escalates restricted risk", () => {
+  const result = evaluateActionConfidence({
+    risk: "restricted",
+    contextReadiness: "sufficient",
+    confidence: 0.99,
+  });
+
+  assert.equal(result.decision, "escalate");
+  assert.equal(result.safeToAct, false);
+});
+
+test("evaluateActionConfidence rejects invalid confidence values", () => {
+  assert.throws(
+    () => evaluateActionConfidence({ confidence: 2 }),
+    /confidence must be a finite number between 0 and 1/,
+  );
+  assert.throws(
+    () => evaluateActionConfidence({
+      retrievedMemories: [{ confidence: -0.1 }],
+    }),
+    /retrievedMemories\[\]\.confidence must be a finite number between 0 and 1/,
+  );
+});
+
+test("renderActionConfidenceText includes interruption budgeting", () => {
+  const text = renderActionConfidenceText(
+    evaluateActionConfidence({
+      risk: "low",
+      contextReadiness: "partial",
+      confidence: 0.62,
+    }),
+  );
+
+  assert.match(text, /Action confidence: draft/);
+  assert.match(text, /interruption_budgeting/);
+  assert.match(text, /A good agent should spend the user's attention carefully/);
+});
+
+test("buildActionConfidenceInputFromOptions validates and builds CLI input", () => {
+  const input = buildActionConfidenceInputFromOptions({
+    action: "ship the change",
+    confidence: "0.81",
+    risk: "medium",
+    context: "sufficient",
+    rule: "ask-before",
+    currentScope: "repo,tool",
+    memoryScope: "repo",
+    stale: true,
+  });
+
+  assert.deepEqual(input, {
+    intendedAction: "ship the change",
+    confidence: 0.81,
+    risk: "medium",
+    contextReadiness: "sufficient",
+    currentContextScopes: ["repo", "tool"],
+    userRules: [{ kind: "ask-before" }],
+    retrievedMemories: [
+      {
+        confidence: 0.81,
+        userContextScopes: ["repo"],
+        stale: true,
+      },
+    ],
+  });
+});

--- a/packages/remnic-core/src/action-confidence.ts
+++ b/packages/remnic-core/src/action-confidence.ts
@@ -1,0 +1,466 @@
+import {
+  normalizeRetrievedMemoryProvenance,
+  type RetrievedMemoryCorrectionState,
+  type RetrievedMemoryProvenance,
+  type RetrievedMemorySafety,
+} from "./memory-provenance.js";
+
+export const ACTION_CONFIDENCE_DECISIONS = [
+  "ask",
+  "draft",
+  "act",
+  "refuse",
+  "escalate",
+] as const;
+
+export type ActionConfidenceDecision = typeof ACTION_CONFIDENCE_DECISIONS[number];
+
+export const ACTION_CONFIDENCE_RISK_CATEGORIES = [
+  "low",
+  "medium",
+  "high",
+  "irreversible",
+  "restricted",
+] as const;
+
+export type ActionConfidenceRiskCategory = typeof ACTION_CONFIDENCE_RISK_CATEGORIES[number];
+
+export const ACTION_CONFIDENCE_CONTEXT_READINESS = [
+  "none",
+  "partial",
+  "sufficient",
+] as const;
+
+export type ActionConfidenceContextReadiness =
+  typeof ACTION_CONFIDENCE_CONTEXT_READINESS[number];
+
+export const ACTION_CONFIDENCE_RULE_KINDS = [
+  "ask-before",
+  "do-not-use-outside-this-context",
+  "never",
+  "requires-escalation",
+] as const;
+
+export type ActionConfidenceRuleKind = typeof ACTION_CONFIDENCE_RULE_KINDS[number];
+
+export interface ActionConfidenceRule {
+  kind: ActionConfidenceRuleKind;
+  description?: string;
+  matched?: boolean;
+}
+
+export interface ActionConfidenceMemoryInput {
+  source?: string;
+  created?: string;
+  updated?: string;
+  scope?: string;
+  userContextScopes?: string[];
+  retrievalReason?: string;
+  confidence?: number;
+  stale?: boolean;
+  corrected?: boolean;
+  correctionState?: RetrievedMemoryCorrectionState;
+  safeToUse?: boolean;
+  safety?: RetrievedMemorySafety;
+  safetyReasons?: string[];
+}
+
+export interface ActionConfidenceInput {
+  intendedAction?: string;
+  confidence?: number;
+  risk?: ActionConfidenceRiskCategory;
+  contextReadiness?: ActionConfidenceContextReadiness;
+  currentContextScopes?: string[];
+  userRules?: ActionConfidenceRule[];
+  retrievedMemories?: ActionConfidenceMemoryInput[];
+}
+
+export interface ActionConfidenceOptionInput {
+  action?: unknown;
+  confidence?: unknown;
+  risk?: unknown;
+  context?: unknown;
+  rule?: unknown;
+  currentScope?: unknown;
+  memoryScope?: unknown;
+  stale?: unknown;
+  corrected?: unknown;
+  unsafe?: unknown;
+}
+
+export interface ActionConfidenceFactor {
+  name: string;
+  status: "positive" | "negative" | "neutral";
+  message: string;
+}
+
+export interface ActionConfidenceResult {
+  schemaVersion: 1;
+  decision: ActionConfidenceDecision;
+  confidence: number;
+  risk: ActionConfidenceRiskCategory;
+  contextReadiness: ActionConfidenceContextReadiness;
+  intendedAction?: string;
+  attentionPolicy: "interruption_budgeting";
+  principle: string;
+  reasons: string[];
+  blockers: string[];
+  factors: ActionConfidenceFactor[];
+  retrievedMemoryCount: number;
+  usableMemoryCount: number;
+  staleMemoryCount: number;
+  correctedMemoryCount: number;
+  scopeMismatchCount: number;
+  safeToAct: boolean;
+}
+
+const ATTENTION_PRINCIPLE =
+  "A good agent should spend the user's attention carefully.";
+
+function assertConfidence(value: number | undefined, label: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new TypeError(`${label} must be a finite number between 0 and 1`);
+  }
+  return value;
+}
+
+function roundConfidence(value: number): number {
+  return Math.round(Math.max(0, Math.min(1, value)) * 100) / 100;
+}
+
+function normalizeMemory(input: ActionConfidenceMemoryInput): RetrievedMemoryProvenance {
+  const normalized = normalizeRetrievedMemoryProvenance({
+    source: input.source,
+    created: input.created,
+    updated: input.updated,
+    scope: input.scope,
+    userContextScopes: input.userContextScopes,
+    retrievalReason: input.retrievalReason,
+    confidence: assertConfidence(input.confidence, "retrievedMemories[].confidence"),
+    stale: input.stale,
+    corrected: input.corrected,
+    correctionState: input.correctionState,
+    safeToUse: input.safeToUse,
+    safety: input.safety,
+    safetyReasons: input.safetyReasons,
+  });
+  if (!normalized) {
+    throw new TypeError("retrievedMemories[] must be an object");
+  }
+  return normalized;
+}
+
+function inferContextReadiness(input: ActionConfidenceInput, memories: RetrievedMemoryProvenance[]): ActionConfidenceContextReadiness {
+  if (input.contextReadiness) return input.contextReadiness;
+  if (memories.some((memory) => memory.safeToUse && !memory.stale)) {
+    return "partial";
+  }
+  return "none";
+}
+
+function hasScopeMismatch(memory: RetrievedMemoryProvenance, currentContextScopes: Set<string>): boolean {
+  if (memory.userContextScopes.length === 0 || currentContextScopes.size === 0) {
+    return false;
+  }
+  return !memory.userContextScopes.some((scope) => currentContextScopes.has(scope));
+}
+
+function matchedRules(input: ActionConfidenceInput): ActionConfidenceRule[] {
+  return (input.userRules ?? []).filter((rule) => rule.matched !== false);
+}
+
+function ruleLabel(rule: ActionConfidenceRule): string {
+  return rule.description?.trim() || rule.kind;
+}
+
+function splitActionConfidenceList(value: unknown): string[] | undefined {
+  if (typeof value !== "string") return undefined;
+  const items = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+  return items.length > 0 ? items : undefined;
+}
+
+export function buildActionConfidenceInputFromOptions(
+  options: ActionConfidenceOptionInput,
+): ActionConfidenceInput {
+  let confidence: number | undefined;
+  if (options.confidence !== undefined) {
+    if (typeof options.confidence !== "string") {
+      throw new Error("--confidence requires a value between 0 and 1");
+    }
+    confidence = Number(options.confidence);
+    if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+      throw new Error(`--confidence must be a finite number between 0 and 1 (got ${JSON.stringify(options.confidence)})`);
+    }
+  }
+
+  let risk: ActionConfidenceRiskCategory | undefined;
+  if (options.risk !== undefined) {
+    if (
+      typeof options.risk !== "string" ||
+      !ACTION_CONFIDENCE_RISK_CATEGORIES.includes(options.risk as ActionConfidenceRiskCategory)
+    ) {
+      throw new Error(`--risk must be one of: ${ACTION_CONFIDENCE_RISK_CATEGORIES.join(", ")}`);
+    }
+    risk = options.risk as ActionConfidenceRiskCategory;
+  }
+
+  let contextReadiness: ActionConfidenceContextReadiness | undefined;
+  if (options.context !== undefined) {
+    if (
+      typeof options.context !== "string" ||
+      !ACTION_CONFIDENCE_CONTEXT_READINESS.includes(options.context as ActionConfidenceContextReadiness)
+    ) {
+      throw new Error(`--context must be one of: ${ACTION_CONFIDENCE_CONTEXT_READINESS.join(", ")}`);
+    }
+    contextReadiness = options.context as ActionConfidenceContextReadiness;
+  }
+
+  const ruleKinds = splitActionConfidenceList(options.rule);
+  const userRules = ruleKinds?.map((kind) => {
+    if (!ACTION_CONFIDENCE_RULE_KINDS.includes(kind as ActionConfidenceRuleKind)) {
+      throw new Error(`--rule entries must be one of: ${ACTION_CONFIDENCE_RULE_KINDS.join(", ")}`);
+    }
+    return { kind: kind as ActionConfidenceRuleKind };
+  });
+  const currentContextScopes = splitActionConfidenceList(options.currentScope);
+  const memoryScopes = splitActionConfidenceList(options.memoryScope);
+  const hasMemoryFlags =
+    memoryScopes !== undefined ||
+    options.stale === true ||
+    options.corrected === true ||
+    options.unsafe === true;
+
+  return {
+    ...(typeof options.action === "string" && options.action.trim().length > 0
+      ? { intendedAction: options.action.trim() }
+      : {}),
+    ...(confidence !== undefined ? { confidence } : {}),
+    ...(risk ? { risk } : {}),
+    ...(contextReadiness ? { contextReadiness } : {}),
+    ...(currentContextScopes ? { currentContextScopes } : {}),
+    ...(userRules ? { userRules } : {}),
+    ...(hasMemoryFlags
+      ? {
+          retrievedMemories: [
+            {
+              ...(confidence !== undefined ? { confidence } : {}),
+              ...(memoryScopes ? { userContextScopes: memoryScopes } : {}),
+              ...(options.stale === true ? { stale: true } : {}),
+              ...(options.corrected === true ? { corrected: true } : {}),
+              ...(options.unsafe === true
+                ? { safeToUse: false, safety: "blocked" as const }
+                : {}),
+            },
+          ],
+        }
+      : {}),
+  };
+}
+
+export function evaluateActionConfidence(input: ActionConfidenceInput = {}): ActionConfidenceResult {
+  const memories = (input.retrievedMemories ?? []).map(normalizeMemory);
+  const currentContextScopes = new Set(
+    (input.currentContextScopes ?? [])
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0),
+  );
+  const rules = matchedRules(input);
+  const risk = input.risk ?? "medium";
+  const contextReadiness = inferContextReadiness(input, memories);
+
+  const blockedMemories = memories.filter((memory) => memory.safety === "blocked");
+  const usableMemories = memories.filter(
+    (memory) => memory.safeToUse && memory.safety !== "blocked",
+  );
+  const staleMemoryCount = usableMemories.filter((memory) => memory.stale).length;
+  const correctedMemoryCount = usableMemories.filter((memory) => memory.corrected).length;
+  const scopeMismatchCount = memories.filter((memory) =>
+    hasScopeMismatch(memory, currentContextScopes),
+  ).length;
+
+  const explicitConfidence = assertConfidence(input.confidence, "confidence");
+  const provenanceConfidence =
+    usableMemories.length > 0
+      ? usableMemories.reduce((sum, memory) => sum + memory.confidence, 0) / usableMemories.length
+      : undefined;
+  let confidence = explicitConfidence ?? provenanceConfidence ?? 0.5;
+
+  const factors: ActionConfidenceFactor[] = [];
+  const reasons: string[] = [];
+  const blockers: string[] = [];
+
+  if (usableMemories.length > 0) {
+    factors.push({
+      name: "provenance",
+      status: "positive",
+      message: `${usableMemories.length} usable retrieved memory source${usableMemories.length === 1 ? "" : "s"}`,
+    });
+    reasons.push("Retrieved memory has usable provenance.");
+  } else if (memories.length > 0) {
+    factors.push({
+      name: "provenance",
+      status: "negative",
+      message: "Retrieved memory exists, but none is safe and usable.",
+    });
+  } else {
+    factors.push({
+      name: "provenance",
+      status: "neutral",
+      message: "No retrieved memories were supplied.",
+    });
+  }
+
+  if (contextReadiness === "none") {
+    confidence -= 0.25;
+    factors.push({
+      name: "context",
+      status: "negative",
+      message: "No usable context was supplied.",
+    });
+  } else if (contextReadiness === "sufficient") {
+    confidence += 0.08;
+    factors.push({
+      name: "context",
+      status: "positive",
+      message: "Caller marked the context as sufficient.",
+    });
+  } else {
+    factors.push({
+      name: "context",
+      status: "neutral",
+      message: "Caller supplied partial context.",
+    });
+  }
+
+  if (staleMemoryCount > 0) {
+    confidence -= Math.min(0.25, staleMemoryCount * 0.08);
+    factors.push({
+      name: "staleness",
+      status: "negative",
+      message: `${staleMemoryCount} retrieved memory source${staleMemoryCount === 1 ? " is" : "s are"} stale.`,
+    });
+  }
+
+  if (correctedMemoryCount > 0) {
+    confidence -= Math.min(0.2, correctedMemoryCount * 0.07);
+    factors.push({
+      name: "correction",
+      status: "negative",
+      message: `${correctedMemoryCount} retrieved memory source${correctedMemoryCount === 1 ? " has" : "s have"} correction history.`,
+    });
+  }
+
+  if (scopeMismatchCount > 0) {
+    confidence -= Math.min(0.35, scopeMismatchCount * 0.12);
+    factors.push({
+      name: "scope",
+      status: "negative",
+      message: `${scopeMismatchCount} retrieved memory source${scopeMismatchCount === 1 ? " does" : "s do"} not match the current context scope.`,
+    });
+  }
+
+  if (blockedMemories.length > 0) {
+    blockers.push(`${blockedMemories.length} retrieved memory source${blockedMemories.length === 1 ? " is" : "s are"} blocked by safety or boundary metadata.`);
+  }
+
+  for (const rule of rules) {
+    if (rule.kind === "never") {
+      blockers.push(`User rule forbids this action: ${ruleLabel(rule)}.`);
+    } else if (rule.kind === "do-not-use-outside-this-context") {
+      blockers.push(`User boundary rule blocks this context: ${ruleLabel(rule)}.`);
+    } else if (rule.kind === "ask-before") {
+      reasons.push(`Matched ask-before rule: ${ruleLabel(rule)}.`);
+    } else if (rule.kind === "requires-escalation") {
+      reasons.push(`Matched escalation rule: ${ruleLabel(rule)}.`);
+    }
+  }
+
+  confidence = roundConfidence(confidence);
+
+  let decision: ActionConfidenceDecision;
+  if (blockers.length > 0) {
+    decision = "refuse";
+  } else if (rules.some((rule) => rule.kind === "requires-escalation") || risk === "restricted") {
+    decision = "escalate";
+  } else if (contextReadiness === "none") {
+    decision = "ask";
+  } else if (rules.some((rule) => rule.kind === "ask-before") || risk === "irreversible") {
+    decision = "ask";
+  } else if (risk === "high") {
+    decision = confidence >= 0.85 && contextReadiness === "sufficient" ? "draft" : "ask";
+  } else if (risk === "medium") {
+    if (confidence >= 0.85 && contextReadiness === "sufficient") {
+      decision = "act";
+    } else if (confidence >= 0.55) {
+      decision = "draft";
+    } else {
+      decision = "ask";
+    }
+  } else {
+    if (confidence >= 0.7 && contextReadiness === "sufficient") {
+      decision = "act";
+    } else if (confidence >= 0.45) {
+      decision = "draft";
+    } else {
+      decision = "ask";
+    }
+  }
+
+  if (decision === "act") {
+    reasons.push("Confidence, context readiness, scope, and risk allow acting without another interruption.");
+  } else if (decision === "draft") {
+    reasons.push("Drafting preserves momentum while avoiding an externally visible action.");
+  } else if (decision === "ask") {
+    reasons.push("Asking is the lowest-cost way to resolve missing or risky context.");
+  } else if (decision === "escalate") {
+    reasons.push("The request is outside the normal action-confidence envelope.");
+  } else {
+    reasons.push("The action should not proceed with the supplied memory context.");
+  }
+
+  return {
+    schemaVersion: 1,
+    decision,
+    confidence,
+    risk,
+    contextReadiness,
+    ...(input.intendedAction ? { intendedAction: input.intendedAction } : {}),
+    attentionPolicy: "interruption_budgeting",
+    principle: ATTENTION_PRINCIPLE,
+    reasons,
+    blockers,
+    factors,
+    retrievedMemoryCount: memories.length,
+    usableMemoryCount: usableMemories.length,
+    staleMemoryCount,
+    correctedMemoryCount,
+    scopeMismatchCount,
+    safeToAct: decision === "act",
+  };
+}
+
+export function renderActionConfidenceText(result: ActionConfidenceResult): string {
+  const lines = [
+    `Action confidence: ${result.decision} (${result.confidence.toFixed(2)})`,
+    `Risk: ${result.risk}`,
+    `Context: ${result.contextReadiness}`,
+    `Policy: interruption_budgeting - ${result.principle}`,
+    `Memories: ${result.usableMemoryCount}/${result.retrievedMemoryCount} usable`,
+  ];
+  if (result.intendedAction) {
+    lines.splice(1, 0, `Action: ${result.intendedAction}`);
+  }
+  if (result.blockers.length > 0) {
+    lines.push("", "Blockers:");
+    for (const blocker of result.blockers) lines.push(`- ${blocker}`);
+  }
+  if (result.reasons.length > 0) {
+    lines.push("", "Reasons:");
+    for (const reason of result.reasons) lines.push(`- ${reason}`);
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -90,6 +90,11 @@ import { GraphDashboardServer, type DashboardStatus } from "./dashboard-runtime.
 import { EngramAccessService } from "./access-service.js";
 import { EngramAccessHttpServer } from "./access-http.js";
 import {
+  buildActionConfidenceInputFromOptions,
+  evaluateActionConfidence,
+  renderActionConfidenceText,
+} from "./action-confidence.js";
+import {
   resolveAgentAccessAuthToken,
   type ResolveSecretRefFn,
 } from "./resolve-auth-token.js";
@@ -6673,6 +6678,35 @@ export function registerCli(
           });
           console.log(JSON.stringify(report, null, 2));
           console.log("OK");
+        });
+
+      cmd
+        .command("action-confidence")
+        .description("Evaluate the read-only ask/draft/act/refuse/escalate advisory policy")
+        .option("--action <text>", "Intended action being evaluated")
+        .option("--confidence <0-1>", "Current confidence score")
+        .option("--risk <level>", "Risk: low, medium, high, irreversible, restricted")
+        .option("--context <state>", "Context readiness: none, partial, sufficient")
+        .option("--rule <kinds>", "Comma-separated user rules: ask-before, do-not-use-outside-this-context, never, requires-escalation")
+        .option("--current-scope <scopes>", "Comma-separated current context scopes")
+        .option("--memory-scope <scopes>", "Comma-separated scopes on the supplied memory")
+        .option("--stale", "Treat the supplied memory as stale")
+        .option("--corrected", "Treat the supplied memory as corrected")
+        .option("--unsafe", "Treat the supplied memory as blocked by safety metadata")
+        .option("--json", "Emit machine-readable JSON")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          try {
+            const result = evaluateActionConfidence(buildActionConfidenceInputFromOptions(options));
+            if (options.json === true) {
+              console.log(JSON.stringify(result, null, 2));
+            } else {
+              process.stdout.write(renderActionConfidenceText(result));
+            }
+          } catch (err) {
+            console.error(`action-confidence: ${(err as Error).message}`);
+            process.exitCode = 2;
+          }
         });
 
       cmd

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -209,6 +209,26 @@ export {
   type RetrievedMemorySafety,
 } from "./memory-provenance.js";
 
+export {
+  ACTION_CONFIDENCE_CONTEXT_READINESS,
+  ACTION_CONFIDENCE_DECISIONS,
+  ACTION_CONFIDENCE_RISK_CATEGORIES,
+  ACTION_CONFIDENCE_RULE_KINDS,
+  buildActionConfidenceInputFromOptions,
+  evaluateActionConfidence,
+  renderActionConfidenceText,
+  type ActionConfidenceContextReadiness,
+  type ActionConfidenceDecision,
+  type ActionConfidenceFactor,
+  type ActionConfidenceInput,
+  type ActionConfidenceMemoryInput,
+  type ActionConfidenceOptionInput,
+  type ActionConfidenceResult,
+  type ActionConfidenceRiskCategory,
+  type ActionConfidenceRule,
+  type ActionConfidenceRuleKind,
+} from "./action-confidence.js";
+
 // ---------------------------------------------------------------------------
 // Hot/cold tier routing (issue #686)
 // ---------------------------------------------------------------------------

--- a/tests/access-http-action-confidence.test.ts
+++ b/tests/access-http-action-confidence.test.ts
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EngramAccessHttpServer } from "../src/access-http.js";
+import type { EngramAccessService } from "../src/access-service.js";
+
+function fakeService(capture: { calls: unknown[] }): EngramAccessService {
+  return {
+    actionConfidence: async (request: unknown) => {
+      capture.calls.push(request);
+      return {
+        schemaVersion: 1,
+        decision: "draft",
+        confidence: 0.64,
+        risk: "medium",
+        contextReadiness: "partial",
+        attentionPolicy: "interruption_budgeting",
+        principle: "A good agent should spend the user's attention carefully.",
+        reasons: ["test"],
+        blockers: [],
+        factors: [],
+        retrievedMemoryCount: 0,
+        usableMemoryCount: 0,
+        staleMemoryCount: 0,
+        correctedMemoryCount: 0,
+        scopeMismatchCount: 0,
+        safeToAct: false,
+      };
+    },
+  } as unknown as EngramAccessService;
+}
+
+test("HTTP action-confidence endpoint is authenticated and read-only", async () => {
+  const capture = { calls: [] as unknown[] };
+  const server = new EngramAccessHttpServer({
+    service: fakeService(capture),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    maxBodyBytes: 4096,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+
+  try {
+    const noAuth = await fetch(`${base}/remnic/v1/action-confidence`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ confidence: 0.7 }),
+    });
+    assert.equal(noAuth.status, 401);
+
+    const response = await fetch(`${base}/remnic/v1/action-confidence`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        confidence: 0.7,
+        risk: "medium",
+        contextReadiness: "partial",
+      }),
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json() as { decision: string; attentionPolicy: string };
+    assert.equal(payload.decision, "draft");
+    assert.equal(payload.attentionPolicy, "interruption_budgeting");
+    assert.deepEqual(capture.calls, [
+      {
+        confidence: 0.7,
+        risk: "medium",
+        contextReadiness: "partial",
+      },
+    ]);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP action-confidence rejects invalid enum values", async () => {
+  const capture = { calls: [] as unknown[] };
+  const server = new EngramAccessHttpServer({
+    service: fakeService(capture),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    maxBodyBytes: 4096,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+
+  try {
+    const response = await fetch(`${base}/engram/v1/action-confidence`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ risk: "maybe" }),
+    });
+    assert.equal(response.status, 400);
+    const payload = await response.json() as { code: string; details: Array<{ field: string }> };
+    assert.equal(payload.code, "validation_error");
+    assert.equal(payload.details[0]?.field, "risk");
+    assert.equal(capture.calls.length, 0);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP action-confidence treats null optional fields as absent", async () => {
+  const capture = { calls: [] as unknown[] };
+  const server = new EngramAccessHttpServer({
+    service: fakeService(capture),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    maxBodyBytes: 4096,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+
+  try {
+    const response = await fetch(`${base}/remnic/v1/action-confidence`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer secret-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        confidence: null,
+        risk: null,
+        contextReadiness: null,
+        currentContextScopes: null,
+        userRules: [{ kind: "ask-before", description: null, matched: null }],
+        retrievedMemories: [{ confidence: null, safety: null, stale: null }],
+      }),
+    });
+    assert.equal(response.status, 200);
+    const call = capture.calls[0] as {
+      userRules?: Array<{ kind?: string }>;
+      retrievedMemories?: Array<Record<string, unknown>>;
+    };
+    assert.doesNotMatch(JSON.stringify(call), /null/);
+    assert.equal(call.userRules?.[0]?.kind, "ask-before");
+    assert.equal(call.retrievedMemories?.[0]?.confidence, undefined);
+    assert.equal(call.retrievedMemories?.[0]?.safety, undefined);
+    assert.equal(call.retrievedMemories?.[0]?.stale, undefined);
+  } finally {
+    await server.stop();
+  }
+});

--- a/tests/access-mcp-action-confidence.test.ts
+++ b/tests/access-mcp-action-confidence.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EngramMcpServer } from "../src/access-mcp.js";
+import type { EngramAccessService } from "../src/access-service.js";
+
+function fakeService(capture: { calls: unknown[] }): EngramAccessService {
+  return {
+    actionConfidence: async (request: unknown) => {
+      capture.calls.push(request);
+      return {
+        schemaVersion: 1,
+        decision: "ask",
+        confidence: 0.42,
+        risk: "medium",
+        contextReadiness: "partial",
+        attentionPolicy: "interruption_budgeting",
+        principle: "A good agent should spend the user's attention carefully.",
+        reasons: ["test"],
+        blockers: [],
+        factors: [],
+        retrievedMemoryCount: 0,
+        usableMemoryCount: 0,
+        staleMemoryCount: 0,
+        correctedMemoryCount: 0,
+        scopeMismatchCount: 0,
+        safeToAct: false,
+      };
+    },
+  } as unknown as EngramAccessService;
+}
+
+test("MCP advertises action_confidence under engram and remnic names", async () => {
+  const server = new EngramMcpServer(fakeService({ calls: [] }));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+  const tools = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/list",
+    params: {},
+  });
+  const names = (tools?.result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
+
+  assert.ok(names.includes("engram.action_confidence"));
+  assert.ok(names.includes("remnic.action_confidence"));
+});
+
+test("MCP action_confidence validates and dispatches to service", async () => {
+  const capture = { calls: [] as unknown[] };
+  const server = new EngramMcpServer(fakeService(capture));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "remnic.action_confidence",
+      arguments: {
+        confidence: 0.74,
+        risk: "medium",
+        contextReadiness: "partial",
+        userRules: [{ kind: "ask-before", description: "Ask before checkout." }],
+      },
+    },
+  });
+
+  const result = response?.result as {
+    isError?: boolean;
+    structuredContent?: { decision?: string; attentionPolicy?: string };
+  };
+  assert.equal(result.isError, false);
+  assert.equal(result.structuredContent?.decision, "ask");
+  assert.equal(result.structuredContent?.attentionPolicy, "interruption_budgeting");
+  assert.deepEqual(capture.calls, [
+    {
+      confidence: 0.74,
+      risk: "medium",
+      contextReadiness: "partial",
+      userRules: [{ kind: "ask-before", description: "Ask before checkout." }],
+    },
+  ]);
+});
+
+test("MCP action_confidence rejects unknown risk values before service dispatch", async () => {
+  const capture = { calls: [] as unknown[] };
+  const server = new EngramMcpServer(fakeService(capture));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "engram.action_confidence",
+      arguments: {
+        confidence: 0.74,
+        risk: "maybe",
+      },
+    },
+  });
+
+  const result = response?.result as {
+    isError?: boolean;
+    content?: Array<{ text?: string }>;
+  };
+  assert.equal(result.isError, true);
+  assert.match(String(result.content?.[0]?.text ?? ""), /Invalid enum value/);
+  assert.equal(capture.calls.length, 0);
+});

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -323,6 +323,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.set_coding_context",
     "engram.recall_tier_explain",
     "engram.recall_xray",
+    "engram.action_confidence",
     "engram.day_summary",
     "engram.capsule_export",
     "engram.capsule_import",


### PR DESCRIPTION
## Summary
- add a host-agnostic action-confidence evaluator for ask/draft/act/refuse/escalate interruption budgeting
- expose the advisory surface through HTTP, MCP, and CLI without side effects
- document the user-aware action-confidence contract and add focused access coverage

## Verification
- pnpm exec tsx --test packages/remnic-core/src/action-confidence.test.ts tests/access-mcp-action-confidence.test.ts tests/access-http-action-confidence.test.ts packages/remnic-cli/src/xray.test.ts
- npm run test:entity-hardening
- gtimeout 900 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new read-only policy evaluator and exposes it via HTTP/MCP/CLI, increasing public surface area and introducing new decision logic that could affect agent behavior if consumers rely on it.
> 
> **Overview**
> Adds a new **read-only “action confidence”** evaluator (`evaluateActionConfidence`) that scores context/provenance/rules/risk to return an advisory decision: `ask`, `draft`, `act`, `refuse`, or `escalate`.
> 
> Exposes this surface end-to-end via **HTTP** (`POST /remnic/v1/action-confidence` and legacy `/engram/v1/action-confidence`), **MCP** (`remnic.action_confidence` plus `engram.*` alias), and **CLI** (`remnic action-confidence` / `openclaw engram action-confidence`), including new Zod request schema validation and updated MCP tool advertisement.
> 
> Adds focused tests for the evaluator plus HTTP/MCP dispatch/validation, and updates docs to describe the new endpoint/tool and dual `remnic.*` + legacy `engram.*` MCP naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c19d8b68e295083e3479c7125f0d8cd72835c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->