### PR TITLE
feat(bench): add memory eval dimensions

### DIFF
--- a/docs/memory-evals.md
+++ b/docs/memory-evals.md
@@ -1,0 +1,54 @@
+# Memory Evals
+
+Agent memory without evals is vibes with a database.
+
+Remnic memory evals measure whether user-aware memory improves agent outcomes
+without crossing boundaries. The first-class contract lives in `@remnic/bench`
+as `MEMORY_EVAL_DIMENSIONS`; each dimension maps to quick-capable benchmark
+surfaces so CI can catch regressions without a second eval harness.
+
+## Questions
+
+| Dimension | Eval question | Quick benchmark coverage |
+| --- | --- | --- |
+| `repeated_context_reduction` | Did memory reduce repeated context? | `assistant-synthesis`, `assistant-morning-brief`, `longmemeval` |
+| `unnecessary_clarification_reduction` | Did memory reduce unnecessary clarification? | `assistant-next-best-action`, `buffer-surprise-trigger` |
+| `retrieval_correctness` | Did the agent retrieve the right memory? | `retrieval-personalization`, `retrieval-direct-answer`, `coding-recall` |
+| `stale_memory_harm` | Did stale memory harm the answer? | `retrieval-temporal`, `retention-aged-dataset`, `contradiction-detection` |
+| `scope_respect` | Did the agent respect scope? | `coding-recall`, `retrieval-personalization`, `memoryagentbench` |
+| `ask_when_needed` | Did the agent ask when it should have asked? | `assistant-next-best-action`, `buffer-surprise-trigger` |
+| `act_when_enough_context` | Did the agent act when it had enough context? | `assistant-next-best-action`, `assistant-morning-brief` |
+| `personalization_quality` | Did personalization improve the output? | `retrieval-personalization`, `assistant-synthesis`, `personamem` |
+
+## Metrics
+
+The contract includes metric names and directionality for each dimension:
+
+- repeated context: `repeated_context_turns_saved` and `context_repetition_rate`
+- clarification: `low_value_clarification_rate` and `clarification_precision`
+- retrieval: `memory_recall_at_k` and `memory_precision_at_k`
+- freshness: `stale_memory_harm_rate` and `freshness_filter_success`
+- scope: `scope_violation_rate` and `allowed_scope_recall`
+- ask when needed: `required_ask_recall` and `unsafe_action_rate`
+- act when ready: `unnecessary_interruption_rate` and `sufficient_context_action_rate`
+- personalization: `personalization_lift` and `preference_alignment`
+
+Lower is better for the rate metrics that describe harm, violations, or
+unnecessary interruptions. Higher is better for recall, precision, lift, and
+turns saved.
+
+## Running Quick Coverage
+
+Use the exported list when building CI or release checks:
+
+```ts
+import { listMemoryEvalBenchmarkIds } from "@remnic/bench";
+
+for (const benchmarkId of listMemoryEvalBenchmarkIds()) {
+  console.log(`remnic bench run --quick ${benchmarkId}`);
+}
+```
+
+Quick mode is for regression detection. Full mode should compare memory-enabled
+and memory-disabled runs, preserve provenance/scope annotations, and use sealed
+qrels or rubric prompts for publishable claims.

--- a/docs/user-aware-agents.md
+++ b/docs/user-aware-agents.md
@@ -103,6 +103,19 @@ The helper is exposed as:
 - MCP: `remnic.action_confidence` and legacy `engram.action_confidence`
 - CLI: `remnic action-confidence`
 
+## Memory Evals
+
+`@remnic/bench` exports `MEMORY_EVAL_DIMENSIONS` as Remnic's shared eval
+contract for user-aware memory. Public line:
+
+> Agent memory without evals is vibes with a database.
+
+The contract covers repeated-context reduction, unnecessary-clarification
+reduction, retrieval correctness, stale-memory harm, scope respect,
+ask-when-needed decisions, act-when-enough-context decisions, and
+personalization quality. See [Memory Evals](memory-evals.md) for the full
+dimension map, metrics, and quick benchmark coverage.
+
 ## Core Exports
 
 `@remnic/core` exports:

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -26,6 +26,27 @@ The CLI loads `@remnic/bench` via a computed-specifier dynamic import. If it's n
 - **Published feed** — `remnic bench publish --target remnic-ai` builds the tamper-evident integrity manifest consumed by remnic.ai.
 - **Provider discovery** — `remnic bench providers discover` enumerates local OpenAI / Anthropic / Ollama / LiteLLM providers for adapter wiring.
 
+## Memory eval dimensions
+
+Agent memory without evals is vibes with a database.
+
+`@remnic/bench` exports `MEMORY_EVAL_DIMENSIONS` as Remnic's shared eval
+contract for user-aware agents. It covers:
+
+- repeated-context reduction
+- unnecessary-clarification reduction
+- retrieval correctness
+- stale-memory harm
+- scope respect
+- ask-when-needed decisions
+- act-when-enough-context decisions
+- personalization quality
+
+Each dimension maps to existing quick-capable benchmark ids. Use
+`listMemoryEvalBenchmarkIds()` when wiring CI coverage, and use the per-dimension
+`fullModeGuidance` strings when designing publishable eval claims. See
+[`docs/memory-evals.md`](../../docs/memory-evals.md) for the full map.
+
 ## CLI quick reference
 
 ```bash

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -94,6 +94,19 @@ export {
 export type {
   SyntheticEmailIngestionAdapterOptions,
 } from "./ingestion-adapters/synthetic-email-adapter.js";
+export {
+  MEMORY_EVAL_DIMENSIONS,
+  MEMORY_EVAL_PUBLIC_LINE,
+  getMemoryEvalDimension,
+  listMemoryEvalBenchmarkIds,
+  listMemoryEvalDimensions,
+} from "./memory-evals.js";
+export type {
+  MemoryEvalCategory,
+  MemoryEvalDimension,
+  MemoryEvalDimensionId,
+  MemoryEvalMetric,
+} from "./memory-evals.js";
 export type {
   AnthropicProviderConfig,
   CodexCliProviderConfig,

--- a/packages/bench/src/memory-evals.test.ts
+++ b/packages/bench/src/memory-evals.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MEMORY_EVAL_DIMENSIONS,
+  MEMORY_EVAL_PUBLIC_LINE,
+  getMemoryEvalDimension,
+  listMemoryEvalBenchmarkIds,
+  listMemoryEvalDimensions,
+  type MemoryEvalDimensionId,
+} from "./memory-evals.ts";
+import { listBenchmarks } from "./registry.ts";
+
+const EXPECTED_DIMENSION_IDS: readonly MemoryEvalDimensionId[] = [
+  "repeated_context_reduction",
+  "unnecessary_clarification_reduction",
+  "retrieval_correctness",
+  "stale_memory_harm",
+  "scope_respect",
+  "ask_when_needed",
+  "act_when_enough_context",
+  "personalization_quality",
+];
+
+test("memory eval contract covers the user-aware agent questions", () => {
+  assert.equal(
+    MEMORY_EVAL_PUBLIC_LINE,
+    "Agent memory without evals is vibes with a database.",
+  );
+  assert.deepEqual(
+    listMemoryEvalDimensions().map((dimension) => dimension.id),
+    EXPECTED_DIMENSION_IDS,
+  );
+});
+
+test("memory eval dimensions have unique ids, metrics, and quick benchmarks", () => {
+  const ids = MEMORY_EVAL_DIMENSIONS.map((dimension) => dimension.id);
+  assert.equal(new Set(ids).size, ids.length);
+
+  for (const dimension of MEMORY_EVAL_DIMENSIONS) {
+    assert.match(dimension.question, /\?$/);
+    assert.ok(dimension.metrics.length > 0, `${dimension.id} has metrics`);
+    assert.ok(
+      dimension.quickBenchmarkIds.length > 0,
+      `${dimension.id} has quick benchmark coverage`,
+    );
+    assert.ok(
+      dimension.fullModeGuidance.length > 20,
+      `${dimension.id} has full-mode guidance`,
+    );
+  }
+});
+
+test("memory eval benchmark list is unique and stable", () => {
+  assert.deepEqual(listMemoryEvalBenchmarkIds(), [
+    "assistant-morning-brief",
+    "assistant-next-best-action",
+    "assistant-synthesis",
+    "buffer-surprise-trigger",
+    "coding-recall",
+    "contradiction-detection",
+    "longmemeval",
+    "memoryagentbench",
+    "personamem",
+    "retention-aged-dataset",
+    "retrieval-direct-answer",
+    "retrieval-personalization",
+    "retrieval-temporal",
+  ]);
+});
+
+test("memory eval benchmark ids reference registered benchmarks", () => {
+  const registeredIds = new Set(listBenchmarks().map((benchmark) => benchmark.id));
+  for (const benchmarkId of listMemoryEvalBenchmarkIds()) {
+    assert.ok(
+      registeredIds.has(benchmarkId),
+      `expected ${benchmarkId} to be a registered benchmark`,
+    );
+  }
+});
+
+test("unknown memory eval dimension throws explicitly", () => {
+  assert.throws(
+    () => getMemoryEvalDimension("missing" as MemoryEvalDimensionId),
+    /Unknown memory eval dimension: missing/,
+  );
+});

--- a/packages/bench/src/memory-evals.ts
+++ b/packages/bench/src/memory-evals.ts
@@ -1,0 +1,264 @@
+export const MEMORY_EVAL_PUBLIC_LINE =
+  "Agent memory without evals is vibes with a database." as const;
+
+export type MemoryEvalDimensionId =
+  | "repeated_context_reduction"
+  | "unnecessary_clarification_reduction"
+  | "retrieval_correctness"
+  | "stale_memory_harm"
+  | "scope_respect"
+  | "ask_when_needed"
+  | "act_when_enough_context"
+  | "personalization_quality";
+
+export type MemoryEvalCategory =
+  | "context-efficiency"
+  | "retrieval-quality"
+  | "boundary-respect"
+  | "action-confidence"
+  | "personalization";
+
+export interface MemoryEvalMetric {
+  name: string;
+  higherIsBetter: boolean;
+  description: string;
+}
+
+export interface MemoryEvalDimension {
+  id: MemoryEvalDimensionId;
+  question: string;
+  category: MemoryEvalCategory;
+  metrics: readonly MemoryEvalMetric[];
+  quickBenchmarkIds: readonly string[];
+  fullModeGuidance: string;
+}
+
+export const MEMORY_EVAL_DIMENSIONS: readonly MemoryEvalDimension[] = [
+  {
+    id: "repeated_context_reduction",
+    question: "Did memory reduce repeated context?",
+    category: "context-efficiency",
+    metrics: [
+      {
+        name: "repeated_context_turns_saved",
+        higherIsBetter: true,
+        description:
+          "Estimated number of user turns avoided because the agent reused durable context.",
+      },
+      {
+        name: "context_repetition_rate",
+        higherIsBetter: false,
+        description:
+          "Share of task turns where the user had to restate information Remnic should already know.",
+      },
+    ],
+    quickBenchmarkIds: [
+      "assistant-synthesis",
+      "assistant-morning-brief",
+      "longmemeval",
+    ],
+    fullModeGuidance:
+      "Run seeded assistant tasks against a baseline with memory disabled and compare repeated setup turns.",
+  },
+  {
+    id: "unnecessary_clarification_reduction",
+    question: "Did memory reduce unnecessary clarification?",
+    category: "context-efficiency",
+    metrics: [
+      {
+        name: "low_value_clarification_rate",
+        higherIsBetter: false,
+        description:
+          "Share of clarifying questions whose answer was already present in safe retrieved memory.",
+      },
+      {
+        name: "clarification_precision",
+        higherIsBetter: true,
+        description:
+          "Share of clarifying questions that were justified by missing, conflicting, stale, or risky context.",
+      },
+    ],
+    quickBenchmarkIds: [
+      "assistant-next-best-action",
+      "buffer-surprise-trigger",
+    ],
+    fullModeGuidance:
+      "Judge ask/draft/act choices over real trajectories where the user previously supplied the needed context.",
+  },
+  {
+    id: "retrieval_correctness",
+    question: "Did the agent retrieve the right memory?",
+    category: "retrieval-quality",
+    metrics: [
+      {
+        name: "memory_recall_at_k",
+        higherIsBetter: true,
+        description:
+          "Recall of labeled relevant memory ids in the top-k retrieved context.",
+      },
+      {
+        name: "memory_precision_at_k",
+        higherIsBetter: true,
+        description:
+          "Precision of labeled relevant memory ids in the top-k retrieved context.",
+      },
+    ],
+    quickBenchmarkIds: [
+      "retrieval-personalization",
+      "retrieval-direct-answer",
+      "coding-recall",
+    ],
+    fullModeGuidance:
+      "Use sealed qrels for real user-aware tasks and report retrieval precision/recall by scope.",
+  },
+  {
+    id: "stale_memory_harm",
+    question: "Did stale memory harm the answer?",
+    category: "retrieval-quality",
+    metrics: [
+      {
+        name: "stale_memory_harm_rate",
+        higherIsBetter: false,
+        description:
+          "Share of tasks where stale, superseded, or corrected memory changed the output for the worse.",
+      },
+      {
+        name: "freshness_filter_success",
+        higherIsBetter: true,
+        description:
+          "Share of tasks where stale memory was withheld, downgraded, or surfaced with the right caveat.",
+      },
+    ],
+    quickBenchmarkIds: [
+      "retrieval-temporal",
+      "retention-aged-dataset",
+      "contradiction-detection",
+    ],
+    fullModeGuidance:
+      "Include correction and supersession fixtures with known stale distractors and outcome labels.",
+  },
+  {
+    id: "scope_respect",
+    question: "Did the agent respect scope?",
+    category: "boundary-respect",
+    metrics: [
+      {
+        name: "scope_violation_rate",
+        higherIsBetter: false,
+        description:
+          "Share of tasks where private, temporary, client, repo, or do-not-use-outside memory crossed its boundary.",
+      },
+      {
+        name: "allowed_scope_recall",
+        higherIsBetter: true,
+        description:
+          "Recall of relevant memories that were safe to use in the current scope.",
+      },
+    ],
+    quickBenchmarkIds: [
+      "coding-recall",
+      "retrieval-personalization",
+      "memoryagentbench",
+    ],
+    fullModeGuidance:
+      "Run multi-namespace cases with explicit private and do-not-use-outside distractors.",
+  },
+  {
+    id: "ask_when_needed",
+    question: "Did the agent ask when it should have asked?",
+    category: "action-confidence",
+    metrics: [
+      {
+        name: "required_ask_recall",
+        higherIsBetter: true,
+        description:
+          "Recall of cases where the correct action was to ask before proceeding.",
+      },
+      {
+        name: "unsafe_action_rate",
+        higherIsBetter: false,
+        description:
+          "Share of risky cases where the agent acted despite missing context, stale memory, or user ask-before rules.",
+      },
+    ],
+    quickBenchmarkIds: [
+      "assistant-next-best-action",
+      "buffer-surprise-trigger",
+    ],
+    fullModeGuidance:
+      "Evaluate action-confidence traces against labeled ask-before, uncertainty, and risk-threshold cases.",
+  },
+  {
+    id: "act_when_enough_context",
+    question: "Did the agent act when it had enough context?",
+    category: "action-confidence",
+    metrics: [
+      {
+        name: "unnecessary_interruption_rate",
+        higherIsBetter: false,
+        description:
+          "Share of low-risk, sufficient-context cases where the agent spent the user's attention anyway.",
+      },
+      {
+        name: "sufficient_context_action_rate",
+        higherIsBetter: true,
+        description:
+          "Share of cases where the agent proceeded appropriately because memory gave it enough safe context.",
+      },
+    ],
+    quickBenchmarkIds: [
+      "assistant-next-best-action",
+      "assistant-morning-brief",
+    ],
+    fullModeGuidance:
+      "Compare memory-enabled and memory-disabled runs on low-risk tasks with complete scoped context.",
+  },
+  {
+    id: "personalization_quality",
+    question: "Did personalization improve the output?",
+    category: "personalization",
+    metrics: [
+      {
+        name: "personalization_lift",
+        higherIsBetter: true,
+        description:
+          "Quality delta between generic output and user-aware output under the same task.",
+      },
+      {
+        name: "preference_alignment",
+        higherIsBetter: true,
+        description:
+          "Share of outputs that honor the user's preferences, constraints, risk tolerance, and definition of good.",
+      },
+    ],
+    quickBenchmarkIds: [
+      "retrieval-personalization",
+      "assistant-synthesis",
+      "personamem",
+    ],
+    fullModeGuidance:
+      "Use paired generic-vs-user-aware judge prompts with provenance and scope annotations preserved.",
+  },
+] as const;
+
+export function listMemoryEvalDimensions(): readonly MemoryEvalDimension[] {
+  return MEMORY_EVAL_DIMENSIONS;
+}
+
+export function getMemoryEvalDimension(
+  id: MemoryEvalDimensionId,
+): MemoryEvalDimension {
+  const dimension = MEMORY_EVAL_DIMENSIONS.find((candidate) => candidate.id === id);
+  if (!dimension) {
+    throw new Error(`Unknown memory eval dimension: ${id}`);
+  }
+  return dimension;
+}
+
+export function listMemoryEvalBenchmarkIds(): string[] {
+  return Array.from(
+    new Set(
+      MEMORY_EVAL_DIMENSIONS.flatMap((dimension) => dimension.quickBenchmarkIds),
+    ),
+  ).sort();
+}


### PR DESCRIPTION
## Summary
- add an exported @remnic/bench memory eval contract for the eight user-aware agent questions
- map each dimension to existing quick-capable benchmark ids and full-mode guidance
- document the memory eval surface in the bench README and user-aware agents docs

## Verification
- pnpm exec tsx --test packages/bench/src/memory-evals.test.ts
- npm run check-types
- gtimeout 900 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new exported contract and docs/tests without changing benchmark execution, scoring, or existing APIs.
> 
> **Overview**
> Introduces a shared **memory eval contract** in `@remnic/bench` via `MEMORY_EVAL_DIMENSIONS`, defining 8 user-aware memory dimensions with associated metric names/directionality, quick-benchmark coverage ids, and full-mode guidance.
> 
> Exports helper APIs (`listMemoryEvalDimensions`, `getMemoryEvalDimension`, `listMemoryEvalBenchmarkIds`) from the package index, adds a unit test to keep the contract and benchmark-id mapping stable/registered, and documents the contract in `docs/memory-evals.md`, `docs/user-aware-agents.md`, and the `@remnic/bench` README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee0b8fa2e62df1d4bc2ec6ca8e54489dbd3d6f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->