### PR TITLE
fix(core): require real contradiction merge replacement

### DIFF
--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -260,8 +260,8 @@ class RemnicClient:
     async def review_list(self, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.review_list", kwargs)
 
-    async def review_resolve(self, pair_id: str, verb: str) -> dict[str, Any]:
-        return await self._mcp_tool("engram.review_resolve", {"pairId": pair_id, "verb": verb})
+    async def review_resolve(self, pair_id: str, verb: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._mcp_tool("engram.review_resolve", {"pairId": pair_id, "verb": verb, **kwargs})
 
     async def suggestion_submit(self, content: str, **kwargs: Any) -> dict[str, Any]:
         return await self._mcp_tool("engram.suggestion_submit", {"content": content, **kwargs})

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -1000,6 +1000,14 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
                 "enum": _REVIEW_RESOLUTION_VERBS,
                 "description": "Resolution action.",
             },
+            "mergedMemoryId": {
+                "type": "string",
+                "description": "Existing merged memory ID to use when verb is merge.",
+            },
+            "mergedContent": {
+                "type": "string",
+                "description": "Content for a new merged memory when verb is merge.",
+            },
         },
         ["pairId", "verb"],
     )
@@ -1608,7 +1616,7 @@ class RemnicMemoryProvider(HermesMemoryProvider):  # type: ignore[misc]
     async def review_resolve(self, pairId: str, verb: str, **kwargs: Any) -> dict[str, Any]:  # noqa: N803
         if not self._client:
             return {"error": "Not connected to Remnic"}
-        return await self._client.review_resolve(pair_id=pairId, verb=verb)
+        return await self._client.review_resolve(pair_id=pairId, verb=verb, **kwargs)
 
     async def suggestion_submit(self, content: str, **kwargs: Any) -> dict[str, Any]:
         if not self._client:

--- a/packages/plugin-hermes/tests/test_issue_807_reviews_suggestions_tools.py
+++ b/packages/plugin-hermes/tests/test_issue_807_reviews_suggestions_tools.py
@@ -24,7 +24,7 @@ async def test_issue_807_client_methods_call_daemon_mcp_tools(client: RemnicClie
 
     await client.review_queue_list(runId="run-1", namespace="project")
     await client.review_list(filter="duplicates", namespace="project", limit=5)
-    await client.review_resolve("pair-1", "merge")
+    await client.review_resolve("pair-1", "merge", mergedMemoryId="mem-merged-003")
     await client.suggestion_submit("Remember this after review.", category="fact", dryRun=True)
 
     calls = client._http.post.await_args_list
@@ -47,6 +47,7 @@ async def test_issue_807_client_methods_call_daemon_mcp_tools(client: RemnicClie
     assert calls[2].kwargs["json"]["params"]["arguments"] == {
         "pairId": "pair-1",
         "verb": "merge",
+        "mergedMemoryId": "mem-merged-003",
     }
     assert calls[3].kwargs["json"]["params"]["arguments"] == {
         "content": "Remember this after review.",
@@ -99,6 +100,8 @@ def test_issue_807_tools_are_registered_with_primary_and_legacy_names() -> None:
         "both-valid",
         "needs-more-context",
     ]
+    assert "mergedMemoryId" in ctx.tools["remnic_review_resolve"]["schema"]["parameters"]["properties"]
+    assert "mergedContent" in ctx.tools["remnic_review_resolve"]["schema"]["parameters"]["properties"]
     assert ctx.tools["remnic_suggestion_submit"]["schema"]["parameters"]["required"] == ["content"]
     assert ctx.tools["engram_suggestion_submit"]["schema"]["name"] == "engram_suggestion_submit"
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1163,7 +1163,10 @@ export class EngramAccessHttpServer {
         this.respondJson(res, 400, { error: `Invalid verb: ${verb}. Must be one of: keep-a, keep-b, merge, both-valid, needs-more-context` });
         return;
       }
-      const result = await executeResolution(this.service.memoryDir, this.service.storageRef, pairId, verb);
+      const result = await executeResolution(this.service.memoryDir, this.service.storageRef, pairId, verb, {
+        mergedMemoryId: typeof body.mergedMemoryId === "string" ? body.mergedMemoryId : undefined,
+        mergedContent: typeof body.mergedContent === "string" ? body.mergedContent : undefined,
+      });
       this.respondJson(res, 200, result);
       return;
     }

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1413,6 +1413,8 @@ export class EngramMcpServer {
           properties: {
             pairId: { type: "string", description: "The contradiction pair ID to resolve." },
             verb: { type: "string", enum: ["keep-a", "keep-b", "merge", "both-valid", "needs-more-context"], description: "Resolution action." },
+            mergedMemoryId: { type: "string", description: "Existing merged memory ID to use when verb is merge." },
+            mergedContent: { type: "string", description: "Content for a new merged memory when verb is merge." },
           },
           required: ["pairId", "verb"],
           additionalProperties: false,
@@ -2813,7 +2815,10 @@ export class EngramMcpServer {
         const { isValidResolutionVerb } = await import("./contradiction/resolution.js");
         if (!isValidResolutionVerb(verb)) throw new Error(`Invalid verb: ${verb}. Must be one of: keep-a, keep-b, merge, both-valid, needs-more-context`);
         const { executeResolution } = await import("./contradiction/resolution.js");
-        return executeResolution(this.service.memoryDir, this.service.storageRef, pairId, verb);
+        return executeResolution(this.service.memoryDir, this.service.storageRef, pairId, verb, {
+          mergedMemoryId: typeof args.mergedMemoryId === "string" ? args.mergedMemoryId : undefined,
+          mergedContent: typeof args.mergedContent === "string" ? args.mergedContent : undefined,
+        });
       }
       case "engram.contradiction_scan_run":
       case "remnic.contradiction_scan_run": {

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -8497,9 +8497,11 @@ export function registerCli(
         .command("resolve <pairId>")
         .description("Resolve a contradiction pair")
         .requiredOption("--verb <verb>", "Resolution verb: keep-a, keep-b, merge, both-valid, needs-more-context")
+        .option("--merged-memory-id <id>", "Existing merged memory ID to use when --verb merge")
+        .option("--merged-content <content>", "Content for a new merged memory when --verb merge")
         .action(async (...args: unknown[]) => {
           const pairId = typeof args[0] === "string" ? args[0] : "";
-          const cmdOpts = (args[1] ?? {}) as Record<string, string>;
+          const cmdOpts = (args[1] ?? {}) as Record<string, string | undefined>;
           if (!pairId) {
             console.error("pairId is required");
             process.exit(1);
@@ -8514,7 +8516,10 @@ export function registerCli(
             console.error(`Invalid verb: ${verb}. Must be one of: keep-a, keep-b, merge, both-valid, needs-more-context`);
             process.exit(1);
           }
-          const result = await executeResolution(orchestrator.config.memoryDir, orchestrator.storage, pairId, verb);
+          const result = await executeResolution(orchestrator.config.memoryDir, orchestrator.storage, pairId, verb, {
+            mergedMemoryId: cmdOpts.mergedMemoryId,
+            mergedContent: cmdOpts.mergedContent,
+          });
           console.log(result.message);
           if (result.affectedIds.length > 0) {
             console.log(`Affected: ${result.affectedIds.join(", ")}`);

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -15,8 +15,12 @@ import {
   type ContradictionPair,
 } from "./contradiction-review.js";
 import { _pairKey, _contentHash } from "./contradiction-judge.js";
-import { isValidResolutionVerb } from "./resolution.js";
+import { executeResolution, isValidResolutionVerb } from "./resolution.js";
 import { ACTIVE_STATUSES } from "./contradiction-scan.js";
+import type { StorageManager } from "../storage.js";
+import type { MemoryCategory, MemoryFile, MemoryFrontmatter } from "../types.js";
+
+type FrontmatterLifecycleOptions = Parameters<StorageManager["writeMemoryFrontmatter"]>[2];
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -37,6 +41,130 @@ function makePair(overrides?: Partial<ContradictionPair>): Omit<ContradictionPai
     detectedAt: new Date().toISOString(),
     ...overrides,
   };
+}
+
+function makeMemory(id: string, category: MemoryCategory = "fact"): MemoryFile {
+  const now = "2026-05-17T00:00:00.000Z";
+  return {
+    path: `/tmp/${id}.md`,
+    content: `content for ${id}`,
+    frontmatter: {
+      id,
+      category,
+      created: now,
+      updated: now,
+      source: "test",
+      confidence: 0.9,
+      confidenceTier: "explicit",
+      tags: [],
+    },
+  };
+}
+
+function cloneMemory(memory: MemoryFile): MemoryFile {
+  return {
+    path: memory.path,
+    content: memory.content,
+    frontmatter: {
+      ...memory.frontmatter,
+      tags: [...(memory.frontmatter.tags ?? [])],
+      lineage: memory.frontmatter.lineage ? [...memory.frontmatter.lineage] : undefined,
+      derived_from: memory.frontmatter.derived_from ? [...memory.frontmatter.derived_from] : undefined,
+    },
+  };
+}
+
+function makeResolutionStorage(options: {
+  failSupersedeFor?: string;
+  failRollbackFor?: string;
+  partialSupersedeBeforeFailureFor?: string;
+} = {}) {
+  const memories = new Map<string, MemoryFile>([
+    ["mem-a-001", makeMemory("mem-a-001")],
+    ["mem-b-002", makeMemory("mem-b-002")],
+    ["mem-merged-003", makeMemory("mem-merged-003")],
+  ]);
+  const supersedeCalls: Array<{ oldId: string; newId: string; reason: string }> = [];
+  const frontmatterWrites: Array<{
+    memoryId: string;
+    beforeStatus: MemoryFrontmatter["status"];
+    patch: Partial<MemoryFrontmatter>;
+    lifecycle?: FrontmatterLifecycleOptions;
+  }> = [];
+  const removedFactHashIds: string[] = [];
+
+  const storage = {
+    memories,
+    supersedeCalls,
+    frontmatterWrites,
+    removedFactHashIds,
+    async getMemoryById(id: string) {
+      const memory = memories.get(id);
+      return memory ? cloneMemory(memory) : null;
+    },
+    async writeMemory(category: MemoryCategory, content: string, writeOptions: {
+      lineage?: string[];
+      derivedFrom?: string[];
+      derivedVia?: string;
+      tags?: string[];
+    }) {
+      const id = `merged-created-${memories.size}`;
+      const memory = makeMemory(id, category);
+      memory.content = content;
+      memory.frontmatter.tags = writeOptions.tags ?? [];
+      memory.frontmatter.lineage = writeOptions.lineage;
+      memory.frontmatter.derived_from = writeOptions.derivedFrom;
+      memory.frontmatter.derived_via = writeOptions.derivedVia as MemoryFrontmatter["derived_via"];
+      memories.set(id, memory);
+      return id;
+    },
+    async supersedeMemory(oldId: string, newId: string, reason: string) {
+      supersedeCalls.push({ oldId, newId, reason });
+      if (oldId === options.failSupersedeFor) return false;
+      const memory = memories.get(oldId);
+      if (!memory) return false;
+      const supersededMemory: MemoryFile = {
+        ...memory,
+        frontmatter: {
+          ...memory.frontmatter,
+          status: "superseded",
+          supersededBy: newId,
+          supersededAt: "2026-05-17T00:01:00.000Z",
+        },
+      };
+      memories.set(oldId, supersededMemory);
+      if (oldId === options.partialSupersedeBeforeFailureFor) return false;
+      return true;
+    },
+    async writeMemoryFrontmatter(
+      memory: MemoryFile,
+      patch: Partial<MemoryFrontmatter>,
+      lifecycle?: FrontmatterLifecycleOptions,
+    ) {
+      const existing = memories.get(memory.frontmatter.id);
+      if (!existing) return false;
+      frontmatterWrites.push({
+        memoryId: memory.frontmatter.id,
+        beforeStatus: memory.frontmatter.status,
+        patch,
+        lifecycle,
+      });
+      if (memory.frontmatter.id === options.failRollbackFor) return false;
+      memories.set(memory.frontmatter.id, {
+        ...memory,
+        frontmatter: { ...memory.frontmatter, ...patch },
+      });
+      return true;
+    },
+    async invalidateMemory(id: string) {
+      return memories.delete(id);
+    },
+    async removeFactContentHashesForMemories(hashMemories: MemoryFile[]) {
+      removedFactHashIds.push(...hashMemories.map((memory) => memory.frontmatter.id));
+    },
+  };
+
+  return storage as typeof storage & StorageManager;
 }
 
 // ── Pair ID determinism ────────────────────────────────────────────────────────
@@ -239,6 +367,219 @@ test("isValidResolutionVerb rejects invalid verbs", () => {
   assert.equal(isValidResolutionVerb("delete"), false);
   assert.equal(isValidResolutionVerb(""), false);
   assert.equal(isValidResolutionVerb("unknown"), false);
+});
+
+test("executeResolution merge requires a real merged memory", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage();
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge");
+
+    assert.deepEqual(storage.supersedeCalls, []);
+    assert.match(result.message, /requires mergedMemoryId or mergedContent/);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution merge supersedes both sources to a verified merged memory", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage();
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedMemoryId: "mem-merged-003",
+    });
+
+    assert.deepEqual(
+      storage.supersedeCalls.map(({ oldId, newId }) => ({ oldId, newId })),
+      [
+        { oldId: "mem-a-001", newId: "mem-merged-003" },
+        { oldId: "mem-b-002", newId: "mem-merged-003" },
+      ],
+    );
+    assert.deepEqual(result.affectedIds, ["mem-a-001", "mem-b-002"]);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.status, "superseded");
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.supersededBy, "mem-merged-003");
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, "superseded");
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.supersededBy, "mem-merged-003");
+    assert.equal(readPair(dir, written.pairId)?.resolution, "merge");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution merge can create and verify a merged memory from content", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage();
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedContent: "merged canonical fact",
+    });
+
+    const mergedId = storage.supersedeCalls[0]?.newId;
+    assert.ok(mergedId);
+    assert.deepEqual(result.affectedIds, ["mem-a-001", "mem-b-002"]);
+    assert.equal(storage.memories.get(mergedId)?.content, "merged canonical fact");
+    assert.deepEqual(storage.memories.get(mergedId)?.frontmatter.derived_from, ["mem-a-001", "mem-b-002"]);
+    assert.equal(storage.memories.get(mergedId)?.frontmatter.derived_via, "merge");
+    assert.equal(readPair(dir, written.pairId)?.resolution, "merge");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution merge rolls back the first supersession when the second fails", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage({ failSupersedeFor: "mem-b-002" });
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedMemoryId: "mem-merged-003",
+    });
+
+    assert.deepEqual(
+      storage.supersedeCalls.map(({ oldId, newId }) => ({ oldId, newId })),
+      [
+        { oldId: "mem-a-001", newId: "mem-merged-003" },
+        { oldId: "mem-b-002", newId: "mem-merged-003" },
+      ],
+    );
+    assert.match(result.message, /restored mem-a-001 and mem-b-002/);
+    assert.deepEqual(result.affectedIds, []);
+    assert.deepEqual(
+      storage.frontmatterWrites.map(({ memoryId, lifecycle }) => ({
+        memoryId,
+        actor: lifecycle?.actor,
+        reasonCode: lifecycle?.reasonCode,
+      })),
+      [
+        {
+          memoryId: "mem-a-001",
+          actor: "contradiction-resolution",
+          reasonCode: "contradiction-resolution:merge-rollback",
+        },
+        {
+          memoryId: "mem-b-002",
+          actor: "contradiction-resolution",
+          reasonCode: "contradiction-resolution:merge-rollback",
+        },
+      ],
+    );
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.status, undefined);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.supersededBy, undefined);
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, undefined);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution merge restores the second source after partial supersede failure", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage({ partialSupersedeBeforeFailureFor: "mem-b-002" });
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedContent: "merged canonical fact",
+    });
+
+    const mergedId = storage.supersedeCalls[0]?.newId;
+    assert.ok(mergedId);
+    assert.match(result.message, /restored mem-a-001 and mem-b-002/);
+    assert.deepEqual(result.affectedIds, []);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.status, undefined);
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, undefined);
+    assert.equal(storage.memories.has(mergedId), false);
+    assert.deepEqual(
+      storage.frontmatterWrites.map(({ memoryId, beforeStatus }) => ({ memoryId, beforeStatus })),
+      [
+        { memoryId: "mem-a-001", beforeStatus: "superseded" },
+        { memoryId: "mem-b-002", beforeStatus: "superseded" },
+      ],
+    );
+    assert.deepEqual(storage.removedFactHashIds, [mergedId]);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution merge restores the first source after partial supersede failure", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage({ partialSupersedeBeforeFailureFor: "mem-a-001" });
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedContent: "merged canonical fact",
+    });
+
+    const mergedId = storage.supersedeCalls[0]?.newId;
+    assert.ok(mergedId);
+    assert.match(result.message, /restored mem-a-001/);
+    assert.deepEqual(result.affectedIds, []);
+    assert.deepEqual(
+      storage.frontmatterWrites.map(({ memoryId, lifecycle }) => ({
+        memoryId,
+        actor: lifecycle?.actor,
+        reasonCode: lifecycle?.reasonCode,
+      })),
+      [
+        {
+          memoryId: "mem-a-001",
+          actor: "contradiction-resolution",
+          reasonCode: "contradiction-resolution:merge-rollback",
+        },
+      ],
+    );
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.status, undefined);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.supersededBy, undefined);
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, undefined);
+    assert.equal(storage.memories.has(mergedId), false);
+    assert.deepEqual(
+      storage.frontmatterWrites.map(({ memoryId, beforeStatus }) => ({ memoryId, beforeStatus })),
+      [{ memoryId: "mem-a-001", beforeStatus: "superseded" }],
+    );
+    assert.deepEqual(storage.removedFactHashIds, [mergedId]);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution merge keeps created replacement when rollback fails", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage({
+      failSupersedeFor: "mem-b-002",
+      failRollbackFor: "mem-a-001",
+    });
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedContent: "merged canonical fact",
+    });
+
+    const mergedId = storage.supersedeCalls[0]?.newId;
+    assert.ok(mergedId);
+    assert.match(result.message, /rollback incomplete for mem-a-001/);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.status, "superseded");
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.supersededBy, mergedId);
+    assert.equal(storage.memories.get(mergedId)?.content, "merged canonical fact");
+    assert.deepEqual(storage.removedFactHashIds, []);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
 });
 
 // ── resolvePair ────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -6,6 +6,7 @@
  */
 
 import type { StorageManager } from "../storage.js";
+import type { MemoryCategory, MemoryFile } from "../types.js";
 import type { ResolutionVerb } from "./contradiction-review.js";
 import { resolvePair, readPair } from "./contradiction-review.js";
 import { log } from "../logger.js";
@@ -19,6 +20,15 @@ export interface ResolutionResult {
   message: string;
 }
 
+export interface ExecuteResolutionOptions {
+  /** Existing merged memory to supersede both source memories to. */
+  mergedMemoryId?: string;
+  /** Content for a new merged memory. Required for merge when mergedMemoryId is omitted. */
+  mergedContent?: string;
+  /** Category for a newly created merged memory. Defaults to the shared source category, or fact. */
+  mergedCategory?: MemoryCategory;
+}
+
 const VALID_VERBS: ResolutionVerb[] = ["keep-a", "keep-b", "merge", "both-valid", "needs-more-context"];
 
 export function isValidResolutionVerb(value: string): value is ResolutionVerb {
@@ -30,7 +40,7 @@ export function isValidResolutionVerb(value: string): value is ResolutionVerb {
  *
  * - `keep-a`: Supersede B, keep A active.
  * - `keep-b`: Supersede A, keep B active.
- * - `merge`: Mark both as superseded by a synthetic merged ID.
+ * - `merge`: Create or verify a real merged memory, then supersede both inputs.
  * - `both-valid`: Mark pair as reviewed; no memories are superseded.
  * - `needs-more-context`: Defer; no action, short cooldown.
  */
@@ -39,6 +49,7 @@ export async function executeResolution(
   storage: StorageManager,
   pairId: string,
   verb: ResolutionVerb,
+  options: ExecuteResolutionOptions = {},
 ): Promise<ResolutionResult> {
   const pair = readPair(memoryDir, pairId);
   if (!pair) {
@@ -68,17 +79,45 @@ export async function executeResolution(
       break;
     }
     case "merge": {
-      const mergedId = `merged-${pairId}`;
-      const okA = await supersedeSafe(storage, idA, mergedId, "contradiction-resolution:merge");
-      const okB = await supersedeSafe(storage, idB, mergedId, "contradiction-resolution:merge");
-      if (okA) affectedIds.push(idA);
-      if (okB) affectedIds.push(idB);
-      if (!okA || !okB) {
+      const replacement = await prepareMergeReplacement(storage, pairId, idA, idB, options);
+      if (!replacement.ok) {
         supersedeFailed = true;
-        message = `Merge incomplete: ${affectedIds.length}/2 superseded; not resolving to allow retry`;
-      } else {
-        message = `Both memories superseded by merged ${mergedId}`;
+        message = replacement.message;
+        break;
       }
+
+      const okA = await supersedeSafe(storage, idA, replacement.mergedId, "contradiction-resolution:merge");
+      if (!okA) {
+        supersedeFailed = true;
+        const rolledBackA = await restoreMemorySnapshot(storage, replacement.sourceA);
+        message = rolledBackA
+          ? `Merge failed for ${idA}; restored ${idA} and did not resolve`
+          : `Merge failed for ${idA}; rollback incomplete for ${idA} and pair is not resolved`;
+        if (rolledBackA) {
+          await cleanupCreatedReplacement(storage, replacement);
+        }
+        break;
+      }
+
+      const okB = await supersedeSafe(storage, idB, replacement.mergedId, "contradiction-resolution:merge");
+      if (!okB) {
+        supersedeFailed = true;
+        const rolledBackA = await restoreMemorySnapshot(storage, replacement.sourceA);
+        const rolledBackB = await restoreMemorySnapshot(storage, replacement.sourceB);
+        message = rolledBackA && rolledBackB
+          ? `Merge failed for ${idB}; restored ${idA} and ${idB} and did not resolve`
+          : `Merge failed for ${idB}; rollback incomplete for ${[
+            rolledBackA ? undefined : idA,
+            rolledBackB ? undefined : idB,
+          ].filter(Boolean).join(", ")} and pair is not resolved`;
+        if (rolledBackA && rolledBackB) {
+          await cleanupCreatedReplacement(storage, replacement);
+        }
+        break;
+      }
+
+      affectedIds.push(idA, idB);
+      message = `Both memories superseded by merged ${replacement.mergedId}`;
       break;
     }
     case "both-valid": {
@@ -96,6 +135,138 @@ export async function executeResolution(
   }
   log.info("[contradiction-resolution] pair=%s verb=%s affected=%d", pairId, verb, affectedIds.length);
   return { pairId, verb, affectedIds, message };
+}
+
+type MergeReplacement =
+  | {
+      ok: true;
+      mergedId: string;
+      sourceA: MemoryFile;
+      sourceB: MemoryFile;
+      created: boolean;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+async function prepareMergeReplacement(
+  storage: StorageManager,
+  pairId: string,
+  idA: string,
+  idB: string,
+  options: ExecuteResolutionOptions,
+): Promise<MergeReplacement> {
+  const sourceA = await storage.getMemoryById(idA);
+  const sourceB = await storage.getMemoryById(idB);
+  if (!sourceA || !sourceB) {
+    return { ok: false, message: `Merge requires both source memories to exist; not resolving ${pairId}` };
+  }
+
+  const requestedMergedId = options.mergedMemoryId?.trim();
+  if (requestedMergedId) {
+    if (requestedMergedId === idA || requestedMergedId === idB) {
+      return { ok: false, message: "Merge replacement must be distinct from both source memories; not resolving" };
+    }
+    const replacement = await storage.getMemoryById(requestedMergedId);
+    if (!replacement) {
+      return { ok: false, message: `Merged memory ${requestedMergedId} not found; not resolving` };
+    }
+    const replacementStatus = replacement.frontmatter.status ?? "active";
+    if (replacementStatus !== "active") {
+      return {
+        ok: false,
+        message: `Merged memory ${requestedMergedId} is ${replacementStatus}; not resolving`,
+      };
+    }
+    return { ok: true, mergedId: requestedMergedId, sourceA, sourceB, created: false };
+  }
+
+  const mergedContent = options.mergedContent;
+  if (typeof mergedContent !== "string" || mergedContent.trim().length === 0) {
+    return {
+      ok: false,
+      message: "Merge requires mergedMemoryId or mergedContent; no memories changed",
+    };
+  }
+
+  const category = options.mergedCategory ?? mergedMemoryCategory(sourceA, sourceB);
+  let mergedId: string;
+  try {
+    mergedId = await storage.writeMemory(category, mergedContent, {
+      actor: "contradiction-resolution",
+      confidence: Math.min(sourceA.frontmatter.confidence ?? 0.8, sourceB.frontmatter.confidence ?? 0.8),
+      tags: ["contradiction-resolution", "merge"],
+      source: "contradiction-resolution",
+      lineage: [idA, idB],
+      derivedFrom: [idA, idB],
+      derivedVia: "merge",
+    });
+  } catch (err) {
+    log.warn(
+      "[contradiction-resolution] merged memory creation failed for %s: %s",
+      pairId,
+      err instanceof Error ? err.message : err,
+    );
+    return { ok: false, message: `Merged memory could not be created; not resolving ${pairId}` };
+  }
+  const replacement = await storage.getMemoryById(mergedId);
+  if (!replacement) {
+    await cleanupMemoryId(storage, mergedId);
+    return { ok: false, message: `Merged memory ${mergedId} could not be verified; not resolving` };
+  }
+  return { ok: true, mergedId, sourceA, sourceB, created: true };
+}
+
+function mergedMemoryCategory(sourceA: MemoryFile, sourceB: MemoryFile): MemoryCategory {
+  return sourceA.frontmatter.category === sourceB.frontmatter.category
+    ? sourceA.frontmatter.category
+    : "fact";
+}
+
+async function restoreMemorySnapshot(storage: StorageManager, memory: MemoryFile): Promise<boolean> {
+  try {
+    const current = await storage.getMemoryById(memory.frontmatter.id);
+    if (!current) return false;
+    const restoredFrontmatter: Partial<MemoryFile["frontmatter"]> = {
+      ...memory.frontmatter,
+      status: memory.frontmatter.status,
+      supersededBy: memory.frontmatter.supersededBy,
+      supersededAt: memory.frontmatter.supersededAt,
+    };
+    return await storage.writeMemoryFrontmatter(current, restoredFrontmatter, {
+      actor: "contradiction-resolution",
+      reasonCode: "contradiction-resolution:merge-rollback",
+    });
+  } catch (err) {
+    log.warn(
+      "[contradiction-resolution] rollback failed for %s: %s",
+      memory.frontmatter.id,
+      err instanceof Error ? err.message : err,
+    );
+    return false;
+  }
+}
+
+async function cleanupCreatedReplacement(storage: StorageManager, replacement: Extract<MergeReplacement, { ok: true }>): Promise<void> {
+  if (!replacement.created) return;
+  await cleanupMemoryId(storage, replacement.mergedId);
+}
+
+async function cleanupMemoryId(storage: StorageManager, memoryId: string): Promise<void> {
+  try {
+    const memory = await storage.getMemoryById(memoryId);
+    const invalidated = await storage.invalidateMemory(memoryId);
+    if (invalidated && memory?.frontmatter.category === "fact") {
+      await storage.removeFactContentHashesForMemories([memory]);
+    }
+  } catch (err) {
+    log.warn(
+      "[contradiction-resolution] cleanup failed for merged memory %s: %s",
+      memoryId,
+      err instanceof Error ? err.message : err,
+    );
+  }
 }
 
 async function supersedeSafe(


### PR DESCRIPTION
## Summary
- require contradiction merge resolutions to use an existing active merged memory or create and verify one from supplied content
- avoid resolving the review pair unless both source memories are superseded successfully, with rollback for partial merge failures
- expose optional merge replacement inputs through CLI, HTTP, MCP, and the Hermes bridge

## Verification
- pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts
- pytest packages/plugin-hermes/tests/test_issue_807_reviews_suggestions_tools.py
- pnpm run check-types
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes contradiction merge resolution to create/validate a real merged memory and adds rollback/cleanup paths on partial supersession failures, affecting core memory mutation behavior. Also expands public surfaces (HTTP/MCP/CLI/Hermes) to accept new merge inputs, so integration correctness depends on consistent argument handling end-to-end.
> 
> **Overview**
> **Contradiction review `merge` resolution now requires a real replacement memory.** `executeResolution` no longer supersedes to a synthetic `merged-<pairId>` id; it either validates an existing *active* `mergedMemoryId` or creates and verifies a new merged memory from `mergedContent`, and it only marks the pair resolved once *both* source memories are successfully superseded.
> 
> **Adds failure handling for partial merges.** If one supersede fails, the code attempts to restore prior frontmatter state (with explicit lifecycle metadata) and cleans up any newly-created merged memory (including fact hash cleanup) to keep the system retryable.
> 
> **Plumbs optional merge inputs through all entrypoints.** HTTP `/engram/v1/review/resolve`, MCP tool `engram.review_resolve`, CLI `review resolve`, and the Hermes bridge (`RemnicClient`/`RemnicMemoryProvider` schemas + forwarding) now accept `mergedMemoryId`/`mergedContent`, with tests updated and expanded to cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f5705f4783c88afd3f02af76a5c229effb32faa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->