### PR TITLE
Publish AMA-Bench agent SOTA evidence

### DIFF
--- a/docs/benchmarks/evidence/ama-bench-gpt-5.5-agent-sota-2026-05-15.md
+++ b/docs/benchmarks/evidence/ama-bench-gpt-5.5-agent-sota-2026-05-15.md
@@ -1,0 +1,116 @@
+# AMA-Bench Agent-Class SOTA Evidence (Codex CLI gpt-5.5)
+
+This document publishes the completed Remnic AMA-Bench full run from the
+`public-matrix-codex-bf9b2643-20260515T052919Z` public-matrix attempt.
+
+## Result
+
+| Field | Value |
+| --- | --- |
+| Benchmark | AMA-Bench |
+| Comparison class | Agent / memory-system leaderboard |
+| Result | Agent-class SOTA |
+| Remnic score | `0.6496122948369937` AMA-Bench leaderboard average; raw question-weighted recommended accuracy `0.6542467948717948` |
+| Prior top verified agent score | `0.557925` |
+| Model-only caveat | The top verified model-only entry was `gpt 5.2` at `0.6982833333333333`; this run does not beat the model-only leaderboard. |
+| Tasks | `2496 / 2496` |
+| Runtime profile | `real` |
+| System provider/model | Codex CLI `gpt-5.5` |
+| Judge provider/model | Codex CLI `gpt-5.5` |
+| Internal provider/model | Codex CLI `gpt-5.5` |
+| Reasoning effort | `xhigh` for system, judge, and internal providers |
+| Service tier | `fast` in Codex CLI diagnostics |
+| Commit | `bf9b264356a537e70fce1bddbca3495bf8a19b31` |
+| Dataset hash | `90826eb21ce703a0b82078752e9eafeaca30b3976c897daff341a9f9ad77277e` |
+| Result hash | `7930b614b3a6085c007315c0a6470130c8d4ed956220a79b61ea822f621c609b` |
+
+## Committed Artifacts
+
+- Public-safe benchmark artifact:
+  `docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/2026-05-15-ama-bench-gpt-5.5-real-bf9b264.json`
+- Raw local benchmark result hash, recorded in the manifest but not committed because it contains full questions, answers, model responses, and recalled text:
+  `7930b614b3a6085c007315c0a6470130c8d4ed956220a79b61ea822f621c609b`
+- Reproducibility manifest:
+  `docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/MANIFEST.ama-bench.json`
+- Codex CLI diagnostic summary:
+  `docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/ama-bench-diagnostics-summary.json`
+
+The diagnostic summary covers completed Codex CLI calls with
+`finishedAt <= MANIFEST.generatedAt` for the AMA-Bench run. It records
+`8307` completed diagnostic records, all with provider `codex-cli`, model
+`gpt-5.5`, reasoning effort `xhigh`, service tier `fast`, status `0`, and
+zero captured errors.
+
+The manifest keeps the raw uncommitted benchmark-result entry in `results[]`
+for compatibility with the standard manifest schema. The committed sanitized
+derivative is listed separately in `publicArtifacts[]`.
+
+## Metrics
+
+From the raw result artifact:
+
+| Metric | Mean |
+| --- | ---: |
+| `ama_bench_leaderboard_average` | `0.6496122948369937` |
+| `ama_bench_recommended_accuracy` | `0.6542467948717948` |
+| `llm_judge` | `0.6542467948717948` |
+| `f1` | `0.37428827221642497` |
+| `contains_answer` | `0.020032051282051284` |
+
+## Public Comparison Source
+
+The comparison target was computed from the AMA-Bench Hugging Face
+leaderboard raw JSONL files on 2026-05-15/2026-05-16:
+
+- `https://huggingface.co/spaces/AMA-bench/AMA-bench-Leaderboard/resolve/main/data/agent.jsonl`
+- `https://huggingface.co/spaces/AMA-bench/AMA-bench-Leaderboard/resolve/main/data/model.jsonl`
+
+Verified leaderboard target summary at publication time:
+
+- Top verified agent average: `0.557925`
+- Top verified model average: `0.6982833333333333` (`gpt 5.2`)
+
+This PR claims only the agent / memory-system leaderboard result.
+
+## Reproduction
+
+Use the same Remnic commit and dataset hash recorded in the manifest.
+The original command envelope was:
+
+```bash
+PATH=/opt/homebrew/bin:/opt/homebrew/sbin:$PATH \
+  packages/remnic-cli/bin/remnic.cjs bench published \
+  --name ama-bench \
+  --dataset evals/datasets/ama-bench \
+  --runtime-profile real \
+  --provider codex-cli \
+  --model gpt-5.5 \
+  --system-codex-reasoning-effort xhigh \
+  --judge-provider codex-cli \
+  --judge-model gpt-5.5 \
+  --judge-codex-reasoning-effort xhigh \
+  --internal-provider codex-cli \
+  --internal-model gpt-5.5 \
+  --internal-codex-reasoning-effort xhigh \
+  --request-timeout 3600000 \
+  --drain-timeout 3600000 \
+  --max-429-wait 86400000 \
+  --seed 1 \
+  --results-dir <results-dir> \
+  --out docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z \
+  --ama-bench-judge-protocol recommended \
+  --trial-concurrency 6
+```
+
+Verify the committed public-safe evidence with:
+
+```bash
+node scripts/bench/verify-public-ama-agent-sota-evidence.mjs
+```
+
+The verifier recomputes the 24-cell AMA leaderboard average from the committed
+per-task scores, checks the public artifact hash, verifies the raw result hash
+recorded in the manifest, and validates the compact Codex CLI diagnostic
+summary.
+
+The committed public-safe artifact includes aggregate metrics and per-task scores, but omits question text, expected answers, model answers, and recalled text. The raw local benchmark result hash is recorded in `MANIFEST.ama-bench.json` for reproducibility. The committed diagnostic summary is intentionally compact; it proves the Codex CLI tuple for the completed AMA window without committing thousands of raw per-call diagnostic files. The original uncommitted raw result and diagnostic folder remain under the local results directory for deeper audit.

--- a/docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/2026-05-15-ama-bench-gpt-5.5-real-bf9b264.json
+++ b/docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/2026-05-15-ama-bench-gpt-5.5-real-bf9b264.json
@@ -1,0 +1,25136 @@
+{
+  "schemaVersion": 1,
+  "benchmarkId": "ama-bench",
+  "datasetVersion": "sha256:90826eb21ce703a0b82078752e9eafeaca30b3976c897daff341a9f9ad77277e",
+  "system": {
+    "name": "remnic",
+    "version": "9.3.388",
+    "gitSha": "bf9b264356a537e70fce1bddbca3495bf8a19b31"
+  },
+  "model": "gpt-5.5",
+  "seed": 1,
+  "metrics": {
+    "ama_bench_recommended_accuracy": 0.6542467948717948,
+    "contains_answer": 0.020032051282051284,
+    "f1": 0.37428827221642497,
+    "llm_judge": 0.6542467948717948,
+    "ama_bench_leaderboard_average": 0.6496122948369937
+  },
+  "perTaskScores": [
+    {
+      "taskId": "3de8b3e6-c5ec-4187-85af-eb0dfb36efef",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3676470588235295,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "c7f578d2-653e-4f13-99b9-81b8cff46f63",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45637583892617456,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "251427f2-a310-4cce-82ad-14f3f3bbfe29",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5360824742268041,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "5cb20ac8-2623-41e3-bcec-52390d923bbc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3505154639175258,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "cf193b62-cadd-4c14-a656-8a36f7324f6d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24193548387096775,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "1d824ff4-a5bd-47ca-8d9e-9504fd8d7686",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.12903225806451613,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "e680ef7b-f350-43b7-b622-1d7d6a1a6c23",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.28800000000000003,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "9a59dca1-c2d4-437a-9053-20a465352e1f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39215686274509803,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "4d2b25c3-c1fd-4077-8fbd-ba783251d95e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20967741935483872,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "c83e562c-fffe-4fe9-a8ed-0b734a929726",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4098360655737705,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "a43ae8c9-1dcd-4212-aac8-295ed5d7f813",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.273972602739726,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "7966eb95-dae6-4f82-a786-3b26daebfbc5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "f95c152b-4541-44c3-9440-aed1fab054bf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "a93cb2f4-87e2-46cd-ac9d-6b342d0b9770",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5056179775280899,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "cc5b7829-439b-41bb-a2d9-cfd7ce6956c6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5549132947976879,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "1f749797-96c9-4fbe-9fb4-acca5c82767e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.423841059602649,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "f11de794-930d-43e6-85f7-f76e80dba234",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2195121951219512,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "1a1c3994-8b64-44ac-be48-26e65813e4c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4497041420118343,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "da50a2e1-8c39-4a4e-a131-67fe3101ff4b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26548672566371684,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "9cacee3c-8403-44ce-a5a3-3fd394af9e7e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3103448275862069,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "cd0ba6e1-9c8a-43fc-821d-8bd4cec81f32",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24242424242424246,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "bdde6d5b-dfd8-40b9-8222-6d787b974667",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.18,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "6ccd6db1-06c7-4574-af62-60a20bf7ac38",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3972602739726027,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "1c425eba-e52a-4882-a6e1-16dba6b644ac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.11627906976744186,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "a6924872-be5d-46b2-b8b7-fa889d85f709",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5594405594405594,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "d01fd8d0-21f4-4c06-b0b4-e12c9a19e83b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.425531914893617,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "99415060-e316-4f39-9266-9e8065d36409",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4901960784313726,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "c5e34952-6403-46c4-9cb8-a565928846d6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2553191489361702,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "84e71060-5248-4ff9-a9b9-54ef04d0e5cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3529411764705882,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "06e06c6a-9f48-4225-ab7c-13d97b91c848",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4625,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "cdcc2a0f-b5ff-424f-b263-e9365c69bd8a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4324324324324325,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "83347cce-5855-4b30-85a3-a5f8ec19278e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2412060301507538,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "12f9ecd9-72f7-4fdf-8f66-48dd8d72ab3d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3703703703703703,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "ee69f1cc-4bb0-4c8e-86f8-cd15e7c5bebd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4750000000000001,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "ec65f88b-ea69-4ca1-908e-e846c29899e7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4587155963302752,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "d0e55cf8-ebb0-4ca0-b195-488c595d3058",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4313725490196078,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "34c96245-93cc-4120-9c61-bb011daeca07",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45360824742268047,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "a037da30-e58c-40b0-bbe0-9120fdfcb460",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27397260273972607,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "e963c86d-bd4d-405e-9a28-838aac105c1b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.513157894736842,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "b9065fe0-567b-4cb2-9285-986f6703a5e4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "3aa1c6f2-544a-4915-90e1-665a62785d55",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4148148148148148,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "49207036-7c69-44a5-9376-e3519e1c558a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4968152866242039,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "08665618-b4e5-41be-a9b2-72e6223fa475",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5145631067961165,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "4a12dd4c-7cf5-4d7a-91b3-90bd3f14f38a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42735042735042733,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "02f41e69-80d4-4cf3-82cb-7128889db83a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5142857142857142,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "d4b7e11f-5d06-4a95-a669-e9ebbfc9f52f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44086021505376344,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "b156014e-2786-4e48-9180-928286f457bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3611111111111111,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "77244419-477c-4bbb-afab-0051b3a224eb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "78edb435-fcdf-4337-bdae-42254be3ed62",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.543046357615894,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "5eff1c78-5f14-4a52-b2df-dffd387b34f9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "08afcf17-ca16-475e-a072-983cd95c7f53",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5669291338582677,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "28b1f47b-902e-404e-8035-b2bb1fdb838d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4900662251655629,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "331a3daf-65fd-4b12-a57e-04ade7bb1aa3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "a64ce219-7695-4fd4-9d0d-d9c40a40debf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4705882352941177,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "edc0dafa-32bd-4817-8619-ea9e641da176",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45054945054945056,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "5246d2fb-2515-4518-95db-2bd93bb2ae52",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3902439024390244,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "0f36b817-4985-4b18-8c2e-022b48b24601",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3764705882352941,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "64602861-4624-4b11-83e4-5e196ec69044",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3387978142076502,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "703b8c39-235d-4db4-a5a5-edbbe4a6ade3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4742268041237113,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "20167c47-66ab-4a7f-95e7-e777e2ee6461",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.17721518987341772,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "292a54ed-9c8c-4d4c-b481-b7eca9012466",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "44345708-9a36-4ed7-b430-31305f83e0e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4800000000000001,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "210143d6-d81f-4814-a154-cff497012dca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5526315789473685,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "9893e9ac-738e-4c18-bec5-f45a45434db5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3214285714285714,
+        "llm_judge": 0
+      },
+      "category": "Game/babaisai/A"
+    },
+    {
+      "taskId": "b8566120-15a6-4c36-b5d5-eacdd3ed864a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3584905660377358,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "8a06c3a5-f470-4522-9b03-ae46a7d9e4e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24000000000000002,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "2495202e-3edc-4b6b-878d-fa72a115cfae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3529411764705882,
+        "llm_judge": 0
+      },
+      "category": "Game/babaisai/B"
+    },
+    {
+      "taskId": "38045aa6-2ce8-4117-a948-3548ebfee182",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2517482517482517,
+        "llm_judge": 0
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "ed677630-d620-464d-b1bf-daa02404562a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4999999999999999,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "d28d4bf1-f18e-497e-8465-842efb5801c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.544378698224852,
+        "llm_judge": 0
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "8136f9a4-d87b-4e1a-8931-4436c15b5f00",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4166666666666667,
+        "llm_judge": 0
+      },
+      "category": "Game/babaisai/D"
+    },
+    {
+      "taskId": "e6dd5858-e93d-410d-9434-00425b4a9a73",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "Game/babaisai/C"
+    },
+    {
+      "taskId": "28b50395-872b-4024-9130-9157b91f87b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "fb184ff3-914e-4795-b0e9-a6fd9b8d2f49",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4117647058823529,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "3393f8b9-bbec-460f-a675-e292ee432fe8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.345679012345679,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "2fff9024-834c-472c-8b5c-18111e81601e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5230769230769231,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "430a0337-6b95-41d0-b53e-7621bd56d134",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5649717514124293,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "ab6690c8-22d9-4b8c-a788-e5e1ecfb6430",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30894308943089427,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "6d0498a1-0905-4efb-8545-7ddc8396c63a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44594594594594594,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "0b57eecf-4ae6-4f0d-8127-3fb0a06dc780",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38167938931297707,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "9a1d2e0f-5fd2-4dbb-bd0a-1bf2f39731b8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4774774774774775,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "7a5a6a1c-883c-47ff-b18d-e100b5feabc6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5476190476190476,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "2ea1b7ee-bfbc-46a2-9b72-6c3650acd4a8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42553191489361697,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "0ed936f6-c74b-4c12-82f9-cdee37accb0d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "ecd622ce-6dd3-4bac-8f18-d2c165420ef0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4666666666666667,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "3b3f9b8a-e2e7-4758-b3e9-dbe80e8ff7e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38759689922480617,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "7720e1e5-c191-4d4b-9f5d-fcaed8c6e908",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3823529411764705,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "41664809-7ae3-47aa-b947-b91d804c2479",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24489795918367344,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "9294a074-827b-4fc2-8551-3e1a3c1d4008",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3439490445859873,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "69fb8d92-3c35-4374-aa70-09f8f3711762",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.52,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "9caeafdb-b755-42ab-afca-13e1d6bd369d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42276422764227645,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "4c6af830-3202-46c0-8a05-09bd144d9419",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "f7683733-0553-4f95-aad1-b3629d1ad2c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3826086956521739,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "a0fd442b-ae97-496f-b7f5-732151f2e678",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40909090909090917,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "58eb957b-6f49-4e88-b196-fada7434c8d2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46060606060606063,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "1c9fc3b6-8d97-44c7-8e72-e780b55c9a65",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3582089552238805,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "dcb45142-4a15-4902-89d1-2750e436fea4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.15000000000000002,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "42efdcb8-3450-4f9a-818e-f7757f9e49f3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "a033f87a-a01f-45c1-a1c6-83bac5c32353",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6308724832214765,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "6d1dffad-3ca8-400a-9fe7-b74ad7b61253",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.375,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "2dca7aa0-50bb-4b20-b9ce-9da7bdaefc27",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36082474226804123,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "5d530505-9c38-4d03-b60d-075f29dc33cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3898305084745763,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "b9101e57-382e-42c0-8938-0e9142cf4924",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3118279569892473,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "c5a9f33d-85d9-495c-9d91-90a7b3712105",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142866,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "39c23091-8340-42f0-b2f1-022fab57166a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48888888888888893,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "f320697b-b84e-4761-ab60-86a2e0426985",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45751633986928103,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "0de91f32-0bda-4b23-85a8-b0a7bcb8d9dc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3529411764705882,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "28a3d559-66e3-4e42-81b7-442363826762",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "45360bb3-d80f-458f-a20d-e2df958c3ba1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.380281690140845,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "d682e7e0-ae5e-40f8-bb10-c5ce2a540579",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5490196078431372,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "1a3327a1-07e2-4df8-8d66-9c37b63a8a27",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25641025641025644,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "17155ce1-fd46-480d-8ffa-bc197eb67aa6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30000000000000004,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "c5132d93-85ec-462d-9e20-212d96f3e95d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.456140350877193,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "34d6fed2-c5bc-43e1-9ab2-6eb4780f281e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4729729729729729,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "8d44e409-7f3c-49cf-a47d-58b6fda8ca84",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14457831325301204,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "2832780d-84cb-43c7-9716-bf9df580cdeb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3898305084745763,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "a666c3d3-5722-416e-9f15-069a7b6713f9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33962264150943394,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "cd63b947-abdf-4923-ac97-681f5e388b94",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36036036036036034,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "46ed98c4-789a-49b7-bcec-a75654839d87",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "810ebe50-9bb5-4f91-861d-a2e1a55023ba",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2545454545454546,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "163c6b72-aac5-4760-8d54-6c03c39eb52b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32499999999999996,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "2ce7b5f7-7517-453c-9c6c-00e6a90f06b1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.40579710144927533,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "f4cc267a-2c80-43bd-a2cf-1be895e8d6eb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4756756756756757,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "3d7f5bd6-0650-40b3-8fa3-0414eaa3b6fc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.27499999999999997,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "0429a578-893b-4266-b0df-a9b88cbac2a0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3622047244094488,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "db2864ec-55e6-476b-a7fd-46690990709e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.358695652173913,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "cb02d5bb-d651-40d1-b356-55209e9fd50a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "5d2716be-4221-4ea5-9bdc-a200663daa13",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3103448275862069,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "80c11b62-f96f-4408-8410-f3920eb4fecd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4571428571428572,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "a9542b91-9891-4581-a6f6-96cf55af1fcd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4672897196261682,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "153108af-2d46-43b5-ac98-d50c691a25e0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3827160493827161,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "e19173bc-d340-4d9d-b7c1-3b153fc6f32d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2647058823529412,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "44c68e51-30ac-4361-83e0-daf29d35c657",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5153374233128833,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "c5f5963a-8206-4362-acf2-f5f8e7d9e224",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4112149532710281,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "732c8532-bea7-4f4c-89e3-c3815405a92c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43243243243243246,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "341f6b04-8ee6-498f-a182-d7a0a4cfb7af",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.34074074074074073,
+        "llm_judge": 0
+      },
+      "category": "Game/crafter/A"
+    },
+    {
+      "taskId": "d0569b90-1d1c-4a32-ac47-a93db2a04fa8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "9e78b817-4353-44eb-8d79-d41ecba62452",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5057471264367815,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "bb8acd79-0e18-4876-b696-007901ea57a2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "b1fc6fce-55b5-4279-aa62-e16906e25596",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5217391304347827,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "4adf72ef-84ac-4149-ad8b-8c622f100fad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4422110552763819,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/C"
+    },
+    {
+      "taskId": "1ca9a534-efaa-47f9-8157-652b24d51eae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47567567567567565,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "e15db4e1-5c33-4cbe-b83e-4e74d8629b03",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4678362573099415,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/D"
+    },
+    {
+      "taskId": "df17ee6d-e82e-4834-b489-1a23c8533605",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4666666666666666,
+        "llm_judge": 1
+      },
+      "category": "Game/crafter/B"
+    },
+    {
+      "taskId": "10bee70e-83bd-40c9-890c-e57e1080d182",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4714285714285714,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "912fb7b7-b04e-4167-bcbd-9e89487150fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4227642276422764,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "f73bbc5e-f194-4aba-ab21-c5591416daa7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "466f5e7f-eb7c-4a08-ab3c-c22295887fcf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4519774011299435,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "d1ffab09-14fa-414d-9fcb-45dd60bb26b3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3680981595092024,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "811b51fa-4d4a-4628-9a02-e96402f8c449",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35185185185185186,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "45ff831c-3fa6-4023-9453-d1e982cb5e99",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.34782608695652173,
+        "llm_judge": 0
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "7402fef4-6b30-4814-ba43-28164efbc6ec",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "6431f00f-9888-4787-9bea-6b36a5b6c6ea",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42580645161290326,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "9b366c76-0d37-4480-9f37-0a29e140d682",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3464566929133859,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "fbb52751-62db-48c5-a805-ec71a8c60b08",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41025641025641024,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "0b3d2b34-d7a2-4996-b4b6-3e963c8c68f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "285b9e70-c2c0-4278-868b-45ae51fd0c90",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4318181818181819,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "73b00b01-c6ca-4a04-a640-a196c5464f49",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5040650406504066,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "526d8986-ffea-4e4a-b4a2-80826cc567af",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3089430894308943,
+        "llm_judge": 0
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "f2d3b082-afd6-44c2-a742-441d04ff1297",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4827586206896552,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "88b86501-9fc7-44e9-b457-b8ad00d729d9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5070422535211268,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "77237088-06f8-4deb-94dc-e27adc3763a2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34825870646766166,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "bb89edcf-b545-44b9-9e52-343be9532cb5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45255474452554745,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "d51f9399-8c60-4a2c-8f07-2c6c6425995a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5100671140939597,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "750bb00c-4bb9-474c-97d1-c753477ea702",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "ae903bae-af07-4d08-8e81-ee550dce29dd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3103448275862069,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "53719041-baab-417f-a28f-84a1aee7d761",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "62e1722e-ee26-4f43-a717-8e3a24b36243",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.23728813559322037,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "df2c4319-7cf2-4228-a25d-8ea2b9070b21",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "8f485adc-72aa-48f4-b9bc-22ef3b7254b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5100671140939598,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "728eeaac-0d29-47b1-9b7e-44b7d4c58cca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4719101123595506,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "516ebeda-c8cd-4036-9b22-ef374a9019bf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.29906542056074764,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "8494077e-0490-47ba-9b0f-79708d17f65f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4225352112676056,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "42928957-833d-472f-a219-949054e4c0fe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4029850746268656,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "78b873a8-b99d-47f6-b8b4-61d519113996",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.02469135802469136,
+        "llm_judge": 0
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "2c819252-a7dc-4dc4-93b7-c38e2634951b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.336,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "bcbeebe3-bb94-4bcc-a985-acc7b6f53d12",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3902439024390244,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "7c763fd4-f568-4ae0-baad-8891b1ef1d11",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41958041958041964,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "58175325-0c2f-479a-8473-95ece092014a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27419354838709675,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "45b30caa-15b8-498b-834e-629e30ff078b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "e6c71e4a-b701-46e0-a737-e6895615b495",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39669421487603307,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "25363606-846c-4f05-b211-c6b23c151093",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4067796610169491,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "ac0d906b-446b-4594-94c5-aba1a37e2e93",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.366412213740458,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "474d4d98-3d92-4479-ad72-c24ba2b4b231",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3434343434343434,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "dc6e3689-58f3-4f2b-977f-02e6f50542a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4487179487179487,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "42814660-1cc7-4899-afe9-2ff6e1bc2f38",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40697674418604646,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "99275fb9-9bbc-45c2-8225-7ac1fe7bef5e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4217687074829932,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "7f275fa7-da8c-4ad1-9520-57e7207b8819",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38016528925619836,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "26f2102f-01d7-47ee-bdbe-e6c5e606ee38",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37869822485207105,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "d3cfdaf7-9bcc-4872-929a-8439e11e32d2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37398373983739835,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "511893aa-399f-4347-a08e-8b4e8c489640",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "3860b720-a5b2-4025-85d3-85c4f9494ac4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "7dbc998b-fd3a-4cd7-b758-3edca8c125cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34210526315789475,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "97249a89-6e11-45e1-83c2-2adbb6904323",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "fcd27261-e00f-4d4c-b220-5fac21f06414",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5434782608695652,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "ec9052b7-6c14-44e3-a0bb-f5814d4ee428",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3188405797101449,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "b39775ef-6682-4239-a852-ed9297d0ec03",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48854961832061067,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "d05556bc-b268-4944-88e4-61a4eeab6bad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32044198895027626,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "1e87b53e-3476-4326-8e72-e0d1f6d08c7f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38888888888888895,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "2517ef1a-7ad2-4bb4-8251-845c8505746f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.22680412371134018,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "8e5391ca-f9ec-4a76-8a06-364d51a52785",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1956521739130435,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "ff94482d-3926-4188-b62d-e559ce31a87c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3478260869565218,
+        "llm_judge": 0
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "a527a750-6c14-41cc-99a1-3336982a4605",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.0697674418604651,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "e77bc9d9-1d19-4d0c-ba8c-7dfcd418ae2d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "2d275ebe-188a-42a4-9b7c-56f225a55209",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5588235294117647,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "3ce78241-9523-4d58-8d6b-51b87ee5a685",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5289256198347108,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "a1b2a6c2-fd18-4e54-a59f-40699b8e6d61",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4122137404580153,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "a2280f2c-7019-4cad-985f-a78a9aa0a3bc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3910614525139665,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/A"
+    },
+    {
+      "taskId": "e4ffe1be-6793-4a98-a145-573329c97549",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46511627906976744,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "1c186e8c-428e-40f8-ad06-ccd28dc9c7b9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45588235294117646,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "e56e669a-7ffe-48c7-9ad9-74721f62216c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/B"
+    },
+    {
+      "taskId": "529c9be1-38d0-4fa4-aa23-b8eb1d7acb8c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4777777777777778,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "65ea6be6-e8f8-47e0-9db5-6d951d7e422e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "b4bf9698-550c-4958-be67-719473cdf249",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20408163265306123,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "7d8485e5-aeea-4943-9386-736de530d4ad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3111111111111111,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/D"
+    },
+    {
+      "taskId": "e5afdf55-5a5f-44f3-ac93-16c80b7b08fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.22535211267605632,
+        "llm_judge": 1
+      },
+      "category": "Game/minihack/C"
+    },
+    {
+      "taskId": "5157d3c9-cde6-428c-9b5b-8aad7afa5220",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.402439024390244,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "b4db534f-8d48-42dd-b28e-f236ae8df7a5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46896551724137936,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "1c73f84c-cfa9-44c3-a8d7-d60ddceb139c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4864864864864864,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "ba5581d7-f901-47ca-9ec3-2868aa52fef4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4267782426778242,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "c43ee98c-6805-484e-b306-da88b5a889a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "2ed670fd-e035-4727-9669-1738bed60456",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49162011173184356,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "832ecbf9-5af8-409a-8b3d-4cfd1aacc72b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5612244897959183,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "5bd578d0-bf37-40c4-8909-e38438194ebe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42028985507246375,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "09a1177d-c15a-4ed8-8978-2d419ce22575",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4239130434782609,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "7134aaf4-e17a-43ae-b380-7ebbd35e5c8f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "487fd35b-c6e4-4ee3-93c2-867e15fe5253",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5066666666666667,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "d7180ef5-1d6a-48dc-832c-2de672c03db2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3684210526315789,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "3b192665-c28e-4d88-9b27-166bc87415d7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "95e38021-0f26-4780-b796-b0e326edf719",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43103448275862066,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "ddc24b39-4283-4301-a562-d6bb478fd78e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5095541401273885,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "711d6873-a97c-4efc-b546-68245615ef60",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "a96e19a0-2881-47fa-b910-f7273d081575",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4342857142857143,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "607218c7-eef5-4b19-be7f-46085ed3204c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45588235294117646,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "e4278915-e949-49f6-a559-0e6da9250ea9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5304659498207884,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "337ca321-57cf-401b-85c9-87ec6d056ba1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4727272727272728,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "01f9818b-58a6-4343-9222-79a24768fe9f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4659090909090909,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "781550d2-f5da-4064-998b-58eaad9554c3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.48437500000000006,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "b856a6c6-0a12-477d-8500-1823991c1921",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4210526315789474,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "7f4e071f-ecaf-4c88-8dc9-43196036d590",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "efdef791-acfe-4cd8-b45f-c773bb3f9852",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13157894736842105,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "6bf5516b-e7b9-4306-a33e-075cf1a04c5a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.484375,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "86832464-252f-42f5-a873-3fe0fd2344cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5106382978723404,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "0b5a1841-1798-460a-9f8c-cbf7743170c1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1565217391304348,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "862b84e0-1aa5-4c28-a728-a06bcad4cb51",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.42424242424242425,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "82ba655d-3744-4ef5-9822-20078d25045c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44755244755244755,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "52dd7af6-f173-4fcc-be66-151cf8f0461a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42290748898678415,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "fd2e20c9-7cee-4611-b60d-f48776f8b39a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6043165467625898,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "43279d37-636b-4b0f-9651-8c4875fcfe66",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.296875,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "4fb5b5ea-0091-45ab-821e-f8131cb6d723",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5056179775280899,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "0ed36444-658d-49b4-8479-6eb50cf4c16a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40909090909090917,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "04b4b060-6df1-4cf2-9296-2998a78f8670",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "902f480b-8bf9-4cf3-9ce7-e512fafd805f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.372093023255814,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "0688693e-9443-410c-a58c-bec265ce70f0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3584905660377359,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "763da223-8426-48a0-b866-78e27e066aad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43356643356643354,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "2a357a4c-1728-4d9e-935c-4e44f450b3e0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49295774647887325,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "1dee04f3-2203-4bf2-ae07-a4eb6090ea7f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44274809160305345,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "f0e8dd81-8eb5-438d-990c-2ddc56dabf86",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5390070921985816,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "93d76e3a-36d8-4d04-84ed-76c0ba7b7fa4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46846846846846846,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "2a1b17e8-73d9-4d26-bad9-c56c89521f45",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21238938053097348,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "5807f4a0-c13f-4f64-9dfe-d03cf951dac6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "565c9bb8-95f3-438a-8145-1bd5520502e3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5048543689320388,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "328ae5b8-41f6-4701-b642-630bdd6a2e3a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5684210526315789,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "bcabebfc-df41-444b-ac37-b6bb294f3746",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.608695652173913,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "2e011944-1de6-4072-861a-4e34202aeeda",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6138613861386139,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "bba86aa9-3b16-46c7-837d-e0124ed7faa8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5476190476190477,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "42c80535-9b45-4c8e-b1a4-988f4cf2e851",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4936708860759493,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "90d94e56-f770-4b4c-ab00-3f7d89bd1b4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.584070796460177,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "3f75e9b1-8268-4b34-940b-6257eb944817",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5507246376811594,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "c2f5326c-cd90-4a72-9548-402c21beb240",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4485981308411215,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "93222c52-cb16-476c-a246-0de30c5a48ba",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47500000000000003,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "17923295-9e06-42e9-bc35-5cb3b51df8cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.358974358974359,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "965069f4-de8a-44cd-aa0b-e59729c60eaf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.36082474226804123,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "119f9967-a4e3-4500-a2fb-58aeaaeddaf3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4305555555555555,
+        "llm_judge": 0
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "5c3b74bb-8fc4-47f5-8763-20bdab181713",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4067796610169492,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "1f68ca9d-4ba9-4075-b88a-7afb8cae3e47",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42424242424242425,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "0f1f4a4a-eae1-4d79-8419-0833050b8d31",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46511627906976744,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "4e1fb401-2abd-4327-8b6b-c474491c748a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5367965367965368,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "0b62e116-65cb-40e5-a148-3917f40712c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49074074074074076,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "2acf74bf-9c49-43d4-b514-72ef6fb3df0f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.592964824120603,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/A"
+    },
+    {
+      "taskId": "6a4f2ef9-3eac-4376-bc84-edfd0d2ced9a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4032258064516129,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "5ac661d8-c7dc-4c4a-9b3f-865cb0f12129",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4883720930232559,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "4f96946b-3d82-4008-9f49-e4991ab35da6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4313725490196078,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/B"
+    },
+    {
+      "taskId": "0b218905-d3b7-46a6-b3fb-4c4d1a985125",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5142857142857142,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "508d90f1-fd1a-407d-b548-09e8d7e7a478",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48958333333333337,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "5eb9f3ae-6191-455b-944f-8772014995a7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48799999999999993,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "0db7f9f7-b146-42e4-a118-94ea265c8c83",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41791044776119407,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/D"
+    },
+    {
+      "taskId": "bf627804-9283-491d-b9f5-0893ca38231d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.391304347826087,
+        "llm_judge": 1
+      },
+      "category": "Game/2048/C"
+    },
+    {
+      "taskId": "747cbe1a-b03f-42c1-98da-dc2d50c330f4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3404255319148936,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "bae5723a-bb6a-4631-ad3b-2ee82a583abf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32608695652173914,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "e66c5622-4ea8-40e1-8a1f-ca9c9ce7b38d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5767441860465117,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "ccf2ee08-1ba0-4de1-b42d-b8608a640a58",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.37037037037037035,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "53f9b0d5-846a-4df6-a1d9-491c2bfe00c9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4585987261146497,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "3b7493b5-2469-4e46-abc3-1e6a93d32bbd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3878787878787879,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "116045f2-0cf6-48a1-b145-aad90eed5be6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37777777777777777,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "5f353527-518d-4384-a81e-078149de43e5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4740740740740741,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "bcf7ba14-a2cd-46a8-a58f-e3689dabeeb4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33149171270718236,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "36b926ea-a533-4429-ba36-7739815b3d15",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.272,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "3facd81c-4a37-4a2c-a240-52bb98b00459",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.39416058394160586,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "f61ac112-3ae0-4072-843a-1cafb425a39e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1714285714285714,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "4018d7f4-c411-4b09-b218-856a0320094f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5411764705882353,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "86411227-7978-4cc9-8ec9-3937eaeac642",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2962962962962963,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "cef36cc4-b72b-49c8-a493-67e7bb5f6224",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48128342245989303,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "8a7a283b-e448-47f3-8e75-0d6be331741f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4885496183206107,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "5e473b4b-eacf-4a96-b7fb-9b9d89e1bf0e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4827586206896552,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "3789faaf-7fec-4769-b506-ef4e421c37a5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4088397790055249,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "c387107a-6773-454c-9128-fea6b2f5396c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "6d7fa2e6-11f7-46c8-8a7d-b006de6f6108",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.19642857142857145,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "8a87d918-1a80-4e0d-a39e-b1d6720b7aaf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3623188405797101,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "9aa5847b-8776-4056-98d6-54c7b875f1b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.358974358974359,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "2ad6c714-1bc9-4b8c-890f-6b599029def0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5354330708661417,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "4a0ab268-c176-42dc-b122-532250173b91",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41791044776119407,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "62325b35-3940-4b27-8513-434ac2ec9293",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4566210045662101,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "60b1d78c-5185-4dc0-968c-1fb3fdaf0853",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4317180616740088,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "02c9186a-ecff-4c24-8cac-dc95ea26b60a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3673469387755102,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "210bedd2-adc1-4aaa-a334-2653a0d10bbe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36123348017621143,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "79addf8f-55df-4a8b-acab-981d72339987",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3875968992248062,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "b54e92a0-b5e3-4ef5-9cf2-c3dd19e22bbf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49142857142857144,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "2f0fe73d-2cb9-4343-8d80-310a3f3aaa97",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2603550295857988,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "f1a5cdb8-0191-4ce1-b522-62293e15ac93",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5047619047619047,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "f37d2b0d-5d54-42d1-bc7c-165d0d1dff40",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35789473684210527,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "5f15cf83-13a3-4405-81c1-7771c8524cba",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35632183908045983,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "999ded5f-34ea-4f28-8d80-8ab45f9c94fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41463414634146345,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "54cfb819-acc2-48f9-9af7-2ac711d8e546",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "98022752-b414-4f71-9654-9d33dbc525a0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5405405405405406,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "71c75a56-acd0-46ff-982c-f174d2807e4d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3825136612021858,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "c8e32445-0984-40f4-9359-bbd6a8af7070",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32967032967032966,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "95f51d87-eb38-48b7-b999-ad30154dd7f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.391304347826087,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "71a9a91d-a17a-47f8-b317-fa450e32f754",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3709677419354839,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "2e3b51db-362a-4d7f-a380-f72ec4ec5790",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.375,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "d3681365-fab0-4174-8879-e0a5a5c295cc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.372093023255814,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "886a2c99-86d4-4ffd-be03-fbe3f6b98ace",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5569620253164557,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "f7103601-d17b-49fb-bc0b-e02bc7a48872",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "6f69e61e-8e0b-4013-b4df-f90323cb52a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4387096774193549,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "24d28c9b-fdbd-4e19-93b3-7a423339eaf5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4982456140350877,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "b3fb13e4-4080-4b71-b498-6a38cc166c8e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "0df8786d-2dfd-49bc-ae8e-c8ff9fb91819",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5263157894736843,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "f1190418-4922-4dff-bbf3-437d1a5975d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4685714285714286,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "1f021b3b-0c33-401d-b6eb-ab54b30a8392",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.35428571428571426,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "875f898b-4b20-4018-baf7-24f74460c754",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3625730994152047,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "5a991e04-ae69-4726-863a-5c0643fb21bb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4802867383512545,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "7a124182-878a-4318-b1af-2b22c816ddf9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3142857142857143,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "2de3187f-d1bc-40d0-b7b2-71d6a8cd51e6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47126436781609193,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "89636e4f-5f2c-4cd5-91b7-b35f30c77d4f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3624161073825504,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "22a4e750-ce72-4051-b90d-e304b7a9117f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3934426229508196,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "83572575-2146-4d29-a785-b1167c230458",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3545454545454546,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "62dc81aa-1d52-4d43-9a24-ad8bd07464bc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4811320754716981,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "bdd11e6c-3b00-4de0-832e-893dce9b3d1d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "9cccb6ac-718a-4b85-a00d-d826ed20e8f7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3259259259259259,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "4204bed0-7190-4c3c-9a74-d53fe75cccac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47457627118644063,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "56e35777-7839-4768-9f58-b3660e857fb9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.43396226415094336,
+        "llm_judge": 0
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "3432f132-98c9-476d-97b9-fb797dc12197",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44360902255639095,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/A"
+    },
+    {
+      "taskId": "349eb04a-5a3f-4e7e-bb0a-7470902927a9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4293193717277487,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "3aaad5ce-67bd-4646-8a89-afcbca79f156",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5178571428571429,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "ebcebe93-7c1c-4a5c-aada-5fe633389da3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4161073825503356,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "a138d0c1-8d27-4ea4-b634-6e9f4954e713",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4236453201970443,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "087b8665-a441-4862-afb4-1c31c4f98c21",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.348314606741573,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/C"
+    },
+    {
+      "taskId": "2dc7a819-5eea-4a1a-849c-537de36e002d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3111111111111111,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "88c1b96b-a949-4904-bc07-805f1263718a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30588235294117644,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/D"
+    },
+    {
+      "taskId": "b38fe6ec-f420-4657-a1e1-e2a51bc8cb67",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.22857142857142856,
+        "llm_judge": 1
+      },
+      "category": "Game/candy_crush/B"
+    },
+    {
+      "taskId": "fc6c1040-2e40-480b-babf-86c9a6e0929d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6153846153846154,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "6330bc03-450b-4d85-a8b8-886b6e752754",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "51179306-c766-4e93-a7ad-0fb682686d80",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2105263157894737,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "f6d5ae5c-02af-4d98-8b48-a47f03506f35",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7894736842105263,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "93f9604b-413c-4777-b10b-5c3bdbc84649",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "af39282c-a7fc-4666-916c-ad0e906a8ae0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38620689655172413,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "873931a4-3b4f-47a6-ac50-2992a573dc36",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4571428571428571,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "74bce77a-edc0-41af-9c5f-9a2119a2e4f7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.463768115942029,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "9a332769-4576-4f4f-add5-0585013e984f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "c1189d9d-18b8-4e6a-a5ac-d8b784aa832b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "27ce2cb2-c882-4964-ac41-4422cc803696",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6736842105263158,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "52f81205-b42f-4078-a78b-6147ac610451",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "7b39270f-166c-4050-bcf4-cb41838d7d42",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2285714285714286,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "a05f35e3-c2b5-4c21-bc36-77ef9ba34cba",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "faa23323-e67f-4663-8b8b-77aaaf51397e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.970873786407767,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "9a2efd05-37b2-417a-bc56-0560b71d0aee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7894736842105263,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "14628b1d-e1f8-48e3-b456-6244d90f9653",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5964912280701754,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "0e6cc419-7810-499e-8116-a08ac475a967",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46666666666666673,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ecb901c9-1597-471f-bf07-fe28fe529413",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3888888888888889,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "b2072819-348d-46d2-a846-830017babcbe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4166666666666667,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "1b6ea9b5-0f75-44c2-b9d0-f0db62897bd2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5853658536585366,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "6c8d1c36-d5f3-439e-afca-920c7e098f5c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "7d2d7f86-0bbc-4352-b697-e90cf0b6e225",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.625,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "34977b2c-512d-4efe-86ee-d36b71471669",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "e38a505e-ca39-4b94-a739-ba16941ef8d4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "66e78c45-5287-4242-938f-b1b971977270",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6197183098591549,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "67bbcdbf-f039-4b71-b9c9-f26f89f44a60",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9776119402985075,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "92838642-c718-407c-a0af-a8f3c70c534b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5483870967741935,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "73aae7c1-34d6-4367-8c15-7b1ffe7c7346",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7894736842105263,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "09a8a358-0470-4b02-bb33-859395ad615b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4901960784313726,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "b182c4a1-2670-4250-a069-186efd5a0251",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "cd01722e-a839-4bc4-91fb-e42ed12a3ed8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4848484848484849,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "603fa4d1-0a3b-4da4-a784-40824fbe2fe8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "52a1ee58-929e-4194-85ad-1fa54131c2e4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.613861386138614,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "d61ad830-9e0f-4b65-a9be-086f818c0a64",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.625,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "1c951a2b-6a70-48bd-a120-7564abfcfb5f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7567567567567568,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "044630dc-2132-4e95-ae79-5069ebd7ae30",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "247b08d0-4ffa-492d-8072-0819188eb4ca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.64,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "a1f6f4c5-638c-4845-9a98-33f0a47f4b02",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9662921348314606,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "9fc40559-8b90-4807-92f1-0679b41ac55c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5833333333333334,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "59503989-e831-4654-b5f5-b0ef2784c4a0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6197183098591549,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "986ce5ec-a2de-4840-8f00-0635ec6c5957",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5652173913043478,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "9ebd5463-3010-4d67-b0d1-79d25eba0b7f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6138613861386139,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "c26ba34d-bd1c-4c28-99bb-3551a808ce7a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5294117647058824,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "5b999631-02ae-4f10-a321-1cd1dff9de85",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "474c575b-9ff7-4c41-bc52-741752e619bc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5853658536585366,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "e0e44b68-a0ae-4e52-b264-21a0d08dbb74",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4406779661016949,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "6b1f5af8-0e77-47d3-b21e-f8b902c4f30a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "32f06f9e-4e6d-4eab-ac5e-3d8988cbf7f7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6206896551724138,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "3a8dc3bf-dedf-4a5e-9cad-2658dafb981d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6373626373626373,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "4cd9e8ef-f07d-4b37-b0da-427d556104ac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9817073170731708,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "51a13dd0-f7f2-4599-b920-dedcf31fcd17",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5806451612903226,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "fe2ea95d-de53-42cf-b7f8-3cba32841589",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6315789473684211,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "4f7e3571-22c8-4ce7-84b2-e2a2a98e183f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5473684210526316,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "3be135ca-fb9a-4cee-91d2-85574760ae4d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3513513513513514,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "f80ad48f-eb29-4dfe-a9ae-b395cf2b8be2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ba821565-a1a4-44f2-bd42-2ecc7350f3c3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5853658536585366,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "1072964d-7dc9-4bae-8964-3c812523ca33",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "888665ce-7073-4c3f-af5c-b44d1afa4096",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.625,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "98a34a75-739b-4779-ae64-5c6865b997ae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "14a6e595-c545-4e60-8f4f-1338fa8a5163",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6538461538461537,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "5191f62b-07f9-470e-8923-3ae5faf34871",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9797297297297297,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "c838f564-d765-4783-bbdc-92c902588607",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5483870967741935,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "d2155a5f-c30a-4c85-b7b5-285426832f96",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.523076923076923,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ba7bb75f-04a2-46bc-9e80-90ae70384ebf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4421052631578948,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ad219e6b-c759-4420-8a04-67937bac84ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25641025641025644,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "163b459e-fda3-4cad-aa31-b9ce0f15f515",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "10525451-d6da-4c7d-8e56-0d7d6980f957",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.463768115942029,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "96378aca-b335-42de-b713-8822c916675c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "3cb16436-7f47-40d3-9f58-a3e494decf51",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "5a62b1b9-92fc-44f4-b6ba-99dcf86e5c5c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4210526315789474,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "766c4950-2cf1-4b9b-8691-093c81fb342d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "ecdde672-81b8-441e-9acb-eeb134f8ca77",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "4c507e67-110c-4698-adfd-346485a429b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.608695652173913,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "264fdfb3-b8cc-4ae5-b536-d9e8b36e2d0e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9776119402985075,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "7109a278-0ae9-4543-b406-4743cf3f53fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5000000000000001,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "69703c4e-1141-43eb-ae0f-b404fcbf8d83",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "1b0f878e-4c25-4362-803c-f95264e4f9b6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6363636363636364,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "961249b0-4f68-48ec-9997-e67ad634276f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "e2b76cf1-5a9f-444e-9ad2-18c74778dd47",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5416666666666667,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "cc22a5e0-301a-426f-921d-61f91a05335b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "d61c5ce1-5638-4c07-a3a3-290a7834a7ad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35789473684210527,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "8542a889-4afb-4986-8e41-0127f84cc493",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5491803278688525,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "3997f6f9-e194-4380-bfdb-28e78652edd1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "fff89e58-664e-486c-9d33-9e7fb4d01fb6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "13eb5835-8b0b-402a-bfcc-d2bf29e58151",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6292134831460674,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "adbea31d-26e1-4184-8e71-1d7cafb2f4a0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32558139534883723,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "0d85a441-3cd7-405c-ad96-c841778f1f57",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9765625,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "701de2e3-cf0c-4b49-84d0-13d9b76b597d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5569620253164557,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "b6c8b47e-ff2b-4dde-b361-cd2b4d436e75",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3620689655172414,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "cc9240d8-1644-40b3-b166-f14917fe6ca2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.49206349206349204,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "d3ed416e-c97c-4333-a473-46b346142cee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6285714285714286,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "02423549-fcb9-4bd4-89b1-0114d940df11",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5585585585585586,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "f59b151a-b04a-4365-bb6a-c84f835c1596",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "0f6dbad9-48e4-433d-8a48-94488759f9a0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "320b14b3-bd4f-4cd1-a1ae-92adaaad7da0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "ad0a5c6f-445a-4461-9550-8f7cf20e64f3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "fc825fd5-c60c-46e5-923b-5bb0b4982d7e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3018867924528302,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "a7d187e8-f7d8-48b5-91fc-cfd51189c75a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9732142857142857,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "e6f373bc-1b8a-471b-8307-b7c5d3936559",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45333333333333337,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "45c182a3-a68c-4e09-8c11-428fda623331",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7547169811320755,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "eeac3802-c43a-4aa5-9e98-54ed044badd4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "129a0e29-a6e7-434d-90ae-85359f5e9c8b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5151515151515151,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "3c999295-3be0-45f2-b668-d62617d5e12c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "0c494f28-852b-4d70-a1e0-b7518d6cd8f7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "aae4afad-7b33-45a0-8e56-b99618fa815f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5060240963855421,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "cfa7d670-910d-4dde-a8cd-73e2e2f63ce4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6056338028169014,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "1497a560-dc42-4a25-8bd9-4d0a61c56bfe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "6509a68d-9024-4c10-a005-bf607437c7c4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5416666666666667,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "6adc16ac-0d10-4aa2-8386-e320b4059142",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6373626373626373,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "26ee33fa-be91-4b80-9060-05c6cf5f04b3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9647058823529412,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "10f8681c-9066-413a-a685-afd8ab2fb24f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4950495049504951,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "99c4ecc0-0516-4276-9f0d-ca41e6f6ec0c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "800a5135-47ba-4040-8c70-4719a53d1482",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43396226415094336,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "305713ea-cd22-4368-b1ec-b7a00b25c417",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "faac9d4e-c682-4298-9fd6-d7f6c6ebb84b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5416666666666667,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "e40e00d7-791c-47fe-bf26-cbec18be632e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "261d8292-5f2a-459d-bf5d-1f9ee8c52785",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "1d05534d-649c-4b59-88fa-c7889be27dc7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5176470588235293,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "e9e54e87-2bb1-4995-af0f-d397f943e323",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "bcaba2e3-051c-47bc-b520-4f27d00de534",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "32487937-2976-4ace-9e7d-7d0c267015cc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6470588235294118,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "277db06e-0528-43d1-9298-7ea9d68dc7bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5846153846153846,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "bd06afef-321e-48c2-bb94-3f0422802f1b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9784172661870503,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "aeab42b8-7219-4e8a-838c-2bbe9b7dc320",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.40540540540540543,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "fa55939e-189d-4f24-9356-0b927c409e52",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6197183098591549,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "1df8abaa-0582-4d9a-83b6-309df14d1621",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5142857142857142,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "4d01f6f1-41fc-48d4-adef-a63ff3a5e6bc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4166666666666667,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "1b40d1ae-b11f-410a-99b7-5dda7127e316",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2352941176470588,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "ab7e2847-a650-4d7b-83e1-b6bfdcdff11a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "8d4b9b1b-a76d-42ff-a2d4-318826922a56",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47222222222222215,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "bc92555f-b6a8-4f14-ba11-7747ce1f893f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "fc923dbf-f32d-44a3-a609-43b0b26392aa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "a9db5008-6c51-4806-bdf8-279c340742bc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5499999999999999,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "be20d6cf-7038-4f75-b04f-0106c1499a92",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5531914893617021,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "83305f37-7227-42e8-aef1-3c828a340b61",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "8152c23e-31fd-4ed3-bccc-e7fd6b599587",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5494505494505494,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "14fb3f17-cd71-417b-ba4c-721e48b2f705",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43750000000000006,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "a7362d9a-5272-4e02-9cb3-569d77b9d5bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5166666666666667,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "3a9090d1-b93b-4a04-9b2c-f49bdaad0002",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.43589743589743585,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "993a20d8-28fb-4f41-8182-c32e5f190e6d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ba401a09-43fa-4e44-b664-637fa7d1fbfd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6024096385542168,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "349d9d9d-f050-4c94-84b1-e3e654ea5311",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5190839694656488,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "f88027d0-8e28-4710-8bc4-5cd7f2ebd2c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7567567567567568,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "16410a4f-3ebd-4734-9576-63c44b4721fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "a0affd72-0de3-485d-87b4-7b19a0569faa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.18604651162790695,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "b909cc8f-cd92-4b50-a156-ca29a4ae39d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9693877551020408,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "7ab86c9f-d511-4ef1-bc3a-fd946ec31ff8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5526315789473684,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "e4b72ca3-5b9a-44cd-9cd8-eb296e31ef0a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.626865671641791,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "48e2c95a-3110-4d18-b793-5e64052e7049",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5499999999999999,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "03660ea1-339f-4cfd-81b6-47cebb421c43",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "a1d5d2fd-eddb-4933-8e70-9a9ebc06d617",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41935483870967744,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "9c0cc505-11d3-4ec0-9375-118478b11561",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "6eaa7e1d-b248-48c0-b7e8-044d86f02225",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "7d57ac01-52d1-4adb-bb94-1355143e4d49",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6037735849056605,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "91f91476-4021-43cc-8706-8d3376f06ecd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "b6b58345-4e5f-4855-a03e-754b209074d9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.45714285714285713,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "5e63b5aa-7608-4e5e-8129-624e17cf1a8d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6117647058823529,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "1a4c2025-4fe0-4e36-a452-5c2314d47175",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9659090909090909,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "1b2c7f9a-fa94-4e5a-927e-9b68c06d552b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "7a932a81-3f66-441f-b79d-203c8e5c12b6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "0178b17c-0f76-4d7b-9d99-84b110e6b399",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "d40d868b-3e55-4579-827a-05efb73142d1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45871559633027525,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "dc68b189-81c0-4abe-bead-09ae7fe37442",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.490566037735849,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "6c3774bf-a71e-46c5-8a90-11d72091fb7c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "e805c186-b91c-431b-9d69-db9df6a72093",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6024096385542168,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "84177ba2-6c07-49cb-87d0-c1f270661845",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6021505376344086,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "d4b2cbac-b1ce-4ade-b03a-9c6faa1a19fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "f26241b7-06ab-4347-be5d-00c4f0258bd4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5423728813559322,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "df0cdd62-a8d6-4d9e-9de8-40d7601f0bd0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "d96df415-0780-49c7-b1de-da9cfa8a4490",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9705882352941176,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "79c42e0f-78f9-4fc6-b4c5-0ab23ab82f69",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6216216216216216,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "905bb60a-4f73-457b-a61f-2df0b5917bac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7096774193548386,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "a47061d8-fb0f-4957-b1d5-6d567e005f33",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "43ef1560-d3f9-4a6a-b2f6-99ef958739f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5531914893617021,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "c034c9bd-5b2e-48b2-a891-a61ed09c7554",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "b346cbe6-abb3-4e3b-86aa-1a0726a0767b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "b9ef6ea6-f08e-4bd1-877a-664a23d6d8e2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4230769230769231,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "c538b4e5-45f2-48ad-80dd-51896a8bd31d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32432432432432434,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "8d6ce8d6-b1e3-4d78-b601-fa3b10e47152",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "fac0f6e8-7cc3-4f16-96e9-8af540a77674",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5909090909090909,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "66a751e2-9b20-4f5a-971e-d20375c698e2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6538461538461537,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "4f5977aa-be7b-4634-9e86-ffabc4343d1b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.970873786407767,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "bb32983e-2508-432e-984d-ae4cecb7bcd3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7058823529411764,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "5dbd23a7-1c86-47cc-896f-521379e6a1fc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "54f8a26c-322f-4f3c-95bf-dc19b0d2246e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41379310344827586,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "0da8611c-0f44-4e96-a4d8-f3a627b3681f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "fd0dc980-06b5-4432-b6ff-200c727e6cbd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40384615384615385,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "15ca01ea-2ea1-4f2c-9efd-90021f768835",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5925925925925926,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "02d78cbc-bc50-48b2-b35f-12ce2b6119e2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5833333333333334,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "267ac829-e6b3-4def-9ffe-88557c747de2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "59b4f50d-2e4d-4d34-a34b-fc226693bd90",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "f30ab020-642c-4629-b684-76f88e2ebd2a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "bef71e36-5baa-451b-9d56-aee53387c477",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "2e4e9ef4-2523-4f4d-9a03-82bfc5a84e3e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5199999999999999,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "68dceed9-1cc7-4766-83ff-4461e6d45af2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9600000000000001,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "675232ba-7751-4946-9a51-5111c127b321",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47191011235955055,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "69b80ece-0d5d-46eb-8433-9a88f504b875",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5432098765432098,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "8f2d87fc-a1b0-47b1-befd-f7a418698cee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41904761904761906,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "69d5e706-38a5-4316-81f4-fcf7a54d3eb5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "0d398a8a-3b65-4463-8e72-011176973c77",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "6e9689d7-9440-4b58-b5e1-1bad18d6a8fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "5371fb9b-c6a3-4d73-bcb5-588c9561ea3c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5925925925925926,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "6296efb1-2e42-41cd-8255-7e89ac09feee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "4d99691a-f8f4-42bb-8ffe-d61d4fd1d652",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5652173913043478,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "8aeb8683-415f-4207-a80b-0ec19e3f3f18",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "576baece-441e-4d66-996c-564a1c2788c7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.958904109589041,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "81936854-1ab7-4e04-a8cb-3549a10bd38f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5783132530120482,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "c1bccee2-d3ff-4285-9e32-37c5190c85c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5194805194805195,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "b0c85971-2c8c-428c-aff8-839b35ae3792",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.48214285714285715,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "18154671-4bab-436c-80d3-ff7a307a982b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "95c9f8e1-bf89-4864-a425-2c8c02cd2273",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.689655172413793,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "576c619f-6b6f-4135-a92d-33326880f0f6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "82b0ff55-5fe4-4a5d-8945-d32764141f76",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5060240963855421,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "2df57c8c-7866-468f-8122-e1522aa28360",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49315068493150693,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "92605f6a-2c87-488f-96e0-44476b452dee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "5ccfdc22-2048-4156-af48-2614bf09ec03",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6363636363636364,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "0467ce51-017c-4f70-a214-e57a5bbfdcac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6470588235294118,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "a239d7ff-55e6-4785-8feb-3a932bf936bb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.970873786407767,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "212be2a3-4704-4cb9-9931-c8739ec213ac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "d347f666-b627-41be-b19d-09e2baaa52b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "7ac812fc-6684-4c15-99bb-b70bc204db02",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6153846153846154,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "895acbc0-2573-4ce1-a490-2241ee24853d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4912280701754386,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ccb29352-2bc8-4cf6-a6a0-7ec541453087",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5151515151515151,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "5f117f28-538e-4a5e-9487-6a8ed561d2fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "3547ad9d-eb6e-4bc5-9779-564d8165b164",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "da6a0eda-0e68-46d4-a164-b7c8d911b0e6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4705882352941177,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "3eecf435-996c-433e-8130-9821f829a3fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7659574468085107,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "d93a7890-47d5-4a92-9af5-5cd1bdde204e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5833333333333334,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "917ca6d3-33cf-476e-9776-d0904d68f57f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5555555555555555,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "bacd7b8f-7d51-4fe7-8d0d-2bc80058e57e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9827586206896551,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "b4af18a8-cd74-4618-9000-de9d91020877",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7894736842105263,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "b6b5cd73-abec-4459-b77e-581144648c61",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6206896551724138,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "1be5305f-01c4-4af0-85e5-bd4e36657f1d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "78e11146-9e07-49d5-82ac-27663f97b466",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "0da410b9-6de3-41d5-b13a-cc2d34dd8633",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "4df46730-fa87-4638-9933-da1ad8f424f0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "0b3628d0-919d-49c2-a9b7-b1345a309c40",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.576271186440678,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "d831bde1-9f91-4988-be5f-1544768290d4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.783625730994152,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "7f17dee5-dccb-47fe-8f42-07ef80403797",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "d326a924-73d4-4376-aa2a-060551c31a0f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5862068965517242,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "5797ff13-699b-486a-88c0-d4d43154b275",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6451612903225806,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "852346b1-38fd-488d-ab20-7d8c54985ac4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9868421052631579,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "709e7d61-db97-4b28-8cca-dc0e3e191298",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "99a0f796-df10-4a18-90e7-8f05c309fab1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "4b2a1323-1f7a-41d4-bad6-f6db6bad3b4b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4528301886792453,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ef2cb9c0-d14f-4b5b-b5af-96aae0fa13e2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6571428571428571,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "100a4c73-b49d-40a1-8f39-3f720f679462",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6250000000000001,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "d9a4667e-2577-4fe1-aebb-c4bb51daf21a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4375,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "082a336c-5b81-49be-9791-2e81bea77fd6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.423076923076923,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "bdb415a9-3512-4a85-9d69-61215d3fc231",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.6075949367088608,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "ba07b305-dc42-4e01-a571-df4e4e2620bf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "68f88975-6c2e-463c-8bfc-9db91d152445",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5882352941176471,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "f354f410-770d-4367-8ba7-39d7eb04ac49",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "9b06e0ad-cf29-4a43-9c22-2f06ee672664",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9693877551020408,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "9dd7dc4e-e3cc-4ac4-9831-d1628cdaba4f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3018867924528302,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "34d5121b-e4e4-4478-9917-078c564b358d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5287356321839081,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "b597dbeb-9adf-43e3-b4e1-08c1e8c28a84",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "8b265e63-8183-4afb-86d7-07aa5016b437",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5517241379310346,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "dca296c0-0955-4ab6-b8ee-68d17465ffeb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7894736842105263,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "6ef1ea68-ea35-45d0-a40c-a940368d58b3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6956521739130435,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "609c5a84-66f8-4377-88da-bae0f712f0a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "462607e0-ae8c-4c33-8717-cf3079a99c17",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2285714285714286,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "4d1187d5-e4df-4abb-b79d-2778190e8323",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3636363636363637,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "73347e68-714d-4b0d-adc5-b7b50c07bfcf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3111111111111111,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "a078e4bf-78d8-46ed-b6b0-ebfc97916325",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6117647058823529,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "f2e30bd3-d4c2-4ab9-b52e-2d5f258471f2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9787234042553191,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "b2f795fa-4420-441d-a718-6e3fa4e46182",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5476190476190476,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "9a00ce92-ee8d-4c7c-86c4-10a5410b29c9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7307692307692307,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "8e9f46ae-6bfb-4952-9691-d6bf8a87bd91",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "feb28fff-c1e6-4f65-a8e0-3de4c999a099",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "18751c5c-56a4-4af2-a213-402998a32d14",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "36efeb96-2711-4cfd-ac54-c9e08cf412b6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "b278db14-253d-44fb-a77b-f980c0944de1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43478260869565216,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "37c83959-e868-463c-8bf3-4c3f45dec2e3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3544303797468354,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "e58ad1b6-5595-4eac-ad3a-381f5396ca2a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5797101449275363,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "530872ca-5c30-426f-8ba5-4155d3bba970",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5294117647058824,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "60d58b2b-c899-4fc1-a2c6-0c5b15feea36",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5846153846153846,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "d2c3d090-f1b6-446c-ac4c-05d3c44f9c21",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9747899159663865,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "5f7d795b-15a4-4ccf-ba21-4a86105bd28a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5614035087719299,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "f400c7d7-4b69-4c0e-af4e-815d44721d3a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.55,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "5bbb8ca8-64ef-4eb4-bb98-e846a6707fb6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5499999999999999,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "b077a360-09f4-44c3-9577-e9827de43904",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "36f1fe1a-4afd-4c25-a039-5f0673ee3313",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48148148148148157,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "08a23e6c-480d-4801-b007-869c2101f57c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "a681ab54-c6f9-4123-85c5-4ed0ad9360cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "32e6e7a6-0113-487a-94e3-812bb48fd00d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28169014084507044,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "0eaa5296-a1a1-4968-af39-1c7f927f4429",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "703562a3-6c61-4b19-a6ef-57be5fbf73a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6206896551724138,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "83a18678-3ae0-4e48-b607-e21a1571c137",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6153846153846154,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "c5863dd8-fddc-42a9-9be2-4723e9d21cda",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9651162790697675,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "00ed9476-3159-4458-8119-2bc1a7bf37c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4266666666666667,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "b0661e97-e5a4-499b-ba11-fd3a6a67aeb2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "9ccbe9a1-ec8f-43eb-b7df-60fcb67865e4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.34782608695652173,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "173cb03b-6812-4deb-915a-00f4c68e2900",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4705882352941176,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "28183c4a-dbfb-41c1-a9da-c27f71c7fb59",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4117647058823529,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ff726ad8-617f-44a6-b945-7324d59c04eb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5517241379310346,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "c8b3afe8-f718-40ad-b895-ec0c5209e848",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3846153846153846,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "734f4d61-6e3d-4e7e-bf70-32ab08a2b852",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7567567567567568,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "b56d823d-83b8-4703-9525-273a8f1ade31",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "630a030b-824d-40e0-9928-060458bdfc4b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6153846153846154,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "8aeba47b-f8a7-4aba-9f58-06376f578145",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "a5584037-5fa9-4873-a7bd-d711ac4ef05a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.975,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "cbe6aee0-d5f0-42e7-a4b5-475b3819aabc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5945945945945946,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "9e35458b-a629-42bd-84ba-b08bcac06c0c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5411764705882354,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "f80537ad-b9dc-4ed7-a6d7-cb2bd5030bb7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.547008547008547,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "6fdea6af-9383-4450-9914-b303abd7872d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3870967741935483,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "6a609b9c-c621-49af-adef-d6184235283b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "b868e3df-4395-498f-a371-addab9f9a474",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "be44c2b6-6f89-4731-97e2-a3fc0ccaec0c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2641509433962264,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "72ea951b-a010-4d89-8281-7d3ea781a21f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "07802d30-8706-46e4-b774-e7be3d049353",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "c6429988-ffbe-4cd2-926e-0ee7a6308dfb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "cf33258a-0011-4985-99f5-1009fba0fe0e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6470588235294118,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "222c4613-da03-40af-9f10-30b08f75329b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9651162790697675,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "3a411752-f29d-4a83-a559-c0d71b4bd7f4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4657534246575343,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "eaf41d0c-f65d-43be-ab48-28b62de2c13e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "c60629c6-33f7-4a74-8e68-faeef0e82409",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.49541284403669716,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "19c7e481-9133-45ce-aad8-6373fc01a12e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "782d3741-e938-400a-8b90-693bbfeb2447",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5925925925925926,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "bf67af84-f211-4451-b554-3a721e736e3c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5585585585585586,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "93219bbc-91b3-43c9-86e8-58070c81ef01",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3636363636363636,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "a24cb155-4f0a-40d7-b1c3-d72930e5e8b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "fc22257b-caac-493a-bd8a-02a3e87540ca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "b67415d5-4122-47df-8544-fa4f9369b2a8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "ea66b7a0-01ab-48a4-a7c8-aa61faccce6f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5294117647058824,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "26a45fac-91fe-4ec3-a4ac-a0fbd4ea7ec1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.64,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "dafabd0a-fb7b-45a8-9a33-99e1463d625c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.980891719745223,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "59168a08-0d28-4fe2-a2f6-77c05edf48a5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5079365079365079,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "c6732dc1-62d3-4b61-9c4c-900db14294c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5625000000000001,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "d856540e-0c91-4664-a52c-4662c3e51c4c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3255813953488372,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "450c44ed-4e05-4104-9fce-bcecc5bdd7e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "8cfeff58-1b5a-490b-98a8-c312d4d1bbb4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5416666666666667,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "5cbb8081-562e-45b5-8cf9-7fee1b6596bc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "54befef1-e12d-4956-b166-4f2c1a6af154",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6474820143884892,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "9aa80ab1-4f46-461d-b617-6c2fd9206bca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "929aea25-d85d-42a2-9d0e-dea1d4e5b10c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "5d625323-285e-492c-8454-041b582b4512",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6153846153846154,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "92ace100-d29a-4208-94ee-6a6847b44b4f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9806451612903226,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "8e229c55-82e3-4ec6-bb3c-e9440e970cf6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5148514851485149,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "d4d60f61-c626-49de-bec3-d5fb268db489",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.42500000000000004,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "2e0256bb-ea18-4e55-8dc0-82ef4ad8c096",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5535714285714286,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "418eec30-e028-40e5-bbe5-ff03a8dc4ce7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6285714285714286,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "17606319-ef7c-47cb-82db-08f65e776f4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48275862068965514,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "060fa2b3-bda5-472a-b2e7-ec3cf3fa2bbf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "974d04bf-e63f-438a-aee2-048c57aef93c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37500000000000006,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "738ebeae-d580-40a3-9be4-90cb9405e5bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7567567567567568,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "c1dd759c-b8d9-473b-a9a9-87a364151b3e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "85c20fb9-9626-4bba-9031-9b7abd938fb0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30303030303030304,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "67ee8408-f93b-497c-ba4a-5244826c26d6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6086956521739131,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "49535101-294a-46a2-b42f-3c26087f4b3d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9872340425531915,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "05db6654-e420-4b7d-a19d-d6001e56ca7d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6315789473684211,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/A"
+    },
+    {
+      "taskId": "be2f102f-e8ce-4f9e-b736-1755201bfdb8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5483870967741935,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ac63efaa-7f13-4d6b-9159-b6c3dadcca7e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5316455696202531,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "ee63d4e0-8d45-4f31-8298-5c5774d7b7c9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/B"
+    },
+    {
+      "taskId": "81ab9300-5296-4b25-b2cd-fb006556213c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6593406593406594,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "a791631b-c990-4fb9-9651-03a1cce6cde8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6285714285714286,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "879a085f-a72e-48c7-a641-124d52e26202",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5652173913043478,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/C"
+    },
+    {
+      "taskId": "149fd630-5f04-47eb-9037-77bd3568f5eb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5543478260869564,
+        "llm_judge": 0
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "cf82cfc4-35f4-4e5e-9540-2a37c02668fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "EMBODIED_AI/alfworld/D"
+    },
+    {
+      "taskId": "25dbb640-735c-4430-beb2-c92bc5a7e17f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "4b312724-00a3-4ade-8035-7f7d8570fc5e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9411764705882353,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "e77addb3-d800-4dde-b5f4-229cf534ea5d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "822418b6-5a3c-48e3-b3fb-111e5183f0e1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4406779661016949,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "e2f7f47e-e42a-4ab7-a5ef-37ed2dd43d9d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37209302325581395,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "259e4421-a1ce-40d8-8092-3b9d29f8f44a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "9124e409-bbc3-4cc0-8d97-ea18f43547d1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "3baf653e-ef33-4291-944b-75d25900fe5c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "c981b030-3462-4ec9-aba0-ce2bc5e1af4a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "c7782358-efac-4ebb-b91b-daf1a107fdc7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "cda547e9-eb0d-43dc-8f58-d5f5b34f52f2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29107981220657275,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "9a203eea-a31a-4856-a4fd-73db54b2e703",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3865546218487395,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "bde8c8c3-349f-4229-b7f7-4491f1979281",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21428571428571427,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "127ac8e4-2a15-456b-9e14-b68954de9522",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "508bec07-512f-4673-add6-0ca48ec1e292",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "aec35e1d-235d-4c35-9c07-5c7a2bcfcc0a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6428571428571429,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "7d21900d-a1a6-4fa8-80b6-cd8b7d36c8c3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.20224719101123598,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "26d33f4a-2079-4672-b7c1-b6c332d8453d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.11764705882352941,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "f0915ae3-b880-419a-ac8a-8516a92da5af",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "c98b7cef-500b-4d83-9efe-570d1e5d94f0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.09523809523809523,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "1555d0ae-e53b-47e1-9dc6-c403583bcd18",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "8b1b6adf-c7e9-44e4-bba6-94a30809e7fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4210526315789474,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "6177f643-3d3c-4f29-a341-0c859fc7e1da",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "f5f6a522-201b-475d-a19d-e18d7793267d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3619047619047619,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "8496b78e-194b-4516-9fbd-ab853c7f55b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "121b63c6-c5d1-414d-b24f-21b739b15ccc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "c1bf9b8c-4faf-4887-bad8-7cce8fec0b9f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "cfffc11e-6fab-4f99-b1aa-324e9d0e528b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "90fcd774-8132-4043-8d56-7a70c98da63d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15686274509803919,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "81fc1393-b675-4ac7-9f36-ae51c623f929",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "bbc29bf3-925e-4ef7-824a-690ce616ed80",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "8fdf4e57-ebe1-4dae-ad94-e8bfa1f6d82d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "7f8d7542-1fc5-4133-9db1-e0df0ee07e45",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "3bee4a5e-6d30-4d9f-8d0c-02efb900e62d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "d9fac628-276f-4241-b7c3-013e1c40bb1c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.37722419928825623,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "5c9ae1c4-a904-4c5a-a095-85d90064aaa4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2790697674418604,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "b799272f-fb32-403d-9e59-5f7605da0c7e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "2343b48b-0394-4742-996a-60152c3a29a9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4782608695652174,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "61a15404-e6b4-4f6e-b197-19cd0cef37cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3783783783783784,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "0ba9d949-6044-4325-b22f-70a2447b6dbe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "a78a5b11-746e-4846-85f9-8fa896abd6e0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45161290322580644,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "e95591a7-64f0-4547-860f-b4c66c7cc13e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37499999999999994,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "03f9396f-319f-447e-b331-c3795cd9388f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "3b54e184-df4e-4c61-988b-16f08d50e925",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "cf4c70f6-8827-4377-a892-435d7edbb36d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "3b2cd8f8-7c85-4407-aab3-42090f8b0bc9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "c54aee19-df24-4ff7-bef0-fcf008f3a075",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.425531914893617,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "6b0e37a7-568f-4669-aa30-1f021aea6eef",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5070422535211268,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "6b3b4520-906e-45a7-8e6f-cb06bfe0a5b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "88dabc73-372f-4a1c-a4b7-c7ddea6e6ffa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2777777777777778,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "b8499bd0-da23-4b56-b889-0bcefeaff48c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.0625,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "39ce0025-0929-4e09-b901-bf15ba275f9b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "9dd552d7-7dea-4469-8464-5bb2b36f9779",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.22641509433962265,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "27222431-d282-467c-ab7e-353a878a7834",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24657534246575344,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "1003cad2-77b9-43c6-96f0-b4f9456b20b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "11153422-73ef-4dfe-9e0e-243a1b7f7344",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9473684210526316,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "2ab5169a-baec-4647-8c3b-7b4f3eb4db4d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7777777777777778,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "6783397e-c648-4a51-ae84-88e322c1c21f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "fe380414-58ee-4b56-be67-38b8f7b38ab3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.28019323671497587,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "98ba4462-cacb-4e75-801e-077156b59189",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5369127516778524,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "d85dd827-80d1-4fc3-addf-fcdffc06c31f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "434c9c5c-d7b7-4b4a-b98b-44f7ceb5ae2a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "4e0d5ab4-bd16-4c78-b5b2-e97bd26050ff",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "f4c70654-1575-4ec4-bda5-2a8517dd5059",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "cd562378-63fa-48fb-8597-11d5a0407411",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26086956521739124,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "042c5d1a-8be6-4474-9bc7-53cad9acb1be",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24242424242424246,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "5f8d45b2-7390-44bb-b275-6cf481605b2f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5454545454545455,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "e1ba25ab-b77b-46d8-828d-03a5814102fe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "1ff90be9-80cf-4253-be3e-975d233b4079",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "92ad0236-42a3-43e1-bed6-875093e4172b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "0b6c5930-e0c2-4ce4-b339-b0528fc6a424",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29565217391304344,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "e57ccaef-82a6-4a46-b71c-1eecc31ba9b9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4175824175824176,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "60e1a82e-40a0-44e2-93cd-d67033fd78bb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "e46bbded-d397-408e-91bc-96651a889d01",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17857142857142858,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "798fff54-47bd-4179-bb4f-9eadb0b779ae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "b4207b69-bceb-4521-9648-d858ec382823",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "7374ed39-b6c3-45cc-9bec-31275b8d2a30",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "9f34837c-134c-469f-8935-506962b9a4f9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "7865ec8b-0971-47ac-b0ed-5a840335a6c0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5405405405405405,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "9a1e1ab0-28bc-41d1-a8fc-c671d7c4c130",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7272727272727273,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "70b93e70-e9f2-4162-9ed7-cc261af1da4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5116279069767442,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "151f6916-6d08-4e44-b5c6-782d003fc52a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5217391304347827,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "fa226964-0005-48e9-aa0b-ec44607e3643",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34408602150537637,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "8bb1f0fb-1e6e-4f2b-a4fd-0ab2f18052e6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35714285714285715,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "af4bb42c-d56c-4913-8fe8-e6e526bf7ab1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "33de4e82-7944-4615-954e-4bd05b67ced6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "57ca5f13-15be-45fa-959a-dbd56d531a6b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16129032258064516,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "7db616ae-a975-4903-ae88-79d61523fc4c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "526fe8ea-7cd3-4467-97fa-672e1aaa6d4c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.09523809523809523,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "6918d4b0-e556-4492-926a-84cfea21c5fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.34146341463414637,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "c693c520-46ae-42dc-aea3-646dd2844d7f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "eace9e3d-0106-4255-979b-98681ba12d3f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "bb25cbc4-16d6-4551-b8c9-6d8f1b6c4d4d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "14106230-3512-4538-ae50-bbe00e1a3527",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "c65950fc-4cb8-47cf-b7cb-07fabfa9e5eb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3053435114503817,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "d91487f4-4743-45f5-b9ac-6fad52b0c874",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "15a16b66-1abe-4f23-9373-1137dac4c750",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "d999eb39-a7d3-498b-bd93-fe81b536654d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43478260869565216,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "f21d9be0-c25f-4b6f-a6c5-d73e620dc371",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "3f892d5c-6790-4dad-8126-fff6607fea02",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "9f94ec1b-b0e9-4584-b202-c09e44acaaf8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48484848484848486,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "0059d6cc-033c-47ca-ba9c-5c694815a5e1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "5583fd30-bf5c-4725-a0dc-c864d1d2daed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "5f9a1738-5958-47b1-bbd9-8bf587d5981f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "47182739-0e21-442f-8d12-94b36b4fcb05",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "121b98c0-e1cf-476c-9cd7-f28d05349e71",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "1ad96d45-fb3c-4fd9-99eb-99d5f984a6b6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.505050505050505,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "d1d9aa9e-967e-4228-847e-8d5bdb180f09",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2625,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "776fe962-1e86-45a2-844d-4424b24c9b71",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13793103448275865,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "245334ba-3a77-4e71-b232-3a48c7df56e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "98a80d34-be88-4fd3-b8ff-806f6f6bbeb4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.6363636363636364,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/A"
+    },
+    {
+      "taskId": "21c2ddef-6a71-40b0-876f-93f4c2e6e0d1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34567901234567905,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "8d11c9ea-df80-40ae-a862-5f07fba6f0ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28205128205128205,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "3dbdda83-fc13-43ec-a11f-4f7800d1bf2f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "5dbf24e0-2a7a-426f-a976-f84a91a615da",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/B"
+    },
+    {
+      "taskId": "0dc41b4a-fdef-4e8f-a3ad-de920ca7a520",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "1bffe2ee-31c7-451e-8f02-5a9ac0b71870",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "4dc1a84a-8f10-4b9f-b652-cb71c04d0fea",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.45454545454545453,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/C"
+    },
+    {
+      "taskId": "63772697-1044-4d82-8bcb-b56eced6fc3e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.31521739130434784,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "de3d18b5-7c11-4b43-bc3a-92bb20f093e5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46913580246913583,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level1/D"
+    },
+    {
+      "taskId": "71b51d1a-027b-467d-a80b-f56b416dadc4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "4dcc3ba8-9053-48f3-bc6a-36f6b0e87fe1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07017543859649124,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "87700ea6-1ded-4441-a040-594bc228452d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "91443c60-437d-4ed2-ac06-693e82a9f849",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.29411764705882354,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "a4930ea5-518e-4f02-9e28-4f459205ff0c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "90bba485-ad62-4fbb-adad-09500d313459",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24000000000000005,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "b7eff135-1bdc-4f8d-815d-1913a75da213",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4210526315789474,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "2584dc7a-f160-4d6b-b017-ac59f3c71b06",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "e175473e-f28e-44f2-8630-58dcfabc82e6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "f918e1bb-df29-41f9-b741-e7e1cdf0942d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "f75e7631-1278-4e74-a429-9edf72699c7f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3055555555555556,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "f2bb4756-aa63-4180-a37d-0d2896288a9b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13636363636363635,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "8e500cb1-66ad-489f-9f82-a399a6765a65",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "b08bf3e9-11d0-4bb2-8ba5-b471dc5e112e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2105263157894737,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "4dcf4b66-32f4-4af4-af87-e18284b4df20",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "ba334c24-24a0-4647-9f67-f0eb1b72ced1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5833333333333334,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "3282faf2-2705-4adc-870e-cbb93f1de41e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "2eaeb9aa-da2f-49e5-aed8-b248d8d8fb15",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7500000000000001,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "6642f1f0-4415-4c44-ad7c-69d91527142d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "125a1c3b-d97d-4f1f-b576-30e5bd78f004",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "08d55d05-0095-4011-8798-eee62d76b910",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "1af4a647-f7d9-4e09-8e37-885e17ab6e7f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "6198ea7e-cbb4-44e5-8ffe-20a4024ea643",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2698412698412698,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "f5f713ae-b63d-4aa1-9321-9708f51151cc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3236994219653179,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "e465644f-8d78-49f1-92fa-292e85ff4411",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2702702702702703,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "3ba34d7b-efb9-408d-86e1-716cf5ee0474",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "4ac29c6f-c539-49f7-8546-6f99d553219d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.19607843137254902,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "2ca5316b-4086-4197-9e73-766f75880e40",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "61d01250-18ad-4d90-8541-8827304371fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "9d747703-7c02-40ad-b3f2-853029d07e87",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2828282828282828,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "dd786cde-52fa-4e23-b92f-d44d2cb1caa0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "a6f282b9-d6ae-496e-82fc-cd91c956a218",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "8f49c5c8-ca3f-4db9-8d55-8a215c0173d0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3181818181818182,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "20fbfe24-9673-43c6-ab21-a345334f2875",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4166666666666667,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "92b40004-6f1c-4262-9a17-c3495f8a87ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3314917127071823,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "67b1f1a4-06de-4d0d-bc48-525ad00713aa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "dfd71a15-1b8b-4559-a807-28b2b3bc15ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5185185185185185,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "9ce8bbcc-49d5-4d45-84af-977e79ae1a90",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30000000000000004,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "cfa6ffb5-e7fc-41b5-aaca-d62f476f1549",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "a2a00cd0-328c-444b-a017-f41f49a4adaa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.19512195121951217,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "ea0a2d5a-0138-49b2-914d-230f3d1f06b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "0dcb6c42-6618-4390-bb38-89be969894ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3389830508474576,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "ce73d24a-ab12-4444-9e8d-6ec7e03ab24c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4090909090909091,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "a8ba8aaf-3e41-43ca-a74f-cabbc8522c6b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "060ed9d3-ac57-46d6-a5c2-f31584e9bc38",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2318840579710145,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "d385879b-f7c4-4135-a0b1-d150ed25a8e0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4888888888888889,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "808f2a4d-3c9f-4c89-aa84-e41719825550",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "b9c25d7e-5e5b-4ee6-946d-d5a942dcc9df",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3609022556390977,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "db477b48-c498-492c-9a84-7766f1691f18",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "ffc344d5-1fd1-45ee-bf71-8a0ad2015ae1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285713,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "d090ec57-29a5-48a3-8754-49a8dfe542a1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5263157894736842,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "0b71d9c0-c1e0-4222-bfe9-34538b33b1b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4067796610169491,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "96f0e286-d126-46cc-9ae7-fed0f60f4377",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4528301886792453,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "16cf96c6-bdcd-45ae-bb06-1802901f600c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4675324675324675,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "c58d962a-02f5-4d91-b214-fcd0161cd93a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20168067226890754,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "643c2135-a166-425f-9051-d3dd8295852d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333336,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "d81f67b1-e0a0-42e3-b1d7-c741809fb566",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25396825396825395,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "88a02824-6f34-450e-9109-37995603d6c7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.06666666666666667,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "32887e09-8353-4d43-8d00-3e754d88a951",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3095238095238095,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "488d093c-6b0a-435c-9a11-6f0ee551b93e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.23121387283236997,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "ba4e3175-dea6-4ed3-86eb-cbf0c3b73d1d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "582edb99-632d-450c-b539-992f060f8ea0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5263157894736842,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "7c7e5444-4683-42d6-9b75-61384e0d2208",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "7af745de-5101-4c6f-8afe-4b550732bde5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38095238095238104,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "da0dbb58-cad9-46ba-969c-414a7352f8ad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4727272727272728,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "523fef22-e0ae-4957-a9d1-d38904c53f1e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5263157894736842,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "cb16728c-5f7d-4fed-b69c-d1d805f25c3e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "43d28da0-01c4-4690-a13e-80c309ed6cbf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "ed4d2db0-b658-42f1-9742-53e3653ca85d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "204112cf-c5e8-49ce-9ed3-647caefc9da2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6363636363636365,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "05e340dc-191e-4db5-8e5e-44d0a181ea4c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3098591549295775,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "f9611fff-648c-4c71-b377-00426d21b46d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2641509433962264,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "84006d93-45f2-48b5-a35a-600ada365a27",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.11111111111111112,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "9dd5a707-e88d-48fc-83d7-9f5cd3e1f6b5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39473684210526316,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "fbdcbae3-b33f-455c-893e-e90e5661e17e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.05714285714285715,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "6d2cf47b-f4c5-4592-9438-69143f32ca34",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4482758620689655,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "f4b194ff-176a-463a-8255-99891a9e92d0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "4ef167e5-5b10-4364-bbd1-aeadc412f283",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26865671641791045,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "0b630b7c-78d5-4141-ace8-e6f5cc4c2c4d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "51a60d2d-37a6-429c-9ee8-33a494322336",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "db885146-3608-4538-bad3-0a2a3fb77082",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "5b025eaf-e85c-44ed-a1d2-a50d1c8aae0c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "75c600c2-8816-4259-9673-343e5c016988",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46153846153846156,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "fcdc8f29-16d1-43bf-bcec-32d050daf47c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "7c8d2c7e-97e4-48aa-a86d-d1b13b0a52da",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2807017543859649,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "fdc4dc72-1f4b-45e7-af06-3cd5cddd4690",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3214285714285714,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "b8995f6e-bcfb-469a-acbe-9b86909c27b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "9dc01a71-46b9-4e64-83d3-d084f11f4d33",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4324324324324324,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "b5951dd6-fa1a-4886-8cd0-af6445ec55c7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5128205128205129,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "0721cb92-7d03-4819-9ae2-799ac5d625d9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "349210d3-9c2d-48d3-b8ed-5217df458a08",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "de373325-22c7-40f0-8a07-177f95b0e341",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "fa87282e-8d7a-4cda-bb3e-53ce632789c1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "0e3467bf-87af-4951-8bcc-8a55ce4f59b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1212121212121212,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "ff768c59-0b58-4f0d-a27f-90bcc8ec8c04",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "da066ab6-c24a-4a0a-b169-e25c3e13d060",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14634146341463414,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "ee01f7d0-9ad3-424c-a19f-07c4b42cf77b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "388848f2-44f4-489c-b38f-2d19cff34525",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "cd2537c5-0224-4966-a348-761975c65de5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "5d4d5e49-c9e4-40e8-bf2f-fab7150127c7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "57dc4ee4-dda6-40cb-a034-048765863b2a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "db1a3a29-b1ff-4e8a-93c8-b2edd7a0448a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "912fc13f-98bb-4e35-8359-137abdc7d687",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4383561643835617,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "390aad51-0700-45b3-bea8-c58fec7d2f3c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.7692307692307692,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "f6c53689-87d9-4c79-a709-ee6bc569d982",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "2d470f65-cdc4-4e3f-9972-7cea03dc49a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "1cdb8d18-d082-402d-a490-a0110fd556ba",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32142857142857145,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "b28ef6d1-4aee-4cc0-bcff-c397ed7b9e3e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41739130434782606,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "d63a5e3f-4328-43ac-a586-2fb5794f8d95",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32258064516129037,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "841782a0-6476-4fdf-8d74-996d1e6456e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.6666666666666665,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "30b50136-adab-4ca1-a638-26b657601a6e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "5100f156-df15-4e69-9f39-4cf8493c660c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "d76e231f-a33b-479a-9dd1-88e9cd665c0b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3636363636363636,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "c4509ac1-bcbf-4a8a-bf44-3c2d7691a689",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "2589d369-1b89-4600-b238-86cb17d64f1e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "bedd12aa-8121-44a5-8954-b281193f0a86",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.923076923076923,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "e3af6609-839d-4d31-a29e-aaf099fa5d0e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "0ed4e8cf-ed83-4e51-97b1-26d93a0f8f6d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "aac0883a-8e94-44aa-8cdd-558aaa99ddc7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23711340206185566,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "de58e4b1-2ec3-43d2-aec9-df9c052f4aa1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27049180327868855,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "97009ed8-eb3f-47c5-a1a7-498ba50da513",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "caaf99d1-3125-4cfd-b697-70c6b9f7d3d1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "3b9b7398-6a9b-47a6-89ed-9c36e9971d23",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "71bc7e71-74ac-4cf6-92d8-42783f3e58b8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17391304347826086,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "da6ccdef-436e-4268-a943-e2c09371c490",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "716d3b19-e5df-44fd-8703-c5c19190cdaa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "69f4c2eb-9586-4374-986e-8800e8424883",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "5b7d9e7e-84f9-4954-9aca-af1b28841212",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "7f0cd872-35a1-4f78-8fc1-210f2753f521",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "14d4d5df-9e30-4acf-b73d-bbfddc079dd3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "44041df8-1ba1-4029-97b2-3589be17dd90",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2833333333333333,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "d117cd59-8c6b-45a0-9b31-27174836c52b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.272108843537415,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "2f5c3571-1962-4374-ba67-887b71bcfe8f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "12bc6de0-f562-4227-b8c2-913cf7e63846",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "4ffcfa05-ded7-46ac-abef-7425a691800e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.06451612903225806,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "b9f4d5b4-2d40-400d-8e66-7e9aca695ca4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "e3b08f04-ee72-40b5-991d-9f19a9ffa86a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "925f380d-d0e7-4a9c-9e63-e50af604b40b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "5b0214c1-2de7-4549-b2bc-e5d1f04d0d65",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "43710c13-aa17-4b65-9118-c4e7da08396d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "c9b3a73b-492b-44ad-b585-16233c993a32",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "9054e5fa-0f3b-49fd-8ba9-2d6328d19da8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "dc85137c-2b5a-44f0-9096-3e3c8f30424d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30508474576271183,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "dd07fe57-b2bc-4f16-aa40-d6cf5dee0a26",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3564356435643564,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "ac1af490-3106-4e5c-aa76-51fc21c6f983",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "a401c318-8af9-4e61-9d02-7cd19d5abd3e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3529411764705882,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "0848851b-a86c-4fb2-a315-a36583d67292",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32558139534883723,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "f41d95aa-588c-444f-a722-19484942e841",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2903225806451613,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "5cdfdb4a-371d-40e3-b7c2-64b38e3bdaf4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "8496e2bf-92cd-4be8-812d-d3f8c53b9a60",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25641025641025644,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "b5dce6c4-a2f1-4588-b1b5-1a1bb47f8159",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "b8574370-e8f5-4640-a9ac-482fac076ce9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09999999999999999,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "40e70661-1ef6-470d-b0c7-b15478506303",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8666666666666666,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "1794182c-f2f2-430d-b00d-837c6d20ba85",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14285714285714288,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "0b8c5d9d-b566-47b2-976b-645c89aa8a6a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.328125,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "15728927-d4fc-4d4f-8a09-83dd39fc7f86",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.20833333333333334,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "44dd051d-6c4c-4a82-9feb-08ee965ff83f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "6fae8bac-9650-4529-8721-0e4df1c557cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "d96eca42-5768-4cb0-a1b7-6de60e176c95",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "27c0a986-76ea-4578-852b-f33c85b9155a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "ae9dda2a-6eb2-494f-b43e-f44d59d9cee2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "9f53b16e-2e10-45ec-ae50-b692e54cdabd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "116df5ca-6fae-4daa-a29c-20b7201281f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24324324324324326,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "9cd134db-bc3a-4059-8cfd-17b707644cd3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5882352941176471,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "e35c9cbc-18fc-4a68-aca4-a0e3b37a0c1c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "e9f04cca-fdc1-4feb-b391-eecc7baffbd6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "4156043a-25ba-473d-be9f-7013b5973fa3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25531914893617025,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "161afa1e-049d-47fe-9292-944931c9cb1e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24806201550387597,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "a5e7574e-412b-4a76-843f-fe62463b75e9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "8d641797-ec24-4f3f-93eb-335964d6802b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "7762a05c-07a4-4a4d-8718-4c19e3fde6e2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.48,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "0fbe8cb7-9e46-4026-b043-161b6023080b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/A"
+    },
+    {
+      "taskId": "d8ca889e-7336-4afd-a1a1-1a110045f060",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5238095238095238,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "43824c11-c5bc-4208-94eb-2b22d8f0ef2b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "fa23dfe5-1b9a-4e35-805a-2202ff4fb97d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.375,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/B"
+    },
+    {
+      "taskId": "a1908455-1427-470d-abfb-26b07598402f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "cef498ee-4613-4b8c-a443-940855002f19",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "bb58b69b-9cb9-4eb8-8855-d23e8cb76243",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/C"
+    },
+    {
+      "taskId": "f07960c9-4a3a-463f-909b-369abbdb7ec9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.18749999999999997,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "b209841b-2147-435d-a738-f5c36049b5a2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38461538461538464,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level2/D"
+    },
+    {
+      "taskId": "0473b03a-0e7d-4396-8fd5-27bd5fa4e168",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "712518ee-7e19-4f25-a0ac-1237a7ea0dfd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "f156ba2e-4f84-4c6f-9b46-8e25bb2c7894",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27368421052631575,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "82f12d1b-2d76-4002-8558-284c2a7cb1c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "d0fa8c50-223c-463a-b393-ca6f78ea0076",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4210526315789473,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "61cd191b-c827-497f-927d-ac925a7c74a4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2790697674418604,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "8cd448fa-b75b-4199-9ef6-8d458a2ac8c4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47619047619047616,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "e3ab5a98-3dab-4027-b985-42506d4678c1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.10526315789473682,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "068414aa-e135-4636-acc7-e6604df69f33",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "b9393811-bc26-4239-b97d-8752c32b6e02",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "0fc3e148-999b-42a0-86a9-e75e55621d11",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "a8c837fd-5d40-4ed3-b668-45449d112bf9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27027027027027023,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "25758566-d05b-4cd7-a57e-f965cab0a32f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "642cfa07-868f-4dbe-8a34-17705def4436",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3846153846153846,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "f50f29c8-93c0-4a85-a4d8-6da78df204da",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3111111111111111,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "b4b03f4f-65c2-42ff-940d-fe56d55b30e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1935483870967742,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "90f27e6e-2ee2-41e7-bc66-a4bc4da1e71c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3846153846153846,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "be56c938-8028-4cbc-9ad8-7c284c164ceb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8888888888888888,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "65be8c31-c44c-4b8e-b36e-6aca83cbdfba",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "424984fd-5cf6-4362-949c-dc433b4fc283",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.923076923076923,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "0bb1e0df-9b5b-4f07-b15e-9f46aee918b5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "813fb6e1-88de-4ee2-85c3-35f3fc010c1c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "22667cf5-0027-4c4b-88c3-a5a86662a585",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3048780487804878,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "d4d71cf9-433b-44f6-97ad-e87b0bf6b9fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17699115044247787,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "57923971-02e4-45ae-ac8a-bf7311b29938",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5106382978723404,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "ca4434dd-8cff-4409-a873-84f4df95316f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "68cdc80d-b668-4a8b-a6f4-dd3a00adcde4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "a624fa55-2f19-4c75-bd3f-3ccf8863c3f3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "2c942322-6deb-4509-9339-a8b7d8b10cdf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32432432432432434,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "93ac0027-dfea-4eab-a458-7b16ff1e995e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4864864864864865,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "36d23525-d5f6-4b16-aa0d-bae310cda6d4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "0f90d3d7-198b-4c6d-8d4a-50f3d7c6d1e6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "1f46aeb0-d8e2-43b5-bcb9-c007eee8ad3b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333336,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "759cec46-c8ea-4478-81cb-e80289874766",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "41cb1f9f-5278-4f0c-8c10-5c34f0392b29",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "91e39a66-fea8-454a-954d-f339ed282298",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4736842105263158,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "b8f3eba4-def0-4e21-8e50-00d602215c73",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.049999999999999996,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "73946d09-23b0-4ef5-9463-9e65000d6363",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5263157894736841,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "e3dc5470-7cfc-42c0-b505-b3d8bb7da60c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3218390804597701,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "7bf43c63-c42e-465f-8a23-8773e8a5e4c4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "43832fd6-7536-4b89-be5f-3324ec5be425",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "19a0055e-4ca7-49ec-8108-5c7c6fd97526",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.18604651162790697,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "c0b38e57-6464-4829-b441-f432a779ab1e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "411151f9-a68e-4bba-80b5-6f4629b3f61e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24999999999999994,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "f528ff01-518e-4ab4-8b6c-2cd29e056bd4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "282565e1-9385-4d45-919a-1ca3e6f94372",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "dfaff4e7-00e6-4a9e-a98f-678ec139f1d3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "91d6d3db-1661-4d01-b839-9dc843ecdec6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2698412698412698,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "7245d898-1067-4cdc-91e4-5801c38538b1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "b358522c-4efd-4b38-942e-23c611978115",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "08ed0111-a507-4e77-9e28-4cd6157c2ed8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22222222222222218,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "69a15aa1-f896-4849-b631-acb31b77b6d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2903225806451613,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "d1d07655-d6d0-4fbe-9d59-28f3f7078fe3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "d139013b-f396-4ee8-9aad-917a313ca444",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/B"
+    },
+    {
+      "taskId": "24c5b749-2514-4eb8-931e-796563211f31",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "505587a8-b0a8-4e34-a4c5-3f7c004764e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16949152542372883,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "8411e9a9-f803-4b52-896a-50ca86f87717",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/C"
+    },
+    {
+      "taskId": "da27bd1b-08ea-4797-b06e-15451e31ea6f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5945945945945946,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/A"
+    },
+    {
+      "taskId": "4c11e0ff-2fb0-46a6-a628-67fc9c926702",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2580645161290322,
+        "llm_judge": 1
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "dc752263-d872-46c4-8cbb-6aa4f48cdd0f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.20253164556962025,
+        "llm_judge": 0
+      },
+      "category": "OPENWORLD_QA/gaia_level3/D"
+    },
+    {
+      "taskId": "f306f6c5-ead2-45fc-b6b0-c21ecf136f45",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "d543e46d-6062-4338-b808-29a511868b72",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4086021505376344,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "b413b294-92b6-4356-babe-e3e792519d64",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4435146443514644,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "06a82ad0-c852-48e2-b951-a8f339d5339b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3384615384615384,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f2956213-daa1-493e-85dc-f8f92422167f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2753623188405797,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "3e6f7cb7-0c89-4b88-b443-b37256b10fb7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46341463414634143,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "830e3465-a318-473d-8e07-fd504bb5321e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20600858369098712,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "eecad47a-eb1a-406f-a328-68ba25f659ae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37426900584795325,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "143afc5a-8a95-45f5-a4e4-0ce605cccbd5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40860215053763443,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "5a5f1a3f-72c2-4299-bff0-68f2d7c2849c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3881578947368421,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "47773a40-b92d-4a35-b9df-ec80cae41e3d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.31578947368421056,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "e3581c2d-6bf0-421a-ab33-53a60ca8c0d6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.31454005934718104,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d68bd599-0752-4da9-837f-7392a8dde68d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6573426573426574,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "5e56733d-3fb9-4385-9567-378e5356c36f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4407713498622589,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9b8a7eb3-6d0c-4ee2-b550-727c898de7a5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.388235294117647,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "6925c3e0-d66f-4bdb-b10b-f0a52c34a262",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5095541401273885,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3e62cb75-1f7c-4113-8ea8-235995d3972d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38190954773869346,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "67f21d52-efbf-46e1-b6ec-6b937d24cfe0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2766798418972332,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "006771b9-147c-48fd-989a-fda674cff28a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4752941176470588,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "a2627e61-5948-4207-889f-243a665a1cab",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.31088082901554404,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "51b07785-fc19-4633-97c1-6b5b1372ea97",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37583892617449666,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "48e842ab-5a2b-4e29-ba18-7c5673913787",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44067796610169485,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c108e38e-adfc-45f5-963a-4ad7c033c1f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28776978417266186,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "a3db5078-af26-4906-9413-292e8adc175a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30612244897959184,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "5b1e6aaa-5e7d-44c3-b022-4904c1659443",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.961038961038961,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "ecf13286-fcc3-4654-9ad7-f40e41fbea09",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3891402714932127,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "c04855c2-bfc3-418c-9844-b051de81c065",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38613861386138615,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "939658fd-7643-47eb-bb83-deb9caafe1aa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4603174603174603,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "58bbd4a5-81ae-459c-b0ac-3a1f18c9267b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.11267605633802817,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3d473515-aebe-4288-9006-d49a2aa78da3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43373493975903615,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "8f9871e5-ce9f-40d1-9994-9e99741c2745",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3214285714285714,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "3c7c4e12-b85d-4778-a85e-f04020847037",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3653846153846154,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "85ed7569-415d-4ff7-9faa-42c542ca2a4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44444444444444436,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "cbd2d538-db33-4316-ae73-b6b23fd23ced",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48461538461538456,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "5f6c3d16-fd70-4d10-b605-842fa5c8ccd6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5063291139240507,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "73a42a40-258f-4165-8617-e4074c6ef87f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "cbd0b0fb-8be7-4a69-98e7-e4e84b5df1c3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7652173913043477,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "93d3f5c3-5fcf-4877-b590-34d6dbf50495",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32231404958677684,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "d839b2fd-6dac-4c78-93cb-2ecbae3f47f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3841059602649007,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f70a622f-ab3f-4258-8fc1-a8e60731b09e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21875000000000003,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0f784b87-cbde-48f0-84fd-79272636aed5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.391304347826087,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "27729e6c-8c13-44c4-87d9-655b85433cc4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30405405405405406,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "31ee2827-d8be-494a-8bbb-baa0d0753355",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28820960698689957,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "737437dc-d356-4579-a223-3b82427e39d3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3474178403755868,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "bdba4f26-016e-474c-b477-f3fda19bf4df",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5212121212121212,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "3f7b15f9-58b8-4aca-8d81-061468f62c8b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41964285714285715,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "0b76039f-90ce-4dd4-b9ac-ba5afca4773b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.38461538461538464,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "510765f7-d6b5-48e7-b112-88ef29aef4d2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3172413793103448,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "224fb4d2-904a-4cc1-95e5-c414b220c845",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a29c7f1c-97d4-4e64-a110-1c2c25e6708f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4030418250950571,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "60f1606a-b848-460d-afe0-55008316af1e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3898916967509025,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9bbf8281-5070-4cd2-a14e-f0d8e1a15a83",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5423728813559322,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "1e4dbbd1-9cd7-4936-942c-1eaa835c9345",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33207547169811324,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "db2b89b7-d8a8-4297-9bd9-3eddd5f2b483",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.381578947368421,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "f5e78a17-9586-408d-8f16-1ad26219a741",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3761467889908257,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "86cd0a23-8ef5-47ab-9ac9-03c52b518d86",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3255813953488372,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "47f60d60-6921-474c-9d2f-b7a5836e7f22",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23809523809523808,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "9a030517-9d6b-43c4-908c-0bea2bf92fd9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46117647058823524,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b9ed8eb1-84f6-4bfb-90c8-69a8019883e1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.19230769230769232,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "37d9cdf0-ed25-40f2-9fa8-b8eb5b44cb77",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3890784982935154,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d058bfd4-cb61-4711-92d1-7f9ccc1931c8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7945205479452054,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "ca1fbfbd-08d4-4d1b-904c-5ddb7b323609",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8513513513513513,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "36ce2d6b-5773-4f8b-a5e9-d9ec103762c7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "6e62298c-4d3e-4f8f-8487-59cccb315b86",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47961630695443647,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "1993e3da-65b2-41b6-bf4e-5fe34fea8e76",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.393939393939394,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "dde65a38-a383-441b-bc27-0a76f4b2d016",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2777777777777778,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "e5ece92f-cc52-4560-8f2c-41d7222184df",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32738095238095244,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "87ed10dc-9440-495b-95a7-9561480b7b97",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35658914728682173,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "8e36da51-b068-41ac-a33f-a421df41a48a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24637681159420288,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "5d03f84e-e50f-4dd2-b73e-386ef3ba0244",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3793103448275862,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "6fd4606e-6075-4017-af81-99cf39530d76",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.18604651162790695,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "2842bd10-a466-4212-9b78-0214a2498a56",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.35471698113207545,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "ba5cf64e-14bd-4726-9fad-ef3f580ff5d6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8118811881188118,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "ffe9db8e-f9a0-41de-9ca9-36629d81950f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5384615384615384,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2ec6d552-cc7e-4830-8313-b1b069f0def8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5633802816901409,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "908d18d8-a5e3-4f2d-9b6e-792b8e21d991",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "b59381ef-732b-4d49-8499-66ce2f7b2f48",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4291187739463601,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "dc139b21-0365-431d-a78c-bd89b98541c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3647058823529412,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "1a254a3b-fdfa-4ef6-81ad-1d927daff3d4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "e58f435c-aeb2-44c2-b97b-1bb0896d817b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3728813559322034,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "0ea375ae-d9e1-4547-9887-b6b29b9b203f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3870967741935484,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "1ea729b8-c7e3-4a2b-be4e-47ba94f7306e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4236111111111111,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "06875647-96d5-4c3b-af2d-00bd308e2da1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4489795918367347,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "0575ec54-c4af-42e4-865c-a9cf71d43ca9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.467005076142132,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "ee0bf1d3-c797-49f8-adac-34e37abd524b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45000000000000007,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0b3e54ff-aca5-45f3-b394-b531ed40f290",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3153526970954357,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2e8d5a51-f402-46b8-b736-1c9a815a2b7e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.29885057471264365,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "adef77bf-708a-450f-bd51-fb55ff3d036d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45914396887159536,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "ecbd4b94-442b-4af6-8d23-a18279ac5059",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "15c3a6ed-4629-44f0-926f-985833d84391",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2626262626262626,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "760c7b41-a6c3-4abd-95a0-e4c5b36580ca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3497757847533632,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "7154a7e2-d0a5-4ab1-9dd6-722f46cb315e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3857142857142857,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "bf9595c7-29b2-46e2-9884-d5c7204c6441",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3165467625899281,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "f288487e-90cd-4dc4-b7a2-d4bf237b40ea",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4161849710982659,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "db6f3c5a-d7e1-4acc-b2e0-9fbc319ebedd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.38509316770186336,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "5dfdc827-85f9-4d8e-9b96-330681cb4477",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34710743801652894,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "53e435d2-2fd9-45b1-a6e7-9eac9fe56a19",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24000000000000002,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9b2aedd1-9154-4191-a9c9-ff84f050a3a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3004694835680751,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f3e87e5c-a4b5-4145-a72e-9ae5890b7f89",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2916666666666667,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0f8321e9-0d52-4ffe-8f05-d1997ff03aca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41111111111111115,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "26bb030b-6263-4a97-963d-e4e13ce79560",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2577319587628866,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "098c2bd8-fa25-49e0-8a1c-7e76d7f567cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33175355450236965,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "c9fa683b-4223-4cf2-ac1b-a5513086bbf0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3806646525679758,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "a76e7356-a6e3-4e24-bd0c-456d427e8420",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.369811320754717,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "21297958-47e8-4a63-a9b8-acb24a36ae61",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20833333333333331,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e9ef18f3-edce-478c-b0fe-d1f0dc332785",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.336734693877551,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "38bea23e-a52d-4705-9102-bbc21e51fae7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.28125,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "de051cef-d132-45e9-9d3d-50c01b09a4de",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29118773946360155,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "19484533-070f-4f49-86b4-cce0caf18b32",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26506024096385544,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "330720af-db5b-4f23-b5b4-6605f0530744",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.40366972477064217,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "c5e51ca3-edf8-4e91-b218-033a617c116c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29069767441860467,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3d5e7763-6377-4f1d-852d-15c4c67c4887",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43262411347517726,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "26328e2a-4935-42b2-8d2b-4db0ad9e71ae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3885714285714286,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "867ba7a3-8151-4148-ae11-e2afba3d2910",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3595505617977528,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "ccaa1adc-db74-443f-aedb-b5b4ad21900c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3293172690763052,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "388fecf5-e3d2-4420-b559-967631d4f57f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.06557377049180328,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "9f4f278a-5465-4eb5-8bec-cf59b745730c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5641025641025642,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "7d832a86-f801-42e8-963e-cf2cae0e6102",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30656934306569344,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "06077f6d-d5bf-4747-ac99-4c2538b721fe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30952380952380953,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "5d6055c1-615a-47d8-83ab-b3782b6892a2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22777777777777777,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "7a501723-61f8-4c56-a169-28975d1bb00e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.459016393442623,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "fef0e216-f0e4-4122-852e-b97449f2173d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "1f2cb1b0-20f3-4be7-b61e-b28d31f3f7b8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44696969696969696,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "816c7bf5-59a8-45b8-a738-74a77b28928e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26373626373626374,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "aa26f152-39a0-4308-bee9-f92cad8e89b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3269230769230769,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "204b9758-be3e-4d91-bdd3-ebe1e4d6c130",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4135021097046414,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "9b9cef7a-74c6-4b53-9f89-cc695050eac7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.35135135135135126,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "0df4fc4b-17db-41eb-ba2a-399f39f1ca14",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "2fac6b0f-034f-4e52-8c4f-9eb1a1a82520",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30588235294117644,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "3732ceca-9107-44c2-8f62-ccfa25939b84",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3829787234042553,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "f1fb9b3d-a0de-4315-bb5d-2c86160ed0ab",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3404255319148936,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "c83e367c-f83f-4000-965e-8d023cc380ff",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32142857142857145,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "25cd102e-e0c7-454e-81ce-8a0efd462f52",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.672566371681416,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "7ca1ca0c-842e-4f10-ba24-2cb878802697",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4392156862745098,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "4b7aacad-21ef-4ae7-af44-06965941d7a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47956403269754766,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "157ac714-eeb0-490e-b1d2-c8e1c4b8ed36",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3945578231292517,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "eaf9cc39-7ed6-4390-ab75-afe16e8bc283",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2b9c6280-ea2d-4be3-8dd5-2fefbd060f70",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38123167155425225,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "5dc14f93-b925-4405-8102-2025ec85590a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.42105263157894735,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "a84c5bdb-eb05-4851-9a34-e963ebc125e1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4535315985130111,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "aad1c646-613f-47c7-afcf-7fdfb03a543a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48484848484848486,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b7669b06-5724-445b-886e-3753f4e45ee8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3879310344827586,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e65fb7c5-9484-4ed5-adf5-2b5b8c5ae2de",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "031c9151-a385-4125-a322-94015470acff",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25205479452054796,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "b4b4039c-ec24-47fb-85c3-dda2b1a80ffe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7333333333333334,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "fa370e0a-cf76-4c03-8d25-3eef25f287e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4183381088825215,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a8232676-b490-413b-a910-c472c13b25c6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42774566473988435,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8f758bb2-9ed8-4e53-b9b9-5dc1512ffa38",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3561643835616438,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "151cef15-6386-497d-986d-0deb583b763c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44884488448844884,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "2a462be1-9ab4-40c9-913b-a750f560777f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5098039215686274,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "9642a20f-836f-441d-a93f-e0b431fa63f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3506849315068493,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "e0fa6911-5b6f-4098-bf61-c288e90eb76c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2764227642276423,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e6569385-c9f3-43f9-a661-5231e998efce",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37614678899082565,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e36c5394-c58f-42dc-9d15-880ee52dff4a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41711229946524064,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "8817a359-64f0-423f-be87-e601487cdc81",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3063063063063063,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "2a1dcd88-0ab3-4fee-aa30-35193008024e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.308300395256917,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "3054eb3b-0261-44df-bce6-1d344e8a5f25",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41269841269841273,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8049de40-1abb-48da-8014-ef9f71f1b75e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7999999999999999,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "88a740bd-b220-43f3-94b6-3ed84be0e6c9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48275862068965514,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "c37fd9be-cecd-45d4-8091-8e4cd9c6d3fe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40963855421686746,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "b12e77bb-3038-472d-b66a-f9155b549c96",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3714285714285714,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "459d96a0-310f-4d5b-9ae1-6da4811a1178",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3018867924528302,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "d9f0c594-fce1-427d-9fcc-dc21d4af9e96",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29972752043596734,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "af513e06-5789-47e1-863f-022f518e78a0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35471698113207545,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "6aa92553-5bc1-40a0-bcd0-3838f5fa0fb9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2935779816513761,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "0a1f5013-e845-49df-97be-580a8acc6619",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5095890410958905,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "0f820ca5-7a54-4538-a598-75fbcdce618e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4854368932038835,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "fddec914-c335-4973-a1ab-9e9384dd8ae0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3819444444444444,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "fdc6478a-b4ac-4c29-950f-4ead8095e1bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7625,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "aca93ba1-fb75-4d71-b411-275fa8929f3a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.385,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8a561604-a6c6-4c60-9361-c5496d4295af",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43333333333333335,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9a684383-29e4-4627-bf24-64689ca42218",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41811846689895465,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "96bb0fb3-3e8b-4c7a-9860-1673b4cb8080",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2965779467680609,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "36c361dd-7ce0-429e-9d29-03a12da6ab94",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3048498845265589,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "7760e759-a385-4809-bc1e-89443c0d9a00",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3347280334728034,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "29a5f81d-eca0-45f3-a965-321a362ae0ff",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2877697841726619,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "9f63efed-c3a9-4471-9392-bc6368ca597f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4078431372549019,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "3d6dbd2b-d104-48c8-a8c8-a40bc73c56d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3475609756097561,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b90add19-9620-440e-8ff1-290316e9f501",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3584905660377358,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "08725ff7-dae3-4def-9894-d11e03a34ffe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2881844380403458,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "488d6e1c-c662-4baa-9816-dd450b1ad231",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9411764705882353,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0b1eccea-2eac-4f68-93af-db034bb39f90",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.484375,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "b5cc676b-e857-46fd-90ad-e5dbf91be1fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4056939501779359,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "831edf13-50b9-4429-b3df-d1b9af302ac7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4166666666666667,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "eef453c9-3662-4dc4-9104-facad9e697fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4288577154308617,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "2062af52-06d3-409e-8f10-92c25fb2b6cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44758064516129037,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "35896d10-8223-4429-aab5-31b8ac8e4403",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30952380952380953,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "c26d4854-5190-4cb5-bccf-38cbd8c4590e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3070175438596491,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "9b9e3f25-e6c4-40e4-bee1-1737278f6c03",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4738292011019283,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e4c1d7f9-7026-43a7-b4bd-305f4c73769f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3529411764705882,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "bca4be8c-9069-4a1c-bd5d-0485bd282e23",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.21311475409836064,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "406baaae-ad9e-4c1a-a461-c4314ca911f3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24918032786885247,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "537fbaa1-4a38-470d-b02a-6aa1de8f35ca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "39bce9d8-d5b9-4af2-a180-6e86711bb354",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "e22da6e1-fbcd-4021-b611-c388159fe55d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34931506849315064,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2d67988c-641c-4172-9e0d-70f4905c4e27",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44295302013422816,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "de21a648-d019-4b31-905e-2fad033b190c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3285714285714286,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "0c7a5564-9b3c-4053-b907-75f67c7d78fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4166666666666667,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "72b3c21e-6cea-4b82-be34-b775df3d54a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4285714285714286,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "5394a33a-0d2a-4d36-b6c3-3cc32becb80f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28800000000000003,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "83204e51-96e1-4868-bb4c-781148e7faa4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41040462427745666,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "4370df3b-215c-4052-bc3a-ce5084feac5b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.44108761329305135,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "f4102751-4255-4707-92dc-5fe0e51b0059",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3829787234042553,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "89900fce-ce53-4a85-a3bc-d0f97b9f2d7b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2864450127877238,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "041d6294-bda2-4e34-85d7-b7259a97b8e7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0e9bc26a-a5e7-4cd2-9bcd-ecf136955380",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.490272373540856,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a33d339b-c6c5-41df-92bd-c1f32ce1a8cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5597014925373134,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8965138b-eb3e-41bf-bab8-81afe84e7360",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.481586402266289,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "edcb4447-20ad-4110-aeba-dd0e04cb95da",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6728971962616822,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "5df572ff-511d-4c56-9d39-7e331ee3b80d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4449648711943794,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "151ea22f-f933-42d7-8647-a69bb189ceca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4263959390862944,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "b1a905bc-cebc-46ec-bed6-3929051cc32c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4192439862542955,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "fa3becc3-5742-45da-b90e-956a0c6d8018",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "f783f0e3-6436-4bbc-81e0-ddd69eb58e5d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4914675767918089,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "048a7d1e-e262-40a3-8e04-0a896e2de9a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.20253164556962025,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "14479ad5-3740-426f-88cf-62a503a6cf00",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3170731707317073,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "01fda5be-66a2-49d2-97ac-a826c54b115a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7547169811320756,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "17400055-9f2b-4fb7-9b9a-cee561aabb95",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.742857142857143,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8e5baf65-3783-43ef-a3a7-fb9d2d626a3a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34254143646408836,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "fb325766-0969-4a6d-b0d8-7de9fb9bfe76",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4197530864197531,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "64c465a8-0d73-41e4-9754-0a7865dbb802",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3364485981308411,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "6a92deea-f6c5-4962-b948-c87a27547ac7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3432835820895523,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "9e594e4d-45d4-4bee-a5ab-35147a2ecebe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4830508474576271,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "a9415ae0-9929-4eaa-ad93-a2879366a5a4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43686006825938567,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "405458b8-dc52-4a7d-aee7-96ba0307f219",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "21764b9f-f5e6-455c-a3dc-5efc3c2a85b5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4718498659517426,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b133cbc7-dfff-412a-8380-4010e36da716",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30666666666666664,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "a0092ca1-5ce7-4c79-aab6-20f20816f8b6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39461883408071746,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "6263a870-65fd-4127-a7ef-b23476ca4c1a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.0784313725490196,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9eb72dd2-313a-425f-ac9e-825e75bfc6ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.23255813953488372,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "565fc2cd-d3c4-4aed-804b-8cbc1a4eadfa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2360248447204969,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "602b177b-a6d0-4899-900e-762d5a00df51",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3303571428571429,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "4d354ae7-bc30-42b4-8827-469c785c4a54",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5526315789473685,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "470835d1-a3e9-4135-ab63-5347d3e3df15",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.40495867768595034,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "d3e861c7-69fd-4ef8-988f-bbce0a3b8b29",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3150684931506849,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "09c40104-a36c-446f-b1ca-12c374d09932",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.31645569620253167,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "2c82d635-b254-4045-89c5-5f600121e23f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "7c22c376-7203-4305-9019-f2a02615c704",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.41975308641975306,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "26d1a76a-6d42-43ef-bbea-16ea31738ff0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5289256198347108,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "b5b22e94-40d6-41ca-b8a4-30db9c8f78fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33000000000000007,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "76fee50d-c155-481e-a586-092123bcdca5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5925925925925926,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "50d2c3ae-7ffa-491c-8fe9-b47958e48ef9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4822134387351778,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "cb21e560-6c12-4d71-b5e7-d501dd8a32c6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4694835680751174,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "d17ad12d-bef6-4c44-ad61-831d075ef206",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2745098039215686,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "90c228b4-dfa4-408c-b91b-d1b9ff70988d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "85fb0037-22fe-4cdf-b860-614853f1a2ba",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29914529914529914,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "0a0f1bc9-1285-43db-8c27-c19672d67868",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2784810126582279,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "ff0e2435-6b03-40cf-920a-3a8fdff3c616",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "7717aaca-163d-45be-bc79-793a428f4833",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4439461883408072,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "704224e5-9e36-4034-a5ae-5808da410d0a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e296db67-5f73-449b-84fe-4e0672f73618",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4511278195488722,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d552cce6-3ce0-4a27-9e56-ba66ff28cffc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23166023166023167,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "f37ef8ed-e1aa-43c0-9ca8-2d07ecd505a4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6037735849056604,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "d9f28e4c-bb18-42f1-a347-dc6956e6b74a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3703703703703704,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2e9e007a-f7dc-456a-b82f-573c9412c908",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5106382978723405,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3abaf57b-3506-44f8-b88c-f0133f21982f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45016077170418,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3f6aeaa8-1c34-4338-abdd-9c731074cd29",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3296703296703297,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "343fbae1-9bf4-4e42-b2be-f2821b9707f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36101083032490977,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "b9f44057-f335-41bf-87cb-5efb56ef229a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40637450199203184,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "128344e8-e85c-4724-a094-3532367bb012",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4525547445255474,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c2f47a0b-0645-46b5-a7d2-d3e03cf9b8f7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2033898305084746,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "0f8ecd29-601b-4659-8db5-8ddea964cc54",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4894514767932489,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "5e004275-83a5-4128-a9f3-2e3ea04aa4d7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24528301886792456,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "7c638e43-bd3b-46ec-a2fa-1aa5b7962b4a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32448377581120946,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "4d928c80-a98f-4efe-a1a2-ff0b85235061",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4357541899441341,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "36c6311d-46b2-4326-8c95-ed34af2c879e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.38095238095238093,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "b4750343-b237-4a20-b944-67ea090a32dd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4516129032258065,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "83df6e7a-bda2-4d0b-b253-8a8beec9e07f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2362204724409449,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8ffca1da-d40c-41be-ab03-f7d418ae1add",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4423676012461059,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "c768e7be-cf54-4ec5-9bb7-1ce4834db10f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44776119402985076,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "a209c7e8-1dc7-4c42-acac-1054b57b0bac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37818181818181823,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "19e8aeb0-0d6f-4c92-aeed-48a5bad129af",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49350649350649356,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b10d18fb-e8ed-4cc8-9be9-526bf2479758",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4275862068965517,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "7e1402a6-357a-48e9-9164-341339f5efbc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47530864197530864,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b1197ec5-834b-4cba-8489-b68eb7709741",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.20454545454545459,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "81dbfe86-6f71-4cf8-a29d-c6882a5f2db2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24376731301939056,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "93cec906-b5dd-4a9f-ac84-32afd95fbe0b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5729166666666666,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "4e5b9ce4-69c2-40ed-8986-2cdf27371e48",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.44836272040302266,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "30f955a6-8f6b-49cc-bb04-975b3eff329e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46218487394957986,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "cf0b44d2-30b8-420a-a1f5-15562baa6089",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3645f0ca-44a8-4013-845e-7aaa65f71bf2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4014869888475836,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "52c5b17a-bbf2-4381-be13-2c63d377b710",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.31075697211155373,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "961c8342-257c-4b8b-bd52-0018f40df409",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33516483516483514,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "71ddcc80-1f48-483e-b3f0-c9322f0de883",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41304347826086957,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "1f2c1154-dc0e-4d97-a733-b45a9f129051",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3859649122807018,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "0b44db88-d338-4758-a354-52c29df390b9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4088397790055249,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "ca5dd366-27df-44a8-a4a7-75d528b39e8e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "69ae7286-ad35-4441-a5b8-c936bfc85f92",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.38016528925619836,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "079d8322-628d-4523-9fb7-de1db300af48",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6808510638297872,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "4463f2b1-e52c-40d1-9f52-1591c0d7d3b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43870967741935485,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "41bff41c-f379-45c3-a2cd-a4f7bbee1e5e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5813953488372093,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "421f4cab-5a94-4252-aa93-2507b6f9f9d2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32258064516129037,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "dccb8a80-f32e-4866-a8a4-86c99e7da9d4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4607843137254902,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "fdcc8e92-a67d-471d-9ab2-e95637375b3b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3731656184486373,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "2f90b5d4-fe04-4bec-a54f-2f941b211790",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3620689655172414,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "23f0bcef-d346-48e4-9123-4ee7211d531b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3839009287925697,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "4f8b4e6b-486e-480b-9c91-a00c41201ccc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1875,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "8271bd3e-bbe7-49c8-889d-04f7c0a60250",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38405797101449274,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "a696069e-7ec7-4642-8a9c-b1a753c02062",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2429906542056075,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "8a04ca1a-265b-4bd1-a583-7bb9705dc11e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2901960784313725,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "ac866f55-1e68-4897-b836-83e58e4ff77a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08888888888888889,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "1d4f78e6-731c-4103-97a7-8c925a50cba0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30208333333333337,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0c3ace7a-29d3-4d07-9557-960d9a4f1d73",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2697674418604651,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "bd77b2a5-cdf4-48e5-9775-29273c01dab7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5535714285714286,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9de91d45-8fb5-46d8-b409-a48139010f1e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38490566037735846,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "2558260e-4eaf-4881-be87-256fb6f56b30",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3858267716535433,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "e83c4e75-2125-4499-9662-481efb587e8b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28965517241379307,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "c2dd8ce6-94fc-40ca-8af0-d3a9e1a981a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.22535211267605632,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "36552819-e109-43b6-83f0-f591988457c7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "752f9700-5a34-4d05-9fe5-ca230a71a9a2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4518828451882846,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "8cfa3cad-b04a-4cf1-adf0-d5f86473ccf9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.358974358974359,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "631c491c-bfed-4755-b883-5ffa9f138202",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36909871244635195,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "c35ace46-e108-4251-b0a6-bbe3e6f8c171",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3928571428571429,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2bf39b7b-390e-4a79-9a92-2548d114344a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40579710144927533,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8d2e456d-b56a-4d17-9e14-d3e14898512b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4431818181818182,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8fdb5eae-67a9-4748-897d-9cbc9e487b2c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6545454545454547,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "c1db81c0-43d3-40c6-a8d9-60e1703d233d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32209737827715357,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "c9eb6f5c-dd28-4279-b77a-c692e96318df",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44444444444444436,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "0f5706ec-b8c0-4ddf-903e-823ea24d9b36",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43243243243243246,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "97ff9647-6b4d-41a8-bd7a-15e5989aeb8f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44285714285714284,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "aa9e72fd-2fb7-4a46-8515-ddd2134ce404",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4235294117647059,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "97db20a3-636a-4e78-90c7-a28d1f73e94b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49266862170087977,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "65fc8204-dacb-467a-9c01-848ede3e8721",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2325581395348837,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "93084d4b-0267-4b6a-80b1-0ecfcb74fb20",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3024390243902439,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d7f54ed4-0c8e-45b4-b11c-e24f0d412ea8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.784,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "e125f0fb-9d7b-4bca-808a-e263815d5d5f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4351145038167939,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8b4131d7-1fbc-4695-bcf4-e1d13e35d846",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.408,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "55e1cfaf-6f2e-4821-8c21-1161506465d2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3111111111111111,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a3f01e0c-25de-490b-878b-e264a41664a1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14285714285714288,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a32e53c7-1f69-499c-8550-a8a397a818d6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3197026022304833,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "2407eeb9-598a-496d-b7b8-29f5c2fd8903",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45435244161358807,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "5978874f-e40c-4da9-9f46-ee7d2cda3cc3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43820224719101125,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "a19717b2-27a6-4716-bf89-649556253b93",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3471074380165289,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e9641ce9-cd7b-4eb8-88e8-60989e151cc0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.545,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b11bef84-e3c2-439e-b208-25cda1edfe38",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.27999999999999997,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "669aade5-4db7-4d3b-ba35-4833180c12b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3777777777777778,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "0dec1e51-c37d-4efa-b75c-6496396c962b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5774058577405857,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "6a52e3c7-c1ca-4cf3-abae-e76bd6e31fac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47953216374269003,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f1497571-5026-42ab-a1b3-79223eedf0a7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2912621359223301,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "d1b3a46c-d0ef-4c8c-a61b-037ea2dcbe95",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4863013698630137,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2fb4f84f-353e-4138-b922-5fd5615e3074",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37931034482758624,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "5fb51560-06dc-404f-a4ce-02bfa7070124",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3579766536964981,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "ca5b5056-354c-44d9-94b8-97bad7788bfa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.17297297297297298,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "a25538e4-ca82-475b-9a2f-6b67db8eceaf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.348314606741573,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "6360c1bb-cc77-4f97-9adb-fa0a4a1e0c42",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.34710743801652894,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c6bd0fdd-468e-46d1-84d5-ca2c552a1e09",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5447154471544715,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "aa5d6cc9-80b6-4cc8-aeb4-7e38a97e025b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24999999999999997,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "83f1b78e-fa21-4f75-9d86-0dba2097988a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.31275720164609055,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "46e6b92b-191d-4eec-bbde-a7e81c914cf8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6976744186046512,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "4ccd31da-d4d5-4a9b-a6b3-2b31c0cc330f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3287671232876712,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "59b20f0d-1ffb-4292-aebf-b3f58ecb5d23",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3700440528634361,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "b2911515-3a13-4c1e-8425-bee76e0e6e0c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.451948051948052,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8583374e-188b-4367-b71d-012233babc67",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4437869822485207,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "2c81ecc5-8b05-424e-b630-f1fe8df21050",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36318407960199006,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "8f3dd074-94bd-4c41-99c5-1272a9efce9f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4149659863945578,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "43fbe771-a65a-45a6-9a72-1a0e480b42dd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3928571428571429,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b524eef1-e28e-480a-ba93-a1469d79da23",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3839009287925697,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "a7aa4c28-4c00-4abc-9623-3fb8d9024fa0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4334600760456274,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "699afd61-5b10-4300-b44b-070e7d978e03",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29577464788732394,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "b6b240a2-1457-4a86-8ec6-3e72eaf13b6b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.31007751937984496,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "c2b6ac59-879e-4b44-b5c3-032fb8f82d7a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "69ad1e4f-05aa-41c7-9284-11874d67b535",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39285714285714285,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8e0f0f26-1752-409c-aa94-01cd9261d552",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3969465648854962,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "7399705e-7e0b-4976-91ec-64df6c201763",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.382716049382716,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "89067299-b646-4d52-9032-bb7d3147c3eb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44984802431610943,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "31b8bcfe-b9c2-4556-8ee8-df88140d1c99",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32183908045977017,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "fd75dcb3-cf5d-4565-8a1b-495807d335f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.38951310861423216,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "3a4f8e68-4beb-4ab1-b58b-6c6e5e70e633",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38281249999999994,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "2182a18c-34da-4453-88ca-ac5f7da255e2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e732aeb4-af12-455d-b45e-7826188685a5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.445141065830721,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "12394c7f-b714-4d13-84e7-d8c3f4a19b98",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4077669902912621,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "9ff46926-df33-4243-be8e-e2bb42cffeb5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23021582733812954,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "a0368ffb-f839-4bec-a30c-608ef8c2a5d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8356164383561644,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9f81a34d-2031-41d4-8333-9b2cd4c31a5b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5241935483870968,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "14aa2e0d-5a49-47c3-820a-2f8c3dcc50fe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43119266055045874,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "1fad1631-cec3-474d-8dae-5677c89fbbf6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.855813953488372,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "b578e614-2db0-408d-91dd-58c33b102b25",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36860068259385664,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "62ce2c12-f9e4-47d9-9edd-27c10b14d796",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2834645669291339,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "d9e09658-d8cd-4ece-b031-de19f5d6aea3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3127572016460905,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "9b004c95-097b-4060-8c3a-3292bfdc5d6d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41134751773049644,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "915192ae-5e43-4477-a2bd-bd5f8610cfcf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4100719424460432,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "04b14c30-73ce-4ccb-bcb1-3c874de216dd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44343891402714936,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "4824db29-a08e-467f-b88b-21106f7909b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3232323232323232,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d7067e04-0091-4b91-8fa0-3ca9c07d393a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3799283154121863,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "87b76347-2590-46e9-b5a1-68cd4ed502d7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6133333333333334,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3f137593-2c0e-4191-95e5-dab2c83557a9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4233128834355829,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "99a35d10-abc4-48ba-af7c-7c66580f2e01",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3422053231939164,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f14d8e93-22af-4d53-9a1c-0e603dca9030",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4361702127659574,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9e61394e-ddf7-468c-ae43-175afecc243c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.29283489096573206,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "5e1bb310-3636-4b48-bb41-cb86229f2cd2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4050632911392405,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "d557fc95-1ebc-4a14-b64c-4ed4e4f56e24",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48593350383631706,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "c2a3e0da-ab70-4491-94d7-654d7c25bbf6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4020618556701031,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "ab1876a3-7d29-410d-a8c5-e111a8ea21ac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48962655601659744,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "1949e7d3-9c50-4dee-9dcb-f7fce137c3b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3592233009708738,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "3d338161-778b-41f1-a114-15a20d43b386",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.39024390243902435,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "6a173546-5d1f-4358-bd96-8b0f50f25ce6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29545454545454547,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "e0399dd4-3431-4ce1-8713-a1b48825758a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9581c13f-8fe6-4ff3-b6cf-6dd119018797",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37681159420289856,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "e625799c-c6da-4c62-8951-b45042763346",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3577981651376147,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "ac40a2a6-d166-4158-9f46-bf57eb99c724",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4263959390862944,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "7608a833-898e-4c59-9b1a-3cf591746088",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.37699680511182115,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "90be36ca-f799-405d-8ad4-f781c29b8543",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3469879518072289,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "86ec2fbf-5f84-49ae-abfb-d11ea79c3297",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2510121457489879,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "d452398a-dcdc-4a1f-820c-502ac6af5ca1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5142857142857142,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "51177b46-e800-4e1c-ab7f-6f6ddc73f60b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14457831325301204,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "e7871b67-e04b-4782-b1f5-ea41fe295231",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37267080745341613,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "0e72963f-8444-4caa-aacf-0ed58397386c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15151515151515152,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "cac0c32e-743e-4fa7-a4de-328f9208d172",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.228287841191067,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "b3a3f7b4-bd6c-494e-a499-78653863cd08",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4473684210526316,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "76d25663-7911-4ed1-a5ad-a2db3beba41c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4043715846994535,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "fdc3b482-0545-4865-966a-8ad80fcff2ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39344262295081966,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "90e3e092-c4cc-4de5-a6be-dbc7248364f6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3816793893129771,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "bb78f4ae-d72a-46be-8fb1-a2e6fc666ad6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.41025641025641024,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "23678b3b-9fb1-4446-a489-58cc3b10cbce",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3825503355704698,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "9aa8953d-1aae-49fb-b85e-fc3558dc851d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34285714285714286,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "cb6ff539-11aa-46d7-bbc4-56fca6f5e9fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.502994011976048,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "bc4e4b22-c942-4b37-ae8b-6e19325e407c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3948220064724919,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "446ccffd-6200-4b0d-b7fb-25d53dd13e86",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44666666666666666,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "8a1d2230-4522-4115-8299-33c92db93469",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4660194174757281,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "1bde1906-203a-4072-8f0c-5a0a57884992",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32098765432098764,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "f9900af8-e09b-4595-a724-ef7e1df0e290",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.28787878787878785,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f9b2b367-924d-4700-a4d5-a66a62be73de",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46808510638297873,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "35bc5e55-215a-4396-a5a7-659a51c46256",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4618937644341801,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f624d12d-fa05-4002-a2ef-70339660702c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "d0c3055f-4065-4424-85a9-c85152b50560",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26956521739130435,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "65134317-fc8b-493b-8e4b-0fb29bdd03e9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3202846975088968,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "f0f33dd1-62fe-4a01-8453-b5b2124846c0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3050847457627119,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "dfd9dbbf-aec0-4cce-a273-4113c275444a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2385321100917431,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "ec445f52-6df0-4e2b-9529-937bfaed932b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.06060606060606061,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c5b17b2d-ecb0-4156-8f62-1cf607a4e16c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46086956521739136,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "451f6528-1637-4287-bea0-675958fb2720",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "17ac1fe3-1451-482d-850f-0089f5c509ce",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2889733840304182,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "c3467eed-6e63-4c07-bf71-57cf53a60208",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4827586206896552,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "d65e3db9-7520-432d-a036-2b07b6322acd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5641025641025641,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2f5e11a4-4149-4fa6-8ad4-8a8ae390df43",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "5c24f1bf-d3f6-43ce-b65a-fbfce36cd7d0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48333333333333334,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "cda28a86-4bab-4c35-b795-29b01e91f2fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2162162162162162,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3ec5ad30-ed85-4dc5-b3a5-8179a3c054ec",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27303754266211605,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "7007bf8d-f2a3-41c8-b5c8-735dadfd540b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40394088669950734,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "55485488-8593-4c50-8521-802b23105671",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5225806451612903,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "78114648-82f5-4dd2-ba67-6e5ec4e9ab51",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5045045045045046,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "8f4cf41f-7ea0-4ad5-83cc-d0e484a87757",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5391849529780565,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "7d493659-5a4f-4fda-b4ad-b4df085524fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "646f5001-3556-4406-8b9a-eaa8a4cede85",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.27058823529411763,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "078634cf-e374-44e6-ac55-b23b7c7e3df2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5560538116591928,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "640556fc-2f3e-44d5-9caa-a3c282c55fe5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5240384615384617,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "439dede1-fc86-4098-b4ea-e5b9f7c82246",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4028268551236749,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a21e22ef-0659-4d09-b95d-afd396bb51ac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5120772946859903,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3f4583b7-d480-47fc-84b1-13a67ac6a52b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40519480519480516,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "e730f309-db26-42a7-951b-6d550a41bc7d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3554006968641115,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "11ba3c77-3be1-4969-a533-5c6cdbcd87fc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.38337182448036955,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "47349701-9fd5-4a57-9382-898a238c7973",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3645833333333333,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "15164441-18b1-4b9e-8074-23f6cd3de102",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3846153846153847,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "70634a33-db60-47d4-baab-a71c5323bcdb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3417721518987342,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "74f3071a-69dc-49a6-9434-72355d55d5f4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "aa85bfa3-519d-44ed-bd80-e213936619e3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28708133971291866,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "2e523756-ed25-472b-bc22-9b73f5173ebe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35616438356164387,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2d9f6311-be8e-46cd-a441-0bb6f75d23d0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3735408560311284,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "3aea1901-18e8-4dcb-9984-74c91a0030d0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37569060773480667,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "bcdc1c1b-7a89-4b73-ac04-f9ffbb0bc033",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3137254901960784,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "5713e03e-d00e-4dc1-bec3-4ee715f86541",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24630541871921183,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "ea9e6e64-1fcf-4a77-936c-eb1edc7f5e63",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3470319634703196,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "1b1c06c1-aec4-4edf-9009-d3b96c711016",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "84217982-e12d-4cbc-9b88-2e50b6f9a527",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.37735849056603776,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c82b3be0-13a2-467d-af04-3aba96d595cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2831050228310502,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "0d0b29ed-bf7e-45b2-97a6-6a9f0c0f4dd1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24731182795698922,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "855552b8-db96-41e9-a675-d0e5ff26d3cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "09897247-e1c6-4f2c-a427-e43f2220cabb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.35606060606060613,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "564c115b-47b3-4998-821c-d3973951ac34",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6956521739130436,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0cfddcd1-48be-4ac5-be09-0ab229d896e3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3505747126436782,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9f8309bc-932b-4ab7-b96e-9060335bd002",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4365482233502538,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "e1fb872e-3e6b-43dd-9d98-ba015f0cc0ca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21782178217821782,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a94660bc-7415-436d-b340-d8c13614e210",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47493403693931396,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "d2e216b8-16b9-4047-870c-257381915375",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33888888888888885,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "7b231aac-a2a1-42eb-bd93-1ab487b82658",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.375,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "106ba429-d7bc-4460-b108-e310b021049e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3289473684210526,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "eeede6a5-5195-4a98-9a34-f5d9b182aee1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43260188087774293,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "b06febdc-f1d4-4675-aa85-6b4e19f52745",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41860465116279066,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "7fc74c3c-5483-4fa7-a7ef-0c2ffa59788f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24817518248175185,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d88b2b21-192b-431a-beb5-359d179b8f97",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.45581395348837206,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "a5d7f338-02b9-420d-92d9-3e954f59f01a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f9fccb88-c078-47da-897d-678d0b59a010",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.463768115942029,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "5ffd207b-36de-45d3-8e84-a05fe15515af",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.535593220338983,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "fc5b36da-9ff5-4db4-8f26-580f7ab84a6b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34831460674157305,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "29b1d66f-2d42-4511-ae0c-41233d346272",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4230769230769231,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a3e43ee8-6a84-447d-96a6-5dab7fef5f14",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.345679012345679,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "dff5c8ad-0581-45c9-83c5-dcbfe6359c97",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2794759825327511,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "81d5a6c8-edc9-42c8-b1e4-5e5686ee3dc4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.40217391304347827,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "5177ae19-9e7f-41a7-83f7-56b8bd38c4d8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3680981595092025,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "74602b70-f58d-4bd4-867f-745bd39c58b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4790874524714829,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "6a8aad28-476d-44e7-9e48-085f1a5e450d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "235862b6-39d8-44be-b55b-86d65bf5352f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.38961038961038963,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "bcf5e603-8282-4f50-b247-77561d2e9a6f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5126353790613718,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f15bace5-077c-4217-9dd1-4731ca40c571",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4233576642335767,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "c62d324c-91ca-43d4-93b1-70bc3c9f5c29",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4679911699779249,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8f4b5151-987f-448e-89ae-a1ffe110e5a1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3441860465116279,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0aeba17c-3bb7-4d27-8388-de2d499d518d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28691983122362874,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "35ffa38c-949c-43b3-a63e-3d05721f22be",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5063291139240506,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "aeeb6a11-e8ca-40a0-b493-d0bbb0763e27",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3342776203966005,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "ffbc2d29-d8ff-4336-8e92-976248a85e36",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3508771929824562,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "1032c0d6-1ad4-41df-9807-45238012f360",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.37662337662337664,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "145f8402-83ad-4401-883a-fa9bcbc3c89f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34944237918215615,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "14754d1a-d483-4157-97b0-de9c948eb2e2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4024390243902439,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "47d20fb9-9e02-4b42-b560-3da45c91c493",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.41454545454545455,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "517790cf-bb4a-4431-a80c-629e37c56d9b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2079207920792079,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9812bf56-02d3-4d8a-9567-3b85c9c1b4fc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.535031847133758,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "e0370a91-8209-46b1-b88e-b6e9110291cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4031620553359684,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "9dc77b64-7ac3-492c-b7e1-5581d69d53e5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39464882943143814,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "886ebdfd-02cf-454e-967b-09edf1913530",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45517241379310347,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "5d714438-c3f0-4890-b80d-2d096b204d6b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.461139896373057,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "98a8541a-d6bf-4492-b2b0-cec40e1b2aa4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48000000000000004,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "0dae19b9-651f-41fa-9694-7594bd5b3726",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.38135593220338987,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "5696d3ed-8d0d-44de-9472-10d6fc4dd6cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27631578947368424,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "027153da-2740-4d2d-abcd-6ae7b8763596",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4201183431952663,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "50c3d485-f237-4258-bdb6-f0dccd951eac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15789473684210525,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "86623748-00b8-49bd-bd8c-9660019054d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.403041825095057,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "da2772d0-f0b8-49cd-8d29-bb42aa88aeb5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7976190476190477,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f8ce9d54-1b1c-462e-9381-da9019b6dfe2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49612403100775193,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8dae2615-a204-480d-ac55-c81ff824b380",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5104895104895105,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "41acab7c-4f5e-4746-8add-409d20e3e628",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4104803493449782,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "671de1ba-f22f-4033-9ba6-40f7c1cf9213",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3580786026200874,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "f78616a8-7eb8-470a-8c0f-5faa584ee075",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25365853658536586,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "9741af6c-be08-4fde-ab6c-5958d820054f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3546099290780142,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "7eae7087-6faf-4dd4-b5a3-8d0a3ca1c700",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27210884353741494,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "f1aa1046-361c-4f18-8104-2300e7687454",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "69737846-c781-4e22-b206-d485fc1b4c3d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5111821086261982,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "f3d2d33b-9c21-46ef-bfaa-1c48b0c1f17c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24000000000000002,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d7634cbd-6847-4eab-b104-3cdd30345070",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4097560975609756,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "19ded39a-784d-430d-9632-6adb30ce329a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5964912280701754,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "82e3a72c-fce1-4aed-b0d2-6416321998ae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4754716981132076,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "e2fabdc7-9721-4d58-aa48-d043c9490fbb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.388663967611336,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "6ed526e8-555c-4a85-8992-8a7719885763",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5289256198347108,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "0306c3f4-4d5f-481f-ab34-85ae46b3d247",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4157706093189964,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "0f6cb336-57c4-4c16-ba57-87a47b540856",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.34745762711864403,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "7df2891a-8dd1-476d-af91-40a2dbf35132",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43609022556390975,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "03bb8d46-f311-4bcd-91c3-ef91c2b83fed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4857142857142857,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "6d20f9ef-f288-41b0-9c67-e43319cbf2f2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4680851063829787,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "6e8ff919-0429-45f6-95d6-d62ca6aedddc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c4023bb0-1bcc-459e-8c94-df53e7aa35e3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.49523809523809526,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d0fa064a-bc4b-4a10-8eef-b372d3a0af11",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "b6655787-e463-4b17-9ce0-9090b4d5dfe5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5384615384615385,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a149a416-0a07-49f9-a3c7-0f2316805a20",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7000000000000001,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "4191bd8c-38e2-4efb-a893-d2c122a59089",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47239263803680986,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "869a7980-d05c-414a-9388-a1b3b514f9e5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.31355932203389836,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "67dc121e-ae45-4f68-ac7b-bc39202c8c73",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4117647058823529,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "e46851ab-a138-45d5-bf05-2ac9e2db0846",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3941605839416058,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "b0cf1ee4-4807-40ac-bfd1-c5140a73632c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "58f3be8e-a192-4c90-ac57-93f964d994b8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3283582089552239,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c20a1271-f882-4553-93bd-04b1ecb987f9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39583333333333326,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c5abe3d9-50f0-43b7-a130-a73b487561a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3791469194312796,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "c84a0dbf-2903-4c87-a9b8-5672d31019fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "2733848d-16d7-44fb-afba-773ac865179a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30522088353413657,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "d31098e0-1a6c-40ba-9ddd-878d9981bde2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8679245283018869,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "65901435-a24a-40e0-bb1c-1356e5e29a15",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4180064308681672,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "88508d32-61a9-42e7-bbfb-70eb753b4f78",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5050505050505051,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "7b5a6a6f-770c-409e-b252-57c0b3b35a4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45714285714285713,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "dd9645ea-300a-4e52-b8b7-6b53852bafb1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46607669616519176,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "fc2ab808-e91a-405c-9b5b-ae2c375be12d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3152454780361757,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "4f54586c-7a32-4c8c-a058-a62b2152e088",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20338983050847456,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "690b0640-3ce7-451c-80e3-e15ce98a6253",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35000000000000003,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "2077da74-50c7-4775-a66c-79e16d6b6b7e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43749999999999994,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "cb4f7877-6ec6-4bac-858d-d7d1f4cdbcad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4854368932038835,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "1881db1f-a112-4357-bae7-aa882fba4bad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3857142857142857,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "e966a582-abc0-42d3-8bb1-68f6ea1af463",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28498727735368956,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "387467ca-7c96-40f5-8f89-769daddfc829",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "898463a8-436c-40e2-82ed-42c3cf29a9e1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41924398625429554,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a0ff6fe4-c132-4e9a-892c-b8510ca6a777",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5465116279069767,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "a740923c-a04f-4e3e-b126-6d2b182902a1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4964539007092199,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "58d2a78c-5736-4160-8412-7aa59301e828",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38461538461538464,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "047351ea-7d49-4656-af89-90815a7c815f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4170616113744076,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "38275812-47bf-4987-96ee-df501271cd45",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4106776180698152,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "01a554bb-c719-4585-b6cc-8aa40b58337a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2962962962962963,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "3241f1b7-9b59-4509-b226-53c47a92e804",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.367816091954023,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "aad31641-efc8-42ce-aabe-7bf6ca03ed59",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4267515923566879,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "155b3ebd-18be-4a32-9fa1-83dcf9428ec8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24742268041237114,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "663cc293-baed-46cc-999d-a2ee1e0959d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3713080168776371,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "f869751d-5595-4acc-9d01-9255c356b38d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9206349206349207,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "2651f460-11da-4f59-bc5c-b609ba73e2f6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5325443786982248,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "5442a3a7-53dd-4c2c-b804-ccf62eea92b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4140350877192983,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "b14767d8-df21-410e-835e-51ecff54d9ab",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "6c9d2833-f8cf-43b5-9e07-5fc8a6e6b9be",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3940520446096655,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "bd20b035-5b44-48af-a28b-71429cc0dcbb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3214285714285714,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "a4e9920e-5fab-445f-a071-e79dfdcab4f5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.35443037974683544,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "bb6b1545-7390-4ce9-b71f-79252f16c886",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45161290322580644,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "e7482a99-2290-41cb-b8e5-ff6287bb383d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4714285714285714,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "a15ad56a-9089-4a47-bd22-67ec66465194",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5941644562334217,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "46bd358b-55b4-4c4e-8608-b6c7e226a281",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4833333333333334,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "bb23cd9b-b33f-4896-983e-b4ae9c139319",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3864406779661017,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "b18a6e77-cf06-4182-bc83-8140ff7efa85",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47727272727272735,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "8b97adca-4d5f-41fa-81cb-e4d2068c2612",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43795620437956206,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "7151d751-e8ca-452e-8617-362b0e22ab8a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3700440528634361,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "35a53286-3b41-46dc-bb16-81a7914e9305",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5565217391304348,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f6e8de61-fce8-42d0-9b07-091878ab5b68",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43749999999999994,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "cf80a435-ad10-4259-b97b-70139ef6be7a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4017857142857143,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "67d7bdb4-7d81-45a2-a9a9-f497a1e6a261",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "89e55fcc-abed-410c-a0fe-8397cf1e325b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36111111111111105,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "89f28e7e-a59d-4593-aa33-39ecd33d1771",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49333333333333335,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "aa8f5424-fda6-4fb9-9cc0-6e90c1c2b759",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2815884476534296,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "7f5ffc2a-0a43-4d54-a581-76ec3af2a245",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.43678160919540227,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "a2a41d52-f3ae-40f9-8826-9566a303b300",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.36981132075471695,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "5e09a712-4fc9-4161-a53a-b68a1a121d41",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45161290322580644,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "395510ce-28cb-4865-b5ee-2e15c9f9ebb9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4948453608247423,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "93c3143a-0888-4ca0-94b2-cec4ca2dc976",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.37010676156583633,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "4d2ea22c-ca4d-4ef0-9cf5-0141597b9583",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.40740740740740744,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/A"
+    },
+    {
+      "taskId": "f6f19405-2f8d-4596-aba3-fb167543e5cc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32394366197183094,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "e21bce63-f70b-475e-9b03-9adc78f3d864",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44108761329305135,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "27c73058-85de-4ea8-988b-4dadccc61548",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4273972602739726,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/B"
+    },
+    {
+      "taskId": "5d8a9f2c-5261-472c-8e81-f6590c4589df",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3025210084033614,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "52c94466-8c45-4153-8f73-59d43788425a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45081967213114754,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "3a2d65b8-8be5-40b7-8463-79826389e6e8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.49206349206349204,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/C"
+    },
+    {
+      "taskId": "aeb0a4cd-4914-4154-8599-2b9b4ed252ce",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5981308411214953,
+        "llm_judge": 1
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "06acd7c9-a654-4ef3-8611-d3ce5d70fcea",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3375796178343949,
+        "llm_judge": 0
+      },
+      "category": "TEXT2SQL/spider2/D"
+    },
+    {
+      "taskId": "5e8ac169-9ab7-49d4-bee2-3634f393ea55",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e91308e3-a10b-4c93-869f-144fe9cde629",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "bf434f61-7835-401c-9ba8-19ac75281bca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9c137f1e-9094-44c1-8594-9ca5b4653156",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "3de0a94a-1cd1-4b8c-b6a2-a7d66eaec3b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08695652173913045,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "d03d6c31-5910-4368-9054-b1fbbabb67fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "82737dee-d133-466c-b060-6473afa2f3c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "df55a43a-921a-45d1-afea-9908e0c6a2a4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "3acbc9ea-d507-49ea-8383-5d07446375de",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "7eba1e42-3e73-4952-8a1d-b70af24b95f9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "61b2fe05-d537-4fe2-95c7-4bd152a46dcc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.288135593220339,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "be38b80c-51f8-49c0-8bb9-41df142b9fc3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2777777777777778,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "9edd896e-8587-43a8-94f6-89c45ef433a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07142857142857144,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "eb14ddff-a774-4193-940f-08e4b9369a7a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4b33ec95-a2d8-402e-ba1b-382c40195566",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "36c15d22-18be-4453-85d9-d83823549a63",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30985915492957744,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "bd11b159-79d3-4df7-874a-c193df0948d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "466c359f-3bba-4d32-9b1a-2d326dc39de0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "3431c072-6fae-4178-86de-4f3c769a88c4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "14995360-e8f2-4448-a3fe-f2833935d98b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "a13a7181-91ee-495b-b89d-b6e1bc768279",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.18181818181818185,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "8bf696dc-467f-419a-9164-3ad0c4a93277",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.05128205128205128,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "20b1cc15-5d30-4ffd-bfd0-f261e3082be8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "287a10aa-96d5-49b8-982b-1c5b13cf7de8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "790983ee-e785-4701-bbc0-e1a57db6b6bf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17142857142857143,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9319c01c-8785-4c78-8a24-a7c023df1070",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "01fc60ed-cd80-4127-beb7-ea60ded28642",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07017543859649124,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4b6f25e9-43c6-4c7a-aa9c-9cece7e23111",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "09e8971f-41cf-4cf1-bf2b-c83ca3f165ff",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21276595744680848,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "543596d4-cdab-45f1-90c3-4966b5aa0253",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "39b9e476-a489-489f-9267-fb2bcadc994b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "66fd71ac-efe8-4fc4-b43b-077b94db2b96",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.04081632653061225,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "b57707a7-36a1-4f3d-92b5-d26fa9b04d9b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8571428571428571,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "7b99cc15-72fc-4bd5-a2ad-d8f67578448f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "5de6c7d0-0ff5-42eb-919e-7e4a67267372",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45783132530120485,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "52255ab8-2bd4-4c11-8305-b991a9b5173b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.380952380952381,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "76f777b1-4a6f-4e71-af89-b0f71b5d902f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.41379310344827586,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "227ad58c-7c34-4968-a372-2c6049bfa72b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4861f140-5971-4b7e-b22e-062ed4929b61",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35000000000000003,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "aa6b7e6a-874f-4c9f-929a-e938f14069b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "5da36f95-03c0-4b45-b447-f0b39fcbcdbc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2285714285714286,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "23e3e5a5-cd48-4f53-a885-f09d8d17538e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.08333333333333333,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "f531fa6d-7c89-4766-a0b3-d85cfcbaaecd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09090909090909093,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "28902f5f-a9a3-40c8-ab5a-8cbe88e7cef0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.08888888888888889,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "7b1b2552-acd0-4b25-8910-1713d71d3d26",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.04761904761904762,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d276e61f-4aa2-4771-8028-dd741e54f8bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "1d84394e-d580-4651-97c0-78c40c6dd694",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30434782608695654,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "9d769c4d-737b-4e68-8691-1846c5f6e509",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.46486486486486484,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "6edc2785-8082-42c0-84a1-5c7e89c6654c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "f6e628a6-109d-4e06-8837-a1af229bc505",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "73645351-2cfc-4032-a7e4-8001d7fd8a0b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.391304347826087,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "57bb814a-ca7f-4461-8a45-28fe462e0fb1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2777777777777778,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "cfde8a17-44ae-4fe7-bc8f-60c2d80f7380",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.608695652173913,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "6e1eeae1-ca6b-4db3-a620-190aece5b37c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "157b68d3-8914-4e9a-a2a3-b7b1ed0499f7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1951219512195122,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "a9ad300f-2db0-41b6-bd90-41d2643b6505",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21212121212121213,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "e8401429-2b58-497c-ba3c-674a406b3e73",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "cd70035e-9ddc-423f-bf2d-92a052fb7877",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "06a46f05-7a8a-4515-a2a3-72909213a654",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5465116279069768,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "ffb75884-b207-4ab8-8afb-d6a74336594c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26490066225165565,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "309e08f8-6cc7-4f91-8339-89ed9b338bb7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "94c8aa69-f7a2-4d7e-9ef2-9744558d808f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "a522a2dd-c6c2-420c-8604-19b1368ab531",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3529411764705882,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4700e6b3-7a99-4edb-9a08-c57886406d18",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c01770ae-f529-4c3d-b5fd-8e84913e739c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "66285561-a00b-4191-aea8-558af4e2db4b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08695652173913043,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "0a532676-8454-4994-a231-43e3627c43c3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "f9318072-523f-4470-883e-136c45768b9e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.043478260869565216,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "97962f4e-7430-4fbc-961e-f1086ed35d5c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e8510af8-cf24-4bdd-9240-dd17f8ffb25e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "794b02d0-d726-4671-be4b-3785e5ca08b7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "5fbbaf3b-27e7-4658-abba-00cd4bc41e1d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2916666666666667,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "4926b984-0b52-40a9-bb95-18df312b4c8c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9060e9bd-7e2c-4656-bd20-0cb114f6c7c4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9e46175c-c9c4-49d8-943b-be87ce399730",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "2616264c-34cb-4ffc-ada0-0402c8bef8da",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9812e507-93f2-4357-a0f3-a4ef165fa00e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "b4c726b2-eefd-4e6f-97ae-0dc388e36e26",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25806451612903225,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "e86447fc-fbb5-4d13-99cf-b052e962de44",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "92a8a2e4-ad6d-4ae3-85c7-3b761e4ff062",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25925925925925924,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "f5ff3be8-bab6-47a3-91bd-3caf761edda2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c89c55a2-3822-4d08-a800-606f495afe2b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07692307692307691,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "6be98a73-b729-4f84-8b0c-1d830c1d37d2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5766871165644172,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "0e9b619e-68da-4a84-a741-886a433704a7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.0879120879120879,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "b2595a09-1c3c-410c-a6bd-e10af3341b19",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "8c236297-a7fb-4139-bb0c-98d0b5cf0c3a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c0d85c9f-81d5-492f-afaa-bda07146caa4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "2a84d1fe-e79e-4ee7-89d3-3ebc3a54cfbf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6428571428571429,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "2a78d1e4-03db-4b24-a8e4-686853443020",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42105263157894735,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "ee34a1a2-f494-46ff-96fb-ced13dc24824",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "4c7e115c-0120-461d-9717-b9c5da487d6c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "1e51f605-a07e-4aad-be41-795a6932d53d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35294117647058826,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "f0104c16-1eb8-4665-8c48-9971265ef31d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.875,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d4289947-e76a-4143-af4d-f7393ca743fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "6ddfc77a-3efb-45cf-b9f9-68a53301f719",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42519685039370075,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "4e6a7097-4876-4eff-bd11-7ccf0f25f320",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4615384615384615,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "9b45a224-f043-4434-a5bd-e50e67d8fd5c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "af826533-56ca-4601-ace1-a755db235fe7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "b5196c95-648f-4139-9cb2-eeeea966ad7d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16000000000000003,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "474ffb9a-85d6-48e8-a4c5-d64f46254a94",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.888888888888889,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "5a0a6862-bc7e-4760-ad1e-ae152eba2a74",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.10714285714285714,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "243c25c0-15ba-4cf0-aaca-d7fed558b921",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.06666666666666667,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "ef306413-875b-4f62-b561-79f4ba50d35b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "05674af5-6120-472c-b7c5-f6643a22a02b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.15000000000000002,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "8b4070ed-1bfb-47dd-bb79-922b1e40c675",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.04166666666666667,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "769200f6-752e-4499-aecd-d72243b31f9f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d6622720-fa53-488e-8be6-4bf0b3d341c0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13861386138613863,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "2bdf5cec-98f3-4479-82c9-cd3da74f9727",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24242424242424243,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "2cdb3988-1e61-49a1-8a9d-1aa3ecff9000",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "81928093-422d-45ba-9ad8-80bc7e5be203",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "371a45c2-75dc-4a75-a3ad-88dcf2f27822",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1951219512195122,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "8c20dc02-69df-4faf-a91f-a633cc8ea708",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08695652173913043,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "070f676a-bec0-483c-97e3-4cd30800fbb2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14634146341463414,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "65529469-f57f-4dd6-b24f-1a79b0f824ac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.12121212121212122,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "59db7cf0-38d8-4b7a-a900-32bc8355f629",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "ee4ae2a5-36f7-48b7-bf55-219c7ea9461d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08450704225352113,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "3a7a8a51-2ca5-4d33-bf19-9b02266b69bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.09090909090909091,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "28941af3-1100-4451-891d-2162764545bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.125,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "5bfeddce-ede3-4b3d-a761-897e1722f0e4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5538461538461538,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "154c4ee4-5d51-49bf-a59f-b6977976e191",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.35748792270531404,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "26ae7df8-8283-4858-8609-a78378bba441",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "31c52bf7-5a56-405a-a75c-7a50b25048c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "6bdee0f0-9725-424b-8db7-62ee2377759d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1568627450980392,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "b7cfeca0-23ef-4c47-bac4-9c9f61ff1ca4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17142857142857143,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "dcbd0e01-2144-4f1b-aaed-72d513d1c40f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5142857142857142,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "bbbbf7f4-2e3a-46e5-90d2-6f42e047ef31",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2962962962962963,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "4e88161d-d5da-4c4a-9ec6-5aeb5e3bd0a0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "0ce00265-592b-42a6-b413-2f881a8a7636",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "a05612b4-a769-4c96-b81d-72a2b2640a6d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08695652173913043,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "11d3946d-6fc6-44ef-8044-47891b912d75",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "f1016f82-4d5e-451f-abd5-36728c894981",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.43859649122807015,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "77010d5e-99f3-42f1-bf4f-fb14610427aa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3778801843317972,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "8185ef1e-28c5-49c4-bc88-4fccba16f38d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.11764705882352942,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "32068e77-818b-467b-abd0-626dcadcaa7d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4c281559-4613-4d69-810a-44d3374b918c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4d64223e-86e5-4d80-bca0-5cb37872e094",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e363ddea-a45e-446a-a834-ae5b6f2121a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "22fc0779-3ba6-4b7e-bf7c-a1b2d3639da3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15217391304347827,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "8e9451f5-3c42-40ab-a3bf-792c28a07a36",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "c5115e9e-bad9-41e7-92f0-77eeaf4719de",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.0888888888888889,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "e370a4d5-86ee-4c27-931b-129def27a175",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.08,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "27abe50f-c71c-41eb-8d99-e6143b3b0d64",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "cf6dd1c6-784a-47f6-bfb5-fa64af437c4a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41904761904761906,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "664c7218-bef8-4976-9c84-6f95bbcefdb0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "3d7adf77-1499-4c95-881e-561078a22d5b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23076923076923075,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "021381fb-6069-4b51-aec5-fbc82418cbbe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "961b1182-db95-40a7-97a1-3d3a1d689f03",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c124bd9e-9f65-4ccf-b49a-f48e56e18ef0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "424fe085-75d7-4f76-b1ee-c2078c04f22c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2352941176470588,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "6d9e9cd9-23ac-4869-aa6e-8493a78ab5a7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "d0abf1d4-0a46-4af9-b6ff-f2d46f999e2a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "8c8bf59a-4679-4b9e-b3db-85b897edee4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.05970149253731343,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "1e91425c-687c-4c2a-a986-d1584fc2d31e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 1,
+        "f1": 0.7777777777777778,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "112bde3f-2ed2-4886-8cfb-4ac7572cb1ea",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.17391304347826086,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "1bc1dcaf-8db4-4039-a1c7-a9829730f15a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5194805194805194,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "a261e69d-a3e6-4d1d-9772-8a671b27344d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3801652892561984,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "803a72cf-7d59-49f7-a494-83a10ca5bb3c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "1af2a338-253d-4ca2-afcb-24dd68ff27dc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9e72b54a-9091-4773-8173-1cebd183767e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3870967741935484,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "76c2bdde-6bb8-4938-b3b9-e7b6fb6f6460",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "8274cfe0-3289-4bee-b7bb-f2d1ce78a972",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17142857142857143,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "3224610b-2cd1-4b4e-9592-c765ab074206",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "e201bcba-6f81-475b-b98b-028086186264",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.09756097560975609,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "5cfd3367-a5bb-454f-95b6-1be59a90b76b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "1351ec12-4550-44b1-881e-56b00f52f00f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "ba7d9aeb-99d0-4130-a177-5238f322845d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "a9e9c110-33de-4cbf-ae37-d470fe80160e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.0851063829787234,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "602f09d7-53b7-4149-9c4b-77abd8336c2b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4411764705882353,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "1810e294-af7f-485e-8be1-1856c7b34079",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.06896551724137931,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "b2d5f6bb-f433-4f2f-9ba4-9f68a8c4f120",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e676656d-27d2-4d22-9c45-d948ad410702",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "05a4993d-60d5-4dfa-aa1a-f3213c41f875",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d20c2590-ea7a-468d-ad83-ceb7404cb5aa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "fb92d6e8-fdcc-4850-b71c-0c588c87e906",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20833333333333334,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "684cbc45-faf6-4f75-bd14-d7ead55a19c6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "9f520f66-3d34-46b5-84f1-540451aada25",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.058823529411764705,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "e068c23d-466e-4e6c-96ec-fddd7fe012bf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "f21a2c86-9388-4190-8f48-eb3ecc9f117c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "ea7e4604-f65c-4009-9729-82feaf7acc66",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.484375,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "d9b076ee-7d47-449d-8cb7-828af43cfa14",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.06299212598425197,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "c6624546-dc9e-40f4-a59f-3706b8198e7d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d3b7ed4f-5f19-43d1-aefc-d63979e32a0e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "1e721e21-4425-435d-8ada-2a128e852d14",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13513513513513511,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "81bf5641-e7b9-46c1-a4c0-242387a11a3e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "d9e73186-fa04-47f2-a48a-b65016a13999",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.0909090909090909,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "d0d3e24a-f72e-4a7e-9b0e-636f6adb2694",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.0909090909090909,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "c4486413-15eb-479f-8593-7bb6146d89b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2325581395348837,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "bed2abc9-903e-4919-8f27-d8365ade1207",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "331809b9-dccb-447c-9676-bcb0ba7d3a16",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.12000000000000001,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "ebc2544c-4c2d-45f0-9b1e-56f3dfe48007",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "a74cc79f-bdcd-4d5e-80b4-aec87530f16c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41739130434782606,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "ae7c0127-6325-4abe-8dde-4417491d4539",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3605150214592275,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "31b399e4-f0bc-4b3b-b258-c8379505c458",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "982ac8c8-1deb-4099-a740-80d0a21b6df8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "6fd42362-b73e-4af0-85f8-465554a26d54",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.12307692307692308,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "952b8519-4966-45f5-832d-507578bbf0bf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285715,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "2423c13e-d118-4e40-8f5c-5d309350d41a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "177062dd-cd3c-4979-b4d2-fe80f9a1d352",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.11428571428571428,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "15bfa7ae-4afb-4c0a-b659-2ad512549ded",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "3c0eb283-ed5a-4ca6-ac1a-c3e97cc3b9a7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38461538461538464,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "fe01d581-4a37-4268-9350-16f18e6a3ad4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "8a0841ef-0aea-4d76-9fc1-2a0ff335a6eb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.06521739130434782,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "5349dafc-3e0e-494e-aba0-94a44b80785b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "a2fb7760-954c-471f-9768-f511100a485c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42396313364055305,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "91feb852-c136-4ad1-a050-c94017cc2b6d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 1,
+        "f1": 0.8181818181818181,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "0a6ed645-6967-424e-9940-fffdda2db131",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "75a65274-7310-4a60-be5b-cc0b6d925709",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.43902439024390244,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "09450ffe-bc5d-4435-b681-1da3b6a449e9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3783783783783784,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "6aafe996-3891-4e2a-b186-86922c79c550",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.17391304347826086,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "a9cf0273-af51-4019-8def-57fae7596b39",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.19718309859154928,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "604b34f8-920c-4546-9a6d-eac7f6d82764",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "e8d8bed3-7610-4b19-bcac-1c90c4b6839d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "771fbe3c-92d1-4ca0-8593-c2111c568ed4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e3b54606-a9c9-4e43-8aa0-02ae42795df0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14634146341463414,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "ce8d6087-e0d7-477b-8e5a-b0a1c37d9c39",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2532467532467532,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "30ceb25e-e73b-46a4-9f5e-a7466e857994",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.336283185840708,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "154c70ab-ddc9-44e7-b21b-e11f9d527faa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.018018018018018018,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "580b0af4-3b67-4f0e-8b46-fe93bf0955d2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "63331c0d-6cf5-4230-9d2d-0cb7565a000c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "aceb48ee-86e6-4eca-9752-6d5f764f8863",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17647058823529413,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "171e4deb-e53f-4c66-b1ac-2f81d12231a0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2564102564102564,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "5431d0f0-3e6d-46b3-881d-e589aab2b8fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.12765957446808512,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "ba4237f4-b211-49a7-9df4-d33d8a31d721",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3684210526315789,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "48e1f6ee-666e-4640-85e3-5b6e690ba0dc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5384615384615385,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "7976ef1b-cb49-41cd-8846-54a6c0614182",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "29ae02dd-2876-4da4-9907-b3220980622a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "dedeebf5-3833-4d4a-9310-853bddee082f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37762237762237766,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "260f4750-be34-4ce1-ac9e-0a0ab5ea5e36",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2261904761904762,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "ee95f0ad-3698-4327-8bc9-2730a4b2fde8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3846153846153846,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "0efb9765-d30d-4cef-8834-4a49b7d85110",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "be61a5a2-73b9-472b-afdb-b380f557dc96",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2222222222222222,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4ccb7445-f7f2-4c60-ba4d-7728372bca51",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1917808219178082,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "78233ead-4d2c-4a06-85b0-b51f9a6f8604",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4242424242424242,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "9f954fb5-eeab-4fc7-bd87-8e4632e0aa1c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "aca90831-c85a-41fa-9826-b2e3659ae9b8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.10526315789473685,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "ce4dcd25-17f5-4312-a056-df4c2a4b90fc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15789473684210525,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "ca9f85a1-639f-4fc9-ab3e-5a0439e11d6b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4af68359-9d50-4466-825a-f5c0383751be",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14814814814814817,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "1af9dd53-e0a5-452a-af5c-3825b124ab6e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3875,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "402d193c-08dc-4bba-b62d-174d11931127",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.29045643153526973,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "7c6bd51f-4d43-414b-a32c-aeee2111580a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "3ecb6806-b3e5-4c08-a7af-d72c9c93ff89",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4d01deda-4f2c-43c4-aa19-fec7859777bb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.27272727272727276,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "0a1d3c8f-76cd-4090-9503-94a0fff50889",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20512820512820515,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "8f452f90-9c41-401e-99e5-fa28499a9b71",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "8be7e33e-aa95-4c6d-af4a-beaa6d712f53",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1095890410958904,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "0f888b13-550b-4df9-b1bf-913081ba4293",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "5edafcd1-f9b6-4080-89e4-09237fb6a6d2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21818181818181817,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "44d53b2a-d5cb-4d1b-bd4b-de6102f9db0c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "640ae403-ac73-4e7a-8a93-9df2a0e8c588",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "07e297cd-f5a0-4a12-abc0-9f3478288f5a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5000000000000001,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "02f9369d-4f39-4eff-8099-1244aa75313f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3645833333333333,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "01bf7439-7e28-4ab0-b05e-2233a0389de8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "b80e9e45-bb72-4787-90d9-8bd839144c53",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "2ec3edb6-7077-48f8-9304-795430ed7cfd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5555555555555556,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "30b5e37b-be67-4f93-889f-a0b82cbf2027",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "035d5132-b19f-46c5-8a63-a376c57c1c97",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "4b29f36b-4518-428d-8ae0-b9baf2aef43a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "18ad066a-b411-410d-8835-546f65572205",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "bba42436-24f0-41db-81ab-a0289aa7480c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3181818181818182,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "bd2e5a17-aaba-4702-a660-54093f2d9062",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "7eb51e6c-c8bb-4419-bb4b-d9a618a284cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "657fca25-a884-430a-a6d7-d4c3e4bea62a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3883495145631068,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "e179534f-0b8b-451a-88cb-048f530edf1e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4838709677419355,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "7843c7a8-e99f-40f2-ae92-151931f6aebc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.47058823529411764,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "ac15fbaa-0ab7-4ade-b332-2738e97f03c9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d947e1f3-f4c7-4268-829e-f29a458ef94a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1818181818181818,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "820838ee-f27b-4ed8-b4c1-5b5c27e64c17",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17391304347826086,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "f1e6fa94-8c97-4b84-be91-41aae6f02dbe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.04,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "0045dd35-6fba-46c1-a240-40689e07aaa3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5714285714285714,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "18c8556e-53f5-4ad0-a9ab-957b9725045c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07692307692307691,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "06cfc806-1b16-4c49-b8d3-30f07ff9d5d0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.04,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "7e426f34-55cf-4b57-b547-713ce8070470",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.15625,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "d30709fb-3680-4d96-be72-b46ac290054c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "3e7319b3-eea5-46de-8bdd-281b6f5354fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14414414414414414,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "f50951b0-df99-460d-adf4-f4dbdc4227b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09756097560975609,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "964eab05-5b42-48f9-8d1a-d19d64f4dac8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e3432e91-814c-4240-80bd-8e506583dd54",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "ba354605-41f7-4fb9-b180-c52241634053",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.20689655172413796,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "f5987521-fe1e-4bfe-bce3-30c06fcd1808",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "eb257356-e103-465c-bdd5-82c3aa0bc631",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.23809523809523805,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "18dd5131-19b2-4c52-9b64-b0a49e9c6fa7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35714285714285715,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "71791058-1b64-40c6-b3fb-1635aaa85593",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.18750000000000003,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "dfc0e7e3-95bf-4f3d-80ea-ddd7567400d7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14285714285714288,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "37dd8423-e742-4ab0-8b7d-efa7f4525380",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e0c454d7-0723-4db5-96aa-8f3e734e1931",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9122cf80-b8e9-4e3a-8de6-6f577f9bc629",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2621359223300971,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "4574a999-23d4-486d-82c1-9ba1093cc1a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.34074074074074073,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "70fa5f93-8e7f-4512-a41d-9fe3ece77ce5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "696ff05f-33bd-458f-99cd-a84d39123ef7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1142857142857143,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "6ee019e5-6cb0-4aeb-8188-748acfc8a99f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "5b87a9bf-348a-4962-b258-c739864037f3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "266c090f-b47b-4650-9608-b3ca83f935cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.08,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c8984adf-87bb-403f-b469-2dac170159f4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.12,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "34ccaebc-b456-43f0-a1dc-c2ea3c25f3c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.196078431372549,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "bcd70c0c-9ee7-4950-b990-99e30a538bfc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "27eb8ee8-ae28-4d24-9cb1-1360f4c0a8c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "238ac09f-8d22-4a1f-a649-a3dfdbf74fcf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d8b765d8-bbb9-428b-8d6c-23842f1693a8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3611111111111111,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "5736fc39-9c57-4bbd-8ceb-071d99ac24d8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "7e47fb6d-4267-49a2-ad12-6113bf6c7d4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "6a2edcb3-0c5d-46d5-a2ca-4c3f393edb9b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "b8c89d83-f617-4624-9d6e-1479330674d4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "6f1d3f00-e094-42b2-8d00-6d4f20cec77b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "6fd67407-8ee5-4acc-a747-a21c9517c14c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2702702702702703,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "9c8a8523-7c2f-4887-983a-323a4b88138c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "555b2acd-2259-4059-93a3-cea017aa641d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30303030303030304,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "c5abccaa-0f42-4925-91a4-66c6ea4c7809",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3703703703703704,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "af4723eb-6cc3-4771-b090-daca02c2f57b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "0c117b39-f90d-484b-8dec-5a66b5c81498",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.41025641025641024,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e82dfc9b-94cd-4c5c-9618-482414f3d2a4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5663716814159292,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "f0d458f9-4005-487c-b498-2bf192506b63",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6009389671361502,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "346dd125-e7fa-495a-ba11-026d82f37b77",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "b9ac54e6-6ba8-430e-9790-200eae8c7c24",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "578b686c-364a-4220-8198-6b061effe147",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5128205128205129,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "24ff631d-e719-43c1-9121-7046fa72b0cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c88d6b7a-6607-45e9-b688-b315b3f9feeb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "6fa30c4b-d1e1-4635-a97a-ef8277a95b79",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2285714285714286,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "8c402d7d-474e-4a15-8c4f-2f04ed4a8fc7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "da22f36c-7d75-40db-b63e-7b8dd8d936e9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2318840579710145,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "e93a454b-1a1c-430d-a4d1-d99916407d74",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.9,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "03771a13-2966-4518-85b5-fc0eb6a837af",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "1ef3e32a-9649-4c88-842c-3c4a88eaf362",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3355704697986577,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "6df3987b-5a24-44da-9b86-7b916fa886b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4153005464480874,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "50aff374-74d8-4d15-9b48-8ae1a27007aa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "6ab5a800-a37c-4740-b18c-bac194c9ef74",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2380952380952381,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "875bbf41-692a-45fe-9b72-e31ffc5065ca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17391304347826086,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "bdbe94ca-9016-4215-be02-b859bf3c2913",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "76e772b1-4188-42cd-a007-0b3be774c01d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.15730337078651685,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "fb4960f4-d125-4690-8010-4cd4ccb05cd2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17543859649122806,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "a37fcf58-4e99-418f-a85e-b3ca1b358013",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16216216216216214,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "23f71b70-1b6d-4dbc-b3cb-bc69a28363d3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08888888888888888,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "8f3a1514-7aff-4810-bf23-bf589ec3a972",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "94f87467-66df-41da-85a7-ce0d645052fc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "10a6ede2-7e66-48e0-9002-a5085faa01ec",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.22448979591836735,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "c757b46f-620c-4d3c-88ce-646a1812e9ae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.375,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "bd37822a-8ffc-4688-9fdc-fd2faa975e8a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 1,
+        "f1": 0.782608695652174,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d317035a-6d65-4b1e-8fcc-2b3d0555e267",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "0c6ab68e-f5f5-4dbe-9b38-b9f9f2db700e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "7e115974-3ca2-482d-b719-c39e830518fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2692307692307692,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "22b5115c-cd59-4e98-95a2-94ba64248f0d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.23809523809523805,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "b55e621f-9686-41bb-837b-092d689b7f09",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "4650616a-e3d9-43ed-96b9-c7e9526d20fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13636363636363635,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "94f8983d-b777-4949-9c4e-ba3a20b1dbdd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32432432432432434,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c8d0eb44-2a63-4ad7-86ab-5c9b3d474439",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e60e9778-0e7f-40e8-ba3a-f3066394e863",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21052631578947367,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "00b2d4a1-2df7-40c4-a6d4-d39107a1553b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1899441340782123,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "eafd852c-a589-46bc-8eb4-d62fe70fc55d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2251655629139073,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "c384507a-b475-4a1f-b02a-470d22d96b43",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39999999999999997,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e438cb70-ae96-4d26-b1a7-e066eda2a02a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "1f44b47c-ac1e-45aa-b655-0f1078f067ee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17647058823529413,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "2f3af792-d9a7-4fe4-b6c5-b1fa22aa2da4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "bf72a66b-eb9f-48ec-8386-b1a425bfaa2d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "545dd291-a5e2-4a2c-a720-fee4236a0ea2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16279069767441862,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "99d714c2-808f-4865-9af6-006f2aac1c11",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "9223955c-df44-40de-94d1-956c2d6f66ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17543859649122806,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "6692fc86-b827-4351-980a-d667cd951fcd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9377e9bf-2d8b-48f3-8da8-3922c7dc3aa2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3243243243243243,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "b3552232-4e64-48c0-9369-88e5680e3d48",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.29139072847682124,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "d395bac1-9367-4a9c-b1b4-06825c07b5d6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3575418994413408,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "a02e57c7-4652-47e1-a328-a9bb00317ac2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 1,
+        "f1": 0.7499999999999999,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "530114fb-6597-4c26-af06-e61e3f468ac1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "98bf10e4-ee24-46b7-8845-0e2875ef1778",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e3e26ec0-3910-4c02-a0ec-10d24ba718d4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09523809523809522,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "a5db3226-faf6-42a5-95ef-4c8ecfc99d10",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1935483870967742,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "676cf5e8-5f49-4f38-b41b-e45b078efa55",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "c2ae9610-bf64-463e-8d14-91a078ae6014",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07228915662650602,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "6694e1de-db31-4251-a432-6a391d7293c5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1111111111111111,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c571a5b7-2473-4258-8dbd-025011584645",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "bf6f526a-0e90-4764-b572-ed98ef8f8fb1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "fca55b30-8c1e-4428-bf1f-498ceb051ec3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.19444444444444445,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "84080577-6420-46ba-81bc-ee1e3b456f37",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "23193dd4-f90c-4dcf-90d3-c61b8ef19a53",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 1,
+        "f1": 0.7777777777777778,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "275a21eb-3a07-4f13-8c82-b6a61757703a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "91bffc46-470f-4143-ab46-0848a86bdbe2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35714285714285715,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "93d9726e-17e3-444a-9fc3-9518747a336c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6363636363636364,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "19b8c05e-7608-40f0-a93a-4b3e60bcb1ac",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "dbe2a4e1-4c61-4a10-b40d-a1811ac01cd8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "e05654ab-9030-44bf-b8d4-c94b66e6e468",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "a1160cc2-c224-4421-850a-1e16be13a0d1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "46a65026-cdb4-4223-8e86-ba64c8afbf1c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4b78765e-b4a0-4c13-be8f-dc56cab6c929",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "edf4ffe2-c8ac-4ee0-98d1-85a8161e460f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.562962962962963,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "aff471fe-f2ac-496a-ba5a-68cb3ee7ab68",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4166666666666667,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "9d047b56-b92b-4203-a6e8-13c118028116",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.923076923076923,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "d1ae8997-c7db-4f75-9ca2-f95fed3bfc90",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "a1f8a734-156f-441a-b80e-a041163e85c6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34146341463414637,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "6b72b257-3a5e-4b76-ab06-cdc41444426a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17391304347826086,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "a835c32b-48bb-4409-b187-cddc866b06b2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "7db9f72d-be84-4da0-ac07-cb8ac010d9b4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "14c940ec-2125-455e-9dbc-eaf3812560d8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07894736842105263,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "3cc58671-ec37-41e8-aa01-a921a6d7374c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.17142857142857146,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9ccd3e8c-1fb1-4eea-b40b-53e2b004a7bf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.04444444444444444,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "7de91e1d-00ac-4d86-a792-f4121f67e52f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.7692307692307693,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "a02bc104-1039-451b-a9ef-13dec7154138",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "1e25a319-1ff3-4b89-b4d3-ea238283aeaa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.35416666666666663,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "6a5dc563-8ba5-47a6-b813-20151878c4b0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.043478260869565216,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "c8efd99c-bf2f-4d37-baa5-5114332ca71c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "b7231bd5-22b4-4357-babb-63d98067a15a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "7647a14f-2ba8-4e07-9c4a-770b0664c5ae",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1904761904761905,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "a6a065ff-c5e4-47ca-9f36-4de65ad57940",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.10169491525423728,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "ce1ff2c3-8d65-4a31-af26-96ceeaf9272c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "092aafad-a3ef-4884-b228-f2d7cd01ddde",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.196078431372549,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "13f1c38b-bfa4-42ce-948d-64af36fd20cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "9d604156-85ea-4c43-b669-262dec064739",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.05970149253731343,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "add8b58c-d106-40c2-b474-93dbf5d0b758",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "a4482165-9e7a-44a3-b22f-586bf44b9901",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35555555555555557,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "9c2f7a02-bc68-4ed6-9dee-e87cc508ea34",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6017699115044247,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "493202d3-4ff9-4cd1-b70d-eb0b93133a50",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "17b52317-9e3a-4e11-9b6b-256a7b5b6eb8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "bd5d9977-8454-4229-ae72-2e90cf73f3a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "12d1b904-353d-4fce-aafe-2f22805e7c67",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2777777777777778,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4bde4534-f396-45c9-9a20-33d015cd448b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2564102564102564,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "43882b27-faa1-4840-aaed-acee71a00c8a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "5208872c-376f-4e47-9812-eac818b484e5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "0ba3d8f5-f4c7-4acc-9f3a-556278e808bc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16438356164383564,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "34f75353-7fd1-4285-ab91-64a8278ddbc3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 0.923076923076923,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "570c451a-a908-4bcc-9acd-5080ee4bc9d6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "e2234099-a770-427f-a15a-8a981a316296",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5599999999999999,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "942a32bd-b395-4643-a22c-661360f9f8a4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4076433121019108,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "79a2ab3d-7640-41c4-9900-1f29dfd8fd81",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13636363636363635,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4ad63014-cbd3-4363-8dab-76477df86302",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.18604651162790697,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "2f94ea9c-1574-4671-87da-f87d9b654f3d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1702127659574468,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "0c499f10-0b55-41eb-b766-b1f9ddf06fb2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "4af176e2-fea2-45e5-af7c-520214507f33",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "8309c673-76bb-49af-b224-68942359e24d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1142857142857143,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "75829a79-fe93-4f22-80c6-6d8195cf02aa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "4a14d100-a7df-4b0c-914f-98da38d7453b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.11764705882352942,
+        "llm_judge": 0
+      },
+      "category": "SOFTWARE/swebench/C"
+    },
+    {
+      "taskId": "02070dcf-4566-4d6f-822c-28e5d3e7d90f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.05,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/B"
+    },
+    {
+      "taskId": "3f9865e3-d391-4c10-840c-9c51bf669aaf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.17142857142857143,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/A"
+    },
+    {
+      "taskId": "bdc479ce-9f75-4a07-90a0-662e4f4e66de",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5257142857142857,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "32813da2-4cd4-4258-95c8-abd60edece01",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32558139534883723,
+        "llm_judge": 1
+      },
+      "category": "SOFTWARE/swebench/D"
+    },
+    {
+      "taskId": "41611ff3-6b23-4086-bdc5-940f659b5e10",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.6037735849056604,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "359be10e-f56f-4c0b-a867-53f2baf359cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4324324324324324,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "a96f87ef-7b58-475c-bfc1-97ca86b05b84",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "7ccbe1de-265d-49b7-8bac-65be98e52d3f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "6617bf63-81f5-4362-840f-cd33743e07f4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4507042253521127,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "6eae2f68-e1ee-4b2d-bdf2-18ef03a55e04",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "93c986de-df73-41d7-ae52-1af2fd94c0c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4523809523809524,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "3d0e1c9d-1ef1-4791-a1d6-e5353c89ad14",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "ec9680dc-dc65-4847-8e50-c2ac678e4563",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.7083333333333334,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "06cb9623-c40d-4f39-a7e9-7c0b26b4408c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "305aa4d5-25eb-45d0-b6ac-84258b9bb61b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.46913580246913583,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "1dbb2ecb-583b-49ff-b74d-7ca27fba4e7e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "7a4800f6-9680-4a6d-ab9c-59d41f0f6bc0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33999999999999997,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "f1e61956-3736-43fa-ad69-b6cc79ec1f38",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.10256410256410257,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "36ef0891-761a-43d8-a488-76afbdd70881",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3283582089552239,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "5ddbf86a-b6d3-4cdf-9ba9-3a39564889dc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15094339622641512,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d292bd83-3c69-4dd3-bf5a-90030fb8a608",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3018867924528302,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "eaec3128-5a9f-4368-a6e2-4d99e96ccc8e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5569620253164557,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "61318761-708a-4c59-a261-43f781ae5847",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33766233766233766,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "1d001a38-5c73-4a20-8dca-416d1047879c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38095238095238093,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "a2053e04-251c-4e9a-bfad-897b3690afd1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333336,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "9ddd6216-2272-4cc1-aab9-a2f21f664675",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.09756097560975609,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "3067ead9-e82d-4a99-8578-6708c52448e7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3157894736842105,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "728d5ee3-36af-456c-8ee2-26ef43c0e0ce",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3246753246753246,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "fc87eece-1bc3-4487-91d0-2be9f601e5cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39306358381502887,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "81d84bb2-6cca-4f58-b384-7054164824d1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3829787234042553,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "847c4e67-6d0c-43b5-9fc8-43ace6d320c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "0d5d509c-a284-4a67-bf11-0070baea156b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3492063492063492,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "707e7c6f-f563-4c16-974c-7e3309495fa6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15625,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "b93ce4bb-3cce-4aad-b865-bd9c5a74c486",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.05555555555555556,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "f4ce032c-3495-40ea-98b8-dc752c79e44e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.05128205128205127,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "e5a9e15c-ad2e-4508-a46b-e414d5e7687d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34343434343434337,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "be66144b-452f-4b1c-acc8-cffb44911f9a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3888888888888889,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "4d3ca813-f075-44d2-bf57-ee600132d05b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.297029702970297,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "932b60e6-5c3f-4f3e-b52b-c16524adadbd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25396825396825395,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "0ee5867d-ad4f-42e9-974a-2d751f1fd17e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.04444444444444444,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "5798d2dd-cd62-4cad-b442-9b24bc0f56b1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.345679012345679,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "5a0bec64-4ef6-41b0-a845-a4514df165de",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44171779141104295,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d3e85f8d-27dc-4d61-acca-975e469a99ad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4933333333333333,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "3a4966b2-e5de-4472-8624-98216c4fa382",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3488372093023256,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "cda578b8-791e-420d-ad07-6b8842596662",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4233576642335766,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "8d6f2ecf-6097-4f46-8431-fe1a47be8df6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3291139240506329,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "af240ed4-ed3f-40c3-ac33-67ca411917e9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4482758620689655,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "259ffe85-a35b-40e4-8908-2687c034f1c4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13513513513513514,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "8967a313-ff24-43f8-9f50-3d8babfd8693",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4727272727272728,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "d21bcf31-d1e7-4095-9a90-9a575566c924",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.437956204379562,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "eefc8e60-f0ee-400e-b408-9ad53fdb4933",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3724137931034483,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "c37691cf-2c1b-4978-a599-94c250ad69e0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.03508771929824561,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "8ea05696-533d-47fe-ae59-2b2d2cb7af6a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3880597014925374,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "4e489529-6900-4e04-8e6a-8d8992f3f68e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.25842696629213485,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "5443837e-2a5c-4b0e-9b94-6815a5910ff0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "a85c41fb-a73f-40d4-99c3-fab71d69abd6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.31250000000000006,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "64525b95-0bab-4ee0-8404-e73c8a33fcbe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444444,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "b86e1bfa-629a-41a7-bad2-2357ed415fea",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44094488188976383,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "07b1f726-f5f7-4208-b90d-86520f78ea0d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09756097560975609,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "6349e3f9-81f3-426b-b8da-9cc4dc663e08",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07407407407407406,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "5541a6cd-ee4d-4f18-88aa-71212cf14c5a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22916666666666669,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f71aa31a-59b8-4d85-89ae-5df02da936c8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3529411764705883,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "d113c3e2-a011-4bb5-9090-cba019675f07",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3036649214659686,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "6d0872c4-118d-4ae2-9c09-ee285ab6952f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4580152671755725,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "99cc5f27-63aa-4888-9994-8ed5b2f9cda9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.46153846153846156,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "a778571a-100c-475f-be34-e580ef6ce27d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4166666666666667,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d65fd738-a273-40eb-8860-1e2db73a7b61",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1935483870967742,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d25ea3c6-3b55-47db-8eb9-9ee23b3ffab7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3376623376623377,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "81ddbc61-f801-48bb-b6c7-2cf72f637cdb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "57dacba2-379d-46b6-9f52-060e132ff363",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4117647058823529,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "0b28e60b-a72c-4b61-a2ee-fa60c978a9c3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30434782608695654,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "559115fa-69d2-402e-ad91-e9f6e0ed4997",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2891566265060241,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "7c387ad8-0a42-4b56-835f-b6f287a85cc7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15625000000000003,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "cb0b272c-0a2f-4c61-9f3d-5b0543272eec",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24390243902439024,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "4dc897e8-067d-4c7e-9008-240a9983ab6e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4528301886792453,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "11eab810-abae-4ebc-aea5-563a78989d9b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26436781609195403,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "48007c10-f9a9-4fed-8f81-1aec8b1c7b1b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4794520547945205,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "c2bf3f7e-f730-4b16-a98e-20d921ed0cb6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3816793893129771,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "c9f2c58e-abaa-435b-9cbc-cf60318d8b0e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "fa407c1b-2546-4dac-b637-105a00ebaf20",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3695652173913044,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "03eb8b21-afa3-4b38-8b36-5b668239ca87",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3870967741935484,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "f133b0b4-eb90-4b9b-9c73-f0c0425219d8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3278688524590164,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "57060ef2-5520-4661-9f18-f9f8277cccc1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3015873015873016,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "061c0cc7-912c-4f6d-aab5-970ec8776c6e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44705882352941173,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f0df5964-592c-4dc1-92b0-5b9715ba9741",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.10526315789473684,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "5605a20c-8d64-407e-90ba-8f5a975f8ec3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24242424242424246,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "e18fa1ef-81ef-442a-a1a5-d52af47b1fa2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35443037974683544,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "3538cdd7-c01d-49ee-b58a-6c2d18a0fb0e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22580645161290322,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "85771bf8-c84d-421a-8dee-bb902c01faa3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.37499999999999994,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "10482397-4a46-4dff-af4a-bb95595b999c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "210ca28a-059c-456c-98da-a23f2beed02f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "91ffdd81-0d59-4c6e-9b41-60eaed93c2cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23255813953488372,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "13ddd10b-06b7-48f5-a0ab-b5b11efd7e11",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5609756097560976,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "4d3f2a31-f145-458f-b0ef-71019f650625",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3370786516853933,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "270ae720-3393-44e4-b38c-015fe1f4ec6b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3278688524590163,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "f9018f29-0631-4054-ac0b-cbcfc58ef79e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f5fc7704-ddc3-4e55-afe5-c3d95d03bdee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.6206896551724138,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "e0430e5e-9e7b-4d64-9d26-7a6f53542402",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "29aa94df-befb-4e1b-90d4-a65c2ffa6713",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35714285714285715,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "6fb9bbbc-0d80-4cc2-9112-19800b593037",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3466666666666667,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "c17b6b76-ab4f-4c96-b4ef-9de1b644023e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.523076923076923,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "595a9924-a896-4f65-be4f-a83803744d24",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4897959183673469,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "61264f91-cd22-442c-b27f-8c6ac2404cec",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3888888888888889,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "38385b65-18da-4ab2-824b-4ba8b90d7352",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.08,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "3c4d2dff-ef41-4d9f-9b9f-f85313016f4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36781609195402304,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "10fe51ac-2642-4d03-81fd-728a1a58dd51",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4096385542168674,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "ce6e0280-fbb9-4e65-b02e-6f34e20b5364",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30612244897959184,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "02503ead-8473-402e-8eff-a91a5347c124",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "38dcf94f-5575-48f2-bd71-b7894d6f48dc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f23e86c1-158e-4892-ba69-2374820f2818",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.761904761904762,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "64bd89e1-7ffb-4c11-8440-10bcb40fa709",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47368421052631576,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "29a5dc24-47b0-45ac-ab5d-a8f027e55cb2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3928571428571428,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "deea437f-9a08-4169-be7e-61ab6d9c416b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.48979591836734687,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "e09d700b-ac5d-439a-886d-249cc4b9f97c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07017543859649122,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "456671ce-e6ee-46cd-ab3a-d78a218da94e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3225806451612903,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "f42fa852-11b0-4bd9-98fa-ceb9d570c006",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.56,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "18cae403-af29-4e3b-8362-7240693e3609",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4912280701754386,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "317aad2d-09e8-4a55-88c7-a6a118a89ede",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "e636a8e9-9703-494c-8bc2-4daa1332ebde",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3291139240506329,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "6cac46f2-9295-48cf-8e0f-fa8b0e0dc012",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8380952380952381,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "c15e33b6-a5ff-4cf3-aca0-689fc652a3e7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "6221bf44-6881-4c93-b4bc-9f0d8c7388fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.44155844155844154,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "19a7b0e5-1b0f-4c95-b941-1ea0dfcfcd67",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7123287671232877,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "65bef64e-c843-43f2-9efc-e9082109d69c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "cf4ede8a-ed72-4507-a501-20c5fc8b6c02",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d793fb13-ccef-4636-be64-8f4429ddad5a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "9993d94b-5ad3-44ab-911b-9c3a979ff855",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 1,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "791e8660-bc32-43aa-b686-397f312bf393",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3673469387755102,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "7d8c3a8c-2764-40ff-a69b-479043a166fd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.09523809523809525,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "6bd8487e-241f-4289-bb6b-1702d8181349",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "9f940622-1514-43f5-a952-48ab488c5a64",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "051aa367-5276-4def-94a0-21125250bc37",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "528f36f8-6a59-47cd-9888-f03da60aee38",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "7a9bcbd4-35be-4fe1-a919-a9a83534c13a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f3a0ee36-eae4-4613-9b44-9b91b5ec7c07",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13953488372093023,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "3152ca63-4918-452d-93d4-865614bb6095",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3529411764705882,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "37009fa0-4e52-4834-93ea-2ac7ea6bcec4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.39766081871345027,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "29bbe7b5-79cd-4d47-a4fa-94d75e647142",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d9d92630-9b44-404b-8735-554c477ff85e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "180c7982-1bfc-48dc-80ad-e17d47e7f120",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "ada3b137-29c0-4d04-a032-0d64db4883d3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5128205128205129,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "12d625b7-3877-46c5-9852-96c043843dca",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "c6147655-55be-4686-b226-a94ddf0236ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "492f889e-48e9-4660-b2dc-51de8cea2f18",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333336,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "3fa89e6f-cb9b-4e01-bef0-a3607df27155",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5098039215686274,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "e9b6471a-f461-4898-9596-77d13d278e3b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.37209302325581395,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "082fd64d-f040-47ff-b331-c65984d882b9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "22b9176a-d65c-461d-9c57-ec152b60bdd5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.039999999999999994,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "0d42ace3-df30-438e-b5f7-110baf977e02",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.18181818181818182,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "fa5d1f27-9796-4945-9932-83f3ab24d619",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "24453238-d120-4113-851c-748d47647667",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "f8576a81-4155-411e-8fac-75fc86e090f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5454545454545454,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "b7dd6396-a4d1-479b-bf9c-b6cb1931ed77",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1875,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "03f2acd7-f522-42d1-82d1-a2f01cf9b6c9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2857142857142857,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "1532e8e7-8b59-4f57-b005-82b95138fb65",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "e3f47d61-d0b6-4e23-b851-22fbab31f615",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.375,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "8da1419c-b99e-43fd-81a6-e7e821d65b79",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "58df479b-ba1e-47bc-8603-fad83b1aa9e4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "24955291-71ed-4b0d-b7da-999210482e92",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.35294117647058826,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "c7945c29-d4b2-4df5-a38e-17f7e86af897",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.24000000000000002,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "f786d414-b13c-414f-855b-ca5d828b991c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.611111111111111,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "8ed8ad7f-60ce-4f0c-b23b-510928d8033d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "a7e04df6-3e90-44eb-a870-dfb2e479e8e6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "fed55df4-55bc-4dca-8038-c5fbb327db22",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "c7589643-1bdd-4eda-bc50-40b97c961ec4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2950819672131147,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "6eaf9848-a6c2-490b-9324-59159734ced9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30985915492957744,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "84b8f2ee-2155-4d6a-8723-2b4c9157ce83",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47619047619047616,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "9ca630fc-f6e8-4e97-9c51-4942439fab1d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "474f8ec6-789b-407e-bd12-bcf3c7ec9173",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "d700b2a7-c7f4-4b80-9bad-573a025c649c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "09c048eb-c006-4967-a1bc-3d1562910831",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.42424242424242425,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "bf5aaf14-66a6-488a-80b0-e1fd9ffbd2ef",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666666,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "3e3fbaeb-616e-4341-8a18-56b2b77529b7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.47619047619047616,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "39688059-93da-4ad6-a649-763482fa1e3b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "ba746233-385c-46b0-8486-12d0996576c2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "eed94b16-c166-42fd-9efd-2e26dedc55b9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "77a9f2d2-59f4-418d-8b01-b63cec443b12",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30769230769230765,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "49cf58d8-d873-43e6-ba18-66873c7d2f2e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.33333333333333326,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "c67261c6-929e-45ff-8bb0-7fbda1dc05fa",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3076923076923077,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "c5340bea-2409-4e88-81fb-dbbad0965fc2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "1ad404bb-ce63-44af-ad1e-36832212cef8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "0cd44831-e99e-4b13-93e3-7f8fa694d2d6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "1e47c3c9-fc98-4f20-86ff-d277144f24df",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.05128205128205127,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "125d81f0-1ccf-41c9-886c-1e76df7f29c3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 1,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "f2f4bcba-85f6-44a3-8701-573586839f69",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "b0d95ec1-1151-49b2-8745-1867464ebec9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "2f489d98-e5fd-4216-8cc7-eb1bd1693e53",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "36328673-1d86-44d9-a029-8e5d269acca6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "31e3d35e-fc28-49c7-91b4-63dbdeab15eb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.42857142857142855,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "96940c53-da44-413a-8410-c1b1ebba36cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22727272727272724,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "45e415d6-2607-4404-b6c8-f535953a8937",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.273972602739726,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "65dca83e-bb1e-4aa0-8718-49c3c86924f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "a8492d11-417a-4dd6-9f6b-cb48b3312d45",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "50ae14c6-8f21-445f-92ad-34b5faff2c7b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "7106f6be-70e6-4ac1-b078-56c6b8a2cbd2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2162162162162162,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "8d4090da-c637-4105-a71c-61d9b9b6c37c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07547169811320753,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "2ed21ea6-6792-4d72-b244-2a89d2779d9c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "8be57d9d-3a15-4369-9070-56be87b73bbd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "11bd5471-25de-45a2-a1bb-def5bd83b063",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "b7e145f8-aacb-4bec-b906-b30ac1942258",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "f5df9045-36d7-4ef4-b60f-218b331b1738",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.12903225806451615,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "b1ae8ad8-8da3-4013-a6f1-2055ecc6b287",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.28571428571428575,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "3ab11a35-715d-4505-bb88-d5e0f411c0d3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.27118644067796605,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "6e9e7e50-f663-4a03-885a-b6e293d69230",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "d12390d2-7d1b-4736-b61c-b16f5d0ff273",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "58ba928b-53ba-4eb0-a8a6-31865773317e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "61384297-bb58-4ef3-9d93-84b638bf56f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.35294117647058826,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "449b5cf5-b0ea-4e0f-a0e9-c6e09b809c52",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "4cb81964-c8de-4013-a019-50ef654e6526",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "872a01bc-4e56-4c80-9fd5-d81702a22865",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "394a9c2c-a49f-4f92-abae-db2e63c9f90b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "4b606836-b7bb-4580-ae18-c84f578239ec",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "a91baddd-5285-423a-b377-afcb914d1439",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "9403bfc4-5fdd-4a57-af11-07ba4201d10d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.19047619047619044,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "1c97f650-b514-4299-a3de-c53093d84c2e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21052631578947364,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "fbf2e32f-e3ca-4bd2-a45c-1ee500d4ca1e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "9bcfbe48-eecb-4d07-b65b-01cddbf8c1f1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "e8ec0652-ce2c-48e4-8690-e63f3755977c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "dd0c5a16-2812-41c1-b57d-32cfab75a6a5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2631578947368421,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "9a6783e2-60fc-4183-9906-ebe0e7a97aad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22857142857142856,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "0c90aa8f-a63d-407d-b1cf-9bcc654f67f0",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "efdbd80a-ceb2-4941-a97c-74a9b84759a3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "71c39e11-2799-4257-9ffc-5402167ad509",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.15384615384615385,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "75c19e85-2ec7-4772-a6e3-1a5332212a08",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "10ca7557-c6e8-4e16-be71-c8308988e43d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "b0150305-1054-4f16-8115-d690eea70b6f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.29787234042553196,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "8f456d22-b818-425a-b7f2-16b2d5b52a88",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "4af6bd7f-2149-4bb9-b078-c4acfb362ba8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "a44b423f-86b5-4b40-b772-7116a3249106",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.75,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "13539956-9fe9-47c5-93b0-3227c3c1b2d5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6666666666666666,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "e8f13956-e55c-4c2c-8028-78760da7afe9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23076923076923075,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "b7d72958-86f5-4252-8439-1baaa900afab",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "5801b9e1-9746-4c83-b1f2-169088dc2f60",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.608695652173913,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "27417a5c-0d82-410c-a123-69b5819b08ad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "ba43db85-4c23-40b3-8361-feb72e1e5fb3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4736842105263159,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "41855045-a764-4310-a6f4-78ea0f86fd65",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "2e9acd63-e730-443d-bac4-06f070ab4b8e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.18666666666666668,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "9cefd9b4-8b35-4819-a2c4-dfbbbabe1155",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.34782608695652173,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "3cd138ef-19b8-4841-8a27-f1d858cf68ed",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.10344827586206896,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "e8241d6b-9cf3-400b-998e-2e3060173264",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3846153846153846,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "e0c56f4b-a952-4341-a5bd-3a400da0594a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "13a19424-a80e-4b6a-bcfd-394dcacba306",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7777777777777778,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "32a27aa9-f5c3-4853-81b2-35f4a988800a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.11428571428571428,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "b6c61ba2-56ba-4b33-9e70-e9c764b10ad2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.33333333333333337,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "6804c503-9ffd-4aeb-a221-76982187e680",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.16666666666666669,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "fce11c0d-e833-47ea-a206-19c296ecfa9d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13333333333333336,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "e38b061b-7d8e-4115-9aba-b080d3b2ea03",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "bd13ed23-6423-4ae3-96f1-6057fe2efb4e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "b935408c-ccb9-4389-a683-f4d8c850915c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2153846153846154,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "7f27b472-3a19-434c-86ec-03f9f60f3ff5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "8df82f80-ac3a-4b86-958b-72538cc5de07",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.23076923076923078,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "a1cdf76a-2dc4-4c4f-90e1-7fadb3ff938f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.625,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "51bea850-52a0-4be0-92d7-c4724faf0000",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.923076923076923,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "6aa72d17-bc99-4947-835d-1f2c8058a60d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "83430b02-da1d-48db-8f25-46363457117a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.25641025641025644,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "c9d9886c-93b8-447a-87c8-bf3e25456bd1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9090909090909091,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "e69bcf0f-228c-4127-a034-cc55c9fdb06a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "95a1bf60-91b4-46d7-a03a-fe4aba47ba46",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5294117647058824,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "86cfca7c-4597-4db0-9aad-956312ff0d30",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "4fe81771-a26f-405e-81bd-b3060dfb9257",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3636363636363636,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "6097c607-cbe0-4205-a358-eaea3867c38e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2285714285714286,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "237ecb9b-1ef9-4f22-86a3-dfdb76e98749",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23076923076923075,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "d8d9453e-e42e-4e5a-93a3-511112b868d9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3404255319148936,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "42a2e032-ad3e-4840-a7ac-9d7d1afa869d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.8421052631578948,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "8020c63a-0cac-4dff-b432-a3d05f48be75",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4285714285714286,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "5ac5a264-9885-48bb-84c6-8d36c22482d3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.26666666666666666,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "ca0bdf2d-9189-4b1d-8658-6e90f4e06e59",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4230769230769231,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "998c354f-6127-438b-8954-294f835e6947",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "5c869ad6-07d6-4bb7-85ea-1bcd830628b6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.21874999999999997,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d08e524a-6449-4546-a347-a951b876e5c9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.19999999999999998,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "aca15b9f-118d-437c-8a95-9175f57f7101",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.09523809523809523,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "580560a0-83a2-40e1-b3db-8aeaf12cfd01",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.1176470588235294,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "42eaf99c-6438-4856-8889-eb08c07e3659",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07142857142857142,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "d0161763-693e-461d-bac5-62752630c726",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4356435643564356,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "e9b3c3f9-59af-410c-ad10-15335c3b68c3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3434343434343434,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "a2004948-d6a8-4ab0-821c-744768ea346c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4597701149425287,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "c3a2611f-bb52-4538-b9c1-73b7a37a5485",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24242424242424243,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "4c6e8f83-9b58-45fa-af79-91894cac8ae4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2962962962962963,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "5e110658-b863-42bd-a6f4-ee4e4fa87881",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.6666666666666667,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "59106411-3b35-4fc4-8d36-fd5f210fe935",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5057471264367817,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "9049ad23-accd-4a32-bd7a-afbb40a580f8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4444444444444445,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "86af8c1c-7e19-456c-9c3a-45995e261e8d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.22222222222222224,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "de9f3a48-e140-4811-b04e-319e076b1858",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "da0e0a55-b35f-423f-a9a9-ad00cddfae44",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5625,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "f0ec89d7-cbd5-4c8b-a76f-fc63e41fd5c7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3783783783783784,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "a3981bba-bc59-4da6-8b50-e293349c57ba",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "fcb4b839-b654-4555-a0cb-66c5e4c546ad",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1739130434782609,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "b96c099b-8493-4870-936d-8b8244e4643b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.4347826086956522,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "878d8e04-a5cc-4759-8c9c-48fa8cc0ffc6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "52597e62-bc40-4505-8a9c-d084b0c3bdc4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.6153846153846153,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "4ebaccaf-5a27-4650-9a5a-901745efc420",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.05,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "8c25e8b1-572c-4aad-9d39-c41165d25833",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "50038f72-d453-4bcf-9dc9-cb9c58dd86fe",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "84a75f49-8220-4bdf-a124-e81c5712482f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "b20e41ed-137e-4d76-9525-9897b3f421e3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "26158581-0589-481b-b2df-3479f663d451",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "8f8233f0-2a71-489c-bc2f-d0999d457a20",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13513513513513514,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "9bb04486-9c7d-48ad-b6e6-f5dd53d578bc",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5333333333333333,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "12265d7d-82b2-4d24-848e-34b6cbd2a312",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.27586206896551724,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "08426824-7942-4240-ba63-db0d755bb2cf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.631578947368421,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "ba421675-ba2d-4d5f-a0f0-b4fedf327f9b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.15384615384615383,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "1f41ec67-2010-41a4-8b9a-8a393a61e349",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "23e60d57-1019-453e-ba77-102fa5b5aa7e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2727272727272727,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "17c18dcd-74dc-41ba-a8b1-0502009231fb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.17391304347826086,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "4cdf5ee7-e4fa-4294-822f-87005ab32ba4",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.45714285714285713,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "3c33b35f-202e-4e2c-b2bd-15fde177b847",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.23529411764705882,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "7e733549-78b0-4522-9005-86ebee0a5f9e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.24,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "125880f4-76a6-47bd-bfe4-8480b267499b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.26229508196721313,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "3d398b83-6d00-4114-848e-15148273ef71",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.6774193548387097,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "90605869-0a08-4ac1-bd57-67d264393e9a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7083333333333334,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "9c6b769f-653c-4ec4-a155-0a544237bc3f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4262295081967213,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "09332439-361e-47aa-ae77-97ae00dbd6a7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.717948717948718,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "c2c41867-775e-4697-8634-f828f4dee13b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.23376623376623376,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "5fd0a363-67b2-4fc3-8870-01ab5fb4eb74",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4878048780487805,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f49e5eec-13a9-4878-9e9d-087cb3c4ba44",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.14814814814814814,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "3b828783-a329-4a20-a1f8-b512f7f72b1f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "993270e0-c1fd-444a-b44b-4bc1713ea36c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "5f1a3db1-0254-48b0-b31b-87f67eda23ee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "fd2fd01f-6374-4c74-b00d-dc353d872215",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "02e69507-acf9-4d25-a7fe-0c35c0e8a1f7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "313accbd-ddcd-4b72-93a5-2fd6b827d690",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "417f8c3e-e82a-4b0c-a0f4-00577a26fe29",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.04444444444444444,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "efbad052-9e6d-43cb-b056-39ff9a8cb8bf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "b3ef2778-5b99-428a-88a7-bbdbb66244e1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8799999999999999,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "8c6b93b8-e42a-40e8-86b5-295c2dee387a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.411764705882353,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "ef8c8c27-fea6-4af1-863d-d6b637914a9c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4722222222222222,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f2e07949-4004-4fe5-a86e-4e3a47daeaf3",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3098591549295775,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "1735f547-10d8-4b78-8f77-e5f8a124cfd5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.9302325581395349,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "71767248-ea90-4bea-b83d-071d8acdf09c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.47916666666666663,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d237b1b8-ae9b-4739-b803-41e0a8476700",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3595505617977528,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "2929b5fd-0435-49f1-9460-9ec5c35192ff",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3870967741935484,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "1c30a352-12f4-4f46-863a-b76f610fb46f",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.07692307692307693,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "e04bcf79-32c6-44be-8c55-2fd63756d251",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32142857142857145,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "8c3969db-1fcc-4bfd-a209-f307f25037d9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7804878048780487,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "a33477d6-3212-4770-903f-d3614514d30b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3888888888888889,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "733a51ff-9e61-40f4-a90f-67d45781aad1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.5,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "c80efe12-c371-4b56-b6cf-5ab41bf4e1a6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.4,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "a6e8ea29-d1a2-48b4-aa82-514d28e8fcd2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f3bc9326-7404-42b7-967b-bd45dc2c0a2a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.10256410256410257,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "a6f1e054-3a69-4bca-a437-1776222860f7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.04761904761904762,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "fcba5fe3-25ab-4abe-9eb2-55e2fe10d439",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.8275862068965517,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "aa769196-b02b-4b6b-9aa9-523f0e083142",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "c7711845-a2e4-41b7-ae16-54a7158ba8bd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.30303030303030304,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "6dae0b4b-464f-4b17-93e8-02f847a2a3e6",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.366412213740458,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "0a452495-543e-41ff-a625-8cdee936c16e",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13333333333333333,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "d478c2a3-23f7-4ef1-877d-3cca04b29b1a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07407407407407407,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "d78106b0-fe08-4e77-94dd-05841b1b7df7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.13793103448275862,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "3705a072-c8c2-4029-afec-0610a5a8e119",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3333333333333333,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "f38c4403-9c57-49b7-853b-7b1e9132980d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.7499999999999999,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "2aad213f-5c3b-40be-a3f8-4497e8c56bee",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "c5bd328f-67e4-4b6a-9bef-33bd997824a9",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.3023255813953488,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "65901be4-4cad-47d2-96da-54fb2df15e0c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.36734693877551017,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "cc347473-5c28-4888-b36f-56f2744547a7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.32323232323232326,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "a82020f7-609b-459c-83d5-1a368878a9e2",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.396039603960396,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "b7b9e4d3-0c7c-4e50-9dca-4fe394c9ee21",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.30612244897959184,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "be10bd78-2a49-406a-8176-e5de94ba3f09",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.028985507246376815,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "dbb0e6e1-dae2-4135-9d46-791283baac62",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.14285714285714285,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "84156030-18b3-43f5-b2b2-202b59399612",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38926174496644295,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "d28b9e48-1689-41df-b5d1-740a5fe0afbb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.38095238095238093,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "cf179869-67db-4c97-a7eb-7cec2179f28c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2524271844660194,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "51d0bc76-2ae6-44aa-a645-9e9a7376b9e5",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.28865979381443296,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "73f2b7b8-11d1-43a3-8c00-09f392c6cdd8",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2916666666666667,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "d4ec4324-b34c-4145-a975-2449082ef6cd",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36065573770491804,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "d694db63-aff9-4f12-a901-44578248a9c7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3185840707964602,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "5883e88c-edb9-47a9-8477-d056947767e1",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.1754385964912281,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "5e50564d-11e3-4f2e-8aad-5728e7662be7",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2745098039215686,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "89727480-4a6f-40cc-9124-ee77bc66189d",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.42748091603053434,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "d2bc4007-6291-4cab-ae3c-7931e3c4145b",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.2903225806451613,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/A"
+    },
+    {
+      "taskId": "ad140f1f-0ca0-458d-a97b-5f671fa233be",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.36363636363636365,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "27fd9fdc-3c6d-4dff-9fa2-070eb93b5fdf",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.39436619718309857,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "aba746a1-11ca-405e-a717-4943c7a6fb64",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.07999999999999999,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/B"
+    },
+    {
+      "taskId": "9291ba92-edc4-489c-8ef7-2c81653329cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.32000000000000006,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "fa7e0eed-15b7-4bfc-8780-458c3e23ec4c",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.3529411764705882,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "4020d87d-9c9e-4679-812e-a1135debad7a",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.5490196078431373,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/C"
+    },
+    {
+      "taskId": "e84e3224-078d-4f88-9df3-c09a678b60ef",
+      "scores": {
+        "ama_bench_recommended_accuracy": 1,
+        "contains_answer": 0,
+        "f1": 0.22950819672131148,
+        "llm_judge": 1
+      },
+      "category": "WEB/webarena/D"
+    },
+    {
+      "taskId": "144682ef-8543-4527-82d8-8b8c5e12c4cb",
+      "scores": {
+        "ama_bench_recommended_accuracy": 0,
+        "contains_answer": 0,
+        "f1": 0.2933333333333334,
+        "llm_judge": 0
+      },
+      "category": "WEB/webarena/D"
+    }
+  ],
+  "startedAt": "2026-05-15T05:29:19.000Z",
+  "finishedAt": "2026-05-15T23:38:04.213Z",
+  "durationMs": 65325213,
+  "env": {
+    "node": "v26.0.0",
+    "os": "darwin",
+    "arch": "arm64"
+  },
+  "note": "Full AMA-Bench run. Public-safe artifact omits question text, expected answers, model answers, and recalled text; see MANIFEST.ama-bench.json for raw local result hash and reproduction command.",
+  "amaBenchLeaderboardCells": [
+    {
+      "domain": "EMBODIED_AI",
+      "qaType": "A",
+      "taskCount": 61,
+      "ama_bench_recommended_accuracy": 0.8524590163934426
+    },
+    {
+      "domain": "EMBODIED_AI",
+      "qaType": "B",
+      "taskCount": 90,
+      "ama_bench_recommended_accuracy": 0.8111111111111111
+    },
+    {
+      "domain": "EMBODIED_AI",
+      "qaType": "C",
+      "taskCount": 150,
+      "ama_bench_recommended_accuracy": 0.8333333333333334
+    },
+    {
+      "domain": "EMBODIED_AI",
+      "qaType": "D",
+      "taskCount": 59,
+      "ama_bench_recommended_accuracy": 0.711864406779661
+    },
+    {
+      "domain": "Game",
+      "qaType": "A",
+      "taskCount": 120,
+      "ama_bench_recommended_accuracy": 0.85
+    },
+    {
+      "domain": "Game",
+      "qaType": "B",
+      "taskCount": 90,
+      "ama_bench_recommended_accuracy": 0.8666666666666667
+    },
+    {
+      "domain": "Game",
+      "qaType": "C",
+      "taskCount": 90,
+      "ama_bench_recommended_accuracy": 0.9111111111111111
+    },
+    {
+      "domain": "Game",
+      "qaType": "D",
+      "taskCount": 60,
+      "ama_bench_recommended_accuracy": 0.8333333333333334
+    },
+    {
+      "domain": "OPENWORLD_QA",
+      "qaType": "A",
+      "taskCount": 98,
+      "ama_bench_recommended_accuracy": 0.45918367346938777
+    },
+    {
+      "domain": "OPENWORLD_QA",
+      "qaType": "B",
+      "taskCount": 95,
+      "ama_bench_recommended_accuracy": 0.6421052631578947
+    },
+    {
+      "domain": "OPENWORLD_QA",
+      "qaType": "C",
+      "taskCount": 107,
+      "ama_bench_recommended_accuracy": 0.4485981308411215
+    },
+    {
+      "domain": "OPENWORLD_QA",
+      "qaType": "D",
+      "taskCount": 60,
+      "ama_bench_recommended_accuracy": 0.6666666666666666
+    },
+    {
+      "domain": "SOFTWARE",
+      "qaType": "A",
+      "taskCount": 212,
+      "ama_bench_recommended_accuracy": 0.41509433962264153
+    },
+    {
+      "domain": "SOFTWARE",
+      "qaType": "B",
+      "taskCount": 75,
+      "ama_bench_recommended_accuracy": 0.4666666666666667
+    },
+    {
+      "domain": "SOFTWARE",
+      "qaType": "C",
+      "taskCount": 73,
+      "ama_bench_recommended_accuracy": 0.3561643835616438
+    },
+    {
+      "domain": "SOFTWARE",
+      "qaType": "D",
+      "taskCount": 72,
+      "ama_bench_recommended_accuracy": 0.5
+    },
+    {
+      "domain": "TEXT2SQL",
+      "qaType": "A",
+      "taskCount": 223,
+      "ama_bench_recommended_accuracy": 0.8923766816143498
+    },
+    {
+      "domain": "TEXT2SQL",
+      "qaType": "B",
+      "taskCount": 153,
+      "ama_bench_recommended_accuracy": 0.6143790849673203
+    },
+    {
+      "domain": "TEXT2SQL",
+      "qaType": "C",
+      "taskCount": 134,
+      "ama_bench_recommended_accuracy": 0.8059701492537313
+    },
+    {
+      "domain": "TEXT2SQL",
+      "qaType": "D",
+      "taskCount": 102,
+      "ama_bench_recommended_accuracy": 0.23529411764705882
+    },
+    {
+      "domain": "WEB",
+      "qaType": "A",
+      "taskCount": 125,
+      "ama_bench_recommended_accuracy": 0.544
+    },
+    {
+      "domain": "WEB",
+      "qaType": "B",
+      "taskCount": 93,
+      "ama_bench_recommended_accuracy": 0.7526881720430108
+    },
+    {
+      "domain": "WEB",
+      "qaType": "C",
+      "taskCount": 93,
+      "ama_bench_recommended_accuracy": 0.5806451612903226
+    },
+    {
+      "domain": "WEB",
+      "qaType": "D",
+      "taskCount": 61,
+      "ama_bench_recommended_accuracy": 0.5409836065573771
+    }
+  ]
+}

--- a/docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/MANIFEST.ama-bench.json
+++ b/docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/MANIFEST.ama-bench.json
@@ -1,0 +1,140 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-15T23:38:08.661Z",
+  "run": {
+    "id": "public-matrix-codex-bf9b2643-20260515T052919Z",
+    "mode": "full",
+    "selectedBenchmarks": [
+      "ama-bench"
+    ],
+    "runtimeProfiles": [
+      "real"
+    ],
+    "seed": 1
+  },
+  "git": {
+    "commit": "bf9b264356a537e70fce1bddbca3495bf8a19b31",
+    "shortCommit": "bf9b2643",
+    "dirty": false,
+    "dirtyEntryCount": 0
+  },
+  "command": {
+    "cwd": "<repo-root>",
+    "argv": [
+      "bench",
+      "published",
+      "--name",
+      "ama-bench",
+      "--dataset",
+      "evals/datasets/ama-bench",
+      "--runtime-profile",
+      "real",
+      "--provider",
+      "codex-cli",
+      "--model",
+      "gpt-5.5",
+      "--system-codex-reasoning-effort",
+      "xhigh",
+      "--judge-provider",
+      "codex-cli",
+      "--judge-model",
+      "gpt-5.5",
+      "--judge-codex-reasoning-effort",
+      "xhigh",
+      "--internal-provider",
+      "codex-cli",
+      "--internal-model",
+      "gpt-5.5",
+      "--internal-codex-reasoning-effort",
+      "xhigh",
+      "--request-timeout",
+      "3600000",
+      "--drain-timeout",
+      "3600000",
+      "--max-429-wait",
+      "86400000",
+      "--seed",
+      "1",
+      "--results-dir",
+      "<results-dir>",
+      "--out",
+      "docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z",
+      "--ama-bench-judge-protocol",
+      "recommended",
+      "--trial-concurrency",
+      "6"
+    ],
+    "envKeys": [
+      "OPENAI_API_KEY"
+    ]
+  },
+  "environment": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "nodeVersion": "v26.0.0",
+    "packageManager": "pnpm@10.32.1"
+  },
+  "qmd": {
+    "collections": [
+      "openclaw-engram-hot-facts"
+    ]
+  },
+  "configFiles": [],
+  "datasets": [
+    {
+      "benchmark": "ama-bench",
+      "status": "hashed",
+      "path": "evals/datasets/ama-bench",
+      "realpath": "evals/datasets/ama-bench",
+      "fileCount": 1,
+      "totalBytes": 50451919,
+      "sha256": "90826eb21ce703a0b82078752e9eafeaca30b3976c897daff341a9f9ad77277e",
+      "files": [
+        {
+          "path": "open_end_qa_set.jsonl",
+          "kind": "file",
+          "sizeBytes": 50451919,
+          "sha256": "45c36052e1520d87ad9de4114f71c9df42d4aac9cf158c0c353e800b653d65ff"
+        }
+      ]
+    }
+  ],
+  "results": [
+    {
+      "path": "ama-bench-v9.3.388-2026-05-15T23-38-04-213Z.json",
+      "sha256": "7930b614b3a6085c007315c0a6470130c8d4ed956220a79b61ea822f621c609b",
+      "sizeBytes": 52351243,
+      "resultId": "de8d43ed-cbfd-452b-8a4e-0696571a5706",
+      "benchmark": "ama-bench",
+      "mode": "full",
+      "gitSha": "bf9b2643",
+      "runCount": 1,
+      "seeds": [
+        1
+      ],
+      "taskCount": 2496,
+      "configHash": "02da8f563277d8908924523ef3f41816e23cf318eed48220c99c988e53f0bfb2"
+    }
+  ],
+  "artifactHash": "6c7ada8333ae6590fd709c614a7036c4c7a4c18c1787e83605e52926cfe94129",
+  "publicArtifacts": [
+    {
+      "path": "2026-05-15-ama-bench-gpt-5.5-real-bf9b264.json",
+      "sha256": "7e4f0454657d10b8f240a61768a260b35cf520d0b745fbfec2573a0cd7ad2bb5",
+      "sizeBytes": 666982,
+      "resultId": "de8d43ed-cbfd-452b-8a4e-0696571a5706",
+      "benchmark": "ama-bench",
+      "mode": "full",
+      "gitSha": "bf9b2643",
+      "runCount": 1,
+      "seeds": [
+        1
+      ],
+      "taskCount": 2496,
+      "publicSafe": true,
+      "sourceResultPath": "ama-bench-v9.3.388-2026-05-15T23-38-04-213Z.json",
+      "sourceResultSha256": "7930b614b3a6085c007315c0a6470130c8d4ed956220a79b61ea822f621c609b",
+      "sourceResultSizeBytes": 52351243
+    }
+  ]
+}

--- a/docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/ama-bench-diagnostics-summary.json
+++ b/docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/ama-bench-diagnostics-summary.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-16T15:36:55.909Z",
+  "manifestGeneratedAt": "2026-05-15T23:38:08.661Z",
+  "runId": "public-matrix-codex-bf9b2643-20260515T052919Z",
+  "cutoffMode": "finishedAt<=manifest.generatedAt",
+  "totalFiles": 11959,
+  "checked": 8307,
+  "complete": 8307,
+  "inFlight": 1,
+  "afterCutoff": 3651,
+  "errored": 0,
+  "nonzero": 0,
+  "providers": {
+    "codex-cli": 8307
+  },
+  "models": {
+    "gpt-5.5": 8307
+  },
+  "reasoningEfforts": {
+    "xhigh": 8307
+  },
+  "serviceTiers": {
+    "fast": 8307
+  },
+  "statuses": {
+    "0": 8307
+  },
+  "minStartedAt": "2026-05-15T05:29:32.862Z",
+  "maxFinishedAt": "2026-05-15T23:38:04.205Z"
+}

--- a/scripts/bench/verify-public-ama-agent-sota-evidence.mjs
+++ b/scripts/bench/verify-public-ama-agent-sota-evidence.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const evidenceDir = process.argv[2] ?? 'docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z';
+const artifactPath = path.join(evidenceDir, '2026-05-15-ama-bench-gpt-5.5-real-bf9b264.json');
+const manifestPath = path.join(evidenceDir, 'MANIFEST.ama-bench.json');
+const diagnosticsPath = path.join(evidenceDir, 'ama-bench-diagnostics-summary.json');
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function sha256File(file) {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const artifact = readJson(artifactPath);
+const manifest = readJson(manifestPath);
+const diagnostics = readJson(diagnosticsPath);
+const resultEntry = manifest.results?.find((entry) => entry.benchmark === 'ama-bench');
+const publicArtifactEntry = manifest.publicArtifacts?.find((entry) => entry.benchmark === 'ama-bench');
+const expectedTaskCount = 2496;
+const expectedRecommendedAccuracy = 0.6542467948717948;
+const expectedLeaderboardAverage = 0.6496122948369937;
+
+function assertClose(actual, expected, message) {
+  assert(typeof actual === 'number' && Number.isFinite(actual), `${message}: value must be finite number`);
+  assert(Math.abs(actual - expected) < 1e-12, `${message}: expected ${expected}, got ${actual}`);
+}
+
+function mean(values) {
+  assert(values.length > 0, 'cannot average an empty list');
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function compareStrings(a, b) {
+  if (a === b) {
+    return 0;
+  }
+  return a < b ? -1 : 1;
+}
+
+function recomputeAmaBenchLeaderboardCells(perTaskScores) {
+  const cells = new Map();
+
+  for (const task of perTaskScores ?? []) {
+    const [domain, , qaType] = String(task.category ?? '').split('/');
+    assert(domain && qaType, `invalid AMA-Bench category for task ${task.taskId ?? '<unknown>'}`);
+
+    const score = task.scores?.ama_bench_recommended_accuracy ?? task.scores?.llm_judge;
+    assert(typeof score === 'number' && Number.isFinite(score), `invalid score for task ${task.taskId ?? '<unknown>'}`);
+
+    const key = `${domain}/${qaType}`;
+    const cell = cells.get(key) ?? { domain, qaType, scores: [] };
+    cell.scores.push(score);
+    cells.set(key, cell);
+  }
+
+  return Array.from(cells.values())
+    .sort((a, b) => compareStrings(a.domain, b.domain) || compareStrings(a.qaType, b.qaType))
+    .map((cell) => ({
+      domain: cell.domain,
+      qaType: cell.qaType,
+      taskCount: cell.scores.length,
+      ama_bench_recommended_accuracy: mean(cell.scores),
+    }));
+}
+
+assert(artifact.schemaVersion === 1, 'artifact schemaVersion must be 1');
+assert(artifact.benchmarkId === 'ama-bench', 'artifact benchmarkId must be ama-bench');
+assert(artifact.system?.name === 'remnic', 'artifact system.name must be remnic');
+assert(artifact.system?.gitSha === manifest.git?.commit, 'artifact git SHA must match manifest commit');
+assert(artifact.model === 'gpt-5.5', 'artifact model must be gpt-5.5');
+assert(artifact.seed === 1, 'artifact seed must be 1');
+assert(artifact.perTaskScores?.length === expectedTaskCount, 'artifact must contain 2496 per-task scores');
+assertClose(artifact.metrics?.ama_bench_recommended_accuracy, expectedRecommendedAccuracy, 'unexpected AMA recommended accuracy');
+assertClose(artifact.metrics?.llm_judge, expectedRecommendedAccuracy, 'unexpected llm_judge');
+assertClose(artifact.metrics?.ama_bench_leaderboard_average, expectedLeaderboardAverage, 'unexpected AMA leaderboard average');
+
+const recomputedCells = recomputeAmaBenchLeaderboardCells(artifact.perTaskScores);
+assert(recomputedCells.length === 24, 'AMA-Bench leaderboard average must be computed from 24 domain x qaType cells');
+assert(artifact.amaBenchLeaderboardCells?.length === recomputedCells.length, 'artifact must contain the 24 leaderboard cells');
+assert(JSON.stringify(artifact.amaBenchLeaderboardCells) === JSON.stringify(recomputedCells), 'artifact leaderboard cells must match per-task scores');
+assertClose(mean(recomputedCells.map((cell) => cell.ama_bench_recommended_accuracy)), expectedLeaderboardAverage, 'recomputed AMA leaderboard average');
+
+assert(resultEntry, 'manifest must contain ama-bench result entry');
+assert(resultEntry.path === 'ama-bench-v9.3.388-2026-05-15T23-38-04-213Z.json', 'manifest result path must point at the raw benchmark result');
+assert(resultEntry.sha256 === '7930b614b3a6085c007315c0a6470130c8d4ed956220a79b61ea822f621c609b', 'manifest result sha256 must match raw result hash');
+assert(resultEntry.taskCount === expectedTaskCount, 'manifest result taskCount must be 2496');
+assert(!('publicSafe' in resultEntry), 'manifest raw result entry must not be marked publicSafe');
+assert(publicArtifactEntry, 'manifest must contain ama-bench public artifact entry');
+assert(publicArtifactEntry.path === path.basename(artifactPath), 'manifest public artifact path must point at public-safe artifact');
+assert(publicArtifactEntry.sha256 === sha256File(artifactPath), 'manifest public artifact sha256 must match artifact file');
+assert(publicArtifactEntry.taskCount === expectedTaskCount, 'manifest public artifact taskCount must be 2496');
+assert(publicArtifactEntry.publicSafe === true, 'manifest public artifact must be marked publicSafe');
+assert(publicArtifactEntry.sourceResultPath === resultEntry.path, 'public artifact source path must match raw result entry');
+assert(publicArtifactEntry.sourceResultSha256 === resultEntry.sha256, 'public artifact source hash must match raw result entry');
+assert(manifest.datasets?.[0]?.sha256 === '90826eb21ce703a0b82078752e9eafeaca30b3976c897daff341a9f9ad77277e', 'dataset hash changed');
+assert(manifest.command?.cwd === '<repo-root>', 'manifest cwd must be scrubbed');
+assert(!JSON.stringify(manifest).includes('/Users/'), 'manifest must not contain local /Users paths');
+assert(!JSON.stringify(manifest).includes('MacStudio'), 'manifest must not contain local hostname');
+assert(diagnostics.runId === manifest.run?.id, 'diagnostic runId must match manifest');
+assert(diagnostics.checked === 8307, 'diagnostics checked count changed');
+assert(diagnostics.errored === 0, 'diagnostics must have zero errors');
+assert(diagnostics.nonzero === 0, 'diagnostics must have zero nonzero exits');
+assert(diagnostics.providers?.['codex-cli'] === 8307, 'diagnostics provider distribution changed');
+assert(diagnostics.models?.['gpt-5.5'] === 8307, 'diagnostics model distribution changed');
+assert(diagnostics.reasoningEfforts?.xhigh === 8307, 'diagnostics reasoning distribution changed');
+assert(diagnostics.serviceTiers?.fast === 8307, 'diagnostics service tier distribution changed');
+
+console.log(JSON.stringify({
+  ok: true,
+  benchmark: artifact.benchmarkId,
+  taskCount: artifact.perTaskScores.length,
+  amaBenchLeaderboardAverage: artifact.metrics.ama_bench_leaderboard_average,
+  amaBenchRecommendedAccuracy: artifact.metrics.ama_bench_recommended_accuracy,
+  artifactSha256: publicArtifactEntry.sha256,
+  rawResultSha256: resultEntry.sha256,
+}, null, 2));

--- a/scripts/bench/verify-public-matrix.ts
+++ b/scripts/bench/verify-public-matrix.ts
@@ -83,6 +83,19 @@ interface ReproManifest {
     gitSha?: string;
     taskCount?: number;
   }>;
+  publicArtifacts?: Array<{
+    benchmark?: string;
+    path?: string;
+    sha256?: string;
+    resultId?: string;
+    mode?: string;
+    gitSha?: string;
+    taskCount?: number;
+    publicSafe?: boolean;
+    sourceResultPath?: string;
+    sourceResultSha256?: string;
+    sourceResultSizeBytes?: number;
+  }>;
   command?: {
     argv?: string[];
     envKeys?: string[];
@@ -99,10 +112,33 @@ interface ReproManifest {
 }
 
 type ReproManifestResult = NonNullable<ReproManifest["results"]>[number];
+type ReproManifestPublicArtifact = NonNullable<ReproManifest["publicArtifacts"]>[number];
 
 interface ManifestResultResolution {
   entry: ReproManifestResult;
   path: string;
+}
+
+interface ManifestPublicArtifactResolution {
+  entry: ReproManifestPublicArtifact;
+  path: string;
+}
+
+interface PublicBenchmarkArtifact {
+  schemaVersion?: number;
+  benchmarkId?: string;
+  system?: {
+    name?: string;
+    gitSha?: string;
+  };
+  model?: string;
+  seed?: number;
+  metrics?: Record<string, number>;
+  perTaskScores?: Array<{
+    taskId?: string;
+    category?: string;
+    scores?: Record<string, number>;
+  }>;
 }
 
 export interface PublicMatrixEvidenceIssue {
@@ -189,10 +225,13 @@ export async function verifyPublicMatrixEvidence(
           issues,
         )
       : undefined;
+    const manifestPublicArtifact = manifest
+      ? resolveManifestPublicArtifact(resultsDir, manifest, row.benchmark, issues)
+      : undefined;
     const resultPath = manifest
       ? manifestResult?.path
       : resolveLatestResultPath(summaries, row.benchmark);
-    if (!resultPath) {
+    if (!resultPath && !manifestPublicArtifact) {
       if (!manifest) {
         issues.push({
           code: "missing-full-result",
@@ -203,14 +242,41 @@ export async function verifyPublicMatrixEvidence(
       continue;
     }
 
-    row.resultPath = resultPath;
-    if (manifestResult) {
+    row.resultPath = resultPath ?? manifestPublicArtifact?.path;
+    if (manifestResult && resultPath && fs.existsSync(resultPath)) {
       await validateManifestResultFile(manifestResult.entry, resultPath, row.benchmark, issues);
     }
     let result: BenchmarkResult;
     try {
-      result = await loadBenchmarkResult(resultPath);
+      result = await loadBenchmarkResult(resultPath ?? "");
     } catch (error) {
+      if (manifestResult && manifestPublicArtifact) {
+        await validateManifestPublicArtifactFile(
+          manifestPublicArtifact.entry,
+          manifestPublicArtifact.path,
+          manifestResult.entry,
+          row.benchmark,
+          issues,
+        );
+        const publicArtifact = await loadPublicBenchmarkArtifact(
+          manifestPublicArtifact.path,
+          row.benchmark,
+          issues,
+        );
+        if (publicArtifact) {
+          row.resultPath = manifestPublicArtifact.path;
+          row.resultId = manifestPublicArtifact.entry.resultId;
+          row.taskCount = publicArtifact.perTaskScores?.length;
+          validatePublicBenchmarkArtifact(publicArtifact, manifestPublicArtifact.entry, manifestResult.entry, {
+            benchmark: row.benchmark,
+            path: manifestPublicArtifact.path,
+            expectedModel,
+            expectedGitSha,
+            issues,
+          });
+        }
+        continue;
+      }
       issues.push({
         code: "manifest-result-unreadable",
         benchmark: row.benchmark,
@@ -372,6 +438,7 @@ function buildManifestArtifactHashIdentity(manifest: ReproManifest): unknown {
     configFiles: manifest.configFiles,
     datasets: manifest.datasets,
     results: manifest.results,
+    ...(manifest.publicArtifacts ? { publicArtifacts: manifest.publicArtifacts } : {}),
   };
 }
 
@@ -599,6 +666,24 @@ function validateManifest(
     } else if (options.expectedGitSha && !gitShaMatches(result.gitSha ?? "", options.expectedGitSha)) {
       addIssue(options.issues, benchmark, manifestPath, "manifest-result-wrong-git", `Expected manifest result git to match ${options.expectedGitSha}, got ${String(result.gitSha)}.`);
     }
+
+    const publicArtifact = manifest.publicArtifacts?.find((entry) => entry.benchmark === benchmark);
+    if (publicArtifact) {
+      if (!isNonEmptyString(publicArtifact.path)) {
+        addIssue(options.issues, benchmark, manifestPath, "manifest-public-artifact-missing-path", "Manifest public artifact entry must include a relative artifact path.");
+      } else if (
+        publicArtifact.mode !== "full" ||
+        !Number.isInteger(publicArtifact.taskCount) ||
+        publicArtifact.taskCount <= 0 ||
+        publicArtifact.publicSafe !== true
+      ) {
+        addIssue(options.issues, benchmark, manifestPath, "manifest-public-artifact-not-full", `Manifest public artifact must be full and publicSafe; got mode=${String(publicArtifact.mode)} taskCount=${String(publicArtifact.taskCount)} publicSafe=${String(publicArtifact.publicSafe)}.`);
+      } else if (options.expectedGitSha && !gitShaMatches(publicArtifact.gitSha ?? "", options.expectedGitSha)) {
+        addIssue(options.issues, benchmark, manifestPath, "manifest-public-artifact-wrong-git", `Expected manifest public artifact git to match ${options.expectedGitSha}, got ${String(publicArtifact.gitSha)}.`);
+      } else if (result && publicArtifact.sourceResultSha256 !== result.sha256) {
+        addIssue(options.issues, benchmark, manifestPath, "manifest-public-artifact-source-mismatch", "Manifest public artifact sourceResultSha256 must match the raw result entry sha256.");
+      }
+    }
   }
 }
 
@@ -646,6 +731,27 @@ async function resolveManifestResult(
   return candidateResults[0];
 }
 
+function resolveManifestPublicArtifact(
+  resultsDir: string,
+  manifest: ReproManifest,
+  benchmark: string,
+  issues: PublicMatrixEvidenceIssue[],
+): ManifestPublicArtifactResolution | undefined {
+  const publicArtifact = manifest.publicArtifacts?.find((entry) => entry.benchmark === benchmark);
+  if (!publicArtifact || !isNonEmptyString(publicArtifact.path)) {
+    return undefined;
+  }
+
+  const resolvedPath = resolveManifestEntryPath(
+    resultsDir,
+    benchmark,
+    publicArtifact.path,
+    issues,
+    "public-artifact",
+  );
+  return resolvedPath ? { entry: publicArtifact, path: resolvedPath } : undefined;
+}
+
 async function validateManifestResultFile(
   entry: ReproManifestResult,
   resultPath: string,
@@ -689,6 +795,151 @@ async function validateManifestResultFile(
   }
 }
 
+async function validateManifestPublicArtifactFile(
+  entry: ReproManifestPublicArtifact,
+  artifactPath: string,
+  rawResultEntry: ReproManifestResult,
+  benchmark: string,
+  issues: PublicMatrixEvidenceIssue[],
+): Promise<void> {
+  if (!isSha256(entry.sha256)) {
+    addIssue(
+      issues,
+      benchmark,
+      artifactPath,
+      "manifest-public-artifact-missing-hash",
+      "Manifest public artifact entry must include the SHA-256 hash of the artifact file.",
+    );
+    return;
+  }
+  if (entry.sourceResultPath !== rawResultEntry.path || entry.sourceResultSha256 !== rawResultEntry.sha256) {
+    addIssue(
+      issues,
+      benchmark,
+      artifactPath,
+      "manifest-public-artifact-source-mismatch",
+      "Manifest public artifact source metadata must match the raw result entry.",
+    );
+  }
+
+  let actualHash: string;
+  try {
+    actualHash = await sha256File(artifactPath);
+  } catch (error) {
+    addIssue(
+      issues,
+      benchmark,
+      artifactPath,
+      "manifest-public-artifact-hash-unreadable",
+      `Could not hash manifest public artifact file: ${error instanceof Error ? error.message : String(error)}.`,
+    );
+    return;
+  }
+
+  const expectedHash = entry.sha256.toLowerCase();
+  if (actualHash !== expectedHash) {
+    addIssue(
+      issues,
+      benchmark,
+      artifactPath,
+      "manifest-public-artifact-hash-mismatch",
+      `Manifest public artifact hash mismatch: expected ${expectedHash}, got ${actualHash}.`,
+    );
+  }
+}
+
+async function loadPublicBenchmarkArtifact(
+  artifactPath: string,
+  benchmark: string,
+  issues: PublicMatrixEvidenceIssue[],
+): Promise<PublicBenchmarkArtifact | undefined> {
+  try {
+    const value = JSON.parse(await readFile(artifactPath, "utf8")) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      addIssue(issues, benchmark, artifactPath, "invalid-public-artifact", "Public artifact JSON must be an object.");
+      return undefined;
+    }
+    return value as PublicBenchmarkArtifact;
+  } catch (error) {
+    addIssue(
+      issues,
+      benchmark,
+      artifactPath,
+      "invalid-public-artifact",
+      `Could not parse public artifact: ${error instanceof Error ? error.message : String(error)}.`,
+    );
+    return undefined;
+  }
+}
+
+function validatePublicBenchmarkArtifact(
+  artifact: PublicBenchmarkArtifact,
+  artifactEntry: ReproManifestPublicArtifact,
+  rawResultEntry: ReproManifestResult,
+  options: {
+    benchmark: string;
+    path: string;
+    expectedModel: string;
+    expectedGitSha: string | undefined;
+    issues: PublicMatrixEvidenceIssue[];
+  },
+): void {
+  const benchmark = options.benchmark;
+  if (artifact.schemaVersion !== 1) {
+    addIssue(options.issues, benchmark, options.path, "invalid-public-artifact-schema", `Expected public artifact schemaVersion=1, got ${String(artifact.schemaVersion)}.`);
+  }
+  if (artifact.benchmarkId !== benchmark) {
+    addIssue(options.issues, benchmark, options.path, "public-artifact-benchmark-mismatch", `Expected public artifact benchmarkId=${benchmark}, got ${String(artifact.benchmarkId)}.`);
+  }
+  if (artifact.system?.name !== "remnic") {
+    addIssue(options.issues, benchmark, options.path, "public-artifact-system-mismatch", `Expected public artifact system.name=remnic, got ${String(artifact.system?.name)}.`);
+  }
+  if (options.expectedGitSha && !gitShaMatches(artifact.system?.gitSha ?? "", options.expectedGitSha)) {
+    addIssue(options.issues, benchmark, options.path, "public-artifact-wrong-git", `Expected public artifact git to match ${options.expectedGitSha}, got ${String(artifact.system?.gitSha)}.`);
+  }
+  if (artifact.model !== options.expectedModel) {
+    addIssue(options.issues, benchmark, options.path, "public-artifact-wrong-model", `Expected public artifact model=${options.expectedModel}, got ${String(artifact.model)}.`);
+  }
+  if (!Array.isArray(artifact.perTaskScores) || artifact.perTaskScores.length === 0) {
+    addIssue(options.issues, benchmark, options.path, "public-artifact-empty-task-set", "Public artifact has no per-task scores.");
+  } else if (
+    Number.isInteger(artifactEntry.taskCount) &&
+    artifact.perTaskScores.length !== artifactEntry.taskCount
+  ) {
+    addIssue(options.issues, benchmark, options.path, "public-artifact-task-count-mismatch", `Public artifact task count ${artifact.perTaskScores.length} does not match manifest count ${artifactEntry.taskCount}.`);
+  } else if (
+    Number.isInteger(rawResultEntry.taskCount) &&
+    artifact.perTaskScores.length !== rawResultEntry.taskCount
+  ) {
+    addIssue(options.issues, benchmark, options.path, "public-artifact-raw-task-count-mismatch", `Public artifact task count ${artifact.perTaskScores.length} does not match raw manifest count ${rawResultEntry.taskCount}.`);
+  }
+
+  if (!artifact.metrics || Object.keys(artifact.metrics).length === 0) {
+    addIssue(options.issues, benchmark, options.path, "public-artifact-empty-metrics", "Public artifact has no aggregate metrics.");
+  } else {
+    for (const [metric, score] of Object.entries(artifact.metrics)) {
+      if (!Number.isFinite(score) || score < 0) {
+        addIssue(options.issues, benchmark, options.path, "public-artifact-invalid-metric", `Public artifact metric ${metric} must be a finite non-negative number.`);
+      }
+    }
+  }
+
+  for (const task of artifact.perTaskScores ?? []) {
+    if (!isNonEmptyString(task.taskId)) {
+      addIssue(options.issues, benchmark, options.path, "public-artifact-task-missing-id", "Public artifact per-task score is missing taskId.");
+    }
+    if (!task.scores || Object.keys(task.scores).length === 0) {
+      addIssue(options.issues, benchmark, options.path, "public-artifact-task-missing-scores", `Public artifact task ${task.taskId ?? "<unknown>"} has no scores.`);
+      continue;
+    }
+    for (const [metric, score] of Object.entries(task.scores)) {
+      if (!Number.isFinite(score) || score < 0) {
+        addIssue(options.issues, benchmark, options.path, "public-artifact-invalid-task-score", `Public artifact task ${task.taskId ?? "<unknown>"} metric ${metric} must be a finite non-negative number.`);
+      }
+    }
+  }
+}
+
 function validateManifestResultIdentity(
   entry: ReproManifestResult,
   result: BenchmarkResult,
@@ -722,14 +973,15 @@ function resolveManifestEntryPath(
   benchmark: string,
   manifestPath: string,
   issues: PublicMatrixEvidenceIssue[],
+  kind = "result",
 ): string | undefined {
   if (path.isAbsolute(manifestPath)) {
     addIssue(
       issues,
       benchmark,
       manifestPath,
-      "manifest-result-absolute-path",
-      "Manifest result path must be relative to the results directory.",
+      `manifest-${kind}-absolute-path`,
+      `Manifest ${kind} path must be relative to the results directory.`,
     );
     return undefined;
   }
@@ -745,8 +997,8 @@ function resolveManifestEntryPath(
       issues,
       benchmark,
       resolvedPath,
-      "manifest-result-path-outside-dir",
-      "Manifest result path must stay inside the results directory.",
+      `manifest-${kind}-path-outside-dir`,
+      `Manifest ${kind} path must stay inside the results directory.`,
     );
     return undefined;
   }


### PR DESCRIPTION
## Summary

Publishes the completed AMA-Bench full-run evidence from `public-matrix-codex-bf9b2643-20260515T052919Z`.

This is an **agent / memory-system leaderboard SOTA** claim, not a model-only leaderboard claim.

## Result

- Benchmark: AMA-Bench
- Tasks: 2496 / 2496
- Runtime profile: real
- System/judge/internal provider: Codex CLI `gpt-5.5`
- Reasoning effort: `xhigh`
- Service tier: `fast` in diagnostic summary
- `ama_bench_recommended_accuracy`: `0.6542467948717948`
- Prior top verified agent average: `0.557925`
- Model-only caveat: top verified model-only entry was `gpt 5.2` at `0.6982833333333333`, so this PR does not claim overall model-only SOTA.

## Evidence Added

- `docs/benchmarks/evidence/ama-bench-gpt-5.5-agent-sota-2026-05-15.md`
- `docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/ama-bench-v9.3.388-2026-05-15T23-38-04-213Z.json`
- `docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/MANIFEST.ama-bench.json`
- `docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/ama-bench-diagnostics-summary.json`

## Verification

```bash
PATH=/opt/homebrew/bin:/opt/homebrew/sbin:$PATH ./node_modules/.bin/tsx scripts/bench/verify-public-matrix.ts \
  --results-dir /private/tmp/remnic-ama-agent-sota-pr/docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z \
  --manifest /private/tmp/remnic-ama-agent-sota-pr/docs/benchmarks/results/public-matrix-codex-bf9b2643-20260515T052919Z/MANIFEST.ama-bench.json \
  --benchmarks ama-bench \
  --git-sha bf9b264356a537e70fce1bddbca3495bf8a19b31 \
  --no-diagnostics \
  --json
```

Result: `ok: true`, no issues, `taskCount: 2496`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding benchmark evidence artifacts and a standalone verification script, with no impact on runtime application logic.
> 
> **Overview**
> Publishes **AMA-Bench agent/memory-system leaderboard SOTA evidence** for a full `real` run using Codex CLI `gpt-5.5` (including reported aggregate metrics, commit/dataset/result hashes, and reproduction command).
> 
> Adds committed public-safe artifacts (manifest and compact diagnostics summary) and a new `scripts/bench/verify-public-ama-agent-sota-evidence.mjs` verifier that recomputes the 24-cell leaderboard average from per-task scores, validates hashes/metadata, and checks the diagnostics summary consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b774581dd4945a744294a812d27766e77b11ecf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->