### PR TITLE
Fix OpenClaw 2026.5.16 beta compatibility

### DIFF
--- a/.changeset/openclaw-2026-5-16-beta2-compat.md
+++ b/.changeset/openclaw-2026-5-16-beta2-compat.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Align OpenClaw adapter metadata and command registration with OpenClaw 2026.5.16-beta.2, and avoid treating env-var-shaped provider markers as literal API keys.

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -140,7 +140,7 @@ OpenClaw runtime surfaces currently wired by the plugin:
 - `agent_end` for buffered extraction
 - `before_compaction` / `after_compaction` for checkpoint and reset flows
 - `before_reset` for reset-time bounded buffer flush and session cleanup
-- `commands.list` for slash-command discovery metadata
+- `api.registerCommand()` for slash-command discovery metadata
 - `session_start` / `session_end`
 - `before_tool_call` / `after_tool_call`
 - `llm_output`
@@ -151,12 +151,14 @@ The plugin manifest advertises compatibility on two surfaces:
 - `supports` stays in place for OpenClaw 2026.4-era slot and lifecycle routing.
 - `contracts.tools` declares every Remnic-owned tool name for OpenClaw 2026.5+
   descriptor planning and tool ownership validation.
-- `setup.providers` mirrors the OpenAI auth env metadata for OpenClaw 2026.5.3+
-  setup/status discovery.
-- `providerAuthEnvVars` remains for older OpenClaw builds during the upstream
-  deprecation window.
+- `setup.requiresRuntime: false` is explicit; Remnic does not claim OpenAI
+  provider setup ownership.
+- `activation.onStartup: false` is explicit so startup activation remains
+  intentional.
+- `providerAuthChoices` advertises the optional plugin-mode OpenAI API key
+  without using the deprecated external-plugin `providerAuthEnvVars` surface.
 
-Keep both blocks. `contracts.tools` is additive for older OpenClaw runtimes, but
+Keep the supported blocks. `contracts.tools` is additive for older OpenClaw runtimes, but
 OpenClaw 2026.5 rejects plugin tool registration when a runtime tool is missing
 from the manifest contract.
 
@@ -201,8 +203,8 @@ Reset cleanup currently clears:
 
 ## Command Discovery
 
-Remnic responds to OpenClaw's `commands.list` surface with the current command
-descriptor group:
+Remnic registers the current command descriptor group through OpenClaw's
+`api.registerCommand()` surface:
 
 - `remnic off`
 - `remnic on`
@@ -211,8 +213,9 @@ descriptor group:
 - `remnic stats`
 - `remnic flush`
 
-This is discovery metadata for the command palette and help surfaces. The
-handlers are live:
+This is discovery metadata for the command palette and help surfaces. When
+`registerCommand` is unavailable, Remnic logs the missing surface instead of
+registering `commands.list` as a typed hook. The handlers are live:
 
 - `remnic off` / `remnic on` write the session toggle store
 - `remnic status` reports current toggle source and the last recall summary

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -156,7 +156,10 @@ The plugin manifest advertises compatibility on two surfaces:
 - `activation.onStartup: false` is explicit so startup activation remains
   intentional.
 - `providerAuthChoices` advertises the optional plugin-mode OpenAI API key
-  without using the deprecated external-plugin `providerAuthEnvVars` surface.
+  for onboarding and CLI surfaces.
+- `providerAuthEnvVars.openai` is retained only as compatibility metadata for
+  OpenClaw's pre-runtime env-var auth probes; it does not reintroduce provider
+  setup ownership.
 
 Keep the supported blocks. `contracts.tools` is additive for older OpenClaw runtimes, but
 OpenClaw 2026.5 rejects plugin tool registration when a runtime tool is missing

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -7,6 +7,11 @@
   "setup": {
     "requiresRuntime": false
   },
+  "providerAuthEnvVars": {
+    "openai": [
+      "OPENAI_API_KEY"
+    ]
+  },
   "providerAuthChoices": [
     {
       "provider": "openai",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,27 +1,11 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {
-    "providers": [
-      {
-        "id": "openai",
-        "authMethods": [
-          "api-key"
-        ],
-        "envVars": [
-          "OPENAI_API_KEY"
-        ]
-      }
-    ],
     "requiresRuntime": false
-  },
-  "providerAuthEnvVars": {
-    "openai": [
-      "OPENAI_API_KEY"
-    ]
   },
   "providerAuthChoices": [
     {
@@ -719,7 +703,7 @@
       "commandsListEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Advertise Remnic slash-command descriptors through the commands.list runtime surface."
+        "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
       },
       "openclawToolsEnabled": {
         "type": "boolean",
@@ -5827,6 +5811,7 @@
     }
   ],
   "activation": {
+    "onStartup": false,
     "onCommands": [
       "remnic"
     ],

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -180,7 +180,7 @@ extension entry, and its package install metadata advertises
 `openclaw.install.npmSpec: "@remnic/plugin-openclaw"`, and
 `openclaw.install.defaultChoice: "clawhub"`. That keeps OpenClaw setup,
 repair, and update flows ClawHub-first while preserving npm as the fallback
-install surface and `>=2026.4.8` as the minimum supported host range.
+install surface and `>=2026.5.16-beta.1` as the minimum supported host range.
 The manifest also declares `activation.onStartup: false`, leaves provider
 ownership to the host, and exposes the optional plugin-mode OpenAI key through
 `providerAuthChoices`.

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -86,7 +86,7 @@ This plugin hooks into the OpenClaw gateway lifecycle:
 - **`agent_end`** -- buffers the conversation turn for extraction
 - **`before_compaction`** / **`after_compaction`** -- saves checkpoints and triggers session reset on context compaction
 - **`before_reset`** -- bounded flush of the in-flight buffer before OpenClaw discards a session
-- **`commands.list`** -- exposes Remnic slash-command descriptors to the command palette
+- **`api.registerCommand()`** -- exposes Remnic slash-command descriptors to the command palette
 - **`session_start`** / **`session_end`** -- session lifecycle tracking
 - **`before_tool_call`** / **`after_tool_call`** -- tool usage observation for analytics
 - **`llm_output`** -- LLM token usage tracking
@@ -164,15 +164,15 @@ CI jobs that provision OpenClaw should use
 `npm run check:openclaw-sdk-surface:required` or pass
 `-- --require --package-root <path>` so a missing SDK fails instead of skipping.
 
-Last compatibility sweep: May 13, 2026. The SDK surface check passed against
+Last compatibility sweep: May 16, 2026. The SDK surface check passed against
 `openclaw@2026.5.3`, `openclaw@2026.5.3-1`, `openclaw@2026.5.4-beta.1`,
 `openclaw@2026.5.4-beta.2`, `openclaw@2026.5.4-beta.3`,
 `openclaw@2026.5.4`, `openclaw@2026.5.5`, `openclaw@2026.5.6`, and
-`openclaw@2026.5.12-beta.4`.
+`openclaw@2026.5.16-beta.2`.
 Keep the peer range broad unless an upstream release removes a runtime surface
 Remnic actively uses.
 
-OpenClaw 2026.5.12 package-entry discovery prefers explicit built runtime
+OpenClaw 2026.5.16 package-entry discovery prefers explicit built runtime
 entries for installed packages. The published Remnic adapter declares
 `openclaw.runtimeExtensions: ["./dist/index.js"]` alongside the existing
 extension entry, and its package install metadata advertises
@@ -181,6 +181,9 @@ extension entry, and its package install metadata advertises
 `openclaw.install.defaultChoice: "clawhub"`. That keeps OpenClaw setup,
 repair, and update flows ClawHub-first while preserving npm as the fallback
 install surface and `>=2026.4.8` as the minimum supported host range.
+The manifest also declares `activation.onStartup: false`, leaves provider
+ownership to the host, and exposes the optional plugin-mode OpenAI key through
+`providerAuthChoices`.
 
 Native memory registrars are tracked separately in
 [`docs/plugins/openclaw-native-memory-registrars.md`](../../docs/plugins/openclaw-native-memory-registrars.md).
@@ -265,7 +268,7 @@ private plugin state, transcript buffers, auth metadata, or artifact paths.
 | `session_start` / `session_end` hooks | Supported | 2026.3.22 |
 | `before_compaction` / `after_compaction` hooks | Supported | 2026.3.22 |
 | `before_reset` hook | Supported | 2026.4.10 |
-| `commands.list` runtime discovery | Supported | 2026.4.10 |
+| `api.registerCommand()` runtime discovery | Supported | 2026.5.16 |
 | `api.resetSession()` (compaction reset) | Supported | 2026.3.22 |
 | Checkpoint saves before compaction | Supported | 2026.3.22 |
 
@@ -296,8 +299,8 @@ registered as the `before_prompt_build` hook timeout on OpenClaw versions with
 per-hook timeout support. Raise it if first-turn recall is timing out during
 slow startup; older OpenClaw versions ignore the extra hook option safely.
 
-Session-scoped recall controls are exposed through OpenClaw's command
-discovery surface:
+Session-scoped recall controls are exposed through OpenClaw's
+`api.registerCommand()` surface when it is available:
 
 - `remnic off` / `remnic on`
 - `remnic status`

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -182,8 +182,9 @@ extension entry, and its package install metadata advertises
 repair, and update flows ClawHub-first while preserving npm as the fallback
 install surface and `>=2026.5.16-beta.1` as the minimum supported host range.
 The manifest also declares `activation.onStartup: false`, leaves provider
-ownership to the host, and exposes the optional plugin-mode OpenAI key through
-`providerAuthChoices`.
+ownership to the host, exposes the optional plugin-mode OpenAI key through
+`providerAuthChoices`, and keeps `providerAuthEnvVars.openai` as compatibility
+metadata for OpenClaw's pre-runtime env-var auth probes.
 
 Native memory registrars are tracked separately in
 [`docs/plugins/openclaw-native-memory-registrars.md`](../../docs/plugins/openclaw-native-memory-registrars.md).

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -7,6 +7,11 @@
   "setup": {
     "requiresRuntime": false
   },
+  "providerAuthEnvVars": {
+    "openai": [
+      "OPENAI_API_KEY"
+    ]
+  },
   "providerAuthChoices": [
     {
       "provider": "openai",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,27 +1,11 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {
-    "providers": [
-      {
-        "id": "openai",
-        "authMethods": [
-          "api-key"
-        ],
-        "envVars": [
-          "OPENAI_API_KEY"
-        ]
-      }
-    ],
     "requiresRuntime": false
-  },
-  "providerAuthEnvVars": {
-    "openai": [
-      "OPENAI_API_KEY"
-    ]
   },
   "providerAuthChoices": [
     {
@@ -719,7 +703,7 @@
       "commandsListEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Advertise Remnic slash-command descriptors through the commands.list runtime surface."
+        "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
       },
       "openclawToolsEnabled": {
         "type": "boolean",
@@ -5827,6 +5811,7 @@
     }
   ],
   "activation": {
+    "onStartup": false,
     "onCommands": [
       "remnic"
     ],

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -26,7 +26,7 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.5.16-beta.1"
     },
     "build": {
       "openclawVersion": "2026.5.16-beta.2",
@@ -36,7 +36,7 @@
       "clawhubSpec": "clawhub:@remnic/plugin-openclaw",
       "npmSpec": "@remnic/plugin-openclaw",
       "defaultChoice": "clawhub",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.5.16-beta.1"
     },
     "environment": {
       "externalServices": [
@@ -79,7 +79,7 @@
     "openai": "^6.0.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.5.16-beta.1"
   },
   "devDependencies": {
     "@openclaw/plugin-inspector": "0.3.10",

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",
@@ -29,8 +29,8 @@
       "pluginApi": ">=2026.4.8"
     },
     "build": {
-      "openclawVersion": "2026.5.12-beta.4",
-      "pluginSdkVersion": "2026.5.12-beta.4"
+      "openclawVersion": "2026.5.16-beta.2",
+      "pluginSdkVersion": "2026.5.16-beta.2"
     },
     "install": {
       "clawhubSpec": "clawhub:@remnic/plugin-openclaw",

--- a/packages/plugin-openclaw/plugin-inspector.config.json
+++ b/packages/plugin-openclaw/plugin-inspector.config.json
@@ -26,8 +26,7 @@
         "after_tool_call",
         "llm_output",
         "subagent_spawning",
-        "subagent_ended",
-        "commands.list"
+        "subagent_ended"
       ],
       "registrations": [
         "registerTool",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-core/src/resolve-provider-secret.test.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.test.ts
@@ -49,6 +49,42 @@ test("resolveProviderApiKey scopes cached gateway secrets by agent directory", a
   }
 });
 
+test("resolveProviderApiKey treats env-var-shaped config strings as markers", async () => {
+  clearSecretCache();
+  const previousOpenAI = process.env.OPENAI_API_KEY;
+  __setGatewayResolverForTest(async () => null);
+
+  try {
+    delete process.env.OPENAI_API_KEY;
+    const unresolved = await resolveProviderApiKey(
+      "openai",
+      "OPENAI_API_KEY",
+      {},
+      "/tmp/openclaw-profile-marker/agent",
+    );
+    assert.equal(
+      unresolved,
+      undefined,
+      "OPENAI_API_KEY must not be sent as a literal bearer token when no env value exists",
+    );
+
+    clearSecretCache();
+    __setGatewayResolverForTest(async () => null);
+    process.env.OPENAI_API_KEY = "sk-from-env";
+    const resolvedFromEnv = await resolveProviderApiKey(
+      "openai",
+      "OPENAI_API_KEY",
+      {},
+      "/tmp/openclaw-profile-marker/agent",
+    );
+    assert.equal(resolvedFromEnv, "sk-from-env");
+  } finally {
+    if (previousOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousOpenAI;
+    clearSecretCache();
+  }
+});
+
 test("findExecutableOnPath skips directories named like the executable", () => {
   const calls: string[] = [];
   const access = (candidate: string): void => {

--- a/packages/remnic-core/src/resolve-provider-secret.test.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.test.ts
@@ -78,6 +78,20 @@ test("resolveProviderApiKey treats env-var-shaped config strings as markers", as
       "/tmp/openclaw-profile-marker/agent",
     );
     assert.equal(resolvedFromEnv, "sk-from-env");
+
+    clearSecretCache();
+    __setGatewayResolverForTest(async () => null);
+    const resolvedNamedMarker = await resolveProviderApiKey(
+      "custom-openai",
+      "OPENAI_API_KEY",
+      {},
+      "/tmp/openclaw-profile-marker/agent",
+    );
+    assert.equal(
+      resolvedNamedMarker,
+      "sk-from-env",
+      "env-var markers should dereference the named variable before provider-derived fallback",
+    );
   } finally {
     if (previousOpenAI === undefined) delete process.env.OPENAI_API_KEY;
     else process.env.OPENAI_API_KEY = previousOpenAI;

--- a/packages/remnic-core/src/resolve-provider-secret.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.ts
@@ -236,6 +236,12 @@ function isNonLiteralAuthMarker(value: string): boolean {
   );
 }
 
+function resolveFromNamedEnvVar(marker: string): string | undefined {
+  if (!ENV_VAR_MARKER_RE.test(marker)) return undefined;
+  const value = readEnvVar(marker);
+  return value && value.trim().length > 0 ? value.trim() : undefined;
+}
+
 /**
  * Resolve a provider API key from various OpenClaw formats.
  *
@@ -269,6 +275,12 @@ export async function resolveProviderApiKey(
     // Skip known non-API-key markers used by the gateway for auth modes,
     // plus env-var-shaped markers such as OPENAI_API_KEY.
     if (isNonLiteralAuthMarker(trimmedApiKeyValue)) {
+      const markerEnvValue = resolveFromNamedEnvVar(trimmedApiKeyValue);
+      if (markerEnvValue) {
+        resolved = markerEnvValue;
+        resolvedCache.set(cacheKey, resolved);
+        return resolved;
+      }
       // Fall through to gateway resolver / env var fallback
     } else {
       resolved = trimmedApiKeyValue;

--- a/packages/remnic-core/src/resolve-provider-secret.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.ts
@@ -45,6 +45,12 @@ let _resolverLoaded = false;
 let _resolverNextRetryAt = 0;
 const RESOLVER_RETRY_BACKOFF_MS = 60_000; // 1 minute between retries after first failure
 const resolvedCache = new Map<string, string | undefined>();
+const NON_LITERAL_AUTH_MARKERS = new Set([
+  "secretref-managed",
+  "lm-studio",
+]);
+const ENV_VAR_MARKER_RE =
+  /^[A-Z][A-Z0-9_]*(?:_API_KEY|_ACCESS_TOKEN|_TOKEN|_SECRET|_CREDENTIALS|_CREDENTIALS_JSON)$/;
 
 /**
  * Lazily load the gateway's resolveApiKeyForProvider function.
@@ -220,6 +226,16 @@ function findExecutableOnPath(
 
 export const __findExecutableOnPathForTest = findExecutableOnPath;
 
+function isNonLiteralAuthMarker(value: string): boolean {
+  return (
+    NON_LITERAL_AUTH_MARKERS.has(value) ||
+    value.endsWith("-oauth") ||
+    value.endsWith("-local") ||
+    value.startsWith("gcp-") ||
+    ENV_VAR_MARKER_RE.test(value)
+  );
+}
+
 /**
  * Resolve a provider API key from various OpenClaw formats.
  *
@@ -249,18 +265,13 @@ export async function resolveProviderApiKey(
 
   // Fast path: plain-text string that looks like an actual API key
   if (typeof apiKeyValue === "string" && apiKeyValue.trim().length > 0) {
-    // Skip known non-API-key markers used by the gateway for auth modes
-    // that don't use bearer tokens (OAuth, local endpoints, GCP credentials)
-    if (
-      apiKeyValue === "secretref-managed" ||
-      apiKeyValue.endsWith("-oauth") ||
-      apiKeyValue.endsWith("-local") ||
-      apiKeyValue === "lm-studio" ||
-      apiKeyValue.startsWith("gcp-")
-    ) {
+    const trimmedApiKeyValue = apiKeyValue.trim();
+    // Skip known non-API-key markers used by the gateway for auth modes,
+    // plus env-var-shaped markers such as OPENAI_API_KEY.
+    if (isNonLiteralAuthMarker(trimmedApiKeyValue)) {
       // Fall through to gateway resolver / env var fallback
     } else {
-      resolved = apiKeyValue;
+      resolved = trimmedApiKeyValue;
       resolvedCache.set(cacheKey, resolved);
       return resolved;
     }

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,27 +1,11 @@
 {
   "id": "openclaw-engram",
   "name": "Remnic OpenClaw Plugin",
-  "version": "9.3.20",
+  "version": "9.3.21",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {
-    "providers": [
-      {
-        "id": "openai",
-        "authMethods": [
-          "api-key"
-        ],
-        "envVars": [
-          "OPENAI_API_KEY"
-        ]
-      }
-    ],
     "requiresRuntime": false
-  },
-  "providerAuthEnvVars": {
-    "openai": [
-      "OPENAI_API_KEY"
-    ]
   },
   "providerAuthChoices": [
     {
@@ -719,7 +703,7 @@
       "commandsListEnabled": {
         "type": "boolean",
         "default": true,
-        "description": "Advertise Remnic slash-command descriptors through the commands.list runtime surface."
+        "description": "Advertise Remnic slash-command descriptors through the registerCommand runtime surface."
       },
       "openclawToolsEnabled": {
         "type": "boolean",
@@ -5827,6 +5811,7 @@
     }
   ],
   "activation": {
+    "onStartup": false,
     "onCommands": [
       "remnic"
     ],

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -7,6 +7,11 @@
   "setup": {
     "requiresRuntime": false
   },
+  "providerAuthEnvVars": {
+    "openai": [
+      "OPENAI_API_KEY"
+    ]
+  },
   "providerAuthChoices": [
     {
       "provider": "openai",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -33,7 +33,7 @@
       "./dist/index.js"
     ],
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.5.16-beta.1"
     },
     "build": {
       "openclawVersion": "2026.5.16-beta.2",
@@ -43,7 +43,7 @@
       "clawhubSpec": "clawhub:@remnic/plugin-openclaw",
       "npmSpec": "@joshuaswarren/openclaw-engram",
       "defaultChoice": "clawhub",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.5.16-beta.1"
     }
   },
   "scripts": {
@@ -58,7 +58,7 @@
     "@remnic/plugin-openclaw": "workspace:^"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.5.16-beta.1"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.20",
+  "version": "9.3.21",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,8 +36,8 @@
       "pluginApi": ">=2026.4.8"
     },
     "build": {
-      "openclawVersion": "2026.5.12-beta.4",
-      "pluginSdkVersion": "2026.5.12-beta.4"
+      "openclawVersion": "2026.5.16-beta.2",
+      "pluginSdkVersion": "2026.5.16-beta.2"
     },
     "install": {
       "clawhubSpec": "clawhub:@remnic/plugin-openclaw",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,6 @@ import {
   forEachRuntimeSurfaceStorage,
 } from "../packages/plugin-openclaw/src/runtime-surface-namespaces.js";
 import {
-  buildLegacySessionCommandDescriptorsFromDescriptors,
   buildSessionCommandDescriptors,
 } from "../packages/plugin-openclaw/src/session-command-descriptors.js";
 import { validateSlotSelection } from "../packages/plugin-openclaw/src/slot-validator.js";
@@ -1011,8 +1010,6 @@ const pluginDefinition = {
         });
       },
     });
-    const legacySessionCommandDescriptors =
-      buildLegacySessionCommandDescriptorsFromDescriptors(sessionCommandDescriptors);
     const activeRecallEngine = createActiveRecallEngine(
       {
         recall: async (query, sessionKey) => orchestrator.recall(query, sessionKey),
@@ -4079,13 +4076,9 @@ const pluginDefinition = {
           commandApi.registerCommand(descriptor);
         }
       } else if (typeof commandApi.registerCommand !== "function") {
-        try {
-          api.on("commands.list", async () => legacySessionCommandDescriptors);
-        } catch (error) {
-          log.debug(
-            `commands.list unavailable on this runtime: ${String(error)}`,
-          );
-        }
+        log.debug(
+          "registerCommand unavailable on this runtime; skipping Remnic session command descriptors because commands.list is a gateway RPC surface, not a typed plugin hook",
+        );
       }
     }
 

--- a/tests/monorepo-structure.test.ts
+++ b/tests/monorepo-structure.test.ts
@@ -148,7 +148,7 @@ test("plugin-openclaw publishes under the Remnic scope", () => {
   );
 });
 
-test("published OpenClaw packages require openclaw 2026.4.8 or greater", () => {
+test("published OpenClaw packages require an OpenClaw release with registerCommand support", () => {
   for (const packageDir of ["plugin-openclaw", "shim-openclaw-engram"]) {
     const pkgJsonPath = path.join(PACKAGES_DIR, packageDir, "package.json");
     assert.ok(fs.existsSync(pkgJsonPath), `${packageDir}/package.json must exist`);
@@ -156,8 +156,8 @@ test("published OpenClaw packages require openclaw 2026.4.8 or greater", () => {
     const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
     assert.equal(
       pkg.peerDependencies?.openclaw,
-      ">=2026.4.8",
-      `${packageDir} must require openclaw >=2026.4.8`,
+      ">=2026.5.16-beta.1",
+      `${packageDir} must require openclaw >=2026.5.16-beta.1`,
     );
   }
 });

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -388,7 +388,7 @@ for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
       "OpenClaw 2026.5.12+ package discovery should have an explicit built runtime entrypoint",
     );
     assert.deepEqual(openclaw.compat, {
-      pluginApi: ">=2026.4.8",
+      pluginApi: ">=2026.5.16-beta.1",
     });
     assert.deepEqual(openclaw.build, {
       openclawVersion: "2026.5.16-beta.2",
@@ -397,7 +397,7 @@ for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
     assert.deepEqual(openclaw.install, {
       ...expectation.install,
       defaultChoice: "clawhub",
-      minHostVersion: ">=2026.4.8",
+      minHostVersion: ">=2026.5.16-beta.1",
     });
   });
 }

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -142,6 +142,7 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
       },
     ]);
     assert.deepEqual(manifest.activation, {
+      onStartup: false,
       onCommands: ["remnic"],
       onCapabilities: ["tool", "hook"],
     });
@@ -160,7 +161,7 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
     }
   });
 
-  test(`${manifestPath} declares pre-runtime auth metadata for OpenAI-backed memory extraction`, () => {
+  test(`${manifestPath} declares plugin-mode auth metadata without provider setup ownership`, () => {
     const manifest = readManifest(manifestPath);
     const packageJsonPath = manifestPath === "packages/shim-openclaw-engram/openclaw.plugin.json"
       ? "packages/shim-openclaw-engram/package.json"
@@ -169,17 +170,17 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
 
     assert.equal(manifest.name, "Remnic OpenClaw Plugin");
     assert.equal(manifest.version, packageJson.version);
-    assert.deepEqual(manifest.setup, {
-      providers: [
-        {
-          id: "openai",
-          authMethods: ["api-key"],
-          envVars: ["OPENAI_API_KEY"],
-        },
-      ],
-      requiresRuntime: false,
-    });
-    assert.deepEqual(manifest.providerAuthEnvVars?.openai, ["OPENAI_API_KEY"]);
+    assert.deepEqual(manifest.setup, { requiresRuntime: false });
+    assert.equal(
+      "providers" in (manifest.setup ?? {}),
+      false,
+      "Remnic must not claim OpenAI provider setup ownership",
+    );
+    assert.equal(
+      "providerAuthEnvVars" in manifest,
+      false,
+      "providerAuthEnvVars is deprecated for external plugins; use providerAuthChoices only",
+    );
     const expectedAuthChoice = manifest.id === "openclaw-engram"
       ? {
           provider: "openai",
@@ -375,7 +376,7 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
 }
 
 for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
-  test(`${expectation.name} declares OpenClaw 2026.5.12-beta.4 package install metadata`, () => {
+  test(`${expectation.name} declares OpenClaw 2026.5.16-beta.2 package install metadata`, () => {
     const packageJson = readPackageJson(expectation.packageJsonPath);
     const openclaw = packageJson.openclaw ?? {};
 
@@ -390,8 +391,8 @@ for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
       pluginApi: ">=2026.4.8",
     });
     assert.deepEqual(openclaw.build, {
-      openclawVersion: "2026.5.12-beta.4",
-      pluginSdkVersion: "2026.5.12-beta.4",
+      openclawVersion: "2026.5.16-beta.2",
+      pluginSdkVersion: "2026.5.16-beta.2",
     });
     assert.deepEqual(openclaw.install, {
       ...expectation.install,

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -176,10 +176,12 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
       false,
       "Remnic must not claim OpenAI provider setup ownership",
     );
-    assert.equal(
-      "providerAuthEnvVars" in manifest,
-      false,
-      "providerAuthEnvVars is deprecated for external plugins; use providerAuthChoices only",
+    assert.deepEqual(
+      manifest.providerAuthEnvVars,
+      {
+        openai: ["OPENAI_API_KEY"],
+      },
+      "providerAuthEnvVars remains compatibility metadata for pre-runtime OpenClaw auth probes",
     );
     const expectedAuthChoice = manifest.id === "openclaw-engram"
       ? {

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -92,7 +92,7 @@ test("OpenClaw security scan wrapper handles minified scanner exports", async ()
     await mkdir(pluginDir, { recursive: true });
     await writeFile(
       path.join(openclawDir, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.5.12-beta.4", type: "module" }),
+      JSON.stringify({ name: "openclaw", version: "2026.5.16-beta.2", type: "module" }),
     );
     await writeFile(
       path.join(openclawDistDir, "skill-scanner-fake.js"),
@@ -116,7 +116,7 @@ test("OpenClaw security scan wrapper handles minified scanner exports", async ()
     );
 
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /OpenClaw 2026\.5\.12-beta\.4 scanner:/);
+    assert.match(result.stdout, /OpenClaw 2026\.5\.16-beta\.2 scanner:/);
     assert.match(result.stdout, /scanned=1 critical=0 warn=0/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -610,30 +610,14 @@ test("legacy SDK api gets legacy hooks only", async () => {
     );
 
     assert.ok(
-      api._registeredHooks.includes("commands.list"),
-      "commands.list should remain registered on legacy SDKs without registerCommand()",
+      !api._registeredHooks.includes("commands.list"),
+      "commands.list should not be registered on legacy SDKs because it is a gateway RPC surface, not a typed hook",
     );
-    const listHandler = api._hookHandlers.get("commands.list") as
-      | (() => Promise<Array<{
-          name?: string;
-          handler?: (ctx?: {
-            sessionKey?: string;
-            agentId?: string;
-            args?: string;
-          }) => Promise<string>;
-        }>>)
-      | undefined;
-    assert.equal(typeof listHandler, "function");
-    const commands = await listHandler?.();
-    const remnicCommand = commands?.find((spec) => spec?.name === "remnic");
-    assert.equal(typeof remnicCommand?.handler, "function");
-    const legacyReply = await remnicCommand?.handler?.({
-      sessionKey: "legacy-session-command-test",
-      agentId: "main",
-      args: "status",
-    });
-    assert.equal(typeof legacyReply, "string");
-    assert.match(String(legacyReply ?? ""), /Remnic recall is/);
+    assert.equal(
+      api._registeredCommands.length,
+      0,
+      "legacy SDKs without registerCommand should not expose session command descriptors",
+    );
 
     // Core hooks still present
     assert.ok(


### PR DESCRIPTION
## Summary
- align OpenClaw manifests and package metadata with `v2026.5.16-beta.2`
- remove external-plugin OpenAI provider ownership metadata while keeping optional plugin-mode auth choices
- expose session commands only through `registerCommand`; stop falling back to `commands.list` as a typed hook
- harden provider-secret resolution so env-var-shaped markers like `OPENAI_API_KEY` are not used as literal bearer tokens
- bump publishable packages: `@remnic/core@1.1.12`, `@remnic/plugin-openclaw@1.0.35`, `@joshuaswarren/openclaw-engram@9.3.21`

Fixes #1004. Supersedes #994, #996, #997, #998, #999, #1000, and #1001.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm rebuild better-sqlite3`
- `npm run check:openclaw-plugin-sync`
- `pnpm exec tsx --test packages/remnic-core/src/resolve-provider-secret.test.ts tests/openclaw-plugin-runtime-surfaces.test.ts tests/release-workflow-public-packages.test.ts tests/sdk-compat-integration.test.ts tests/sdk-compat-hook-handlers.test.ts`
- `npm run check:openclaw-sdk-surface -- --package-root /tmp/openclaw-2026.5.16-beta.2`
- `pnpm --filter @remnic/plugin-openclaw run plugin:inspect`
- `npm run test:entity-hardening`
- `npm run preflight:quick`
- `pnpm --filter @remnic/core build`
- `pnpm --filter @remnic/plugin-openclaw build`
- `pnpm run verify:openclaw-clawpack`

Note: `preflight:quick` printed existing review-pattern warnings, then passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes command registration behavior (dropping the legacy `commands.list` fallback) and adjusts provider credential resolution logic, which can impact runtime UX and authentication flows.
> 
> **Overview**
> Updates Remnic’s OpenClaw adapter to target **OpenClaw `2026.5.16-beta.2`**: bumps package/manifest versions, raises `openclaw` peer/min-host requirements, and refreshes related docs/tests.
> 
> Adjusts plugin metadata to **stop claiming provider setup ownership** (removes `setup.providers`, keeps `providerAuthChoices` and `providerAuthEnvVars` as compatibility metadata) and makes activation explicit with `activation.onStartup: false`.
> 
> Changes slash-command discovery to **only use `api.registerCommand()`** and removes the `commands.list` typed-hook fallback (now logs and skips when `registerCommand` is unavailable), with corresponding inspector/test updates.
> 
> Hardens `resolveProviderApiKey` so **env-var-shaped config markers** (e.g. `OPENAI_API_KEY`) are treated as markers and dereferenced from the environment (or ignored) rather than sent as literal API keys, with new unit coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369f195bde4bd5f4aed2960cadb91ea8ba0531cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->