### PR TITLE
fix: secure migrated token stores

### DIFF
--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -395,7 +395,13 @@ async function backupFile(
   const digest = createHash("sha256").update(targetPath).digest("hex").slice(0, 12);
   const backupPath = path.join(backupRoot(homeDir), "mcp", `${digest}.json`);
   await ensureParent(backupPath);
-  await writeOwnerOnlyFile(backupPath, originalContent);
+  if (isRemnicTokenStorePath(targetPath, homeDir)) {
+    await writeOwnerOnlyFile(backupPath, originalContent);
+  } else {
+    const originalMode = (await stat(targetPath)).mode & 0o777;
+    await writeFile(backupPath, originalContent, { encoding: "utf8", mode: originalMode });
+    await chmod(backupPath, originalMode);
+  }
   manifest.entries.push({ targetPath, backupPath });
 }
 

--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
 import {
+  chmod,
   copyFile,
   mkdir,
   open,
@@ -63,6 +64,7 @@ const BACKUP_DIR = ".backup";
 const LOCK_RETRY_MS = 100;
 const LOCK_STALE_MS = 30_000;
 const LOCK_TIMEOUT_MS = 5_000;
+const TOKEN_STORE_MODE = 0o600;
 
 function resolvePlatform(options?: MigrationOptions): NodeJS.Platform {
   return options?.platform ?? process.platform;
@@ -134,6 +136,23 @@ async function ensureParent(filePath: string): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
 }
 
+async function secureTokenFilePermissions(filePath: string): Promise<void> {
+  await chmod(filePath, TOKEN_STORE_MODE);
+}
+
+async function writeOwnerOnlyFile(filePath: string, content: string): Promise<void> {
+  await writeFile(filePath, content, { encoding: "utf8", mode: TOKEN_STORE_MODE });
+  await chmod(filePath, TOKEN_STORE_MODE);
+}
+
+async function writeTokenStoreFile(filePath: string, content: string): Promise<void> {
+  await writeOwnerOnlyFile(filePath, content);
+}
+
+function isRemnicTokenStorePath(filePath: string, homeDir: string): boolean {
+  return path.resolve(filePath) === path.resolve(path.join(remnicRoot(homeDir), "tokens.json"));
+}
+
 async function copyTreeMissing(source: string, destination: string, copied: string[]): Promise<void> {
   if (!existsSync(source)) return;
   const sourceStat = await stat(source);
@@ -203,6 +222,7 @@ function parseTokenEntries(raw: unknown): TokenEntry[] {
 
 async function rewriteTokensIfPresent(filePath: string): Promise<number> {
   if (!existsSync(filePath)) return 0;
+  await secureTokenFilePermissions(filePath);
   let raw: Record<string, unknown>;
   try {
     raw = JSON.parse(await readFile(filePath, "utf8")) as Record<string, unknown>;
@@ -234,7 +254,7 @@ async function rewriteTokensIfPresent(filePath: string): Promise<number> {
   }
 
   if (rewritten > 0) {
-    await writeFile(filePath, `${JSON.stringify(raw, null, 2)}\n`, "utf8");
+    await writeTokenStoreFile(filePath, `${JSON.stringify(raw, null, 2)}\n`);
   }
   return rewritten;
 }
@@ -278,10 +298,9 @@ async function mergeLegacyTokens(
       await backupFile(remnicTokensPath, originalRemnic, homeDir, manifest);
     }
 
-    await writeFile(
+    await writeTokenStoreFile(
       remnicTokensPath,
       `${JSON.stringify({ tokens: recoveredEntries }, null, 2)}\n`,
-      "utf8",
     );
     return rewritten;
   }
@@ -318,10 +337,9 @@ async function mergeLegacyTokens(
     await backupFile(remnicTokensPath, originalRemnic, homeDir, manifest);
   }
 
-  await writeFile(
+  await writeTokenStoreFile(
     remnicTokensPath,
     `${JSON.stringify({ tokens: mergedEntries }, null, 2)}\n`,
-    "utf8",
   );
   return rewritten;
 }
@@ -376,7 +394,7 @@ async function backupFile(
   const digest = createHash("sha256").update(targetPath).digest("hex").slice(0, 12);
   const backupPath = path.join(backupRoot(homeDir), "mcp", `${digest}.json`);
   await ensureParent(backupPath);
-  await writeFile(backupPath, originalContent, "utf8");
+  await writeOwnerOnlyFile(backupPath, originalContent);
   manifest.entries.push({ targetPath, backupPath });
 }
 
@@ -593,6 +611,9 @@ export async function rollbackFromEngramMigration(options?: MigrationOptions): P
     if (entry.backupPath && existsSync(entry.backupPath)) {
       await ensureParent(entry.targetPath);
       await copyFile(entry.backupPath, entry.targetPath);
+      if (isRemnicTokenStorePath(entry.targetPath, homeDir)) {
+        await secureTokenFilePermissions(entry.targetPath);
+      }
       restored.push(entry.targetPath);
       continue;
     }

--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -267,6 +267,7 @@ async function mergeLegacyTokens(
   backupExisting: boolean,
 ): Promise<number> {
   if (!existsSync(remnicTokensPath)) return 0;
+  await secureTokenFilePermissions(remnicTokensPath);
   if (!existsSync(legacyTokensPath)) return rewriteTokensIfPresent(remnicTokensPath);
 
   let remnicRaw: unknown;

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { chmod, mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import {
   migrateFromEngram,
@@ -11,6 +11,18 @@ import {
 
 async function makeTempHome(prefix: string): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+async function setModeIfPosix(filePath: string, mode: number): Promise<void> {
+  if (process.platform !== "win32") {
+    await chmod(filePath, mode);
+  }
+}
+
+async function assertOwnerOnlyMode(filePath: string): Promise<void> {
+  if (process.platform === "win32") return;
+  const mode = (await stat(filePath)).mode & 0o777;
+  assert.equal(mode, 0o600, `${filePath} should be owner-only`);
 }
 
 test("migrateFromEngram returns fresh-install when no legacy Engram state exists", async () => {
@@ -44,8 +56,9 @@ test("migrateFromEngram copies legacy state, rewrites tokens, updates connector 
   await mkdir(path.dirname(codexConfig), { recursive: true });
   await mkdir(path.dirname(legacyLaunchAgent), { recursive: true });
 
+  const legacyTokensPath = path.join(legacyRoot, "tokens.json");
   await writeFile(
-    path.join(legacyRoot, "tokens.json"),
+    legacyTokensPath,
     JSON.stringify({
       tokens: [
         { connector: "claude-code", token: "engram_cc_abc123", createdAt: "2026-04-08T00:00:00.000Z" },
@@ -53,6 +66,7 @@ test("migrateFromEngram copies legacy state, rewrites tokens, updates connector 
     }),
     "utf8",
   );
+  await setModeIfPosix(legacyTokensPath, 0o644);
   await writeFile(path.join(legacyRoot, "logs", "daemon.log"), "legacy log\n", "utf8");
   await writeFile(
     legacyConfig,
@@ -121,10 +135,12 @@ test("migrateFromEngram copies legacy state, rewrites tokens, updates connector 
   assert.ok(existsSync(path.join(homeDir, "Library", "LaunchAgents", "ai.remnic.daemon.plist")));
   assert.deepEqual(result.servicesReinstalled, ["ai.remnic.daemon"]);
 
-  const tokens = JSON.parse(await readFile(path.join(homeDir, ".remnic", "tokens.json"), "utf8")) as {
+  const remnicTokensPath = path.join(homeDir, ".remnic", "tokens.json");
+  const tokens = JSON.parse(await readFile(remnicTokensPath, "utf8")) as {
     tokens: Array<{ token: string }>;
   };
   assert.equal(tokens.tokens[0]?.token, "remnic_cc_abc123");
+  await assertOwnerOnlyMode(remnicTokensPath);
 
   const migratedConfig = JSON.parse(await readFile(path.join(homeDir, ".config", "remnic", "config.json"), "utf8")) as {
     remnic?: { memoryDir?: string };
@@ -168,10 +184,77 @@ test("migrateFromEngram is idempotent after the marker is written", async () => 
   assert.equal(second.status, "already-migrated");
 });
 
+test("migrateFromEngram tightens copied token store permissions even when tokens do not need rewriting", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-token-copy-mode-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const legacyTokensPath = path.join(legacyRoot, "tokens.json");
+  const remnicTokensPath = path.join(remnicRoot, "tokens.json");
+
+  await mkdir(legacyRoot, { recursive: true });
+  await writeFile(
+    legacyTokensPath,
+    JSON.stringify({
+      tokens: [
+        { connector: "claude-code", token: "remnic_cc_already", createdAt: "2026-04-08T00:00:00.000Z" },
+      ],
+    }),
+    "utf8",
+  );
+  await setModeIfPosix(legacyTokensPath, 0o644);
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.equal(result.tokensRegenerated, 0);
+  await assertOwnerOnlyMode(remnicTokensPath);
+});
+
+test("migrateFromEngram tightens rewritten existing token store permissions without legacy tokens", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-token-rewrite-mode-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const remnicTokensPath = path.join(remnicRoot, "tokens.json");
+
+  await mkdir(legacyRoot, { recursive: true });
+  await mkdir(remnicRoot, { recursive: true });
+  await writeFile(
+    remnicTokensPath,
+    JSON.stringify({
+      tokens: [
+        { connector: "openclaw", token: "engram_oc_existing", createdAt: "2026-04-09T00:00:00.000Z" },
+      ],
+    }),
+    "utf8",
+  );
+  await setModeIfPosix(remnicTokensPath, 0o644);
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.equal(result.tokensRegenerated, 1);
+  const tokens = JSON.parse(await readFile(remnicTokensPath, "utf8")) as {
+    tokens: Array<{ connector: string; token: string }>;
+  };
+  assert.deepEqual(tokens.tokens.map(({ connector, token }) => ({ connector, token })), [
+    { connector: "openclaw", token: "remnic_oc_existing" },
+  ]);
+  await assertOwnerOnlyMode(remnicTokensPath);
+});
+
 test("migrateFromEngram merges legacy tokens into an existing remnic token store", async () => {
   const homeDir = await makeTempHome("remnic-migrate-token-merge-");
   const legacyRoot = path.join(homeDir, ".engram");
   const remnicRoot = path.join(homeDir, ".remnic");
+  const remnicTokensPath = path.join(remnicRoot, "tokens.json");
 
   await mkdir(legacyRoot, { recursive: true });
   await mkdir(remnicRoot, { recursive: true });
@@ -186,7 +269,7 @@ test("migrateFromEngram merges legacy tokens into an existing remnic token store
     "utf8",
   );
   await writeFile(
-    path.join(remnicRoot, "tokens.json"),
+    remnicTokensPath,
     JSON.stringify({
       tokens: [
         { connector: "claude-code", token: "remnic_cc_current", createdAt: "2026-04-09T00:00:00.000Z" },
@@ -195,6 +278,7 @@ test("migrateFromEngram merges legacy tokens into an existing remnic token store
     }),
     "utf8",
   );
+  await setModeIfPosix(remnicTokensPath, 0o644);
 
   const result = await migrateFromEngram({
     homeDir,
@@ -205,7 +289,7 @@ test("migrateFromEngram merges legacy tokens into an existing remnic token store
   assert.equal(result.status, "migrated");
   assert.equal(result.tokensRegenerated, 3);
 
-  const tokens = JSON.parse(await readFile(path.join(remnicRoot, "tokens.json"), "utf8")) as {
+  const tokens = JSON.parse(await readFile(remnicTokensPath, "utf8")) as {
     tokens: Array<{ connector: string; token: string }>;
   };
   assert.deepEqual(tokens.tokens.map(({ connector, token }) => ({ connector, token })), [
@@ -213,12 +297,25 @@ test("migrateFromEngram merges legacy tokens into an existing remnic token store
     { connector: "openclaw", token: "remnic_oc_existing" },
     { connector: "codex", token: "remnic_cx_legacy" },
   ]);
+  await assertOwnerOnlyMode(remnicTokensPath);
+
+  const manifest = JSON.parse(await readFile(path.join(remnicRoot, ".rollback.json"), "utf8")) as {
+    entries: Array<{ targetPath: string; backupPath?: string }>;
+  };
+  const tokenBackupPath = manifest.entries.find((entry) => entry.targetPath === remnicTokensPath)?.backupPath;
+  assert.ok(tokenBackupPath, "expected token store backup in rollback manifest");
+  await assertOwnerOnlyMode(tokenBackupPath);
+
+  const rollback = await rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true });
+  assert.ok(rollback.restored.includes(remnicTokensPath));
+  await assertOwnerOnlyMode(remnicTokensPath);
 });
 
 test("migrateFromEngram recovers from a malformed remnic token store by rebuilding from legacy tokens", async () => {
   const homeDir = await makeTempHome("remnic-migrate-token-recovery-");
   const legacyRoot = path.join(homeDir, ".engram");
   const remnicRoot = path.join(homeDir, ".remnic");
+  const remnicTokensPath = path.join(remnicRoot, "tokens.json");
 
   await mkdir(legacyRoot, { recursive: true });
   await mkdir(remnicRoot, { recursive: true });
@@ -232,7 +329,8 @@ test("migrateFromEngram recovers from a malformed remnic token store by rebuildi
     }),
     "utf8",
   );
-  await writeFile(path.join(remnicRoot, "tokens.json"), "{", "utf8");
+  await writeFile(remnicTokensPath, "{", "utf8");
+  await setModeIfPosix(remnicTokensPath, 0o644);
 
   const result = await migrateFromEngram({
     homeDir,
@@ -243,13 +341,14 @@ test("migrateFromEngram recovers from a malformed remnic token store by rebuildi
   assert.equal(result.status, "migrated");
   assert.equal(result.tokensRegenerated, 2);
 
-  const tokens = JSON.parse(await readFile(path.join(remnicRoot, "tokens.json"), "utf8")) as {
+  const tokens = JSON.parse(await readFile(remnicTokensPath, "utf8")) as {
     tokens: Array<{ connector: string; token: string }>;
   };
   assert.deepEqual(tokens.tokens.map(({ connector, token }) => ({ connector, token })), [
     { connector: "claude-code", token: "remnic_cc_legacy" },
     { connector: "codex", token: "remnic_cx_legacy" },
   ]);
+  await assertOwnerOnlyMode(remnicTokensPath);
 });
 
 test("migrateFromEngram clears malformed migration locks before acquiring a fresh lock", async () => {

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -20,9 +20,17 @@ async function setModeIfPosix(filePath: string, mode: number): Promise<void> {
 }
 
 async function assertOwnerOnlyMode(filePath: string): Promise<void> {
+  await assertFileMode(filePath, 0o600);
+}
+
+async function assertFileMode(filePath: string, expectedMode: number): Promise<void> {
   if (process.platform === "win32") return;
   const mode = (await stat(filePath)).mode & 0o777;
-  assert.equal(mode, 0o600, `${filePath} should be owner-only`);
+  assert.equal(
+    mode,
+    expectedMode,
+    `${filePath} should have mode ${expectedMode.toString(8)}`,
+  );
 }
 
 test("migrateFromEngram returns fresh-install when no legacy Engram state exists", async () => {
@@ -488,6 +496,7 @@ test("rollbackFromEngramMigration restores backed up connector configs and remov
     }),
     "utf8",
   );
+  await setModeIfPosix(claudeConfig, 0o644);
   await writeFile(legacyLaunchAgent, "<plist>ai.engram.daemon</plist>", "utf8");
 
   await migrateFromEngram({
@@ -498,6 +507,13 @@ test("rollbackFromEngramMigration restores backed up connector configs and remov
     connectorConfigPaths: [claudeConfig],
     execCommand: () => undefined,
   });
+
+  const manifest = JSON.parse(await readFile(path.join(homeDir, ".remnic", ".rollback.json"), "utf8")) as {
+    entries: Array<{ targetPath: string; backupPath?: string }>;
+  };
+  const configBackupPath = manifest.entries.find((entry) => entry.targetPath === claudeConfig)?.backupPath;
+  assert.ok(configBackupPath, "expected connector config backup in rollback manifest");
+  await assertFileMode(configBackupPath, 0o644);
 
   const rollback = await rollbackFromEngramMigration({
     homeDir,
@@ -516,6 +532,7 @@ test("rollbackFromEngramMigration restores backed up connector configs and remov
   };
   assert.ok(restoredClaudeConfig.mcpServers.engram);
   assert.equal(restoredClaudeConfig.mcpServers.remnic, undefined);
+  await assertFileMode(claudeConfig, 0o644);
 });
 
 test("rollbackFromEngramMigration reloads systemd after removing migrated unit files", async () => {

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -250,6 +250,51 @@ test("migrateFromEngram tightens rewritten existing token store permissions with
   await assertOwnerOnlyMode(remnicTokensPath);
 });
 
+test("migrateFromEngram tightens unchanged merged token store permissions", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-token-unchanged-merge-mode-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const remnicTokensPath = path.join(remnicRoot, "tokens.json");
+
+  await mkdir(legacyRoot, { recursive: true });
+  await mkdir(remnicRoot, { recursive: true });
+  await writeFile(
+    path.join(legacyRoot, "tokens.json"),
+    JSON.stringify({
+      tokens: [
+        { connector: "claude-code", token: "remnic_cc_legacy", createdAt: "2026-04-08T00:00:00.000Z" },
+      ],
+    }),
+    "utf8",
+  );
+  await writeFile(
+    remnicTokensPath,
+    JSON.stringify({
+      tokens: [
+        { connector: "claude-code", token: "remnic_cc_current", createdAt: "2026-04-09T00:00:00.000Z" },
+      ],
+    }),
+    "utf8",
+  );
+  await setModeIfPosix(remnicTokensPath, 0o644);
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.equal(result.tokensRegenerated, 0);
+  const tokens = JSON.parse(await readFile(remnicTokensPath, "utf8")) as {
+    tokens: Array<{ connector: string; token: string }>;
+  };
+  assert.deepEqual(tokens.tokens.map(({ connector, token }) => ({ connector, token })), [
+    { connector: "claude-code", token: "remnic_cc_current" },
+  ]);
+  await assertOwnerOnlyMode(remnicTokensPath);
+});
+
 test("migrateFromEngram merges legacy tokens into an existing remnic token store", async () => {
   const homeDir = await makeTempHome("remnic-migrate-token-merge-");
   const legacyRoot = path.join(homeDir, ".engram");


### PR DESCRIPTION
## Summary
- write migrated Remnic token stores with owner-only permissions
- tighten copied or rewritten token stores before and after migration writes
- keep rollback backups and restored Remnic token stores owner-only
- add migration regression coverage for copied, rewritten, merged, recovered, backed-up, and restored token stores

## Finding addressed
- clawpatch: Token migration writes auth tokens without tightening file permissions

## Verification
- pnpm exec tsx --test tests/remnic-migration.test.ts
- pnpm run check-types
- pnpm --filter @remnic/core run build
- pnpm rebuild better-sqlite3
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how auth token files are written, backed up, and restored during migration/rollback, so mistakes could leave tokens unreadable or still overly permissive on some platforms. Coverage is added, but it primarily exercises POSIX semantics and may behave differently on Windows/filesystems that ignore chmod.
> 
> **Overview**
> Ensures the migrated Remnic token store (`~/.remnic/tokens.json`) is always tightened to **owner-only** permissions (`0600`) when copied, merged, recovered, rewritten, and after rollback restores.
> 
> Updates migration backup behavior to preserve original modes for non-token files while forcing token-store backups to `0600`, and adds tests validating token-store and backup/restore file modes across the main migration paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c29e5017474ed0ad8adbeced50630e110f9c6a7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->