### PR TITLE
fix(local-llm): detect llama.cpp servers

### DIFF
--- a/packages/remnic-core/src/local-llm-thinking.test.ts
+++ b/packages/remnic-core/src/local-llm-thinking.test.ts
@@ -111,6 +111,18 @@ test("disableThinking injects chat_template_kwargs for vllm backend (#548)", asy
   assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
 });
 
+test("disableThinking injects chat_template_kwargs for llama.cpp backend (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "llamacpp" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+});
+
 test("disableThinking fails open for generic backend — no kwarg sent (#548 Codex P1)", async () => {
   // Regression for Codex P1 on PR #550: `chat_template_kwargs` is a
   // llama.cpp / LM-Studio / vLLM extension.  Strict OpenAI-compat

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -13,6 +13,94 @@ function trimTrailingSlashes(s: string): string {
   return s.substring(0, end);
 }
 
+function stripTrailingV1Path(s: string): string {
+  return s.endsWith("/v1") ? s.slice(0, -3) : s;
+}
+
+function explicitPortFromUrl(s: string): number | null {
+  try {
+    const parsed = new URL(s);
+    if (!parsed.port) return null;
+    const port = Number(parsed.port);
+    return Number.isInteger(port) ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isLlamaCppPropsResponse(value: unknown): boolean {
+  return (
+    isObjectRecord(value) &&
+    isObjectRecord(value.default_generation_settings) &&
+    typeof value.total_slots === "number" &&
+    (
+      typeof value.model_path === "string" ||
+      typeof value.chat_template === "string" ||
+      typeof value.build_info === "string"
+    )
+  );
+}
+
+function isLlamaCppModelsResponse(value: unknown): boolean {
+  if (!isObjectRecord(value) || !Array.isArray(value.data)) {
+    return false;
+  }
+  return value.data.some((entry) => {
+    if (!isObjectRecord(entry)) return false;
+    if (entry.owned_by === "llamacpp") return true;
+    if (typeof entry.id === "string" && entry.id.endsWith(".gguf")) return true;
+    const meta = entry.meta;
+    return (
+      isObjectRecord(meta) &&
+      ("n_ctx_train" in meta || "n_params" in meta || "vocab_type" in meta)
+    );
+  });
+}
+
+function isLmStudioApiV1ModelsResponse(value: unknown): boolean {
+  if (!isObjectRecord(value) || !Array.isArray(value.models)) {
+    return false;
+  }
+  return value.models.some((entry) => {
+    if (!isObjectRecord(entry)) return false;
+    return (
+      typeof entry.key === "string" &&
+      typeof entry.display_name === "string" &&
+      (
+        typeof entry.format === "string" ||
+        typeof entry.max_context_length === "number" ||
+        Array.isArray(entry.loaded_instances)
+      )
+    );
+  });
+}
+
+function isLmStudioApiV0ModelsResponse(value: unknown): boolean {
+  if (!isObjectRecord(value) || !Array.isArray(value.data)) {
+    return false;
+  }
+  return value.data.some((entry) => {
+    if (!isObjectRecord(entry)) return false;
+    return (
+      typeof entry.id === "string" &&
+      typeof entry.publisher === "string" &&
+      (
+        typeof entry.compatibility_type === "string" ||
+        typeof entry.max_context_length === "number" ||
+        typeof entry.state === "string"
+      )
+    );
+  });
+}
+
+function isLmStudioNativeModelsResponse(value: unknown): boolean {
+  return isLmStudioApiV1ModelsResponse(value) || isLmStudioApiV0ModelsResponse(value);
+}
+
 /**
  * Local LLM client for OpenAI-compatible endpoints (LM Studio, Ollama, MLX, etc.)
  *
@@ -20,12 +108,12 @@ function trimTrailingSlashes(s: string): string {
  * Provides privacy-preserving, cost-effective LLM operations with
  * graceful fallback to cloud providers when local LLM is unavailable.
  */
-export type LocalLlmType = "lmstudio" | "ollama" | "mlx" | "vllm" | "generic";
+export type LocalLlmType = "lmstudio" | "ollama" | "mlx" | "vllm" | "llamacpp" | "generic";
 
 /**
  * Backends known to honor `chat_template_kwargs: { enable_thinking: false }`
- * on OpenAI-compatible `/v1/chat/completions`.  LM Studio and vLLM both
- * forward this field to the jinja chat template, where thinking-capable
+ * on OpenAI-compatible `/v1/chat/completions`.  LM Studio, vLLM, and
+ * llama.cpp forward this field to the jinja chat template, where thinking-capable
  * models (Qwen 3.5, Gemma 4, DeepSeek) suppress reasoning tokens.
  *
  * Strict OpenAI-compatible backends (standard OpenAI, Azure OpenAI, some
@@ -37,6 +125,7 @@ export type LocalLlmType = "lmstudio" | "ollama" | "mlx" | "vllm" | "generic";
 const THINKING_COMPATIBLE_BACKENDS: ReadonlySet<LocalLlmType> = new Set([
   "lmstudio",
   "vllm",
+  "llamacpp",
 ]);
 
 interface LocalServerConfig {
@@ -56,35 +145,48 @@ const LOCAL_SERVERS: LocalServerConfig[] = [
     detectFn: (resp) => typeof resp === "string" && resp.includes("Ollama"),
   },
   {
+    type: "llamacpp",
+    defaultPort: 8080,
+    healthEndpoint: "/health",
+    modelsEndpoint: "/v1/models",
+    detectFn: (resp) => isObjectRecord(resp) && resp.status === "ok",
+  },
+  {
     type: "mlx",
     defaultPort: 8080,
     healthEndpoint: "/v1/models",
     modelsEndpoint: "/v1/models",
-    detectFn: (resp) =>
-      typeof resp === "object" &&
-      resp !== null &&
-      "data" in resp &&
-      Array.isArray((resp as { data: unknown[] }).data),
+    detectFn: (resp) => isObjectRecord(resp) && Array.isArray(resp.data),
   },
   {
     type: "lmstudio",
     defaultPort: 1234,
     healthEndpoint: "/v1/models",
     modelsEndpoint: "/v1/models",
-    detectFn: (resp) =>
-      typeof resp === "object" &&
-      resp !== null &&
-      "data" in resp &&
-      Array.isArray((resp as { data: unknown[] }).data),
+    detectFn: (resp) => isObjectRecord(resp) && Array.isArray(resp.data),
   },
   {
     type: "vllm",
     defaultPort: 8000,
     healthEndpoint: "/health",
     modelsEndpoint: "/v1/models",
-    detectFn: (resp) => resp === "" || (typeof resp === "object" && resp !== null),
+    detectFn: (resp) => resp === "" || (isObjectRecord(resp) && !("status" in resp)),
   },
 ];
+
+function orderedLocalServers(configuredBaseUrl: string): LocalServerConfig[] {
+  const configuredPort = explicitPortFromUrl(configuredBaseUrl);
+  if (configuredPort === null) return LOCAL_SERVERS;
+  const matching = LOCAL_SERVERS.filter(
+    (serverConfig) => serverConfig.defaultPort === configuredPort,
+  );
+  if (matching.length === 0) return LOCAL_SERVERS;
+  const matchingTypes = new Set(matching.map((serverConfig) => serverConfig.type));
+  return [
+    ...matching,
+    ...LOCAL_SERVERS.filter((serverConfig) => !matchingTypes.has(serverConfig.type)),
+  ];
+}
 
 export interface LocalModelInfo {
   id: string;
@@ -303,6 +405,22 @@ export class LocalLlmClient {
     }
   }
 
+  private async probeLmStudioNativeModels(
+    probeBaseUrl: string,
+  ): Promise<{ matched: boolean; unauthorized: boolean }> {
+    let unauthorized = false;
+    for (const endpoint of ["/api/v1/models", "/api/v0/models"]) {
+      const probe = await this.fetchWithTimeout(`${probeBaseUrl}${endpoint}`);
+      if (probe.ok && isLmStudioNativeModelsResponse(probe.data)) {
+        return { matched: true, unauthorized };
+      }
+      if (probe.status === 401 || probe.status === 403) {
+        unauthorized = true;
+      }
+    }
+    return { matched: false, unauthorized };
+  }
+
   /**
    * Check if local LLM is available
    * Uses 127.0.0.1 instead of localhost to avoid DNS issues (consistent with tactician)
@@ -323,23 +441,66 @@ export class LocalLlmClient {
       return this.isAvailable;
     }
 
-    // Normalize URL - replace localhost with 127.0.0.1, remove trailing slashes
-    const baseUrl = trimTrailingSlashes(
+    // Normalize URL - replace localhost with 127.0.0.1, remove trailing slashes.
+    // Probe server-native endpoints from the server root even when users configure
+    // the OpenAI-compatible `/v1` base URL for chat completions.
+    const configuredBaseUrl = trimTrailingSlashes(
       this.config.localLlmUrl.replace("localhost", "127.0.0.1"),
     );
+    const probeBaseUrl = stripTrailingV1Path(configuredBaseUrl);
     let sawUnauthorizedProbe = false;
 
     // Try to detect which server type is running
-    for (const serverConfig of LOCAL_SERVERS) {
-      const healthUrl = `${baseUrl}${serverConfig.healthEndpoint}`;
+    for (const serverConfig of orderedLocalServers(configuredBaseUrl)) {
+      const healthUrl = `${probeBaseUrl}${serverConfig.healthEndpoint}`;
       log.debug(`checking ${serverConfig.type} at ${healthUrl}`);
 
       const result = await this.fetchWithTimeout(healthUrl);
       if (result.ok && serverConfig.detectFn(result.data)) {
+        if (serverConfig.type === "mlx") {
+          const lmStudioProbe = await this.probeLmStudioNativeModels(probeBaseUrl);
+          if (lmStudioProbe.unauthorized) {
+            sawUnauthorizedProbe = true;
+          }
+          if (lmStudioProbe.matched) {
+            this.isAvailable = true;
+            this.detectedType = "lmstudio";
+            this.lastHealthCheck = now;
+            log.info(`detected lmstudio at ${configuredBaseUrl}`);
+            return true;
+          }
+        }
+        if (serverConfig.type === "llamacpp") {
+          let sawLlamaCppSignal = false;
+          const propsProbe = await this.fetchWithTimeout(`${probeBaseUrl}/props`);
+          if (propsProbe.ok && isLlamaCppPropsResponse(propsProbe.data)) {
+            sawLlamaCppSignal = true;
+          }
+          if (propsProbe.status === 401 || propsProbe.status === 403) {
+            sawUnauthorizedProbe = true;
+          }
+
+          const modelsUrl = `${probeBaseUrl}${serverConfig.modelsEndpoint}`;
+          const modelsProbe = await this.fetchWithTimeout(modelsUrl);
+          if (modelsProbe.ok && isLlamaCppModelsResponse(modelsProbe.data)) {
+            sawLlamaCppSignal = true;
+          }
+          if (modelsProbe.status === 401 || modelsProbe.status === 403) {
+            sawUnauthorizedProbe = true;
+            continue;
+          }
+
+          const authConfigured =
+            Boolean(this.config.localLlmApiKey) &&
+            this.config.localLlmAuthHeader !== false;
+          if (!sawLlamaCppSignal || (authConfigured && !modelsProbe.ok)) {
+            continue;
+          }
+        }
         this.isAvailable = true;
         this.detectedType = serverConfig.type;
         this.lastHealthCheck = now;
-        log.info(`detected ${serverConfig.type} at ${baseUrl}`);
+        log.info(`detected ${serverConfig.type} at ${configuredBaseUrl}`);
         return true;
       }
       if (result.status === 401 || result.status === 403) {
@@ -349,13 +510,13 @@ export class LocalLlmClient {
 
     // Generic check if specific detection failed
     try {
-      const modelsUrl = `${baseUrl}/v1/models`;
+      const modelsUrl = `${probeBaseUrl}/v1/models`;
       const result = await this.fetchWithTimeout(modelsUrl);
       if (result.ok) {
         this.isAvailable = true;
         this.detectedType = "generic";
         this.lastHealthCheck = now;
-        log.info(`detected generic OpenAI-compatible server at ${baseUrl}`);
+        log.info(`detected generic OpenAI-compatible server at ${configuredBaseUrl}`);
         return true;
       }
       if (result.status === 401 || result.status === 403) {
@@ -370,10 +531,10 @@ export class LocalLlmClient {
     this.lastHealthCheck = now;
     if (sawUnauthorizedProbe) {
       log.warn(
-        `local LLM availability probe was unauthorized at ${baseUrl}; verify localLlmApiKey and localLlmAuthHeader settings`,
+        `local LLM availability probe was unauthorized at ${configuredBaseUrl}; verify localLlmApiKey and localLlmAuthHeader settings`,
       );
     }
-    log.debug("local LLM not available at", baseUrl);
+    log.debug("local LLM not available at", configuredBaseUrl);
     return false;
   }
 

--- a/tests/local-llm.test.ts
+++ b/tests/local-llm.test.ts
@@ -124,7 +124,10 @@ test("LocalLlmClient checkAvailability sends auth headers to health probes", asy
     true,
   );
 
-  const client = new LocalLlmClient(buildConfig({ localLlmApiKey: "top-secret" }));
+  const client = new LocalLlmClient(buildConfig({
+    localLlmApiKey: "top-secret",
+    localLlmUrl: "http://localhost:11434",
+  }));
   const originalFetch = globalThis.fetch;
   const authHeaders: string[] = [];
   globalThis.fetch = (async (_input, init) => {
@@ -140,6 +143,484 @@ test("LocalLlmClient checkAvailability sends auth headers to health probes", asy
     const available = await client.checkAvailability();
     assert.equal(available, true);
     assert.deepEqual(authHeaders, ["Bearer top-secret"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LocalLlmClient detects llama.cpp from health response with /v1 config URL", async () => {
+  initLogger(
+    {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(buildConfig({ localLlmUrl: "http://localhost:8081/v1" }));
+  const originalFetch = globalThis.fetch;
+  const urls: string[] = [];
+  globalThis.fetch = (async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    urls.push(url);
+    if (url.endsWith("/health")) {
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.endsWith("/props")) {
+      return new Response(
+        JSON.stringify({
+          default_generation_settings: {},
+          total_slots: 1,
+          model_path: "/models/qwen.gguf",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (url.endsWith("/v1/models")) {
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          data: [
+            {
+              id: "/models/qwen.gguf",
+              object: "model",
+              owned_by: "llamacpp",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    return new Response("not found", {
+      status: 404,
+      headers: { "content-type": "text/plain" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, true);
+    assert.equal(client.getDetectedType(), "llamacpp");
+    assert.ok(urls.includes("http://127.0.0.1:8081/health"));
+    assert.ok(urls.includes("http://127.0.0.1:8081/props"));
+    assert.ok(urls.includes("http://127.0.0.1:8081/v1/models"));
+    assert.equal(
+      urls.some((url) => url.includes("/v1/health") || url.includes("/v1/v1/models")),
+      false,
+      "availability probes should normalize configured /v1 URLs back to the server root",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LocalLlmClient preserves LM Studio detection for /v1 config URLs", async () => {
+  initLogger(
+    {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(buildConfig({ localLlmUrl: "http://localhost:1234/v1" }));
+  client.disableThinking = true;
+  const originalFetch = globalThis.fetch;
+  const urls: string[] = [];
+  const bodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (input, init) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    urls.push(url);
+    if (url.endsWith("/v1/models")) {
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          data: [{ id: "lm-studio-model", object: "model", owned_by: "lmstudio" }],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (url.endsWith("/v1/chat/completions")) {
+      if (init?.body) {
+        bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+      }
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "{\"ok\":true}" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    return new Response("not found", {
+      status: 404,
+      headers: { "content-type": "text/plain" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, true);
+    assert.equal(client.getDetectedType(), "lmstudio");
+    assert.equal(urls[0], "http://127.0.0.1:1234/v1/models");
+
+    const out = await client.chatCompletion(
+      [{ role: "user", content: "hello" }],
+      { operation: "extraction" },
+    );
+    assert.ok(out);
+    assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LocalLlmClient preserves LM Studio detection on custom /v1 ports", async () => {
+  initLogger(
+    {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(buildConfig({ localLlmUrl: "http://127.0.0.1:8081/v1" }));
+  client.disableThinking = true;
+  const originalFetch = globalThis.fetch;
+  const urls: string[] = [];
+  const bodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (input, init) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    urls.push(url);
+    if (url.endsWith("/api/v1/models")) {
+      return new Response(
+        JSON.stringify({
+          models: [
+            {
+              type: "llm",
+              publisher: "google",
+              key: "google/gemma-4-26b-a4b",
+              display_name: "Gemma 4 26B A4B",
+              format: "gguf",
+              max_context_length: 262144,
+              loaded_instances: [],
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (url.endsWith("/v1/models")) {
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          data: [{ id: "lm-studio-model", object: "model", owned_by: "organization_owner" }],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (url.endsWith("/v1/chat/completions")) {
+      if (init?.body) {
+        bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+      }
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "{\"ok\":true}" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    return new Response("not found", {
+      status: 404,
+      headers: { "content-type": "text/plain" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, true);
+    assert.equal(client.getDetectedType(), "lmstudio");
+    assert.ok(urls.includes("http://127.0.0.1:8081/api/v1/models"));
+
+    const out = await client.chatCompletion(
+      [{ role: "user", content: "hello" }],
+      { operation: "extraction" },
+    );
+    assert.ok(out);
+    assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LocalLlmClient does not accept public llama.cpp health when authenticated models reject", async () => {
+  const warns: string[] = [];
+  initLogger(
+    {
+      info() {},
+      warn(msg: string) {
+        warns.push(msg);
+      },
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(
+    buildConfig({
+      localLlmUrl: "http://127.0.0.1:8081/v1",
+      localLlmApiKey: "wrong-key",
+      localLlmAuthHeader: true,
+    }),
+  );
+  const originalFetch = globalThis.fetch;
+  const urls: string[] = [];
+  globalThis.fetch = (async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    urls.push(url);
+    if (url.endsWith("/health")) {
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.endsWith("/v1/models")) {
+      return new Response("Unauthorized", {
+        status: 401,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    return new Response("not found", {
+      status: 404,
+      headers: { "content-type": "text/plain" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, false);
+    assert.equal(client.getDetectedType(), null);
+    assert.ok(urls.includes("http://127.0.0.1:8081/health"));
+    assert.ok(urls.includes("http://127.0.0.1:8081/props"));
+    assert.ok(urls.includes("http://127.0.0.1:8081/v1/models"));
+    assert.ok(
+      warns.some((msg) => msg.includes("availability probe was unauthorized")),
+      "expected unauthorized warning when authenticated llama.cpp model probe rejects",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LocalLlmClient rejects unauthorized llama.cpp models probes with custom auth headers", async () => {
+  const warns: string[] = [];
+  initLogger(
+    {
+      info() {},
+      warn(msg: string) {
+        warns.push(msg);
+      },
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(
+    buildConfig({
+      localLlmUrl: "http://127.0.0.1:8081/v1",
+      localLlmAuthHeader: false,
+      localLlmHeaders: { Authorization: "Bearer wrong-custom-token" },
+    }),
+  );
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.endsWith("/health")) {
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.endsWith("/props")) {
+      return new Response(
+        JSON.stringify({
+          default_generation_settings: {},
+          total_slots: 1,
+          model_path: "/models/qwen.gguf",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (url.endsWith("/v1/models")) {
+      return new Response("Unauthorized", {
+        status: 401,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    return new Response("not found", {
+      status: 404,
+      headers: { "content-type": "text/plain" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, false);
+    assert.equal(client.getDetectedType(), null);
+    assert.ok(
+      warns.some((msg) => msg.includes("availability probe was unauthorized")),
+      "expected unauthorized warning for custom-auth llama.cpp model probe rejection",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LocalLlmClient does not treat generic status health as llama.cpp", async () => {
+  initLogger(
+    {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(buildConfig({ localLlmUrl: "http://127.0.0.1:8081/v1" }));
+  client.disableThinking = true;
+  const originalFetch = globalThis.fetch;
+  const bodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (input, init) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.endsWith("/health")) {
+      return new Response(JSON.stringify({ status: "ok" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.endsWith("/props")) {
+      return new Response("not found", {
+        status: 404,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    if (url.endsWith("/v1/models")) {
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          models: [{ id: "native-style-field-that-is-not-llama-cpp" }],
+          data: [{ id: "strict-proxy-model", object: "model", owned_by: "proxy" }],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (url.endsWith("/v1/chat/completions")) {
+      if (init?.body) {
+        bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+      }
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "{\"ok\":true}" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    return new Response("not found", {
+      status: 404,
+      headers: { "content-type": "text/plain" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, true);
+    assert.notEqual(client.getDetectedType(), "llamacpp");
+    const out = await client.chatCompletion(
+      [{ role: "user", content: "hello" }],
+      { operation: "extraction" },
+    );
+    assert.ok(out);
+    assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LocalLlmClient still detects vLLM from empty health response", async () => {
+  initLogger(
+    {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(buildConfig({ localLlmUrl: "http://127.0.0.1:8000" }));
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.endsWith("/health")) {
+      return new Response("", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    return new Response("not found", {
+      status: 404,
+      headers: { "content-type": "text/plain" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, true);
+    assert.equal(client.getDetectedType(), "vllm");
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- Adds a first-class `llamacpp` local LLM backend detected from `/health` returning `{ "status": "ok" }`.
- Normalizes `/v1` local LLM URLs before server health/model probes so detection works with either root or OpenAI-compatible base URLs.
- Keeps vLLM detection for empty `/health` responses while avoiding broad matches on llama.cpp-style status payloads.

Refs #979

## Test Plan
- [x] `pnpm exec tsx --test packages/remnic-core/src/local-llm-thinking.test.ts`
- [x] `pnpm exec tsx --test tests/local-llm.test.ts`
- [x] `npm run preflight:quick`
- [ ] `npm run review:cursor` skipped locally because the macOS login keychain is locked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies local backend detection and availability probing (including auth/401 handling), which could change which servers are classified as available and what capabilities are enabled. Main risk is false-positive/false-negative detection impacting local LLM usage, mitigated by expanded test coverage.
> 
> **Overview**
> **Adds first-class `llamacpp` backend detection** to `LocalLlmClient.checkAvailability()`, including extra confirmation probes (`/props` and `/v1/models`) to avoid misclassifying generic OpenAI-compatible servers.
> 
> **Normalizes availability probes to the server root** when users configure a `/v1` base URL, and reorders detection attempts based on the configured port to reduce ambiguity (while keeping vLLM’s empty-`/health` detection and tightening its match to avoid llama.cpp-style payloads).
> 
> **Extends thinking-suppression support** (`chat_template_kwargs: { enable_thinking: false }`) to llama.cpp and adds comprehensive tests covering llama.cpp detection, LM Studio disambiguation, unauthorized probe behavior, and the new thinking kwarg injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b847f64ae58e5edf49e70c30f1ae51f04e0eb85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->