### PR TITLE
Align OpenClaw beta4 package metadata

### DIFF
--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -164,12 +164,23 @@ CI jobs that provision OpenClaw should use
 `npm run check:openclaw-sdk-surface:required` or pass
 `-- --require --package-root <path>` so a missing SDK fails instead of skipping.
 
-Last compatibility sweep: May 7, 2026. The SDK surface check passed against
+Last compatibility sweep: May 13, 2026. The SDK surface check passed against
 `openclaw@2026.5.3`, `openclaw@2026.5.3-1`, `openclaw@2026.5.4-beta.1`,
 `openclaw@2026.5.4-beta.2`, `openclaw@2026.5.4-beta.3`,
-`openclaw@2026.5.4`, `openclaw@2026.5.5`, and `openclaw@2026.5.6`.
+`openclaw@2026.5.4`, `openclaw@2026.5.5`, `openclaw@2026.5.6`, and
+`openclaw@2026.5.12-beta.4`.
 Keep the peer range broad unless an upstream release removes a runtime surface
 Remnic actively uses.
+
+OpenClaw 2026.5.12 package-entry discovery prefers explicit built runtime
+entries for installed packages. The published Remnic adapter declares
+`openclaw.runtimeExtensions: ["./dist/index.js"]` alongside the existing
+extension entry, and its package install metadata advertises
+`openclaw.install.clawhubSpec: "clawhub:@remnic/plugin-openclaw"`,
+`openclaw.install.npmSpec: "@remnic/plugin-openclaw"`, and
+`openclaw.install.defaultChoice: "clawhub"`. That keeps OpenClaw setup,
+repair, and update flows ClawHub-first while preserving npm as the fallback
+install surface and `>=2026.4.8` as the minimum supported host range.
 
 Native memory registrars are tracked separately in
 [`docs/plugins/openclaw-native-memory-registrars.md`](../../docs/plugins/openclaw-native-memory-registrars.md).

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -22,14 +22,20 @@
     "extensions": [
       "./dist/index.js"
     ],
+    "runtimeExtensions": [
+      "./dist/index.js"
+    ],
     "compat": {
       "pluginApi": ">=2026.4.8"
     },
     "build": {
-      "openclawVersion": "2026.5.9-beta.1",
-      "pluginSdkVersion": "2026.5.9-beta.1"
+      "openclawVersion": "2026.5.12-beta.4",
+      "pluginSdkVersion": "2026.5.12-beta.4"
     },
     "install": {
+      "clawhubSpec": "clawhub:@remnic/plugin-openclaw",
+      "npmSpec": "@remnic/plugin-openclaw",
+      "defaultChoice": "clawhub",
       "minHostVersion": ">=2026.4.8"
     },
     "environment": {

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -28,7 +28,23 @@
     "plugin": "./openclaw.plugin.json",
     "extensions": [
       "./dist/index.js"
-    ]
+    ],
+    "runtimeExtensions": [
+      "./dist/index.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.4.8"
+    },
+    "build": {
+      "openclawVersion": "2026.5.12-beta.4",
+      "pluginSdkVersion": "2026.5.12-beta.4"
+    },
+    "install": {
+      "clawhubSpec": "clawhub:@remnic/plugin-openclaw",
+      "npmSpec": "@joshuaswarren/openclaw-engram",
+      "defaultChoice": "clawhub",
+      "minHostVersion": ">=2026.4.8"
+    }
   },
   "scripts": {
     "build": "node ./scripts/sync-openclaw-plugin.mjs && tsup --config tsup.config.ts",

--- a/scripts/openclaw-plugin-security-scan.mjs
+++ b/scripts/openclaw-plugin-security-scan.mjs
@@ -60,22 +60,69 @@ function findScannerModule(openclawPackageDir) {
 }
 
 function selectScannerFunction(moduleExports) {
+  const exportedFunctions = Object.entries(moduleExports)
+    .filter(([, value]) => typeof value === "function");
+  const byExportName = (name) => exportedFunctions.find(([exportName]) => exportName === name)?.[1];
+  const byFunctionName = (name) => exportedFunctions.find(([, value]) => value.name === name)?.[1];
+
   if (typeof moduleExports.scanDirectoryWithSummary === "function") {
     return moduleExports.scanDirectoryWithSummary;
   }
+
+  const namedSummaryScanner = byFunctionName("scanDirectoryWithSummary");
+  if (namedSummaryScanner) return namedSummaryScanner;
 
   if (typeof moduleExports.scanDirectory === "function") {
     return moduleExports.scanDirectory;
   }
 
-  if (typeof moduleExports.t === "function") return moduleExports.t;
+  const namedDirectoryScanner = byFunctionName("scanDirectory");
+  if (namedDirectoryScanner) return namedDirectoryScanner;
 
-  const exportedFunctions = Object.values(moduleExports).filter((value) => typeof value === "function");
-  if (exportedFunctions.length === 1) return exportedFunctions[0];
+  const legacyMinifiedScanner = byExportName("t");
+  if (
+    legacyMinifiedScanner &&
+    legacyMinifiedScanner.name !== "clearSkillScanCacheForTest" &&
+    legacyMinifiedScanner.length > 0
+  ) {
+    return legacyMinifiedScanner;
+  }
+
+  if (exportedFunctions.length === 1) return exportedFunctions[0][1];
 
   throw new Error(
     `Unable to identify OpenClaw scanner export; found exports: ${Object.keys(moduleExports).join(", ")}`,
   );
+}
+
+function normalizeScanSummary(rawSummary, scannerName) {
+  const countSeverity = (findings, severity) =>
+    findings.filter((finding) => finding?.severity === severity).length;
+
+  if (Array.isArray(rawSummary)) {
+    return {
+      scannedFiles: "unknown",
+      critical: countSeverity(rawSummary, "critical"),
+      warn: countSeverity(rawSummary, "warn"),
+      findings: rawSummary,
+    };
+  }
+
+  if (!rawSummary || typeof rawSummary !== "object") {
+    throw new Error(
+      `OpenClaw scanner ${scannerName || "unknown"} returned ${rawSummary === null ? "null" : typeof rawSummary}; expected a scan summary.`,
+    );
+  }
+
+  const findings = Array.isArray(rawSummary.findings) ? rawSummary.findings : [];
+  return {
+    scannedFiles: rawSummary.scannedFiles ?? "unknown",
+    critical: typeof rawSummary.critical === "number"
+      ? rawSummary.critical
+      : countSeverity(findings, "critical"),
+    warn: typeof rawSummary.warn === "number" ? rawSummary.warn : countSeverity(findings, "warn"),
+    findings,
+  };
 }
 
 function formatFinding(finding) {
@@ -97,8 +144,8 @@ const openclawPackageJson = JSON.parse(fs.readFileSync(path.join(openclawPackage
 const scannerModule = findScannerModule(openclawPackageDir);
 const scannerExports = await import(pathToFileURL(scannerModule).href);
 const scan = selectScannerFunction(scannerExports);
-const summary = await scan(packageDir);
-const findings = Array.isArray(summary.findings) ? summary.findings : [];
+const summary = normalizeScanSummary(await scan(packageDir), scan.name);
+const findings = summary.findings;
 
 console.log(`OpenClaw ${openclawPackageJson.version} scanner: ${scannerModule}`);
 for (const finding of findings) console.log(formatFinding(finding));

--- a/scripts/verify-openclaw-clawpack.mjs
+++ b/scripts/verify-openclaw-clawpack.mjs
@@ -72,6 +72,10 @@ for (const extension of packageJson.openclaw?.extensions ?? []) {
   requiredFiles.add(extension.replace(/^\.\//, ""));
 }
 
+for (const runtimeExtension of packageJson.openclaw?.runtimeExtensions ?? []) {
+  requiredFiles.add(runtimeExtension.replace(/^\.\//, ""));
+}
+
 for (const requiredFile of requiredFiles) {
   if (!files.has(requiredFile)) {
     fail(`${packageJson.name}@${packageJson.version} packlist is missing ${requiredFile}`);

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -46,6 +46,24 @@ const OPENCLAW_MANIFEST_PATHS = [
   "packages/plugin-openclaw/openclaw.plugin.json",
   "packages/shim-openclaw-engram/openclaw.plugin.json",
 ];
+const OPENCLAW_PACKAGE_EXPECTATIONS = [
+  {
+    packageJsonPath: "packages/plugin-openclaw/package.json",
+    name: "@remnic/plugin-openclaw",
+    install: {
+      clawhubSpec: "clawhub:@remnic/plugin-openclaw",
+      npmSpec: "@remnic/plugin-openclaw",
+    },
+  },
+  {
+    packageJsonPath: "packages/shim-openclaw-engram/package.json",
+    name: "@joshuaswarren/openclaw-engram",
+    install: {
+      clawhubSpec: "clawhub:@remnic/plugin-openclaw",
+      npmSpec: "@joshuaswarren/openclaw-engram",
+    },
+  },
+];
 const TOOL_SOURCE_PATHS = [
   "src/tools.ts",
   "packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.ts",
@@ -353,6 +371,33 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
     assert.equal(briefing.properties?.maxFollowups?.maximum, 10);
     assert.deepEqual(briefing.properties?.calendarSource?.type, ["string", "null"]);
     assert.deepEqual(briefing.properties?.saveDir?.type, ["string", "null"]);
+  });
+}
+
+for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
+  test(`${expectation.name} declares OpenClaw 2026.5.12-beta.4 package install metadata`, () => {
+    const packageJson = readPackageJson(expectation.packageJsonPath);
+    const openclaw = packageJson.openclaw ?? {};
+
+    assert.equal(packageJson.name, expectation.name);
+    assert.deepEqual(openclaw.extensions, ["./dist/index.js"]);
+    assert.deepEqual(
+      openclaw.runtimeExtensions,
+      ["./dist/index.js"],
+      "OpenClaw 2026.5.12+ package discovery should have an explicit built runtime entrypoint",
+    );
+    assert.deepEqual(openclaw.compat, {
+      pluginApi: ">=2026.4.8",
+    });
+    assert.deepEqual(openclaw.build, {
+      openclawVersion: "2026.5.12-beta.4",
+      pluginSdkVersion: "2026.5.12-beta.4",
+    });
+    assert.deepEqual(openclaw.install, {
+      ...expectation.install,
+      defaultChoice: "clawhub",
+      minHostVersion: ">=2026.4.8",
+    });
   });
 }
 

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -92,7 +92,7 @@ test("OpenClaw security scan wrapper handles minified scanner exports", async ()
     await mkdir(pluginDir, { recursive: true });
     await writeFile(
       path.join(openclawDir, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.5.12-beta.4" }),
+      JSON.stringify({ name: "openclaw", version: "2026.5.12-beta.4", type: "module" }),
     );
     await writeFile(
       path.join(openclawDistDir, "skill-scanner-fake.js"),

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 // Topological publish order: core first, then the à-la-carte companion
@@ -72,4 +75,50 @@ test("release workflow verifies the OpenClaw ClawHub packlist after build", asyn
     /packageJson\.openclaw\?\.extensions/,
     "ClawPack verifier must check every declared OpenClaw extension",
   );
+  assert.match(
+    verifyScript,
+    /packageJson\.openclaw\?\.runtimeExtensions/,
+    "ClawPack verifier must check every declared OpenClaw runtime extension",
+  );
+});
+
+test("OpenClaw security scan wrapper handles minified scanner exports", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-openclaw-scan-"));
+  try {
+    const openclawDir = path.join(tempDir, "openclaw");
+    const openclawDistDir = path.join(openclawDir, "dist");
+    const pluginDir = path.join(tempDir, "plugin");
+    await mkdir(openclawDistDir, { recursive: true });
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      path.join(openclawDir, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.5.12-beta.4" }),
+    );
+    await writeFile(
+      path.join(openclawDistDir, "skill-scanner-fake.js"),
+      [
+        "function clearSkillScanCacheForTest() {}",
+        "async function scanDirectoryWithSummary(dirPath) {",
+        "  return { scannedFiles: 1, critical: 0, warn: 0, findings: [] };",
+        "}",
+        "export { scanDirectoryWithSummary as i, clearSkillScanCacheForTest as t };",
+      ].join("\n"),
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/openclaw-plugin-security-scan.mjs", pluginDir],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, OPENCLAW_PACKAGE_DIR: openclawDir },
+        encoding: "utf8",
+      },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OpenClaw 2026\.5\.12-beta\.4 scanner:/);
+    assert.match(result.stdout, /scanned=1 critical=0 warn=0/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- Declare explicit `openclaw.runtimeExtensions` and OpenClaw `2026.5.12-beta.4` build/SDK metadata for the Remnic OpenClaw adapter and legacy shim.
- Add ClawHub-first install metadata with npm fallback while preserving the existing `>=2026.4.8` host floor.
- Extend package/runtime metadata tests, ClawPack packlist verification, README compatibility notes, and harden the OpenClaw security-scan wrapper for minified scanner exports.

## Compatibility Review
- OpenClaw `v2026.5.12-beta.4` SDK surface matches Remnic’s expected snapshot: 14 registrars, 22 hooks, 2 manifest contracts.
- No runtime hook, memory slot, setup/auth, gateway LLM, or `openclaw.plugin.json` schema code changes were required.
- Package-entry/install metadata needed updates for the newer OpenClaw installed-package guidance.

## Test Plan
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test tests/openclaw-plugin-runtime-surfaces.test.ts tests/release-workflow-public-packages.test.ts`
- `npm run check:openclaw-plugin-sync`
- `npm run check:openclaw-sdk-surface -- --package-root /tmp/openclaw-beta4`
- `pnpm --filter @remnic/plugin-openclaw run build`
- `pnpm --filter @joshuaswarren/openclaw-engram run build`
- `pnpm --filter @remnic/plugin-openclaw run plugin:inspect`
- `node scripts/verify-openclaw-clawpack.mjs`
- `node scripts/verify-openclaw-clawpack.mjs packages/shim-openclaw-engram`
- `npm run scan:openclaw-plugin`
- `npm run preflight:quick`
- `git diff --check`

Closes #991

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to OpenClaw package metadata, verification/tests, and a scan-wrapper robustness tweak, with no runtime plugin behavior or auth/memory logic changes.
> 
> **Overview**
> Updates the Remnic OpenClaw plugin and legacy shim `package.json` metadata for OpenClaw `2026.5.12-beta.4`, including explicit `openclaw.runtimeExtensions` and **ClawHub-first** install hints (`clawhubSpec`/`npmSpec`/`defaultChoice`) while keeping the `>=2026.4.8` host floor.
> 
> Hardens tooling around these metadata changes: `verify-openclaw-clawpack.mjs` now verifies `runtimeExtensions` are included in the packlist, the security-scan wrapper can select/normalize minified or renamed scanner exports, and tests were extended to assert the new package install/build metadata and cover the minified-scanner case. Documentation updates the compatibility sweep date and notes the new discovery behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df173996c4a3cdf73b95dfe1116337bbf2239c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->