### PR TITLE
Fix Remnic CLI bin wrapper execution

### DIFF
--- a/packages/remnic-cli/bin/engram.cjs
+++ b/packages/remnic-cli/bin/engram.cjs
@@ -49,6 +49,8 @@ try {
   // execFileSync throws on non-zero exit — propagate the child's exit code.
   if (err.status != null) {
     process.exitCode = err.status;
+  } else if (err.signal) {
+    process.kill(process.pid, err.signal);
   } else {
     process.stderr.write(`Fatal: ${err.message}\n`);
     process.exitCode = 1;

--- a/packages/remnic-cli/bin/engram.cjs
+++ b/packages/remnic-cli/bin/engram.cjs
@@ -7,6 +7,7 @@
 const { resolve } = require("node:path");
 const { existsSync } = require("node:fs");
 const { execFileSync } = require("node:child_process");
+const { constants: osConstants } = require("node:os");
 
 const cwd = __dirname;
 const distEntry = resolve(cwd, "../dist/index.js");
@@ -16,6 +17,11 @@ const srcEntry = resolve(cwd, "../src/index.ts");
 const colorEnv = {};
 if (!process.env.NO_COLOR && process.env.FORCE_COLOR === undefined) {
   colorEnv.FORCE_COLOR = "1";
+}
+
+function exitCodeForSignal(signal) {
+  const signalNumber = osConstants.signals?.[signal];
+  return typeof signalNumber === "number" ? 128 + signalNumber : 1;
 }
 
 try {
@@ -50,6 +56,7 @@ try {
   if (err.status != null) {
     process.exitCode = err.status;
   } else if (err.signal) {
+    process.exitCode = exitCodeForSignal(err.signal);
     process.kill(process.pid, err.signal);
   } else {
     process.stderr.write(`Fatal: ${err.message}\n`);

--- a/packages/remnic-cli/bin/remnic.cjs
+++ b/packages/remnic-cli/bin/remnic.cjs
@@ -7,6 +7,7 @@
 const { resolve } = require("node:path");
 const { existsSync } = require("node:fs");
 const { execFileSync } = require("node:child_process");
+const { constants: osConstants } = require("node:os");
 
 const cwd = __dirname;
 const distEntry = resolve(cwd, "../dist/index.js");
@@ -15,6 +16,11 @@ const srcEntry = resolve(cwd, "../src/index.ts");
 const colorEnv = {};
 if (!process.env.NO_COLOR && process.env.FORCE_COLOR === undefined) {
   colorEnv.FORCE_COLOR = "1";
+}
+
+function exitCodeForSignal(signal) {
+  const signalNumber = osConstants.signals?.[signal];
+  return typeof signalNumber === "number" ? 128 + signalNumber : 1;
 }
 
 try {
@@ -38,6 +44,7 @@ try {
   if (err.status != null) {
     process.exitCode = err.status;
   } else if (err.signal) {
+    process.exitCode = exitCodeForSignal(err.signal);
     process.kill(process.pid, err.signal);
   } else {
     process.stderr.write(`Fatal: ${err.message}\n`);

--- a/packages/remnic-cli/bin/remnic.cjs
+++ b/packages/remnic-cli/bin/remnic.cjs
@@ -37,6 +37,8 @@ try {
 } catch (err) {
   if (err.status != null) {
     process.exitCode = err.status;
+  } else if (err.signal) {
+    process.kill(process.pid, err.signal);
   } else {
     process.stderr.write(`Fatal: ${err.message}\n`);
     process.exitCode = 1;

--- a/tests/remnic-cli-bin-wrapper.test.ts
+++ b/tests/remnic-cli-bin-wrapper.test.ts
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import { constants } from "node:fs";
 import { chmod, copyFile, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { constants as osConstants, tmpdir } from "node:os";
 
 const packageBinDir = join(process.cwd(), "packages", "remnic-cli", "bin");
 const remnicBin = join(packageBinDir, "remnic.cjs");
@@ -46,6 +46,51 @@ test("package bin wrappers preserve child signal termination", async () => {
 
       assert.equal(result.status, null);
       assert.equal(result.signal, "SIGTERM");
+      assert.doesNotMatch(result.stderr, /Fatal:/);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+test("package bin wrappers keep a failing exit code when a self-signal is ignored", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const sigpipeExitCode = 128 + osConstants.signals.SIGPIPE;
+
+  for (const sourceBin of [remnicBin, engramBin]) {
+    const tempRoot = await mkdtemp(join(tmpdir(), "remnic-cli-bin-wrapper-"));
+    try {
+      const tempBinDir = join(tempRoot, "bin");
+      await mkdir(tempBinDir, { recursive: true });
+
+      const tempBin = join(tempBinDir, "wrapper.cjs");
+      const preload = join(tempRoot, "throw-sigpipe.cjs");
+      await copyFile(sourceBin, tempBin);
+      await chmod(tempBin, 0o755);
+      await writeFile(
+        preload,
+        [
+          'const childProcess = require("node:child_process");',
+          "childProcess.execFileSync = () => {",
+          '  const err = new Error("child terminated by SIGPIPE");',
+          '  err.signal = "SIGPIPE";',
+          "  throw err;",
+          "};",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        ["--require", preload, tempBin],
+        { encoding: "utf8" },
+      );
+
+      assert.equal(result.status, sigpipeExitCode);
+      assert.equal(result.signal, null);
       assert.doesNotMatch(result.stderr, /Fatal:/);
     } finally {
       await rm(tempRoot, { recursive: true, force: true });

--- a/tests/remnic-cli-bin-wrapper.test.ts
+++ b/tests/remnic-cli-bin-wrapper.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { constants } from "node:fs";
+import { chmod, copyFile, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const packageBinDir = join(process.cwd(), "packages", "remnic-cli", "bin");
+const remnicBin = join(packageBinDir, "remnic.cjs");
+const engramBin = join(packageBinDir, "engram.cjs");
+
+test("remnic package bins are executable on POSIX checkouts", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  for (const binPath of [remnicBin, engramBin]) {
+    const mode = (await stat(binPath)).mode;
+    assert.notEqual(mode & (constants.S_IXUSR | constants.S_IXGRP | constants.S_IXOTH), 0);
+  }
+});
+
+test("package bin wrappers preserve child signal termination", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  for (const sourceBin of [remnicBin, engramBin]) {
+    const tempRoot = await mkdtemp(join(tmpdir(), "remnic-cli-bin-wrapper-"));
+    try {
+      const tempBinDir = join(tempRoot, "bin");
+      const tempDistDir = join(tempRoot, "dist");
+      await mkdir(tempBinDir, { recursive: true });
+      await mkdir(tempDistDir, { recursive: true });
+
+      const tempBin = join(tempBinDir, "wrapper.cjs");
+      await copyFile(sourceBin, tempBin);
+      await chmod(tempBin, 0o755);
+      await writeFile(
+        join(tempDistDir, "index.js"),
+        'process.kill(process.pid, "SIGTERM");\n',
+      );
+
+      const result = spawnSync(process.execPath, [tempBin], { encoding: "utf8" });
+
+      assert.equal(result.status, null);
+      assert.equal(result.signal, "SIGTERM");
+      assert.doesNotMatch(result.stderr, /Fatal:/);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Mark `packages/remnic-cli/bin/remnic.cjs` executable in git so the advertised `remnic` package bin can be invoked directly.
- Preserve child signal termination from the `remnic` and legacy `engram` CJS bin wrappers instead of converting signal exits into a generic fatal exit 1.
- Add wrapper-level regression tests for POSIX executable bits and signal propagation.

## Test Plan

- `pnpm exec tsx --test tests/remnic-cli-bin-wrapper.test.ts`
- `pnpm exec tsx --test tests/remnic-cli-bin-wrapper.test.ts tests/remnic-cli-package.test.ts tests/remnic-cli-bench-surface.test.ts`
- `./packages/remnic-cli/bin/remnic.cjs --help`
- `npm run preflight:quick`

Notes: in this fresh worktree, the first preflight attempt failed because `better-sqlite3` native bindings had not been built after install. I ran `pnpm rebuild better-sqlite3` and reran `npm run preflight:quick`, which passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk wrapper-level changes that only affect how the CLI process exits; main risk is altered exit behavior for tooling that depends on prior (incorrect) exit codes.
> 
> **Overview**
> Fixes the `remnic` and legacy `engram` CJS bin wrappers to **preserve signal-based termination** from the spawned CLI (compute `128+signal` and re-raise the signal) instead of falling back to a generic fatal `exit 1`.
> 
> Adds POSIX-only regression tests to ensure the published bin scripts are *executable* and that both wrappers correctly propagate signal termination and signal-derived exit codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2413cdf74ae4d6ce22e2d865cfd628c6d51d300a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->