### PR TITLE
feat(mcp): add ChatGPT Apps memory inspector demo

### DIFF
--- a/docs/chatgpt-apps-demo.md
+++ b/docs/chatgpt-apps-demo.md
@@ -1,0 +1,70 @@
+# ChatGPT Apps Demo
+
+Remnic exposes a small ChatGPT Apps-compatible memory inspector on the
+existing MCP runtime. This is a local developer demo, not a public app
+submission package.
+
+Archetype: `vanilla-widget`.
+
+## What It Adds
+
+- MCP widget resource: `ui://remnic/memory-inspector.v1.html`
+- MIME type: `text/html;profile=mcp-app`
+- Render tool: `remnic.chatgpt_memory_inspector`
+- Legacy alias: `engram.chatgpt_memory_inspector`
+
+The tool is read-only. It runs a safe recall preview, captures Recall X-ray
+provenance, evaluates action confidence, and renders the result in a widget.
+Correction, forget, and scoping controls send follow-up prompts only; persistent
+changes still require a separate Remnic tool call and user confirmation.
+
+## Why This Shape
+
+OpenAI's Apps SDK quickstart says ChatGPT apps use an MCP server to expose
+tools and can optionally render a web component in ChatGPT. The server guide
+shows widget resources with `text/html;profile=mcp-app` and tools that point to
+the widget via `_meta.ui.resourceUri`. The UI guide recommends the MCP Apps
+bridge first, while keeping `window.openai` as the ChatGPT compatibility layer.
+
+Docs used:
+
+- https://developers.openai.com/apps-sdk/quickstart
+- https://developers.openai.com/apps-sdk/build/mcp-server
+- https://developers.openai.com/apps-sdk/build/chatgpt-ui
+- https://developers.openai.com/apps-sdk/reference
+- https://developers.openai.com/apps-sdk/plan/tools
+
+## Local Smoke Test
+
+Start Remnic's standalone server, then point MCP Inspector or ChatGPT developer
+mode at the existing `/mcp` endpoint:
+
+```bash
+REMNIC_AUTH_TOKEN=dev-token remnic-server --port 4318
+```
+
+Use the normal bearer token header:
+
+```text
+Authorization: Bearer dev-token
+```
+
+Then call:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "remnic.chatgpt_memory_inspector",
+    "arguments": {
+      "query": "What preferences matter for this answer?",
+      "currentContextScopes": ["work", "repo"]
+    }
+  }
+}
+```
+
+The widget resource is served through MCP `resources/read`; there is no second
+Remnic MCP server and no extra frontend build step.

--- a/docs/user-aware-agents.md
+++ b/docs/user-aware-agents.md
@@ -116,6 +116,15 @@ ask-when-needed decisions, act-when-enough-context decisions, and
 personalization quality. See [Memory Evals](memory-evals.md) for the full
 dimension map, metrics, and quick benchmark coverage.
 
+## ChatGPT Apps Demo
+
+The existing Remnic MCP runtime exposes a local ChatGPT Apps-compatible memory
+inspector as `remnic.chatgpt_memory_inspector` with a widget resource at
+`ui://remnic/memory-inspector.v1.html`. It shows safe recall previews,
+provenance, scope/safety signals, action-confidence guidance, and follow-up
+prompts for correction, forget, and scoping flows. See
+[ChatGPT Apps Demo](chatgpt-apps-demo.md).
+
 ## Core Exports
 
 `@remnic/core` exports:

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -505,6 +505,7 @@ export class EngramAccessHttpServer {
       const response = await this.service.recall({
         query: body.query ?? "",
         sessionKey: body.sessionKey,
+        authenticatedPrincipal: this.resolveRequestPrincipal(req),
         namespace: this.resolveNamespace(req, body.namespace),
         topK: body.topK,
         mode: body.mode as RecallPlanMode | "auto" | undefined,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1690,14 +1690,7 @@ export class EngramMcpServer {
         jsonrpc: "2.0",
         id,
         result: {
-          resourceTemplates: this.resources.map((resource) => ({
-            uriTemplate: resource.uri,
-            name: resource.name,
-            title: resource.title,
-            description: resource.description,
-            mimeType: resource.mimeType,
-            _meta: resource._meta,
-          })),
+          resourceTemplates: [],
         },
       };
     }

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1697,7 +1697,8 @@ export class EngramMcpServer {
     if (method === "resources/read") {
       const params = request.params ?? {};
       const uri = typeof params.uri === "string" ? params.uri : "";
-      if (uri !== REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI) {
+      const resource = this.resources.find((entry) => entry.uri === uri);
+      if (!resource) {
         return {
           jsonrpc: "2.0",
           id,
@@ -1713,9 +1714,10 @@ export class EngramMcpServer {
         result: {
           contents: [
             {
-              uri,
-              mimeType: REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
+              uri: resource.uri,
+              mimeType: resource.mimeType,
               text: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_HTML,
+              _meta: resource._meta,
             },
           ],
         },
@@ -2206,6 +2208,7 @@ export class EngramMcpServer {
           query: input.query,
           sessionKey: input.sessionKey,
           namespace: input.namespace,
+          currentContextScopes: input.currentContextScopes,
           authenticatedPrincipal: effectivePrincipal,
         });
         const xray = xrayResponse.snapshotFound === true

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -146,6 +146,7 @@ export class EngramMcpServer {
   private flushTask: Promise<void> | null = null;
   private readonly tools: McpTool[];
   private readonly resources: McpResource[];
+  private readonly resourceTextByUri: Map<string, string>;
   private readonly authenticatedPrincipal?: string;
   /**
    * MCP client info keyed by server-assigned session ID. On each `initialize`
@@ -198,6 +199,12 @@ export class EngramMcpServer {
         },
       },
     ];
+    this.resourceTextByUri = new Map([
+      [
+        REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+        REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_HTML,
+      ],
+    ]);
     this.tools = [
       {
         name: "engram.recall",
@@ -1717,6 +1724,17 @@ export class EngramMcpServer {
           },
         };
       }
+      const text = this.resourceTextByUri.get(resource.uri);
+      if (text === undefined) {
+        return {
+          jsonrpc: "2.0",
+          id,
+          error: {
+            code: -32603,
+            message: `Resource content unavailable: ${resource.uri}`,
+          },
+        };
+      }
       return {
         jsonrpc: "2.0",
         id,
@@ -1725,7 +1743,7 @@ export class EngramMcpServer {
             {
               uri: resource.uri,
               mimeType: resource.mimeType,
-              text: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_HTML,
+              text,
               _meta: resource._meta,
             },
           ],

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -455,6 +455,7 @@ export class EngramMcpServer {
           properties: {
             app: { type: "object" },
             query: { type: "string" },
+            sessionKey: { type: "string" },
             namespace: { type: "string" },
             safeRecallPreview: { type: "string" },
             memoryCount: { type: "number" },

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2228,14 +2228,6 @@ export class EngramMcpServer {
           input.sessionKey,
           effectivePrincipal,
         );
-        const recall = await this.service.recall({
-          query: input.query,
-          sessionKey: recallSessionKey,
-          namespace: input.namespace,
-          authenticatedPrincipal: effectivePrincipal,
-          mode: "full",
-          disclosure: "chunk",
-        });
         const xrayResponse = await this.service.recallXray({
           query: input.query,
           sessionKey: recallSessionKey,
@@ -2243,10 +2235,23 @@ export class EngramMcpServer {
           currentContextScopes: input.currentContextScopes,
           authenticatedPrincipal: effectivePrincipal,
           mode: "full",
+          disclosure: "chunk",
+          includeRecall: true,
         });
         const xray = xrayResponse.snapshotFound === true
           ? xrayResponse.snapshot ?? null
           : null;
+        const recall = xrayResponse.recall ?? {
+          query: input.query,
+          namespace: input.namespace ?? xray?.namespace ?? "global",
+          context: "",
+          count: 0,
+          memoryIds: [],
+          results: [],
+          fallbackUsed: false,
+          sourcesUsed: [],
+          disclosure: "chunk",
+        };
         const actionRequest = buildChatGptMemoryInspectorActionRequest(
           input,
           recall,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2201,6 +2201,7 @@ export class EngramMcpServer {
           query: input.query,
           sessionKey: input.sessionKey,
           namespace: input.namespace,
+          authenticatedPrincipal: effectivePrincipal,
           mode: "full",
           disclosure: "chunk",
         });
@@ -2210,6 +2211,7 @@ export class EngramMcpServer {
           namespace: input.namespace,
           currentContextScopes: input.currentContextScopes,
           authenticatedPrincipal: effectivePrincipal,
+          mode: "full",
         });
         const xray = xrayResponse.snapshotFound === true
           ? xrayResponse.snapshot ?? null

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -77,6 +77,15 @@ function withToolAliases(tool: McpTool): McpTool[] {
   return [canonicalTool, tool];
 }
 
+function resolveChatGptInspectorRecallSessionKey(
+  explicitSessionKey: string | undefined,
+  authenticatedPrincipal: string | undefined,
+): string | undefined {
+  if (explicitSessionKey) return explicitSessionKey;
+  if (!authenticatedPrincipal) return undefined;
+  return `remnic:chatgpt-memory-inspector:${randomUUID()}`;
+}
+
 const STRICT_MCP_SCHEMA_KEYS: Partial<Record<SchemaName, readonly string[]>> = {
   capsuleExport: [
     "name",
@@ -2197,9 +2206,13 @@ export class EngramMcpServer {
         if (currentContextScopes !== undefined) {
           input.currentContextScopes = currentContextScopes;
         }
+        const recallSessionKey = resolveChatGptInspectorRecallSessionKey(
+          input.sessionKey,
+          effectivePrincipal,
+        );
         const recall = await this.service.recall({
           query: input.query,
-          sessionKey: input.sessionKey,
+          sessionKey: recallSessionKey,
           namespace: input.namespace,
           authenticatedPrincipal: effectivePrincipal,
           mode: "full",
@@ -2207,7 +2220,7 @@ export class EngramMcpServer {
         });
         const xrayResponse = await this.service.recallXray({
           query: input.query,
-          sessionKey: input.sessionKey,
+          sessionKey: recallSessionKey,
           namespace: input.namespace,
           currentContextScopes: input.currentContextScopes,
           authenticatedPrincipal: effectivePrincipal,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -16,6 +16,15 @@ import type { RecallDisclosure, RecallPlanMode } from "./types.js";
 import { validateBriefingFormat } from "./briefing.js";
 import { buildCitationGuidance, type CitationMetadata } from "./citations.js";
 import { expandTildePath } from "./utils/path.js";
+import {
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_HTML,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+  buildChatGptMemoryInspectorActionRequest,
+  buildChatGptMemoryInspectorResult,
+  type RemnicChatGptMemoryInspectorInput,
+} from "./mcp-memory-inspector-app.js";
 
 type JsonRpcId = string | number | null;
 
@@ -28,8 +37,21 @@ type JsonRpcRequest = {
 
 type McpTool = {
   name: string;
+  title?: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+};
+
+type McpResource = {
+  uri: string;
+  name: string;
+  title?: string;
+  description?: string;
+  mimeType: string;
+  _meta?: Record<string, unknown>;
 };
 
 const MCP_PROTOCOL_VERSION = "2024-11-05";
@@ -114,6 +136,7 @@ export class EngramMcpServer {
   private buffer = Buffer.alloc(0);
   private flushTask: Promise<void> | null = null;
   private readonly tools: McpTool[];
+  private readonly resources: McpResource[];
   private readonly authenticatedPrincipal?: string;
   /**
    * MCP client info keyed by server-assigned session ID. On each `initialize`
@@ -145,6 +168,27 @@ export class EngramMcpServer {
       options.principal?.trim() ||
       readEnvVar("OPENCLAW_ENGRAM_ACCESS_PRINCIPAL")?.trim() ||
       undefined;
+    this.resources = [
+      {
+        uri: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+        name: "remnic-memory-inspector",
+        title: "Remnic Memory Inspector",
+        description:
+          "Apps-compatible widget for inspecting retrieved Remnic memories, provenance, safety, and correction/scoping affordances.",
+        mimeType: REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
+        _meta: {
+          ui: {
+            csp: {
+              connectDomains: [],
+              resourceDomains: [],
+            },
+            prefersBorder: true,
+          },
+          "openai/widgetDescription":
+            "Inspect retrieved Remnic memories, provenance, safety, and correction/scoping affordances.",
+        },
+      },
+    ];
     this.tools = [
       {
         name: "engram.recall",
@@ -374,6 +418,80 @@ export class EngramMcpServer {
             },
           },
           additionalProperties: false,
+        },
+      },
+      {
+        name: REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL,
+        title: "Show Remnic Memory Inspector",
+        description:
+          "Use this when the user wants a ChatGPT Apps-compatible UI for inspecting Remnic recall, provenance, safety, and correction/forget/scoping affordances. Read-only; correction and forget actions are proposed as follow-up prompts.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "Memory question to inspect.",
+            },
+            sessionKey: {
+              type: "string",
+              description: "Optional Remnic session key for scoped recall.",
+            },
+            namespace: {
+              type: "string",
+              description: "Optional Remnic namespace to inspect.",
+            },
+            currentContextScopes: {
+              type: "array",
+              items: { type: "string" },
+              description:
+                "Optional current user-context scopes, such as repo, work, personal, client, or private.",
+            },
+          },
+          required: ["query"],
+          additionalProperties: false,
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            app: { type: "object" },
+            query: { type: "string" },
+            namespace: { type: "string" },
+            safeRecallPreview: { type: "string" },
+            memoryCount: { type: "number" },
+            memoryIds: { type: "array", items: { type: "string" } },
+            memories: { type: "array", items: { type: "object" } },
+            actionConfidence: { type: "object" },
+            affordances: { type: "array", items: { type: "object" } },
+            guidance: { type: "object" },
+          },
+          required: [
+            "app",
+            "query",
+            "namespace",
+            "safeRecallPreview",
+            "memoryCount",
+            "memoryIds",
+            "memories",
+            "actionConfidence",
+            "affordances",
+            "guidance",
+          ],
+          additionalProperties: false,
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+        _meta: {
+          ui: {
+            resourceUri: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+            visibility: ["model", "app"],
+          },
+          "openai/outputTemplate": REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+          "openai/toolInvocation/invoking": "Inspecting Remnic memory...",
+          "openai/toolInvocation/invoked": "Remnic memory inspector ready.",
         },
       },
       {
@@ -1539,6 +1657,7 @@ export class EngramMcpServer {
           protocolVersion: MCP_PROTOCOL_VERSION,
           capabilities: {
             tools: {},
+            resources: {},
           },
           serverInfo: {
             name: "remnic",
@@ -1553,6 +1672,58 @@ export class EngramMcpServer {
         id,
         result: {
           tools: this.tools,
+        },
+      };
+    }
+    if (method === "resources/list") {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          resources: this.resources,
+        },
+      };
+    }
+    if (method === "resources/templates/list") {
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          resourceTemplates: this.resources.map((resource) => ({
+            uriTemplate: resource.uri,
+            name: resource.name,
+            title: resource.title,
+            description: resource.description,
+            mimeType: resource.mimeType,
+            _meta: resource._meta,
+          })),
+        },
+      };
+    }
+    if (method === "resources/read") {
+      const params = request.params ?? {};
+      const uri = typeof params.uri === "string" ? params.uri : "";
+      if (uri !== REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI) {
+        return {
+          jsonrpc: "2.0",
+          id,
+          error: {
+            code: -32602,
+            message: `Unknown resource URI: ${uri}`,
+          },
+        };
+      }
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: {
+          contents: [
+            {
+              uri,
+              mimeType: REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
+              text: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_HTML,
+            },
+          ],
         },
       };
     }
@@ -1982,6 +2153,82 @@ export class EngramMcpServer {
       case "engram.action_confidence": {
         const body: ActionConfidenceRequest = parseMcpRequest("actionConfidence", args);
         return this.service.actionConfidence(body);
+      }
+      case REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL: {
+        if (typeof args.query !== "string" || args.query.trim().length === 0) {
+          throw new EngramAccessInputError(
+            "chatgpt_memory_inspector requires a non-empty query string",
+          );
+        }
+        if (
+          "sessionKey" in args &&
+          args.sessionKey !== undefined &&
+          args.sessionKey !== null &&
+          typeof args.sessionKey !== "string"
+        ) {
+          throw new EngramAccessInputError("sessionKey must be a string");
+        }
+        if (
+          "namespace" in args &&
+          args.namespace !== undefined &&
+          args.namespace !== null &&
+          typeof args.namespace !== "string"
+        ) {
+          throw new EngramAccessInputError("namespace must be a string");
+        }
+        let currentContextScopes: string[] | undefined;
+        if (args.currentContextScopes !== undefined && args.currentContextScopes !== null) {
+          if (
+            !Array.isArray(args.currentContextScopes) ||
+            !args.currentContextScopes.every((scope) => typeof scope === "string")
+          ) {
+            throw new EngramAccessInputError(
+              "currentContextScopes must be an array of strings",
+            );
+          }
+          currentContextScopes = args.currentContextScopes;
+        }
+
+        const input: RemnicChatGptMemoryInspectorInput = {
+          query: args.query.trim(),
+        };
+        if (typeof args.sessionKey === "string" && args.sessionKey.trim().length > 0) {
+          input.sessionKey = args.sessionKey;
+        }
+        if (typeof args.namespace === "string" && args.namespace.trim().length > 0) {
+          input.namespace = args.namespace;
+        }
+        if (currentContextScopes !== undefined) {
+          input.currentContextScopes = currentContextScopes;
+        }
+        const recall = await this.service.recall({
+          query: input.query,
+          sessionKey: input.sessionKey,
+          namespace: input.namespace,
+          mode: "full",
+          disclosure: "chunk",
+        });
+        const xrayResponse = await this.service.recallXray({
+          query: input.query,
+          sessionKey: input.sessionKey,
+          namespace: input.namespace,
+          authenticatedPrincipal: effectivePrincipal,
+        });
+        const xray = xrayResponse.snapshotFound === true
+          ? xrayResponse.snapshot ?? null
+          : null;
+        const actionRequest = buildChatGptMemoryInspectorActionRequest(
+          input,
+          recall,
+          xray,
+        );
+        const actionConfidence = await this.service.actionConfidence(actionRequest);
+        return buildChatGptMemoryInspectorResult(
+          input,
+          recall,
+          xray,
+          actionConfidence,
+        );
       }
       case "engram.day_summary":
         return this.service.daySummary({

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1995,6 +1995,7 @@ export class EngramMcpServer {
         const response = await this.service.recall({
           query: typeof args.query === "string" ? args.query : "",
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
+          authenticatedPrincipal: effectivePrincipal,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
           topK: typeof args.topK === "number" && Number.isFinite(args.topK) ? args.topK : undefined,
           mode: typeof args.mode === "string" ? args.mode as RecallPlanMode | "auto" : undefined,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1945,6 +1945,12 @@ export class EngramAccessService {
     tags?: string[];
     /** Match mode for `tags`. See `EngramAccessRecallRequest.tagMatch`. */
     tagMatch?: "any" | "all";
+    /**
+     * User-aware context scopes active for this recall. Forwarded into
+     * provenance construction so boundary scopes are evaluated against
+     * the caller's real context instead of an empty-context default.
+     */
+    currentContextScopes?: readonly unknown[];
   }): Promise<{
     snapshotFound: boolean;
     snapshot?: import("./recall-xray.js").RecallXraySnapshot;
@@ -2058,6 +2064,9 @@ export class EngramAccessService {
         // (CLAUDE.md rule 42).
         ...(authenticatedPrincipal
           ? { principalOverride: authenticatedPrincipal }
+          : {}),
+        ...(request.currentContextScopes !== undefined
+          ? { currentContextScopes: request.currentContextScopes }
           : {}),
       });
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -213,6 +213,7 @@ export interface EngramAccessRecallRequest {
   query: string;
   sessionKey?: string;
   namespace?: string;
+  authenticatedPrincipal?: string;
   topK?: number;
   mode?: RecallPlanMode | "auto";
   includeDebug?: boolean;
@@ -956,18 +957,22 @@ export class EngramAccessService {
     throw new EngramAccessInputError(`unsupported recall mode: ${mode}`);
   }
 
-  private resolveRecallNamespace(namespace: string | undefined, sessionKey: string | undefined): string | undefined {
+  private resolveRecallNamespace(
+    namespace: string | undefined,
+    sessionKey: string | undefined,
+    authenticatedPrincipal?: string,
+  ): string | undefined {
     const requested = namespace?.trim();
     if (!requested) return undefined;
     const resolved = this.resolveNamespace(requested);
-    const principal = resolvePrincipal(sessionKey, this.orchestrator.config);
+    const principal = this.resolveRequestPrincipal(sessionKey, authenticatedPrincipal);
     if (!canReadNamespace(principal, resolved, this.orchestrator.config)) {
       throw new EngramAccessInputError(`namespace override is not readable: ${resolved}`);
     }
     return resolved;
   }
 
-  private resolveWritePrincipal(sessionKey: string | undefined, authenticatedPrincipal?: string): string {
+  private resolveRequestPrincipal(sessionKey: string | undefined, authenticatedPrincipal?: string): string {
     const trusted = authenticatedPrincipal?.trim();
     if (trusted) return trusted;
     return resolvePrincipal(sessionKey, this.orchestrator.config);
@@ -979,7 +984,7 @@ export class EngramAccessService {
     authenticatedPrincipal?: string,
   ): string {
     const resolved = this.resolveNamespace(namespace);
-    const principal = this.resolveWritePrincipal(sessionKey, authenticatedPrincipal);
+    const principal = this.resolveRequestPrincipal(sessionKey, authenticatedPrincipal);
     if (!canWriteNamespace(principal, resolved, this.orchestrator.config)) {
       throw new EngramAccessInputError(`namespace is not writable: ${resolved}`);
     }
@@ -1534,12 +1539,17 @@ export class EngramAccessService {
         projectTag: request.projectTag,
       });
     }
-    const namespaceOverride = this.resolveRecallNamespace(request.namespace, request.sessionKey);
+    const authenticatedPrincipal = request.authenticatedPrincipal?.trim();
+    const namespaceOverride = this.resolveRecallNamespace(
+      request.namespace,
+      request.sessionKey,
+      authenticatedPrincipal,
+    );
     const namespace = namespaceOverride ?? this.orchestrator.config.defaultNamespace;
     // Normalize mode early so that no_recall / invalid modes skip budget
     // accounting (Codex P1: budget recorded before mode validation).
     const mode = this.normalizeRecallMode(request.mode);
-    const principal = resolvePrincipal(request.sessionKey, this.orchestrator.config);
+    const principal = this.resolveRequestPrincipal(request.sessionKey, authenticatedPrincipal);
     const principalNamespace = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
     // Skip budget checks for modes that never perform a cross-namespace read.
     const modeSkipsBudget = mode === "no_recall";
@@ -1642,6 +1652,7 @@ export class EngramAccessService {
       namespace: namespaceOverride,
       topK,
       mode,
+      ...(authenticatedPrincipal ? { principalOverride: authenticatedPrincipal } : {}),
       ...(asOf !== undefined ? { asOf } : {}),
       ...(request.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
     };
@@ -1779,10 +1790,7 @@ export class EngramAccessService {
     let auditAnomalies: AccessAuditResult["anomalies"] | undefined;
     if (this.auditAdapter) {
       try {
-        const resolvedAgentId = resolvePrincipal(
-          request.sessionKey,
-          this.orchestrator.config,
-        );
+        const resolvedAgentId = principal;
         const auditEntry = {
           ts: new Date().toISOString(),
           sessionKey: request.sessionKey ?? "",
@@ -1945,6 +1953,8 @@ export class EngramAccessService {
     tags?: string[];
     /** Match mode for `tags`. See `EngramAccessRecallRequest.tagMatch`. */
     tagMatch?: "any" | "all";
+    /** Recall planner mode override. Mirrors `EngramAccessRecallRequest.mode`. */
+    mode?: RecallPlanMode | "auto";
     /**
      * User-aware context scopes active for this recall. Forwarded into
      * provenance construction so boundary scopes are evaluated against
@@ -2025,6 +2035,7 @@ export class EngramAccessService {
       }
       budgetOverride = parsed;
     }
+    const mode = this.normalizeRecallMode(request.mode);
 
     // Serialize x-ray invocations behind a per-service mutex so the
     // per-process `getLastXraySnapshot()` slot cannot be clobbered by
@@ -2052,6 +2063,7 @@ export class EngramAccessService {
         ...(budgetOverride !== undefined
           ? { budgetCharsOverride: budgetOverride }
           : {}),
+        ...(mode !== undefined ? { mode } : {}),
         // When the caller supplies an authenticated principal, forward
         // it via the dedicated override channel so orchestrator-side
         // ACL decisions use the SAME principal the access-surface
@@ -3387,7 +3399,7 @@ export class EngramAccessService {
     const hasExplicitNamespace =
       typeof request.namespace === "string" &&
       request.namespace.trim().length > 0;
-    const principal = this.resolveWritePrincipal(
+    const principal = this.resolveRequestPrincipal(
       request.sessionKey,
       request.authenticatedPrincipal,
     );
@@ -3526,7 +3538,7 @@ export class EngramAccessService {
       throw new EngramAccessInputError("query is required and must be a non-empty string");
     }
 
-    const principal = this.resolveWritePrincipal(request.sessionKey, request.authenticatedPrincipal);
+    const principal = this.resolveRequestPrincipal(request.sessionKey, request.authenticatedPrincipal);
     const namespace = this.resolveReadableNamespace(request.namespace, principal);
 
     if (!this.orchestrator.lcmEngine || !this.orchestrator.lcmEngine.enabled) {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -98,7 +98,7 @@ import type {
   RecallPlanMode,
 } from "./types.js";
 import { DEFAULT_RECALL_DISCLOSURE, isRecallDisclosure } from "./types.js";
-import { estimateRecallTokens } from "./recall-xray.js";
+import { estimateRecallTokens, type RecallXraySnapshot } from "./recall-xray.js";
 import type {
   LcmMessagePartInput,
   MessagePartSourceFormat,
@@ -1059,6 +1059,84 @@ export class EngramAccessService {
       : undefined;
   }
 
+  private async buildRecallResponseFromXraySnapshot(options: {
+    query: string;
+    sessionKey?: string;
+    snapshot: RecallXraySnapshot;
+    disclosure: RecallDisclosure;
+    startedAt: number;
+    requestedMode?: RecallPlanMode | "auto";
+    normalizedMode?: RecallPlanMode;
+  }): Promise<EngramAccessRecallResponse> {
+    const memoryIds = options.snapshot.results.map((result) => result.memoryId);
+    const resultPaths = options.snapshot.results.map((result) => result.path);
+    const namespace = options.snapshot.namespace
+      ? this.resolveNamespace(options.snapshot.namespace)
+      : this.orchestrator.config.defaultNamespace;
+    const sourcesUsed = Array.from(
+      new Set(options.snapshot.results.map((result) => result.servedBy)),
+    );
+    const snapshotForSerialization: LastRecallSnapshot = {
+      sessionKey: options.sessionKey ?? "",
+      recordedAt: new Date(options.snapshot.capturedAt).toISOString(),
+      queryHash: createHash("sha256").update(options.query).digest("hex"),
+      queryLen: options.query.length,
+      memoryIds,
+      namespace,
+      traceId: options.snapshot.traceId,
+      plannerMode: options.normalizedMode,
+      requestedMode:
+        options.requestedMode && options.requestedMode !== "auto"
+          ? options.requestedMode
+          : undefined,
+      sourcesUsed,
+      budgetsApplied: {
+        appliedTopK: memoryIds.length,
+        recallBudgetChars: options.snapshot.budget.chars,
+        maxMemoryTokens: this.orchestrator.config.maxMemoryTokens,
+        finalContextChars: options.snapshot.budget.used,
+      },
+      latencyMs: Date.now() - options.startedAt,
+      resultPaths,
+    };
+    const results = await this.serializeRecallResults(
+      snapshotForSerialization,
+      options.disclosure,
+      {
+        query: options.query,
+        ...(options.sessionKey ? { sessionKey: options.sessionKey } : {}),
+      },
+    );
+    const context = results
+      .map((result) => {
+        const content =
+          typeof result.content === "string" && result.content.length > 0
+            ? result.content
+            : "";
+        return content || result.preview;
+      })
+      .filter((text) => text.length > 0)
+      .join("\n\n");
+
+    return {
+      query: options.query,
+      ...(options.sessionKey ? { sessionKey: options.sessionKey } : {}),
+      namespace,
+      context,
+      count: memoryIds.length,
+      memoryIds,
+      results,
+      recordedAt: snapshotForSerialization.recordedAt,
+      traceId: options.snapshot.traceId,
+      plannerMode: options.normalizedMode,
+      fallbackUsed: sourcesUsed.some((source) => source !== "hybrid"),
+      sourcesUsed,
+      disclosure: options.disclosure,
+      budgetsApplied: snapshotForSerialization.budgetsApplied,
+      latencyMs: snapshotForSerialization.latencyMs,
+    };
+  }
+
   private async serializeRecallResults(
     snapshot: LastRecallSnapshot | null,
     disclosure: RecallDisclosure,
@@ -1961,10 +2039,18 @@ export class EngramAccessService {
      * the caller's real context instead of an empty-context default.
      */
     currentContextScopes?: readonly unknown[];
+    /**
+     * Internal inspector affordance: include a recall-shaped response
+     * derived from the same X-ray snapshot. Left off by default so the
+     * regular X-ray API/CLI/MCP surfaces keep their existing payload shape.
+     */
+    includeRecall?: boolean;
   }): Promise<{
     snapshotFound: boolean;
-    snapshot?: import("./recall-xray.js").RecallXraySnapshot;
+    snapshot?: RecallXraySnapshot;
+    recall?: EngramAccessRecallResponse;
   }> {
+    const startedAt = Date.now();
     const query = typeof request.query === "string" ? request.query : "";
     if (query.trim().length === 0) {
       // Match the CLI contract (CLAUDE.md rule 51): reject empty
@@ -2036,6 +2122,7 @@ export class EngramAccessService {
       budgetOverride = parsed;
     }
     const mode = this.normalizeRecallMode(request.mode);
+    const disclosure = request.disclosure ?? DEFAULT_RECALL_DISCLOSURE;
 
     // Serialize x-ray invocations behind a per-service mutex so the
     // per-process `getLastXraySnapshot()` slot cannot be clobbered by
@@ -2057,7 +2144,8 @@ export class EngramAccessService {
       // `{snapshotFound: false}` rather than returning stale data
       // from an earlier call on the same orchestrator.
       this.orchestrator.clearLastXraySnapshot();
-      await this.orchestrator.recall(query, request.sessionKey?.trim() || undefined, {
+      const recallSessionKey = request.sessionKey?.trim() || undefined;
+      await this.orchestrator.recall(query, recallSessionKey, {
         xrayCapture: true,
         ...(requestedNamespace ? { namespace: requestedNamespace } : {}),
         ...(budgetOverride !== undefined
@@ -2254,12 +2342,42 @@ export class EngramAccessService {
             estimatedTokens: estimateRecallTokens(rawExcerptText),
           };
         }
+        const decoratedSnapshot = { ...snapshot, results: decorated };
         return {
           snapshotFound: true,
-          snapshot: { ...snapshot, results: decorated },
+          snapshot: decoratedSnapshot,
+          ...(request.includeRecall === true
+            ? {
+                recall: await this.buildRecallResponseFromXraySnapshot({
+                  query,
+                  sessionKey: recallSessionKey,
+                  snapshot: decoratedSnapshot,
+                  disclosure,
+                  startedAt,
+                  requestedMode: request.mode,
+                  normalizedMode: mode,
+                }),
+              }
+            : {}),
         };
       }
-      return { snapshotFound: true, snapshot };
+      return {
+        snapshotFound: true,
+        snapshot,
+        ...(request.includeRecall === true
+          ? {
+              recall: await this.buildRecallResponseFromXraySnapshot({
+                query,
+                sessionKey: recallSessionKey,
+                snapshot,
+                disclosure,
+                startedAt,
+                requestedMode: request.mode,
+                normalizedMode: mode,
+              }),
+            }
+          : {}),
+      };
     } finally {
       release();
     }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2139,12 +2139,17 @@ export class EngramAccessService {
     });
     await previousQueue;
 
+    const recallSessionKey = request.sessionKey?.trim() || undefined;
+    let xrayResponse: {
+      snapshotFound: boolean;
+      snapshot?: RecallXraySnapshot;
+    } = { snapshotFound: false };
+
     try {
       // Clear any prior snapshot so a capture failure surfaces as
       // `{snapshotFound: false}` rather than returning stale data
       // from an earlier call on the same orchestrator.
       this.orchestrator.clearLastXraySnapshot();
-      const recallSessionKey = request.sessionKey?.trim() || undefined;
       await this.orchestrator.recall(query, recallSessionKey, {
         xrayCapture: true,
         ...(requestedNamespace ? { namespace: requestedNamespace } : {}),
@@ -2171,73 +2176,77 @@ export class EngramAccessService {
       });
 
       const rawSnapshot = this.orchestrator.getLastXraySnapshot();
-      if (!rawSnapshot) return { snapshotFound: false };
       // Re-check namespace after capture: the recall may have served
       // from a different namespace than the caller requested.  Drop
       // the snapshot rather than leak cross-tenant data (CLAUDE.md
       // rules 42 + 47).  The comparison is strict so a snapshot whose
       // namespace is `undefined` cannot bypass the scope the caller
       // asked for.
-      if (requestedNamespace && rawSnapshot.namespace !== requestedNamespace) {
-        return { snapshotFound: false };
-      }
-      // Tag filter (issue #689). Mirrors `recall()` semantics — applied
-      // post-capture by reading each result's frontmatter tags and
-      // dropping non-matching results. Filter activity surfaces as a
-      // `tag-filter` entry in `snapshot.filters` so X-ray consumers can
-      // see the "considered → admitted" delta.
-      let snapshot = rawSnapshot;
-      const xrayFilterTags = normalizeTags(request.tags);
-      let xrayTagMatch: TagMatchMode | undefined;
-      try {
-        xrayTagMatch = parseTagMatch(request.tagMatch);
-      } catch (err) {
-        throw new EngramAccessInputError(
-          err instanceof Error ? err.message : String(err),
-        );
-      }
-      if (xrayFilterTags && xrayFilterTags.length > 0) {
-        const namespace = snapshot.namespace
-          ? this.resolveNamespace(snapshot.namespace)
-          : this.orchestrator.config.defaultNamespace;
-        const tagsByIndex = await Promise.all(
-          snapshot.results.map(async (result) => {
-            try {
-              const storage = await this.orchestrator.getStorage(namespace);
-              const memory = await storage.readMemoryByPath(result.path);
-              const t = memory?.frontmatter?.tags;
-              // Normalize identically to the recall path
-              // (`normalizeProjectionTags`): trim and drop empty strings
-              // so X-ray tag matching stays consistent with the recall
-              // surface. Without this, a frontmatter tag like " draft "
-              // would match in recall but not in X-ray (cursor review).
-              return Array.isArray(t) ? normalizeProjectionTags(t) : [];
-            } catch {
-              return [];
-            }
-          }),
-        );
-        const tagged = snapshot.results.map((result, index) => ({
-          result,
-          tags: tagsByIndex[index] ?? [],
-        }));
-        const { results: admittedTagged, trace } = applyTagFilter(tagged, {
-          tags: xrayFilterTags,
-          tagMatch: xrayTagMatch,
-        });
-        const admittedResults = admittedTagged.map((entry) => entry.result);
-        const filters = trace ? [...snapshot.filters, trace] : snapshot.filters;
-        snapshot = { ...snapshot, results: admittedResults, filters };
-      }
-      // Decorate per-result disclosure + token estimate when the caller
-      // wired a depth knob (issue #677 PR 3/4 — codex review on #699
-      // flagged that the renderer's per-disclosure summary stays empty
-      // until callers populate these fields).  Estimate tokens from
-      // the actual rendered payload at the requested depth so the
-      // summary reflects real spend; chunk uses the preview, section
-      // and raw use full content.  Best-effort only — a missing
-      // memory or read failure is silently dropped (CLAUDE.md rule 13).
-      if (request.disclosure !== undefined) {
+      const namespaceMismatch =
+        requestedNamespace !== undefined &&
+        rawSnapshot?.namespace !== requestedNamespace;
+      if (!rawSnapshot) {
+        xrayResponse = { snapshotFound: false };
+      } else if (namespaceMismatch) {
+        xrayResponse = { snapshotFound: false };
+      } else {
+        // Tag filter (issue #689). Mirrors `recall()` semantics — applied
+        // post-capture by reading each result's frontmatter tags and
+        // dropping non-matching results. Filter activity surfaces as a
+        // `tag-filter` entry in `snapshot.filters` so X-ray consumers can
+        // see the "considered → admitted" delta.
+        let snapshot = rawSnapshot;
+        const xrayFilterTags = normalizeTags(request.tags);
+        let xrayTagMatch: TagMatchMode | undefined;
+        try {
+          xrayTagMatch = parseTagMatch(request.tagMatch);
+        } catch (err) {
+          throw new EngramAccessInputError(
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+        if (xrayFilterTags && xrayFilterTags.length > 0) {
+          const namespace = snapshot.namespace
+            ? this.resolveNamespace(snapshot.namespace)
+            : this.orchestrator.config.defaultNamespace;
+          const tagsByIndex = await Promise.all(
+            snapshot.results.map(async (result) => {
+              try {
+                const storage = await this.orchestrator.getStorage(namespace);
+                const memory = await storage.readMemoryByPath(result.path);
+                const t = memory?.frontmatter?.tags;
+                // Normalize identically to the recall path
+                // (`normalizeProjectionTags`): trim and drop empty strings
+                // so X-ray tag matching stays consistent with the recall
+                // surface. Without this, a frontmatter tag like " draft "
+                // would match in recall but not in X-ray (cursor review).
+                return Array.isArray(t) ? normalizeProjectionTags(t) : [];
+              } catch {
+                return [];
+              }
+            }),
+          );
+          const tagged = snapshot.results.map((result, index) => ({
+            result,
+            tags: tagsByIndex[index] ?? [],
+          }));
+          const { results: admittedTagged, trace } = applyTagFilter(tagged, {
+            tags: xrayFilterTags,
+            tagMatch: xrayTagMatch,
+          });
+          const admittedResults = admittedTagged.map((entry) => entry.result);
+          const filters = trace ? [...snapshot.filters, trace] : snapshot.filters;
+          snapshot = { ...snapshot, results: admittedResults, filters };
+        }
+        // Decorate per-result disclosure + token estimate when the caller
+        // wired a depth knob (issue #677 PR 3/4 — codex review on #699
+        // flagged that the renderer's per-disclosure summary stays empty
+        // until callers populate these fields).  Estimate tokens from
+        // the actual rendered payload at the requested depth so the
+        // summary reflects real spend; chunk uses the preview, section
+        // and raw use full content.  Best-effort only — a missing
+        // memory or read failure is silently dropped (CLAUDE.md rule 13).
+        if (request.disclosure !== undefined) {
         // Disclosure already validated up front; pin to the narrowed
         // type here.  Re-validation inside the queue would be dead code.
         const disclosure: RecallDisclosure = request.disclosure;
@@ -2343,44 +2352,40 @@ export class EngramAccessService {
           };
         }
         const decoratedSnapshot = { ...snapshot, results: decorated };
-        return {
+        xrayResponse = {
           snapshotFound: true,
           snapshot: decoratedSnapshot,
-          ...(request.includeRecall === true
-            ? {
-                recall: await this.buildRecallResponseFromXraySnapshot({
-                  query,
-                  sessionKey: recallSessionKey,
-                  snapshot: decoratedSnapshot,
-                  disclosure,
-                  startedAt,
-                  requestedMode: request.mode,
-                  normalizedMode: mode,
-                }),
-              }
-            : {}),
+        };
+      } else {
+        xrayResponse = {
+          snapshotFound: true,
+          snapshot,
         };
       }
-      return {
-        snapshotFound: true,
-        snapshot,
-        ...(request.includeRecall === true
-          ? {
-              recall: await this.buildRecallResponseFromXraySnapshot({
-                query,
-                sessionKey: recallSessionKey,
-                snapshot,
-                disclosure,
-                startedAt,
-                requestedMode: request.mode,
-                normalizedMode: mode,
-              }),
-            }
-          : {}),
-      };
+      }
     } finally {
       release();
     }
+
+    if (
+      request.includeRecall === true &&
+      xrayResponse.snapshotFound === true &&
+      xrayResponse.snapshot
+    ) {
+      return {
+        ...xrayResponse,
+        recall: await this.buildRecallResponseFromXraySnapshot({
+          query,
+          sessionKey: recallSessionKey,
+          snapshot: xrayResponse.snapshot,
+          disclosure,
+          startedAt,
+          requestedMode: request.mode,
+          normalizedMode: mode,
+        }),
+      };
+    }
+    return xrayResponse;
   }
   // Sequence lock for `recallXray` — see comment inside the method.
   // Lives on the instance so every x-ray call on the same service

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2050,7 +2050,6 @@ export class EngramAccessService {
     snapshot?: RecallXraySnapshot;
     recall?: EngramAccessRecallResponse;
   }> {
-    const startedAt = Date.now();
     const query = typeof request.query === "string" ? request.query : "";
     if (query.trim().length === 0) {
       // Match the CLI contract (CLAUDE.md rule 51): reject empty
@@ -2138,6 +2137,7 @@ export class EngramAccessService {
       release = resolve;
     });
     await previousQueue;
+    const recallStartedAt = Date.now();
 
     const recallSessionKey = request.sessionKey?.trim() || undefined;
     let xrayResponse: {
@@ -2247,121 +2247,121 @@ export class EngramAccessService {
         // and raw use full content.  Best-effort only — a missing
         // memory or read failure is silently dropped (CLAUDE.md rule 13).
         if (request.disclosure !== undefined) {
-        // Disclosure already validated up front; pin to the narrowed
-        // type here.  Re-validation inside the queue would be dead code.
-        const disclosure: RecallDisclosure = request.disclosure;
-        const namespace = snapshot.namespace
-          ? this.resolveNamespace(snapshot.namespace)
-          : this.orchestrator.config.defaultNamespace;
-        // Pre-fetch raw excerpts ONCE so the first raw-disclosure
-        // result's token estimate includes the LCM-side excerpt spend
-        // that `shapeMemorySummary` actually attaches in the recall
-        // response.  Without this, raw recalls systematically
-        // undercounted spend on the first result (Cursor Medium review
-        // on PR #699).  Excerpts are scoped to the same session +
-        // namespace as the recall.
-        // Trim sessionKey to match what `orchestrator.recall(...)`
-        // already does (`request.sessionKey?.trim() || undefined`),
-        // otherwise a whitespace-padded key drives recall under one
-        // identity but probes LCM under a different prefix and
-        // misses stored excerpts (Cursor Low review on PR #699).
-        const trimmedSessionKey = request.sessionKey?.trim() || undefined;
-        const rawExcerpts =
-          disclosure === "raw"
-            ? await this.fetchRawExcerpts(disclosure, {
-                query,
-                ...(trimmedSessionKey ? { sessionKey: trimmedSessionKey } : {}),
-                namespace,
-              })
-            : null;
-        const rawExcerptText =
-          rawExcerpts && rawExcerpts.length > 0
-            ? rawExcerpts.map((e) => e.content).join("\n")
-            : "";
-        // Pre-load every memory in parallel so we can:
-        //   (a) re-attribute raw excerpts to the *first readable* result
-        //       rather than always to index 0 (Cursor Low review on PR
-        //       #699: a missing/unreadable result[0] orphaned the excerpt
-        //       budget); and
-        //   (b) include the metadata fields `shapeMemorySummary` actually
-        //       emits at every depth (id, path, category, status, created,
-        //       updated, tags, entityRef) in the token estimate, so the
-        //       summary reflects real spend rather than only payload-body
-        //       spend (Cursor Low review on PR #699).
-        const memoryByIndex = await Promise.all(
-          snapshot.results.map(async (result) => {
-            try {
-              const storage = await this.orchestrator.getStorage(namespace);
-              return await storage.readMemoryByPath(result.path);
-            } catch {
-              return null;
-            }
-          }),
-        );
-        const firstReadableIndex = memoryByIndex.findIndex((m) => m !== null);
-        const baseDir =
-          (await this.orchestrator.getStorage(namespace)).dir;
-        const decorated = snapshot.results.map((result, index) => {
-          const memory = memoryByIndex[index];
-          if (!memory) {
-            // Unreadable result: attach the disclosure tag anyway so
-            // the per-disclosure summary classifies it correctly,
-            // but skip the token estimate since we don't have the
-            // content to measure.  Without the disclosure tag the
-            // result silently flows into the `unspecified` bucket
-            // even though the caller explicitly requested a depth
-            // (Cursor Low review on PR #699).
-            return { ...result, disclosure };
-          }
-          // Build a representative shaped summary so the estimate
-          // counts every field `shapeMemorySummary` actually emits.
-          // The serialized JSON form is a close-enough proxy for the
-          // wire payload size.
-          const shaped = shapeMemorySummary(
-            memory,
-            baseDir,
-            disclosure,
-            disclosure === "raw" &&
-            index === firstReadableIndex &&
-            rawExcerpts &&
-            rawExcerpts.length > 0
-              ? rawExcerpts
-              : undefined,
+          // Disclosure already validated up front; pin to the narrowed
+          // type here.  Re-validation inside the queue would be dead code.
+          const disclosure: RecallDisclosure = request.disclosure;
+          const namespace = snapshot.namespace
+            ? this.resolveNamespace(snapshot.namespace)
+            : this.orchestrator.config.defaultNamespace;
+          // Pre-fetch raw excerpts ONCE so the first raw-disclosure
+          // result's token estimate includes the LCM-side excerpt spend
+          // that `shapeMemorySummary` actually attaches in the recall
+          // response.  Without this, raw recalls systematically
+          // undercounted spend on the first result (Cursor Medium review
+          // on PR #699).  Excerpts are scoped to the same session +
+          // namespace as the recall.
+          // Trim sessionKey to match what `orchestrator.recall(...)`
+          // already does (`request.sessionKey?.trim() || undefined`),
+          // otherwise a whitespace-padded key drives recall under one
+          // identity but probes LCM under a different prefix and
+          // misses stored excerpts (Cursor Low review on PR #699).
+          const trimmedSessionKey = request.sessionKey?.trim() || undefined;
+          const rawExcerpts =
+            disclosure === "raw"
+              ? await this.fetchRawExcerpts(disclosure, {
+                  query,
+                  ...(trimmedSessionKey ? { sessionKey: trimmedSessionKey } : {}),
+                  namespace,
+                })
+              : null;
+          const rawExcerptText =
+            rawExcerpts && rawExcerpts.length > 0
+              ? rawExcerpts.map((e) => e.content).join("\n")
+              : "";
+          // Pre-load every memory in parallel so we can:
+          //   (a) re-attribute raw excerpts to the *first readable* result
+          //       rather than always to index 0 (Cursor Low review on PR
+          //       #699: a missing/unreadable result[0] orphaned the excerpt
+          //       budget); and
+          //   (b) include the metadata fields `shapeMemorySummary` actually
+          //       emits at every depth (id, path, category, status, created,
+          //       updated, tags, entityRef) in the token estimate, so the
+          //       summary reflects real spend rather than only payload-body
+          //       spend (Cursor Low review on PR #699).
+          const memoryByIndex = await Promise.all(
+            snapshot.results.map(async (result) => {
+              try {
+                const storage = await this.orchestrator.getStorage(namespace);
+                return await storage.readMemoryByPath(result.path);
+              } catch {
+                return null;
+              }
+            }),
           );
-          return {
-            ...result,
-            disclosure,
-            estimatedTokens: estimateRecallTokens(JSON.stringify(shaped)),
+          const firstReadableIndex = memoryByIndex.findIndex((m) => m !== null);
+          const baseDir =
+            (await this.orchestrator.getStorage(namespace)).dir;
+          const decorated = snapshot.results.map((result, index) => {
+            const memory = memoryByIndex[index];
+            if (!memory) {
+              // Unreadable result: attach the disclosure tag anyway so
+              // the per-disclosure summary classifies it correctly,
+              // but skip the token estimate since we don't have the
+              // content to measure.  Without the disclosure tag the
+              // result silently flows into the `unspecified` bucket
+              // even though the caller explicitly requested a depth
+              // (Cursor Low review on PR #699).
+              return { ...result, disclosure };
+            }
+            // Build a representative shaped summary so the estimate
+            // counts every field `shapeMemorySummary` actually emits.
+            // The serialized JSON form is a close-enough proxy for the
+            // wire payload size.
+            const shaped = shapeMemorySummary(
+              memory,
+              baseDir,
+              disclosure,
+              disclosure === "raw" &&
+              index === firstReadableIndex &&
+              rawExcerpts &&
+              rawExcerpts.length > 0
+                ? rawExcerpts
+                : undefined,
+            );
+            return {
+              ...result,
+              disclosure,
+              estimatedTokens: estimateRecallTokens(JSON.stringify(shaped)),
+            };
+          });
+          // Edge case: every result was unreadable but rawExcerpts
+          // still has content — credit that spend to result[0] rather
+          // than dropping it on the floor.  Without this, the raw row
+          // in the per-disclosure summary under-reports spend whenever
+          // every memory file is missing/unreadable.
+          if (
+            disclosure === "raw" &&
+            firstReadableIndex === -1 &&
+            rawExcerptText.length > 0 &&
+            decorated.length > 0
+          ) {
+            decorated[0] = {
+              ...decorated[0]!,
+              disclosure,
+              estimatedTokens: estimateRecallTokens(rawExcerptText),
+            };
+          }
+          const decoratedSnapshot = { ...snapshot, results: decorated };
+          xrayResponse = {
+            snapshotFound: true,
+            snapshot: decoratedSnapshot,
           };
-        });
-        // Edge case: every result was unreadable but rawExcerpts
-        // still has content — credit that spend to result[0] rather
-        // than dropping it on the floor.  Without this, the raw row
-        // in the per-disclosure summary under-reports spend whenever
-        // every memory file is missing/unreadable.
-        if (
-          disclosure === "raw" &&
-          firstReadableIndex === -1 &&
-          rawExcerptText.length > 0 &&
-          decorated.length > 0
-        ) {
-          decorated[0] = {
-            ...decorated[0]!,
-            disclosure,
-            estimatedTokens: estimateRecallTokens(rawExcerptText),
+        } else {
+          xrayResponse = {
+            snapshotFound: true,
+            snapshot,
           };
         }
-        const decoratedSnapshot = { ...snapshot, results: decorated };
-        xrayResponse = {
-          snapshotFound: true,
-          snapshot: decoratedSnapshot,
-        };
-      } else {
-        xrayResponse = {
-          snapshotFound: true,
-          snapshot,
-        };
-      }
       }
     } finally {
       release();
@@ -2379,7 +2379,7 @@ export class EngramAccessService {
           sessionKey: recallSessionKey,
           snapshot: xrayResponse.snapshot,
           disclosure,
-          startedAt,
+          startedAt: recallStartedAt,
           requestedMode: request.mode,
           normalizedMode: mode,
         }),

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -322,6 +322,18 @@ export {
 export { EngramAccessService, EngramAccessInputError } from "./access-service.js";
 export { EngramAccessHttpServer } from "./access-http.js";
 export { EngramMcpServer } from "./access-mcp.js";
+export {
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_HTML,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+  buildChatGptMemoryInspectorActionRequest,
+  buildChatGptMemoryInspectorResult,
+  type RemnicChatGptMemoryCard,
+  type RemnicChatGptMemoryInspectorInput,
+  type RemnicChatGptMemoryInspectorResult,
+} from "./mcp-memory-inspector-app.js";
 
 // agentAccessHttp.authToken SecretRef resolution (issue #757). Exposed so
 // host-specific bootstrap code (the OpenClaw plugin in `src/index.ts`, the

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -112,6 +112,7 @@ export function buildChatGptMemoryInspectorResult(
   xray: RecallXraySnapshot | null,
   actionConfidence: ActionConfidenceResult,
 ): RemnicChatGptMemoryInspectorResult {
+  const xrayUnavailable = xray === null;
   const xrayById = new Map<string, RecallXrayResult>();
   for (const result of xray?.results ?? []) {
     xrayById.set(result.memoryId, result);
@@ -121,14 +122,17 @@ export function buildChatGptMemoryInspectorResult(
     const xrayResult = xrayById.get(summary.id);
     const provenance = xrayResult?.provenance;
     const blocked = provenance?.safety === "blocked";
+    const preview = xrayUnavailable
+      ? "Preview withheld: X-ray provenance was unavailable for this recall."
+      : blocked
+        ? "Preview withheld: this memory is blocked in the current context."
+        : summary.preview;
     return {
       id: summary.id,
       path: summary.path,
       category: summary.category,
       status: summary.status,
-      preview: blocked
-        ? "Preview withheld: this memory is blocked in the current context."
-        : summary.preview,
+      preview,
       servedBy: xrayResult?.servedBy,
       score: xrayResult?.scoreDecomposition.final,
       source: provenance?.source,
@@ -146,6 +150,11 @@ export function buildChatGptMemoryInspectorResult(
   const blockedCount = (xray?.results ?? [])
     .filter((result) => result.provenance?.safety === "blocked")
     .length;
+  const safeRecallPreview = xrayUnavailable
+    ? "Recall preview withheld: X-ray provenance was unavailable, so memory safety could not be verified."
+    : blockedCount > 0
+      ? `Recall preview withheld: ${blockedCount} retrieved memory ${blockedCount === 1 ? "is" : "are"} blocked in the current context.`
+      : truncate(recall.context, 1_500);
 
   const primaryMemoryId = memories[0]?.id ?? "<memory-id>";
   return {
@@ -157,9 +166,7 @@ export function buildChatGptMemoryInspectorResult(
     query: recall.query || input.query,
     ...(input.sessionKey ? { sessionKey: input.sessionKey } : {}),
     namespace: recall.namespace,
-    safeRecallPreview: blockedCount > 0
-      ? `Recall preview withheld: ${blockedCount} retrieved memory ${blockedCount === 1 ? "is" : "are"} blocked in the current context.`
-      : truncate(recall.context, 1_500),
+    safeRecallPreview,
     memoryCount: recall.count,
     memoryIds: recall.memoryIds,
     memories,

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -73,8 +73,7 @@ export function buildChatGptMemoryInspectorActionRequest(
   xray: RecallXraySnapshot | null,
 ): ActionConfidenceRequest {
   const provenances = (xray?.results ?? [])
-    .map((result) => result.provenance)
-    .filter((value): value is RetrievedMemoryProvenance => value !== undefined);
+    .map((result) => result.provenance ?? missingProvenance(result));
 
   const request: ActionConfidenceRequest = {
     intendedAction: `Use Remnic memory to answer: ${input.query}`,
@@ -119,14 +118,20 @@ export function buildChatGptMemoryInspectorResult(
     xrayById.set(result.memoryId, result);
     xrayByPath.set(result.path, result);
   }
+  const matchXrayResult = (summary: EngramAccessRecallResponse["results"][number]) =>
+    (summary.path ? xrayByPath.get(summary.path) : undefined)
+    ?? xrayById.get(summary.id);
+  const matchedXrayResults = recall.results.map(matchXrayResult);
 
   const memories = recall.results.slice(0, 8).map((summary) => {
-    const xrayResult = (summary.path ? xrayByPath.get(summary.path) : undefined)
-      ?? xrayById.get(summary.id);
+    const xrayResult = matchXrayResult(summary);
     const provenance = xrayResult?.provenance;
+    const unverified = !xrayUnavailable && provenance === undefined;
     const blocked = provenance?.safety === "blocked";
     const preview = xrayUnavailable
       ? "Preview withheld: X-ray provenance was unavailable for this recall."
+      : unverified
+        ? "Preview withheld: X-ray provenance was missing for this memory."
       : blocked
         ? "Preview withheld: this memory is blocked in the current context."
         : summary.preview;
@@ -144,19 +149,25 @@ export function buildChatGptMemoryInspectorResult(
       confidence: provenance?.confidence,
       stale: provenance?.stale,
       corrected: provenance?.corrected,
-      safeToUse: provenance?.safeToUse,
-      safety: provenance?.safety,
-      safetyReasons: provenance?.safetyReasons ?? [],
+      safeToUse: provenance?.safeToUse ?? (unverified ? false : undefined),
+      safety: provenance?.safety ?? (unverified ? "blocked" : undefined),
+      safetyReasons: provenance?.safetyReasons
+        ?? (unverified ? ["X-ray provenance was missing for this memory."] : []),
       userContextScopes: provenance?.userContextScopes ?? [],
     };
   });
-  const blockedCount = (xray?.results ?? [])
-    .filter((result) => result.provenance?.safety === "blocked")
+  const blockedCount = matchedXrayResults
+    .filter((result) => result?.provenance?.safety === "blocked")
+    .length;
+  const missingProvenanceCount = xrayUnavailable
+    ? 0
+    : matchedXrayResults
+      .filter((result) => result?.provenance === undefined)
     .length;
   const safeRecallPreview = xrayUnavailable
     ? "Recall preview withheld: X-ray provenance was unavailable, so memory safety could not be verified."
-    : blockedCount > 0
-      ? `Recall preview withheld: ${blockedCount} retrieved ${blockedCount === 1 ? "memory is" : "memories are"} blocked in the current context.`
+    : blockedCount > 0 || missingProvenanceCount > 0
+      ? formatUnsafeRecallPreview(blockedCount, missingProvenanceCount)
       : truncate(recall.context, 1_500);
 
   const primaryMemoryId = memories[0]?.id ?? "<memory-id>";
@@ -357,6 +368,51 @@ export const REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_HTML = `
 function average(values: number[]): number | undefined {
   if (values.length === 0) return undefined;
   return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function missingProvenance(result: RecallXrayResult): RetrievedMemoryProvenance {
+  return {
+    source: "unknown",
+    scope: "unknown",
+    userContextScopes: [],
+    retrievalReason: `X-ray provenance missing for ${result.memoryId || result.path}`,
+    confidence: 0,
+    stale: false,
+    corrected: false,
+    correctionState: "none",
+    safeToUse: false,
+    safety: "blocked",
+    safetyReasons: ["X-ray provenance was missing for this memory."],
+  };
+}
+
+function formatUnsafeRecallPreview(
+  blockedCount: number,
+  missingProvenanceCount: number,
+): string {
+  const reasons: string[] = [];
+  if (blockedCount > 0) {
+    reasons.push(`${blockedCount} retrieved ${memoryNoun(blockedCount)} ${isAre(blockedCount)} blocked`);
+  }
+  if (missingProvenanceCount > 0) {
+    reasons.push(
+      `${missingProvenanceCount} retrieved ${memoryNoun(missingProvenanceCount)} ${isAre(missingProvenanceCount)} missing X-ray provenance`,
+    );
+  }
+  return `Recall preview withheld: ${joinReasons(reasons)} in the current context.`;
+}
+
+function memoryNoun(count: number): string {
+  return count === 1 ? "memory" : "memories";
+}
+
+function isAre(count: number): string {
+  return count === 1 ? "is" : "are";
+}
+
+function joinReasons(reasons: string[]): string {
+  if (reasons.length <= 1) return reasons[0] ?? "memory safety could not be verified";
+  return `${reasons.slice(0, -1).join(", ")} and ${reasons[reasons.length - 1]}`;
 }
 
 function truncate(value: string, maxChars: number): string {

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -114,12 +114,15 @@ export function buildChatGptMemoryInspectorResult(
 ): RemnicChatGptMemoryInspectorResult {
   const xrayUnavailable = xray === null;
   const xrayById = new Map<string, RecallXrayResult>();
+  const xrayByPath = new Map<string, RecallXrayResult>();
   for (const result of xray?.results ?? []) {
     xrayById.set(result.memoryId, result);
+    xrayByPath.set(result.path, result);
   }
 
   const memories = recall.results.slice(0, 8).map((summary) => {
-    const xrayResult = xrayById.get(summary.id);
+    const xrayResult = (summary.path ? xrayByPath.get(summary.path) : undefined)
+      ?? xrayById.get(summary.id);
     const provenance = xrayResult?.provenance;
     const blocked = provenance?.safety === "blocked";
     const preview = xrayUnavailable
@@ -153,7 +156,7 @@ export function buildChatGptMemoryInspectorResult(
   const safeRecallPreview = xrayUnavailable
     ? "Recall preview withheld: X-ray provenance was unavailable, so memory safety could not be verified."
     : blockedCount > 0
-      ? `Recall preview withheld: ${blockedCount} retrieved memory ${blockedCount === 1 ? "is" : "are"} blocked in the current context.`
+      ? `Recall preview withheld: ${blockedCount} retrieved ${blockedCount === 1 ? "memory is" : "memories are"} blocked in the current context.`
       : truncate(recall.context, 1_500);
 
   const primaryMemoryId = memories[0]?.id ?? "<memory-id>";

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -1,0 +1,350 @@
+import type { EngramAccessRecallResponse } from "./access-service.js";
+import type { ActionConfidenceRequest } from "./access-schema.js";
+import type { RecallXrayResult, RecallXraySnapshot } from "./recall-xray.js";
+import type { ActionConfidenceResult } from "./action-confidence.js";
+import type { RetrievedMemoryProvenance } from "./memory-provenance.js";
+
+export const REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL =
+  "engram.chatgpt_memory_inspector" as const;
+export const REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL =
+  "remnic.chatgpt_memory_inspector" as const;
+export const REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI =
+  "ui://remnic/memory-inspector.v1.html" as const;
+export const REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE =
+  "text/html;profile=mcp-app" as const;
+
+export interface RemnicChatGptMemoryInspectorInput {
+  query: string;
+  sessionKey?: string;
+  namespace?: string;
+  currentContextScopes?: string[];
+}
+
+export interface RemnicChatGptMemoryCard {
+  id: string;
+  path?: string;
+  category?: string;
+  status?: string;
+  preview?: string;
+  servedBy?: string;
+  score?: number;
+  source?: string;
+  scope?: string;
+  retrievalReason?: string;
+  confidence?: number;
+  stale?: boolean;
+  corrected?: boolean;
+  safeToUse?: boolean;
+  safety?: string;
+  safetyReasons: string[];
+  userContextScopes: string[];
+}
+
+export interface RemnicChatGptMemoryInspectorResult {
+  app: {
+    name: "Remnic Memory Inspector";
+    resourceUri: typeof REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI;
+    archetype: "vanilla-widget";
+  };
+  query: string;
+  sessionKey?: string;
+  namespace: string;
+  safeRecallPreview: string;
+  memoryCount: number;
+  memoryIds: string[];
+  memories: RemnicChatGptMemoryCard[];
+  actionConfidence: ActionConfidenceResult;
+  affordances: Array<{
+    id: "why" | "correct" | "forget" | "scope";
+    label: string;
+    followUpPrompt: string;
+  }>;
+  guidance: {
+    correctionTool: "remnic.suggestion_submit";
+    forgetTool: "remnic.memory_action_apply";
+    scopeTool: "remnic.memory_action_apply";
+    note: string;
+  };
+}
+
+export function buildChatGptMemoryInspectorActionRequest(
+  input: RemnicChatGptMemoryInspectorInput,
+  recall: EngramAccessRecallResponse,
+  xray: RecallXraySnapshot | null,
+): ActionConfidenceRequest {
+  const provenances = (xray?.results ?? [])
+    .map((result) => result.provenance)
+    .filter((value): value is RetrievedMemoryProvenance => value !== undefined);
+
+  const request: ActionConfidenceRequest = {
+    intendedAction: `Use Remnic memory to answer: ${input.query}`,
+    risk: "medium",
+    contextReadiness: recall.count > 0 ? "sufficient" : "partial",
+    retrievedMemories: provenances.map((provenance) => ({
+      source: provenance.source,
+      created: provenance.created,
+      updated: provenance.updated,
+      scope: provenance.scope,
+      userContextScopes: provenance.userContextScopes,
+      retrievalReason: provenance.retrievalReason,
+      confidence: provenance.confidence,
+      stale: provenance.stale,
+      corrected: provenance.corrected,
+      correctionState: provenance.correctionState,
+      safeToUse: provenance.safeToUse,
+      safety: provenance.safety,
+      safetyReasons: provenance.safetyReasons,
+    })),
+  };
+  const confidence = provenances.length > 0
+    ? average(provenances.map((provenance) => provenance.confidence ?? 0.5))
+    : undefined;
+  if (confidence !== undefined) request.confidence = confidence;
+  if (input.currentContextScopes !== undefined) {
+    request.currentContextScopes = input.currentContextScopes;
+  }
+  return request;
+}
+
+export function buildChatGptMemoryInspectorResult(
+  input: RemnicChatGptMemoryInspectorInput,
+  recall: EngramAccessRecallResponse,
+  xray: RecallXraySnapshot | null,
+  actionConfidence: ActionConfidenceResult,
+): RemnicChatGptMemoryInspectorResult {
+  const xrayById = new Map<string, RecallXrayResult>();
+  for (const result of xray?.results ?? []) {
+    xrayById.set(result.memoryId, result);
+  }
+
+  const memories = recall.results.slice(0, 8).map((summary) => {
+    const xrayResult = xrayById.get(summary.id);
+    const provenance = xrayResult?.provenance;
+    return {
+      id: summary.id,
+      path: summary.path,
+      category: summary.category,
+      status: summary.status,
+      preview: summary.preview,
+      servedBy: xrayResult?.servedBy,
+      score: xrayResult?.scoreDecomposition.final,
+      source: provenance?.source,
+      scope: provenance?.scope,
+      retrievalReason: provenance?.retrievalReason,
+      confidence: provenance?.confidence,
+      stale: provenance?.stale,
+      corrected: provenance?.corrected,
+      safeToUse: provenance?.safeToUse,
+      safety: provenance?.safety,
+      safetyReasons: provenance?.safetyReasons ?? [],
+      userContextScopes: provenance?.userContextScopes ?? [],
+    };
+  });
+  const blockedCount = memories.filter((memory) => memory.safety === "blocked").length;
+
+  const primaryMemoryId = memories[0]?.id ?? "<memory-id>";
+  return {
+    app: {
+      name: "Remnic Memory Inspector",
+      resourceUri: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+      archetype: "vanilla-widget",
+    },
+    query: recall.query || input.query,
+    ...(input.sessionKey ? { sessionKey: input.sessionKey } : {}),
+    namespace: recall.namespace,
+    safeRecallPreview: blockedCount > 0
+      ? `Recall preview withheld: ${blockedCount} retrieved memory ${blockedCount === 1 ? "is" : "are"} blocked in the current context.`
+      : truncate(recall.context, 1_500),
+    memoryCount: recall.count,
+    memoryIds: recall.memoryIds,
+    memories,
+    actionConfidence,
+    affordances: [
+      {
+        id: "why",
+        label: "Why retrieved",
+        followUpPrompt:
+          `Explain why Remnic retrieved memory ${primaryMemoryId} for "${input.query}" using its provenance, score, safety, and retrieval reason.`,
+      },
+      {
+        id: "correct",
+        label: "Correct",
+        followUpPrompt:
+          `Help me correct memory ${primaryMemoryId}. Draft a replacement or correction and use remnic.suggestion_submit with dryRun first.`,
+      },
+      {
+        id: "forget",
+        label: "Forget",
+        followUpPrompt:
+          `Help me forget or quarantine memory ${primaryMemoryId}. Ask me to confirm before using any destructive or persistent Remnic action.`,
+      },
+      {
+        id: "scope",
+        label: "Scope",
+        followUpPrompt:
+          `Help me scope memory ${primaryMemoryId} so it is only used in the right context. Prefer a dry-run Remnic action before any persistent change.`,
+      },
+    ],
+    guidance: {
+      correctionTool: "remnic.suggestion_submit",
+      forgetTool: "remnic.memory_action_apply",
+      scopeTool: "remnic.memory_action_apply",
+      note:
+        "The demo only proposes correction, forget, and scoping flows. The widget sends follow-up prompts; persistent changes still require an explicit tool call and user confirmation.",
+    },
+  };
+}
+
+export const REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_HTML = `
+<div id="root" class="remnic-app">Loading Remnic memory inspector...</div>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f8faf8;
+    --panel: #ffffff;
+    --text: #17201b;
+    --muted: #56635b;
+    --line: #d8e0da;
+    --accent: #2f7d57;
+    --warn: #9a5b14;
+    --bad: #9c2b2b;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #101512;
+      --panel: #18201b;
+      --text: #edf4ef;
+      --muted: #a8b6ad;
+      --line: #304036;
+      --accent: #75c79a;
+      --warn: #e0ad63;
+      --bad: #f08a8a;
+    }
+  }
+  body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  .remnic-app { padding: 14px; display: grid; gap: 12px; }
+  .header, .section, .memory { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 12px; }
+  .title { font-size: 16px; font-weight: 650; margin: 0; }
+  .muted { color: var(--muted); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; }
+  .pill { display: inline-flex; align-items: center; gap: 4px; border: 1px solid var(--line); border-radius: 999px; padding: 2px 8px; margin: 2px 4px 2px 0; color: var(--muted); }
+  .safe { color: var(--accent); }
+  .review { color: var(--warn); }
+  .blocked { color: var(--bad); }
+  .memory { display: grid; gap: 8px; }
+  .memory-title { display: flex; justify-content: space-between; gap: 12px; align-items: baseline; font-weight: 650; }
+  .preview { white-space: pre-wrap; overflow-wrap: anywhere; }
+  .actions { display: flex; flex-wrap: wrap; gap: 8px; }
+  button { border: 1px solid var(--line); background: transparent; color: var(--text); border-radius: 6px; padding: 6px 9px; font: inherit; cursor: pointer; }
+  button:hover { border-color: var(--accent); }
+  pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; color: var(--muted); }
+</style>
+<script>
+  const root = document.getElementById("root");
+
+  function escapeHtml(value) {
+    return String(value ?? "").replace(/[&<>"']/g, (char) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    }[char]));
+  }
+
+  function statusClass(value) {
+    if (value === "blocked" || value === false) return "blocked";
+    if (value === "requires-review") return "review";
+    return "safe";
+  }
+
+  function followUp(prompt) {
+    if (window.openai?.sendFollowUpMessage) {
+      window.openai.sendFollowUpMessage({ prompt, scrollToBottom: true });
+      return;
+    }
+    window.parent.postMessage({
+      jsonrpc: "2.0",
+      method: "ui/message",
+      params: {
+        role: "user",
+        content: [{ type: "text", text: prompt }],
+      },
+    }, "*");
+  }
+
+  function actionButtons(actions) {
+    return (actions ?? []).map((action) =>
+      '<button type="button" data-prompt="' + escapeHtml(action.followUpPrompt) + '">' +
+      escapeHtml(action.label) +
+      '</button>'
+    ).join("");
+  }
+
+  function render(payload) {
+    const data = payload?.structuredContent ?? payload ?? window.openai?.toolOutput ?? {};
+    const confidence = data.actionConfidence ?? {};
+    const memories = Array.isArray(data.memories) ? data.memories : [];
+    root.innerHTML = [
+      '<section class="header">',
+        '<p class="title">Remnic Memory Inspector</p>',
+        '<div class="muted">' + escapeHtml(data.query ?? "No query") + '</div>',
+        '<div class="grid">',
+          '<div><strong>Namespace</strong><br><span class="muted">' + escapeHtml(data.namespace ?? "default") + '</span></div>',
+          '<div><strong>Decision</strong><br><span class="' + statusClass(confidence.decision) + '">' + escapeHtml(confidence.decision ?? "unknown") + '</span></div>',
+          '<div><strong>Memories</strong><br><span class="muted">' + escapeHtml(data.memoryCount ?? memories.length) + '</span></div>',
+        '</div>',
+      '</section>',
+      '<section class="section">',
+        '<strong>Safe recall preview</strong>',
+        '<pre>' + escapeHtml(data.safeRecallPreview ?? "") + '</pre>',
+      '</section>',
+      '<section class="section actions">',
+        actionButtons(data.affordances),
+      '</section>',
+      memories.map((memory) => [
+        '<article class="memory">',
+          '<div class="memory-title"><span>' + escapeHtml(memory.id) + '</span><span class="' + statusClass(memory.safety) + '">' + escapeHtml(memory.safety ?? "safe") + '</span></div>',
+          '<div class="preview">' + escapeHtml(memory.preview ?? "") + '</div>',
+          '<div>',
+            '<span class="pill">source ' + escapeHtml(memory.source ?? "unknown") + '</span>',
+            '<span class="pill">scope ' + escapeHtml(memory.scope ?? "unknown") + '</span>',
+            '<span class="pill">reason ' + escapeHtml(memory.retrievalReason ?? memory.servedBy ?? "unknown") + '</span>',
+            '<span class="pill">confidence ' + escapeHtml(memory.confidence ?? "n/a") + '</span>',
+          '</div>',
+          '<div class="muted">' + escapeHtml((memory.safetyReasons ?? []).join("; ")) + '</div>',
+        '</article>',
+      ].join("")).join(""),
+    ].join("");
+
+    root.querySelectorAll("button[data-prompt]").forEach((button) => {
+      button.addEventListener("click", () => followUp(button.getAttribute("data-prompt") ?? ""));
+    });
+  }
+
+  render(window.openai?.toolOutput);
+
+  window.addEventListener("message", (event) => {
+    if (event.source !== window.parent) return;
+    const message = event.data;
+    if (!message || message.jsonrpc !== "2.0") return;
+    if (message.method === "ui/notifications/tool-result") {
+      render(message.params);
+    }
+  }, { passive: true });
+
+  window.addEventListener("openai:set_globals", (event) => {
+    render(event.detail?.globals?.toolOutput ?? window.openai?.toolOutput);
+  }, { passive: true });
+</script>
+`.trim();
+
+function average(values: number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 3))}...`;
+}

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -140,7 +140,9 @@ export function buildChatGptMemoryInspectorResult(
       userContextScopes: provenance?.userContextScopes ?? [],
     };
   });
-  const blockedCount = memories.filter((memory) => memory.safety === "blocked").length;
+  const blockedCount = (xray?.results ?? [])
+    .filter((result) => result.provenance?.safety === "blocked")
+    .length;
 
   const primaryMemoryId = memories[0]?.id ?? "<memory-id>";
   return {

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -120,12 +120,15 @@ export function buildChatGptMemoryInspectorResult(
   const memories = recall.results.slice(0, 8).map((summary) => {
     const xrayResult = xrayById.get(summary.id);
     const provenance = xrayResult?.provenance;
+    const blocked = provenance?.safety === "blocked";
     return {
       id: summary.id,
       path: summary.path,
       category: summary.category,
       status: summary.status,
-      preview: summary.preview,
+      preview: blocked
+        ? "Preview withheld: this memory is blocked in the current context."
+        : summary.preview,
       servedBy: xrayResult?.servedBy,
       score: xrayResult?.scoreDecomposition.final,
       source: provenance?.source,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -602,6 +602,12 @@ export interface RecallInvocationOptions {
    * normally be pruned by confidence decay.  Default `false`.
    */
   includeLowConfidence?: boolean;
+  /**
+   * User-aware context scopes active for this recall. X-ray provenance
+   * uses these to decide whether boundary-tagged memories are safe in
+   * the current context.
+   */
+  currentContextScopes?: readonly unknown[];
 }
 
 type QueryAwarePrefilter = {
@@ -9715,6 +9721,7 @@ export class Orchestrator {
             result.provenance = buildRetrievedMemoryProvenance(memory, {
               namespace: this.namespaceFromPath(recalledPath),
               retrievalReason: `served-by=${servedBy}`,
+              currentContextScopes: options.currentContextScopes,
             });
           }
           results.push(result);

--- a/src/mcp-memory-inspector-app.ts
+++ b/src/mcp-memory-inspector-app.ts
@@ -1,0 +1,1 @@
+export * from "../packages/remnic-core/src/mcp-memory-inspector-app.js";

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -263,6 +263,7 @@ test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, a
       query: "What preferences matter here?",
       sessionKey: "sess-1",
       namespace: "work",
+      authenticatedPrincipal: "user-a",
       mode: "full",
       disclosure: "chunk",
     },
@@ -274,6 +275,7 @@ test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, a
       namespace: "work",
       currentContextScopes: ["work", "repo"],
       authenticatedPrincipal: "user-a",
+      mode: "full",
     },
   ]);
   assert.equal(capture.actionRequests[0]?.risk, "medium");

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -139,9 +139,11 @@ test("ChatGPT Apps inspector advertises app-compatible tool metadata and aliases
   ) as {
     title?: string;
     annotations?: Record<string, unknown>;
+    outputSchema?: { properties?: Record<string, unknown> };
     _meta?: Record<string, unknown>;
   };
   assert.equal(descriptor.title, "Show Remnic Memory Inspector");
+  assert.deepEqual(descriptor.outputSchema?.properties?.sessionKey, { type: "string" });
   assert.deepEqual(descriptor.annotations, {
     readOnlyHint: true,
     destructiveHint: false,

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -1,0 +1,278 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL,
+  REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+  type RemnicChatGptMemoryInspectorResult,
+} from "../src/mcp-memory-inspector-app.js";
+import { EngramMcpServer } from "../src/access-mcp.js";
+import type { EngramAccessService } from "../src/access-service.js";
+
+interface Capture {
+  recalls: Array<Record<string, unknown>>;
+  xrays: Array<Record<string, unknown>>;
+  actionRequests: Array<Record<string, unknown>>;
+}
+
+function fakeService(capture: Capture): EngramAccessService {
+  return {
+    recall: async (request: Record<string, unknown>) => {
+      capture.recalls.push({ ...request });
+      return {
+        query: String(request.query ?? ""),
+        sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : undefined,
+        namespace: typeof request.namespace === "string" ? request.namespace : "global",
+        context: "Prefers concise, implementation-focused updates.",
+        count: 1,
+        memoryIds: ["mem-preference-1"],
+        results: [
+          {
+            id: "mem-preference-1",
+            path: "preferences/2026-05-01/update-style.md",
+            category: "preference",
+            status: "active",
+            preview: "Prefers concise, implementation-focused updates.",
+          },
+        ],
+        fallbackUsed: false,
+        sourcesUsed: ["memories"],
+        disclosure: "chunk",
+      };
+    },
+    recallXray: async (request: Record<string, unknown>) => {
+      capture.xrays.push({ ...request });
+      return {
+        snapshotFound: true,
+        snapshot: {
+          schemaVersion: "1" as const,
+          query: String(request.query ?? ""),
+          snapshotId: "snap-chatgpt-app",
+          capturedAt: 1_779_000_000_000,
+          tierExplain: null,
+          results: [
+            {
+              memoryId: "mem-preference-1",
+              path: "preferences/2026-05-01/update-style.md",
+              servedBy: "hybrid" as const,
+              scoreDecomposition: { final: 0.91 },
+              admittedBy: ["scope-match", "fresh"],
+              provenance: {
+                source: "conversation",
+                created: "2026-05-01T10:00:00.000Z",
+                updated: "2026-05-01T10:00:00.000Z",
+                namespace: "work",
+                scope: "namespace:work",
+                userContextScopes: ["work", "repo"],
+                retrievalReason: "hybrid match",
+                confidence: 0.83,
+                stale: false,
+                corrected: false,
+                correctionState: "none" as const,
+                safeToUse: true,
+                safety: "safe" as const,
+                safetyReasons: [],
+              },
+            },
+          ],
+          filters: [],
+          budget: { chars: 4096, used: 51 },
+          namespace: typeof request.namespace === "string" ? request.namespace : "global",
+          sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : undefined,
+        },
+      };
+    },
+    actionConfidence: async (request: Record<string, unknown>) => {
+      capture.actionRequests.push(JSON.parse(JSON.stringify(request)) as Record<string, unknown>);
+      return {
+        schemaVersion: 1,
+        decision: "draft",
+        confidence: 0.83,
+        risk: "medium",
+        contextReadiness: "sufficient",
+        intendedAction: String(request.intendedAction ?? ""),
+        attentionPolicy: "interruption_budgeting",
+        principle: "A good agent should spend the user's attention carefully.",
+        reasons: ["relevant scoped memory"],
+        blockers: [],
+        factors: [],
+        retrievedMemoryCount: 1,
+        usableMemoryCount: 1,
+        staleMemoryCount: 0,
+        correctedMemoryCount: 0,
+        scopeMismatchCount: 0,
+        safeToAct: false,
+      };
+    },
+  } as unknown as EngramAccessService;
+}
+
+function resultText(response: unknown): string {
+  const result = response as { result?: { content?: Array<{ text?: string }> } };
+  return result.result?.content?.[0]?.text ?? "";
+}
+
+test("ChatGPT Apps inspector advertises app-compatible tool metadata and aliases", async () => {
+  const server = new EngramMcpServer(fakeService({ recalls: [], xrays: [], actionRequests: [] }));
+  const init = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {},
+  });
+  assert.deepEqual((init?.result as { capabilities: Record<string, unknown> }).capabilities.resources, {});
+
+  const toolsResponse = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/list",
+    params: {},
+  });
+  const tools = (toolsResponse?.result as { tools: Array<Record<string, unknown>> }).tools;
+  const names = tools.map((tool) => tool.name);
+  assert.ok(names.includes(REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL));
+  assert.ok(names.includes(REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL));
+
+  const descriptor = tools.find(
+    (tool) => tool.name === REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL,
+  ) as {
+    title?: string;
+    annotations?: Record<string, unknown>;
+    _meta?: Record<string, unknown>;
+  };
+  assert.equal(descriptor.title, "Show Remnic Memory Inspector");
+  assert.deepEqual(descriptor.annotations, {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  });
+  assert.equal(
+    (descriptor._meta?.ui as { resourceUri?: string } | undefined)?.resourceUri,
+    REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+  );
+  assert.equal(
+    descriptor._meta?.["openai/outputTemplate"],
+    REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+  );
+});
+
+test("ChatGPT Apps inspector serves a widget resource over MCP resources/read", async () => {
+  const server = new EngramMcpServer(fakeService({ recalls: [], xrays: [], actionRequests: [] }));
+  const resourcesResponse = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "resources/list",
+    params: {},
+  });
+  const resources = (resourcesResponse?.result as { resources: Array<Record<string, unknown>> })
+    .resources;
+  const resource = resources.find(
+    (entry) => entry.uri === REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
+  );
+  assert.equal(resource?.mimeType, REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE);
+  assert.deepEqual(
+    ((resource?._meta as { ui?: { csp?: unknown } } | undefined)?.ui?.csp),
+    { connectDomains: [], resourceDomains: [] },
+  );
+
+  const readResponse = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "resources/read",
+    params: { uri: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI },
+  });
+  const contents = (readResponse?.result as {
+    contents: Array<{ uri: string; mimeType: string; text: string }>;
+  }).contents;
+  assert.equal(contents[0]?.uri, REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI);
+  assert.equal(contents[0]?.mimeType, REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE);
+  assert.match(contents[0]?.text ?? "", /ui\/notifications\/tool-result/);
+  assert.match(contents[0]?.text ?? "", /window\.openai/);
+  assert.match(contents[0]?.text ?? "", /sendFollowUpMessage/);
+});
+
+test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, and action confidence", async () => {
+  const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
+  const server = new EngramMcpServer(fakeService(capture), { principal: "user-a" });
+
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL,
+      arguments: {
+        query: " What preferences matter here? ",
+        sessionKey: "sess-1",
+        namespace: "work",
+        currentContextScopes: ["work", "repo"],
+      },
+    },
+  });
+
+  const result = response?.result as {
+    isError?: boolean;
+    structuredContent?: RemnicChatGptMemoryInspectorResult;
+  };
+  assert.equal(result.isError, false);
+  const structured = result.structuredContent;
+  assert.ok(structured, "expected structured content");
+  assert.equal(structured.app.resourceUri, REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI);
+  assert.equal(structured.query, "What preferences matter here?");
+  assert.equal(structured.namespace, "work");
+  assert.equal(structured.safeRecallPreview, "Prefers concise, implementation-focused updates.");
+  assert.equal(structured.memoryCount, 1);
+  assert.deepEqual(structured.memoryIds, ["mem-preference-1"]);
+  assert.equal(structured.memories[0]?.source, "conversation");
+  assert.equal(structured.memories[0]?.scope, "namespace:work");
+  assert.equal(structured.memories[0]?.retrievalReason, "hybrid match");
+  assert.equal(structured.memories[0]?.safeToUse, true);
+  assert.equal(structured.actionConfidence.decision, "draft");
+  assert.equal(structured.affordances.length, 4);
+
+  assert.deepEqual(capture.recalls, [
+    {
+      query: "What preferences matter here?",
+      sessionKey: "sess-1",
+      namespace: "work",
+      mode: "full",
+      disclosure: "chunk",
+    },
+  ]);
+  assert.deepEqual(capture.xrays, [
+    {
+      query: "What preferences matter here?",
+      sessionKey: "sess-1",
+      namespace: "work",
+      authenticatedPrincipal: "user-a",
+    },
+  ]);
+  assert.equal(capture.actionRequests[0]?.risk, "medium");
+  assert.equal(capture.actionRequests[0]?.confidence, 0.83);
+  assert.deepEqual(capture.actionRequests[0]?.currentContextScopes, ["work", "repo"]);
+  assert.equal(
+    (capture.actionRequests[0]?.retrievedMemories as Array<Record<string, unknown>>)[0]?.source,
+    "conversation",
+  );
+});
+
+test("ChatGPT Apps inspector rejects malformed currentContextScopes before service dispatch", async () => {
+  const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
+  const server = new EngramMcpServer(fakeService(capture));
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL,
+      arguments: {
+        query: "q",
+        currentContextScopes: ["work", 42],
+      },
+    },
+  });
+  assert.match(resultText(response), /currentContextScopes must be an array of strings/);
+  assert.deepEqual(capture, { recalls: [], xrays: [], actionRequests: [] });
+});

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -197,10 +197,23 @@ test("ChatGPT Apps inspector serves a widget resource over MCP resources/read", 
     params: { uri: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI },
   });
   const contents = (readResponse?.result as {
-    contents: Array<{ uri: string; mimeType: string; text: string }>;
+    contents: Array<{
+      uri: string;
+      mimeType: string;
+      text: string;
+      _meta?: Record<string, unknown>;
+    }>;
   }).contents;
   assert.equal(contents[0]?.uri, REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI);
   assert.equal(contents[0]?.mimeType, REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE);
+  assert.deepEqual(
+    ((contents[0]?._meta as { ui?: { csp?: unknown } } | undefined)?.ui?.csp),
+    { connectDomains: [], resourceDomains: [] },
+  );
+  assert.equal(
+    contents[0]?._meta?.["openai/widgetDescription"],
+    "Inspect retrieved Remnic memories, provenance, safety, and correction/scoping affordances.",
+  );
   assert.match(contents[0]?.text ?? "", /ui\/notifications\/tool-result/);
   assert.match(contents[0]?.text ?? "", /window\.openai/);
   assert.match(contents[0]?.text ?? "", /sendFollowUpMessage/);
@@ -259,6 +272,7 @@ test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, a
       query: "What preferences matter here?",
       sessionKey: "sess-1",
       namespace: "work",
+      currentContextScopes: ["work", "repo"],
       authenticatedPrincipal: "user-a",
     },
   ]);

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -497,6 +497,198 @@ test("ChatGPT Apps inspector redacts blocked visible memory card previews", () =
   assert.doesNotMatch(result.memories[0]?.preview ?? "", /blocked private detail/);
 });
 
+test("ChatGPT Apps inspector matches X-ray provenance by path before duplicate ids", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "blocked private detail\nsafe work detail",
+    count: 2,
+    memoryIds: ["mem-shared", "mem-shared"],
+    results: [
+      {
+        id: "mem-shared",
+        path: "private/mem-shared.md",
+        category: "preference",
+        status: "active",
+        preview: "blocked private detail",
+      },
+      {
+        id: "mem-shared",
+        path: "work/mem-shared.md",
+        category: "preference",
+        status: "active",
+        preview: "safe work detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    {
+      schemaVersion: "1",
+      query: "show preferences",
+      snapshotId: "snap-duplicate-id-paths",
+      capturedAt: 1_779_000_000_000,
+      tierExplain: null,
+      results: [
+        {
+          memoryId: "mem-shared",
+          path: "private/mem-shared.md",
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.9 },
+          admittedBy: ["test"],
+          provenance: {
+            source: "conversation",
+            scope: "namespace:private",
+            userContextScopes: ["work"],
+            retrievalReason: "test",
+            confidence: 0.9,
+            stale: false,
+            corrected: false,
+            correctionState: "none",
+            safeToUse: false,
+            safety: "blocked",
+            safetyReasons: ["blocked in current context"],
+          },
+        },
+        {
+          memoryId: "mem-shared",
+          path: "work/mem-shared.md",
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.8 },
+          admittedBy: ["test"],
+          provenance: {
+            source: "conversation",
+            scope: "namespace:work",
+            userContextScopes: ["work"],
+            retrievalReason: "test",
+            confidence: 0.8,
+            stale: false,
+            corrected: false,
+            correctionState: "none",
+            safeToUse: true,
+            safety: "safe",
+            safetyReasons: [],
+          },
+        },
+      ],
+      filters: [],
+      budget: { chars: 4096, used: 100 },
+      namespace: "work",
+    },
+    {
+      schemaVersion: 1,
+      decision: "ask",
+      confidence: 0.5,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: [],
+      factors: [],
+      retrievedMemoryCount: 2,
+      usableMemoryCount: 1,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 1,
+      safeToAct: false,
+    },
+  );
+
+  assert.match(result.memories[0]?.preview ?? "", /Preview withheld/);
+  assert.doesNotMatch(result.memories[0]?.preview ?? "", /blocked private detail/);
+  assert.equal(result.memories[1]?.preview, "safe work detail");
+});
+
+test("ChatGPT Apps inspector pluralizes blocked memory preview messages", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "blocked first detail\nblocked second detail",
+    count: 2,
+    memoryIds: ["mem-blocked-1", "mem-blocked-2"],
+    results: [
+      {
+        id: "mem-blocked-1",
+        path: "memories/mem-blocked-1.md",
+        category: "preference",
+        status: "active",
+        preview: "blocked first detail",
+      },
+      {
+        id: "mem-blocked-2",
+        path: "memories/mem-blocked-2.md",
+        category: "preference",
+        status: "active",
+        preview: "blocked second detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const blockedXrayResults = recall.results.map((summary) => ({
+    memoryId: summary.id,
+    path: summary.path ?? "",
+    servedBy: "hybrid" as const,
+    scoreDecomposition: { final: 0.9 },
+    admittedBy: ["test"],
+    provenance: {
+      source: "conversation",
+      scope: "namespace:private",
+      userContextScopes: ["work"],
+      retrievalReason: "test",
+      confidence: 0.9,
+      stale: false,
+      corrected: false,
+      correctionState: "none" as const,
+      safeToUse: false,
+      safety: "blocked" as const,
+      safetyReasons: ["blocked in current context"],
+    },
+  }));
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    {
+      schemaVersion: "1",
+      query: "show preferences",
+      snapshotId: "snap-two-blocked",
+      capturedAt: 1_779_000_000_000,
+      tierExplain: null,
+      results: blockedXrayResults,
+      filters: [],
+      budget: { chars: 4096, used: 100 },
+      namespace: "work",
+    },
+    {
+      schemaVersion: 1,
+      decision: "ask",
+      confidence: 0.5,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: [],
+      factors: [],
+      retrievedMemoryCount: 2,
+      usableMemoryCount: 0,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 2,
+      safeToAct: false,
+    },
+  );
+
+  assert.match(result.safeRecallPreview, /2 retrieved memories are blocked/);
+  assert.doesNotMatch(result.safeRecallPreview, /2 retrieved memory are blocked/);
+});
+
 test("ChatGPT Apps inspector withholds previews when X-ray provenance is unavailable", () => {
   const recall: EngramAccessRecallResponse = {
     query: "show preferences",

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -291,6 +291,40 @@ test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, a
   );
 });
 
+test("ChatGPT Apps inspector uses internal session metadata for sessionless authenticated calls", async () => {
+  const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
+  const server = new EngramMcpServer(fakeService(capture), { principal: "user-a" });
+
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL,
+      arguments: {
+        query: "What preferences matter here?",
+        namespace: "work",
+      },
+    },
+  });
+
+  const result = response?.result as {
+    isError?: boolean;
+    structuredContent?: RemnicChatGptMemoryInspectorResult;
+  };
+  assert.equal(result.isError, false);
+  assert.ok(result.structuredContent, "expected structured content");
+  assert.equal(result.structuredContent.sessionKey, undefined);
+  assert.equal(result.structuredContent.memoryCount, 1);
+  assert.deepEqual(result.structuredContent.memoryIds, ["mem-preference-1"]);
+
+  const recallSessionKey = capture.recalls[0]?.sessionKey;
+  assert.equal(typeof recallSessionKey, "string");
+  assert.match(String(recallSessionKey), /^remnic:chatgpt-memory-inspector:/);
+  assert.equal(capture.xrays[0]?.sessionKey, recallSessionKey);
+  assert.notEqual(recallSessionKey, "user-a");
+});
+
 test("ChatGPT Apps inspector withholds preview when blocked memory is beyond visible cards", () => {
   const recallResults = Array.from({ length: 9 }, (_, index) => ({
     id: `mem-${index + 1}`,

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildChatGptMemoryInspectorResult,
   REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL,
   REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
   REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL,
@@ -8,7 +9,10 @@ import {
   type RemnicChatGptMemoryInspectorResult,
 } from "../src/mcp-memory-inspector-app.js";
 import { EngramMcpServer } from "../src/access-mcp.js";
-import type { EngramAccessService } from "../src/access-service.js";
+import type {
+  EngramAccessRecallResponse,
+  EngramAccessService,
+} from "../src/access-service.js";
 
 interface Capture {
   recalls: Array<Record<string, unknown>>;
@@ -285,6 +289,84 @@ test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, a
     (capture.actionRequests[0]?.retrievedMemories as Array<Record<string, unknown>>)[0]?.source,
     "conversation",
   );
+});
+
+test("ChatGPT Apps inspector withholds preview when blocked memory is beyond visible cards", () => {
+  const recallResults = Array.from({ length: 9 }, (_, index) => ({
+    id: `mem-${index + 1}`,
+    path: `memories/mem-${index + 1}.md`,
+    category: "preference",
+    status: "active",
+    preview: index === 8 ? "blocked private detail" : `safe preview ${index + 1}`,
+  }));
+  const xrayResults = recallResults.map((memory, index) => ({
+    memoryId: memory.id,
+    path: memory.path,
+    servedBy: "hybrid" as const,
+    scoreDecomposition: { final: 0.9 },
+    admittedBy: ["test"],
+    provenance: {
+      source: "conversation",
+      scope: "namespace:work",
+      userContextScopes: ["work"],
+      retrievalReason: "test",
+      confidence: 0.9,
+      stale: false,
+      corrected: false,
+      correctionState: "none" as const,
+      safeToUse: index !== 8,
+      safety: index === 8 ? ("blocked" as const) : ("safe" as const),
+      safetyReasons: index === 8 ? ["blocked in current context"] : [],
+    },
+  }));
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "safe public detail\nblocked private detail",
+    count: 9,
+    memoryIds: recallResults.map((memory) => memory.id),
+    results: recallResults,
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    {
+      schemaVersion: "1",
+      query: "show preferences",
+      snapshotId: "snap-blocked-after-visible-slice",
+      capturedAt: 1_779_000_000_000,
+      tierExplain: null,
+      results: xrayResults,
+      filters: [],
+      budget: { chars: 4096, used: 100 },
+      namespace: "work",
+    },
+    {
+      schemaVersion: 1,
+      decision: "ask",
+      confidence: 0.5,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: [],
+      factors: [],
+      retrievedMemoryCount: 9,
+      usableMemoryCount: 8,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 1,
+      safeToAct: false,
+    },
+  );
+
+  assert.equal(result.memories.length, 8);
+  assert.match(result.safeRecallPreview, /1 retrieved memory is blocked/);
+  assert.doesNotMatch(result.safeRecallPreview, /blocked private detail/);
 });
 
 test("ChatGPT Apps inspector rejects malformed currentContextScopes before service dispatch", async () => {

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -179,9 +179,20 @@ test("ChatGPT Apps inspector serves a widget resource over MCP resources/read", 
     { connectDomains: [], resourceDomains: [] },
   );
 
+  const templatesResponse = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "resources/templates/list",
+    params: {},
+  });
+  assert.deepEqual(
+    (templatesResponse?.result as { resourceTemplates: unknown[] }).resourceTemplates,
+    [],
+  );
+
   const readResponse = await server.handleRequest({
     jsonrpc: "2.0",
-    id: 2,
+    id: 4,
     method: "resources/read",
     params: { uri: REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI },
   });

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -47,6 +47,26 @@ function fakeService(capture: Capture): EngramAccessService {
     },
     recallXray: async (request: Record<string, unknown>) => {
       capture.xrays.push({ ...request });
+      const recall = {
+        query: String(request.query ?? ""),
+        sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : undefined,
+        namespace: typeof request.namespace === "string" ? request.namespace : "global",
+        context: "Prefers concise, implementation-focused updates.",
+        count: 1,
+        memoryIds: ["mem-preference-1"],
+        results: [
+          {
+            id: "mem-preference-1",
+            path: "preferences/2026-05-01/update-style.md",
+            category: "preference",
+            status: "active",
+            preview: "Prefers concise, implementation-focused updates.",
+          },
+        ],
+        fallbackUsed: false,
+        sourcesUsed: ["memories"],
+        disclosure: "chunk",
+      };
       return {
         snapshotFound: true,
         snapshot: {
@@ -85,6 +105,7 @@ function fakeService(capture: Capture): EngramAccessService {
           namespace: typeof request.namespace === "string" ? request.namespace : "global",
           sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : undefined,
         },
+        recall,
       };
     },
     actionConfidence: async (request: Record<string, unknown>) => {
@@ -223,7 +244,7 @@ test("ChatGPT Apps inspector serves a widget resource over MCP resources/read", 
   assert.match(contents[0]?.text ?? "", /sendFollowUpMessage/);
 });
 
-test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, and action confidence", async () => {
+test("ChatGPT Apps inspector dispatches canonical alias through X-ray and action confidence", async () => {
   const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
   const server = new EngramMcpServer(fakeService(capture), { principal: "user-a" });
 
@@ -262,16 +283,7 @@ test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, a
   assert.equal(structured.actionConfidence.decision, "draft");
   assert.equal(structured.affordances.length, 4);
 
-  assert.deepEqual(capture.recalls, [
-    {
-      query: "What preferences matter here?",
-      sessionKey: "sess-1",
-      namespace: "work",
-      authenticatedPrincipal: "user-a",
-      mode: "full",
-      disclosure: "chunk",
-    },
-  ]);
+  assert.deepEqual(capture.recalls, []);
   assert.deepEqual(capture.xrays, [
     {
       query: "What preferences matter here?",
@@ -280,6 +292,8 @@ test("ChatGPT Apps inspector dispatches canonical alias through recall, X-ray, a
       currentContextScopes: ["work", "repo"],
       authenticatedPrincipal: "user-a",
       mode: "full",
+      disclosure: "chunk",
+      includeRecall: true,
     },
   ]);
   assert.equal(capture.actionRequests[0]?.risk, "medium");
@@ -318,10 +332,10 @@ test("ChatGPT Apps inspector uses internal session metadata for sessionless auth
   assert.equal(result.structuredContent.memoryCount, 1);
   assert.deepEqual(result.structuredContent.memoryIds, ["mem-preference-1"]);
 
-  const recallSessionKey = capture.recalls[0]?.sessionKey;
+  assert.deepEqual(capture.recalls, []);
+  const recallSessionKey = capture.xrays[0]?.sessionKey;
   assert.equal(typeof recallSessionKey, "string");
   assert.match(String(recallSessionKey), /^remnic:chatgpt-memory-inspector:/);
-  assert.equal(capture.xrays[0]?.sessionKey, recallSessionKey);
   assert.notEqual(recallSessionKey, "user-a");
 });
 

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildChatGptMemoryInspectorActionRequest,
   buildChatGptMemoryInspectorResult,
   REMNIC_CHATGPT_MEMORY_INSPECTOR_CANONICAL_TOOL,
   REMNIC_CHATGPT_MEMORY_INSPECTOR_MIME_TYPE,
@@ -735,6 +736,87 @@ test("ChatGPT Apps inspector withholds previews when X-ray provenance is unavail
 
   assert.match(result.safeRecallPreview, /X-ray provenance was unavailable/);
   assert.doesNotMatch(result.safeRecallPreview, /unverified memory detail/);
+  assert.match(result.memories[0]?.preview ?? "", /Preview withheld/);
+  assert.doesNotMatch(result.memories[0]?.preview ?? "", /unverified memory detail/);
+});
+
+test("ChatGPT Apps inspector treats missing per-memory provenance as unsafe", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "unverified memory detail",
+    count: 1,
+    memoryIds: ["mem-unverified"],
+    results: [
+      {
+        id: "mem-unverified",
+        path: "memories/mem-unverified.md",
+        category: "preference",
+        status: "active",
+        preview: "unverified memory detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const xray = {
+    schemaVersion: "1" as const,
+    query: "show preferences",
+    snapshotId: "snap-missing-provenance",
+    capturedAt: 1_779_000_000_000,
+    tierExplain: null,
+    results: [
+      {
+        memoryId: "mem-unverified",
+        path: "memories/mem-unverified.md",
+        servedBy: "hybrid" as const,
+        scoreDecomposition: { final: 0.9 },
+        admittedBy: ["test"],
+      },
+    ],
+    filters: [],
+    budget: { chars: 4096, used: 100 },
+    namespace: "work",
+  };
+  const actionRequest = buildChatGptMemoryInspectorActionRequest(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    xray,
+  );
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    xray,
+    {
+      schemaVersion: 1,
+      decision: "refuse",
+      confidence: 0.2,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: ["missing xray provenance"],
+      factors: [],
+      retrievedMemoryCount: 1,
+      usableMemoryCount: 0,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 0,
+      safeToAct: false,
+    },
+  );
+
+  assert.equal(actionRequest.retrievedMemories?.[0]?.safety, "blocked");
+  assert.equal(actionRequest.retrievedMemories?.[0]?.safeToUse, false);
+  assert.match(
+    actionRequest.retrievedMemories?.[0]?.safetyReasons?.[0] ?? "",
+    /provenance was missing/,
+  );
+  assert.match(result.safeRecallPreview, /1 retrieved memory is missing X-ray provenance/);
+  assert.doesNotMatch(result.safeRecallPreview, /unverified memory detail/);
+  assert.equal(result.memories[0]?.safety, "blocked");
   assert.match(result.memories[0]?.preview ?? "", /Preview withheld/);
   assert.doesNotMatch(result.memories[0]?.preview ?? "", /unverified memory detail/);
 });

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -497,6 +497,56 @@ test("ChatGPT Apps inspector redacts blocked visible memory card previews", () =
   assert.doesNotMatch(result.memories[0]?.preview ?? "", /blocked private detail/);
 });
 
+test("ChatGPT Apps inspector withholds previews when X-ray provenance is unavailable", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "unverified memory detail",
+    count: 1,
+    memoryIds: ["mem-unverified"],
+    results: [
+      {
+        id: "mem-unverified",
+        path: "memories/mem-unverified.md",
+        category: "preference",
+        status: "active",
+        preview: "unverified memory detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    null,
+    {
+      schemaVersion: 1,
+      decision: "ask",
+      confidence: 0.2,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: ["missing xray provenance"],
+      factors: [],
+      retrievedMemoryCount: 1,
+      usableMemoryCount: 0,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 0,
+      safeToAct: false,
+    },
+  );
+
+  assert.match(result.safeRecallPreview, /X-ray provenance was unavailable/);
+  assert.doesNotMatch(result.safeRecallPreview, /unverified memory detail/);
+  assert.match(result.memories[0]?.preview ?? "", /Preview withheld/);
+  assert.doesNotMatch(result.memories[0]?.preview ?? "", /unverified memory detail/);
+});
+
 test("ChatGPT Apps inspector rejects malformed currentContextScopes before service dispatch", async () => {
   const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
   const server = new EngramMcpServer(fakeService(capture));

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -403,6 +403,86 @@ test("ChatGPT Apps inspector withholds preview when blocked memory is beyond vis
   assert.doesNotMatch(result.safeRecallPreview, /blocked private detail/);
 });
 
+test("ChatGPT Apps inspector redacts blocked visible memory card previews", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "blocked private detail",
+    count: 1,
+    memoryIds: ["mem-blocked"],
+    results: [
+      {
+        id: "mem-blocked",
+        path: "memories/mem-blocked.md",
+        category: "preference",
+        status: "active",
+        preview: "blocked private detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    {
+      schemaVersion: "1",
+      query: "show preferences",
+      snapshotId: "snap-visible-blocked",
+      capturedAt: 1_779_000_000_000,
+      tierExplain: null,
+      results: [
+        {
+          memoryId: "mem-blocked",
+          path: "memories/mem-blocked.md",
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.9 },
+          admittedBy: ["test"],
+          provenance: {
+            source: "conversation",
+            scope: "namespace:work/private",
+            userContextScopes: ["private"],
+            retrievalReason: "test",
+            confidence: 0.9,
+            stale: false,
+            corrected: false,
+            correctionState: "none",
+            safeToUse: false,
+            safety: "blocked",
+            safetyReasons: ["blocked in current context"],
+          },
+        },
+      ],
+      filters: [],
+      budget: { chars: 4096, used: 100 },
+      namespace: "work",
+    },
+    {
+      schemaVersion: 1,
+      decision: "ask",
+      confidence: 0.5,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: [],
+      factors: [],
+      retrievedMemoryCount: 1,
+      usableMemoryCount: 0,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 1,
+      safeToAct: false,
+    },
+  );
+
+  assert.match(result.safeRecallPreview, /1 retrieved memory is blocked/);
+  assert.match(result.memories[0]?.preview ?? "", /Preview withheld/);
+  assert.doesNotMatch(result.memories[0]?.preview ?? "", /blocked private detail/);
+});
+
 test("ChatGPT Apps inspector rejects malformed currentContextScopes before service dispatch", async () => {
   const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
   const server = new EngramMcpServer(fakeService(capture));

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -324,6 +324,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.recall_tier_explain",
     "engram.recall_xray",
     "engram.action_confidence",
+    "engram.chatgpt_memory_inspector",
     "engram.day_summary",
     "engram.capsule_export",
     "engram.capsule_import",

--- a/tests/access-recall-principal.test.ts
+++ b/tests/access-recall-principal.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { EngramAccessHttpServer } from "../src/access-http.js";
+import { EngramMcpServer } from "../src/access-mcp.js";
+import type {
+  EngramAccessRecallRequest,
+  EngramAccessRecallResponse,
+  EngramAccessService,
+} from "../src/access-service.js";
+
+function recallResponse(request: EngramAccessRecallRequest): EngramAccessRecallResponse {
+  return {
+    query: request.query,
+    ...(request.sessionKey ? { sessionKey: request.sessionKey } : {}),
+    namespace: request.namespace ?? "global",
+    context: "",
+    count: 0,
+    memoryIds: [],
+    results: [],
+    fallbackUsed: false,
+    sourcesUsed: [],
+    disclosure: "chunk",
+  };
+}
+
+function fakeService(capture: { recall?: EngramAccessRecallRequest }): EngramAccessService {
+  return {
+    briefingEnabled: false,
+    recall: async (request: EngramAccessRecallRequest) => {
+      capture.recall = { ...request };
+      return recallResponse(request);
+    },
+  } as unknown as EngramAccessService;
+}
+
+test("HTTP recall forwards the authenticated transport principal", async () => {
+  const capture: { recall?: EngramAccessRecallRequest } = {};
+  const server = new EngramAccessHttpServer({
+    service: fakeService(capture),
+    authToken: "test-token",
+    principal: "tenant-a",
+    port: 0,
+  });
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://${status.host}:${status.port}/engram/v1/recall`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        query: "what matters here?",
+        namespace: "work",
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(capture.recall?.authenticatedPrincipal, "tenant-a");
+    assert.equal(capture.recall?.namespace, "work");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("MCP recall forwards the effective transport principal", async () => {
+  const capture: { recall?: EngramAccessRecallRequest } = {};
+  const server = new EngramMcpServer(fakeService(capture));
+
+  const response = await server.handleRequest(
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "engram.recall",
+        arguments: {
+          query: "what matters here?",
+          namespace: "work",
+        },
+      },
+    },
+    { principalOverride: "tenant-a" },
+  );
+
+  assert.equal((response?.result as { isError?: boolean } | undefined)?.isError, false);
+  assert.equal(capture.recall?.authenticatedPrincipal, "tenant-a");
+  assert.equal(capture.recall?.namespace, "work");
+});

--- a/tests/access-service-recall-xray.test.ts
+++ b/tests/access-service-recall-xray.test.ts
@@ -146,6 +146,13 @@ test("recallXray forwards current context scopes through invocation options", as
   assert.deepEqual(state.lastOptions?.currentContextScopes, ["work", "repo"]);
 });
 
+test("recallXray forwards recall mode through invocation options", async () => {
+  const { orchestrator, state } = stubOrchestrator({ snapshot: null });
+  const service = new EngramAccessService(orchestrator as any);
+  await service.recallXray({ query: "q", mode: "full" });
+  assert.equal(state.lastOptions?.mode, "full");
+});
+
 test("recallXray clears any prior snapshot before capturing", async () => {
   const { orchestrator, state } = stubOrchestrator({
     snapshot: fakeSnapshot({ snapshotId: "stale" }),

--- a/tests/access-service-recall-xray.test.ts
+++ b/tests/access-service-recall-xray.test.ts
@@ -136,6 +136,16 @@ test("recallXray forwards xrayCapture:true to orchestrator.recall", async () => 
   assert.equal(state.lastOptions?.xrayCapture, true);
 });
 
+test("recallXray forwards current context scopes through invocation options", async () => {
+  const { orchestrator, state } = stubOrchestrator({ snapshot: null });
+  const service = new EngramAccessService(orchestrator as any);
+  await service.recallXray({
+    query: "q",
+    currentContextScopes: ["work", "repo"],
+  });
+  assert.deepEqual(state.lastOptions?.currentContextScopes, ["work", "repo"]);
+});
+
 test("recallXray clears any prior snapshot before capturing", async () => {
   const { orchestrator, state } = stubOrchestrator({
     snapshot: fakeSnapshot({ snapshotId: "stale" }),

--- a/tests/access-service-recall-xray.test.ts
+++ b/tests/access-service-recall-xray.test.ts
@@ -285,6 +285,54 @@ test("recallXray releases the snapshot mutex before optional recall serializatio
   assert.equal(secondResponse.snapshot?.snapshotId, "snap-second");
 });
 
+test("recallXray includeRecall latency starts after waiting for the snapshot mutex", async () => {
+  const originalDateNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const firstSnapshot = fakeSnapshot({ snapshotId: "snap-first" });
+    const secondSnapshot = fakeSnapshot({ snapshotId: "snap-second" });
+    let resolveFirstRecallStarted: () => void = () => {};
+    const firstRecallStarted = new Promise<void>((resolve) => {
+      resolveFirstRecallStarted = resolve;
+    });
+    let releaseFirstRecall: () => void = () => {};
+    const firstRecallReleased = new Promise<void>((resolve) => {
+      releaseFirstRecall = resolve;
+    });
+    const { orchestrator, state } = stubOrchestrator({});
+    orchestrator.recall = async (prompt: string) => {
+      if (prompt === "first") {
+        resolveFirstRecallStarted();
+        await firstRecallReleased;
+        state.snapshot = firstSnapshot;
+        return "ctx";
+      }
+      state.snapshot = secondSnapshot;
+      now = 5_030;
+      return "ctx";
+    };
+
+    const service = new EngramAccessService(orchestrator as any);
+    const first = service.recallXray({ query: "first" });
+    await firstRecallStarted;
+    now = 1_500;
+    const second = service.recallXray({
+      query: "second",
+      includeRecall: true,
+    });
+    now = 5_000;
+    releaseFirstRecall();
+
+    const [firstResponse, secondResponse] = await Promise.all([first, second]);
+    assert.equal(firstResponse.snapshot?.snapshotId, "snap-first");
+    assert.equal(secondResponse.snapshot?.snapshotId, "snap-second");
+    assert.equal(secondResponse.recall?.latencyMs, 30);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test("recallXray forwards xrayCapture:true to orchestrator.recall", async () => {
   const { orchestrator, state } = stubOrchestrator({ snapshot: null });
   const service = new EngramAccessService(orchestrator as any);

--- a/tests/access-service-recall-xray.test.ts
+++ b/tests/access-service-recall-xray.test.ts
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 
 import { EngramAccessService } from "../src/access-service.js";
 import type { RecallXraySnapshot } from "../src/recall-xray.js";
+import type { MemoryFile } from "../src/types.js";
 
 function fakeSnapshot(
   overrides: Partial<RecallXraySnapshot> = {},
@@ -42,6 +43,7 @@ function stubOrchestrator(opts: {
     sessionKey: string | undefined,
     options: Record<string, unknown>,
   ) => void;
+  memoriesByPath?: Map<string, MemoryFile>;
 }) {
   const state = {
     clearedSnapshot: 0,
@@ -85,7 +87,15 @@ function stubOrchestrator(opts: {
       getMostRecent: () => null,
     },
     getStorage: async () => ({
-      getMemoryById: async () => null,
+      dir: "/tmp/engram",
+      readMemoryByPath: async (memoryPath: string) =>
+        opts.memoriesByPath?.get(memoryPath) ?? null,
+      getMemoryById: async (memoryId: string) => {
+        if (!opts.memoriesByPath) return null;
+        return Array.from(opts.memoriesByPath.values()).find(
+          (memory) => memory.frontmatter.id === memoryId,
+        ) ?? null;
+      },
       getMemoryTimeline: async () => [],
     }),
   };
@@ -127,6 +137,68 @@ test("recallXray returns the captured snapshot when present", async () => {
   assert.equal(response.snapshotFound, true);
   assert.ok(response.snapshot);
   assert.equal(response.snapshot?.snapshotId, "snap-1");
+  assert.equal(response.recall, undefined);
+});
+
+test("recallXray can return recall metadata from the same captured snapshot", async () => {
+  const memoryPath = "/tmp/engram/memories/mem-a.md";
+  const memory: MemoryFile = {
+    path: memoryPath,
+    frontmatter: {
+      id: "mem-a",
+      category: "preference",
+      created: "2026-05-01T00:00:00.000Z",
+      updated: "2026-05-01T00:00:00.000Z",
+      source: "test",
+      confidence: 0.95,
+      confidenceTier: "explicit",
+      tags: ["style"],
+      status: "active",
+    },
+    content: "Same captured memory content for the inspector.",
+  };
+  const snap = fakeSnapshot({
+    namespace: "global",
+    traceId: "trace-same-snapshot",
+    results: [
+      {
+        memoryId: "mem-a",
+        path: memoryPath,
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.91 },
+        admittedBy: ["hybrid-search"],
+      },
+    ],
+    budget: { chars: 4096, used: memory.content.length },
+  });
+  const { orchestrator, state } = stubOrchestrator({
+    memoriesByPath: new Map([[memoryPath, memory]]),
+  });
+  orchestrator.recall = async () => {
+    state.snapshot = snap;
+    return "independent recall context that must not be used";
+  };
+
+  const service = new EngramAccessService(orchestrator as any);
+  const response = await service.recallXray({
+    query: "q",
+    sessionKey: "sess-1",
+    disclosure: "chunk",
+    includeRecall: true,
+  });
+
+  assert.equal(response.snapshotFound, true);
+  assert.equal(response.snapshot?.snapshotId, "snap-1");
+  assert.equal(response.recall?.sessionKey, "sess-1");
+  assert.equal(response.recall?.traceId, "trace-same-snapshot");
+  assert.deepEqual(response.recall?.memoryIds, ["mem-a"]);
+  assert.equal(response.recall?.results[0]?.id, "mem-a");
+  assert.equal(response.recall?.results[0]?.path, memoryPath);
+  assert.match(response.recall?.context ?? "", /Same captured memory content/);
+  assert.notEqual(
+    response.recall?.context,
+    "independent recall context that must not be used",
+  );
 });
 
 test("recallXray forwards xrayCapture:true to orchestrator.recall", async () => {

--- a/tests/access-service-recall-xray.test.ts
+++ b/tests/access-service-recall-xray.test.ts
@@ -8,6 +8,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { EngramAccessService } from "../src/access-service.js";
 import type { RecallXraySnapshot } from "../src/recall-xray.js";
@@ -44,6 +45,7 @@ function stubOrchestrator(opts: {
     options: Record<string, unknown>,
   ) => void;
   memoriesByPath?: Map<string, MemoryFile>;
+  onReadMemoryByPath?: (memoryPath: string) => Promise<void> | void;
 }) {
   const state = {
     clearedSnapshot: 0,
@@ -88,8 +90,10 @@ function stubOrchestrator(opts: {
     },
     getStorage: async () => ({
       dir: "/tmp/engram",
-      readMemoryByPath: async (memoryPath: string) =>
-        opts.memoriesByPath?.get(memoryPath) ?? null,
+      readMemoryByPath: async (memoryPath: string) => {
+        await opts.onReadMemoryByPath?.(memoryPath);
+        return opts.memoriesByPath?.get(memoryPath) ?? null;
+      },
       getMemoryById: async (memoryId: string) => {
         if (!opts.memoriesByPath) return null;
         return Array.from(opts.memoriesByPath.values()).find(
@@ -199,6 +203,86 @@ test("recallXray can return recall metadata from the same captured snapshot", as
     response.recall?.context,
     "independent recall context that must not be used",
   );
+});
+
+test("recallXray releases the snapshot mutex before optional recall serialization I/O", async () => {
+  const memoryPath = "/tmp/engram/memories/mem-a.md";
+  const memory: MemoryFile = {
+    path: memoryPath,
+    frontmatter: {
+      id: "mem-a",
+      category: "preference",
+      created: "2026-05-01T00:00:00.000Z",
+      updated: "2026-05-01T00:00:00.000Z",
+      source: "test",
+      confidence: 0.95,
+      confidenceTier: "explicit",
+      tags: ["style"],
+      status: "active",
+    },
+    content: "Same captured memory content for the inspector.",
+  };
+  const firstSnapshot = fakeSnapshot({
+    snapshotId: "snap-first",
+    results: [
+      {
+        memoryId: "mem-a",
+        path: memoryPath,
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.91 },
+        admittedBy: ["hybrid-search"],
+      },
+    ],
+    budget: { chars: 4096, used: memory.content.length },
+  });
+  const secondSnapshot = fakeSnapshot({ snapshotId: "snap-second" });
+  let resolveReadStarted: () => void = () => {};
+  const readStarted = new Promise<void>((resolve) => {
+    resolveReadStarted = resolve;
+  });
+  let releaseRead: () => void = () => {};
+  const readReleased = new Promise<void>((resolve) => {
+    releaseRead = resolve;
+  });
+  let resolveSecondRecallStarted: () => void = () => {};
+  const secondRecallStarted = new Promise<void>((resolve) => {
+    resolveSecondRecallStarted = resolve;
+  });
+  const { orchestrator, state } = stubOrchestrator({
+    memoriesByPath: new Map([[memoryPath, memory]]),
+    onReadMemoryByPath: async () => {
+      resolveReadStarted();
+      await readReleased;
+    },
+  });
+  orchestrator.recall = async (prompt: string) => {
+    if (prompt === "first") {
+      state.snapshot = firstSnapshot;
+    } else {
+      state.snapshot = secondSnapshot;
+      resolveSecondRecallStarted();
+    }
+    return "ctx";
+  };
+
+  const service = new EngramAccessService(orchestrator as any);
+  const first = service.recallXray({
+    query: "first",
+    includeRecall: true,
+  });
+  await readStarted;
+  const second = service.recallXray({ query: "second" });
+  const secondStartedBeforeReadFinished = await Promise.race([
+    secondRecallStarted.then(() => true),
+    delay(250).then(() => false),
+  ]);
+  releaseRead();
+
+  assert.equal(secondStartedBeforeReadFinished, true);
+  const [firstResponse, secondResponse] = await Promise.all([first, second]);
+  assert.equal(firstResponse.snapshot?.snapshotId, "snap-first");
+  assert.equal(firstResponse.recall?.memoryIds[0], "mem-a");
+  assert.equal(secondResponse.snapshot?.snapshotId, "snap-second");
 });
 
 test("recallXray forwards xrayCapture:true to orchestrator.recall", async () => {

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -1059,6 +1059,62 @@ test("access service allows readable namespace overrides outside default recall 
   });
 });
 
+test("access service recall uses authenticated principal for namespace authorization", async () => {
+  let capturedOptions: unknown;
+  const service = new EngramAccessService({
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "project-y",
+          readPrincipals: ["chatgpt-user"],
+          writePrincipals: ["project-y"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+    },
+    recall: async (_query: string, _sessionKey?: string, options?: unknown) => {
+      capturedOptions = options;
+      return "ctx";
+    },
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async () => ({
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  } as any);
+
+  const response = await service.recall({
+    query: "hello",
+    namespace: "project-y",
+    authenticatedPrincipal: "chatgpt-user",
+    mode: "full",
+  });
+
+  assert.equal(response.namespace, "project-y");
+  assert.deepEqual(capturedOptions, {
+    namespace: "project-y",
+    topK: undefined,
+    mode: "full",
+    principalOverride: "chatgpt-user",
+  });
+});
+
 test("access service rejects unreadable namespace-scoped recall overrides", async () => {
   const service = createService();
   await assert.rejects(


### PR DESCRIPTION
## Summary
- add a ChatGPT Apps-compatible Remnic memory inspector on the existing MCP runtime
- expose the widget resource through MCP resources/list and resources/read, with read-only tool annotations and canonical/legacy tool aliases
- document the local developer demo and cover the MCP Apps contract with focused tests

## Verification
- pnpm exec tsx --test tests/access-mcp-chatgpt-app.test.ts
- pnpm exec tsx --test tests/access-mcp.test.ts tests/access-mcp-chatgpt-app.test.ts tests/access-mcp-action-confidence.test.ts tests/access-mcp-recall-xray.test.ts packages/remnic-core/src/access-mcp.test.ts
- npm run check-types
- npm run test:entity-hardening
- gtimeout 900 npm run preflight:quick
- npm run review:cursor (skipped: macOS login keychain locked)

Docs used for Apps SDK alignment:
- https://developers.openai.com/apps-sdk/quickstart
- https://developers.openai.com/apps-sdk/build/mcp-server
- https://developers.openai.com/apps-sdk/build/chatgpt-ui
- https://developers.openai.com/apps-sdk/reference
- https://developers.openai.com/apps-sdk/plan/tools

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new MCP `resources/*` surface and a new tool that threads authenticated principals and context scopes through recall/X-ray/action-confidence; mistakes here could affect namespace authorization or leak/redact memory previews incorrectly. Changes are well-covered by new targeted tests but touch core access-service and orchestrator wiring.
> 
> **Overview**
> Adds a local **ChatGPT Apps-compatible “Remnic Memory Inspector” demo** on the existing MCP runtime: a new read-only tool (`remnic.chatgpt_memory_inspector` with legacy alias) that runs `recallXray` + `actionConfidence` and returns structured output rendered by a served widget (`ui://remnic/memory-inspector.v1.html`, `text/html;profile=mcp-app`).
> 
> Extends the MCP server to advertise and serve widget resources via `resources/list`, `resources/templates/list`, and `resources/read`, and annotates the tool with app UI metadata/output schema so ChatGPT can render it.
> 
> Tightens principal/namespace handling by forwarding an `authenticatedPrincipal` through HTTP and MCP recall paths, and enhances `recallXray` to accept `mode`/`currentContextScopes` and optionally return a recall-shaped response derived from the captured X-ray snapshot (used by the inspector) without changing the default payload.
> 
> Includes new docs and comprehensive tests covering tool/resource metadata, aliasing, safe preview redaction when provenance is missing/blocked, and principal propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c96c5ac3334a803b24e9a2f735236504e49160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->