### PR TITLE
fix: validate server cli values

### DIFF
--- a/packages/remnic-server/bin/server-bin.js
+++ b/packages/remnic-server/bin/server-bin.js
@@ -1,4 +1,9 @@
-export async function runServerBin(commandName) {
+export function shouldPrintHelpWithoutCli(argv) {
+  return argv.length === 1 && (argv[0] === "--help" || argv[0] === "-h");
+}
+
+export async function runServerBin(commandName, options = {}) {
+  const argv = options.argv ?? process.argv.slice(2);
   const help = `
 ${commandName} - Standalone Remnic memory server
 
@@ -13,15 +18,16 @@ Options:
   --help              Show this help
 `;
 
-  if (process.argv.includes("--help") || process.argv.includes("-h")) {
-    console.log(help);
+  if (shouldPrintHelpWithoutCli(argv)) {
+    (options.stdout ?? console.log)(help);
     return;
   }
 
-  const { cliMain } = await import("../dist/index.js");
+  const loadCliMain = options.loadCliMain ?? (() => import("../dist/index.js"));
+  const { cliMain } = await loadCliMain();
 
-  await cliMain().catch((err) => {
-    process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
+  await cliMain(argv).catch((err) => {
+    (options.stderr ?? process.stderr.write.bind(process.stderr))(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+    (options.exit ?? process.exit)(1);
   });
 }

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -22,7 +22,7 @@ export interface ServerConfig {
   remnic: Record<string, unknown>;
   server: {
     host?: string;
-    port?: number;
+    port?: unknown;
     authToken?: string;
     principal?: string;
     maxBodyBytes?: number;
@@ -33,6 +33,19 @@ export interface ServerConfig {
 
 function readCompatEnv(primary: string, legacy: string): string | undefined {
   return process.env[primary] ?? process.env[legacy];
+}
+
+function parseServerPort(value: unknown, source: string): number {
+  const port = typeof value === "string" ? Number(value.trim()) : value;
+  if (
+    typeof port !== "number" ||
+    !Number.isInteger(port) ||
+    port < 1 ||
+    port > 65535
+  ) {
+    throw new Error(`Invalid ${source}: expected an integer port from 1 to 65535`);
+  }
+  return port;
 }
 
 function resolveConfigPath(cliPath?: string): string {
@@ -70,7 +83,7 @@ function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Record<str
   const port = readCompatEnv("REMNIC_PORT", "ENGRAM_PORT");
   const host = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST");
   const authToken = readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN");
-  if (port) overrides.port = parseInt(port, 10);
+  if (port) overrides.port = port;
   if (host) overrides.host = host;
   if (authToken) overrides.authToken = authToken;
 
@@ -128,16 +141,28 @@ export async function startServer(options?: {
     : { remnic: {}, server: {} };
 
   const env = envOverrides();
+  const { remnic: envRemnic, ...envServer } = env;
 
   // Merge: file < env < cli flags
-  const remnicConfig = { ...fileConfig.remnic, ...(env.remnic ?? {}) };
+  const remnicConfig = { ...fileConfig.remnic, ...(envRemnic ?? {}) };
+  const cliServerConfig: Partial<ServerConfig["server"]> = {};
+  if (options?.host !== undefined) cliServerConfig.host = options.host;
+  if (options?.port !== undefined) cliServerConfig.port = parseServerPort(options.port, "options.port");
+  if (options?.authToken !== undefined) cliServerConfig.authToken = options.authToken;
+
   const serverConfig = {
     ...fileConfig.server,
-    ...env,
-    ...(options?.host ? { host: options.host } : {}),
-    ...(options?.port ? { port: options.port } : {}),
-    ...(options?.authToken ? { authToken: options.authToken } : {}),
+    ...envServer,
+    ...cliServerConfig,
   };
+  const portSource = cliServerConfig.port !== undefined
+    ? "options.port"
+    : envServer.port !== undefined
+      ? "REMNIC_PORT/ENGRAM_PORT"
+      : "server.port";
+  const serverPort = serverConfig.port === undefined
+    ? 4318
+    : parseServerPort(serverConfig.port, portSource);
 
   const config = parseConfig(remnicConfig);
   const orchestrator = new Orchestrator(config);
@@ -158,7 +183,7 @@ export async function startServer(options?: {
   const httpServer = new EngramAccessHttpServer({
     service,
     host: serverConfig.host ?? "127.0.0.1",
-    port: serverConfig.port ?? 4318,
+    port: serverPort,
     authToken: authToken || undefined,
     authTokensGetter: () => getAllValidTokensCached(),
     principal: serverConfig.principal,
@@ -235,10 +260,10 @@ export async function startServer(options?: {
       }
 
       log.warn("QMD startup-sync retry: exhausted all retries; search index may be stale");
-    })().catch((err) => {
+    })().catch((err: unknown) => {
       log.warn(`QMD startup-sync retry: unexpected error: ${err}`);
     });
-  }).catch((err) => {
+  }).catch((err: unknown) => {
     log.warn(`Deferred init error: ${err}`);
   });
 
@@ -247,19 +272,47 @@ export async function startServer(options?: {
 
 // ── CLI entry point ──────────────────────────────────────────────────────────
 
+const BOOLEAN_CLI_OPTIONS = new Set(["help"]);
+const VALUE_CLI_OPTIONS = new Set(["config", "host", "port", "auth-token"]);
+
 function parseCliArgs(argv: string[]): Record<string, string | undefined> {
   const args: Record<string, string | undefined> = {};
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i];
+    if (token === "-h") {
+      args.help = "true";
+      continue;
+    }
+
     if (token.startsWith("--")) {
-      const key = token.slice(2);
-      const next = argv[i + 1];
-      if (next && !next.startsWith("--")) {
-        args[key] = next;
-        i++;
-      } else {
-        args[key] = "true";
+      const [key, inlineValue] = token.slice(2).split(/=(.*)/s, 2);
+      if (!key) {
+        throw new Error(`Invalid option ${token}`);
       }
+
+      if (BOOLEAN_CLI_OPTIONS.has(key)) {
+        if (inlineValue !== undefined) {
+          throw new Error(`Option --${key} does not accept a value`);
+        }
+        args[key] = "true";
+        continue;
+      }
+
+      if (!VALUE_CLI_OPTIONS.has(key)) {
+        throw new Error(`Unknown option --${key}`);
+      }
+
+      const value = inlineValue ?? argv[i + 1];
+      if (
+        value === undefined ||
+        (inlineValue === undefined && value.startsWith("--")) ||
+        value.trim() === ""
+      ) {
+        throw new Error(`Missing value for --${key}`);
+      }
+
+      args[key] = value;
+      if (inlineValue === undefined) i++;
     }
   }
   return args;
@@ -296,7 +349,7 @@ Environment:
   const result = await startServer({
     configPath: args.config,
     host: args.host,
-    port: args.port ? parseInt(args.port, 10) : undefined,
+    port: args.port === undefined ? undefined : parseServerPort(args.port, "--port"),
     authToken: args["auth-token"],
   });
 

--- a/tests/remnic-server-cli.test.ts
+++ b/tests/remnic-server-cli.test.ts
@@ -1,0 +1,197 @@
+import test, { type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import net from "node:net";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { cliMain, startServer } from "../packages/remnic-server/src/index.js";
+import { runServerBin } from "../packages/remnic-server/bin/server-bin.js";
+
+function restoreEnv(t: TestContext, keys: string[]): void {
+  const snapshot = new Map(keys.map((key) => [key, process.env[key]]));
+  t.after(() => {
+    for (const [key, value] of snapshot) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        if (!address || typeof address === "string") {
+          reject(new Error("Failed to allocate a free TCP port"));
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+test("remnic-server CLI rejects documented value options without values", async () => {
+  for (const option of ["--config", "--host", "--port", "--auth-token"]) {
+    await assert.rejects(
+      () => cliMain([option]),
+      new RegExp(`Missing value for ${option}`),
+      `${option} should require a following value`,
+    );
+
+    await assert.rejects(
+      () => cliMain([option, "--help"]),
+      new RegExp(`Missing value for ${option}`),
+      `${option} should not consume the next option as its value`,
+    );
+  }
+});
+
+test("remnic-server CLI rejects empty inline values", async () => {
+  await assert.rejects(
+    () => cliMain(["--auth-token="]),
+    /Missing value for --auth-token/,
+  );
+});
+
+test("remnic-server CLI accepts inline values that look like options", async () => {
+  await assert.rejects(
+    () => cliMain(["--auth-token=--some-secret", "--port", "0"]),
+    /Invalid --port: expected an integer port from 1 to 65535/,
+  );
+});
+
+test("remnic-server CLI rejects invalid port values before startup", async () => {
+  for (const port of ["0", "65536", "3.7", "abc"]) {
+    await assert.rejects(
+      () => cliMain(["--port", port]),
+      /Invalid --port: expected an integer port from 1 to 65535/,
+      `port ${port} should be rejected`,
+    );
+  }
+});
+
+test("remnic-server CLI rejects unknown long options", async () => {
+  await assert.rejects(
+    () => cliMain(["--auth-tokn", "secret"]),
+    /Unknown option --auth-tokn/,
+  );
+});
+
+test("remnic-server bin wrapper delegates help-mixed value flags to CLI validation", async () => {
+  let stderr = "";
+  let exitCode: number | undefined;
+  let receivedArgv: string[] | undefined;
+
+  await assert.rejects(
+    () =>
+      runServerBin("remnic-server", {
+        argv: ["--auth-token", "--help"],
+        loadCliMain: async () => ({
+          cliMain: async (argv: string[]) => {
+            receivedArgv = argv;
+            throw new Error("Missing value for --auth-token");
+          },
+        }),
+        stderr: (value: string) => {
+          stderr += value;
+        },
+        exit: (code: number) => {
+          exitCode = code;
+          throw new Error(`exit ${code}`);
+        },
+      }),
+    /exit 1/,
+  );
+
+  assert.deepEqual(receivedArgv, ["--auth-token", "--help"]);
+  assert.equal(exitCode, 1);
+  assert.match(stderr, /Missing value for --auth-token/);
+});
+
+test("startServer rejects invalid direct option ports before initializing", async (t) => {
+  restoreEnv(t, ["REMNIC_PORT", "ENGRAM_PORT"]);
+  delete process.env.REMNIC_PORT;
+  delete process.env.ENGRAM_PORT;
+
+  await assert.rejects(
+    () =>
+      startServer({
+        configPath: path.join(os.tmpdir(), "remnic-missing-config.json"),
+        port: 0,
+      }),
+    /Invalid options\.port: expected an integer port from 1 to 65535/,
+  );
+});
+
+test("startServer lets direct option port override invalid environment ports", async (t) => {
+  restoreEnv(t, [
+    "REMNIC_PORT",
+    "ENGRAM_PORT",
+    "REMNIC_MEMORY_DIR",
+    "ENGRAM_MEMORY_DIR",
+    "REMNIC_AUTH_TOKEN",
+    "ENGRAM_AUTH_TOKEN",
+  ]);
+  process.env.REMNIC_PORT = "abc";
+  delete process.env.ENGRAM_PORT;
+  delete process.env.ENGRAM_MEMORY_DIR;
+  process.env.REMNIC_AUTH_TOKEN = "test-token";
+  delete process.env.ENGRAM_AUTH_TOKEN;
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-env-port-"));
+  process.env.REMNIC_MEMORY_DIR = tempDir;
+  const port = await getFreePort();
+  const result = await startServer({
+    configPath: path.join(tempDir, "missing-config.json"),
+    port,
+  });
+
+  try {
+    assert.equal(result.port, port);
+  } finally {
+    result.cancelStartupSync();
+    result.abortDeferredInit();
+    await result.httpServer.stop();
+  }
+});
+
+test("startServer rejects invalid environment ports before initializing", async (t) => {
+  restoreEnv(t, ["REMNIC_PORT", "ENGRAM_PORT"]);
+  process.env.REMNIC_PORT = "abc";
+  delete process.env.ENGRAM_PORT;
+
+  await assert.rejects(
+    () =>
+      startServer({
+        configPath: path.join(os.tmpdir(), "remnic-missing-config.json"),
+      }),
+    /Invalid REMNIC_PORT\/ENGRAM_PORT: expected an integer port from 1 to 65535/,
+  );
+});
+
+test("startServer rejects invalid config file ports before initializing", async (t) => {
+  restoreEnv(t, ["REMNIC_PORT", "ENGRAM_PORT"]);
+  delete process.env.REMNIC_PORT;
+  delete process.env.ENGRAM_PORT;
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-config-port-"));
+  const configPath = path.join(tempDir, "remnic.config.json");
+  await writeFile(configPath, JSON.stringify({ server: { port: "abc" } }), "utf8");
+
+  await assert.rejects(
+    () => startServer({ configPath }),
+    /Invalid server\.port: expected an integer port from 1 to 65535/,
+  );
+});


### PR DESCRIPTION
## Summary
- reject missing values for documented remnic-server CLI value flags before server startup
- validate server ports from CLI, env, direct options, and config files as integers in the 1-65535 range
- add regression coverage for missing auth-token values and invalid ports

## Findings addressed
- clawpatch high: Missing auth token value becomes the literal bearer token `true`
- related medium: invalid port inputs are silently coerced
- related medium: required CLI values can fall through as literal auth tokens or invalid ports

## Verification
- pnpm exec tsx --test tests/remnic-server-cli.test.ts
- pnpm run check-types
- pnpm --filter @remnic/core run build && pnpm --filter @remnic/server run check-types && pnpm --filter @remnic/server run build
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI parsing and server startup validation, which may break existing invocation patterns (e.g., previously-tolerated flags/values) but is limited to argument/config handling before the server starts.
> 
> **Overview**
> **Hardens `remnic-server` argument parsing and startup validation.** The CLI now validates known long options (including `--key=value`), rejects unknown flags and missing/empty values for value options, and validates `--port` as an integer in the `1..65535` range.
> 
> Server startup now validates `server.port` consistently across config file, environment variables, and direct `startServer` options (with clearer error sources) and ensures the bin wrapper only prints help without invoking the CLI when `--help`/`-h` is the sole argument. Adds regression tests covering missing `--auth-token` values and invalid port handling/precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45b47f177fbbbeb68b30359e8521e24adef34eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->