### PR TITLE
Ensure QMD daemon cleanup reaps children

### DIFF
--- a/packages/remnic-core/src/qmd-daemon-cleanup.test.ts
+++ b/packages/remnic-core/src/qmd-daemon-cleanup.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { QmdClient } from "./qmd.js";
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      if (await predicate()) return;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`${message}${lastError ? `: ${String(lastError)}` : ""}`);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("QmdClient.dispose force-kills daemon children that ignore SIGTERM", async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-qmd-cleanup-"));
+  const qmdPath = path.join(tempDir, "fake-qmd.mjs");
+  const pidFile = path.join(tempDir, "qmd.pid");
+  const signalLog = path.join(tempDir, "signals.log");
+  let daemonPid: number | undefined;
+
+  t.after(async () => {
+    if (daemonPid !== undefined && processIsAlive(daemonPid)) {
+      process.kill(daemonPid, "SIGKILL");
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  await writeFile(
+    qmdPath,
+    `#!/usr/bin/env node
+import { appendFileSync, writeFileSync } from "node:fs";
+
+if (process.argv[2] === "--version") {
+  console.log("qmd 2.0.0");
+  process.exit(0);
+}
+
+if (process.argv[2] !== "mcp") {
+  process.exit(2);
+}
+
+writeFileSync(process.env.REMNIC_FAKE_QMD_PID_FILE, String(process.pid));
+process.on("SIGTERM", () => {
+  appendFileSync(process.env.REMNIC_FAKE_QMD_SIGNAL_LOG, "SIGTERM\\n");
+});
+
+let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newlineIndex;
+  while ((newlineIndex = buffer.indexOf("\\n")) !== -1) {
+    const line = buffer.slice(0, newlineIndex).trim();
+    buffer = buffer.slice(newlineIndex + 1);
+    if (!line) continue;
+    const message = JSON.parse(line);
+    if (message.method === "initialize") {
+      process.stdout.write(JSON.stringify({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          serverInfo: { name: "fake-qmd", version: "2.0.0" }
+        }
+      }) + "\\n");
+    }
+  }
+});
+
+setInterval(() => {}, 1_000);
+`,
+    { mode: 0o700 },
+  );
+  await chmod(qmdPath, 0o700);
+
+  process.env.REMNIC_FAKE_QMD_PID_FILE = pidFile;
+  process.env.REMNIC_FAKE_QMD_SIGNAL_LOG = signalLog;
+  t.after(() => {
+    delete process.env.REMNIC_FAKE_QMD_PID_FILE;
+    delete process.env.REMNIC_FAKE_QMD_SIGNAL_LOG;
+  });
+
+  const client = new QmdClient("test", 1, {
+    qmdPath,
+    daemonUrl: "stdio",
+    daemonRecheckIntervalMs: 0,
+  });
+
+  assert.equal(await client.probe(), true);
+  assert.match(client.debugStatus(), /daemon=true/);
+  daemonPid = Number(await readFile(pidFile, "utf8"));
+  assert.equal(processIsAlive(daemonPid), true);
+
+  client.dispose();
+
+  await waitFor(
+    async () => (await readFile(signalLog, "utf8")).includes("SIGTERM"),
+    "fake qmd daemon did not receive SIGTERM",
+  );
+  await waitFor(
+    () => daemonPid !== undefined && !processIsAlive(daemonPid),
+    "fake qmd daemon survived disposal escalation",
+  );
+});

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -34,6 +34,7 @@ const QMD_PROBE_TIMEOUT_MS = 8_000;
 const QMD_UPDATE_BACKOFF_MS = 15 * 60 * 1000; // 15m
 const QMD_EMBED_BACKOFF_MS = 60 * 60 * 1000; // 60m
 const QMD_CLI_WARN_THROTTLE_MS = 15 * 60 * 1000; // 15m
+const QMD_DAEMON_TERMINATE_GRACE_MS = 1_000;
 const QMD_FALLBACK_PATHS = [
   path.join(os.homedir(), ".bun", "bin", "qmd"),
   "/usr/local/bin/qmd",
@@ -630,8 +631,8 @@ class QmdDaemonSession {
     if (opts?.child && this.child !== opts.child) {
       return;
     }
-    if (opts?.killChild && !target.killed) {
-      target.kill("SIGTERM");
+    if (opts?.killChild) {
+      terminateQmdDaemonChild(target);
     }
     this.initialized = false;
     for (const [, pending] of this.pendingRequests) {
@@ -644,6 +645,37 @@ class QmdDaemonSession {
     this.child = null;
     this.buffer = "";
   }
+}
+
+function hasExited(child: CommandChildProcess): boolean {
+  return (
+    (child.exitCode !== null && child.exitCode !== undefined) ||
+    (child.signalCode !== null && child.signalCode !== undefined)
+  );
+}
+
+function terminateQmdDaemonChild(child: CommandChildProcess): void {
+  if (hasExited(child)) return;
+
+  let forceTimer: ReturnType<typeof setTimeout> | undefined;
+  const clearForceTimer = () => {
+    if (forceTimer) {
+      clearTimeout(forceTimer);
+      forceTimer = undefined;
+    }
+  };
+  child.once("close", clearForceTimer);
+
+  if (!child.killed) {
+    child.kill("SIGTERM");
+  }
+
+  forceTimer = setTimeout(() => {
+    if (!hasExited(child)) {
+      child.kill("SIGKILL");
+    }
+  }, QMD_DAEMON_TERMINATE_GRACE_MS);
+  forceTimer.unref?.();
 }
 
 /** Matches `#<hex-docid> <score>% <rest-of-line>` — rest is split in a second pass. */

--- a/packages/remnic-core/src/runtime/child-process.ts
+++ b/packages/remnic-core/src/runtime/child-process.ts
@@ -30,6 +30,7 @@ export type CommandChildProcess = {
   exitCode?: number | null;
   killed?: boolean;
   pid?: number;
+  signalCode?: NodeJS.Signals | null;
   stderr?: ProcessStream | null;
   stdin?: ProcessStream | null;
   stdout?: ProcessStream | null;


### PR DESCRIPTION
## Summary
- force-escalate QMD daemon disposal from SIGTERM to SIGKILL when a child ignores the graceful signal
- include signalCode in the benchmark child-process type so cleanup can recognize signal exits
- add a fake-QMD regression test proving dispose reaps a daemon that ignores SIGTERM

## Verification
- pnpm exec tsx --test packages/remnic-core/src/qmd-daemon-cleanup.test.ts
- pnpm exec tsx --test packages/remnic-core/src/qmd-recall-cache.test.ts packages/remnic-core/src/qmd-daemon-cleanup.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon process lifecycle management; mistakes could kill the wrong process or leave hung daemons, but the change is small and covered by a targeted regression test.
> 
> **Overview**
> **Improves QMD stdio-daemon cleanup** by escalating `QmdClient` disposal from `SIGTERM` to `SIGKILL` after a short grace period when the daemon process doesn’t exit.
> 
> Adds exit detection via `signalCode` on the `CommandChildProcess` type and introduces a regression test that runs a fake `qmd mcp` process to assert `dispose()` sends `SIGTERM` and ultimately reaps the process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816ed360cea78dea819486947f730270f73b3190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->