### PR TITLE
fix: validate import conflict policies

### DIFF
--- a/packages/remnic-core/src/transfer/conflict-policy.ts
+++ b/packages/remnic-core/src/transfer/conflict-policy.ts
@@ -1,0 +1,16 @@
+const CONFLICT_POLICIES = ["skip", "overwrite", "dedupe"] as const;
+
+export type ConflictPolicy = typeof CONFLICT_POLICIES[number];
+
+export function parseConflictPolicy(
+  value: unknown,
+  context: string,
+): ConflictPolicy {
+  if (value === undefined) return "skip";
+  if (typeof value === "string" && (CONFLICT_POLICIES as readonly string[]).includes(value)) {
+    return value as ConflictPolicy;
+  }
+  throw new Error(
+    `${context}: invalid conflict policy "${String(value)}"; expected skip, overwrite, or dedupe`,
+  );
+}

--- a/packages/remnic-core/src/transfer/import-json.ts
+++ b/packages/remnic-core/src/transfer/import-json.ts
@@ -8,8 +8,9 @@ import {
   resolveSafeArchiveTarget,
   type SafeArchiveRoot,
 } from "./fs-utils.js";
+import { parseConflictPolicy, type ConflictPolicy } from "./conflict-policy.js";
 
-export type ConflictPolicy = "skip" | "overwrite" | "dedupe";
+export type { ConflictPolicy };
 
 export interface ImportJsonOptions {
   targetMemoryDir: string;
@@ -24,7 +25,7 @@ function normalizeForDedupe(s: string): string {
 }
 
 export async function importJsonBundle(opts: ImportJsonOptions): Promise<{ written: number; skipped: number }> {
-  const conflict = opts.conflict ?? "skip";
+  const conflict = parseConflictPolicy(opts.conflict, "importJsonBundle");
   const fromDirAbs = path.resolve(opts.fromDir);
   const bundlePath = path.join(fromDirAbs, "bundle.json");
   const bundle = ExportBundleV1Schema.parse(await readJsonFile(bundlePath));

--- a/packages/remnic-core/src/transfer/import-md.ts
+++ b/packages/remnic-core/src/transfer/import-md.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { fileExists, listFilesRecursive, toPosixRelPath, fromPosixRelPath } from "./fs-utils.js";
+import { parseConflictPolicy, type ConflictPolicy } from "./conflict-policy.js";
 
-export type ConflictPolicy = "skip" | "overwrite" | "dedupe";
+export type { ConflictPolicy };
 
 export interface ImportMdOptions {
   targetMemoryDir: string;
@@ -16,7 +17,7 @@ function normalizeForDedupe(s: string): string {
 }
 
 export async function importMarkdownBundle(opts: ImportMdOptions): Promise<{ written: number; skipped: number }> {
-  const conflict = opts.conflict ?? "skip";
+  const conflict = parseConflictPolicy(opts.conflict, "importMarkdownBundle");
   const fromAbs = path.resolve(opts.fromDir);
   const targetAbs = path.resolve(opts.targetMemoryDir);
 
@@ -61,4 +62,3 @@ export async function importMarkdownBundle(opts: ImportMdOptions): Promise<{ wri
 
   return { written: writes.length, skipped };
 }
-

--- a/packages/remnic-core/src/transfer/import-sqlite.ts
+++ b/packages/remnic-core/src/transfer/import-sqlite.ts
@@ -6,9 +6,10 @@ import {
   prepareSafeArchiveRoot,
   resolveSafeArchiveTarget,
 } from "./fs-utils.js";
+import { parseConflictPolicy, type ConflictPolicy } from "./conflict-policy.js";
 import { openBetterSqlite3 } from "../runtime/better-sqlite.js";
 
-export type ConflictPolicy = "skip" | "overwrite" | "dedupe";
+export type { ConflictPolicy };
 
 export interface ImportSqliteOptions {
   targetMemoryDir: string;
@@ -22,7 +23,7 @@ function normalizeForDedupe(s: string): string {
 }
 
 export async function importSqlite(opts: ImportSqliteOptions): Promise<{ written: number; skipped: number }> {
-  const conflict = opts.conflict ?? "skip";
+  const conflict = parseConflictPolicy(opts.conflict, "importSqlite");
   const memDirAbs = path.resolve(opts.targetMemoryDir);
   const memoryRoot = await prepareSafeArchiveRoot(
     memDirAbs,

--- a/tests/export-import-json.test.ts
+++ b/tests/export-import-json.test.ts
@@ -67,6 +67,30 @@ test("v2.3 json export/import round-trips (without transcripts by default)", asy
   assert.match(fact, /The user likes pianos/);
 });
 
+test("json import rejects invalid conflict policy without overwriting existing files", async () => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const targetPath = path.join(targetDir, "profile.md");
+
+  await writeJsonBundle(outDir, [
+    {
+      path: "profile.md",
+      content: "incoming profile\n",
+    },
+  ]);
+  await writeFile(targetPath, "original profile\n", "utf-8");
+
+  await assert.rejects(
+    importJsonBundle({
+      targetMemoryDir: targetDir,
+      fromDir: outDir,
+      conflict: "replace" as any,
+    }),
+    /invalid conflict policy/i,
+  );
+  assert.equal(await readFile(targetPath, "utf-8"), "original profile\n");
+});
+
 test("json import rejects memory records that escape the target directory", async () => {
   const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
   const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));

--- a/tests/export-import-md.test.ts
+++ b/tests/export-import-md.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { importMarkdownBundle } from "../src/transfer/import-md.js";
+
+test("markdown import rejects invalid conflict policy without overwriting existing files", async () => {
+  const fromDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const targetPath = path.join(targetDir, "profile.md");
+
+  await writeFile(path.join(fromDir, "profile.md"), "incoming profile\n", "utf-8");
+  await writeFile(targetPath, "original profile\n", "utf-8");
+
+  await assert.rejects(
+    importMarkdownBundle({
+      targetMemoryDir: targetDir,
+      fromDir,
+      conflict: "replace" as any,
+    }),
+    /invalid conflict policy/i,
+  );
+  assert.equal(await readFile(targetPath, "utf-8"), "original profile\n");
+});

--- a/tests/export-import-sqlite.test.ts
+++ b/tests/export-import-sqlite.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { access, mkdtemp, readFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { writeFixtureMemoryDir } from "./transfer-fixtures.js";
@@ -55,6 +55,31 @@ test("v2.3 sqlite export/import round-trips basic files", async () => {
 
   const importedProfile = await readFile(path.join(targetDir, "profile.md"), "utf-8");
   assert.match(importedProfile, /Profile/);
+});
+
+test("sqlite import rejects invalid conflict policy without overwriting existing files", async () => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-sqlite-"));
+  const sqliteFile = path.join(outDir, "export.sqlite");
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const targetPath = path.join(targetDir, "profile.md");
+
+  writeSqliteExport(sqliteFile, [
+    {
+      path: "profile.md",
+      content: "incoming profile\n",
+    },
+  ]);
+  await writeFile(targetPath, "original profile\n", "utf-8");
+
+  await assert.rejects(
+    importSqlite({
+      targetMemoryDir: targetDir,
+      fromFile: sqliteFile,
+      conflict: "replace" as any,
+    }),
+    /invalid conflict policy/i,
+  );
+  assert.equal(await readFile(targetPath, "utf-8"), "original profile\n");
 });
 
 test("sqlite import rejects records that escape the target directory", async () => {


### PR DESCRIPTION
## Summary

This fixes the import conflict-policy handling flagged by clawpatch. JSON, Markdown, and SQLite imports now validate `opts.conflict` against the supported policies before doing any import work, so invalid runtime values fail instead of falling through to overwrite behavior.

## Changes

- Add a shared transfer conflict-policy parser for `skip`, `overwrite`, and `dedupe`.
- Use it in JSON, Markdown, and SQLite import paths.
- Add regressions proving invalid policies are rejected without overwriting existing files.

## Verification

- `pnpm exec tsx --test tests/export-import-json.test.ts tests/export-import-md.test.ts tests/export-import-sqlite.test.ts`
- `pnpm run check-types`
- `pnpm --filter @remnic/core run build`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in import paths now throw on invalid `conflict` values (previously could fall through to overwrite), which may impact callers relying on permissive runtime inputs. Core file-writing import code is touched, but changes are small and covered by new regression tests.
> 
> **Overview**
> Adds a shared `parseConflictPolicy` helper to validate import conflict handling (`skip`, `overwrite`, `dedupe`) and default `undefined` to `skip`.
> 
> Updates JSON, Markdown, and SQLite import functions to use this parser up front, preventing unexpected overwrite behavior when `opts.conflict` is an invalid runtime value.
> 
> Adds tests for all three import formats to ensure invalid policies are rejected and existing target files are not overwritten.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51b6ee1b0192581290b5a77d23bdebd78f2c85a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->