### PR TITLE
fix: harden eval shadow paths

### DIFF
--- a/packages/remnic-core/src/evals.ts
+++ b/packages/remnic-core/src/evals.ts
@@ -277,6 +277,34 @@ function assertSafeBenchmarkId(benchmarkId: string): string {
   return assertSafePathSegment(benchmarkId, "benchmarkId");
 }
 
+const ISO_UTC_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+function assertIsoTimestamp(value: unknown, field: string): string {
+  const timestamp = assertString(value, field);
+  if (!ISO_UTC_TIMESTAMP_RE.test(timestamp)) {
+    throw new Error(`${field} must be a valid ISO timestamp`);
+  }
+  const parsed = Date.parse(timestamp);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${field} must be a valid ISO timestamp`);
+  }
+  const normalized = new Date(parsed).toISOString();
+  if (normalized !== timestamp) {
+    throw new Error(`${field} must be a valid ISO timestamp`);
+  }
+  return normalized;
+}
+
+function assertPathWithin(rootDir: string, targetPath: string, field: string): void {
+  const resolvedRoot = path.resolve(rootDir);
+  const resolvedTarget = path.resolve(targetPath);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+    return;
+  }
+  throw new Error(`${field} must stay within ${rootDir}`);
+}
+
 export function validateEvalBenchmarkManifest(
   raw: unknown,
   options?: { memoryRedTeamBenchEnabled?: boolean },
@@ -497,8 +525,8 @@ export function validateEvalShadowRecallRecord(raw: unknown): EvalShadowRecallRe
 
   return {
     schemaVersion: 1,
-    traceId: assertString(raw.traceId, "traceId"),
-    recordedAt: assertString(raw.recordedAt, "recordedAt"),
+    traceId: assertSafePathSegment(assertString(raw.traceId, "traceId"), "traceId"),
+    recordedAt: assertIsoTimestamp(raw.recordedAt, "recordedAt"),
     sessionKey: assertString(raw.sessionKey, "sessionKey"),
     promptHash: assertString(raw.promptHash, "promptHash"),
     promptLength,
@@ -896,8 +924,10 @@ export async function recordEvalShadowRecall(options: {
   const rootDir = resolveEvalStoreDir(options.memoryDir, options.evalStoreDir);
   const validated = validateEvalShadowRecallRecord(options.record);
   const day = validated.recordedAt.slice(0, 10);
-  const shadowDir = path.join(rootDir, "shadow", day);
+  const shadowRoot = path.join(rootDir, "shadow");
+  const shadowDir = path.join(shadowRoot, day);
   const targetPath = path.join(shadowDir, `${validated.traceId}.json`);
+  assertPathWithin(shadowRoot, targetPath, "shadow recall record path");
   await mkdir(shadowDir, { recursive: true });
   await writeFile(targetPath, JSON.stringify(validated, null, 2), "utf-8");
   return targetPath;

--- a/tests/evals-shadow-recording.test.ts
+++ b/tests/evals-shadow-recording.test.ts
@@ -2,10 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp } from "node:fs/promises";
+import { access, mkdtemp, readFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
-import { getEvalHarnessStatus } from "../src/evals.js";
+import { getEvalHarnessStatus, recordEvalShadowRecall, type EvalShadowRecallRecord } from "../src/evals.js";
 
 async function waitForShadowCount(options: {
   memoryDir: string;
@@ -28,6 +28,40 @@ async function waitForShadowCount(options: {
       return status;
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+function makeShadowRecord(overrides: Partial<EvalShadowRecallRecord> = {}): EvalShadowRecallRecord {
+  return {
+    schemaVersion: 1,
+    traceId: "trace-001",
+    recordedAt: "2026-03-06T10:03:00.000Z",
+    sessionKey: "agent:main",
+    promptHash: "prompt-hash",
+    promptLength: 42,
+    retrievalQueryHash: "query-hash",
+    retrievalQueryLength: 19,
+    recallMode: "full",
+    recallResultLimit: 8,
+    source: "hot_qmd",
+    recalledMemoryCount: 1,
+    injected: true,
+    contextChars: 120,
+    memoryIds: ["mem-1"],
+    durationMs: 12,
+    ...overrides,
+  };
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
   }
 }
 
@@ -176,4 +210,48 @@ test("shadow recall recording includes no_recall decisions", async () => {
   assert.equal(status.latestShadow?.source, "none");
   assert.equal(status.latestShadow?.injected, false);
   assert.deepEqual(status.latestShadow?.memoryIds, []);
+});
+
+test("recordEvalShadowRecall writes valid records under the dated shadow directory", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-evals-shadow-safe-"));
+  const evalStoreDir = path.join(memoryDir, "evals");
+
+  const targetPath = await recordEvalShadowRecall({
+    memoryDir,
+    evalStoreDir,
+    record: makeShadowRecord(),
+  });
+
+  assert.equal(targetPath, path.join(evalStoreDir, "shadow", "2026-03-06", "trace-001.json"));
+  const written = JSON.parse(await readFile(targetPath, "utf8")) as EvalShadowRecallRecord;
+  assert.equal(written.traceId, "trace-001");
+  assert.equal(written.recordedAt, "2026-03-06T10:03:00.000Z");
+});
+
+test("recordEvalShadowRecall rejects path traversal in shadow path components", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-evals-shadow-traversal-"));
+  const evalStoreDir = path.join(memoryDir, "evals");
+  const escapePath = path.join(memoryDir, "escape.json");
+
+  await assert.rejects(
+    () =>
+      recordEvalShadowRecall({
+        memoryDir,
+        evalStoreDir,
+        record: makeShadowRecord({ traceId: "../escape" }),
+      }),
+    /traceId must be a safe path segment/,
+  );
+  assert.equal(await pathExists(escapePath), false);
+
+  await assert.rejects(
+    () =>
+      recordEvalShadowRecall({
+        memoryDir,
+        evalStoreDir,
+        record: makeShadowRecord({ recordedAt: "../../escape" }),
+      }),
+    /recordedAt must be a valid ISO timestamp/,
+  );
+  assert.equal(await pathExists(path.join(memoryDir, "escape", "trace-001.json")), false);
 });


### PR DESCRIPTION
## Summary
- validate eval shadow trace IDs as safe path segments
- require UTC ISO timestamps before deriving shadow day directories
- assert shadow recall writes stay under the shadow root
- add direct regression coverage for valid writes and traversal rejection

## Findings addressed
- clawpatch: Eval shadow recall can write outside the shadow ledger via unsanitized traceId/recordedAt
- clawpatch: Shadow recall recording permits path traversal through traceId and recordedAt

## Verification
- pnpm exec tsx --test tests/evals-shadow-recording.test.ts
- pnpm run check-types
- pnpm --filter @remnic/core run build
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens validation around filesystem write paths and timestamps, which is security-relevant and may cause previously accepted shadow records to be rejected as invalid.
> 
> **Overview**
> **Hardens eval shadow recall recording against path traversal.** `validateEvalShadowRecallRecord` now requires `traceId` to be a safe path segment and `recordedAt` to be a strictly normalized UTC ISO timestamp before deriving the day directory.
> 
> `recordEvalShadowRecall` now asserts the computed output path stays within the `shadow` root, and tests add regression coverage for a valid write plus rejection of traversal attempts via `traceId` and `recordedAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b452e1412a1dd1362222742ab629590022b3985a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->