### PR TITLE
fix(local-llm): scope thinking suppression by operation

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction-judge.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-judge.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { judgeContradictionPairs } from "./contradiction-judge.js";
+import type { LocalLlmClient } from "../local-llm.js";
+import type { PluginConfig } from "../types.js";
+
+test("contradiction judge tags local LLM calls for thinking suppression", async () => {
+  const optionsSeen: Array<Record<string, unknown>> = [];
+  const localLlm = {
+    async chatCompletion(
+      _messages: Array<{ role: string; content: string }>,
+      options: Record<string, unknown>,
+    ) {
+      optionsSeen.push(options);
+      return {
+        content: JSON.stringify([
+          {
+            pairKey: "a:b",
+            verdict: "independent",
+            rationale: "The memories cover different details.",
+            confidence: 0.9,
+          },
+        ]),
+      };
+    },
+  } as unknown as LocalLlmClient;
+
+  const result = await judgeContradictionPairs(
+    [
+      {
+        memoryIdA: "a",
+        memoryIdB: "b",
+        textA: "Joshua uses pnpm",
+        textB: "Joshua works on Remnic",
+      },
+    ],
+    {} as PluginConfig,
+    localLlm,
+    null,
+    new Map(),
+  );
+
+  assert.equal(optionsSeen[0]?.operation, "contradiction-judge");
+  assert.equal(result.judged, 1);
+  assert.equal(result.results.get("a:b")?.verdict, "independent");
+});

--- a/packages/remnic-core/src/contradiction/contradiction-judge.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-judge.ts
@@ -244,6 +244,7 @@ async function callLlm(
     const result = await client.chatCompletion(messages, {
       temperature: 0.1,
       maxTokens: 4096,
+      operation: "contradiction-judge",
     });
     return result?.content ?? "";
   }

--- a/packages/remnic-core/src/local-llm-thinking.test.ts
+++ b/packages/remnic-core/src/local-llm-thinking.test.ts
@@ -79,10 +79,16 @@ function captureFetchBodies(): {
   };
 }
 
-async function runOneChatCompletion(client: LocalLlmClient): Promise<void> {
+async function runOneChatCompletion(
+  client: LocalLlmClient,
+  operation: string | null = "extraction",
+  options: { forceDisableThinking?: boolean } = {},
+): Promise<void> {
   await client.chatCompletion(
     [{ role: "user", content: "hello" }],
-    { maxTokens: 16 },
+    operation === null
+      ? { maxTokens: 16, ...options }
+      : { maxTokens: 16, operation, ...options },
   );
 }
 
@@ -99,6 +105,46 @@ test("disableThinking injects chat_template_kwargs for lmstudio backend (#548)",
   assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
 });
 
+test("disableThinking injects chat_template_kwargs for extraction judge (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "extraction-judge");
+  } finally {
+    restore();
+  }
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("disableThinking injects chat_template_kwargs for contradiction judge (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "contradiction-judge");
+  } finally {
+    restore();
+  }
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("disableThinking injects chat_template_kwargs for extraction enrichment (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "contradiction_verification");
+    await runOneChatCompletion(client, "link_suggestion");
+    await runOneChatCompletion(client, "memory_summarization");
+  } finally {
+    restore();
+  }
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+  assert.deepEqual(bodies[1]?.chat_template_kwargs, { enable_thinking: false });
+  assert.deepEqual(bodies[2]?.chat_template_kwargs, { enable_thinking: false });
+});
+
 test("disableThinking injects chat_template_kwargs for vllm backend (#548)", async () => {
   const client = new LocalLlmClient(createConfig());
   primeClient(client, { thinking: true, detected: "vllm" });
@@ -109,6 +155,70 @@ test("disableThinking injects chat_template_kwargs for vllm backend (#548)", asy
     restore();
   }
   assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("disableThinking injects chat_template_kwargs for day summaries (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "day_summary");
+  } finally {
+    restore();
+  }
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("disableThinking injects chat_template_kwargs for hourly summaries (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "hourly_summary");
+    await runOneChatCompletion(client, "hourly_summary_extended");
+  } finally {
+    restore();
+  }
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+  assert.deepEqual(bodies[1]?.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("disableThinking leaves consolidation thinking enabled (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "semantic-consolidation");
+  } finally {
+    restore();
+  }
+  assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
+});
+
+test("forceDisableThinking suppresses thinking for fast-tier consolidation (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: false, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, "semantic-consolidation", {
+      forceDisableThinking: true,
+    });
+  } finally {
+    restore();
+  }
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("disableThinking leaves untagged operations thinking-enabled (#979)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client, null);
+  } finally {
+    restore();
+  }
+  assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
 });
 
 test("disableThinking fails open for generic backend — no kwarg sent (#548 Codex P1)", async () => {

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -39,6 +39,20 @@ const THINKING_COMPATIBLE_BACKENDS: ReadonlySet<LocalLlmType> = new Set([
   "vllm",
 ]);
 
+const THINKING_SUPPRESSED_OPERATIONS: ReadonlySet<string> = new Set([
+  "extraction",
+  "extraction-judge",
+  "contradiction-judge",
+  "contradiction_verification",
+  "link_suggestion",
+  "memory_summarization",
+  "proactive_extraction",
+  "lcm-summarize",
+  "day_summary",
+  "hourly_summary",
+  "hourly_summary_extended",
+]);
+
 interface LocalServerConfig {
   type: LocalLlmType;
   defaultPort: number;
@@ -100,6 +114,7 @@ interface LocalLlmChatCompletionOptions {
   responseFormat?: { type: string };
   timeoutMs?: number;
   operation?: string;
+  forceDisableThinking?: boolean;
   priority?: LocalLlmRequestPriority;
 }
 
@@ -157,8 +172,10 @@ export class LocalLlmClient {
    * (LM Studio, vLLM; see `THINKING_COMPATIBLE_BACKENDS`).  Strict
    * OpenAI-compat backends reject unknown fields with 400; on those the
    * client fails open (thinking runs normally).  This is the safe
-   * default for Remnic extraction / consolidation: measurable latency
-   * win on thinking-capable backends, zero risk on others.  Issue #548.
+   * default for Remnic extraction-style operations: measurable latency
+   * win on thinking-capable backends, zero risk on others. Consolidation
+   * operations keep thinking enabled unless explicitly added to
+   * `THINKING_SUPPRESSED_OPERATIONS`. Issues #548 and #979.
    */
   set disableThinking(value: boolean) {
     this._disableThinking = value;
@@ -791,11 +808,15 @@ export class LocalLlmClient {
         requestBody.response_format = options.responseFormat;
       }
 
-      // Suppress thinking/reasoning for thinking-capable models
-      // (Qwen 3.5, Gemma 4, DeepSeek).  These models default to
-      // thinking-on via their chat template; sending
-      // `chat_template_kwargs: { enable_thinking: false }` tells the
-      // template to skip reasoning tokens.
+      // Suppress thinking/reasoning for operations that benefit from terse,
+      // structured output. Thinking-capable models (Qwen 3.5, Gemma 4,
+      // DeepSeek) default to thinking-on via their chat template; sending
+      // `chat_template_kwargs: { enable_thinking: false }` tells the template
+      // to skip reasoning tokens. Consolidation operations on the main client
+      // intentionally keep thinking enabled so entity resolution and
+      // deduplication can use the model's reasoning path. Fast-tier callers can
+      // still force suppression per request to preserve their low-latency
+      // contract.
       //
       // Gate the injection on detected backend support (issue #548,
       // Codex P1 on PR #550): `chat_template_kwargs` is an LM Studio /
@@ -804,8 +825,12 @@ export class LocalLlmClient {
       // unknown fields with 400, which trips the 400-cooldown path and
       // can effectively disable local extraction.  Fail open when the
       // backend hasn't been positively identified as thinking-capable.
+      const shouldSuppressThinking =
+        options.forceDisableThinking === true ||
+        (this._disableThinking &&
+          THINKING_SUPPRESSED_OPERATIONS.has(operation));
       if (
-        this._disableThinking &&
+        shouldSuppressThinking &&
         this.detectedType !== null &&
         THINKING_COMPATIBLE_BACKENDS.has(this.detectedType)
       ) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2154,7 +2154,10 @@ export class Orchestrator {
       );
       return result ? { content: result.content } : null;
     }
-    const result = await this.fastLlm.chatCompletion(messages, options);
+    const result = await this.fastLlm.chatCompletion(messages, {
+      ...options,
+      forceDisableThinking: true,
+    });
     return result ? { content: result.content } : null;
   }
 
@@ -2175,7 +2178,13 @@ export class Orchestrator {
           this.fastChatCompletion(messages, options ?? {}),
       };
     }
-    return this.fastLlm;
+    return {
+      chatCompletion: (messages, options) =>
+        this.fastLlm.chatCompletion(messages, {
+          ...(options ?? {}),
+          forceDisableThinking: true,
+        }),
+    };
   }
 
   async initialize(): Promise<void> {
@@ -3226,6 +3235,7 @@ export class Orchestrator {
             maxTokens: llmOpts.maxTokens,
             temperature: llmOpts.temperature,
             priority: "background",
+            forceDisableThinking: true,
           });
           response = fastResult ? { content: fastResult.content } : null;
         } else {


### PR DESCRIPTION
## Summary
- Limits local LLM `chat_template_kwargs: { enable_thinking: false }` injection to extraction-style and selected summary operations.
- Leaves thinking enabled for consolidation and untagged operations so entity resolution and deduplication can use reasoning-capable local models.
- Adds regression coverage for extraction, day summary, consolidation, and untagged operation behavior.

Refs #979

## Test Plan
- [x] `pnpm exec tsx --test packages/remnic-core/src/local-llm-thinking.test.ts`
- [x] `npm run preflight:quick`
- [ ] `npm run review:cursor` skipped locally because the macOS login keychain is locked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `LocalLlmClient` decides to inject `chat_template_kwargs` and adds a new `forceDisableThinking` override, which can affect local LLM output quality/latency for different operations and fast-tier routing.
> 
> **Overview**
> Thinking suppression for local LLMs is now **scoped by operation** instead of being globally applied whenever `disableThinking` is set: `LocalLlmClient` only injects `chat_template_kwargs: { enable_thinking: false }` for a curated set of extraction/summarization operations, while leaving consolidation and untagged calls thinking-enabled.
> 
> Adds a per-request override (`forceDisableThinking`) and uses it from the orchestrator fast-tier paths to keep fast operations low-latency regardless of the global setting. The contradiction judge now tags its local LLM calls with `operation: "contradiction-judge"`, and new/expanded tests cover the operation gating, consolidation behavior, and the new override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40b02d3accc50b157a2f7731d3b8932a2e688bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->