### PR TITLE
Encode transcript and thread storage paths

### DIFF
--- a/packages/remnic-core/src/storage-paths.ts
+++ b/packages/remnic-core/src/storage-paths.ts
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { lstat, realpath } from "node:fs/promises";
+import path from "node:path";
+
+export function encodeStoragePathSegment(value: string, fallback = "unknown"): string {
+  const raw = value.length > 0 ? value : fallback;
+  try {
+    return encodeURIComponent(raw).replaceAll(".", "%2E");
+  } catch {
+    return `encoded-${storagePathHash(raw)}`;
+  }
+}
+
+export function storagePathHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+export function encodeStoragePathSegmentWithHash(value: string, fallback = "unknown"): string {
+  const raw = value.length > 0 ? value : fallback;
+  return `${encodeStoragePathSegment(value, fallback)}--${storagePathHash(raw)}`;
+}
+
+export function isSafeLegacyPathSegment(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value !== "." &&
+    value !== ".." &&
+    !value.includes("/") &&
+    !value.includes("\\")
+  );
+}
+
+export function isPathInsideStorageRoot(rootAbs: string, targetAbs: string): boolean {
+  const rel = path.relative(rootAbs, targetAbs);
+  if (rel === "") return true;
+  if (rel === "..") return false;
+  if (rel.startsWith(`..${path.sep}`)) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
+}
+
+export function resolvePathInsideStorageRoot(
+  root: string,
+  ...parts: string[]
+): string {
+  const rootAbs = path.resolve(root);
+  const targetAbs = path.resolve(rootAbs, ...parts);
+  if (!isPathInsideStorageRoot(rootAbs, targetAbs)) {
+    throw new Error(`resolved storage path escapes root: ${targetAbs}`);
+  }
+  return targetAbs;
+}
+
+async function assertNoSymlinkInExistingPath(
+  rootAbs: string,
+  targetAbs: string,
+): Promise<void> {
+  let current = rootAbs;
+  while (current !== path.dirname(current)) {
+    const stat = await lstat(current).catch(() => null);
+    if (stat !== null) {
+      if (stat.isSymbolicLink()) {
+        throw new Error(`storage path must not pass through a symlink: ${current}`);
+      }
+      break;
+    }
+    current = path.dirname(current);
+  }
+
+  const relative = path.relative(rootAbs, targetAbs);
+  if (relative === "") return;
+
+  current = rootAbs;
+  for (const segment of relative.split(path.sep)) {
+    current = path.join(current, segment);
+    const stat = await lstat(current).catch(() => null);
+    if (stat === null) return;
+    if (stat.isSymbolicLink()) {
+      throw new Error(`storage path must not pass through a symlink: ${current}`);
+    }
+  }
+}
+
+async function assertRealPathInsideStorageRoot(
+  rootAbs: string,
+  targetAbs: string,
+): Promise<void> {
+  const rootReal = await resolvePossiblyMissingRealPath(rootAbs);
+  const targetReal = await resolvePossiblyMissingRealPath(targetAbs);
+  if (!isPathInsideStorageRoot(rootReal, targetReal)) {
+    throw new Error(`resolved storage path escapes root: ${targetAbs}`);
+  }
+}
+
+async function resolvePossiblyMissingRealPath(absPath: string): Promise<string> {
+  let existing = absPath;
+  const suffix: string[] = [];
+  while (existing !== path.dirname(existing)) {
+    const stat = await lstat(existing).catch(() => null);
+    if (stat !== null) break;
+    suffix.unshift(path.basename(existing));
+    existing = path.dirname(existing);
+  }
+  const existingReal = await realpath(existing).catch(() => existing);
+  return suffix.length > 0 ? path.join(existingReal, ...suffix) : existingReal;
+}
+
+export async function resolveSafeStoragePath(
+  root: string,
+  ...parts: string[]
+): Promise<string> {
+  const rootAbs = path.resolve(root);
+  const targetAbs = resolvePathInsideStorageRoot(rootAbs, ...parts);
+  await assertNoSymlinkInExistingPath(rootAbs, targetAbs);
+  await assertRealPathInsideStorageRoot(rootAbs, targetAbs);
+  return targetAbs;
+}

--- a/packages/remnic-core/src/threading.ts
+++ b/packages/remnic-core/src/threading.ts
@@ -5,10 +5,15 @@
  * Thread boundary detection: new session key OR time gap > threshold.
  */
 
-import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
-import path from "node:path";
+import { readdir, readFile, writeFile, mkdir, stat } from "node:fs/promises";
 import { log } from "./logger.js";
 import type { BufferTurn, ConversationThread } from "./types.js";
+import {
+  encodeStoragePathSegment,
+  encodeStoragePathSegmentWithHash,
+  isSafeLegacyPathSegment,
+  resolveSafeStoragePath,
+} from "./storage-paths.js";
 
 /** Stop words for title extraction */
 const STOP_WORDS = new Set([
@@ -58,6 +63,28 @@ function generateTitle(keywords: string[]): string {
     .join(", ");
 }
 
+function isConversationThread(value: unknown): value is ConversationThread {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Partial<ConversationThread>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.createdAt === "string" &&
+    typeof candidate.updatedAt === "string" &&
+    Array.isArray(candidate.episodeIds) &&
+    Array.isArray(candidate.linkedThreadIds)
+  );
+}
+
+function parseConversationThread(raw: string): ConversationThread | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isConversationThread(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 export class ThreadingManager {
   private currentThreadId: string | null = null;
   private lastTurnTimestamp: number | null = null;
@@ -70,6 +97,69 @@ export class ThreadingManager {
 
   async ensureDirectory(): Promise<void> {
     await mkdir(this.threadsDir, { recursive: true });
+  }
+
+  private encodedThreadFileName(threadId: string): string {
+    return `${encodeStoragePathSegment(threadId)}.json`;
+  }
+
+  private collisionSafeThreadFileName(threadId: string): string {
+    return `${encodeStoragePathSegmentWithHash(threadId)}.json`;
+  }
+
+  private legacyThreadFileName(threadId: string): string | undefined {
+    if (!isSafeLegacyPathSegment(threadId)) return undefined;
+    const legacyFile = `${threadId}.json`;
+    return legacyFile === this.encodedThreadFileName(threadId) ? undefined : legacyFile;
+  }
+
+  private async threadCandidateStatus(
+    filePath: string,
+    threadId: string,
+  ): Promise<"missing" | "matches" | "invalid" | "mismatches"> {
+    try {
+      if (!(await stat(filePath)).isFile()) return "mismatches";
+      const thread = parseConversationThread(await readFile(filePath, "utf-8"));
+      if (!thread) return "invalid";
+      return thread.id === threadId ? "matches" : "mismatches";
+    } catch (err) {
+      const code =
+        err && typeof err === "object" && "code" in err
+          ? (err as { code?: string }).code
+          : undefined;
+      if (code === "ENOENT") return "missing";
+      throw err;
+    }
+  }
+
+  private async threadFilePathForWrite(threadId: string): Promise<string> {
+    const encodedPath = await resolveSafeStoragePath(
+      this.threadsDir,
+      this.encodedThreadFileName(threadId),
+    );
+    const encodedStatus = await this.threadCandidateStatus(encodedPath, threadId);
+    if (encodedStatus === "matches") return encodedPath;
+
+    const legacyFile = this.legacyThreadFileName(threadId);
+    if (legacyFile) {
+      const legacyPath = await resolveSafeStoragePath(this.threadsDir, legacyFile);
+      if ((await this.threadCandidateStatus(legacyPath, threadId)) === "matches") {
+        return legacyPath;
+      }
+    }
+
+    if (encodedStatus === "missing") return encodedPath;
+
+    const collisionSafePath = await resolveSafeStoragePath(
+      this.threadsDir,
+      this.collisionSafeThreadFileName(threadId),
+    );
+    const collisionSafeStatus = await this.threadCandidateStatus(collisionSafePath, threadId);
+    if (collisionSafeStatus === "mismatches") {
+      throw new Error(`thread storage path collision for thread id: ${threadId}`);
+    }
+
+    return collisionSafePath;
   }
 
   /**
@@ -191,15 +281,40 @@ export class ThreadingManager {
   async getAllThreads(): Promise<ConversationThread[]> {
     try {
       const files = await readdir(this.threadsDir);
-      const threads: ConversationThread[] = [];
+      const threadsById = new Map<
+        string,
+        { thread: ConversationThread; storagePriority: number }
+      >();
 
       for (const file of files) {
         if (!file.endsWith(".json")) continue;
-        const thread = await this.loadThread(file.replace(".json", ""));
-        if (thread) threads.push(thread);
+        try {
+          const raw = await readFile(
+            await resolveSafeStoragePath(this.threadsDir, file),
+            "utf-8",
+          );
+          const thread = parseConversationThread(raw);
+          if (!thread) continue;
+
+          const legacyFile = this.legacyThreadFileName(thread.id);
+          const storagePriority =
+            file === this.encodedThreadFileName(thread.id)
+              ? 3
+              : file === this.collisionSafeThreadFileName(thread.id)
+                ? 2
+                : legacyFile && file === legacyFile
+                  ? 1
+                  : 0;
+          const current = threadsById.get(thread.id);
+          if (!current || storagePriority > current.storagePriority) {
+            threadsById.set(thread.id, { thread, storagePriority });
+          }
+        } catch {
+          // skip unreadable or malformed thread files
+        }
       }
 
-      return threads.sort(
+      return [...threadsById.values()].map(({ thread }) => thread).sort(
         (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
       );
     } catch {
@@ -211,13 +326,23 @@ export class ThreadingManager {
    * Get a thread by ID.
    */
   async loadThread(threadId: string): Promise<ConversationThread | null> {
-    const filePath = path.join(this.threadsDir, `${threadId}.json`);
-    try {
-      const raw = await readFile(filePath, "utf-8");
-      return JSON.parse(raw) as ConversationThread;
-    } catch {
-      return null;
+    const candidates = [
+      this.encodedThreadFileName(threadId),
+      this.legacyThreadFileName(threadId),
+      this.collisionSafeThreadFileName(threadId),
+    ];
+    for (const file of candidates) {
+      if (!file) continue;
+      try {
+        const filePath = await resolveSafeStoragePath(this.threadsDir, file);
+        const raw = await readFile(filePath, "utf-8");
+        const thread = parseConversationThread(raw);
+        if (thread?.id === threadId) return thread;
+      } catch {
+        // try the next candidate
+      }
     }
+    return null;
   }
 
   /**
@@ -225,7 +350,7 @@ export class ThreadingManager {
    */
   async saveThread(thread: ConversationThread): Promise<void> {
     await this.ensureDirectory();
-    const filePath = path.join(this.threadsDir, `${thread.id}.json`);
+    const filePath = await this.threadFilePathForWrite(thread.id);
     await writeFile(filePath, JSON.stringify(thread, null, 2), "utf-8");
   }
 

--- a/packages/remnic-core/src/transcript.ts
+++ b/packages/remnic-core/src/transcript.ts
@@ -3,6 +3,31 @@ import path from "node:path";
 import { log } from "./logger.js";
 import type { TranscriptEntry, Checkpoint, PluginConfig } from "./types.js";
 import { analyzeSessionIntegrity, type SessionIntegrityReport } from "./session-integrity.js";
+import {
+  encodeStoragePathSegment,
+  encodeStoragePathSegmentWithHash,
+  isSafeLegacyPathSegment,
+  resolveSafeStoragePath,
+  storagePathHash,
+} from "./storage-paths.js";
+
+type DirectorySessionStatus = "missing" | "empty" | "matches" | "occupied";
+type DirectoryOwnershipCacheEntry = {
+  status: "empty" | "matches";
+  fileSizes: Map<string, number>;
+};
+
+function legacyTranscriptDirFor(
+  channelType: string,
+  channelId: string,
+  encodedDir: string,
+): string | undefined {
+  if (!isSafeLegacyPathSegment(channelType) || !isSafeLegacyPathSegment(channelId)) {
+    return undefined;
+  }
+  const legacyDir = path.join(channelType, channelId);
+  return legacyDir === encodedDir ? undefined : legacyDir;
+}
 
 /**
  * Manages conversation transcript storage, checkpointing, and recall formatting.
@@ -23,6 +48,7 @@ export class TranscriptManager {
     string,
     { totalBytes: number; fileBytes: Map<string, number>; fileSizes: Map<string, number> }
   >();
+  private directoryOwnershipCache = new Map<string, DirectoryOwnershipCacheEntry>();
 
   /** Default checkpoint TTL in hours */
   private static readonly DEFAULT_CHECKPOINT_TTL_HOURS = 24;
@@ -46,9 +72,16 @@ export class TranscriptManager {
    *   - agent:<agent-id>:cron:<job-id> → type="cron", id="<job-id>"
    *   - agent:<agent-id>:slack:channel:<channel-id> → type="slack", id="<channel-id>"
    *
-   * @returns Object with dir (channel type/channel id) and file (YYYY-MM-DD.jsonl)
+   * @returns Object with raw channel identifiers and encoded storage path pieces.
    */
-  getTranscriptPath(sessionKey: string): { dir: string; file: string } {
+  getTranscriptPath(sessionKey: string): {
+    dir: string;
+    file: string;
+    channelType: string;
+    channelId: string;
+    alternateDir: string;
+    legacyDir?: string;
+  } {
     const parts = sessionKey.split(":");
 
     // Default fallback
@@ -76,9 +109,21 @@ export class TranscriptManager {
 
     // Daily rotation: transcripts/{channelType}/{channelId}/YYYY-MM-DD.jsonl
     const today = new Date().toISOString().slice(0, 10);
+    const dir = path.join(
+      encodeStoragePathSegment(channelType),
+      encodeStoragePathSegment(channelId),
+    );
+    const alternateDir = path.join(
+      encodeStoragePathSegmentWithHash(channelType),
+      `${encodeStoragePathSegmentWithHash(channelId)}--session-${storagePathHash(sessionKey)}`,
+    );
     return {
-      dir: path.join(channelType, channelId),
+      dir,
       file: `${today}.jsonl`,
+      channelType,
+      channelId,
+      alternateDir,
+      legacyDir: legacyTranscriptDirFor(channelType, channelId, dir),
     };
   }
 
@@ -133,17 +178,221 @@ export class TranscriptManager {
     return Array.from(sessionKeys);
   }
 
-  getToolUsagePath(sessionKey: string): { dir: string; file: string } {
+  getToolUsagePath(sessionKey: string): {
+    dir: string;
+    file: string;
+    alternateDir: string;
+    legacyDir?: string;
+  } {
     const p = this.getTranscriptPath(sessionKey);
-    return { dir: p.dir, file: p.file };
+    return { dir: p.dir, file: p.file, alternateDir: p.alternateDir, legacyDir: p.legacyDir };
+  }
+
+  private async selectStorageDirForWrite(
+    root: string,
+    dir: string,
+    legacyDir?: string,
+    sessionKey?: string,
+    alternateDir?: string,
+  ): Promise<{ dir: string; channelDir: string }> {
+    const channelDir = await resolveSafeStoragePath(root, dir);
+    const encodedStatus = await this.directorySessionStatus(root, dir, sessionKey);
+    if (encodedStatus === "matches" || encodedStatus === "empty") return { dir, channelDir };
+
+    if (legacyDir) {
+      const legacyChannelDir = await resolveSafeStoragePath(root, legacyDir);
+      if ((await this.directorySessionStatus(root, legacyDir, sessionKey)) === "matches") {
+        return { dir: legacyDir, channelDir: legacyChannelDir };
+      }
+    }
+
+    if (encodedStatus === "missing") return { dir, channelDir };
+
+    if (alternateDir) {
+      const alternateChannelDir = await resolveSafeStoragePath(root, alternateDir);
+      const alternateStatus = await this.directorySessionStatus(root, alternateDir, sessionKey);
+      if (
+        alternateStatus === "missing" ||
+        alternateStatus === "empty" ||
+        alternateStatus === "matches"
+      ) {
+        return { dir: alternateDir, channelDir: alternateChannelDir };
+      }
+    }
+
+    throw new Error(`transcript storage path collision for session: ${sessionKey ?? "(unknown)"}`);
+  }
+
+  private async directorySessionStatus(
+    root: string,
+    dir: string,
+    sessionKey?: string,
+  ): Promise<DirectorySessionStatus> {
+    let channelDir: string;
+    try {
+      channelDir = await resolveSafeStoragePath(root, dir);
+      if (!(await stat(channelDir)).isDirectory()) return "occupied";
+    } catch (err) {
+      const code =
+        err && typeof err === "object" && "code" in err
+          ? (err as { code?: string }).code
+          : undefined;
+      if (code === "ENOENT") return "missing";
+      throw err;
+    }
+
+    let names: string[];
+    try {
+      names = (await readdir(channelDir)).filter((file) => file.endsWith(".jsonl"));
+    } catch {
+      return "occupied";
+    }
+
+    const fileSizes = await this.directoryJsonlFileSizes(root, dir, names);
+    if (!fileSizes) return "occupied";
+
+    if (!sessionKey) return "matches";
+    const cacheKey = this.directoryOwnershipCacheKey(root, dir, sessionKey);
+    const cached = this.directoryOwnershipCache.get(cacheKey);
+    if (cached && this.sameFileSizes(cached.fileSizes, fileSizes)) {
+      return cached.status;
+    }
+
+    let hasEntries = false;
+    let hasMatchingEntry = false;
+
+    for (const name of names) {
+      const filePath = await resolveSafeStoragePath(root, dir, name).catch(() => null);
+      if (filePath === null) return "occupied";
+      try {
+        const raw = await readFile(filePath, "utf-8");
+        for (const line of raw.split("\n")) {
+          if (!line.trim()) continue;
+          hasEntries = true;
+          try {
+            const obj = JSON.parse(line) as { sessionKey?: string };
+            if (obj.sessionKey === sessionKey) {
+              hasMatchingEntry = true;
+            } else {
+              return "occupied";
+            }
+          } catch {
+            return "occupied";
+          }
+        }
+      } catch {
+        return "occupied";
+      }
+    }
+
+    const status = hasMatchingEntry ? "matches" : hasEntries ? "occupied" : "empty";
+    if (status === "matches" || status === "empty") {
+      this.directoryOwnershipCache.set(cacheKey, { status, fileSizes });
+    }
+    return status;
+  }
+
+  private directoryOwnershipCacheKey(root: string, dir: string, sessionKey: string): string {
+    return `${path.resolve(root)}\0${dir}\0${sessionKey}`;
+  }
+
+  private sameFileSizes(left: Map<string, number>, right: Map<string, number>): boolean {
+    if (left.size !== right.size) return false;
+    for (const [name, size] of left) {
+      if (right.get(name) !== size) return false;
+    }
+    return true;
+  }
+
+  private async directoryJsonlFileSizes(
+    root: string,
+    dir: string,
+    names: string[],
+  ): Promise<Map<string, number> | null> {
+    const fileSizes = new Map<string, number>();
+    for (const name of names) {
+      const filePath = await resolveSafeStoragePath(root, dir, name).catch(() => null);
+      if (filePath === null) return null;
+      const fileInfo = await stat(filePath).catch(() => null);
+      if (!fileInfo?.isFile()) return null;
+      fileSizes.set(name, Math.max(0, fileInfo.size));
+    }
+    return fileSizes;
+  }
+
+  private async rememberDirectoryOwnership(
+    root: string,
+    dir: string,
+    sessionKey: string,
+  ): Promise<void> {
+    try {
+      const channelDir = await resolveSafeStoragePath(root, dir);
+      const names = (await readdir(channelDir)).filter((file) => file.endsWith(".jsonl"));
+      const fileSizes = await this.directoryJsonlFileSizes(root, dir, names);
+      if (!fileSizes) return;
+      this.directoryOwnershipCache.set(
+        this.directoryOwnershipCacheKey(root, dir, sessionKey),
+        { status: "matches", fileSizes },
+      );
+    } catch {
+      // Cache refresh is best-effort; write path correctness does not depend on it.
+    }
+  }
+
+  private async getSessionStorageFiles(
+    root: string,
+    dir: string,
+    legacyDir?: string,
+    alternateDir?: string,
+  ): Promise<Array<{ cacheKey: string; name: string; path: string }>> {
+    const files: Array<{ cacheKey: string; name: string; path: string }> = [];
+    const seenDirs = new Set<string>();
+
+    for (const candidateDir of [dir, alternateDir, legacyDir]) {
+      if (!candidateDir || seenDirs.has(candidateDir)) continue;
+      seenDirs.add(candidateDir);
+
+      let channelDir: string;
+      try {
+        channelDir = await resolveSafeStoragePath(root, candidateDir);
+      } catch {
+        continue;
+      }
+
+      let names: string[];
+      try {
+        names = (await readdir(channelDir)).filter((file) => file.endsWith(".jsonl")).sort();
+      } catch {
+        continue;
+      }
+
+      for (const name of names) {
+        const filePath = await resolveSafeStoragePath(root, candidateDir, name).catch(() => null);
+        if (filePath === null) continue;
+        files.push({
+          cacheKey: path.join(candidateDir, name),
+          name,
+          path: filePath,
+        });
+      }
+    }
+
+    return files.sort((a, b) => a.cacheKey.localeCompare(b.cacheKey));
   }
 
   async appendToolUse(entry: { timestamp: string; sessionKey: string; tool: string }): Promise<void> {
-    const { dir, file } = this.getToolUsagePath(entry.sessionKey);
-    const channelDir = path.join(this.toolUsageDir, dir);
+    const { dir, file, alternateDir, legacyDir } = this.getToolUsagePath(entry.sessionKey);
+    const { dir: writeDir, channelDir } = await this.selectStorageDirForWrite(
+      this.toolUsageDir,
+      dir,
+      legacyDir,
+      entry.sessionKey,
+      alternateDir,
+    );
     await mkdir(channelDir, { recursive: true });
-    const filePath = path.join(channelDir, file);
+    const filePath = await resolveSafeStoragePath(this.toolUsageDir, writeDir, file);
     await appendFile(filePath, JSON.stringify(entry) + "\n", "utf-8");
+    await this.rememberDirectoryOwnership(this.toolUsageDir, writeDir, entry.sessionKey);
   }
 
   async readToolUse(
@@ -151,15 +400,12 @@ export class TranscriptManager {
     startTime: Date,
     endTime: Date,
   ): Promise<Array<{ timestamp: string; sessionKey: string; tool: string }>> {
-    const { dir } = this.getToolUsagePath(sessionKey);
-    const channelDir = path.join(this.toolUsageDir, dir);
+    const { dir, alternateDir, legacyDir } = this.getToolUsagePath(sessionKey);
     try {
-      const files = await readdir(channelDir);
+      const files = await this.getSessionStorageFiles(this.toolUsageDir, dir, legacyDir, alternateDir);
       const out: Array<{ timestamp: string; sessionKey: string; tool: string }> = [];
       for (const file of files) {
-        if (!file.endsWith(".jsonl")) continue;
-        const fp = path.join(channelDir, file);
-        const raw = await readFile(fp, "utf-8");
+        const raw = await readFile(file.path, "utf-8");
         for (const line of raw.split("\n")) {
           if (!line.trim()) continue;
           try {
@@ -168,7 +414,9 @@ export class TranscriptManager {
             if (!Number.isFinite(ts)) continue;
             if (ts >= startTime.getTime() && ts < endTime.getTime()) {
               if (typeof obj.tool === "string" && typeof obj.sessionKey === "string") {
-                out.push({ timestamp: obj.timestamp, sessionKey: obj.sessionKey, tool: obj.tool });
+                if (obj.sessionKey === sessionKey) {
+                  out.push({ timestamp: obj.timestamp, sessionKey: obj.sessionKey, tool: obj.tool });
+                }
               }
             }
           } catch {
@@ -183,26 +431,24 @@ export class TranscriptManager {
   }
 
   async estimateSessionFootprint(sessionKey: string): Promise<{ bytes: number; tokens: number }> {
-    const { dir } = this.getTranscriptPath(sessionKey);
-    const channelDir = path.join(this.transcriptsDir, dir);
+    const { dir, alternateDir, legacyDir } = this.getTranscriptPath(sessionKey);
     let bytes = 0;
 
     try {
-      const files = (await readdir(channelDir)).filter((file) => file.endsWith(".jsonl")).sort();
+      const files = await this.getSessionStorageFiles(this.transcriptsDir, dir, legacyDir, alternateDir);
       const cached = this.sessionFootprintCache.get(sessionKey);
       if (!cached) {
         const fileBytes = new Map<string, number>();
         const fileSizes = new Map<string, number>();
         for (const file of files) {
           try {
-            const fullPath = path.join(channelDir, file);
-            const fileInfo = await stat(fullPath);
+            const fileInfo = await stat(file.path);
             const sessionBytes = await this.estimateSessionBytesInFile(
-              fullPath,
+              file.path,
               sessionKey,
             );
-            fileBytes.set(file, sessionBytes);
-            fileSizes.set(file, Math.max(0, fileInfo.size));
+            fileBytes.set(file.cacheKey, sessionBytes);
+            fileSizes.set(file.cacheKey, Math.max(0, fileInfo.size));
             bytes += sessionBytes;
           } catch {
             // fail-open
@@ -211,7 +457,7 @@ export class TranscriptManager {
         this.sessionFootprintCache.set(sessionKey, { totalBytes: bytes, fileBytes, fileSizes });
       } else {
         bytes = cached.totalBytes;
-        const seen = new Set(files);
+        const seen = new Set(files.map((file) => file.cacheKey));
 
         // Drop removed files from the cached total.
         for (const [cachedFile, cachedSessionBytes] of cached.fileBytes.entries()) {
@@ -224,32 +470,31 @@ export class TranscriptManager {
 
         // Read only newly discovered files.
         for (const file of files) {
-          if (cached.fileBytes.has(file)) continue;
+          if (cached.fileBytes.has(file.cacheKey)) continue;
           try {
-            const fullPath = path.join(channelDir, file);
-            const fileInfo = await stat(fullPath);
-            const sessionBytes = await this.estimateSessionBytesInFile(fullPath, sessionKey);
-            cached.fileBytes.set(file, sessionBytes);
-            cached.fileSizes.set(file, Math.max(0, fileInfo.size));
+            const fileInfo = await stat(file.path);
+            const sessionBytes = await this.estimateSessionBytesInFile(file.path, sessionKey);
+            cached.fileBytes.set(file.cacheKey, sessionBytes);
+            cached.fileSizes.set(file.cacheKey, Math.max(0, fileInfo.size));
             bytes += sessionBytes;
           } catch {
             // fail-open
           }
         }
 
-        // Recompute only the newest shard, where growth usually happens.
-        const newestFile = files[files.length - 1];
-        if (newestFile) {
+        // Recompute any shard whose file size changed. A session can have both
+        // encoded and legacy directories during migration, so path ordering does
+        // not reliably identify the file that can grow.
+        for (const file of files) {
           try {
-            const newestPath = path.join(channelDir, newestFile);
-            const fileInfo = await stat(newestPath);
+            const fileInfo = await stat(file.path);
             const size = Math.max(0, fileInfo.size);
-            const previousSessionBytes = cached.fileBytes.get(newestFile) ?? 0;
-            const previousSize = cached.fileSizes.get(newestFile) ?? -1;
+            const previousSessionBytes = cached.fileBytes.get(file.cacheKey) ?? 0;
+            const previousSize = cached.fileSizes.get(file.cacheKey) ?? -1;
             if (size !== previousSize) {
-              const sessionBytes = await this.estimateSessionBytesInFile(newestPath, sessionKey);
-              cached.fileBytes.set(newestFile, sessionBytes);
-              cached.fileSizes.set(newestFile, size);
+              const sessionBytes = await this.estimateSessionBytesInFile(file.path, sessionKey);
+              cached.fileBytes.set(file.cacheKey, sessionBytes);
+              cached.fileSizes.set(file.cacheKey, size);
               bytes += sessionBytes - previousSessionBytes;
             }
           } catch {
@@ -307,22 +552,28 @@ export class TranscriptManager {
    */
   async append(entry: TranscriptEntry): Promise<void> {
     try {
-      const { dir, file } = this.getTranscriptPath(entry.sessionKey);
+      const { dir, file, channelType, alternateDir, legacyDir } = this.getTranscriptPath(entry.sessionKey);
 
       // Skip if this channel type is in the skip list
-      const channelType = dir.split(path.sep)[0] ?? dir;
       if (this.config.transcriptSkipChannelTypes.includes(channelType)) {
         return;
       }
 
-      const channelDir = path.join(this.transcriptsDir, dir);
-      const filePath = path.join(channelDir, file);
+      const { dir: writeDir, channelDir } = await this.selectStorageDirForWrite(
+        this.transcriptsDir,
+        dir,
+        legacyDir,
+        entry.sessionKey,
+        alternateDir,
+      );
+      const filePath = await resolveSafeStoragePath(this.transcriptsDir, writeDir, file);
 
       // Ensure channel directory exists
       await mkdir(channelDir, { recursive: true });
 
       const line = JSON.stringify(entry) + "\n";
       await appendFile(filePath, line, "utf-8");
+      await this.rememberDirectoryOwnership(this.transcriptsDir, writeDir, entry.sessionKey);
       log.debug(`appended transcript entry for ${entry.sessionKey}: ${entry.turnId}`);
     } catch (err) {
       log.error("failed to append transcript entry:", err);
@@ -460,8 +711,7 @@ export class TranscriptManager {
     end: Date,
     sessionKey: string,
   ): Promise<TranscriptEntry[]> {
-    const { dir } = this.getTranscriptPath(sessionKey);
-    const channelDir = path.join(this.transcriptsDir, dir);
+    const { dir, alternateDir, legacyDir } = this.getTranscriptPath(sessionKey);
 
     // Build set of date strings that overlap with [start, end].
     // Always include end's date to handle midnight-crossing lookbacks
@@ -475,20 +725,15 @@ export class TranscriptManager {
     dateStrings.add(end.toISOString().slice(0, 10));
 
     const entries: TranscriptEntry[] = [];
-    let files: string[];
-    try {
-      files = (await readdir(channelDir)).filter((f) => f.endsWith(".jsonl"));
-    } catch {
-      return [];
-    }
+    const files = await this.getSessionStorageFiles(this.transcriptsDir, dir, legacyDir, alternateDir);
 
     for (const file of files) {
       // Only read files whose date is within the window
-      const dateStr = file.slice(0, 10);
+      const dateStr = file.name.slice(0, 10);
       if (!dateStrings.has(dateStr)) continue;
 
       try {
-        const content = await readFile(path.join(channelDir, file), "utf-8");
+        const content = await readFile(file.path, "utf-8");
         for (const line of content.split("\n")) {
           if (!line.trim()) continue;
           try {

--- a/tests/threading.test.ts
+++ b/tests/threading.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -55,5 +55,342 @@ test("appendEpisodeIds de-duplicates existing IDs", async () => {
     assert.deepEqual(thread!.episodeIds, ["fact-1", "fact-2"]);
   } finally {
     await cleanup(dir);
+  }
+});
+
+test("thread IDs are encoded before reading and writing thread files", async () => {
+  const dir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    const outsideDir = path.join(dir, "escape");
+    const outsidePath = path.join(outsideDir, "thread.json");
+    const outsideContent = JSON.stringify({ id: "outside" });
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(outsidePath, outsideContent, "utf-8");
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    const unsafeThreadId = "../escape/thread";
+    await tm.saveThread({
+      id: unsafeThreadId,
+      title: "Unsafe Thread ID",
+      createdAt: "2026-02-22T15:00:00.000Z",
+      updatedAt: "2026-02-22T15:00:00.000Z",
+      sessionKey: "s1",
+      episodeIds: ["fact-1"],
+      linkedThreadIds: [],
+    });
+
+    assert.equal(await readFile(outsidePath, "utf-8"), outsideContent);
+
+    const loaded = await tm.loadThread(unsafeThreadId);
+    assert.equal(loaded?.id, unsafeThreadId);
+    assert.deepEqual(loaded?.episodeIds, ["fact-1"]);
+
+    const threadFiles = await readdir(threadsDir);
+    assert.ok(
+      threadFiles.includes("%2E%2E%2Fescape%2Fthread.json"),
+      "unsafe thread ID should be encoded as one filename segment",
+    );
+
+    const allThreads = await tm.getAllThreads();
+    assert.ok(allThreads.some((thread) => thread.id === unsafeThreadId));
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+test("legacy safe thread filenames remain loadable and writable", async () => {
+  const dir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    await mkdir(threadsDir, { recursive: true });
+    await writeFile(
+      path.join(threadsDir, "release.v1.json"),
+      JSON.stringify({
+        id: "release.v1",
+        title: "Release V1",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-22T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["fact-1"],
+        linkedThreadIds: [],
+      }),
+      "utf-8",
+    );
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    const loaded = await tm.loadThread("release.v1");
+    assert.equal(loaded?.title, "Release V1");
+
+    await tm.appendEpisodeIds("release.v1", ["fact-2"]);
+    const legacyRaw = await readFile(path.join(threadsDir, "release.v1.json"), "utf-8");
+    assert.match(legacyRaw, /fact-2/);
+    await assert.rejects(
+      readFile(path.join(threadsDir, "release%2Ev1.json"), "utf-8"),
+      { code: "ENOENT" },
+    );
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+test("thread writes keep using encoded file when encoded and legacy files both exist", async () => {
+  const dir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    await mkdir(threadsDir, { recursive: true });
+    await writeFile(
+      path.join(threadsDir, "release.v1.json"),
+      JSON.stringify({
+        id: "release.v1",
+        title: "Legacy Release V1",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-22T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["legacy-fact"],
+        linkedThreadIds: [],
+      }),
+      "utf-8",
+    );
+    await writeFile(
+      path.join(threadsDir, "release%2Ev1.json"),
+      JSON.stringify({
+        id: "release.v1",
+        title: "Encoded Release V1",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-23T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["encoded-fact"],
+        linkedThreadIds: [],
+      }),
+      "utf-8",
+    );
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    const loaded = await tm.loadThread("release.v1");
+    assert.equal(loaded?.title, "Encoded Release V1");
+
+    await tm.appendEpisodeIds("release.v1", ["new-fact"]);
+    const encodedRaw = await readFile(path.join(threadsDir, "release%2Ev1.json"), "utf-8");
+    const legacyRaw = await readFile(path.join(threadsDir, "release.v1.json"), "utf-8");
+    assert.match(encodedRaw, /new-fact/);
+    assert.doesNotMatch(legacyRaw, /new-fact/);
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+test("getAllThreads de-duplicates legacy and encoded copies by thread ID", async () => {
+  const dir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    await mkdir(threadsDir, { recursive: true });
+    await writeFile(
+      path.join(threadsDir, "release.v1.json"),
+      JSON.stringify({
+        id: "release.v1",
+        title: "Legacy Release V1",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-23T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["legacy-fact"],
+        linkedThreadIds: [],
+      }),
+      "utf-8",
+    );
+    await writeFile(
+      path.join(threadsDir, "release%2Ev1.json"),
+      JSON.stringify({
+        id: "release.v1",
+        title: "Encoded Release V1",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-22T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["encoded-fact"],
+        linkedThreadIds: [],
+      }),
+      "utf-8",
+    );
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    const threads = await tm.getAllThreads();
+
+    assert.deepEqual(threads.map((thread) => thread.id), ["release.v1"]);
+    assert.equal(threads[0]?.title, "Encoded Release V1");
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+test("legacy thread fallback does not reuse a colliding encoded filename", async () => {
+  const dir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    await mkdir(threadsDir, { recursive: true });
+    await writeFile(
+      path.join(threadsDir, "release%2Ev1.json"),
+      JSON.stringify({
+        id: "release.v1",
+        title: "Release V1",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-22T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["fact-1"],
+        linkedThreadIds: [],
+      }),
+      "utf-8",
+    );
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    assert.equal(await tm.loadThread("release%2Ev1"), null);
+
+    await tm.saveThread({
+      id: "release%2Ev1",
+      title: "Encoded Percent Thread",
+      createdAt: "2026-02-22T15:00:00.000Z",
+      updatedAt: "2026-02-22T15:00:00.000Z",
+      sessionKey: "s1",
+      episodeIds: ["fact-2"],
+      linkedThreadIds: [],
+    });
+
+    const originalRaw = await readFile(path.join(threadsDir, "release%2Ev1.json"), "utf-8");
+    const encodedRaw = await readFile(path.join(threadsDir, "release%252Ev1.json"), "utf-8");
+    assert.match(originalRaw, /"id":"release\.v1"/);
+    assert.match(encodedRaw, /"id": "release%2Ev1"/);
+    assert.equal((await tm.loadThread("release%2Ev1"))?.title, "Encoded Percent Thread");
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+test("thread writes fall back to encoded file when legacy file is malformed", async () => {
+  const dir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    await mkdir(threadsDir, { recursive: true });
+    await writeFile(path.join(threadsDir, "release.v1.json"), "{not json", "utf-8");
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    await tm.saveThread({
+      id: "release.v1",
+      title: "Release V1",
+      createdAt: "2026-02-22T15:00:00.000Z",
+      updatedAt: "2026-02-22T15:00:00.000Z",
+      sessionKey: "s1",
+      episodeIds: ["fact-1"],
+      linkedThreadIds: [],
+    });
+
+    assert.equal(await readFile(path.join(threadsDir, "release.v1.json"), "utf-8"), "{not json");
+    const encodedRaw = await readFile(path.join(threadsDir, "release%2Ev1.json"), "utf-8");
+    assert.match(encodedRaw, /"id": "release\.v1"/);
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+test("thread writes do not overwrite encoded paths occupied by another thread ID", async () => {
+  const dir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    await mkdir(threadsDir, { recursive: true });
+    await writeFile(
+      path.join(threadsDir, "release%2Ev1.json"),
+      JSON.stringify({
+        id: "release%2Ev1",
+        title: "Legacy Percent Thread",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-22T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["legacy-fact"],
+        linkedThreadIds: [],
+      }),
+      "utf-8",
+    );
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    await tm.saveThread({
+      id: "release.v1",
+      title: "Release V1",
+      createdAt: "2026-02-22T15:00:00.000Z",
+      updatedAt: "2026-02-22T15:00:00.000Z",
+      sessionKey: "s2",
+      episodeIds: ["new-fact"],
+      linkedThreadIds: [],
+    });
+
+    const originalRaw = await readFile(path.join(threadsDir, "release%2Ev1.json"), "utf-8");
+    assert.match(originalRaw, /"id":"release%2Ev1"/);
+    assert.match(originalRaw, /legacy-fact/);
+    assert.equal((await tm.loadThread("release.v1"))?.title, "Release V1");
+    assert.equal((await tm.loadThread("release%2Ev1"))?.title, "Legacy Percent Thread");
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+test("getAllThreads skips null thread files without dropping valid threads", async () => {
+  const dir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    await mkdir(threadsDir, { recursive: true });
+    await writeFile(path.join(threadsDir, "bad.json"), "null", "utf-8");
+    await writeFile(
+      path.join(threadsDir, "good.json"),
+      JSON.stringify({
+        id: "good",
+        title: "Good Thread",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-22T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["fact-1"],
+        linkedThreadIds: [],
+      }),
+      "utf-8",
+    );
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    const threads = await tm.getAllThreads();
+
+    assert.equal(threads.length, 1);
+    assert.equal(threads[0]?.id, "good");
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+test("thread writes reject symlinked thread roots", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const dir = await makeTmp();
+  const outsideDir = await makeTmp();
+  try {
+    const threadsDir = path.join(dir, "threads");
+    await symlink(outsideDir, threadsDir, "dir");
+
+    const tm = new ThreadingManager(threadsDir, 30);
+    await assert.rejects(
+      tm.saveThread({
+        id: "thread-1",
+        title: "Thread",
+        createdAt: "2026-02-22T15:00:00.000Z",
+        updatedAt: "2026-02-22T15:00:00.000Z",
+        sessionKey: "s1",
+        episodeIds: ["fact-1"],
+        linkedThreadIds: [],
+      }),
+      /symlink/i,
+    );
+    await assert.rejects(
+      readFile(path.join(outsideDir, "thread-1.json"), "utf-8"),
+      { code: "ENOENT" },
+    );
+  } finally {
+    await cleanup(dir);
+    await cleanup(outsideDir);
   }
 });

--- a/tests/transcript-footprint-cache.test.ts
+++ b/tests/transcript-footprint-cache.test.ts
@@ -80,3 +80,44 @@ test("estimateSessionFootprint cache handles shard removal and new shard additio
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("estimateSessionFootprint refreshes encoded shard growth when legacy directory also exists", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-footprint-mixed-"));
+  try {
+    const transcript = new TranscriptManager({
+      memoryDir: dir,
+      transcriptSkipChannelTypes: [],
+    } as any);
+
+    const sessionKey = "agent:bot:custom:nightly.summary";
+    const { dir: encodedDir, legacyDir } = transcript.getTranscriptPath(sessionKey);
+    assert.equal(encodedDir, "custom/nightly%2Esummary");
+    assert.equal(legacyDir, "custom/nightly.summary");
+
+    const encodedChannelDir = path.join(dir, "transcripts", encodedDir);
+    const legacyChannelDir = path.join(dir, "transcripts", legacyDir!);
+    await mkdir(encodedChannelDir, { recursive: true });
+    await mkdir(legacyChannelDir, { recursive: true });
+
+    const encodedShard = path.join(encodedChannelDir, "2026-02-25.jsonl");
+    const legacyShard = path.join(legacyChannelDir, "2026-02-25.jsonl");
+    const encodedOwn = makeLine(sessionKey, "encoded-own");
+    const legacyOwn = makeLine(sessionKey, "legacy-own");
+    await writeFile(encodedShard, encodedOwn, "utf-8");
+    await writeFile(legacyShard, legacyOwn, "utf-8");
+
+    const first = await transcript.estimateSessionFootprint(sessionKey);
+    assert.equal(first.bytes, Buffer.byteLength(encodedOwn) + Buffer.byteLength(legacyOwn));
+
+    const encodedGrowth = makeLine(sessionKey, "encoded-growth");
+    await writeFile(encodedShard, `${encodedOwn}${encodedGrowth}`, "utf-8");
+
+    const second = await transcript.estimateSessionFootprint(sessionKey);
+    assert.equal(
+      second.bytes,
+      Buffer.byteLength(encodedOwn) + Buffer.byteLength(encodedGrowth) + Buffer.byteLength(legacyOwn),
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/transcript-path-safety.test.ts
+++ b/tests/transcript-path-safety.test.ts
@@ -1,0 +1,671 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { parseConfig } from "../src/config.js";
+import { TranscriptManager } from "../src/transcript.js";
+
+async function assertPathMissing(filePath: string): Promise<void> {
+  await assert.rejects(access(filePath), { code: "ENOENT" });
+}
+
+async function writeJsonl(filePath: string, value: unknown): Promise<void> {
+  await writeFile(filePath, `${JSON.stringify(value)}\n`, "utf-8");
+}
+
+test("transcript append encodes session path components before writing", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-path-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+      transcriptSkipChannelTypes: [],
+    }));
+    await transcript.initialize();
+
+    const sessionKey = "agent:bot:../escape:channel";
+    await transcript.append({
+      timestamp: "2026-05-16T12:00:00.000Z",
+      role: "user",
+      content: "hello",
+      sessionKey,
+      turnId: "turn-1",
+    });
+
+    const { dir, file } = transcript.getTranscriptPath(sessionKey);
+    const transcriptRoot = path.join(memoryDir, "transcripts");
+    const storedPath = path.join(transcriptRoot, dir, file);
+    const relativePath = path.relative(transcriptRoot, storedPath);
+    assert.equal(relativePath.startsWith(".."), false);
+    assert.match(relativePath, /^%2E%2E%2Fescape\/channel\//);
+
+    const raw = await readFile(storedPath, "utf-8");
+    assert.match(raw, /"sessionKey":"agent:bot:\.\.\/escape:channel"/);
+    await assertPathMissing(path.join(memoryDir, "escape", "channel", file));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("tool-use append encodes session path components before writing", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-tool-path-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+      transcriptSkipChannelTypes: [],
+    }));
+    await transcript.initialize();
+
+    const sessionKey = "agent:bot:discord:channel:../../tool-escape";
+    await transcript.appendToolUse({
+      timestamp: "2026-05-16T12:00:00.000Z",
+      sessionKey,
+      tool: "memory_search",
+    });
+
+    const { dir, file } = transcript.getToolUsagePath(sessionKey);
+    const toolRoot = path.join(memoryDir, "state", "tool-usage");
+    const storedPath = path.join(toolRoot, dir, file);
+    const relativePath = path.relative(toolRoot, storedPath);
+    assert.equal(relativePath.startsWith(".."), false);
+    assert.match(relativePath, /^discord\/%2E%2E%2F%2E%2E%2Ftool-escape\//);
+
+    const raw = await readFile(storedPath, "utf-8");
+    assert.match(raw, /"tool":"memory_search"/);
+    await assertPathMissing(path.join(memoryDir, "state", "tool-escape", file));
+
+    const entries = await transcript.readToolUse(
+      sessionKey,
+      new Date("2026-05-16T11:59:00.000Z"),
+      new Date("2026-05-16T12:01:00.000Z"),
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.sessionKey, sessionKey);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("transcript skip channel types compare raw channel names", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-skip-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+      transcriptSkipChannelTypes: ["custom.type"],
+    }));
+    await transcript.initialize();
+
+    const sessionKey = "agent:bot:custom.type:channel-1";
+    const { dir, file } = transcript.getTranscriptPath(sessionKey);
+
+    await transcript.append({
+      timestamp: "2026-05-16T12:00:00.000Z",
+      role: "user",
+      content: "skip this",
+      sessionKey,
+      turnId: "turn-1",
+    });
+
+    await assertPathMissing(path.join(memoryDir, "transcripts", dir, file));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("safe legacy transcript directories remain readable and writable", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-legacy-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+
+    const sessionKey = "agent:bot:custom:nightly.summary";
+    const now = new Date();
+    const { dir, file } = transcript.getTranscriptPath(sessionKey);
+    const legacyDir = path.join(memoryDir, "transcripts", "custom", "nightly.summary");
+    await mkdir(legacyDir, { recursive: true });
+    await writeJsonl(path.join(legacyDir, file), {
+      timestamp: now.toISOString(),
+      role: "user",
+      content: "legacy transcript entry",
+      sessionKey,
+      turnId: "legacy-turn",
+    });
+
+    const footprint = await transcript.estimateSessionFootprint(sessionKey);
+    assert.ok(footprint.bytes > 0);
+
+    const entries = await transcript.readRecent(1, sessionKey);
+    assert.deepEqual(entries.map((entry) => entry.turnId), ["legacy-turn"]);
+
+    await transcript.append({
+      timestamp: now.toISOString(),
+      role: "assistant",
+      content: "new transcript entry",
+      sessionKey,
+      turnId: "new-turn",
+    });
+
+    const raw = await readFile(path.join(legacyDir, file), "utf-8");
+    assert.match(raw, /legacy transcript entry/);
+    assert.match(raw, /new transcript entry/);
+    await assertPathMissing(path.join(memoryDir, "transcripts", dir, file));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("safe legacy tool-use directories remain readable and writable", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-tool-legacy-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+
+    const sessionKey = "agent:bot:custom:nightly.summary";
+    const timestamp = new Date().toISOString();
+    const { dir, file } = transcript.getToolUsagePath(sessionKey);
+    const legacyDir = path.join(memoryDir, "state", "tool-usage", "custom", "nightly.summary");
+    await mkdir(legacyDir, { recursive: true });
+    await writeJsonl(path.join(legacyDir, file), {
+      timestamp,
+      sessionKey,
+      tool: "memory_search",
+    });
+
+    const before = await transcript.readToolUse(
+      sessionKey,
+      new Date(Date.now() - 60_000),
+      new Date(Date.now() + 60_000),
+    );
+    assert.deepEqual(before.map((entry) => entry.tool), ["memory_search"]);
+
+    await transcript.appendToolUse({
+      timestamp,
+      sessionKey,
+      tool: "memory_store",
+    });
+
+    const raw = await readFile(path.join(legacyDir, file), "utf-8");
+    assert.match(raw, /memory_search/);
+    assert.match(raw, /memory_store/);
+    await assertPathMissing(path.join(memoryDir, "state", "tool-usage", dir, file));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("encoded-looking session IDs do not reuse colliding legacy transcript directories", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-collision-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+
+    const ownerSessionKey = "agent:bot:custom:nightly.summary";
+    const collidingSessionKey = "agent:bot:custom:nightly%2Esummary";
+    const timestamp = new Date().toISOString();
+    const { dir: ownerDir, file } = transcript.getTranscriptPath(ownerSessionKey);
+    const { dir: collidingDir } = transcript.getTranscriptPath(collidingSessionKey);
+    const ownerTranscriptDir = path.join(memoryDir, "transcripts", ownerDir);
+    const ownerToolDir = path.join(memoryDir, "state", "tool-usage", ownerDir);
+    await mkdir(ownerTranscriptDir, { recursive: true });
+    await mkdir(ownerToolDir, { recursive: true });
+    await writeJsonl(path.join(ownerTranscriptDir, file), {
+      timestamp,
+      role: "user",
+      content: "owner transcript entry",
+      sessionKey: ownerSessionKey,
+      turnId: "owner-turn",
+    });
+    await writeJsonl(path.join(ownerToolDir, file), {
+      timestamp,
+      sessionKey: ownerSessionKey,
+      tool: "owner_tool",
+    });
+
+    assert.equal(ownerDir, "custom/nightly%2Esummary");
+    assert.equal(collidingDir, "custom/nightly%252Esummary");
+    assert.deepEqual(await transcript.readRecent(1, collidingSessionKey), []);
+    assert.deepEqual(
+      await transcript.readToolUse(
+        collidingSessionKey,
+        new Date(Date.now() - 60_000),
+        new Date(Date.now() + 60_000),
+      ),
+      [],
+    );
+
+    await transcript.append({
+      timestamp,
+      role: "assistant",
+      content: "colliding transcript entry",
+      sessionKey: collidingSessionKey,
+      turnId: "colliding-turn",
+    });
+    await transcript.appendToolUse({
+      timestamp,
+      sessionKey: collidingSessionKey,
+      tool: "colliding_tool",
+    });
+
+    const ownerTranscriptRaw = await readFile(path.join(ownerTranscriptDir, file), "utf-8");
+    const collidingTranscriptRaw = await readFile(
+      path.join(memoryDir, "transcripts", collidingDir, file),
+      "utf-8",
+    );
+    const ownerToolRaw = await readFile(path.join(ownerToolDir, file), "utf-8");
+    const collidingToolRaw = await readFile(
+      path.join(memoryDir, "state", "tool-usage", collidingDir, file),
+      "utf-8",
+    );
+
+    assert.match(ownerTranscriptRaw, /owner transcript entry/);
+    assert.doesNotMatch(ownerTranscriptRaw, /colliding transcript entry/);
+    assert.match(collidingTranscriptRaw, /colliding transcript entry/);
+    assert.match(ownerToolRaw, /owner_tool/);
+    assert.doesNotMatch(ownerToolRaw, /colliding_tool/);
+    assert.match(collidingToolRaw, /colliding_tool/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("transcript append does not reuse encoded directories occupied by another session", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-encoded-collision-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+
+    const legacyPercentSessionKey = "agent:bot:custom:nightly%2Esummary";
+    const encodedDotSessionKey = "agent:bot:custom:nightly.summary";
+    const timestamp = new Date().toISOString();
+    const { dir, file, alternateDir } = transcript.getTranscriptPath(encodedDotSessionKey);
+    const occupiedTranscriptDir = path.join(memoryDir, "transcripts", dir);
+    const occupiedToolDir = path.join(memoryDir, "state", "tool-usage", dir);
+    await mkdir(occupiedTranscriptDir, { recursive: true });
+    await mkdir(occupiedToolDir, { recursive: true });
+    await writeJsonl(path.join(occupiedTranscriptDir, file), {
+      timestamp,
+      role: "user",
+      content: "legacy percent transcript entry",
+      sessionKey: legacyPercentSessionKey,
+      turnId: "legacy-percent-turn",
+    });
+    await writeJsonl(path.join(occupiedToolDir, file), {
+      timestamp,
+      sessionKey: legacyPercentSessionKey,
+      tool: "legacy_percent_tool",
+    });
+
+    await transcript.append({
+      timestamp,
+      role: "assistant",
+      content: "encoded dot transcript entry",
+      sessionKey: encodedDotSessionKey,
+      turnId: "encoded-dot-turn",
+    });
+    await transcript.appendToolUse({
+      timestamp,
+      sessionKey: encodedDotSessionKey,
+      tool: "encoded_dot_tool",
+    });
+
+    const occupiedTranscriptRaw = await readFile(path.join(occupiedTranscriptDir, file), "utf-8");
+    const alternateTranscriptRaw = await readFile(
+      path.join(memoryDir, "transcripts", alternateDir, file),
+      "utf-8",
+    );
+    const occupiedToolRaw = await readFile(path.join(occupiedToolDir, file), "utf-8");
+    const alternateToolRaw = await readFile(
+      path.join(memoryDir, "state", "tool-usage", alternateDir, file),
+      "utf-8",
+    );
+
+    assert.match(occupiedTranscriptRaw, /legacy percent transcript entry/);
+    assert.doesNotMatch(occupiedTranscriptRaw, /encoded dot transcript entry/);
+    assert.match(alternateTranscriptRaw, /encoded dot transcript entry/);
+    assert.match(occupiedToolRaw, /legacy_percent_tool/);
+    assert.doesNotMatch(occupiedToolRaw, /encoded_dot_tool/);
+    assert.match(alternateToolRaw, /encoded_dot_tool/);
+    assert.deepEqual(
+      (await transcript.readRecent(1, encodedDotSessionKey)).map((entry) => entry.turnId),
+      ["encoded-dot-turn"],
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("transcript append treats mixed session directories as occupied", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-mixed-collision-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+
+    const otherSessionKey = "agent:bot:custom:nightly%2Esummary";
+    const sessionKey = "agent:bot:custom:nightly.summary";
+    const timestamp = new Date().toISOString();
+    const { dir, file, alternateDir } = transcript.getTranscriptPath(sessionKey);
+    const mixedTranscriptDir = path.join(memoryDir, "transcripts", dir);
+    await mkdir(mixedTranscriptDir, { recursive: true });
+    await writeFile(
+      path.join(mixedTranscriptDir, file),
+      `${JSON.stringify({
+        timestamp,
+        role: "user",
+        content: "current session existing entry",
+        sessionKey,
+        turnId: "current-existing-turn",
+      })}\n${JSON.stringify({
+        timestamp,
+        role: "user",
+        content: "other session entry",
+        sessionKey: otherSessionKey,
+        turnId: "other-turn",
+      })}\n`,
+      "utf-8",
+    );
+
+    await transcript.append({
+      timestamp,
+      role: "assistant",
+      content: "current session new entry",
+      sessionKey,
+      turnId: "current-new-turn",
+    });
+
+    const mixedRaw = await readFile(path.join(mixedTranscriptDir, file), "utf-8");
+    const alternateRaw = await readFile(
+      path.join(memoryDir, "transcripts", alternateDir, file),
+      "utf-8",
+    );
+    assert.match(mixedRaw, /current session existing entry/);
+    assert.match(mixedRaw, /other session entry/);
+    assert.doesNotMatch(mixedRaw, /current session new entry/);
+    assert.match(alternateRaw, /current session new entry/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("transcript append invalidates ownership cache when a directory changes", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-cache-collision-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+
+    const otherSessionKey = "agent:bot:custom:nightly%2Esummary";
+    const sessionKey = "agent:bot:custom:nightly.summary";
+    const timestamp = new Date().toISOString();
+    const { dir, file, alternateDir } = transcript.getTranscriptPath(sessionKey);
+    const transcriptDir = path.join(memoryDir, "transcripts", dir);
+
+    await transcript.append({
+      timestamp,
+      role: "user",
+      content: "first current entry",
+      sessionKey,
+      turnId: "first-current-turn",
+    });
+
+    const transcriptPath = path.join(transcriptDir, file);
+    const originalRaw = await readFile(transcriptPath, "utf-8");
+    await writeFile(
+      transcriptPath,
+      `${originalRaw}${JSON.stringify({
+        timestamp,
+        role: "user",
+        content: "externally mixed entry",
+        sessionKey: otherSessionKey,
+        turnId: "external-other-turn",
+      })}\n`,
+      "utf-8",
+    );
+
+    await transcript.append({
+      timestamp,
+      role: "assistant",
+      content: "second current entry",
+      sessionKey,
+      turnId: "second-current-turn",
+    });
+
+    const mixedRaw = await readFile(transcriptPath, "utf-8");
+    const alternateRaw = await readFile(
+      path.join(memoryDir, "transcripts", alternateDir, file),
+      "utf-8",
+    );
+    assert.match(mixedRaw, /first current entry/);
+    assert.match(mixedRaw, /externally mixed entry/);
+    assert.doesNotMatch(mixedRaw, /second current entry/);
+    assert.match(alternateRaw, /second current entry/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("alternate transcript directories are session-specific for shared channels", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-shared-channel-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+
+    const timestamp = new Date().toISOString();
+    const sessionKeys = ["agent:alpha:main", "agent:beta:main", "agent:gamma:main"];
+    const alternateDirs = sessionKeys.map((sessionKey) => (
+      transcript.getTranscriptPath(sessionKey).alternateDir
+    ));
+    assert.equal(new Set(alternateDirs).size, sessionKeys.length);
+
+    for (const [index, sessionKey] of sessionKeys.entries()) {
+      await transcript.append({
+        timestamp,
+        role: "user",
+        content: `shared channel transcript ${index}`,
+        sessionKey,
+        turnId: `shared-turn-${index}`,
+      });
+      await transcript.appendToolUse({
+        timestamp,
+        sessionKey,
+        tool: `shared_tool_${index}`,
+      });
+    }
+
+    for (const [index, sessionKey] of sessionKeys.entries()) {
+      const entries = await transcript.readRecent(1, sessionKey);
+      assert.deepEqual(entries.map((entry) => entry.turnId), [`shared-turn-${index}`]);
+      const tools = await transcript.readToolUse(
+        sessionKey,
+        new Date(Date.now() - 60_000),
+        new Date(Date.now() + 60_000),
+      );
+      assert.deepEqual(tools.map((entry) => entry.tool), [`shared_tool_${index}`]);
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("transcript and tool-use reads skip symlinked jsonl files", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("file symlink setup is platform-specific");
+    return;
+  }
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-jsonl-symlink-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-jsonl-outside-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+
+    const sessionKey = "agent:bot:main";
+    const timestamp = new Date().toISOString();
+    const { dir, file } = transcript.getTranscriptPath(sessionKey);
+    const transcriptDir = path.join(memoryDir, "transcripts", dir);
+    await mkdir(transcriptDir, { recursive: true });
+    const outsideTranscript = path.join(outsideDir, "outside-transcript.jsonl");
+    await writeJsonl(outsideTranscript, {
+      timestamp,
+      role: "user",
+      content: "outside transcript",
+      sessionKey,
+      turnId: "outside-turn",
+    });
+    await symlink(outsideTranscript, path.join(transcriptDir, file), "file");
+
+    const toolDir = path.join(memoryDir, "state", "tool-usage", dir);
+    await mkdir(toolDir, { recursive: true });
+    const outsideToolUse = path.join(outsideDir, "outside-tool.jsonl");
+    await writeJsonl(outsideToolUse, {
+      timestamp,
+      sessionKey,
+      tool: "memory_search",
+    });
+    await symlink(outsideToolUse, path.join(toolDir, file), "file");
+
+    assert.deepEqual(await transcript.readRecent(1, sessionKey), []);
+    assert.deepEqual(
+      await transcript.readToolUse(
+        sessionKey,
+        new Date(Date.now() - 60_000),
+        new Date(Date.now() + 60_000),
+      ),
+      [],
+    );
+    assert.equal((await transcript.estimateSessionFootprint(sessionKey)).bytes, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("transcript append rejects symlinked channel ancestors", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-symlink-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-transcript-outside-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+    await symlink(outsideDir, path.join(memoryDir, "transcripts", "discord"), "dir");
+
+    const sessionKey = "agent:bot:discord:channel:secret";
+    const { file } = transcript.getTranscriptPath(sessionKey);
+
+    await assert.rejects(
+      transcript.append({
+        timestamp: "2026-05-16T12:00:00.000Z",
+        role: "user",
+        content: "hello",
+        sessionKey,
+        turnId: "turn-1",
+      }),
+      /symlink/i,
+    );
+    await assertPathMissing(path.join(outsideDir, "secret", file));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("tool-use append rejects symlinked tool roots", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-tool-symlink-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-tool-outside-"));
+  try {
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    await transcript.initialize();
+    await rm(path.join(memoryDir, "state", "tool-usage"), { recursive: true, force: true });
+    await mkdir(path.join(memoryDir, "state"), { recursive: true });
+    await symlink(outsideDir, path.join(memoryDir, "state", "tool-usage"), "dir");
+
+    const sessionKey = "agent:bot:main";
+    const { file } = transcript.getToolUsagePath(sessionKey);
+
+    await assert.rejects(
+      transcript.appendToolUse({
+        timestamp: "2026-05-16T12:00:00.000Z",
+        sessionKey,
+        tool: "memory_search",
+      }),
+      /symlink/i,
+    );
+    await assertPathMissing(path.join(outsideDir, "main", "default", file));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("tool-use append rejects symlinked state ancestors before root exists", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("directory symlink setup is platform-specific");
+    return;
+  }
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-tool-parent-symlink-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-tool-parent-outside-"));
+  try {
+    await symlink(outsideDir, path.join(memoryDir, "state"), "dir");
+
+    const transcript = new TranscriptManager(parseConfig({
+      memoryDir,
+      transcriptEnabled: true,
+    }));
+    const sessionKey = "agent:bot:main";
+    const { file } = transcript.getToolUsagePath(sessionKey);
+
+    await assert.rejects(
+      transcript.appendToolUse({
+        timestamp: "2026-05-16T12:00:00.000Z",
+        sessionKey,
+        tool: "memory_search",
+      }),
+      /symlink/i,
+    );
+    await assertPathMissing(path.join(outsideDir, "tool-usage", "main", "default", file));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- encode transcript channel/session path components before writing transcript and tool-usage files
- encode thread IDs before reading or writing thread JSON files
- add regression coverage for traversal-style session keys and thread IDs

## Verification
- pnpm exec tsx --test tests/transcript-path-safety.test.ts tests/threading.test.ts tests/transcript-footprint-cache.test.ts
- pnpm run check-types
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how transcripts, tool-usage logs, and thread JSON files are mapped to filesystem paths, including new collision-handling and symlink/path-escape checks; mistakes could cause missing data reads or unexpected new storage locations.
> 
> **Overview**
> **Hardens on-disk storage paths for transcripts/tool-usage and conversation threads.** Session/channel identifiers and `threadId`s are now percent-encoded before becoming directory/file names, preventing `..`/separator traversal and normalizing `.` handling.
> 
> Adds `storage-paths.ts` with `resolveSafeStoragePath` to ensure resolved paths stay within the configured root and do not traverse symlinks; both `TranscriptManager` and `ThreadingManager` now use it for reads/writes. Storage selection logic prefers the encoded location, falls back to *safe* legacy locations when they already contain matching data, and otherwise writes to a hashed alternate path to avoid collisions.
> 
> Thread loading/listing is made more defensive (schema-validated JSON parsing, unreadable/malformed files skipped) and `getAllThreads` de-duplicates multiple copies by `thread.id`. Extensive new tests cover traversal inputs, collisions, legacy compatibility, symlink attacks, and footprint-cache behavior across mixed legacy/encoded directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0be2f7e854a65de826c77303a23cfc398f8bc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->