### PR TITLE
fix: avoid stealing live migration locks

### DIFF
--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -62,7 +62,6 @@ const LOCK_FILE = ".migration.lock";
 const ROLLBACK_MANIFEST = ".rollback.json";
 const BACKUP_DIR = ".backup";
 const LOCK_RETRY_MS = 100;
-const LOCK_STALE_MS = 30_000;
 const LOCK_TIMEOUT_MS = 5_000;
 const TOKEN_STORE_MODE = 0o600;
 
@@ -558,16 +557,18 @@ async function acquireLock(homeDir: string): Promise<() => Promise<void>> {
       const code = (error as NodeJS.ErrnoException).code;
       if (code !== "EEXIST") throw error;
 
-      const details = await readFile(target, "utf8").catch(() => "");
-      const lines = details.split("\n");
-      const pid = Number.parseInt(lines[0] ?? "", 10);
-      const createdAt = Number.parseInt(lines[1] ?? "", 10);
-      const malformed = !Number.isSafeInteger(pid) || pid <= 0 || !Number.isFinite(createdAt);
-      const stale = Number.isFinite(createdAt) && Date.now() - createdAt > LOCK_STALE_MS;
-      const deadPid = !malformed && !processIsAlive(pid);
-      if (malformed || (stale && deadPid)) {
-        await removeLockIfUnchanged(target, details);
-        continue;
+      const details = await readFile(target, "utf8").catch(() => null);
+      if (details === null) {
+        if (await removeLock(target)) continue;
+      } else {
+        const lines = details.split("\n");
+        const pid = Number.parseInt(lines[0] ?? "", 10);
+        const createdAt = Number.parseInt(lines[1] ?? "", 10);
+        const malformed = !Number.isSafeInteger(pid) || pid <= 0 || !Number.isFinite(createdAt);
+        const deadPid = !malformed && !processIsAlive(pid);
+        if (malformed || deadPid) {
+          if (await removeLockIfUnchanged(target, details)) continue;
+        }
       }
       if (Date.now() - started > LOCK_TIMEOUT_MS) {
         throw new Error(`timed out waiting for migration lock: ${target}`);
@@ -577,10 +578,19 @@ async function acquireLock(homeDir: string): Promise<() => Promise<void>> {
   }
 }
 
-async function removeLockIfUnchanged(target: string, expectedContent: string): Promise<void> {
+async function removeLockIfUnchanged(target: string, expectedContent: string): Promise<boolean> {
   const current = await readFile(target, "utf8").catch(() => null);
-  if (current !== expectedContent) return;
-  await rm(target, { force: true }).catch(() => undefined);
+  if (current !== expectedContent) return false;
+  return removeLock(target);
+}
+
+async function removeLock(target: string): Promise<boolean> {
+  try {
+    await rm(target, { force: true });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function processIsAlive(pid: number): boolean {

--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -562,11 +562,11 @@ async function acquireLock(homeDir: string): Promise<() => Promise<void>> {
       const lines = details.split("\n");
       const pid = Number.parseInt(lines[0] ?? "", 10);
       const createdAt = Number.parseInt(lines[1] ?? "", 10);
-      const malformed = !Number.isFinite(pid) || !Number.isFinite(createdAt);
+      const malformed = !Number.isSafeInteger(pid) || pid <= 0 || !Number.isFinite(createdAt);
       const stale = Number.isFinite(createdAt) && Date.now() - createdAt > LOCK_STALE_MS;
-      const deadPid = Number.isFinite(pid) && pid > 0 ? !processIsAlive(pid) : false;
-      if (malformed || stale || deadPid) {
-        await rm(target, { force: true }).catch(() => undefined);
+      const deadPid = !malformed && !processIsAlive(pid);
+      if (malformed || (stale && deadPid)) {
+        await removeLockIfUnchanged(target, details);
         continue;
       }
       if (Date.now() - started > LOCK_TIMEOUT_MS) {
@@ -577,11 +577,18 @@ async function acquireLock(homeDir: string): Promise<() => Promise<void>> {
   }
 }
 
+async function removeLockIfUnchanged(target: string, expectedContent: string): Promise<void> {
+  const current = await readFile(target, "utf8").catch(() => null);
+  if (current !== expectedContent) return;
+  await rm(target, { force: true }).catch(() => undefined);
+}
+
 function processIsAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EPERM") return true;
     return false;
   }
 }

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { chmod, mkdtemp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
@@ -11,6 +12,16 @@ import {
 
 async function makeTempHome(prefix: string): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+async function makeExitedPid(): Promise<number> {
+  const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+  assert.ok(child.pid, "expected child process pid");
+  await new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", () => resolve());
+  });
+  return child.pid;
 }
 
 async function setModeIfPosix(filePath: string, mode: number): Promise<void> {
@@ -422,6 +433,54 @@ test("migrateFromEngram clears malformed migration locks before acquiring a fres
 
   assert.equal(result.status, "migrated");
   assert.equal(existsSync(path.join(remnicRoot, ".migration.lock")), false);
+  assert.equal(existsSync(path.join(remnicRoot, ".migrated-from-engram")), true);
+});
+
+test("migrateFromEngram clears migration locks from dead processes immediately", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-dead-lock-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const lockPath = path.join(remnicRoot, ".migration.lock");
+  const deadPid = await makeExitedPid();
+
+  await mkdir(legacyRoot, { recursive: true });
+  await mkdir(remnicRoot, { recursive: true });
+  await writeFile(path.join(legacyRoot, "tokens.json"), JSON.stringify({ tokens: [] }), "utf8");
+  await writeFile(lockPath, `${deadPid}\n${Date.now()}\n`, "utf8");
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.equal(existsSync(lockPath), false);
+  assert.equal(existsSync(path.join(remnicRoot, ".migrated-from-engram")), true);
+});
+
+test("migrateFromEngram clears unreadable migration locks before acquiring a fresh lock", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-unreadable-lock-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const lockPath = path.join(remnicRoot, ".migration.lock");
+
+  await mkdir(legacyRoot, { recursive: true });
+  await mkdir(remnicRoot, { recursive: true });
+  await writeFile(path.join(legacyRoot, "tokens.json"), JSON.stringify({ tokens: [] }), "utf8");
+  await writeFile(lockPath, "unreadable\n", "utf8");
+  await chmod(lockPath, 0o000);
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.equal(existsSync(lockPath), false);
   assert.equal(existsSync(path.join(remnicRoot, ".migrated-from-engram")), true);
 });
 

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -425,6 +425,31 @@ test("migrateFromEngram clears malformed migration locks before acquiring a fres
   assert.equal(existsSync(path.join(remnicRoot, ".migrated-from-engram")), true);
 });
 
+test("migrateFromEngram does not steal a stale lock from a live process", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-live-lock-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const lockPath = path.join(remnicRoot, ".migration.lock");
+  const lockContent = `${process.pid}\n${Date.now() - 31_000}\n`;
+
+  await mkdir(legacyRoot, { recursive: true });
+  await mkdir(remnicRoot, { recursive: true });
+  await writeFile(path.join(legacyRoot, "tokens.json"), JSON.stringify({ tokens: [] }), "utf8");
+  await writeFile(lockPath, lockContent, "utf8");
+
+  await assert.rejects(
+    migrateFromEngram({
+      homeDir,
+      cwd: homeDir,
+      quiet: true,
+    }),
+    /timed out waiting for migration lock/,
+  );
+
+  assert.equal(await readFile(lockPath, "utf8"), lockContent);
+  assert.equal(existsSync(path.join(remnicRoot, ".migrated-from-engram")), false);
+});
+
 test("migrateFromEngram stops a service command batch after the first command failure", {
   skip: process.platform === "win32",
 }, async () => {


### PR DESCRIPTION
## Summary

Fixes the clawpatch finding that Engram -> Remnic migration locks could be treated as stale solely by age while the owning process was still alive.

## Changes

- Treat a migration lock as removable only when it is malformed, or when it is both stale and owned by a dead PID.
- Re-read the lock file before removal so a changed lock is not removed based on stale contents.
- Treat `EPERM` from `process.kill(pid, 0)` as an alive process.
- Add a regression showing a stale timestamp with the current live PID times out instead of allowing migration to proceed.

## Verification

- `pnpm exec tsx --test tests/remnic-migration.test.ts`
- `pnpm run check-types`
- `pnpm --filter @remnic/core run build`
- `npm run preflight:quick` *(rerun after `pnpm rebuild better-sqlite3`; first run failed because the fresh worktree lacked the native SQLite binding)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes cross-process lock acquisition/removal logic; mistakes could cause migrations to hang or run concurrently, but coverage is improved with new targeted tests.
> 
> **Overview**
> Prevents `migrateFromEngram` from deleting `.migration.lock` files based on age alone, so a *live* process holding an old lock is no longer “stolen” from.
> 
> Lock cleanup is tightened to only remove unreadable/malformed locks or locks whose PID is confirmed dead, with an extra re-read guard (`removeLockIfUnchanged`) to avoid deleting a lock that changed between read and removal; `processIsAlive` now treats `EPERM` as alive.
> 
> Adds regression tests covering dead-PID lock cleanup, unreadable lock cleanup, and verifying that a stale timestamp with a live PID causes lock acquisition to time out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083a9a4718796ef5bd8f94467658c4d7b2cbc7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->