### PR TITLE
Wire BEAM benchmark runner to dataset files

### DIFF
--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -39,11 +39,12 @@
   },
   "dependencies": {
     "@remnic/core": "workspace:^",
+    "hyparquet": "^1.25.7",
     "yaml": "^2.4.2"
   },
   "devDependencies": {
-    "typescript": "^5.9.3",
-    "tsup": "^8.5.1"
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
   },
   "files": [
     "dist",

--- a/packages/bench/src/benchmarks/published/beam/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.test.ts
@@ -4,7 +4,77 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { beamDefinition, runBeamBenchmark } from "./runner.ts";
+import {
+  beamDefinition,
+  loadBeamDatasetPreview,
+  runBeamBenchmark,
+} from "./runner.ts";
+
+test("BEAM dataset preview validates dataset files without model calls", async () => {
+  const datasetDir = await mkdtemp(path.join(tmpdir(), "remnic-beam-preview-"));
+  await writeFile(
+    path.join(datasetDir, "beam_100k.json"),
+    JSON.stringify([
+      {
+        conversation_id: "preview",
+        chat: [[{ role: "user", content: "Remember the sprint ends March 29." }]],
+        probing_questions: {
+          date_recall: [
+            {
+              question: "When does the sprint end?",
+              answer: "March 29",
+            },
+          ],
+          instruction_following: [
+            {
+              question: "How should implementation help be formatted?",
+              answer: "Use syntax-highlighted code blocks.",
+            },
+          ],
+        },
+      },
+    ]),
+  );
+
+  const preview = await loadBeamDatasetPreview({
+    mode: "full",
+    datasetDir,
+  });
+
+  assert.equal(preview.source, "dataset");
+  assert.deepEqual(preview.files, ["beam_100k.json"]);
+  assert.equal(preview.items, 1);
+  assert.equal(preview.tasks, 2);
+  assert.deepEqual(preview.errors, []);
+});
+
+test("BEAM dataset preview detects parquet dataset files", async () => {
+  const datasetDir = await mkdtemp(path.join(tmpdir(), "remnic-beam-parquet-"));
+  await writeFile(path.join(datasetDir, "beam_100k.parquet"), "");
+
+  const preview = await loadBeamDatasetPreview({
+    mode: "full",
+    datasetDir,
+    limit: 1,
+  });
+
+  assert.equal(preview.source, "missing");
+  assert.deepEqual(preview.files, ["beam_100k.parquet"]);
+  assert.equal(preview.errors.length, 1);
+  assert.ok((preview.errors[0] ?? "").length > 0);
+});
+
+test("BEAM dataset preview reports missing full datasets", async () => {
+  const preview = await loadBeamDatasetPreview({
+    mode: "full",
+    datasetDir: path.join(tmpdir(), "missing-remnic-beam-dataset"),
+  });
+
+  assert.equal(preview.source, "missing");
+  assert.equal(preview.items, 0);
+  assert.equal(preview.tasks, 0);
+  assert.equal(preview.errors.length, 1);
+});
 
 test("BEAM quick mode uses answer formats for concise facts and remembered instructions", async () => {
   const prompts: string[] = [];
@@ -100,6 +170,58 @@ test("BEAM quick mode uses answer formats for concise facts and remembered instr
     )?.scores.rubric_coverage,
     1,
   );
+});
+
+test("BEAM task filter runs only matching diagnostic tasks", async () => {
+  const result = await runBeamBenchmark({
+    benchmark: beamDefinition,
+    mode: "quick",
+    benchmarkOptions: { taskFilter: "instruction_following" },
+    system: {
+      async reset() {},
+      async store() {},
+      async recall(_sessionId, question) {
+        return [
+          "Whenever I ask about implementation, format the answer with syntax-highlighted code blocks.",
+          `Question: ${question}`,
+        ].join("\n");
+      },
+      async search() {
+        return [{ id: "hit", text: "hit" }];
+      },
+      async destroy() {},
+      async getStats() {
+        return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+      responder: {
+        async respond() {
+          return {
+            text: "Always format implementation help with syntax-highlighted code blocks.",
+            tokens: { input: 1, output: 1 },
+            latencyMs: 1,
+            model: "beam-test-responder",
+          };
+        },
+      },
+      judge: {
+        async score() {
+          return 1;
+        },
+        async scoreWithMetrics() {
+          return {
+            score: 1,
+            tokens: { input: 0, output: 0 },
+            latencyMs: 0,
+            model: "beam-test-judge",
+          };
+        },
+      },
+    },
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.match(result.results.tasks[0]?.taskId ?? "", /instruction_following/);
+  assert.equal(result.config.benchmarkOptions?.taskFilter, "instruction_following");
 });
 
 test("BEAM refines unknown and hedged answers from source-chat evidence", async () => {

--- a/packages/bench/src/benchmarks/published/beam/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -62,6 +62,19 @@ test("BEAM dataset preview detects parquet dataset files", async () => {
   assert.deepEqual(preview.files, ["beam_100k.parquet"]);
   assert.equal(preview.errors.length, 1);
   assert.ok((preview.errors[0] ?? "").length > 0);
+});
+
+test("BEAM parquet loader reads bounded row batches instead of whole shards", async () => {
+  const source = await readFile(new URL("./runner.ts", import.meta.url), "utf8");
+
+  assert.match(source, /const PARQUET_ROW_BATCH_SIZE = 256;/);
+  assert.match(source, /rowStart \+= PARQUET_ROW_BATCH_SIZE/);
+  assert.match(source, /metadata,/);
+  assert.match(source, /useOffsetIndex: true,/);
+  assert.doesNotMatch(
+    source,
+    /const rows = await parquetReadObjects\(\{\s*file,\s*rowStart: 0,\s*rowEnd,/s,
+  );
 });
 
 test("BEAM dataset preview reports missing full datasets", async () => {

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -7,6 +7,11 @@ import { createReadStream } from "node:fs";
 import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
+import {
+  asyncBufferFromFile,
+  parquetMetadataAsync,
+  parquetReadObjects,
+} from "hyparquet";
 import type { Message } from "../../../adapters/types.js";
 import {
   answerBenchmarkQuestion,
@@ -16,6 +21,7 @@ import {
 import { benchmarkRecallBudgetForSessionCount } from "../../../recall-budget.js";
 import type {
   BenchmarkDefinition,
+  BenchmarkMode,
   BenchmarkResult,
   ResolvedRunBenchmarkOptions,
   TaskResult,
@@ -113,9 +119,80 @@ interface BeamDatasetSource {
   entries(): AsyncIterable<BeamDatasetEntry>;
 }
 
+export interface BeamDatasetPreview {
+  source: "dataset" | "smoke" | "missing";
+  files: string[];
+  items: number;
+  tasks: number;
+  errors: string[];
+}
+
 interface SyntaxExtraTargetDetails {
   normalized: string;
   punctuatedTokens: string[];
+}
+
+export async function loadBeamDatasetPreview(options: {
+  mode: BenchmarkMode;
+  datasetDir?: string;
+  limit?: number;
+}): Promise<BeamDatasetPreview> {
+  const files: string[] = [];
+  if (options.datasetDir) {
+    try {
+      files.push(...(await listBeamDatasetFiles(options.datasetDir)));
+    } catch (error) {
+      return {
+        source: "missing",
+        files,
+        items: 0,
+        tasks: 0,
+        errors: [error instanceof Error ? error.message : String(error)],
+      };
+    }
+  }
+
+  let dataset: BeamDatasetSource;
+  try {
+    dataset = await loadDataset(
+      options.mode === "quick" ? "quick" : "full",
+      options.datasetDir,
+      options.limit,
+    );
+  } catch (error) {
+    return {
+      source: "missing",
+      files,
+      items: 0,
+      tasks: 0,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+
+  let items = 0;
+  let tasks = 0;
+  try {
+    for await (const entry of dataset.entries()) {
+      items += 1;
+      tasks += countQuestions(entry.conversation);
+    }
+  } catch (error) {
+    return {
+      source: "missing",
+      files,
+      items,
+      tasks,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+
+  return {
+    source: options.datasetDir ? "dataset" : "smoke",
+    files,
+    items,
+    tasks,
+    errors: [],
+  };
 }
 
 export async function runBeamBenchmark(
@@ -123,7 +200,10 @@ export async function runBeamBenchmark(
 ): Promise<BenchmarkResult> {
   const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
-  const totalTasks = dataset.totalTasks;
+  const taskFilter = normalizeBeamTaskFilter(
+    options.benchmarkOptions?.taskFilter,
+  );
+  const totalTasks = taskFilter.length > 0 ? undefined : dataset.totalTasks;
   let entryCount = 0;
 
   for await (const entry of dataset.entries()) {
@@ -152,6 +232,17 @@ export async function runBeamBenchmark(
     for (const [ability, questions] of Object.entries(questionMap)) {
       for (const probe of questions) {
         const taskResultId = `${entry.scale}-${entry.conversation.conversation_id}-${ability}-${taskIndex}`;
+        taskIndex += 1;
+        if (
+          taskFilter.length > 0 &&
+          !matchesBeamTaskFilter(taskFilter, {
+            taskId: taskResultId,
+            ability,
+            question: probe.question,
+          })
+        ) {
+          continue;
+        }
         const expected = buildExpectedAnswer(probe);
         const answerFormat = answerFormatForAbility(ability);
         try {
@@ -258,7 +349,6 @@ export async function runBeamBenchmark(
         }
 
         options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalTasks);
-        taskIndex += 1;
       }
     }
   }
@@ -288,8 +378,15 @@ export async function runBeamBenchmark(
     config: {
       systemProvider: options.systemProvider ?? null,
       judgeProvider: options.judgeProvider ?? null,
+      internalProvider: options.internalProvider ?? null,
       adapterMode: options.adapterMode ?? "direct",
       remnicConfig: options.remnicConfig ?? {},
+      ...(options.runtimeProfile !== undefined
+        ? { runtimeProfile: options.runtimeProfile }
+        : {}),
+      ...(options.benchmarkOptions
+        ? { benchmarkOptions: options.benchmarkOptions }
+        : {}),
     },
     cost: {
       totalTokens: totalInputTokens + totalOutputTokens,
@@ -327,20 +424,20 @@ async function loadDataset(
   if (datasetDir) {
     let filenames: string[];
     try {
-      filenames = await readdir(datasetDir);
+      filenames = await listBeamDatasetFiles(datasetDir);
     } catch (error) {
       throw new Error(
         `BEAM dataset not found under ${datasetDir}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
-    const datasetFiles = filenames
-      .filter((filename) => filename.endsWith(".json") || filename.endsWith(".jsonl"))
-      .sort((left, right) => compareDatasetFiles(left, right));
+    const datasetFiles = filenames.sort((left, right) =>
+      compareDatasetFiles(left, right),
+    );
 
     if (datasetFiles.length === 0) {
       throw new Error(
-        `BEAM dataset not found under ${datasetDir}: no .json or .jsonl files were found.`,
+        `BEAM dataset not found under ${datasetDir}: no .json, .jsonl, or .parquet files were found.`,
       );
     }
 
@@ -378,6 +475,33 @@ async function loadDataset(
   };
 }
 
+async function listBeamDatasetFiles(datasetDir: string): Promise<string[]> {
+  const filenames = await readdir(datasetDir);
+  const directFiles = filenames.filter((filename) =>
+    isBeamDatasetFilename(filename),
+  );
+  if (directFiles.length > 0) {
+    return directFiles;
+  }
+
+  try {
+    const nestedFilenames = await readdir(path.join(datasetDir, "data"));
+    return nestedFilenames
+      .filter((filename) => isBeamDatasetFilename(filename))
+      .map((filename) => path.join("data", filename));
+  } catch {
+    return [];
+  }
+}
+
+function isBeamDatasetFilename(filename: string): boolean {
+  return (
+    filename.endsWith(".json") ||
+    filename.endsWith(".jsonl") ||
+    filename.endsWith(".parquet")
+  );
+}
+
 function compareDatasetFiles(left: string, right: string): number {
   const scaleDelta =
     (SPLIT_ORDER[inferScaleFromFilename(left)] ?? Number.MAX_SAFE_INTEGER) -
@@ -408,7 +532,9 @@ async function* iterateDatasetFiles(
     const filePath = path.join(datasetDir, filename);
     const conversations = filename.endsWith(".jsonl")
       ? streamJsonlDataset(filePath, filename, remainingLimit)
-      : streamJsonDataset(filePath, filename, remainingLimit);
+      : filename.endsWith(".parquet")
+        ? streamParquetDataset(filePath, filename, remainingLimit)
+        : streamJsonDataset(filePath, filename, remainingLimit);
 
     for await (const conversation of conversations) {
       yield {
@@ -423,6 +549,33 @@ async function* iterateDatasetFiles(
       break;
     }
   }
+}
+
+function normalizeBeamTaskFilter(value: unknown): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .flatMap((entry) =>
+      typeof entry === "string" ? entry.split(",") : [],
+    )
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
+function matchesBeamTaskFilter(
+  filters: readonly string[],
+  task: { taskId: string; ability: string; question: string },
+): boolean {
+  const taskId = task.taskId.toLowerCase();
+  const ability = task.ability.toLowerCase();
+  const question = task.question.toLowerCase();
+  return filters.some((filter) =>
+    taskId.includes(filter) ||
+    ability.includes(filter) ||
+    question.includes(filter),
+  );
 }
 
 function answerFormatForAbility(ability: string): BenchmarkAnswerFormat {
@@ -826,6 +979,34 @@ async function* streamJsonlDataset(
   }
 }
 
+async function* streamParquetDataset(
+  filePath: string,
+  filename: string,
+  limit: number | undefined,
+): AsyncIterable<BeamConversation> {
+  const file = await asyncBufferFromFile(filePath);
+  const metadata = await parquetMetadataAsync(file);
+  const rowCount = Number(metadata.num_rows);
+  if (!Number.isSafeInteger(rowCount) || rowCount < 0) {
+    throw new Error(
+      `BEAM dataset file ${filename} has an invalid parquet row count.`,
+    );
+  }
+  const rowEnd = limit === undefined ? rowCount : Math.min(rowCount, limit);
+  const rows = await parquetReadObjects({
+    file,
+    rowStart: 0,
+    rowEnd,
+  });
+
+  for (let index = 0; index < rows.length; index += 1) {
+    yield validateConversation(
+      normalizeParquetValue(rows[index]),
+      `${filename}[${index}]`,
+    );
+  }
+}
+
 function countQuestions(conversation: BeamConversation): number {
   return Object.values(normalizeQuestionMap(conversation.probing_questions)).reduce(
     (sum, questions) => sum + questions.length,
@@ -870,6 +1051,25 @@ function validateConversation(
   }
 
   return record as unknown as BeamConversation;
+}
+
+function normalizeParquetValue(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    const asNumber = Number(value);
+    return Number.isSafeInteger(asNumber) ? asNumber : value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeParquetValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    normalized[key] = normalizeParquetValue(entry);
+  }
+  return normalized;
 }
 
 function isChatCollection(value: unknown): value is BeamChatTurn[][] | BeamChatTurn[] {

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -52,6 +52,7 @@ const SPLIT_ORDER: Record<string, number> = {
   "1M": 2,
   "10M": 3,
 };
+const PARQUET_ROW_BATCH_SIZE = 256;
 const SYNTAX_HIGHLIGHTING_RUBRIC_PATTERN =
   "(?:syntax highlight(?:ed|ing) code blocks?|code blocks? with syntax highlighting)";
 const SYNTAX_HIGHLIGHTING_WEAKENING_AFTER_PATTERN =
@@ -992,18 +993,29 @@ async function* streamParquetDataset(
       `BEAM dataset file ${filename} has an invalid parquet row count.`,
     );
   }
-  const rowEnd = limit === undefined ? rowCount : Math.min(rowCount, limit);
-  const rows = await parquetReadObjects({
-    file,
-    rowStart: 0,
-    rowEnd,
-  });
+  const requestedRows =
+    limit === undefined ? rowCount : Math.min(rowCount, limit);
 
-  for (let index = 0; index < rows.length; index += 1) {
-    yield validateConversation(
-      normalizeParquetValue(rows[index]),
-      `${filename}[${index}]`,
-    );
+  for (
+    let rowStart = 0;
+    rowStart < requestedRows;
+    rowStart += PARQUET_ROW_BATCH_SIZE
+  ) {
+    const rowEnd = Math.min(rowStart + PARQUET_ROW_BATCH_SIZE, requestedRows);
+    const rows = await parquetReadObjects({
+      file,
+      metadata,
+      rowStart,
+      rowEnd,
+      useOffsetIndex: true,
+    });
+
+    for (let offset = 0; offset < rows.length; offset += 1) {
+      yield validateConversation(
+        normalizeParquetValue(rows[offset]),
+        `${filename}[${rowStart + offset}]`,
+      );
+    }
   }
 }
 

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -281,6 +281,12 @@ export {
   loadLoCoMo10,
   loadLongMemEvalS,
 } from "./benchmarks/published/dataset-loader.js";
+export {
+  loadBeamDatasetPreview,
+} from "./benchmarks/published/beam/runner.js";
+export type {
+  BeamDatasetPreview,
+} from "./benchmarks/published/beam/runner.js";
 export type {
   DatasetSource,
   LoadedDataset,

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -581,6 +581,65 @@ test("parseBenchArgs accepts BEAM diagnostic --task-filter", () => {
   assert.deepEqual(parsed.benchmarks, []);
 });
 
+test("parseBenchArgs accepts --task-filter for bench run beam", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "beam",
+    "--task-filter",
+    "instruction_following",
+  ]);
+
+  assert.equal(parsed.publishedTaskFilter, "instruction_following");
+  assert.deepEqual(parsed.benchmarks, ["beam"]);
+});
+
+test("parseBenchArgs rejects --task-filter for non-BEAM benchmarks", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "locomo",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "m",
+        "--task-filter",
+        "instruction_following",
+      ]),
+    /--task-filter is currently supported only for BEAM/,
+  );
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "longmemeval",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "m",
+        "--task-filter",
+        "instruction_following",
+      ]),
+    /--task-filter is currently supported only for BEAM/,
+  );
+});
+
+test("parseBenchArgs rejects --task-filter when BEAM is not the only selected benchmark", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "beam",
+        "locomo",
+        "--task-filter",
+        "instruction_following",
+      ]),
+    /--task-filter is currently supported only for BEAM/,
+  );
+});
+
 test("parseBenchArgs rejects empty --task-filter", () => {
   assert.throws(
     () =>

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -62,8 +62,25 @@ test("parseBenchArgs rejects unknown published --name", () => {
         "--model",
         "m",
       ]),
-    /--name must be one of longmemeval, locomo/,
+    /--name must be one of longmemeval, locomo, beam/,
   );
+});
+
+test("parseBenchArgs accepts BEAM as a published benchmark", () => {
+  const parsed = parseBenchArgs([
+    "published",
+    "--name",
+    "beam",
+    "--dataset",
+    "/tmp/bench-datasets/beam",
+    "--model",
+    "gpt-5.5",
+  ]);
+
+  assert.equal(parsed.action, "published");
+  assert.equal(parsed.publishedName, "beam");
+  assert.equal(parsed.datasetDir, "/tmp/bench-datasets/beam");
+  assert.equal(parsed.systemModel, "gpt-5.5");
 });
 
 test("parseBenchArgs rejects non-integer --limit", () => {
@@ -136,6 +153,21 @@ test("parseBenchArgs rejects published --trial-limit for non-LoCoMo benchmarks",
         "published",
         "--name",
         "longmemeval",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "m",
+        "--trial-limit",
+        "1",
+      ]),
+    /--trial-limit is currently supported only for LoCoMo/,
+  );
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "beam",
         "--dataset",
         "/tmp",
         "--model",
@@ -531,6 +563,40 @@ test("parseBenchArgs --dry-run sets publishedDryRun = true", () => {
     "--dry-run",
   ]);
   assert.equal(parsed.publishedDryRun, true);
+});
+
+test("parseBenchArgs accepts BEAM diagnostic --task-filter", () => {
+  const parsed = parseBenchArgs([
+    "published",
+    "--name",
+    "beam",
+    "--dataset",
+    "/tmp",
+    "--model",
+    "m",
+    "--task-filter",
+    "instruction_following",
+  ]);
+  assert.equal(parsed.publishedTaskFilter, "instruction_following");
+  assert.deepEqual(parsed.benchmarks, []);
+});
+
+test("parseBenchArgs rejects empty --task-filter", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "beam",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "m",
+        "--task-filter",
+        " ",
+      ]),
+    /--task-filter must not be empty/,
+  );
 });
 
 test("parseBenchArgs --limit 0 preserved (CLAUDE.md rule 27 slice-negative-zero)", () => {

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -86,7 +86,7 @@ export interface ParsedBenchArgs {
   amaBenchCrossJudgeBaseUrl?: string;
   amaBenchCrossJudgeApiKey?: string;
   amaBenchCrossJudgeCodexReasoningEffort?: BenchCodexReasoningEffort;
-  /** `bench published` — specific benchmark to run (longmemeval|locomo). */
+  /** `bench published` — specific benchmark to run (longmemeval|locomo|beam). */
   publishedName?: PublishedBenchmarkName;
   /** `bench published` — seed forwarded into the harness context. */
   publishedSeed?: number;
@@ -94,6 +94,8 @@ export interface ParsedBenchArgs {
   publishedLimit?: number;
   /** `bench published` — scored trial cap forwarded into benchmark-specific options. */
   publishedTrialLimit?: number;
+  /** `bench published` — benchmark-specific task/ability filter for diagnostic runs. */
+  publishedTaskFilter?: string;
   /** `bench published` — published artifact output directory. */
   publishedOut?: string;
   /** `bench published` — dry-run: validate + load but do NOT call the model. */
@@ -104,9 +106,9 @@ export interface ParsedBenchArgs {
   retryFailed?: boolean;
 }
 
-export type PublishedBenchmarkName = "longmemeval" | "locomo";
+export type PublishedBenchmarkName = "longmemeval" | "locomo" | "beam";
 export const PUBLISHED_BENCHMARK_NAMES: readonly PublishedBenchmarkName[] =
-  Object.freeze(["longmemeval", "locomo"]);
+  Object.freeze(["longmemeval", "locomo", "beam"]);
 
 function isBenchRuntimeProfile(value: string): value is BenchRuntimeProfile {
   return (
@@ -233,6 +235,7 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--model" ||
       arg === "--limit" ||
       arg === "--trial-limit" ||
+      arg === "--task-filter" ||
       arg === "--seed" ||
       arg === "--out" ||
       arg === "--provider" ||
@@ -591,6 +594,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const publishedModelRaw = readBenchOptionValue(args, "--model");
   const publishedLimitRaw = readBenchOptionValue(args, "--limit");
   const publishedTrialLimitRaw = readBenchOptionValue(args, "--trial-limit");
+  const publishedTaskFilterRaw = readBenchOptionValue(args, "--task-filter");
   const publishedSeedRaw = readBenchOptionValue(args, "--seed");
   const publishedOutRaw = readBenchOptionValue(args, "--out");
   const publishedProviderRaw = readBenchOptionValue(args, "--provider");
@@ -644,6 +648,15 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     );
   if (publishedTrialLimit !== undefined && !trialLimitTargetsLoCoMo) {
     throw new Error("ERROR: --trial-limit is currently supported only for LoCoMo.");
+  }
+
+  let publishedTaskFilter: string | undefined;
+  if (publishedTaskFilterRaw !== undefined) {
+    const trimmed = publishedTaskFilterRaw.trim();
+    if (trimmed.length === 0) {
+      throw new Error("ERROR: --task-filter must not be empty.");
+    }
+    publishedTaskFilter = trimmed;
   }
 
   let publishedSeed: number | undefined;
@@ -837,6 +850,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     publishedSeed,
     publishedLimit,
     publishedTrialLimit,
+    publishedTaskFilter,
     publishedOut: publishedOutRaw
       ? path.resolve(expandTilde(publishedOutRaw))
       : undefined,

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -652,6 +652,18 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
 
   let publishedTaskFilter: string | undefined;
   if (publishedTaskFilterRaw !== undefined) {
+    const taskFilterTargetsBeam =
+      publishedName === "beam" ||
+      (
+        publishedName === undefined &&
+        action !== "published" &&
+        !args.includes("--all") &&
+        benchmarks.length === 1 &&
+        benchmarks[0] === "beam"
+      );
+    if (!taskFilterTargetsBeam) {
+      throw new Error("ERROR: --task-filter is currently supported only for BEAM.");
+    }
     const trimmed = publishedTaskFilterRaw.trim();
     if (trimmed.length === 0) {
       throw new Error("ERROR: --task-filter must not be empty.");

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -357,6 +357,12 @@ export const BENCHMARK_CATALOG: BenchCatalogEntry[] = [
     category: "conversational",
     summary: "Long-conversation memory benchmark for persistent dialogue context.",
   },
+  {
+    id: "beam",
+    title: "BEAM",
+    category: "retrieval",
+    summary: "Beyond a Million Tokens benchmark for long-term memory abilities.",
+  },
 ];
 
 const BENCHMARK_IDS = new Set(BENCHMARK_CATALOG.map((entry) => entry.id));
@@ -579,6 +585,17 @@ type PackageBenchModule = {
     items: unknown[];
     errors: string[];
   }>;
+  loadBeamDatasetPreview?: (options: {
+    mode: "full" | "quick";
+    datasetDir?: string;
+    limit?: number;
+  }) => Promise<{
+    source: "dataset" | "smoke" | "missing";
+    files: string[];
+    items: number;
+    tasks: number;
+    errors: string[];
+  }>;
 };
 
 interface TrainingExportOptions {
@@ -721,7 +738,7 @@ export function getBenchUsageText(): string {
 Commands:
   list                     List published benchmark packs
   run [benchmark...]       Run one or more benchmark packs
-  published --name <longmemeval|locomo> --dataset <path> --model <id>
+  published --name <longmemeval|locomo|beam> --dataset <path> --model <id>
                            Run a published benchmark with leaderboard-friendly flags
                            (see issue #566 slice 4). Accepts --limit, --seed,
                            --trial-limit, --out, --dry-run, --provider, --base-url.
@@ -802,6 +819,7 @@ Options:
   --baselines-dir <path>   Override the named baseline directory
   --threshold <value>      Regression threshold for compare (default: 0.05)
   --trial-limit <n>        Cap scored LoCoMo QA trials for staged published runs
+  --task-filter <pattern>  BEAM diagnostic filter; match task id, ability, or question text
   --detail                 Include per-task details for bench results
   --format <json|csv|html> Output format for bench export
   --output <path>          Write bench export output to a file
@@ -1176,6 +1194,11 @@ const DOWNLOADED_DATASET_MARKERS: Record<string, { anyOf?: string[]; ext?: strin
       "500k.json",
       "1m.json",
       "10m.json",
+      "data/100K-00000-of-00001.parquet",
+      "data/500K-00000-of-00001.parquet",
+      "data/1M-00000-of-00001.parquet",
+      "data/10M-00000-of-00002.parquet",
+      "data/10M-00001-of-00002.parquet",
     ],
   },
   personamem: {
@@ -2127,13 +2150,13 @@ async function publishBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
 }
 
 /**
- * `remnic bench published --name <longmemeval|locomo> --dataset <path>
+ * `remnic bench published --name <longmemeval|locomo|beam> --dataset <path>
  *    --model <id> --limit <n> --trial-limit <n> --seed <n> --out <dir> [--dry-run]
  *    [--provider openai|anthropic|ollama|litellm] [--base-url <url>]`
  *
  * Issue #566 PR 4/7. Thin wrapper that routes the user's flags into the
  * existing `runBenchViaPackage` machinery. The wrapper is deliberately
- * narrow: it only accepts the two published benchmark IDs, enforces the
+ * narrow: it only accepts the supported published benchmark IDs, enforces the
  * `--name` + `--dataset` invariants at the boundary, and — in `--dry-run`
  * — loads the dataset and prints a preview without calling any LLM.
  *
@@ -2145,7 +2168,7 @@ async function publishBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
 async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
   if (!parsed.publishedName) {
     console.error(
-      "ERROR: `bench published` requires --name longmemeval|locomo.",
+      "ERROR: `bench published` requires --name longmemeval|locomo|beam.",
     );
     process.exit(1);
   }
@@ -2224,6 +2247,22 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
       itemCount = loadResult.items.length;
       console.log(
         `[dry-run] locomo: source=${loadResult.source} filename=${loadResult.filename ?? "<smoke>"} items=${itemCount} errors=${loadResult.errors.length}`,
+      );
+    } else if (benchmarkId === "beam" && benchModule.loadBeamDatasetPreview) {
+      const preview = await benchModule.loadBeamDatasetPreview({
+        mode,
+        datasetDir: parsed.datasetDir,
+        limit: effectiveLimit,
+      });
+      loadResult = {
+        source: preview.source,
+        filename: preview.files.join(",") || undefined,
+        items: [],
+        errors: preview.errors,
+      };
+      itemCount = preview.items;
+      console.log(
+        `[dry-run] beam: source=${preview.source} files=${preview.files.length} items=${preview.items} tasks=${preview.tasks} errors=${preview.errors.length}`,
       );
     } else {
       console.error(
@@ -2428,6 +2467,8 @@ async function runBenchViaPackage(
             : {}),
           replayExtractionMode: "skip",
         }
+      : benchmarkId === "beam" && parsed.publishedTaskFilter !== undefined
+        ? { taskFilter: parsed.publishedTaskFilter }
       : undefined;
 
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
+      hyparquet:
+        specifier: ^1.25.7
+        version: 1.25.7
       yaml:
         specifier: ^2.4.2
         version: 2.8.3
@@ -1308,6 +1311,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hyparquet@1.25.7:
+    resolution: {integrity: sha512-F+FoqZ1mQZK+nHaNMIOjKo6o8pH34L29oZ9oMNIQHdvMonaq+Inh5blMWlvNFvC1LUyyGkJjTrv1WEMTAEHAKQ==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -2472,6 +2478,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  hyparquet@1.25.7: {}
 
   ieee754@1.2.1: {}
 

--- a/scripts/bench/fetch-datasets.sh
+++ b/scripts/bench/fetch-datasets.sh
@@ -111,18 +111,18 @@ huggingface-cli download snap-research/locomo10 \\
 #   "https://huggingface.co/datasets/snap-research/locomo10/resolve/main/locomo10.json"
 
 # 4. BEAM 100K/500K/1M  (https://huggingface.co/datasets/Mohammadta/BEAM)
-huggingface-cli download Mohammadta/BEAM \
-  --repo-type dataset \
-  --local-dir "${BEAM_DIR}" \
-  --include "data/100K-00000-of-00001.parquet" \
-            "data/500K-00000-of-00001.parquet" \
+huggingface-cli download Mohammadta/BEAM \\
+  --repo-type dataset \\
+  --local-dir "${BEAM_DIR}" \\
+  --include "data/100K-00000-of-00001.parquet" \\
+            "data/500K-00000-of-00001.parquet" \\
             "data/1M-00000-of-00001.parquet"
 
 # BEAM 10M  (https://huggingface.co/datasets/Mohammadta/BEAM-10M)
-huggingface-cli download Mohammadta/BEAM-10M \
-  --repo-type dataset \
-  --local-dir "${BEAM_DIR}" \
-  --include "data/10M-00000-of-00002.parquet" \
+huggingface-cli download Mohammadta/BEAM-10M \\
+  --repo-type dataset \\
+  --local-dir "${BEAM_DIR}" \\
+  --include "data/10M-00000-of-00002.parquet" \\
             "data/10M-00001-of-00002.parquet"
 
 # 5. Smoke-check that the runner sees your files (quick-mode, no model calls):
@@ -130,7 +130,7 @@ huggingface-cli download Mohammadta/BEAM-10M \
 #    pnpm exec remnic bench run --quick locomo      --dataset-dir "${LOCOMO_DIR}"
 #    pnpm exec remnic bench published --name beam --dataset "${BEAM_DIR}/data" --model gpt-5.5 --dry-run --limit 1
 #
-# The `bench published --dry-run` command validates dataset loading without model calls.
+# The 'bench published --dry-run' command validates dataset loading without model calls.
 
 EOF
 

--- a/scripts/bench/fetch-datasets.sh
+++ b/scripts/bench/fetch-datasets.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # fetch-datasets.sh — Documentation + optional helpers for downloading the
-# LongMemEval-S and LoCoMo-10 datasets used by the published-benchmark
+# LongMemEval-S, LoCoMo-10, and BEAM datasets used by the published-benchmark
 # runners in `@remnic/bench`.
 #
 # This script does NOT auto-download by default. It prints the exact
@@ -29,6 +29,13 @@
 #     locomo/
 #       locomo10.json                      # preferred
 #       locomo.json                        # optional alternate
+#     beam/
+#       data/
+#         100K-00000-of-00001.parquet      # official Hugging Face file
+#         500K-00000-of-00001.parquet      # official Hugging Face file
+#         1M-00000-of-00001.parquet        # official Hugging Face file
+#         10M-00000-of-00002.parquet       # official Hugging Face file
+#         10M-00001-of-00002.parquet       # official Hugging Face file
 
 set -euo pipefail
 
@@ -66,6 +73,7 @@ done
 
 LONG_MEM_EVAL_DIR="${TARGET_DIR}/longmemeval"
 LOCOMO_DIR="${TARGET_DIR}/locomo"
+BEAM_DIR="${TARGET_DIR}/beam"
 
 cat <<EOF
 # Remnic published-benchmark datasets — download instructions
@@ -77,6 +85,7 @@ cat <<EOF
 # 1. Create the target directories
 mkdir -p "${LONG_MEM_EVAL_DIR}"
 mkdir -p "${LOCOMO_DIR}"
+mkdir -p "${BEAM_DIR}"
 
 # 2. LongMemEval-S  (https://huggingface.co/datasets/xiaowu0162/LongMemEval)
 #    Prefer the huggingface-cli path. Install via:  pipx install "huggingface_hub[cli]"
@@ -101,12 +110,27 @@ huggingface-cli download snap-research/locomo10 \\
 # wget -P "${LOCOMO_DIR}" \\
 #   "https://huggingface.co/datasets/snap-research/locomo10/resolve/main/locomo10.json"
 
-# 4. Smoke-check that the runner sees your files (quick-mode, no model calls):
+# 4. BEAM 100K/500K/1M  (https://huggingface.co/datasets/Mohammadta/BEAM)
+huggingface-cli download Mohammadta/BEAM \
+  --repo-type dataset \
+  --local-dir "${BEAM_DIR}" \
+  --include "data/100K-00000-of-00001.parquet" \
+            "data/500K-00000-of-00001.parquet" \
+            "data/1M-00000-of-00001.parquet"
+
+# BEAM 10M  (https://huggingface.co/datasets/Mohammadta/BEAM-10M)
+huggingface-cli download Mohammadta/BEAM-10M \
+  --repo-type dataset \
+  --local-dir "${BEAM_DIR}" \
+  --include "data/10M-00000-of-00002.parquet" \
+            "data/10M-00001-of-00002.parquet"
+
+# 5. Smoke-check that the runner sees your files (quick-mode, no model calls):
 #    pnpm exec remnic bench run --quick longmemeval --dataset-dir "${LONG_MEM_EVAL_DIR}"
 #    pnpm exec remnic bench run --quick locomo      --dataset-dir "${LOCOMO_DIR}"
+#    pnpm exec remnic bench published --name beam --dataset "${BEAM_DIR}/data" --model gpt-5.5 --dry-run --limit 1
 #
-# (A dedicated `remnic bench published --dry-run` subcommand is planned
-#  for issue #566 slice 4 and is not shipped yet.)
+# The `bench published --dry-run` command validates dataset loading without model calls.
 
 EOF
 


### PR DESCRIPTION
## Summary
- add BEAM dataset preview/export support and parquet-backed dataset loading
- expose BEAM through the CLI published benchmark catalog and parser
- add BEAM dataset fetch support plus focused runner/CLI tests

## Verification
- `./node_modules/.bin/tsx --test packages/bench/src/benchmarks/published/beam/runner.test.ts`
- `./node_modules/.bin/tsx --test packages/remnic-cli/src/bench-args.test.ts`
- `npm run --workspace @remnic/bench check-types`
- `npm run --workspace @remnic/bench build`
- `npm run preflight:quick`

## Notes
- `npm run --workspace @remnic/cli check-types` still fails on existing unrelated import module errors in `src/import-bundle-detect.ts` and `src/import-lossless-claw-cmd.ts` after bench declarations are built.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new published benchmark surface (BEAM) and introduces parquet-backed dataset loading, which changes I/O and execution paths in the benchmark runner and CLI argument validation.
> 
> **Overview**
> Adds **BEAM** as a first-class published benchmark in the CLI (`bench published --name beam`) including help/catalog updates, dataset filename expectations (including `data/*.parquet`), and a BEAM-only diagnostic `--task-filter` flag.
> 
> In `@remnic/bench`, introduces `loadBeamDatasetPreview` (exported from `src/index.ts`) to validate/preview BEAM datasets without model calls, expands dataset discovery to support `.parquet` and `data/` subdirectories, and adds a parquet streaming loader via `hyparquet` that reads bounded row batches (plus parquet bigint normalization).
> 
> Updates BEAM runner behavior to optionally filter executed tasks by `benchmarkOptions.taskFilter` and to persist additional run config fields (`internalProvider`, `runtimeProfile`, `benchmarkOptions`) in results; adds focused tests covering preview behavior, parquet batching, missing datasets, and task filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b1bad3ba59e89f467b9e9354e61db12d6fa9c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->