### PR TITLE
fix(cli): validate standalone daemon launchd path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10164,8 +10164,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@remnic/core": "file:../remnic-core",
-        "@remnic/server": "file:../remnic-server"
+        "@remnic/core": "file:../remnic-core"
       },
       "devDependencies": {
         "@openclaw/plugin-inspector": "0.3.10",
@@ -10181,7 +10180,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@remnic/core": "file:../remnic-core"
+        "@remnic/core": "file:../remnic-core",
+        "@remnic/server": "file:../remnic-server"
       },
       "bin": {
         "remnic": "bin/remnic.cjs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10164,7 +10164,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@remnic/core": "file:../remnic-core"
+        "@remnic/core": "file:../remnic-core",
+        "@remnic/server": "file:../remnic-server"
       },
       "devDependencies": {
         "@openclaw/plugin-inspector": "0.3.10",

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -28,12 +28,13 @@
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "precheck-types": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/import-dispatch.test.ts src/import-bundle-detect.test.ts src/optional-importer.test.ts src/bench-args.test.ts src/xray.test.ts",
+    "test": "tsx --test src/import-dispatch.test.ts src/import-bundle-detect.test.ts src/optional-importer.test.ts src/bench-args.test.ts src/daemon-service.test.ts src/xray.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@remnic/core": "workspace:^",
     "@remnic/plugin-pi": "workspace:^",
+    "@remnic/server": "workspace:^",
     "yaml": "^2.4.2"
   },
   "peerDependencies": {

--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -104,7 +104,7 @@ test("inspectLaunchdPlist fails when installed plist points to missing server bi
   assert.match(result.remediation ?? "", /remnic daemon install/);
 });
 
-test("inspectLaunchdPlist accepts an existing built server binary", () => {
+test("inspectLaunchdPlist rejects an existing package import entry that does not run the CLI", () => {
   const plistPath = "/Users/test/Library/LaunchAgents/ai.remnic.daemon.plist";
   const server = "/opt/homebrew/lib/node_modules/@remnic/server/dist/index.js";
   const result = inspectLaunchdPlist(plistPath, {
@@ -121,6 +121,28 @@ test("inspectLaunchdPlist accepts an existing built server binary", () => {
   });
 
   assert.equal(result.installed, true);
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /does not invoke/);
+  assert.match(result.remediation ?? "", /remnic daemon install/);
+});
+
+test("inspectLaunchdPlist accepts an existing built server binary", () => {
+  const plistPath = "/Users/test/Library/LaunchAgents/ai.remnic.daemon.plist";
+  const server = "/opt/homebrew/lib/node_modules/@remnic/server/dist/bin/remnic-server.js";
+  const result = inspectLaunchdPlist(plistPath, {
+    existsSync: (candidate) => candidate === plistPath || candidate === server,
+    readFileSync: () => `
+      <plist><dict>
+        <key>ProgramArguments</key>
+        <array>
+          <string>/opt/homebrew/bin/node</string>
+          <string>${server}</string>
+        </array>
+      </dict></plist>
+    `,
+  });
+
+  assert.equal(result.installed, true);
   assert.equal(result.ok, true);
-  assert.match(result.detail, /dist\/index\.js/);
+  assert.match(result.detail, /dist\/bin\/remnic-server\.js/);
 });

--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -146,3 +146,35 @@ test("inspectLaunchdPlist accepts an existing built server binary", () => {
   assert.equal(result.ok, true);
   assert.match(result.detail, /dist\/bin\/remnic-server\.js/);
 });
+
+test("inspectLaunchdPlist expands shared home aliases in server arguments", () => {
+  const originalHome = process.env.HOME;
+  process.env.HOME = "/Users/test";
+
+  try {
+    const plistPath = "/Users/test/Library/LaunchAgents/ai.remnic.daemon.plist";
+    const server = "/Users/test/.npm/lib/node_modules/@remnic/server/dist/bin/remnic-server.js";
+    const result = inspectLaunchdPlist(plistPath, {
+      existsSync: (candidate) => candidate === plistPath || candidate === server,
+      readFileSync: () => `
+        <plist><dict>
+          <key>ProgramArguments</key>
+          <array>
+            <string>/opt/homebrew/bin/node</string>
+            <string>\${HOME}/.npm/lib/node_modules/@remnic/server/dist/bin/remnic-server.js</string>
+          </array>
+        </dict></plist>
+      `,
+    });
+
+    assert.equal(result.installed, true);
+    assert.equal(result.ok, true);
+    assert.match(result.detail, /\/Users\/test\/\.npm/);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  }
+});

--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -9,19 +9,20 @@ import {
   resolveServerBinDetails,
 } from "./daemon-service.js";
 
-test("resolveServerBinDetails prefers installed @remnic/server package entry through ESM resolution", () => {
+test("resolveServerBinDetails prefers installed @remnic/server bin through ESM resolution", () => {
   const packageEntry = "/opt/homebrew/lib/node_modules/@remnic/server/dist/index.js";
+  const packageBin = "/opt/homebrew/lib/node_modules/@remnic/server/dist/bin/remnic-server.js";
   const result = resolveServerBinDetails({
     moduleDir: "/repo/packages/remnic-cli/dist",
     packageResolve: (specifier) => {
       assert.equal(specifier, "@remnic/server");
       return pathToFileURL(packageEntry).href;
     },
-    existsSync: (candidate) => candidate === packageEntry,
+    existsSync: (candidate) => candidate === packageBin,
   });
 
   assert.deepEqual(result, {
-    path: packageEntry,
+    path: packageBin,
     source: "package",
     exists: true,
     loadableByNode: true,

--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -147,6 +147,26 @@ test("inspectLaunchdPlist accepts an existing built server binary", () => {
   assert.match(result.detail, /dist\/bin\/remnic-server\.js/);
 });
 
+test("inspectLaunchdPlist recognizes legacy engram-server index paths", () => {
+  const plistPath = "/Users/test/Library/LaunchAgents/ai.engram.daemon.plist";
+  const server = "/opt/homebrew/lib/node_modules/engram-server/dist/index.js";
+  const result = inspectLaunchdPlist(plistPath, {
+    existsSync: (candidate) => candidate === plistPath || candidate === server,
+    readFileSync: () => `
+      <plist><dict>
+        <key>ProgramArguments</key>
+        <array>
+          <string>${server}</string>
+        </array>
+      </dict></plist>
+    `,
+  });
+
+  assert.equal(result.installed, true);
+  assert.equal(result.ok, true);
+  assert.match(result.detail, /engram-server\/dist\/index\.js/);
+});
+
 test("inspectLaunchdPlist expands shared home aliases in server arguments", () => {
   const originalHome = process.env.HOME;
   process.env.HOME = "/Users/test";

--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import {
+  inspectLaunchdPlist,
+  readLaunchdProgramArguments,
+  resolveServerBinDetails,
+} from "./daemon-service.js";
+
+test("resolveServerBinDetails prefers installed @remnic/server package entry", () => {
+  const packageEntry = "/opt/homebrew/lib/node_modules/@remnic/server/dist/index.js";
+  const result = resolveServerBinDetails({
+    moduleDir: "/repo/packages/remnic-cli/dist",
+    requireResolve: (specifier) => {
+      assert.equal(specifier, "@remnic/server");
+      return packageEntry;
+    },
+    existsSync: (candidate) => candidate === packageEntry,
+  });
+
+  assert.deepEqual(result, {
+    path: packageEntry,
+    source: "package",
+    exists: true,
+    loadableByNode: true,
+  });
+});
+
+test("resolveServerBinDetails falls back to workspace dist before source", () => {
+  const moduleDir = "/repo/packages/remnic-cli/dist";
+  const workspaceDist = path.resolve(moduleDir, "../../remnic-server/dist/index.js");
+  const workspaceSource = path.resolve(moduleDir, "../../remnic-server/src/index.ts");
+  const result = resolveServerBinDetails({
+    moduleDir,
+    requireResolve: () => {
+      throw new Error("not installed");
+    },
+    existsSync: (candidate) => candidate === workspaceDist || candidate === workspaceSource,
+  });
+
+  assert.equal(result.path, workspaceDist);
+  assert.equal(result.source, "workspace-dist");
+  assert.equal(result.exists, true);
+  assert.equal(result.loadableByNode, true);
+});
+
+test("resolveServerBinDetails reports TypeScript source as not launchd-loadable", () => {
+  const moduleDir = "/repo/packages/remnic-cli/src";
+  const workspaceSource = path.resolve(moduleDir, "../../remnic-server/src/index.ts");
+  const result = resolveServerBinDetails({
+    moduleDir,
+    requireResolve: () => {
+      throw new Error("not installed");
+    },
+    existsSync: (candidate) => candidate === workspaceSource,
+  });
+
+  assert.equal(result.path, workspaceSource);
+  assert.equal(result.source, "workspace-source");
+  assert.equal(result.exists, true);
+  assert.equal(result.loadableByNode, false);
+});
+
+test("readLaunchdProgramArguments parses plist string entries", () => {
+  const args = readLaunchdProgramArguments(`
+    <plist><dict>
+      <key>ProgramArguments</key>
+      <array>
+        <string>/usr/local/bin/node</string>
+        <string>/Users/test/Remnic &amp; Server/dist/index.js</string>
+      </array>
+    </dict></plist>
+  `);
+
+  assert.deepEqual(args, [
+    "/usr/local/bin/node",
+    "/Users/test/Remnic & Server/dist/index.js",
+  ]);
+});
+
+test("inspectLaunchdPlist fails when installed plist points to missing server binary", () => {
+  const plistPath = "/Users/test/Library/LaunchAgents/ai.remnic.daemon.plist";
+  const missingServer = "/opt/homebrew/lib/node_modules/@remnic/server/dist/bin/remnic-server.js";
+  const result = inspectLaunchdPlist(plistPath, {
+    existsSync: (candidate) => candidate === plistPath,
+    readFileSync: () => `
+      <plist><dict>
+        <key>ProgramArguments</key>
+        <array>
+          <string>/opt/homebrew/bin/node</string>
+          <string>${missingServer}</string>
+        </array>
+      </dict></plist>
+    `,
+  });
+
+  assert.equal(result.installed, true);
+  assert.equal(result.ok, false);
+  assert.match(result.detail, /missing/);
+  assert.match(result.detail, /@remnic\/server/);
+  assert.match(result.remediation ?? "", /remnic daemon install/);
+});
+
+test("inspectLaunchdPlist accepts an existing built server binary", () => {
+  const plistPath = "/Users/test/Library/LaunchAgents/ai.remnic.daemon.plist";
+  const server = "/opt/homebrew/lib/node_modules/@remnic/server/dist/index.js";
+  const result = inspectLaunchdPlist(plistPath, {
+    existsSync: (candidate) => candidate === plistPath || candidate === server,
+    readFileSync: () => `
+      <plist><dict>
+        <key>ProgramArguments</key>
+        <array>
+          <string>/opt/homebrew/bin/node</string>
+          <string>${server}</string>
+        </array>
+      </dict></plist>
+    `,
+  });
+
+  assert.equal(result.installed, true);
+  assert.equal(result.ok, true);
+  assert.match(result.detail, /dist\/index\.js/);
+});

--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import {
   inspectLaunchdPlist,
@@ -8,13 +9,13 @@ import {
   resolveServerBinDetails,
 } from "./daemon-service.js";
 
-test("resolveServerBinDetails prefers installed @remnic/server package entry", () => {
+test("resolveServerBinDetails prefers installed @remnic/server package entry through ESM resolution", () => {
   const packageEntry = "/opt/homebrew/lib/node_modules/@remnic/server/dist/index.js";
   const result = resolveServerBinDetails({
     moduleDir: "/repo/packages/remnic-cli/dist",
-    requireResolve: (specifier) => {
+    packageResolve: (specifier) => {
       assert.equal(specifier, "@remnic/server");
-      return packageEntry;
+      return pathToFileURL(packageEntry).href;
     },
     existsSync: (candidate) => candidate === packageEntry,
   });
@@ -33,7 +34,7 @@ test("resolveServerBinDetails falls back to workspace dist before source", () =>
   const workspaceSource = path.resolve(moduleDir, "../../remnic-server/src/index.ts");
   const result = resolveServerBinDetails({
     moduleDir,
-    requireResolve: () => {
+    packageResolve: () => {
       throw new Error("not installed");
     },
     existsSync: (candidate) => candidate === workspaceDist || candidate === workspaceSource,
@@ -50,7 +51,7 @@ test("resolveServerBinDetails reports TypeScript source as not launchd-loadable"
   const workspaceSource = path.resolve(moduleDir, "../../remnic-server/src/index.ts");
   const result = resolveServerBinDetails({
     moduleDir,
-    requireResolve: () => {
+    packageResolve: () => {
       throw new Error("not installed");
     },
     existsSync: (candidate) => candidate === workspaceSource,

--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -64,6 +64,30 @@ test("resolveServerBinDetails reports TypeScript source as not launchd-loadable"
   assert.equal(result.loadableByNode, false);
 });
 
+test("resolveServerBinDetails falls back to PATH before TypeScript source", () => {
+  const moduleDir = "/repo/packages/remnic-cli/dist";
+  const pathServer = "/opt/homebrew/bin/remnic-server";
+  const workspaceSource = path.resolve(moduleDir, "../../remnic-server/src/index.ts");
+  const result = resolveServerBinDetails({
+    moduleDir,
+    pathEnv: "/opt/homebrew/bin",
+    packageResolve: () => {
+      throw new Error("not installed");
+    },
+    findCommandOnPath: (command, pathEnv) => {
+      assert.equal(command, "remnic-server");
+      assert.equal(pathEnv, "/opt/homebrew/bin");
+      return pathServer;
+    },
+    existsSync: (candidate) => candidate === pathServer || candidate === workspaceSource,
+  });
+
+  assert.equal(result.path, pathServer);
+  assert.equal(result.source, "path");
+  assert.equal(result.exists, true);
+  assert.equal(result.loadableByNode, true);
+});
+
 test("readLaunchdProgramArguments parses plist string entries", () => {
   const args = readLaunchdProgramArguments(`
     <plist><dict>

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -188,8 +188,8 @@ export function readLaunchdProgramArguments(plistContent: string): string[] {
 function findLaunchdServerArgument(args: string[]): string | undefined {
   const explicit = args.find((arg) =>
     /(?:^|[/\\])@remnic[/\\]server[/\\]/.test(arg) ||
-    /(?:^|[/\\])remnic-server(?:\.js)?$/.test(arg) ||
-    /(?:^|[/\\])remnic-server[/\\](?:dist|src)[/\\]index\.[jt]s$/.test(arg)
+    /(?:^|[/\\])(?:remnic-server|engram-server)(?:\.js)?$/.test(arg) ||
+    /(?:^|[/\\])(?:remnic-server|engram-server)[/\\](?:dist|src)[/\\]index\.[jt]s$/.test(arg)
   );
   if (explicit) return explicit;
 

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -40,8 +40,9 @@ export function resolveServerBinDetails(options: ResolveServerBinOptions = {}): 
   const candidates: Array<{ path: string; source: ServerBinSource }> = [];
 
   try {
+    const packageEntry = normalizeResolvedPath(packageResolve("@remnic/server"));
     candidates.push({
-      path: normalizeResolvedPath(packageResolve("@remnic/server")),
+      path: packageServerBinFromEntry(packageEntry),
       source: "package",
     });
   } catch {
@@ -205,6 +206,13 @@ function resolveImportSpecifier(specifier: string): string {
 function normalizeResolvedPath(resolved: string): string {
   if (resolved.startsWith("file:")) return fileURLToPath(resolved);
   return resolved;
+}
+
+function packageServerBinFromEntry(packageEntry: string): string {
+  if (path.basename(packageEntry) === "index.js" && path.basename(path.dirname(packageEntry)) === "dist") {
+    return path.join(path.dirname(packageEntry), "bin", "remnic-server.js");
+  }
+  return packageEntry;
 }
 
 function unescapeXml(input: string): string {

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -155,6 +155,15 @@ export function inspectLaunchdPlist(
     };
   }
 
+  if (!isRunnableServerNodePath(expandedServerArg)) {
+    return {
+      installed: true,
+      ok: false,
+      detail: `${expandedServerArg} (does not invoke the Remnic server CLI)`,
+      remediation: "Run `remnic daemon install` to rewrite the launchd service with the Remnic server bin path.",
+    };
+  }
+
   return {
     installed: true,
     ok: true,
@@ -213,6 +222,14 @@ function packageServerBinFromEntry(packageEntry: string): string {
     return path.join(path.dirname(packageEntry), "bin", "remnic-server.js");
   }
   return packageEntry;
+}
+
+function isRunnableServerNodePath(candidate: string): boolean {
+  const normalized = candidate.replaceAll("\\", "/");
+  return (
+    /(?:^|\/)(?:remnic-server|engram-server)(?:\.js)?$/.test(normalized) ||
+    /(?:^|\/)(?:remnic-server|engram-server)\/(?:dist|src)\/index\.[jt]s$/.test(normalized)
+  );
 }
 
 function unescapeXml(input: string): string {

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -1,0 +1,208 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type ServerBinSource = "package" | "workspace-dist" | "workspace-source";
+
+export interface ServerBinResolution {
+  path: string;
+  source: ServerBinSource;
+  exists: boolean;
+  loadableByNode: boolean;
+}
+
+export interface ResolveServerBinOptions {
+  existsSync?: (candidate: string) => boolean;
+  moduleDir?: string;
+  requireResolve?: (specifier: string) => string;
+}
+
+export interface LaunchdPlistInspection {
+  installed: boolean;
+  ok: boolean;
+  warn?: boolean;
+  detail: string;
+  remediation?: string;
+}
+
+export interface InspectLaunchdPlistOptions {
+  existsSync?: (candidate: string) => boolean;
+  readFileSync?: (file: string, encoding: BufferEncoding) => string;
+}
+
+const thisRequire = createRequire(import.meta.url);
+const thisModuleDir = path.dirname(fileURLToPath(import.meta.url));
+
+export function resolveServerBinDetails(options: ResolveServerBinOptions = {}): ServerBinResolution {
+  const existsSync = options.existsSync ?? fs.existsSync;
+  const moduleDir = options.moduleDir ?? thisModuleDir;
+  const requireResolve = options.requireResolve ?? thisRequire.resolve.bind(thisRequire);
+  const candidates: Array<{ path: string; source: ServerBinSource }> = [];
+
+  try {
+    candidates.push({
+      path: requireResolve("@remnic/server"),
+      source: "package",
+    });
+  } catch {
+    // @remnic/server may not be installed beside @remnic/cli in older or
+    // development setups. Fall through to workspace-relative candidates.
+  }
+
+  candidates.push(
+    {
+      path: path.resolve(moduleDir, "../../remnic-server/dist/index.js"),
+      source: "workspace-dist",
+    },
+    {
+      path: path.resolve(moduleDir, "../../remnic-server/src/index.ts"),
+      source: "workspace-source",
+    },
+  );
+
+  const selected = candidates.find((candidate) => existsSync(candidate.path)) ?? candidates[0] ?? {
+    path: path.resolve(moduleDir, "../../remnic-server/dist/index.js"),
+    source: "workspace-dist" as const,
+  };
+
+  const exists = existsSync(selected.path);
+  return {
+    ...selected,
+    exists,
+    loadableByNode: exists && !selected.path.endsWith(".ts"),
+  };
+}
+
+export function resolveServerBin(options: ResolveServerBinOptions = {}): string {
+  return resolveServerBinDetails(options).path;
+}
+
+export function inspectLaunchdPlist(
+  plistPath: string,
+  options: InspectLaunchdPlistOptions = {},
+): LaunchdPlistInspection {
+  const existsSync = options.existsSync ?? fs.existsSync;
+  const readFileSync = options.readFileSync ?? fs.readFileSync;
+
+  if (!existsSync(plistPath)) {
+    return {
+      installed: false,
+      ok: true,
+      warn: true,
+      detail: `${plistPath} (not installed)`,
+    };
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(plistPath, "utf8");
+  } catch {
+    return {
+      installed: true,
+      ok: false,
+      detail: `${plistPath} (cannot read)`,
+      remediation: "Fix the launchd plist permissions or run `remnic daemon install` to recreate it.",
+    };
+  }
+
+  const args = readLaunchdProgramArguments(content);
+  if (args.length === 0) {
+    return {
+      installed: true,
+      ok: false,
+      detail: `${plistPath} (missing ProgramArguments)`,
+      remediation: "Run `remnic daemon install` to recreate the launchd service.",
+    };
+  }
+
+  const serverArg = findLaunchdServerArgument(args);
+  if (!serverArg) {
+    return {
+      installed: true,
+      ok: false,
+      detail: `${plistPath} (ProgramArguments do not include a Remnic server binary)`,
+      remediation: "Run `remnic daemon install` to recreate the launchd service.",
+    };
+  }
+
+  const expandedServerArg = expandHome(serverArg);
+  if (!path.isAbsolute(expandedServerArg)) {
+    return {
+      installed: true,
+      ok: false,
+      detail: `${serverArg} (not an absolute path in ${plistPath})`,
+      remediation: "Run `remnic daemon install` so launchd uses an absolute Remnic server path.",
+    };
+  }
+
+  if (!existsSync(expandedServerArg)) {
+    return {
+      installed: true,
+      ok: false,
+      detail: `${expandedServerArg} (missing; referenced by ${plistPath})`,
+      remediation:
+        "Run `remnic daemon install` to rewrite the launchd service, or `remnic daemon uninstall` if you only use the OpenClaw plugin.",
+    };
+  }
+
+  if (expandedServerArg.endsWith(".ts")) {
+    return {
+      installed: true,
+      ok: false,
+      detail: expandedServerArg + " (TypeScript source is not loadable by launchd node)",
+      remediation: "Build @remnic/server and run `remnic daemon install` again.",
+    };
+  }
+
+  return {
+    installed: true,
+    ok: true,
+    detail: `${expandedServerArg} (from ${plistPath})`,
+  };
+}
+
+export function readLaunchdProgramArguments(plistContent: string): string[] {
+  const programArguments = plistContent.match(
+    /<key>\s*ProgramArguments\s*<\/key>\s*<array>([\s\S]*?)<\/array>/,
+  );
+  if (!programArguments) return [];
+  const args: string[] = [];
+  const stringPattern = /<string>([\s\S]*?)<\/string>/g;
+  let match: RegExpExecArray | null;
+  while ((match = stringPattern.exec(programArguments[1] ?? "")) !== null) {
+    args.push(unescapeXml(match[1] ?? ""));
+  }
+  return args;
+}
+
+function findLaunchdServerArgument(args: string[]): string | undefined {
+  const explicit = args.find((arg) =>
+    /(?:^|[/\\])@remnic[/\\]server[/\\]/.test(arg) ||
+    /(?:^|[/\\])remnic-server(?:\.js)?$/.test(arg) ||
+    /(?:^|[/\\])remnic-server[/\\](?:dist|src)[/\\]index\.[jt]s$/.test(arg)
+  );
+  if (explicit) return explicit;
+
+  const [program, firstArg] = args;
+  if (program && firstArg && /(?:^|[/\\])node(?:\.exe)?$/.test(program)) {
+    return firstArg;
+  }
+  return undefined;
+}
+
+function expandHome(input: string): string {
+  if (input === "~") return os.homedir();
+  if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
+  return input;
+}
+
+function unescapeXml(input: string): string {
+  return input
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { findCommandOnPath as findCommandOnPathDefault } from "./daemon-service-candidates.js";
 import { expandTilde } from "./path-utils.js";
 
-export type ServerBinSource = "package" | "workspace-dist" | "workspace-source";
+export type ServerBinSource = "package" | "path" | "workspace-dist" | "workspace-source";
 
 export interface ServerBinResolution {
   path: string;
@@ -14,8 +15,10 @@ export interface ServerBinResolution {
 
 export interface ResolveServerBinOptions {
   existsSync?: (candidate: string) => boolean;
+  findCommandOnPath?: (command: string, pathEnv?: string) => string | undefined;
   moduleDir?: string;
   packageResolve?: (specifier: string) => string;
+  pathEnv?: string;
 }
 
 export interface LaunchdPlistInspection {
@@ -35,6 +38,7 @@ const thisModuleDir = path.dirname(fileURLToPath(import.meta.url));
 
 export function resolveServerBinDetails(options: ResolveServerBinOptions = {}): ServerBinResolution {
   const existsSync = options.existsSync ?? fs.existsSync;
+  const findCommandOnPath = options.findCommandOnPath ?? findCommandOnPathDefault;
   const moduleDir = options.moduleDir ?? thisModuleDir;
   const packageResolve = options.packageResolve ?? resolveImportSpecifier;
   const candidates: Array<{ path: string; source: ServerBinSource }> = [];
@@ -55,11 +59,20 @@ export function resolveServerBinDetails(options: ResolveServerBinOptions = {}): 
       path: path.resolve(moduleDir, "../../remnic-server/dist/index.js"),
       source: "workspace-dist",
     },
-    {
-      path: path.resolve(moduleDir, "../../remnic-server/src/index.ts"),
-      source: "workspace-source",
-    },
   );
+
+  const pathBin = findCommandOnPath("remnic-server", options.pathEnv);
+  if (pathBin) {
+    candidates.push({
+      path: pathBin,
+      source: "path",
+    });
+  }
+
+  candidates.push({
+    path: path.resolve(moduleDir, "../../remnic-server/src/index.ts"),
+    source: "workspace-source",
+  });
 
   const selected = candidates.find((candidate) => existsSync(candidate.path)) ?? candidates[0] ?? {
     path: path.resolve(moduleDir, "../../remnic-server/dist/index.js"),

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { expandTilde } from "./path-utils.js";
 
 export type ServerBinSource = "package" | "workspace-dist" | "workspace-source";
 
@@ -126,7 +126,7 @@ export function inspectLaunchdPlist(
     };
   }
 
-  const expandedServerArg = expandHome(serverArg);
+  const expandedServerArg = expandTilde(serverArg);
   if (!path.isAbsolute(expandedServerArg)) {
     return {
       installed: true,
@@ -198,12 +198,6 @@ function findLaunchdServerArgument(args: string[]): string | undefined {
     return firstArg;
   }
   return undefined;
-}
-
-function expandHome(input: string): string {
-  if (input === "~") return os.homedir();
-  if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
-  return input;
 }
 
 function resolveImportSpecifier(specifier: string): string {

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,7 +15,7 @@ export interface ServerBinResolution {
 export interface ResolveServerBinOptions {
   existsSync?: (candidate: string) => boolean;
   moduleDir?: string;
-  requireResolve?: (specifier: string) => string;
+  packageResolve?: (specifier: string) => string;
 }
 
 export interface LaunchdPlistInspection {
@@ -32,18 +31,17 @@ export interface InspectLaunchdPlistOptions {
   readFileSync?: (file: string, encoding: BufferEncoding) => string;
 }
 
-const thisRequire = createRequire(import.meta.url);
 const thisModuleDir = path.dirname(fileURLToPath(import.meta.url));
 
 export function resolveServerBinDetails(options: ResolveServerBinOptions = {}): ServerBinResolution {
   const existsSync = options.existsSync ?? fs.existsSync;
   const moduleDir = options.moduleDir ?? thisModuleDir;
-  const requireResolve = options.requireResolve ?? thisRequire.resolve.bind(thisRequire);
+  const packageResolve = options.packageResolve ?? resolveImportSpecifier;
   const candidates: Array<{ path: string; source: ServerBinSource }> = [];
 
   try {
     candidates.push({
-      path: requireResolve("@remnic/server"),
+      path: normalizeResolvedPath(packageResolve("@remnic/server")),
       source: "package",
     });
   } catch {
@@ -196,6 +194,17 @@ function expandHome(input: string): string {
   if (input === "~") return os.homedir();
   if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
   return input;
+}
+
+function resolveImportSpecifier(specifier: string): string {
+  const resolver = (import.meta as ImportMeta & { resolve?: (target: string) => string }).resolve;
+  if (!resolver) throw new Error("import.meta.resolve is unavailable");
+  return resolver.call(import.meta, specifier);
+}
+
+function normalizeResolvedPath(resolved: string): string {
+  if (resolved.startsWith("file:")) return fileURLToPath(resolved);
+  return resolved;
 }
 
 function unescapeXml(input: string): string {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -6588,8 +6588,8 @@ function renderTemplate(templateContent: string, vars: Record<string, string>): 
 }
 
 function isStandaloneServiceInstalled(): boolean {
-  if (isMacOS()) return fs.existsSync(LAUNCHD_PLIST_PATH) || fs.existsSync(LEGACY_LAUNCHD_PLIST_PATH);
-  if (isLinux()) return fs.existsSync(SYSTEMD_UNIT_PATH) || fs.existsSync(LEGACY_SYSTEMD_UNIT_PATH);
+  if (isMacOS()) return anyFileExists(LAUNCHD_PLIST_PATHS);
+  if (isLinux()) return anyFileExists(SYSTEMD_UNIT_PATHS);
   return false;
 }
 
@@ -6602,13 +6602,16 @@ function selectLaunchdInspection(openclawPluginModeConfigured: boolean): {
   const canonical = inspectLaunchdPlist(LAUNCHD_PLIST_PATH);
   if (canonical.installed) return canonical;
 
-  const legacy = inspectLaunchdPlist(LEGACY_LAUNCHD_PLIST_PATH);
-  if (legacy.installed) {
+  for (const plistPath of LAUNCHD_PLIST_PATHS.slice(1)) {
+    const legacy = inspectLaunchdPlist(plistPath);
+    if (!legacy.installed) continue;
+
+    const label = path.basename(plistPath, ".plist");
     return legacy.ok
       ? {
           ...legacy,
           warn: true,
-          detail: `${legacy.detail} (legacy ${LEGACY_LAUNCHD_LABEL}; reinstall recommended)`,
+          detail: `${legacy.detail} (legacy ${label}; reinstall recommended)`,
           remediation: "Run `remnic daemon install` to migrate the launchd service to ai.remnic.daemon.",
         }
       : legacy;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5040,7 +5040,7 @@ async function cmdDoctor(): Promise<void> {
       ? "set"
       : openaiKeyOptionalForGateway
       ? "not set (not required for OpenClaw gateway modelSource)"
-      : "not set (required only for direct OpenAI-backed extraction)",
+      : "not set (required for direct OpenAI-backed extraction)",
   });
 
   const svcState = isServiceRunning();

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -195,6 +195,11 @@ import {
   swapDirectoryWithRollback,
 } from "./openclaw-upgrade-swap.js";
 import { expandTilde, resolveHomeDir } from "./path-utils.js";
+import {
+  inspectLaunchdPlist,
+  resolveServerBin,
+  resolveServerBinDetails,
+} from "./daemon-service.js";
 export { hasFlag, resolveFlag, stripResolveFlags, TAXONOMY_RESOLVE_BOOLEAN_FLAGS } from "./cli-args.js";
 import { hasFlag, resolveFlag, stripResolveFlags, TAXONOMY_RESOLVE_BOOLEAN_FLAGS } from "./cli-args.js";
 import { parseConnectorConfig, stripConfigArgv } from "./parse-connector-config.js";
@@ -4818,13 +4823,6 @@ async function cmdDoctor(): Promise<void> {
   const configExists = fs.existsSync(configPath);
   checks.push({ name: "Config file", ok: configExists, detail: configPath });
 
-  const hasApiKey = !!process.env.OPENAI_API_KEY;
-  checks.push({
-    name: "OPENAI_API_KEY",
-    ok: hasApiKey,
-    detail: hasApiKey ? "set" : "not set (extraction will not work)",
-  });
-
   const memoryDir = resolveMemoryDir();
   try {
     fs.mkdirSync(memoryDir, { recursive: true });
@@ -4833,18 +4831,13 @@ async function cmdDoctor(): Promise<void> {
     checks.push({ name: "Memory directory", ok: false, detail: `cannot create ${memoryDir}` });
   }
 
-  const svcState = isServiceRunning();
-  checks.push({
-    name: "Server daemon",
-    ok: svcState.running,
-    detail: svcState.running ? `running${svcState.pid ? ` (pid ${svcState.pid})` : ""}` : "stopped",
-  });
-
   // ── OpenClaw config checks ──────────────────────────────────────────────────
   const openclawConfigPath = resolveOpenclawConfigPath();
   const openclawConfigExists = fs.existsSync(openclawConfigPath);
   let openclawConfig: Record<string, unknown> = {};
   let openclawConfigValid = false;
+  let openclawPluginModeConfigured = false;
+  let activeOpenclawModelSource: string | undefined;
 
   if (openclawConfigExists) {
     try {
@@ -4986,6 +4979,14 @@ async function cmdDoctor(): Promise<void> {
       const entryConfig = entryToCheck?.config && typeof entryToCheck.config === "object"
         ? entryToCheck.config as Record<string, unknown>
         : null;
+      if (
+        slotMatchesEntry &&
+        (slotValue === REMNIC_OPENCLAW_PLUGIN_ID || slotValue === REMNIC_OPENCLAW_LEGACY_PLUGIN_ID)
+      ) {
+        openclawPluginModeConfigured = true;
+        activeOpenclawModelSource =
+          typeof entryConfig?.modelSource === "string" ? entryConfig.modelSource : undefined;
+      }
       const rawMemoryDir = entryConfig?.memoryDir;
       const configuredMemoryDir = typeof rawMemoryDir === "string" ? rawMemoryDir : undefined;
       if (configuredMemoryDir) {
@@ -5017,6 +5018,48 @@ async function cmdDoctor(): Promise<void> {
         });
       }
     }
+  }
+
+  const hasApiKey = !!process.env.OPENAI_API_KEY;
+  const openaiKeyOptionalForGateway =
+    openclawPluginModeConfigured && activeOpenclawModelSource === "gateway";
+  checks.push({
+    name: "OPENAI_API_KEY",
+    ok: hasApiKey || openaiKeyOptionalForGateway,
+    warn: !hasApiKey,
+    detail: hasApiKey
+      ? "set"
+      : openaiKeyOptionalForGateway
+      ? "not set (not required for OpenClaw gateway modelSource)"
+      : "not set (required only for direct OpenAI-backed extraction)",
+  });
+
+  const svcState = isServiceRunning();
+  const standaloneServiceInstalled = isStandaloneServiceInstalled();
+  const daemonOptionalForOpenclaw = openclawPluginModeConfigured && !standaloneServiceInstalled;
+  checks.push({
+    name: "Server daemon",
+    ok: svcState.running || daemonOptionalForOpenclaw,
+    warn: !svcState.running,
+    detail: svcState.running
+      ? `running${svcState.pid ? ` (pid ${svcState.pid})` : ""}`
+      : daemonOptionalForOpenclaw
+      ? "stopped (not required for OpenClaw plugin mode)"
+      : "stopped",
+    remediation: !svcState.running && standaloneServiceInstalled
+      ? "Run `remnic daemon start`, or `remnic daemon uninstall` if you only use the OpenClaw plugin."
+      : undefined,
+  });
+
+  if (isMacOS()) {
+    const launchdInspection = selectLaunchdInspection(openclawPluginModeConfigured);
+    checks.push({
+      name: "Standalone launchd plist",
+      ok: launchdInspection.ok,
+      warn: launchdInspection.warn,
+      detail: launchdInspection.detail,
+      remediation: launchdInspection.remediation,
+    });
   }
 
   // ── Coding-agent context (issue #569) ──────────────────────────────────
@@ -6545,14 +6588,6 @@ function resolveNodePath(): string {
   return process.execPath;
 }
 
-function resolveServerBin(): string {
-  // Prefer built dist (production), fall back to source (dev)
-  const distPath = path.resolve(import.meta.dirname, "../../remnic-server/dist/index.js");
-  if (fs.existsSync(distPath)) return distPath;
-  const srcPath = path.resolve(import.meta.dirname, "../../remnic-server/src/index.ts");
-  return srcPath;
-}
-
 function isMacOS(): boolean {
   return process.platform === "darwin";
 }
@@ -6569,16 +6604,61 @@ function renderTemplate(templateContent: string, vars: Record<string, string>): 
   return result;
 }
 
+function isStandaloneServiceInstalled(): boolean {
+  if (isMacOS()) return fs.existsSync(LAUNCHD_PLIST_PATH) || fs.existsSync(LEGACY_LAUNCHD_PLIST_PATH);
+  if (isLinux()) return fs.existsSync(SYSTEMD_UNIT_PATH) || fs.existsSync(LEGACY_SYSTEMD_UNIT_PATH);
+  return false;
+}
+
+function selectLaunchdInspection(openclawPluginModeConfigured: boolean): {
+  ok: boolean;
+  warn?: boolean;
+  detail: string;
+  remediation?: string;
+} {
+  const canonical = inspectLaunchdPlist(LAUNCHD_PLIST_PATH);
+  if (canonical.installed) return canonical;
+
+  const legacy = inspectLaunchdPlist(LEGACY_LAUNCHD_PLIST_PATH);
+  if (legacy.installed) {
+    return legacy.ok
+      ? {
+          ...legacy,
+          warn: true,
+          detail: `${legacy.detail} (legacy ${LEGACY_LAUNCHD_LABEL}; reinstall recommended)`,
+          remediation: "Run `remnic daemon install` to migrate the launchd service to ai.remnic.daemon.",
+        }
+      : legacy;
+  }
+
+  return {
+    ok: true,
+    warn: !openclawPluginModeConfigured,
+    detail: openclawPluginModeConfigured
+      ? "not installed (OpenClaw plugin mode does not require standalone launchd)"
+      : `${LAUNCHD_PLIST_PATH} (not installed)`,
+    remediation: openclawPluginModeConfigured
+      ? undefined
+      : "Run `remnic daemon install` to install the standalone launchd service.",
+  };
+}
+
 function daemonInstall(): void {
   const home = resolveHomeDir();
   const nodePath = resolveNodePath();
-  const serverBin = resolveServerBin();
+  const serverBinDetails = resolveServerBinDetails();
+  const serverBin = serverBinDetails.path;
 
   // Service templates use plain `node` — TypeScript source won't work
-  if (serverBin.endsWith(".ts")) {
+  if (!serverBinDetails.exists) {
+    console.error("Error: @remnic/server could not be found.");
+    console.error("  Install @remnic/server beside @remnic/cli, or build it from the workspace first.");
+    console.error(`  Expected: ${serverBin}`);
+    process.exit(1);
+  }
+  if (!serverBinDetails.loadableByNode) {
     console.error("Error: @remnic/server has not been built. Run 'pnpm run build --filter=@remnic/server' first.");
-    console.error(`  Expected: ${path.resolve(import.meta.dirname, "../../remnic-server/dist/index.js")}`);
-    console.error(`  Found:    ${serverBin} (TypeScript source — not loadable by node)`);
+    console.error(`  Found:    ${serverBin} (TypeScript source — not loadable by launchd/systemd node)`);
     process.exit(1);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       '@remnic/plugin-pi':
         specifier: workspace:^
         version: link:../plugin-pi
+      '@remnic/server':
+        specifier: workspace:^
+        version: link:../remnic-server
       yaml:
         specifier: ^2.4.2
         version: 2.8.3

--- a/tests/openclaw-doctor-checks.test.ts
+++ b/tests/openclaw-doctor-checks.test.ts
@@ -93,6 +93,31 @@ test("doctor: CLI handles legacy openclaw-engram warn case", async () => {
   );
 });
 
+test("doctor: CLI distinguishes OpenClaw plugin mode from standalone launchd", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes("Standalone launchd plist"),
+    "CLI doctor must include standalone launchd plist validation",
+  );
+  assert.ok(
+    src.includes("OpenClaw plugin mode does not require standalone launchd") ||
+      src.includes("not required for OpenClaw plugin mode"),
+    "CLI doctor must not require launchd when OpenClaw plugin mode is configured",
+  );
+});
+
+test("doctor: CLI validates stale launchd server binary paths", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes("inspectLaunchdPlist"),
+    "CLI doctor must inspect the installed launchd plist",
+  );
+  assert.ok(
+    src.includes("remnic daemon install") && src.includes("remnic daemon uninstall"),
+    "CLI doctor must tell users how to rewrite or remove a stale standalone daemon",
+  );
+});
+
 // ── Logic unit tests (pure config parsing) ───────────────────────────────────
 
 interface OpenclawConfig {

--- a/tests/openclaw-doctor-checks.test.ts
+++ b/tests/openclaw-doctor-checks.test.ts
@@ -118,6 +118,23 @@ test("doctor: CLI validates stale launchd server binary paths", async () => {
   );
 });
 
+test("doctor: standalone service checks use merged service path arrays", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes("anyFileExists(LAUNCHD_PLIST_PATHS)"),
+    "CLI doctor must check all launchd candidate paths",
+  );
+  assert.ok(
+    src.includes("anyFileExists(SYSTEMD_UNIT_PATHS)"),
+    "CLI doctor must check all systemd candidate paths",
+  );
+  assert.equal(
+    src.includes("LEGACY_LAUNCHD_PLIST_PATH") || src.includes("LEGACY_SYSTEMD_UNIT_PATH"),
+    false,
+    "CLI doctor must not reference removed legacy path constants",
+  );
+});
+
 // ── Logic unit tests (pure config parsing) ───────────────────────────────────
 
 interface OpenclawConfig {

--- a/tests/openclaw-doctor-checks.test.ts
+++ b/tests/openclaw-doctor-checks.test.ts
@@ -135,6 +135,19 @@ test("doctor: standalone service checks use merged service path arrays", async (
   );
 });
 
+test("doctor: OPENAI_API_KEY failure message is unambiguous", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes("not set (required for direct OpenAI-backed extraction)"),
+    "CLI doctor must make the failing OPENAI_API_KEY case explicit",
+  );
+  assert.equal(
+    src.includes("not set (required only for direct OpenAI-backed extraction)"),
+    false,
+    "CLI doctor must not imply OPENAI_API_KEY is optional when the check fails",
+  );
+});
+
 // ── Logic unit tests (pure config parsing) ───────────────────────────────────
 
 interface OpenclawConfig {

--- a/tests/workspace-runtime-deps.test.ts
+++ b/tests/workspace-runtime-deps.test.ts
@@ -10,6 +10,7 @@ const packageExpectations = [
     path: new URL("../packages/remnic-cli/package.json", testDir),
     deps: {
       "@remnic/core": "workspace:^",
+      "@remnic/server": "workspace:^",
     },
   },
   {
@@ -57,4 +58,29 @@ test("runtime workspace packages preserve local linking in source manifests", as
       );
     }
   }
+});
+
+test("npm package lock keeps the Remnic server dependency beside the CLI", async () => {
+  const raw = await readFile(new URL("../package-lock.json", testDir), "utf8");
+  const lock = JSON.parse(raw) as {
+    packages?: Record<
+      string,
+      {
+        dependencies?: Record<string, string>;
+      }
+    >;
+  };
+
+  assert.equal(
+    lock.packages?.["packages/remnic-cli"]?.dependencies?.["@remnic/server"],
+    "file:../remnic-server",
+    "package-lock should install @remnic/server beside @remnic/cli",
+  );
+  assert.equal(
+    lock.packages?.["packages/plugin-openclaw"]?.dependencies?.[
+      "@remnic/server"
+    ],
+    undefined,
+    "plugin-openclaw should not gain the CLI daemon server dependency",
+  );
 });


### PR DESCRIPTION
Fixes #1003.

Summary:
- Resolve @remnic/server through package resolution first, with workspace fallback for development.
- Fail daemon install before writing launchd/systemd services when the server binary is missing or only TypeScript source is available.
- Add doctor validation for stale standalone launchd plists and distinguish OpenClaw plugin mode from standalone daemon requirements.
- Treat OpenClaw gateway modelSource as not requiring a direct OPENAI_API_KEY.

Tests:
- pnpm exec tsx --test packages/remnic-cli/src/daemon-service.test.ts tests/openclaw-doctor-checks.test.ts
- pnpm --filter @remnic/cli test
- pnpm exec tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --types node packages/remnic-cli/src/daemon-service.ts
- npm run preflight:quick

Note:
- pnpm --filter @remnic/cli check-types still reports pre-existing CLI fixture/type errors outside this change; root preflight:quick passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon installation and `doctor` validation logic around launchd/systemd service detection and server binary resolution, which can affect users’ ability to start/manage the background server. Risk is mitigated by added unit tests covering resolution/inspection edge cases.
> 
> **Overview**
> Improves `@remnic/cli` daemon management by adding a new `daemon-service.ts` module that *resolves the Remnic server executable more robustly* (prefer ESM package resolution of `@remnic/server`, then workspace dist/PATH, and treats TS source as not launchd/systemd-loadable).
> 
> `remnic daemon install` now fails fast with clearer errors when the server binary is missing or only TypeScript source is available, instead of writing invalid launchd/systemd service files. `remnic doctor` is updated to distinguish **OpenClaw plugin mode** from **standalone daemon** requirements, validate stale/legacy macOS launchd plists (including missing or incorrect server paths), and treat `OPENAI_API_KEY` as optional when OpenClaw is configured with `modelSource: "gateway"`.
> 
> Updates workspace/runtime deps so the CLI depends on `@remnic/server`, and adds focused tests for server-bin resolution, plist parsing/inspection, and new doctor expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 394b1ac238144a2c8a9f5b08a4dad5bd54a39d0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->