### PR TITLE
Record OpenClaw 2026.5.16 beta3 compatibility

### DIFF
--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -167,8 +167,8 @@ CI jobs that provision OpenClaw should use
 Last compatibility sweep: May 16, 2026. The SDK surface check passed against
 `openclaw@2026.5.3`, `openclaw@2026.5.3-1`, `openclaw@2026.5.4-beta.1`,
 `openclaw@2026.5.4-beta.2`, `openclaw@2026.5.4-beta.3`,
-`openclaw@2026.5.4`, `openclaw@2026.5.5`, `openclaw@2026.5.6`, and
-`openclaw@2026.5.16-beta.2`.
+`openclaw@2026.5.4`, `openclaw@2026.5.5`, `openclaw@2026.5.6`,
+`openclaw@2026.5.16-beta.2`, and `openclaw@2026.5.16-beta.3`.
 Keep the peer range broad unless an upstream release removes a runtime surface
 Remnic actively uses.
 
@@ -185,6 +185,13 @@ The manifest also declares `activation.onStartup: false`, leaves provider
 ownership to the host, exposes the optional plugin-mode OpenAI key through
 `providerAuthChoices`, and keeps `providerAuthEnvVars.openai` as compatibility
 metadata for OpenClaw's pre-runtime env-var auth probes.
+
+OpenClaw 2026.5.16-beta.3 keeps those install and auth ownership contracts
+intact. The sweep confirmed that Remnic still relies on host-owned gateway
+restart/reload behavior after plugin install changes, uses `gateway_stop`
+instead of the deprecated `deactivate` cleanup alias, and should not claim
+OpenAI `setup.providers` ownership because gateway/provider configuration
+remains host-owned.
 
 Native memory registrars are tracked separately in
 [`docs/plugins/openclaw-native-memory-registrars.md`](../../docs/plugins/openclaw-native-memory-registrars.md).

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -29,8 +29,8 @@
       "pluginApi": ">=2026.5.16-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.5.16-beta.2",
-      "pluginSdkVersion": "2026.5.16-beta.2"
+      "openclawVersion": "2026.5.16-beta.3",
+      "pluginSdkVersion": "2026.5.16-beta.3"
     },
     "install": {
       "clawhubSpec": "clawhub:@remnic/plugin-openclaw",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -36,8 +36,8 @@
       "pluginApi": ">=2026.5.16-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.5.16-beta.2",
-      "pluginSdkVersion": "2026.5.16-beta.2"
+      "openclawVersion": "2026.5.16-beta.3",
+      "pluginSdkVersion": "2026.5.16-beta.3"
     },
     "install": {
       "clawhubSpec": "clawhub:@remnic/plugin-openclaw",

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -378,7 +378,7 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
 }
 
 for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
-  test(`${expectation.name} declares OpenClaw 2026.5.16-beta.2 package install metadata`, () => {
+  test(`${expectation.name} declares OpenClaw 2026.5.16-beta.3 package install metadata`, () => {
     const packageJson = readPackageJson(expectation.packageJsonPath);
     const openclaw = packageJson.openclaw ?? {};
 
@@ -393,8 +393,8 @@ for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
       pluginApi: ">=2026.5.16-beta.1",
     });
     assert.deepEqual(openclaw.build, {
-      openclawVersion: "2026.5.16-beta.2",
-      pluginSdkVersion: "2026.5.16-beta.2",
+      openclawVersion: "2026.5.16-beta.3",
+      pluginSdkVersion: "2026.5.16-beta.3",
     });
     assert.deepEqual(openclaw.install, {
       ...expectation.install,

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -92,7 +92,7 @@ test("OpenClaw security scan wrapper handles minified scanner exports", async ()
     await mkdir(pluginDir, { recursive: true });
     await writeFile(
       path.join(openclawDir, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.5.16-beta.2", type: "module" }),
+      JSON.stringify({ name: "openclaw", version: "2026.5.16-beta.3", type: "module" }),
     );
     await writeFile(
       path.join(openclawDistDir, "skill-scanner-fake.js"),
@@ -116,7 +116,7 @@ test("OpenClaw security scan wrapper handles minified scanner exports", async ()
     );
 
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /OpenClaw 2026\.5\.16-beta\.2 scanner:/);
+    assert.match(result.stdout, /OpenClaw 2026\.5\.16-beta\.3 scanner:/);
     assert.match(result.stdout, /scanned=1 critical=0 warn=0/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- record OpenClaw 2026.5.16-beta.3 as the current compatibility sweep for the Remnic OpenClaw plugin and legacy shim
- document the beta3 review findings around host-owned gateway restart/reload behavior, `gateway_stop`, and host-owned provider setup
- update tests that enforce the recorded OpenClaw package metadata and scanner version

## Verification
- `npm run preflight:quick`
- `npm run check:openclaw-sdk-surface -- --package-root /tmp/openclaw-1011`
- `npx tsx --test tests/openclaw-plugin-runtime-surfaces.test.ts tests/monorepo-structure.test.ts tests/release-workflow-public-packages.test.ts`
- `npm run plugin:inspect`

Refs #1011

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a metadata/documentation + test expectation bump to the recorded OpenClaw beta version, with no runtime logic changes.
> 
> **Overview**
> Records compatibility with **OpenClaw `2026.5.16-beta.3`** by bumping the declared `openclaw.build.openclawVersion`/`pluginSdkVersion` in both the Remnic OpenClaw plugin and the legacy Engram shim.
> 
> Updates documentation to note the beta.3 sweep findings (host-owned gateway restart/reload behavior, `gateway_stop`, and avoiding provider setup ownership), and adjusts tests that assert the recorded OpenClaw package metadata and security-scan wrapper version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9145751aabb05bc15213b5cbb0d07c9cb7956fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->