### PR TITLE
Guard transfer archive import paths

### DIFF
--- a/packages/remnic-core/src/transfer/fs-utils.ts
+++ b/packages/remnic-core/src/transfer/fs-utils.ts
@@ -72,6 +72,99 @@ export function fromPosixRelPath(relPath: string): string {
   return relPath.split("/").join(path.sep);
 }
 
+export interface SafeArchiveRoot {
+  abs: string;
+  real: string;
+  errorPrefix: string;
+  argName: string;
+}
+
+export async function prepareSafeArchiveRoot(
+  absPath: string,
+  errorPrefix: string,
+  argName: string,
+): Promise<SafeArchiveRoot> {
+  const rootAbs = path.resolve(absPath);
+  await assertIsDirectoryNotSymlink(rootAbs, errorPrefix, argName);
+  return {
+    abs: rootAbs,
+    real: await realpath(rootAbs),
+    errorPrefix,
+    argName,
+  };
+}
+
+export function validateArchiveRelativePath(
+  relPath: string,
+  errorPrefix: string,
+): string {
+  if (relPath.length === 0) {
+    throw new Error(`${errorPrefix}: record path must not be empty`);
+  }
+  if (relPath.includes("\\")) {
+    throw new Error(
+      `${errorPrefix}: record path must use POSIX separators: ${relPath}`,
+    );
+  }
+  if (path.posix.isAbsolute(relPath)) {
+    throw new Error(
+      `${errorPrefix}: record path must be relative: ${relPath}`,
+    );
+  }
+
+  const segments = relPath.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    throw new Error(
+      `${errorPrefix}: record path contains unsafe segments: ${relPath}`,
+    );
+  }
+
+  const normalized = path.posix.normalize(relPath);
+  if (
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error(
+      `${errorPrefix}: record path escapes target root: ${relPath}`,
+    );
+  }
+
+  return normalized;
+}
+
+export async function resolveSafeArchiveTarget(
+  root: SafeArchiveRoot,
+  relPath: string,
+): Promise<string> {
+  const safeRelPath = validateArchiveRelativePath(relPath, root.errorPrefix);
+  const targetAbs = path.resolve(root.abs, fromPosixRelPath(safeRelPath));
+  if (!isPathInsideRoot(root.abs, targetAbs)) {
+    throw new Error(
+      `${root.errorPrefix}: record path escapes target root: ${relPath}`,
+    );
+  }
+
+  const targetStat = await lstat(targetAbs).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  });
+  if (targetStat?.isSymbolicLink()) {
+    throw new Error(
+      `${root.errorPrefix}: record path targets a symlink: ${relPath}`,
+    );
+  }
+
+  await assertRealpathInsideRoot(
+    root.real,
+    targetAbs,
+    relPath,
+    root.errorPrefix,
+  );
+  return targetAbs;
+}
+
 // ---------------------------------------------------------------------------
 // Shared path-safety helpers (used by capsule-import, capsule-merge, and
 // capsule-fork).

--- a/packages/remnic-core/src/transfer/import-json.ts
+++ b/packages/remnic-core/src/transfer/import-json.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import { ExportBundleV1Schema } from "./types.js";
-import { fileExists, readJsonFile, fromPosixRelPath } from "./fs-utils.js";
+import {
+  fileExists,
+  prepareSafeArchiveRoot,
+  readJsonFile,
+  resolveSafeArchiveTarget,
+  type SafeArchiveRoot,
+} from "./fs-utils.js";
 
 export type ConflictPolicy = "skip" | "overwrite" | "dedupe";
 
@@ -24,20 +30,36 @@ export async function importJsonBundle(opts: ImportJsonOptions): Promise<{ writt
   const bundle = ExportBundleV1Schema.parse(await readJsonFile(bundlePath));
 
   const memDirAbs = path.resolve(opts.targetMemoryDir);
+  const memoryRoot = await prepareSafeArchiveRoot(
+    memDirAbs,
+    "importJsonBundle",
+    "targetMemoryDir",
+  );
   const written: Array<{ abs: string; content: string }> = [];
 
   let skipped = 0;
+  let workspaceRoot: SafeArchiveRoot | null = null;
 
   for (const rec of bundle.records) {
     const isWorkspace = rec.path.startsWith("workspace/");
-    const targetBase = isWorkspace ? (opts.workspaceDir ? path.resolve(opts.workspaceDir) : null) : memDirAbs;
-    if (isWorkspace && !targetBase) {
-      skipped += 1;
-      continue;
+    let absTarget: string;
+    if (isWorkspace) {
+      if (!opts.workspaceDir) {
+        skipped += 1;
+        continue;
+      }
+      workspaceRoot ??= await prepareSafeArchiveRoot(
+        path.resolve(opts.workspaceDir),
+        "importJsonBundle",
+        "workspaceDir",
+      );
+      absTarget = await resolveSafeArchiveTarget(
+        workspaceRoot,
+        rec.path.slice("workspace/".length),
+      );
+    } else {
+      absTarget = await resolveSafeArchiveTarget(memoryRoot, rec.path);
     }
-
-    const relFs = fromPosixRelPath(isWorkspace ? rec.path.replace(/^workspace\//, "") : rec.path);
-    const absTarget = path.join(targetBase!, relFs);
 
     const exists = await fileExists(absTarget);
     if (exists) {
@@ -81,4 +103,3 @@ export function looksLikeEngramJsonExport(fromDir: string): Promise<boolean> {
     fileExists(path.join(dir, "bundle.json")),
   ]).then(([m, b]) => m && b);
 }
-

--- a/packages/remnic-core/src/transfer/import-sqlite.ts
+++ b/packages/remnic-core/src/transfer/import-sqlite.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import { SQLITE_SCHEMA_VERSION } from "./sqlite-schema.js";
-import { fileExists, fromPosixRelPath } from "./fs-utils.js";
+import {
+  fileExists,
+  prepareSafeArchiveRoot,
+  resolveSafeArchiveTarget,
+} from "./fs-utils.js";
 import { openBetterSqlite3 } from "../runtime/better-sqlite.js";
 
 export type ConflictPolicy = "skip" | "overwrite" | "dedupe";
@@ -20,6 +24,11 @@ function normalizeForDedupe(s: string): string {
 export async function importSqlite(opts: ImportSqliteOptions): Promise<{ written: number; skipped: number }> {
   const conflict = opts.conflict ?? "skip";
   const memDirAbs = path.resolve(opts.targetMemoryDir);
+  const memoryRoot = await prepareSafeArchiveRoot(
+    memDirAbs,
+    "importSqlite",
+    "targetMemoryDir",
+  );
   const fromAbs = path.resolve(opts.fromFile);
   const db = openBetterSqlite3(fromAbs, { readonly: true });
 
@@ -35,8 +44,7 @@ export async function importSqlite(opts: ImportSqliteOptions): Promise<{ written
 
     const rows = db.prepare("SELECT path_rel, content FROM files").all() as Array<{ path_rel: string; content: string }>;
     for (const r of rows) {
-      const relFs = fromPosixRelPath(r.path_rel);
-      const absTarget = path.join(memDirAbs, relFs);
+      const absTarget = await resolveSafeArchiveTarget(memoryRoot, r.path_rel);
 
       const exists = await fileExists(absTarget);
       if (exists) {

--- a/tests/export-import-json.test.ts
+++ b/tests/export-import-json.test.ts
@@ -1,11 +1,44 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, readdir } from "node:fs/promises";
+import { access, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { exportJsonBundle } from "../src/transfer/export-json.js";
 import { importJsonBundle } from "../src/transfer/import-json.js";
 import { writeFixtureMemoryDir } from "./transfer-fixtures.js";
+
+async function assertPathMissing(filePath: string): Promise<void> {
+  await assert.rejects(access(filePath), { code: "ENOENT" });
+}
+
+async function writeJsonBundle(
+  outDir: string,
+  records: Array<{ path: string; content: string }>,
+): Promise<void> {
+  const manifest = {
+    format: "openclaw-engram-export",
+    schemaVersion: 1,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    pluginVersion: "test",
+    includesTranscripts: false,
+    files: records.map((record) => ({
+      path: record.path,
+      sha256: "test",
+      bytes: Buffer.byteLength(record.content),
+    })),
+  };
+
+  await writeFile(
+    path.join(outDir, "manifest.json"),
+    JSON.stringify(manifest),
+    "utf-8",
+  );
+  await writeFile(
+    path.join(outDir, "bundle.json"),
+    JSON.stringify({ manifest, records }),
+    "utf-8",
+  );
+}
 
 test("v2.3 json export/import round-trips (without transcripts by default)", async () => {
   const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
@@ -34,3 +67,73 @@ test("v2.3 json export/import round-trips (without transcripts by default)", asy
   assert.match(fact, /The user likes pianos/);
 });
 
+test("json import rejects memory records that escape the target directory", async () => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-outside-"));
+  const outsidePath = path.join(outsideDir, "outside.md");
+
+  await writeJsonBundle(outDir, [
+    {
+      path: `../${path.basename(outsideDir)}/outside.md`,
+      content: "escaped",
+    },
+  ]);
+
+  await assert.rejects(
+    importJsonBundle({ targetMemoryDir: targetDir, fromDir: outDir }),
+    /unsafe segments|escapes target root/i,
+  );
+  await assertPathMissing(outsidePath);
+});
+
+test("json import rejects workspace records that escape the workspace directory", async () => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "engram-workspace-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-workspace-outside-"));
+  const outsidePath = path.join(outsideDir, "outside.md");
+
+  await writeJsonBundle(outDir, [
+    {
+      path: `workspace/../${path.basename(outsideDir)}/outside.md`,
+      content: "escaped",
+    },
+  ]);
+
+  await assert.rejects(
+    importJsonBundle({
+      targetMemoryDir: targetDir,
+      fromDir: outDir,
+      workspaceDir,
+    }),
+    /unsafe segments|escapes target root/i,
+  );
+  await assertPathMissing(outsidePath);
+});
+
+test("json import rejects paths whose existing parent is a symlink", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-outside-"));
+  const outsidePath = path.join(outsideDir, "secret.md");
+  await symlink(outsideDir, path.join(targetDir, "facts"), "dir");
+
+  await writeJsonBundle(outDir, [
+    {
+      path: "facts/secret.md",
+      content: "escaped",
+    },
+  ]);
+
+  await assert.rejects(
+    importJsonBundle({ targetMemoryDir: targetDir, fromDir: outDir }),
+    /symlink/i,
+  );
+  await assertPathMissing(outsidePath);
+});

--- a/tests/export-import-sqlite.test.ts
+++ b/tests/export-import-sqlite.test.ts
@@ -1,11 +1,44 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { access, mkdtemp, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { writeFixtureMemoryDir } from "./transfer-fixtures.js";
 import { exportSqlite } from "../src/transfer/export-sqlite.js";
 import { importSqlite } from "../src/transfer/import-sqlite.js";
+import { openBetterSqlite3 } from "../src/runtime/better-sqlite.js";
+import { SQLITE_SCHEMA_VERSION, SQLITE_TABLES_SQL } from "../src/transfer/sqlite-schema.js";
+
+async function assertPathMissing(filePath: string): Promise<void> {
+  await assert.rejects(access(filePath), { code: "ENOENT" });
+}
+
+function writeSqliteExport(
+  sqliteFile: string,
+  rows: Array<{ path: string; content: string }>,
+): void {
+  const db = openBetterSqlite3(sqliteFile);
+  try {
+    db.exec(SQLITE_TABLES_SQL);
+    db.prepare("INSERT INTO meta(key,value) VALUES (?,?)").run(
+      "schemaVersion",
+      String(SQLITE_SCHEMA_VERSION),
+    );
+    const insert = db.prepare(
+      "INSERT INTO files(path_rel,bytes,sha256,content) VALUES (?,?,?,?)",
+    );
+    for (const row of rows) {
+      insert.run(
+        row.path,
+        Buffer.byteLength(row.content),
+        "test",
+        row.content,
+      );
+    }
+  } finally {
+    db.close();
+  }
+}
 
 test("v2.3 sqlite export/import round-trips basic files", async () => {
   const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
@@ -24,3 +57,23 @@ test("v2.3 sqlite export/import round-trips basic files", async () => {
   assert.match(importedProfile, /Profile/);
 });
 
+test("sqlite import rejects records that escape the target directory", async () => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-sqlite-"));
+  const sqliteFile = path.join(outDir, "export.sqlite");
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-outside-"));
+  const outsidePath = path.join(outsideDir, "outside.md");
+
+  writeSqliteExport(sqliteFile, [
+    {
+      path: `../${path.basename(outsideDir)}/outside.md`,
+      content: "escaped",
+    },
+  ]);
+
+  await assert.rejects(
+    importSqlite({ targetMemoryDir: targetDir, fromFile: sqliteFile }),
+    /unsafe segments|escapes target root/i,
+  );
+  await assertPathMissing(outsidePath);
+});


### PR DESCRIPTION
## Summary
- validate JSON and SQLite export record paths before resolving import targets
- reject absolute, traversal, empty-segment, backslash, and symlink-escaping archive paths
- add JSON and SQLite regression coverage for hostile archive paths

## Verification
- pnpm exec tsx --test tests/export-import-json.test.ts tests/export-import-sqlite.test.ts
- pnpm run check-types
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-critical import path handling to prevent path traversal and symlink escape; mistakes could block legitimate imports or still allow unsafe writes if edge cases are missed.
> 
> **Overview**
> **Hardens transfer imports against hostile archive paths.** JSON and SQLite import now validate record paths as POSIX-relative and reject empty/absolute/traversal/backslash paths, then resolve targets using a *safe root* that enforces staying within the destination directory.
> 
> Imports now also guard against symlink-based escapes (including existing parent directories being symlinks) before writing files, and new regression tests cover traversal and symlink attacks for both JSON and SQLite imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e381b345ac188213b43f4d67b6f345494fad005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->