### PR TITLE
feat(demo): add agentic commerce scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,6 +931,7 @@ openclaw engram access mcp-serve   # Start OpenClaw-hosted stdio MCP server
 
 # Trust-zone demos
 openclaw engram trust-zone-demo-seed --dry-run       # Preview the opt-in buyer demo dataset
+openclaw engram trust-zone-demo-seed --scenario agentic-commerce-v1 --dry-run
 openclaw engram trust-zone-demo-seed                 # Explicitly seed the demo dataset
 openclaw engram trust-zone-promote --record-id <id> --target-zone working --reason "Operator review"
 ```
@@ -943,13 +944,23 @@ Trust zones now ship with a dedicated admin-console view plus an explicit demo s
 - **Explicit only** — demo records appear only after you run `openclaw engram trust-zone-demo-seed` or trigger the matching admin-console action.
 - **Buyer-friendly story** — the trust-zone view surfaces provenance strength, promotion readiness, corroboration requirements, and operator promotion actions in one place.
 
-The seeded scenario is `enterprise-buyer-v1`, which creates a small, opinionated dataset covering:
+The default scenario is `enterprise-buyer-v1`, which creates a small, opinionated dataset covering:
 
 - quarantine records that are ready for review
 - working records that are blocked on missing provenance
 - working records that still need corroboration
 - working records with independent corroboration support
 - a trusted operator policy record
+
+The commerce scenario is `agentic-commerce-v1`. It models buyer-aware recommendations using synthetic catalog data plus:
+
+- brand, size, fit, budget, gift, and shipping preferences
+- excluded products and never-suggest rules
+- ask-before-checkout boundaries
+- a blocked unverified upsell claim
+- retrieval eval coverage for commerce personalization and checkout boundaries
+
+See [Agentic Commerce Demo](docs/agentic-commerce-demo.md) for the end-to-end walkthrough.
 
 See the [full CLI reference](docs/api.md#cli-commands) for all commands.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@
 - [Recall X-ray](xray.md) — Per-result retrieval attribution, provenance, safety, and why each memory surfaced (issue #570)
 - [Recall Disclosure](recall-disclosure.md) — Three-tier progressive disclosure (chunk / section / raw): cost/quality tradeoffs, auto-escalation policy, and the disclosure-vs-retrieval-tier distinction (issue #677)
 - [User-Aware Agents](user-aware-agents.md) — User-model dimensions, context scopes, and boundary principles
+- [Agentic Commerce Demo](agentic-commerce-demo.md) — Buyer-aware recommendations, checkout boundaries, and commerce eval coverage
 - [Temporal Recall](temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and `as_of` recall filter (issue #680)
 - [Tags](tags.md) — Free-form tag filter on recall and propose; tags vs taxonomy (issue #689)
 - [Live Connectors](live-connectors.md) — Continuous-sync framework for external sources (issue #683)

--- a/docs/agentic-commerce-demo.md
+++ b/docs/agentic-commerce-demo.md
@@ -1,0 +1,102 @@
+# Agentic Commerce Demo
+
+Remnic's commerce demo shows the product direction for user-aware agents:
+recommendations get better when the agent understands the buyer, not only the
+catalog.
+
+The demo is local and synthetic. It uses ACP-style structured catalog concepts,
+but it does not require live Agentic Commerce Protocol partner access or a real
+merchant account.
+
+## What It Models
+
+The `agentic-commerce-v1` scenario covers buyer context that a commerce agent
+needs before it recommends, drafts, or acts:
+
+- brand preferences
+- size and fit preferences
+- budget thresholds
+- excluded products and never-suggest rules
+- gift preferences
+- shipping urgency
+- risk tolerance
+- ask-before-checkout rules
+- scoped use of commerce-only context
+
+The point is boundary-respecting personalization. Remnic should help the agent
+choose a better product, but it should also know when to ask before checkout,
+when a memory is out of scope, and when an unverified upsell should stay out of
+the answer.
+
+## Seed The Demo
+
+Preview the trust-zone records without writing anything:
+
+```bash
+openclaw engram trust-zone-demo-seed --scenario agentic-commerce-v1 --dry-run
+```
+
+Write the demo records explicitly:
+
+```bash
+openclaw engram trust-zone-demo-seed --scenario agentic-commerce-v1
+```
+
+The same scenario is available through the HTTP access layer:
+
+```bash
+curl -sS http://127.0.0.1:4318/engram/v1/trust-zones/demo-seed \
+  -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"scenario":"agentic-commerce-v1","dryRun":true}'
+```
+
+The records are never seeded automatically. They appear only after the explicit
+CLI or HTTP request.
+
+## Inspect The Scenario
+
+Use the trust-zone status and record browser to inspect the seeded provenance:
+
+```bash
+openclaw engram trust-zone-status
+```
+
+The scenario includes:
+
+- a quarantined catalog candidate before personalization
+- trusted buyer preferences for brand, size, fit, budget, and exclusions
+- a trusted checkout boundary that permits recommendations and draft carts but
+  requires asking before checkout or subscription enrollment
+- a working shipping-urgency estimate with independent corroboration
+- a blocked unverified upsell claim that should not influence recommendations
+
+## Evaluate It
+
+The `retrieval-personalization` benchmark includes commerce-specific cases for
+Taylor's buyer profile and checkout boundaries. Quick mode keeps one commerce
+case in the CI-sized fixture:
+
+```bash
+remnic bench run --quick retrieval-personalization
+```
+
+These cases assert that user-aware retrieval surfaces the right buyer context
+for recommendation quality and the right boundary memory for ask-before-checkout
+behavior.
+
+## Demo Prompt Shape
+
+Use prompts like these against a seeded local store:
+
+```text
+Recommend a rain shell for Taylor using the catalog candidate and Taylor's
+commerce preferences. Draft a cart, but do not check out.
+```
+
+```text
+Can the agent buy this for Taylor now, or should it ask first?
+```
+
+A good answer should use the buyer profile, respect exclusions, explain shipping
+confidence, and ask before irreversible purchase actions.

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,7 @@ Core routes:
 - `GET /engram/v1/trust-zones/status` — trust-zone store status, counts, and latest record summary
 - `GET /engram/v1/trust-zones/records` — browse trust-zone records with zone/source/query filters
 - `POST /engram/v1/trust-zones/promote` — dry-run or apply a trust-zone promotion
-- `POST /engram/v1/trust-zones/demo-seed` — explicitly seed the opt-in buyer demo dataset
+- `POST /engram/v1/trust-zones/demo-seed` — explicitly seed an opt-in buyer demo dataset
 - `POST /engram/v1/review-disposition` — operator review decision write path
 - `POST /engram/v1/observe` — feed conversation messages into LCM archive and extraction pipeline
 - `POST /engram/v1/lcm/search` — full-text search over LCM-archived conversations
@@ -139,12 +139,13 @@ Request fields:
 
 Request fields:
 
-- `scenario` (optional, default: `enterprise-buyer-v1`)
+- `scenario` (optional, default: `enterprise-buyer-v1`; also supports `agentic-commerce-v1`)
 - `recordedAt` (optional base ISO timestamp for demo records)
 - `dryRun`
 - `namespace`
 
 This route is intentionally explicit and never runs automatically. Use it only when you want seeded demo data in the selected namespace.
+`agentic-commerce-v1` is the synthetic commerce walkthrough for buyer preferences, exclusions, shipping urgency, and ask-before-checkout boundaries.
 
 #### `POST /engram/v1/observe`
 
@@ -565,7 +566,7 @@ Run via `openclaw engram <command>`:
 | `action-confidence [--confidence N] [--risk low\|medium\|high\|irreversible\|restricted] [--context none\|partial\|sufficient]` | Evaluate ask/draft/act/refuse/escalate advisory policy |
 | `trust-zone-status` | Show trust-zone store status and aggregate counts |
 | `trust-zone-promote --record-id <id> --target-zone <zone> --reason <text> [--dry-run]` | Preview or apply a trust-zone promotion |
-| `trust-zone-demo-seed [--scenario enterprise-buyer-v1] [--recorded-at <iso>] [--dry-run]` | Explicitly preview or seed the opt-in trust-zone buyer demo dataset |
+| `trust-zone-demo-seed [--scenario enterprise-buyer-v1\|agentic-commerce-v1] [--recorded-at <iso>] [--dry-run]` | Explicitly preview or seed an opt-in trust-zone buyer demo dataset |
 | `versions <list\|show\|diff\|revert> <page-path> [version-id(s)]` | Page version history management |
 | `taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
 | `enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |

--- a/docs/memory-evals.md
+++ b/docs/memory-evals.md
@@ -52,3 +52,7 @@ for (const benchmarkId of listMemoryEvalBenchmarkIds()) {
 Quick mode is for regression detection. Full mode should compare memory-enabled
 and memory-disabled runs, preserve provenance/scope annotations, and use sealed
 qrels or rubric prompts for publishable claims.
+
+`retrieval-personalization` includes synthetic commerce cases for buyer profile
+matching and ask-before-checkout boundary retrieval. These are the eval hooks
+used by the [Agentic Commerce Demo](agentic-commerce-demo.md).

--- a/docs/user-aware-agents.md
+++ b/docs/user-aware-agents.md
@@ -125,6 +125,14 @@ provenance, scope/safety signals, action-confidence guidance, and follow-up
 prompts for correction, forget, and scoping flows. See
 [ChatGPT Apps Demo](chatgpt-apps-demo.md).
 
+## Agentic Commerce Demo
+
+The `agentic-commerce-v1` scenario shows user-aware memory for buyer-facing
+agents: brand preferences, fit, budget, exclusions, gift constraints, shipping
+urgency, risk tolerance, and ask-before-checkout rules. It uses synthetic
+catalog data and local trust-zone records, not live merchant access. See
+[Agentic Commerce Demo](agentic-commerce-demo.md).
+
 ## Core Exports
 
 `@remnic/core` exports:

--- a/packages/bench/src/fixtures/schema-tiers/index.ts
+++ b/packages/bench/src/fixtures/schema-tiers/index.ts
@@ -187,6 +187,60 @@ const CLEAN_PAGES: SchemaTierPage[] = [
     dirtySignals: [],
   },
   {
+    id: "taylor-commerce-profile",
+    owner: "taylor",
+    namespace: "taylor/personal",
+    canonicalTitle: "Taylor Commerce Profile",
+    title: "Taylor Commerce Profile",
+    type: "preference",
+    createdAt: "2026-09-10T12:00:00.000Z",
+    aliases: ["Taylor shopping preferences", "Taylor buyer profile"],
+    body:
+      "Taylor prefers repairable outdoor brands, medium tops, 32x32 pants, relaxed fit, easy returns, and routine apparel recommendations under $180.",
+    frontmatter: {
+      title: "Taylor Commerce Profile",
+      type: "preference",
+      state: "active",
+      created: "2026-09-10T12:00:00.000Z",
+      seeAlso: ["taylor-commerce-boundaries"],
+      timeline: [
+        "2026-09-10: recorded brand, size, fit, return-window, and budget preferences for shopping agents",
+      ],
+    },
+    seeAlso: ["taylor-commerce-boundaries"],
+    timeline: [
+      "2026-09-10: recorded brand, size, fit, return-window, and budget preferences for shopping agents",
+    ],
+    dirtySignals: [],
+  },
+  {
+    id: "taylor-commerce-boundaries",
+    owner: "taylor",
+    namespace: "taylor/personal",
+    canonicalTitle: "Taylor Commerce Boundaries",
+    title: "Taylor Commerce Boundaries",
+    type: "rule",
+    createdAt: "2026-09-10T12:05:00.000Z",
+    aliases: ["Taylor checkout rules", "Taylor purchase boundaries"],
+    body:
+      "Taylor allows recommendations and draft carts, but the agent must ask before checkout, subscription enrollment, or any purchase above $75. Never suggest leather goods, fragrances, or final-sale shoes.",
+    frontmatter: {
+      title: "Taylor Commerce Boundaries",
+      type: "rule",
+      state: "active",
+      created: "2026-09-10T12:05:00.000Z",
+      seeAlso: ["taylor-commerce-profile"],
+      timeline: [
+        "2026-09-10: set ask-before-checkout and never-suggest boundaries for commerce agents",
+      ],
+    },
+    seeAlso: ["taylor-commerce-profile"],
+    timeline: [
+      "2026-09-10: set ask-before-checkout and never-suggest boundaries for commerce agents",
+    ],
+    dirtySignals: [],
+  },
+  {
     id: "riley-hiring-advice",
     owner: "riley",
     namespace: "riley/advisory",
@@ -289,6 +343,23 @@ function buildDirtyCorpus(cleanPages: SchemaTierPage[]): SchemaTierPage[] {
         dirtyPage.frontmatter.timeline = [...dirtyPage.timeline];
         dirtyPage.dirtySignals.push("stale-created-date", "stale-timeline-date");
         break;
+      case "taylor-commerce-profile":
+        delete dirtyPage.frontmatter.created;
+        dirtyPage.timeline = [];
+        dirtyPage.frontmatter.timeline = [];
+        dirtyPage.dirtySignals.push("missing-frontmatter-created", "missing-timeline");
+        break;
+      case "taylor-commerce-boundaries":
+        dirtyPage.title = "taylor commerce boundaries";
+        delete dirtyPage.frontmatter.type;
+        dirtyPage.seeAlso = [];
+        dirtyPage.frontmatter.seeAlso = [];
+        dirtyPage.dirtySignals.push(
+          "missing-frontmatter-type",
+          "orphan-page",
+          "title-casing-drift",
+        );
+        break;
       case "riley-hiring-advice":
         delete dirtyPage.frontmatter.title;
         dirtyPage.seeAlso = ["morgan-coffee-preferences"];
@@ -324,6 +395,20 @@ const PERSONALIZATION_CASES: PersonalizationRetrievalCase[] = [
     expectedPageIds: ["riley-hiring-advice"],
     expectedNamespace: "riley/advisory",
     expectedOwner: "riley",
+  },
+  {
+    id: "taylor-commerce-recommendation-context",
+    query: "Which commerce profile should guide Taylor's rain shell recommendation by brand, fit, and budget?",
+    expectedPageIds: ["taylor-commerce-profile"],
+    expectedNamespace: "taylor/personal",
+    expectedOwner: "taylor",
+  },
+  {
+    id: "taylor-commerce-checkout-boundary",
+    query: "What should a shopping agent ask before checkout for Taylor?",
+    expectedPageIds: ["taylor-commerce-boundaries"],
+    expectedNamespace: "taylor/personal",
+    expectedOwner: "taylor",
   },
 ];
 
@@ -389,10 +474,13 @@ export function buildSchemaTierSmokeFixture(seed = DEFAULT_SCHEMA_TIER_SEED): Sc
     "alex-partner-onboarding-brief",
     "morgan-coffee-preferences",
     "morgan-q3-training-plan",
+    "taylor-commerce-profile",
+    "taylor-commerce-boundaries",
   ]);
   const smokeCaseIds = new Set([
     "alex-scope-q3-launch",
     "morgan-scope-coffee",
+    "taylor-commerce-checkout-boundary",
     "alex-last-tuesday-meeting",
     "missing-fact-paris-summit",
   ]);

--- a/packages/remnic-core/src/trust-zones.ts
+++ b/packages/remnic-core/src/trust-zones.ts
@@ -139,12 +139,19 @@ export interface TrustZonePromotionReadiness {
 }
 
 export interface TrustZoneDemoSeedResult {
-  scenario: string;
+  scenario: TrustZoneDemoScenario;
   dryRun: boolean;
   recordsWritten: number;
   records: TrustZoneRecord[];
   filePaths: string[];
 }
+
+export type TrustZoneDemoScenario = "enterprise-buyer-v1" | "agentic-commerce-v1";
+
+const TRUST_ZONE_DEMO_SCENARIOS: TrustZoneDemoScenario[] = [
+  "enterprise-buyer-v1",
+  "agentic-commerce-v1",
+];
 
 function validateMetadata(raw: unknown): Record<string, string> | undefined {
   return validateStringRecord(raw, "metadata");
@@ -245,7 +252,7 @@ function hasOverlap(left: string[] | undefined, right: string[] | undefined): bo
 
 function corroborationTags(record: TrustZoneRecord): string[] | undefined {
   if (!record.tags || record.tags.length === 0) return undefined;
-  const filtered = record.tags.filter((tag) => tag !== "trust-zone-demo" && tag !== "enterprise-demo");
+  const filtered = record.tags.filter((tag) => tag !== "trust-zone-demo" && tag !== "enterprise-demo" && tag !== "commerce-demo");
   return filtered.length > 0 ? filtered : undefined;
 }
 
@@ -699,7 +706,15 @@ function buildTrustZoneDemoRecordId(baseId: string, seedRunId: string): string {
   return `${baseId}-${seedRunId}`;
 }
 
-function buildTrustZoneDemoRecords(baseRecordedAt: string, scenario: string): TrustZoneRecord[] {
+function parseTrustZoneDemoScenario(raw: string | undefined): TrustZoneDemoScenario {
+  const scenario = (raw ?? "enterprise-buyer-v1").trim();
+  if (!TRUST_ZONE_DEMO_SCENARIOS.includes(scenario as TrustZoneDemoScenario)) {
+    throw new Error(`unsupported trust-zone demo scenario: ${scenario}`);
+  }
+  return scenario as TrustZoneDemoScenario;
+}
+
+function buildEnterpriseBuyerTrustZoneDemoRecords(baseRecordedAt: string, scenario: TrustZoneDemoScenario): TrustZoneRecord[] {
   const demoTag = "trust-zone-demo";
   const commonMetadata = {
     demoScenario: scenario,
@@ -835,6 +850,236 @@ function buildTrustZoneDemoRecords(baseRecordedAt: string, scenario: string): Tr
   ];
 }
 
+function buildAgenticCommerceTrustZoneDemoRecords(baseRecordedAt: string, scenario: TrustZoneDemoScenario): TrustZoneRecord[] {
+  const demoTag = "trust-zone-demo";
+  const commerceTag = "commerce-demo";
+  const commonMetadata = {
+    demoScenario: scenario,
+    demoSeed: "true",
+    category: "user-aware-commerce",
+  };
+  const seedRunId = buildTrustZoneDemoSeedRunId(baseRecordedAt);
+  return [
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-quarantine-catalog-rainshell", seedRunId),
+      zone: "quarantine",
+      recordedAt: addMinutes(baseRecordedAt, 0),
+      kind: "external",
+      summary: "Merchant catalog candidate: ArcTrail rain shell, price $148, recycled nylon, medium regular fit, two-day shipping eligible.",
+      provenance: {
+        sourceClass: "web_content",
+        observedAt: addMinutes(baseRecordedAt, -3),
+        sessionKey: "demo:agentic-commerce-v1",
+        sourceId: "acp-catalog:merchant.example/products/arctrail-rain-shell",
+        evidenceHash: "sha256:acp-catalog-arctrail-rain-shell",
+      },
+      entityRefs: ["product:arctrail-rain-shell", "merchant:trailhead-outfitters"],
+      tags: [demoTag, commerceTag, "catalog-product", "rain-shell"],
+      metadata: {
+        ...commonMetadata,
+        story: "catalog-candidate-before-personalization",
+        commerceFacet: "product_discovery",
+        scope: "commerce/catalog",
+      },
+    },
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-trusted-brand-preferences", seedRunId),
+      zone: "trusted",
+      recordedAt: addMinutes(baseRecordedAt, 2),
+      kind: "memory",
+      summary: "Buyer prefers repairable outdoor brands such as Patagonia, REI, and Arc'teryx, and avoids fast-fashion marketplaces.",
+      provenance: {
+        sourceClass: "user_input",
+        observedAt: addMinutes(baseRecordedAt, 1),
+        sessionKey: "demo:agentic-commerce-v1",
+        sourceId: "conversation:buyer-preferences",
+        evidenceHash: "sha256:buyer-brand-preferences",
+      },
+      entityRefs: ["buyer:self", "preference:brand"],
+      tags: [demoTag, commerceTag, "brand-preference"],
+      metadata: {
+        ...commonMetadata,
+        story: "trusted-brand-preferences",
+        commerceFacet: "brand_preferences",
+        scope: "personal/commerce",
+      },
+    },
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-trusted-size-fit", seedRunId),
+      zone: "trusted",
+      recordedAt: addMinutes(baseRecordedAt, 4),
+      kind: "memory",
+      summary: "Buyer wears medium tops, 32x32 pants, and prefers relaxed fit with an easy return window.",
+      provenance: {
+        sourceClass: "user_input",
+        observedAt: addMinutes(baseRecordedAt, 3),
+        sessionKey: "demo:agentic-commerce-v1",
+        sourceId: "conversation:size-fit",
+        evidenceHash: "sha256:buyer-size-fit",
+      },
+      entityRefs: ["buyer:self", "preference:size-fit"],
+      tags: [demoTag, commerceTag, "size-fit"],
+      metadata: {
+        ...commonMetadata,
+        story: "trusted-size-fit",
+        commerceFacet: "size_fit",
+        scope: "personal/commerce",
+      },
+    },
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-trusted-budget", seedRunId),
+      zone: "trusted",
+      recordedAt: addMinutes(baseRecordedAt, 6),
+      kind: "memory",
+      summary: "Routine apparel recommendations should stay under $180, and any checkout above $75 requires an explicit ask before purchase.",
+      provenance: {
+        sourceClass: "manual",
+        observedAt: addMinutes(baseRecordedAt, 5),
+        sessionKey: "demo:agentic-commerce-v1",
+        sourceId: "review:buyer-commerce-rules",
+        evidenceHash: "sha256:buyer-budget-thresholds",
+      },
+      entityRefs: ["buyer:self", "rule:ask-before-checkout", "constraint:budget"],
+      tags: [demoTag, commerceTag, "budget-threshold", "ask-before-checkout"],
+      metadata: {
+        ...commonMetadata,
+        story: "trusted-budget-and-ask-before-checkout",
+        commerceFacet: "budget_thresholds",
+        askBefore: "checkout-over-75",
+        scope: "personal/commerce",
+      },
+    },
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-trusted-exclusions", seedRunId),
+      zone: "trusted",
+      recordedAt: addMinutes(baseRecordedAt, 8),
+      kind: "memory",
+      summary: "Never suggest leather goods, fragrances, or final-sale shoes for this buyer.",
+      provenance: {
+        sourceClass: "user_input",
+        observedAt: addMinutes(baseRecordedAt, 7),
+        sessionKey: "demo:agentic-commerce-v1",
+        sourceId: "conversation:excluded-products",
+        evidenceHash: "sha256:buyer-exclusions",
+      },
+      entityRefs: ["buyer:self", "rule:never-suggest", "constraint:excluded-products"],
+      tags: [demoTag, commerceTag, "excluded-products", "never-suggest"],
+      metadata: {
+        ...commonMetadata,
+        story: "trusted-excluded-products",
+        commerceFacet: "excluded_products",
+        neverSuggest: "leather,fragrance,final-sale-shoes",
+        scope: "personal/commerce",
+      },
+    },
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-working-shipping-estimate", seedRunId),
+      zone: "working",
+      recordedAt: addMinutes(baseRecordedAt, 10),
+      kind: "state",
+      summary: "Shipping estimator says the weekend-trip gift can arrive before Friday with two-day delivery.",
+      provenance: {
+        sourceClass: "tool_output",
+        observedAt: addMinutes(baseRecordedAt, 9),
+        sessionKey: "demo:agentic-commerce-v1",
+        sourceId: "tool:shipping-estimate-run-17",
+        evidenceHash: "sha256:shipping-estimate-weekend-trip",
+      },
+      entityRefs: ["purchase:weekend-trip-gift", "constraint:shipping-urgency"],
+      tags: [demoTag, commerceTag, "shipping-urgency", "gift-purchase"],
+      metadata: {
+        ...commonMetadata,
+        story: "working-shipping-urgency",
+        commerceFacet: "shipping_urgency",
+        scope: "commerce/session",
+      },
+    },
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-working-shipping-corroboration", seedRunId),
+      zone: "working",
+      recordedAt: addMinutes(baseRecordedAt, 12),
+      kind: "external",
+      summary: "Merchant shipping policy independently confirms two-day delivery cutoff for the same weekend-trip gift window.",
+      provenance: {
+        sourceClass: "web_content",
+        observedAt: addMinutes(baseRecordedAt, 11),
+        sessionKey: "demo:agentic-commerce-v1",
+        sourceId: "https://merchant.example/shipping/two-day-cutoff",
+        evidenceHash: "sha256:merchant-two-day-cutoff",
+      },
+      entityRefs: ["purchase:weekend-trip-gift", "constraint:shipping-urgency"],
+      tags: [demoTag, commerceTag, "shipping-urgency", "gift-purchase"],
+      metadata: {
+        ...commonMetadata,
+        story: "working-shipping-corroboration",
+        commerceFacet: "shipping_urgency",
+        scope: "commerce/session",
+      },
+    },
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-working-blocked-upsell", seedRunId),
+      zone: "working",
+      recordedAt: addMinutes(baseRecordedAt, 14),
+      kind: "external",
+      summary: "Unverified influencer note claims the buyer wants luxury watch gifts over $500.",
+      provenance: {
+        sourceClass: "subagent_trace",
+        observedAt: addMinutes(baseRecordedAt, 13),
+        sessionKey: "demo:agentic-commerce-v1",
+      },
+      entityRefs: ["buyer:self", "risk:upsell"],
+      tags: [demoTag, commerceTag, "blocked-upsell", "needs-evidence"],
+      metadata: {
+        ...commonMetadata,
+        story: "commerce-blocked-unverified-upsell",
+        commerceFacet: "risk_tolerance",
+        scope: "commerce/session",
+      },
+    },
+    {
+      schemaVersion: 1,
+      recordId: buildTrustZoneDemoRecordId("tz-demo-agentic-commerce-v1-trusted-checkout-boundary", seedRunId),
+      zone: "trusted",
+      recordedAt: addMinutes(baseRecordedAt, 16),
+      kind: "memory",
+      summary: "The agent may recommend products and draft a cart, but must ask before checkout, subscription enrollment, or irreversible purchase actions.",
+      provenance: {
+        sourceClass: "manual",
+        observedAt: addMinutes(baseRecordedAt, 15),
+        sessionKey: "demo:agentic-commerce-v1",
+        sourceId: "review:commerce-action-boundaries",
+        evidenceHash: "sha256:commerce-action-boundaries",
+      },
+      entityRefs: ["buyer:self", "rule:ask-before-checkout", "policy:action-confidence"],
+      tags: [demoTag, commerceTag, "ask-before-checkout", "action-confidence"],
+      metadata: {
+        ...commonMetadata,
+        story: "trusted-checkout-boundary",
+        commerceFacet: "ask_before_checkout",
+        riskTolerance: "low-for-irreversible-purchase-actions",
+        scope: "personal/commerce",
+      },
+    },
+  ];
+}
+
+function buildTrustZoneDemoRecords(baseRecordedAt: string, scenario: TrustZoneDemoScenario): TrustZoneRecord[] {
+  switch (scenario) {
+    case "enterprise-buyer-v1":
+      return buildEnterpriseBuyerTrustZoneDemoRecords(baseRecordedAt, scenario);
+    case "agentic-commerce-v1":
+      return buildAgenticCommerceTrustZoneDemoRecords(baseRecordedAt, scenario);
+  }
+}
+
 export async function seedTrustZoneDemoDataset(options: {
   memoryDir: string;
   trustZoneStoreDir?: string;
@@ -847,10 +1092,7 @@ export async function seedTrustZoneDemoDataset(options: {
     throw new Error("trust zone demo seed requires trustZonesEnabled=true");
   }
 
-  const scenario = (options.scenario ?? "enterprise-buyer-v1").trim();
-  if (scenario !== "enterprise-buyer-v1") {
-    throw new Error(`unsupported trust-zone demo scenario: ${scenario}`);
-  }
+  const scenario = parseTrustZoneDemoScenario(options.scenario);
 
   const baseRecordedAt = assertIsoRecordedAt(options.recordedAt ?? new Date().toISOString(), "recordedAt");
   if (!Number.isFinite(Date.parse(baseRecordedAt))) {

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -93,7 +93,7 @@ test("runBenchmark executes retrieval-personalization in quick mode", async () =
 
   assert.equal(result.meta.benchmark, "retrieval-personalization");
   assert.equal(result.meta.benchmarkTier, "remnic");
-  assert.equal(result.results.tasks.length, 4);
+  assert.equal(result.results.tasks.length, 6);
   assert.equal(result.results.aggregates["clean.p_at_1"].mean, 1);
   assert.equal(result.results.aggregates["dirty.p_at_1"].mean, 1);
   assert.equal(result.results.aggregates["dirty_penalty.p_at_1"].mean, 0);

--- a/tests/bench-schema-tier-fixtures.test.ts
+++ b/tests/bench-schema-tier-fixtures.test.ts
@@ -37,7 +37,7 @@ test("schema tier fixture models real schema degradation in the dirty corpus", (
 });
 
 test("schema tier fixture includes personalization, temporal, and abstention coverage", () => {
-  assert.equal(SCHEMA_TIER_FIXTURE.personalizationCases.length, 3);
+  assert.equal(SCHEMA_TIER_FIXTURE.personalizationCases.length, 5);
   assert.equal(SCHEMA_TIER_FIXTURE.temporalCases.length, 2);
   assert.equal(SCHEMA_TIER_FIXTURE.abstentionCases.length, 3);
 
@@ -55,6 +55,10 @@ test("schema tier fixture includes personalization, temporal, and abstention cov
   assert.equal(
     SCHEMA_TIER_FIXTURE.abstentionCases[1]?.reason,
     "cross_tenant",
+  );
+  assert.equal(
+    SCHEMA_TIER_FIXTURE.personalizationCases.find((item) => item.id === "taylor-commerce-checkout-boundary")?.expectedPageIds[0],
+    "taylor-commerce-boundaries",
   );
 });
 
@@ -84,9 +88,9 @@ test("schema tier fixture builders return deep-cloned retrieval cases", () => {
 });
 
 test("schema tier smoke fixture preserves shared semantics while trimming the corpus", () => {
-  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.clean.pages.length, 4);
-  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.dirty.pages.length, 4);
-  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.personalizationCases.length, 2);
+  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.clean.pages.length, 6);
+  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.dirty.pages.length, 6);
+  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.personalizationCases.length, 3);
   assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.temporalCases.length, 1);
   assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.abstentionCases.length, 1);
 });

--- a/tests/trust-zones.test.ts
+++ b/tests/trust-zones.test.ts
@@ -865,6 +865,79 @@ test("seedTrustZoneDemoDataset stays explicit and writes the enterprise demo sce
   assert.equal(status.records.byZone.trusted, 2);
 });
 
+test("seedTrustZoneDemoDataset previews the agentic commerce scenario with boundaries", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-trust-zone-commerce-demo-seed-"));
+  const preview = await seedTrustZoneDemoDataset({
+    memoryDir,
+    enabled: true,
+    dryRun: true,
+    scenario: "agentic-commerce-v1",
+    recordedAt: "2026-04-02T16:00:00.000Z",
+  });
+
+  assert.equal(preview.dryRun, true);
+  assert.equal(preview.scenario, "agentic-commerce-v1");
+  assert.equal(preview.recordsWritten, 0);
+  assert.equal(preview.records.length, 9);
+  assert.equal(new Set(preview.records.map((record) => record.recordId)).size, 9);
+  assert.equal(
+    preview.records.filter((record) => record.metadata?.commerceFacet === "ask_before_checkout").length,
+    1,
+  );
+  assert.equal(
+    preview.records.filter((record) => record.metadata?.commerceFacet === "excluded_products").length,
+    1,
+  );
+  assert.equal(
+    preview.records.filter((record) => record.metadata?.commerceFacet === "shipping_urgency").length,
+    2,
+  );
+
+  const blockedUpsell = preview.records.find((record) => record.metadata?.story === "commerce-blocked-unverified-upsell");
+  assert.ok(blockedUpsell);
+  assert.equal(blockedUpsell.zone, "working");
+  const blockedReadiness = summarizeTrustZonePromotionReadiness({
+    record: blockedUpsell,
+    allRecords: preview.records,
+    poisoningDefenseEnabled: true,
+  });
+  assert.equal(blockedReadiness.allowed, false);
+  assert.match(blockedReadiness.reasons.join(" "), /sourceId|evidenceHash/i);
+
+  const shippingEstimate = preview.records.find((record) => record.metadata?.story === "working-shipping-urgency");
+  assert.ok(shippingEstimate);
+  const shippingReadiness = summarizeTrustZonePromotionReadiness({
+    record: shippingEstimate,
+    allRecords: preview.records,
+    poisoningDefenseEnabled: true,
+  });
+  assert.equal(shippingReadiness.allowed, true);
+  assert.equal(shippingReadiness.corroborationCount, 1);
+  assert.deepEqual(shippingReadiness.corroborationSourceClasses, ["web_content"]);
+
+  const written = await runTrustZoneDemoSeedCliCommand({
+    memoryDir,
+    trustZonesEnabled: true,
+    dryRun: false,
+    scenario: "agentic-commerce-v1",
+    recordedAt: "2026-04-02T16:00:00.000Z",
+  });
+  assert.equal(written.dryRun, false);
+  assert.equal(written.recordsWritten, 9);
+  assert.equal(written.scenario, "agentic-commerce-v1");
+
+  const status = await getTrustZoneStoreStatus({
+    memoryDir,
+    enabled: true,
+    promotionEnabled: true,
+    poisoningDefenseEnabled: true,
+  });
+  assert.equal(status.records.valid, 9);
+  assert.equal(status.records.byZone.quarantine, 1);
+  assert.equal(status.records.byZone.working, 3);
+  assert.equal(status.records.byZone.trusted, 5);
+});
+
 test("seedTrustZoneDemoDataset rejects non-parsable recordedAt values before date math", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-trust-zone-demo-seed-invalid-"));
   await assert.rejects(


### PR DESCRIPTION
## Summary
- add `agentic-commerce-v1` as an explicit trust-zone demo scenario for buyer-aware commerce workflows
- document the local Agentic Commerce demo and expose it from the README/docs/API surfaces
- add commerce personalization and ask-before-checkout cases to `retrieval-personalization`

## Verification
- `pnpm exec tsx --test tests/trust-zones.test.ts tests/bench-schema-tier-fixtures.test.ts tests/bench-remnic-deterministic-runners.test.ts`
- `npm run check-types`
- `pnpm exec tsx --test tests/access-service.test.ts tests/access-http.test.ts`
- `git diff --check`
- `gtimeout 900 npm run preflight:quick`
- `npm run review:cursor` skipped because the macOS login keychain is locked

## Notes
- Rebuilt `better-sqlite3` locally for Node 26 before rerunning access-service projection tests.
- The commerce scenario is synthetic and ACP-style; it does not require live merchant or ACP partner access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: extends core trust-zone demo seeding logic (new scenario parsing, record generation, and tag filtering), which could affect demo-seed behavior and corroboration/promotion heuristics if misconfigured. Changes are otherwise additive with updated fixtures/tests and documentation.
> 
> **Overview**
> Adds a new opt-in trust-zone demo scenario, `agentic-commerce-v1`, and updates `seedTrustZoneDemoDataset` to validate scenario IDs and generate a dedicated set of synthetic commerce-focused trust-zone records (preferences, exclusions, shipping urgency corroboration, and ask-before-checkout boundaries).
> 
> Extends the `retrieval-personalization` benchmark fixtures with Taylor commerce pages and new retrieval cases, updating smoke fixtures and task counts to keep CI coverage aligned.
> 
> Updates docs/README/API/README surfaces to describe the new scenario and adds a new walkthrough doc, `docs/agentic-commerce-demo.md`, plus minor API wording to reflect multiple demo datasets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7b1c81000ded7cf98a67cb1ee78d4370cb89b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->