### PR TITLE
feat(demo): add developer workflow scenario

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@
 - [Recall Disclosure](recall-disclosure.md) — Three-tier progressive disclosure (chunk / section / raw): cost/quality tradeoffs, auto-escalation policy, and the disclosure-vs-retrieval-tier distinction (issue #677)
 - [User-Aware Agents](user-aware-agents.md) — User-model dimensions, context scopes, and boundary principles
 - [Agentic Commerce Demo](agentic-commerce-demo.md) — Buyer-aware recommendations, checkout boundaries, and commerce eval coverage
+- [Developer Workflow Demo](developer-workflow-demo.md) — Coding-agent memory for repo conventions, review behavior, checks, and ask-before rules
 - [Temporal Recall](temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and `as_of` recall filter (issue #680)
 - [Tags](tags.md) — Free-form tag filter on recall and propose; tags vs taxonomy (issue #689)
 - [Live Connectors](live-connectors.md) — Continuous-sync framework for external sources (issue #683)

--- a/docs/coding-agent.md
+++ b/docs/coding-agent.md
@@ -257,6 +257,23 @@ recall candidate list; it never removes candidates. Memories whose
 `entityRefs` mention a touched file float up, so an agent reviewing a
 PR sees prior decisions about those exact files first.
 
+## Developer workflow demo
+
+The same project-scoped recall path now has a synthetic developer workflow demo
+for coding agents. It covers repo conventions, preferred architecture patterns,
+test expectations, release process, common failure modes, past bugs, review
+preferences, ask-before-public-API rules, and always-run-checks rules.
+
+Run it through the deterministic benchmark:
+
+```bash
+remnic bench run --quick coding-recall
+```
+
+The benchmark reports `workflow_coverage` for the developer workflow cases,
+alongside the existing precision and isolation metrics. See
+[Developer Workflow Demo](developer-workflow-demo.md).
+
 ## Per-connector behavior
 
 Since the `recall` and `observe` endpoints now accept `cwd` and

--- a/docs/developer-workflow-demo.md
+++ b/docs/developer-workflow-demo.md
@@ -1,0 +1,86 @@
+# Developer Workflow Demo
+
+Remnic's developer workflow demo shows how user-aware memory helps coding
+agents plan changes, modify repositories, run checks, and review work with less
+repeated setup context.
+
+The demo is local and synthetic. It does not require a live Codex, Cursor,
+Cognition, or LangChain integration. It uses the existing coding-agent memory
+path and the deterministic `coding-recall` benchmark.
+
+## What It Models
+
+The demo covers developer-agent context that should be remembered across
+sessions:
+
+- repo conventions
+- preferred architecture patterns
+- test expectations
+- release process
+- common failure modes
+- past bugs
+- review preferences
+- "ask before changing public API" rules
+- "always run these checks" rules
+
+The point is not to make an agent ask zero questions. The point is to make the
+agent spend attention on the questions that matter: risky API changes,
+conflicting memories, missing context, or actions that cross a user-defined
+boundary.
+
+## Existing Remnic Surfaces
+
+This demo builds on shipped Remnic behavior:
+
+- Coding agent mode scopes memory to a git project and optionally a branch.
+- Global fallback can surface cross-project user preferences without leaking
+  project-specific details.
+- Diff-aware review-context recall boosts memories tied to touched files.
+- Action confidence can represent "ask", "draft", "act", "refuse", or
+  "escalate" for risky developer actions.
+- Recall X-ray and provenance explain why a memory was retrieved and whether it
+  is safe to use in the current context.
+
+## Evaluate It
+
+Run the deterministic benchmark:
+
+```bash
+remnic bench run --quick coding-recall
+```
+
+Quick mode keeps a developer workflow case at the front of the smoke fixture so
+task-capped CLI runs still exercise workflow memory. Full mode includes both
+developer workflow cases plus the existing project, branch, and review-context
+isolation cases.
+
+The `developer-workflow-change-plan` case asserts that planning a public API
+change recalls architecture boundaries, test gates, release process, review
+preferences, and ask-before-public-API rules without pulling in another repo's
+memory.
+
+The `developer-workflow-review-risk` case asserts that review recall boosts
+past bugs and common failure modes for touched files, while still respecting
+project boundaries.
+
+Developer workflow cases report `workflow_coverage`, which measures whether
+the retrieved context covers the required developer workflow facets.
+
+## Demo Prompt Shape
+
+Use prompts like these against a project-scoped store:
+
+```text
+Plan a change to the Remnic core public API for a new memory field. Use the
+repo conventions, architecture boundaries, release process, and test
+expectations you know. Ask before making irreversible public API changes.
+```
+
+```text
+Review this PR touching packages/remnic-core/src/storage.ts. Surface prior bugs,
+common failure modes, and the checks I expect before merge.
+```
+
+A good agent should recall the repository's architecture boundary before
+editing core, run the expected gates before claiming merge readiness, and ask
+before changing public API behavior.

--- a/docs/memory-evals.md
+++ b/docs/memory-evals.md
@@ -56,3 +56,9 @@ qrels or rubric prompts for publishable claims.
 `retrieval-personalization` includes synthetic commerce cases for buyer profile
 matching and ask-before-checkout boundary retrieval. These are the eval hooks
 used by the [Agentic Commerce Demo](agentic-commerce-demo.md).
+
+`coding-recall` includes synthetic developer workflow cases for repo
+conventions, architecture boundaries, test expectations, release process,
+common failure modes, past bugs, review preferences, ask-before-public-API
+rules, and always-run-checks rules. These cases report `workflow_coverage` and
+back the [Developer Workflow Demo](developer-workflow-demo.md).

--- a/docs/user-aware-agents.md
+++ b/docs/user-aware-agents.md
@@ -133,6 +133,15 @@ urgency, risk tolerance, and ask-before-checkout rules. It uses synthetic
 catalog data and local trust-zone records, not live merchant access. See
 [Agentic Commerce Demo](agentic-commerce-demo.md).
 
+## Developer Workflow Demo
+
+The coding-agent workflow demo shows Remnic memory for repo conventions,
+preferred architecture patterns, test expectations, release process, common
+failure modes, past bugs, review preferences, ask-before-public-API rules, and
+always-run-checks rules. It extends the existing project/branch-scoped
+`coding-recall` benchmark with workflow coverage cases. See
+[Developer Workflow Demo](developer-workflow-demo.md).
+
 ## Core Exports
 
 `@remnic/core` exports:

--- a/packages/bench/src/benchmarks/remnic/coding-recall/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/coding-recall/fixture.ts
@@ -1,7 +1,8 @@
 /**
  * Fixtures for the coding-agent recall benchmark (issue #569 PR 8).
  *
- * Covers the three invariants PRs 2–4 introduced:
+ * Covers the three invariants PRs 2–4 introduced, plus developer
+ * workflow memory for user-aware coding agents:
  *
  *   1. Cross-project isolation — a memory written under project A is not
  *      retrievable under project B.
@@ -11,6 +12,10 @@
  *   3. Review-context ranking — on a review-intent prompt, a memory whose
  *      `entityRefs` mention a touched file outranks an unrelated memory of
  *      equal score.
+ *   4. Developer workflow recall — repo conventions, architecture patterns,
+ *      test expectations, release process, common failure modes, past bugs,
+ *      review preferences, ask-before rules, and always-run checks surface
+ *      in the same project-scoped recall path.
  *
  * All fixtures synthetic — no real repositories, no real user data.
  */
@@ -21,15 +26,28 @@ export interface CodingRecallCaseMemory {
   namespace: string;
   /** Optional file-path refs that `review-context` ranking consults. */
   entityRefs?: string[];
+  /** Developer-workflow facets covered by this memory, when applicable. */
+  workflowFacets?: DeveloperWorkflowFacet[];
   /** Baseline relevance score from the upstream recall pipeline. */
   score: number;
 }
+
+export type DeveloperWorkflowFacet =
+  | "repo_conventions"
+  | "preferred_architecture_patterns"
+  | "test_expectations"
+  | "release_process"
+  | "common_failure_modes"
+  | "past_bugs"
+  | "review_preferences"
+  | "ask_before_public_api"
+  | "always_run_checks";
 
 export interface CodingRecallCase {
   id: string;
   title: string;
   /** Invariant being exercised — reported in details. */
-  kind: "cross-project" | "branch-isolation" | "review-context";
+  kind: "cross-project" | "branch-isolation" | "review-context" | "developer-workflow";
   /** Session's effective read namespaces. The benchmark scorer filters
    *  candidates to these before ranking. */
   sessionNamespaces: string[];
@@ -43,6 +61,8 @@ export interface CodingRecallCase {
   expectedIds: string[];
   /** Memories that MUST NOT appear — cross-project / cross-branch leaks. */
   forbiddenIds: string[];
+  /** Developer-workflow facets that must be represented in retrieved memory. */
+  requiredWorkflowFacets?: DeveloperWorkflowFacet[];
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -119,6 +139,151 @@ const REVIEW_CONTEXT_CASE: CodingRecallCase = {
 };
 
 // ──────────────────────────────────────────────────────────────────────────
+// Developer workflow memory
+// ──────────────────────────────────────────────────────────────────────────
+
+const REMNIC_PROJECT_NAMESPACE = "project-origin-1234abcd";
+const USER_GLOBAL_NAMESPACE = "user-global";
+
+const DEVELOPER_WORKFLOW_PLANNING_CASE: CodingRecallCase = {
+  id: "developer-workflow-change-plan",
+  title:
+    "Developer workflow — public API planning recalls architecture boundaries, release process, tests, and ask-before rules",
+  kind: "developer-workflow",
+  sessionNamespaces: [REMNIC_PROJECT_NAMESPACE, USER_GLOBAL_NAMESPACE],
+  candidates: [
+    {
+      id: "dev-architecture-core-host-agnostic",
+      namespace: REMNIC_PROJECT_NAMESPACE,
+      score: 0.97,
+      entityRefs: [
+        "packages/remnic-core/src/types.ts",
+        "docs/architecture/monorepo-structure.md",
+      ],
+      workflowFacets: [
+        "repo_conventions",
+        "preferred_architecture_patterns",
+      ],
+    },
+    {
+      id: "dev-test-gate-preflight",
+      namespace: REMNIC_PROJECT_NAMESPACE,
+      score: 0.95,
+      entityRefs: ["package.json", "docs/ops/pr-review-hardening-playbook.md"],
+      workflowFacets: ["test_expectations", "always_run_checks"],
+    },
+    {
+      id: "dev-release-process-changeset",
+      namespace: REMNIC_PROJECT_NAMESPACE,
+      score: 0.86,
+      entityRefs: ["docs/development/release-process.md"],
+      workflowFacets: ["release_process"],
+    },
+    {
+      id: "dev-ask-before-public-api",
+      namespace: USER_GLOBAL_NAMESPACE,
+      score: 0.84,
+      entityRefs: ["packages/remnic-core/src/index.ts"],
+      workflowFacets: ["ask_before_public_api"],
+    },
+    {
+      id: "dev-review-batch-subsystem",
+      namespace: USER_GLOBAL_NAMESPACE,
+      score: 0.8,
+      entityRefs: ["docs/ops/pr-review-hardening-playbook.md"],
+      workflowFacets: ["review_preferences"],
+    },
+    {
+      id: "dev-other-repo-fast-path",
+      namespace: "project-origin-ffffffff",
+      score: 0.99,
+      entityRefs: ["src/api.ts"],
+      workflowFacets: ["repo_conventions"],
+    },
+  ],
+  expectedIds: [
+    "dev-architecture-core-host-agnostic",
+    "dev-test-gate-preflight",
+    "dev-release-process-changeset",
+    "dev-ask-before-public-api",
+    "dev-review-batch-subsystem",
+  ],
+  forbiddenIds: ["dev-other-repo-fast-path"],
+  requiredWorkflowFacets: [
+    "repo_conventions",
+    "preferred_architecture_patterns",
+    "test_expectations",
+    "release_process",
+    "review_preferences",
+    "ask_before_public_api",
+    "always_run_checks",
+  ],
+};
+
+const DEVELOPER_WORKFLOW_REVIEW_CASE: CodingRecallCase = {
+  id: "developer-workflow-review-risk",
+  title:
+    "Developer workflow — review recall boosts past bugs and common failure modes for touched files",
+  kind: "developer-workflow",
+  sessionNamespaces: [REMNIC_PROJECT_NAMESPACE, USER_GLOBAL_NAMESPACE],
+  touchedFiles: [
+    "packages/remnic-core/src/storage.ts",
+    "packages/remnic-core/src/coding/review-context.ts",
+  ],
+  prompt: "review this PR before merge",
+  candidates: [
+    {
+      id: "dev-past-bug-hash-dedup",
+      namespace: REMNIC_PROJECT_NAMESPACE,
+      score: 0.42,
+      entityRefs: ["packages/remnic-core/src/storage.ts"],
+      workflowFacets: ["past_bugs", "common_failure_modes"],
+    },
+    {
+      id: "dev-storage-cache-invalidation",
+      namespace: REMNIC_PROJECT_NAMESPACE,
+      score: 0.41,
+      entityRefs: ["packages/remnic-core/src/storage.ts"],
+      workflowFacets: ["common_failure_modes"],
+    },
+    {
+      id: "dev-untouched-style-preference",
+      namespace: USER_GLOBAL_NAMESPACE,
+      score: 0.75,
+      entityRefs: ["docs/development/plugin-development.md"],
+      workflowFacets: ["review_preferences"],
+    },
+    {
+      id: "dev-review-hardening-gate",
+      namespace: REMNIC_PROJECT_NAMESPACE,
+      score: 0.39,
+      entityRefs: ["docs/ops/pr-review-hardening-playbook.md"],
+      workflowFacets: ["review_preferences", "always_run_checks"],
+    },
+    {
+      id: "dev-client-app-storage-bug",
+      namespace: "project-origin-99999999",
+      score: 0.99,
+      entityRefs: ["packages/remnic-core/src/storage.ts"],
+      workflowFacets: ["past_bugs"],
+    },
+  ],
+  expectedIds: [
+    "dev-past-bug-hash-dedup",
+    "dev-storage-cache-invalidation",
+    "dev-untouched-style-preference",
+    "dev-review-hardening-gate",
+  ],
+  forbiddenIds: ["dev-client-app-storage-bug"],
+  requiredWorkflowFacets: [
+    "common_failure_modes",
+    "past_bugs",
+    "review_preferences",
+    "always_run_checks",
+  ],
+};
+
+// ──────────────────────────────────────────────────────────────────────────
 // Exported fixtures
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -126,8 +291,17 @@ export const CODING_RECALL_FIXTURE: CodingRecallCase[] = [
   CROSS_PROJECT_CASE,
   BRANCH_ISOLATION_CASE,
   REVIEW_CONTEXT_CASE,
+  DEVELOPER_WORKFLOW_PLANNING_CASE,
+  DEVELOPER_WORKFLOW_REVIEW_CASE,
 ];
 
-// Smoke fixture — a single representative case per invariant kind. In this
-// benchmark the full fixture is already small, so smoke === full.
-export const CODING_RECALL_SMOKE_FIXTURE: CodingRecallCase[] = CODING_RECALL_FIXTURE;
+// Smoke fixture keeps developer-workflow cases first so CLI quick runs that
+// apply a task cap still exercise the workflow coverage metric instead of
+// reporting only the older namespace-isolation cases.
+export const CODING_RECALL_SMOKE_FIXTURE: CodingRecallCase[] = [
+  DEVELOPER_WORKFLOW_PLANNING_CASE,
+  DEVELOPER_WORKFLOW_REVIEW_CASE,
+  CROSS_PROJECT_CASE,
+  BRANCH_ISOLATION_CASE,
+  REVIEW_CONTEXT_CASE,
+];

--- a/packages/bench/src/benchmarks/remnic/coding-recall/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/coding-recall/runner.test.ts
@@ -65,6 +65,64 @@ test("coding-recall: review-context case boosts touched-file memories via tie-br
   assert.deepEqual(actual, ["strong", "touched", "untouched"]);
 });
 
+test("coding-recall: developer workflow planning covers project conventions and action boundaries", async () => {
+  const result = await runCodingRecallBenchmark({
+    benchmark: codingRecallDefinition,
+    mode: "full",
+    seed: 0,
+  } as unknown as Parameters<typeof runCodingRecallBenchmark>[0]);
+
+  const task = result.results.tasks.find((t) => t.taskId === "developer-workflow-change-plan");
+  assert.ok(task);
+  assert.equal(task!.scores.isolation, 1);
+  assert.equal(task!.scores.workflow_coverage, 1);
+  const actual = JSON.parse(task!.actual);
+  assert.deepEqual(actual, [
+    "dev-architecture-core-host-agnostic",
+    "dev-test-gate-preflight",
+    "dev-release-process-changeset",
+    "dev-ask-before-public-api",
+    "dev-review-batch-subsystem",
+  ]);
+  assert.ok(!actual.includes("dev-other-repo-fast-path"));
+  assert.deepEqual(task!.details?.missingWorkflowFacets, []);
+});
+
+test("coding-recall: developer workflow review boosts touched-file past bugs", async () => {
+  const result = await runCodingRecallBenchmark({
+    benchmark: codingRecallDefinition,
+    mode: "full",
+    seed: 0,
+  } as unknown as Parameters<typeof runCodingRecallBenchmark>[0]);
+
+  const task = result.results.tasks.find((t) => t.taskId === "developer-workflow-review-risk");
+  assert.ok(task);
+  assert.equal(task!.scores.isolation, 1);
+  assert.equal(task!.scores.workflow_coverage, 1);
+  const actual = JSON.parse(task!.actual);
+  assert.deepEqual(actual, [
+    "dev-past-bug-hash-dedup",
+    "dev-storage-cache-invalidation",
+    "dev-untouched-style-preference",
+    "dev-review-hardening-gate",
+  ]);
+  assert.ok(!actual.includes("dev-client-app-storage-bug"));
+});
+
+test("coding-recall: quick task caps still exercise workflow coverage", async () => {
+  const result = await runCodingRecallBenchmark({
+    benchmark: codingRecallDefinition,
+    mode: "quick",
+    limit: 1,
+    seed: 0,
+  } as unknown as Parameters<typeof runCodingRecallBenchmark>[0]);
+
+  const task = result.results.tasks[0];
+  assert.ok(task);
+  assert.equal(task!.taskId, "developer-workflow-change-plan");
+  assert.equal(task!.scores.workflow_coverage, 1);
+});
+
 test("coding-recall: aggregates include all metrics", async () => {
   const result = await runCodingRecallBenchmark({
     benchmark: codingRecallDefinition,
@@ -75,6 +133,9 @@ test("coding-recall: aggregates include all metrics", async () => {
   const agg = result.results.aggregates;
   assert.ok(typeof agg.isolation === "object" && agg.isolation !== null);
   assert.ok(typeof agg.p_at_1 === "object" && agg.p_at_1 !== null);
-  // Overall isolation mean should be 1.0 (all three fixtures isolate cleanly).
+  assert.ok(typeof agg.workflow_coverage === "object" && agg.workflow_coverage !== null);
+  assert.equal(result.results.tasks.length, 5);
+  // Overall isolation and workflow coverage means should be 1.0.
   assert.equal(agg.isolation!.mean, 1, "overall isolation mean across fixture must be 1.0");
+  assert.equal(agg.workflow_coverage!.mean, 1, "workflow facet coverage across fixture must be 1.0");
 });

--- a/packages/bench/src/benchmarks/remnic/coding-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/coding-recall/runner.ts
@@ -3,8 +3,12 @@
  *
  * Measures whether the retrieval layer correctly honours the three #569
  * invariants: cross-project isolation, branch isolation with project
- * fallback, and review-context ranking. The benchmark is deterministic —
- * no LLM, no storage — so it runs in CI without any daemon.
+ * fallback, and review-context ranking. It also covers the developer
+ * workflow memory shape Remnic should support for coding agents: repo
+ * conventions, architecture patterns, tests, release process, past bugs,
+ * common failure modes, review preferences, ask-before rules, and
+ * always-run checks. The benchmark is deterministic — no LLM, no storage —
+ * so it runs in CI without any daemon.
  */
 
 import { randomUUID } from "node:crypto";
@@ -24,11 +28,12 @@ import {
   CODING_RECALL_SMOKE_FIXTURE,
   type CodingRecallCase,
   type CodingRecallCaseMemory,
+  type DeveloperWorkflowFacet,
 } from "./fixture.js";
 
 export const codingRecallDefinition: BenchmarkDefinition = {
   id: "coding-recall",
-  title: "Coding-Agent Recall (project/branch isolation + review context)",
+  title: "Coding-Agent Recall (project/branch isolation + developer workflow)",
   tier: "remnic",
   status: "ready",
   runnerAvailable: true,
@@ -36,7 +41,7 @@ export const codingRecallDefinition: BenchmarkDefinition = {
     name: "coding-recall",
     version: "1.0.0",
     description:
-      "Deterministic benchmark for the #569 coding-agent features: project/branch namespace isolation and diff-aware review-context ranking.",
+      "Deterministic benchmark for coding-agent memory: project/branch namespace isolation, diff-aware review-context ranking, and developer workflow context.",
     category: "retrieval",
     citation: "Remnic internal synthetic benchmark for issue #569",
   },
@@ -61,27 +66,43 @@ export async function runCodingRecallBenchmark(
     // Isolation metric — 1.0 when no forbidden id leaks, 0.0 on any leak.
     const leaked = retrievedIds.filter((id) => sample.forbiddenIds.includes(id));
     const isolationScore = leaked.length === 0 ? 1 : 0;
+    const requiredWorkflowFacets = sample.requiredWorkflowFacets ?? [];
+    const retrievedWorkflowFacets = collectWorkflowFacets(retrieved);
+    const missingWorkflowFacets = requiredWorkflowFacets.filter(
+      (facet) => !retrievedWorkflowFacets.includes(facet),
+    );
+    const scores: Record<string, number> = {
+      p_at_1: precisionAtK(retrievedIds, sample.expectedIds, 1),
+      p_at_3: precisionAtK(retrievedIds, sample.expectedIds, 3),
+      p_at_5: precisionAtK(retrievedIds, sample.expectedIds, 5),
+      isolation: isolationScore,
+    };
+    const details: Record<string, unknown> = {
+      kind: sample.kind,
+      sessionNamespaces: sample.sessionNamespaces,
+      forbiddenIds: sample.forbiddenIds,
+      leaked,
+      retrievedIds,
+    };
+
+    if (requiredWorkflowFacets.length > 0) {
+      scores.workflow_coverage =
+        (requiredWorkflowFacets.length - missingWorkflowFacets.length) /
+        requiredWorkflowFacets.length;
+      details.requiredWorkflowFacets = requiredWorkflowFacets;
+      details.retrievedWorkflowFacets = retrievedWorkflowFacets;
+      details.missingWorkflowFacets = missingWorkflowFacets;
+    }
 
     tasks.push({
       taskId: sample.id,
       question: sample.title,
       expected: expectedJson,
       actual: actualJson,
-      scores: {
-        p_at_1: precisionAtK(retrievedIds, sample.expectedIds, 1),
-        p_at_3: precisionAtK(retrievedIds, sample.expectedIds, 3),
-        p_at_5: precisionAtK(retrievedIds, sample.expectedIds, 5),
-        isolation: isolationScore,
-      },
+      scores,
       latencyMs,
       tokens: { input: 0, output: 0 },
-      details: {
-        kind: sample.kind,
-        sessionNamespaces: sample.sessionNamespaces,
-        forbiddenIds: sample.forbiddenIds,
-        leaked,
-        retrievedIds,
-      },
+      details,
     });
   }
 
@@ -159,6 +180,14 @@ function scoreCase(sample: CodingRecallCase): CodingRecallCaseMemory[] {
   return ranked
     .map((r) => byId.get(r.id))
     .filter((c): c is CodingRecallCaseMemory => c !== undefined);
+}
+
+function collectWorkflowFacets(
+  memories: CodingRecallCaseMemory[],
+): DeveloperWorkflowFacet[] {
+  return Array.from(
+    new Set(memories.flatMap((memory) => memory.workflowFacets ?? [])),
+  ).sort();
 }
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a Developer Workflow Demo guide for coding-agent memory
- extend coding-recall with synthetic developer workflow cases for repo conventions, architecture boundaries, test expectations, release process, common failure modes, past bugs, review preferences, ask-before-public-API rules, and always-run checks
- add workflow_coverage scoring and docs links from user-aware agents, coding-agent mode, and memory evals

## Verification
- pnpm exec tsx --test packages/bench/src/benchmarks/remnic/coding-recall/runner.test.ts tests/bench-remnic-deterministic-runners.test.ts packages/bench/src/memory-evals.test.ts
- npm run check-types
- git diff --check
- npm run preflight:quick
- npm run review:cursor (skipped: macOS login keychain locked)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `coding-recall` benchmark fixture ordering, adds a new `workflow_coverage` score to task/aggregate outputs, and updates tests/docs that may be consumed by CI or downstream tooling.
> 
> **Overview**
> Adds a new **Developer Workflow Demo** doc and links it from the main docs index plus related guides (`coding-agent.md`, `user-aware-agents.md`, `memory-evals.md`).
> 
> Extends the deterministic `coding-recall` benchmark with two synthetic *developer workflow* cases (planning + PR review) by tagging candidate memories with workflow facets, requiring facet coverage, and adding a new `workflow_coverage` metric to task results and aggregates. Quick/smoke fixtures are reordered to keep workflow cases first under task caps, and the runner tests are expanded to assert the new cases and metric behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f65aa90c599317fa9e86d956381739d307b951c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->