### PR TITLE
Fix legacy Remnic daemon detection

### DIFF
--- a/.changeset/legacy-remnic-server-daemon.md
+++ b/.changeset/legacy-remnic-server-daemon.md
@@ -1,0 +1,14 @@
+---
+"@remnic/cli": patch
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Detect legacy macOS `ai.remnic.server` launchd services as Remnic daemons.
+
+The OpenClaw bridge now delegates when the legacy service plist is present and
+healthy, and also performs a local health probe before selecting embedded mode.
+The CLI daemon commands now share service candidate metadata, include the legacy
+`ai.remnic.server` label for status/start/stop/uninstall, and resolve a global
+`remnic-server` binary from PATH before falling back to TypeScript source during
+daemon install.

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -67,6 +67,7 @@ try {
 `;
 const LAUNCHD_SERVICE_PATHS = [
   ["Library", "LaunchAgents", "ai.remnic.daemon.plist"],
+  ["Library", "LaunchAgents", "ai.remnic.server.plist"],
   ["Library", "LaunchAgents", "ai.engram.daemon.plist"],
 ] as const;
 const SYSTEMD_SERVICE_PATHS = [
@@ -175,6 +176,17 @@ function checkDaemonHealthSync(host: string, port: number, timeoutMs = SYNC_HEAL
   }
 }
 
+function shouldProbeDaemonHealth(host: string): boolean {
+  const normalized = host.trim().toLowerCase();
+  return (
+    normalized === DEFAULT_HOST ||
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized === "[::1]" ||
+    isDaemonServiceConfigured()
+  );
+}
+
 /**
  * Read daemon port from environment or remnic config.
  */
@@ -223,8 +235,8 @@ export function detectBridgeMode(): BridgeConfig {
   const daemonHost = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST") ?? DEFAULT_HOST;
   const daemonPort = readDaemonPort();
 
-  // Auto-detect: if daemon is running or service-managed and live, delegate; otherwise embedded.
-  if (isDaemonRunning() || (isDaemonServiceConfigured() && checkDaemonHealthSync(daemonHost, daemonPort))) {
+  // Auto-detect: if daemon is running or reachable locally, delegate; otherwise embedded.
+  if (isDaemonRunning() || (shouldProbeDaemonHealth(daemonHost) && checkDaemonHealthSync(daemonHost, daemonPort))) {
     return {
       mode: "delegate",
       daemonHost,

--- a/packages/remnic-cli/src/daemon-service-candidates.ts
+++ b/packages/remnic-cli/src/daemon-service-candidates.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const LAUNCHD_LABEL = "ai.remnic.daemon";
+export const LEGACY_REMNIC_SERVER_LAUNCHD_LABEL = "ai.remnic.server";
+export const LEGACY_LAUNCHD_LABEL = "ai.engram.daemon";
+export const LAUNCHD_LABEL_CANDIDATES = [
+  LAUNCHD_LABEL,
+  LEGACY_REMNIC_SERVER_LAUNCHD_LABEL,
+  LEGACY_LAUNCHD_LABEL,
+] as const;
+
+export const SYSTEMD_SERVICE = "remnic.service";
+export const LEGACY_SYSTEMD_SERVICE = "engram.service";
+export const SYSTEMD_SERVICE_CANDIDATES = [SYSTEMD_SERVICE, LEGACY_SYSTEMD_SERVICE] as const;
+
+export function launchdPlistPaths(homeDir: string): string[] {
+  return LAUNCHD_LABEL_CANDIDATES.map((label) => (
+    path.join(homeDir, "Library", "LaunchAgents", `${label}.plist`)
+  ));
+}
+
+export function systemdUnitPaths(homeDir: string): string[] {
+  return SYSTEMD_SERVICE_CANDIDATES.map((service) => (
+    path.join(homeDir, ".config", "systemd", "user", service)
+  ));
+}
+
+export function anyFileExists(paths: readonly string[]): boolean {
+  return paths.some((candidate) => {
+    try {
+      return fs.statSync(candidate).isFile();
+    } catch {
+      return false;
+    }
+  });
+}
+
+function commandNames(command: string): string[] {
+  if (process.platform !== "win32") return [command];
+  return [command, `${command}.cmd`, `${command}.exe`, `${command}.bat`];
+}
+
+export function findCommandOnPath(command: string, pathEnv = process.env.PATH ?? ""): string | undefined {
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const name of commandNames(command)) {
+      const candidate = path.join(dir, name);
+      try {
+        const stat = fs.statSync(candidate);
+        if (!stat.isFile()) continue;
+        if (process.platform !== "win32") fs.accessSync(candidate, fs.constants.X_OK);
+        return fs.realpathSync(candidate);
+      } catch {
+        // Try the next PATH candidate.
+      }
+    }
+  }
+  return undefined;
+}
+
+export function resolveServerBinPath(importMetaDir: string, pathEnv = process.env.PATH ?? ""): string {
+  const distPath = path.resolve(importMetaDir, "../../remnic-server/dist/index.js");
+  if (fs.existsSync(distPath)) return distPath;
+
+  const pathBin = findCommandOnPath("remnic-server", pathEnv);
+  if (pathBin) return pathBin;
+
+  return path.resolve(importMetaDir, "../../remnic-server/src/index.ts");
+}

--- a/packages/remnic-cli/src/daemon-service-candidates.ts
+++ b/packages/remnic-cli/src/daemon-service-candidates.ts
@@ -45,12 +45,10 @@ function isRunnableNodeScript(filePath: string): boolean {
   try {
     const text = fs.readFileSync(filePath, "utf8").slice(0, 4096);
     const firstLine = text.split(/\r?\n/, 1)[0] ?? "";
-    return (
-      /^#!.*\bnode\b/.test(firstLine) ||
-      /\bimport\s+/.test(text) ||
-      /\bexport\s+/.test(text) ||
-      /\brequire\s*\(/.test(text)
-    );
+    if (/^#!.*\bnode\b/.test(firstLine)) return true;
+    if (firstLine.startsWith("#!")) return false;
+    if (/\.(?:cjs|mjs|js)$/i.test(filePath)) return true;
+    return /\bimport\s+/.test(text) || /\bexport\s+/.test(text) || /\brequire\s*\(/.test(text);
   } catch {
     return false;
   }

--- a/packages/remnic-cli/src/daemon-service-candidates.ts
+++ b/packages/remnic-cli/src/daemon-service-candidates.ts
@@ -41,6 +41,58 @@ function commandNames(command: string): string[] {
   return [command, `${command}.cmd`, `${command}.exe`, `${command}.bat`];
 }
 
+function isRunnableNodeScript(filePath: string): boolean {
+  try {
+    const text = fs.readFileSync(filePath, "utf8").slice(0, 4096);
+    const firstLine = text.split(/\r?\n/, 1)[0] ?? "";
+    return (
+      /^#!.*\bnode\b/.test(firstLine) ||
+      /\bimport\s+/.test(text) ||
+      /\bexport\s+/.test(text) ||
+      /\brequire\s*\(/.test(text)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function resolveShimNodeScript(filePath: string): string | undefined {
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, "utf8").slice(0, 16_384);
+  } catch {
+    return undefined;
+  }
+
+  const basedir = path.dirname(filePath);
+  const jsReferencePattern = /"([^"]+\.js)"|'([^']+\.js)'|([^\s"'`]+\.js)/g;
+  for (const match of text.matchAll(jsReferencePattern)) {
+    const raw = match[1] ?? match[2] ?? match[3];
+    if (!raw) continue;
+    const candidate = raw
+      .replaceAll("${basedir}", basedir)
+      .replaceAll("$basedir", basedir)
+      .replaceAll("\\ ", " ");
+    const resolved = path.isAbsolute(candidate)
+      ? candidate
+      : path.resolve(basedir, candidate);
+    try {
+      if (fs.statSync(resolved).isFile() && isRunnableNodeScript(resolved)) {
+        return fs.realpathSync(resolved);
+      }
+    } catch {
+      // Try the next JavaScript reference in the shim.
+    }
+  }
+  return undefined;
+}
+
+function resolveRunnableNodeScript(filePath: string): string | undefined {
+  const realPath = fs.realpathSync(filePath);
+  if (isRunnableNodeScript(realPath)) return realPath;
+  return resolveShimNodeScript(realPath);
+}
+
 export function findCommandOnPath(command: string, pathEnv = process.env.PATH ?? ""): string | undefined {
   for (const dir of pathEnv.split(path.delimiter)) {
     if (!dir) continue;
@@ -50,7 +102,8 @@ export function findCommandOnPath(command: string, pathEnv = process.env.PATH ??
         const stat = fs.statSync(candidate);
         if (!stat.isFile()) continue;
         if (process.platform !== "win32") fs.accessSync(candidate, fs.constants.X_OK);
-        return fs.realpathSync(candidate);
+        const runnable = resolveRunnableNodeScript(candidate);
+        if (runnable) return runnable;
       } catch {
         // Try the next PATH candidate.
       }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -156,6 +156,16 @@ import {
   loadBenchModule,
   tryLoadBenchModule,
 } from "./optional-bench.js";
+import {
+  LAUNCHD_LABEL,
+  LAUNCHD_LABEL_CANDIDATES,
+  SYSTEMD_SERVICE,
+  SYSTEMD_SERVICE_CANDIDATES,
+  anyFileExists,
+  launchdPlistPaths,
+  resolveServerBinPath,
+  systemdUnitPaths,
+} from "./daemon-service-candidates.js";
 import type {
   BenchConfig,
   BenchMemoryAdapter,
@@ -6488,36 +6498,10 @@ Options:
 // ── Daemon management ────────────────────────────────────────────────────────
 
 const LOGS_DIR = path.join(PID_DIR, "logs");
-const LAUNCHD_LABEL = "ai.remnic.daemon";
-const LEGACY_LAUNCHD_LABEL = "ai.engram.daemon";
-const LAUNCHD_PLIST_PATH = path.join(
-  resolveHomeDir(),
-  "Library",
-  "LaunchAgents",
-  `${LAUNCHD_LABEL}.plist`,
-);
-const LEGACY_LAUNCHD_PLIST_PATH = path.join(
-  resolveHomeDir(),
-  "Library",
-  "LaunchAgents",
-  `${LEGACY_LAUNCHD_LABEL}.plist`,
-);
-const SYSTEMD_SERVICE = "remnic.service";
-const LEGACY_SYSTEMD_SERVICE = "engram.service";
-const SYSTEMD_UNIT_PATH = path.join(
-  resolveHomeDir(),
-  ".config",
-  "systemd",
-  "user",
-  SYSTEMD_SERVICE,
-);
-const LEGACY_SYSTEMD_UNIT_PATH = path.join(
-  resolveHomeDir(),
-  ".config",
-  "systemd",
-  "user",
-  LEGACY_SYSTEMD_SERVICE,
-);
+const LAUNCHD_PLIST_PATHS = launchdPlistPaths(resolveHomeDir());
+const [LAUNCHD_PLIST_PATH] = LAUNCHD_PLIST_PATHS;
+const SYSTEMD_UNIT_PATHS = systemdUnitPaths(resolveHomeDir());
+const [SYSTEMD_UNIT_PATH] = SYSTEMD_UNIT_PATHS;
 
 
 function readPid(): number | undefined {
@@ -6546,11 +6530,7 @@ function resolveNodePath(): string {
 }
 
 function resolveServerBin(): string {
-  // Prefer built dist (production), fall back to source (dev)
-  const distPath = path.resolve(import.meta.dirname, "../../remnic-server/dist/index.js");
-  if (fs.existsSync(distPath)) return distPath;
-  const srcPath = path.resolve(import.meta.dirname, "../../remnic-server/src/index.ts");
-  return srcPath;
+  return resolveServerBinPath(import.meta.dirname);
 }
 
 function isMacOS(): boolean {
@@ -6628,7 +6608,7 @@ function daemonInstall(): void {
 function daemonUninstall(): void {
   if (isMacOS()) {
     let removed = false;
-    for (const plistPath of [LAUNCHD_PLIST_PATH, LEGACY_LAUNCHD_PLIST_PATH]) {
+    for (const plistPath of LAUNCHD_PLIST_PATHS) {
       try {
         childProcess.execSync(`launchctl unload "${plistPath}"`, { stdio: "pipe" });
       } catch {
@@ -6646,7 +6626,7 @@ function daemonUninstall(): void {
       console.log("Launchd plist not found — nothing to remove.");
     }
   } else if (isLinux()) {
-    for (const serviceName of [SYSTEMD_SERVICE, LEGACY_SYSTEMD_SERVICE]) {
+    for (const serviceName of SYSTEMD_SERVICE_CANDIDATES) {
       try {
         childProcess.execSync(`systemctl --user stop ${serviceName}`, { stdio: "pipe" });
         childProcess.execSync(`systemctl --user disable ${serviceName}`, { stdio: "pipe" });
@@ -6655,7 +6635,7 @@ function daemonUninstall(): void {
       }
     }
     let removed = false;
-    for (const unitPath of [SYSTEMD_UNIT_PATH, LEGACY_SYSTEMD_UNIT_PATH]) {
+    for (const unitPath of SYSTEMD_UNIT_PATHS) {
       try {
         fs.unlinkSync(unitPath);
         removed = true;
@@ -6694,7 +6674,7 @@ function isServiceRunning(): { running: boolean; pid?: number } {
   }
   // Check service manager (launchd/systemd from `daemon install`)
   if (isMacOS()) {
-    const status = firstSuccessfulResult([LAUNCHD_LABEL, LEGACY_LAUNCHD_LABEL], (label) => {
+    const status = firstSuccessfulResult(LAUNCHD_LABEL_CANDIDATES, (label) => {
       const out = childProcess.execSync(`launchctl list ${label} 2>/dev/null`, { encoding: "utf8" });
       const pidMatch = out.match(/"PID"\s*=\s*(\d+)/);
       if (pidMatch) return { running: true, pid: parseInt(pidMatch[1], 10) };
@@ -6702,7 +6682,7 @@ function isServiceRunning(): { running: boolean; pid?: number } {
     });
     if (status) return status;
   } else if (isLinux()) {
-    const status = firstSuccessfulResult([SYSTEMD_SERVICE, LEGACY_SYSTEMD_SERVICE], (serviceName) => {
+    const status = firstSuccessfulResult(SYSTEMD_SERVICE_CANDIDATES, (serviceName) => {
       const out = childProcess.execSync(`systemctl --user is-active ${serviceName} 2>/dev/null`, {
         encoding: "utf8",
       }).trim();
@@ -6728,9 +6708,9 @@ async function daemonStatus(): Promise<void> {
   const { running, pid } = isServiceRunning();
   const port = inferPort();
   const serviceInstalled = isMacOS()
-    ? fs.existsSync(LAUNCHD_PLIST_PATH) || fs.existsSync(LEGACY_LAUNCHD_PLIST_PATH)
+    ? anyFileExists(LAUNCHD_PLIST_PATHS)
     : isLinux()
-      ? fs.existsSync(SYSTEMD_UNIT_PATH) || fs.existsSync(LEGACY_SYSTEMD_UNIT_PATH)
+      ? anyFileExists(SYSTEMD_UNIT_PATHS)
       : false;
 
   console.log(`Remnic daemon status:`);
@@ -6771,16 +6751,16 @@ function daemonStart(): void {
   }
 
   // Try service manager first (for daemons installed via `remnic daemon install`)
-  if (isMacOS() && (fs.existsSync(LAUNCHD_PLIST_PATH) || fs.existsSync(LEGACY_LAUNCHD_PLIST_PATH))) {
-    const label = firstSuccessfulCandidate([LAUNCHD_LABEL, LEGACY_LAUNCHD_LABEL], (candidate) => {
+  if (isMacOS() && anyFileExists(LAUNCHD_PLIST_PATHS)) {
+    const label = firstSuccessfulCandidate(LAUNCHD_LABEL_CANDIDATES, (candidate) => {
       childProcess.execSync(`launchctl start ${candidate} 2>/dev/null`, { stdio: "pipe" });
     });
     if (label) {
       console.log(`Started remnic daemon via launchd (${label})`);
       return;
     }
-  } else if (isLinux() && (fs.existsSync(SYSTEMD_UNIT_PATH) || fs.existsSync(LEGACY_SYSTEMD_UNIT_PATH))) {
-    const serviceName = firstSuccessfulCandidate([SYSTEMD_SERVICE, LEGACY_SYSTEMD_SERVICE], (candidate) => {
+  } else if (isLinux() && anyFileExists(SYSTEMD_UNIT_PATHS)) {
+    const serviceName = firstSuccessfulCandidate(SYSTEMD_SERVICE_CANDIDATES, (candidate) => {
       childProcess.execSync(`systemctl --user start ${candidate}`, { stdio: "pipe" });
     });
     if (serviceName) {
@@ -6825,16 +6805,16 @@ function daemonStart(): void {
 
 function daemonStop(): void {
   // Try service manager first (for daemons started via `remnic daemon install`)
-  if (isMacOS() && (fs.existsSync(LAUNCHD_PLIST_PATH) || fs.existsSync(LEGACY_LAUNCHD_PLIST_PATH))) {
-    const label = firstSuccessfulCandidate([LAUNCHD_LABEL, LEGACY_LAUNCHD_LABEL], (candidate) => {
+  if (isMacOS() && anyFileExists(LAUNCHD_PLIST_PATHS)) {
+    const label = firstSuccessfulCandidate(LAUNCHD_LABEL_CANDIDATES, (candidate) => {
       childProcess.execSync(`launchctl stop ${candidate} 2>/dev/null`, { stdio: "pipe" });
     });
     if (label) {
       console.log(`Stopped remnic daemon via launchd (${label})`);
       return;
     }
-  } else if (isLinux() && (fs.existsSync(SYSTEMD_UNIT_PATH) || fs.existsSync(LEGACY_SYSTEMD_UNIT_PATH))) {
-    const serviceName = firstSuccessfulCandidate([SYSTEMD_SERVICE, LEGACY_SYSTEMD_SERVICE], (candidate) => {
+  } else if (isLinux() && anyFileExists(SYSTEMD_UNIT_PATHS)) {
+    const serviceName = firstSuccessfulCandidate(SYSTEMD_SERVICE_CANDIDATES, (candidate) => {
       childProcess.execSync(`systemctl --user stop ${candidate}`, { stdio: "pipe" });
     });
     if (serviceName) {

--- a/tests/integration/bridge-mode.test.ts
+++ b/tests/integration/bridge-mode.test.ts
@@ -35,10 +35,12 @@ setInterval(() => {}, 1000);
 test("detectBridgeMode defaults to embedded when no daemon running", async (t) => {
   const previousHome = process.env.HOME;
   const previousPath = process.env.PATH;
+  const previousPort = process.env.REMNIC_PORT;
   const tempHome = await mkdtemp(path.join(os.tmpdir(), "bridge-mode-default-"));
 
   process.env.HOME = tempHome;
   process.env.PATH = "/definitely-missing-bridge-tools";
+  process.env.REMNIC_PORT = "49999";
   delete process.env.REMNIC_BRIDGE_MODE;
   delete process.env.ENGRAM_BRIDGE_MODE;
 
@@ -47,6 +49,8 @@ test("detectBridgeMode defaults to embedded when no daemon running", async (t) =
     else process.env.HOME = previousHome;
     if (previousPath === undefined) delete process.env.PATH;
     else process.env.PATH = previousPath;
+    if (previousPort === undefined) delete process.env.REMNIC_PORT;
+    else process.env.REMNIC_PORT = previousPort;
   });
 
   const { detectBridgeMode } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
@@ -194,6 +198,88 @@ test("detectBridgeMode delegates when daemon service is installed and healthy wi
 
   await mkdir(launchAgentsDir, { recursive: true });
   await writeFile(path.join(launchAgentsDir, "ai.remnic.daemon.plist"), "<plist />\n", "utf8");
+
+  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
+  const view = new Int32Array(state);
+  const serverWorker = new Worker(
+    new URL(`data:text/javascript,${encodeURIComponent(HEALTH_SERVER_WORKER_SOURCE)}`),
+    { type: "module", workerData: { state } },
+  );
+  Atomics.wait(view, 0, 0, 1000);
+  const port = Atomics.load(view, 1);
+  assert.ok(port > 0);
+
+  try {
+    process.env.HOME = homeDir;
+    process.env.REMNIC_PORT = String(port);
+    delete process.env.REMNIC_BRIDGE_MODE;
+    delete process.env.ENGRAM_BRIDGE_MODE;
+
+    const { detectBridgeMode } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
+    const config = detectBridgeMode();
+    assert.equal(config.mode, "delegate");
+  } finally {
+    await serverWorker.terminate();
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousPort === undefined) delete process.env.REMNIC_PORT;
+    else process.env.REMNIC_PORT = previousPort;
+    if (previousMode === undefined) delete process.env.REMNIC_BRIDGE_MODE;
+    else process.env.REMNIC_BRIDGE_MODE = previousMode;
+    if (previousLegacyMode === undefined) delete process.env.ENGRAM_BRIDGE_MODE;
+    else process.env.ENGRAM_BRIDGE_MODE = previousLegacyMode;
+  }
+});
+
+test("detectBridgeMode delegates when legacy ai.remnic.server launchd service is healthy", async () => {
+  const previousHome = process.env.HOME;
+  const previousPort = process.env.REMNIC_PORT;
+  const previousMode = process.env.REMNIC_BRIDGE_MODE;
+  const previousLegacyMode = process.env.ENGRAM_BRIDGE_MODE;
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "bridge-legacy-server-service-"));
+  const launchAgentsDir = path.join(homeDir, "Library", "LaunchAgents");
+
+  await mkdir(launchAgentsDir, { recursive: true });
+  await writeFile(path.join(launchAgentsDir, "ai.remnic.server.plist"), "<plist />\n", "utf8");
+
+  const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
+  const view = new Int32Array(state);
+  const serverWorker = new Worker(
+    new URL(`data:text/javascript,${encodeURIComponent(HEALTH_SERVER_WORKER_SOURCE)}`),
+    { type: "module", workerData: { state } },
+  );
+  Atomics.wait(view, 0, 0, 1000);
+  const port = Atomics.load(view, 1);
+  assert.ok(port > 0);
+
+  try {
+    process.env.HOME = homeDir;
+    process.env.REMNIC_PORT = String(port);
+    delete process.env.REMNIC_BRIDGE_MODE;
+    delete process.env.ENGRAM_BRIDGE_MODE;
+
+    const { detectBridgeMode } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
+    const config = detectBridgeMode();
+    assert.equal(config.mode, "delegate");
+  } finally {
+    await serverWorker.terminate();
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousPort === undefined) delete process.env.REMNIC_PORT;
+    else process.env.REMNIC_PORT = previousPort;
+    if (previousMode === undefined) delete process.env.REMNIC_BRIDGE_MODE;
+    else process.env.REMNIC_BRIDGE_MODE = previousMode;
+    if (previousLegacyMode === undefined) delete process.env.ENGRAM_BRIDGE_MODE;
+    else process.env.ENGRAM_BRIDGE_MODE = previousLegacyMode;
+  }
+});
+
+test("detectBridgeMode delegates to a reachable local daemon without service metadata", async () => {
+  const previousHome = process.env.HOME;
+  const previousPort = process.env.REMNIC_PORT;
+  const previousMode = process.env.REMNIC_BRIDGE_MODE;
+  const previousLegacyMode = process.env.ENGRAM_BRIDGE_MODE;
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "bridge-local-health-probe-"));
 
   const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
   const view = new Int32Array(state);

--- a/tests/remnic-cli-service-candidates.test.ts
+++ b/tests/remnic-cli-service-candidates.test.ts
@@ -62,3 +62,34 @@ test("daemon server binary resolution falls back to remnic-server on PATH before
   const resolved = resolveServerBinPath(packageDir, binDir);
   assert.equal(resolved, fs.realpathSync(globalServer));
 });
+
+test("daemon server binary resolution unwraps shell shims to runnable JavaScript", async () => {
+  const {
+    resolveServerBinPath,
+  } = await import(path.join(ROOT, "packages/remnic-cli/src/daemon-service-candidates.ts"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-shim-"));
+  const packageDir = path.join(tempDir, "packages", "remnic-cli", "dist");
+  const binDir = path.join(tempDir, "bin");
+  const globalServer = path.join(tempDir, "lib", "node_modules", "@remnic", "server", "dist", "bin", "remnic-server.js");
+  const pathServer = path.join(binDir, "remnic-server");
+
+  fs.mkdirSync(path.dirname(globalServer), { recursive: true });
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(packageDir, { recursive: true });
+  await writeFile(globalServer, "#!/usr/bin/env node\nimport '../index.js';\n", "utf8");
+  await chmod(globalServer, 0o755);
+  await writeFile(
+    pathServer,
+    [
+      "#!/bin/sh",
+      "basedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")",
+      "exec node \"$basedir/../lib/node_modules/@remnic/server/dist/bin/remnic-server.js\" \"$@\"",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(pathServer, 0o755);
+
+  const resolved = resolveServerBinPath(packageDir, binDir);
+  assert.equal(resolved, fs.realpathSync(globalServer));
+});

--- a/tests/remnic-cli-service-candidates.test.ts
+++ b/tests/remnic-cli-service-candidates.test.ts
@@ -82,6 +82,7 @@ test("daemon server binary resolution unwraps shell shims to runnable JavaScript
     pathServer,
     [
       "#!/bin/sh",
+      "export REMNIC_SERVER_ENV=test",
       "basedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")",
       "exec node \"$basedir/../lib/node_modules/@remnic/server/dist/bin/remnic-server.js\" \"$@\"",
       "",

--- a/tests/remnic-cli-service-candidates.test.ts
+++ b/tests/remnic-cli-service-candidates.test.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { chmod, mkdtemp, symlink, writeFile } from "node:fs/promises";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -19,4 +22,43 @@ test("cli service candidate helper falls through to legacy service labels after 
   });
   assert.equal(result, "engram.service");
   assert.deepEqual(calls, ["remnic.service", "engram.service"]);
+});
+
+test("daemon service candidates include legacy ai.remnic.server launchd service", async () => {
+  const {
+    LAUNCHD_LABEL_CANDIDATES,
+    launchdPlistPaths,
+  } = await import(path.join(ROOT, "packages/remnic-cli/src/daemon-service-candidates.ts"));
+  const homeDir = path.join(os.tmpdir(), "remnic-service-candidates-home");
+
+  assert.deepEqual(
+    LAUNCHD_LABEL_CANDIDATES,
+    ["ai.remnic.daemon", "ai.remnic.server", "ai.engram.daemon"],
+  );
+  assert.ok(
+    launchdPlistPaths(homeDir).includes(
+      path.join(homeDir, "Library", "LaunchAgents", "ai.remnic.server.plist"),
+    ),
+  );
+});
+
+test("daemon server binary resolution falls back to remnic-server on PATH before TypeScript source", async () => {
+  const {
+    resolveServerBinPath,
+  } = await import(path.join(ROOT, "packages/remnic-cli/src/daemon-service-candidates.ts"));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-bin-"));
+  const packageDir = path.join(tempDir, "packages", "remnic-cli", "dist");
+  const binDir = path.join(tempDir, "bin");
+  const globalServer = path.join(tempDir, "lib", "node_modules", "@remnic", "server", "dist", "bin", "remnic-server.js");
+  const pathServer = path.join(binDir, "remnic-server");
+
+  fs.mkdirSync(path.dirname(globalServer), { recursive: true });
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(packageDir, { recursive: true });
+  await writeFile(globalServer, "#!/usr/bin/env node\n", "utf8");
+  await chmod(globalServer, 0o755);
+  await symlink(globalServer, pathServer);
+
+  const resolved = resolveServerBinPath(packageDir, binDir);
+  assert.equal(resolved, fs.realpathSync(globalServer));
 });


### PR DESCRIPTION
## Summary

Fixes #1002.

- Treat legacy macOS `ai.remnic.server` launchd installs as Remnic daemon candidates in the OpenClaw bridge and CLI daemon commands.
- Add a local health probe before OpenClaw bridge auto-detection falls back to embedded mode, preventing double-binding when a compatible local daemon is already listening.
- Resolve a globally installed `remnic-server` from PATH before `remnic daemon install` falls back to TypeScript source.
- Add a patch changeset for the CLI and OpenClaw plugin packages.

## Verification

- `pnpm exec tsx --test tests/integration/bridge-mode.test.ts`
- `pnpm exec tsx --test tests/remnic-cli-service-candidates.test.ts`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates daemon auto-detection and service-manager candidate logic (launchd/systemd) plus `remnic-server` binary resolution, which could change whether the bridge/CLI delegates vs starts embedded or which service gets managed on user machines.
> 
> **Overview**
> Fixes legacy daemon detection across the OpenClaw bridge and CLI daemon commands by treating macOS `ai.remnic.server` (in addition to `ai.remnic.daemon`/`ai.engram.daemon`) as a valid launchd candidate for status/start/stop/uninstall.
> 
> Bridge auto-detection now performs a *local-only* health probe (and recognizes the legacy plist) before falling back to embedded mode, reducing double-binding when a compatible local daemon is already listening.
> 
> CLI daemon install now resolves the `remnic-server` executable from `PATH` (including shim scripts) before falling back to local TypeScript source, and adds tests plus a patch changeset for the affected packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e27db2702aea56977cdd128b8412210756faa44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->