### PR TITLE
fix(bench): exercise adapter in temporal retrieval

### DIFF
--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  BenchMemoryAdapter,
+  BenchRecallOptions,
+  MemoryStats,
+  Message,
+  SearchResult,
+} from "../../../adapters/types.js";
+import type { ResolvedRunBenchmarkOptions } from "../../../types.js";
+import {
+  RETRIEVAL_TEMPORAL_SMOKE_FIXTURE,
+  type RetrievalTemporalCase,
+} from "./fixture.js";
+import {
+  retrievalTemporalDefinition,
+  runRetrievalTemporalBenchmark,
+} from "./runner.js";
+
+interface RecallCall {
+  sessionId: string;
+  query: string;
+  budgetChars?: number;
+  options?: BenchRecallOptions;
+}
+
+class SpyTemporalAdapter implements BenchMemoryAdapter {
+  readonly resetSessions: string[] = [];
+  readonly storeCalls: Array<{ sessionId: string; messages: Message[] }> = [];
+  readonly recallCalls: RecallCall[] = [];
+  drainCalls = 0;
+
+  constructor(
+    private readonly recallTextForCase: (sample: RetrievalTemporalCase) => string,
+  ) {}
+
+  async reset(sessionId?: string): Promise<void> {
+    assert.ok(sessionId, "retrieval-temporal should reset the case session");
+    this.resetSessions.push(sessionId);
+  }
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    this.storeCalls.push({ sessionId, messages });
+  }
+
+  async recall(
+    sessionId: string,
+    query: string,
+    budgetChars?: number,
+    options?: BenchRecallOptions,
+  ): Promise<string> {
+    const sample = sampleForSession(sessionId);
+    assert.equal(query, sample.query);
+    assert.equal(budgetChars, 12_000);
+    assert.equal(options?.asOf, sample.window.end);
+    this.recallCalls.push({ sessionId, query, budgetChars, options });
+    return this.recallTextForCase(sample);
+  }
+
+  async search(): Promise<SearchResult[]> {
+    throw new Error("retrieval-temporal should use recall with asOf, not untimed search");
+  }
+
+  async getStats(): Promise<MemoryStats> {
+    return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+  }
+
+  async drain(): Promise<void> {
+    this.drainCalls += 1;
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+function buildOptions(system: BenchMemoryAdapter): ResolvedRunBenchmarkOptions {
+  return {
+    benchmark: {
+      ...retrievalTemporalDefinition,
+      run: runRetrievalTemporalBenchmark,
+    },
+    mode: "quick",
+    system,
+  } as ResolvedRunBenchmarkOptions;
+}
+
+function sampleForSession(sessionId: string): RetrievalTemporalCase {
+  const sampleId = sessionId.replace(/^retrieval-temporal:/, "");
+  const sample = RETRIEVAL_TEMPORAL_SMOKE_FIXTURE.find(
+    (entry) => entry.id === sampleId,
+  );
+  assert.ok(sample, `unexpected session ${sessionId}`);
+  return sample;
+}
+
+test("retrieval-temporal seeds and queries the supplied system adapter", async () => {
+  const adapter = new SpyTemporalAdapter(
+    (sample) => `recall hit\npage_id: ${sample.expectedPageIds[0]}`,
+  );
+
+  const result = await runRetrievalTemporalBenchmark(buildOptions(adapter));
+
+  assert.equal(result.results.tasks.length, RETRIEVAL_TEMPORAL_SMOKE_FIXTURE.length);
+  assert.deepEqual(
+    adapter.resetSessions,
+    RETRIEVAL_TEMPORAL_SMOKE_FIXTURE.map((sample) => `retrieval-temporal:${sample.id}`),
+  );
+  assert.equal(adapter.storeCalls.length, RETRIEVAL_TEMPORAL_SMOKE_FIXTURE.length);
+  assert.equal(adapter.recallCalls.length, RETRIEVAL_TEMPORAL_SMOKE_FIXTURE.length);
+  assert.equal(adapter.drainCalls, RETRIEVAL_TEMPORAL_SMOKE_FIXTURE.length);
+
+  for (const [index, call] of adapter.storeCalls.entries()) {
+    const sample = RETRIEVAL_TEMPORAL_SMOKE_FIXTURE[index]!;
+    assert.equal(call.messages.length, sample.pages.length);
+    assert.match(call.messages[0]!.content, /^page_id: /);
+    assert.equal(call.messages[0]!.timestamp, sample.pages[0]!.createdAt);
+  }
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.qrel_at_1, 1);
+    assert.equal(task.scores.qrel_at_3, 1);
+    assert.equal(task.scores.qrel_at_5, 1);
+  }
+});
+
+test("retrieval-temporal scores adapter-returned page ids instead of fixture ranking", async () => {
+  const adapter = new SpyTemporalAdapter((sample) => {
+    const wrongPage = sample.pages.find(
+      (page) => !sample.expectedPageIds.includes(page.id),
+    );
+    assert.ok(wrongPage);
+    return `recall hit\npage_id: ${wrongPage.id}`;
+  });
+
+  const result = await runRetrievalTemporalBenchmark(buildOptions(adapter));
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.qrel_at_1, 0);
+    assert.equal(task.scores.qrel_at_3, 0);
+    assert.equal(task.scores.qrel_at_5, 0);
+  }
+});
+
+test("retrieval-temporal fails when the system adapter cannot be reset", async () => {
+  const adapter = new SpyTemporalAdapter(() => "");
+  adapter.reset = async () => {
+    throw new Error("forced reset failure");
+  };
+
+  await assert.rejects(
+    () => runRetrievalTemporalBenchmark(buildOptions(adapter)),
+    /forced reset failure/,
+  );
+  assert.equal(adapter.storeCalls.length, 0);
+  assert.equal(adapter.recallCalls.length, 0);
+});

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -9,11 +9,11 @@ import type {
   ResolvedRunBenchmarkOptions,
   TaskResult,
 } from "../../../types.js";
+import type { Message } from "../../../adapters/types.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {
   buildTieredAggregates,
-  overlapCount,
 } from "../retrieval-shared.js";
 import {
   RETRIEVAL_TEMPORAL_FIXTURE,
@@ -47,10 +47,20 @@ export async function runRetrievalTemporalBenchmark(
     validateHalfOpenWindow(sample.window.start, sample.window.end);
     validateExpectedPageIds(sample);
     const startedAt = performance.now();
-    const rankedPages = rankPages(sample.query, sample.pages);
+    const sessionId = `retrieval-temporal:${sample.id}`;
+    await options.system.reset(sessionId);
+    await options.system.store(sessionId, buildTemporalMessages(sample.pages));
+    await options.system.drain?.();
+    const recallText = await options.system.recall(
+      sessionId,
+      sample.query,
+      12_000,
+      { asOf: sample.window.end },
+    );
     const latencyMs = Math.round(performance.now() - startedAt);
-    const topRetrievedPageIds = rankedPages.slice(0, 5).map((page) => page.id);
-    const matchedPageIds = matchingPageIds(rankedPages, sample);
+    const retrievedPageIds = extractRankedPageIds(recallText, sample.pages);
+    const topRetrievedPageIds = retrievedPageIds.slice(0, 5);
+    const matchedPageIds = matchingPageIds(retrievedPageIds, sample);
     const expectedJson = JSON.stringify({
       expectedPageIds: sample.expectedPageIds,
       window: sample.window,
@@ -66,15 +76,17 @@ export async function runRetrievalTemporalBenchmark(
       expected: expectedJson,
       actual: actualJson,
       scores: {
-        qrel_at_1: temporalQrelAtK(rankedPages, sample, 1),
-        qrel_at_3: temporalQrelAtK(rankedPages, sample, 3),
-        qrel_at_5: temporalQrelAtK(rankedPages, sample, 5),
+        qrel_at_1: temporalQrelAtK(retrievedPageIds, sample, 1),
+        qrel_at_3: temporalQrelAtK(retrievedPageIds, sample, 3),
+        qrel_at_5: temporalQrelAtK(retrievedPageIds, sample, 5),
       },
       latencyMs,
       tokens: { input: 0, output: 0 },
       details: {
         tier: sample.tier,
         window: sample.window,
+        asOf: sample.window.end,
+        recallLengthChars: recallText.length,
         retrievedPageIds: topRetrievedPageIds,
         matchingPageIds: matchedPageIds,
       },
@@ -146,33 +158,17 @@ function loadCases(
   return limited;
 }
 
-function rankPages(query: string, pages: SchemaTierPage[]): SchemaTierPage[] {
-  return [...pages].sort((left, right) => {
-    const scoreDelta = scorePage(query, right) - scorePage(query, left);
-    if (scoreDelta !== 0) return scoreDelta;
-    return left.id.localeCompare(right.id);
-  });
-}
-
-function scorePage(query: string, page: SchemaTierPage): number {
-  const queryTokens = tokenize(query);
-  const ownerHit = queryTokens.has(page.owner.toLowerCase()) ? 3 : 0;
-  const titleScore = overlapCount(queryTokens, tokenize(page.title)) * 4;
-  const canonicalTitleScore = overlapCount(queryTokens, tokenize(page.canonicalTitle)) * 3;
-  const aliasScore = overlapCount(queryTokens, tokenize(page.aliases.join(" "))) * 2;
-  const bodyScore = overlapCount(queryTokens, tokenize(page.body)) * 2;
-  const timelineScore = overlapCount(queryTokens, tokenize(page.timeline.join(" "))) * 1.5;
-
-  return ownerHit + titleScore + canonicalTitleScore + aliasScore + bodyScore + timelineScore;
-}
-
 function temporalQrelAtK(
-  rankedPages: SchemaTierPage[],
+  rankedPageIds: string[],
   sample: RetrievalTemporalCase,
   k: number,
 ): number {
-  const topK = rankedPages.slice(0, k);
-  return topK.some((page) => pageQualifies(page, sample)) ? 1 : 0;
+  const pageById = new Map(sample.pages.map((page) => [page.id, page]));
+  const topK = rankedPageIds.slice(0, k);
+  return topK.some((pageId) => {
+    const page = pageById.get(pageId);
+    return page ? pageQualifies(page, sample) : false;
+  }) ? 1 : 0;
 }
 
 function pageQualifies(page: SchemaTierPage, sample: RetrievalTemporalCase): boolean {
@@ -218,6 +214,9 @@ function validateExpectedPageIds(sample: RetrievalTemporalCase): void {
 
 function collectEvidenceTimestamps(page: SchemaTierPage): number[] {
   const timestamps = new Set<number>();
+
+  const createdAt = parseTimestamp(page.createdAt);
+  if (createdAt !== null) timestamps.add(createdAt);
 
   const created = parseTimestamp(page.frontmatter.created);
   if (created !== null) timestamps.add(created);
@@ -269,20 +268,57 @@ function parseStrictIsoTimestamp(value: string): number | null {
 }
 
 function matchingPageIds(
-  rankedPages: SchemaTierPage[],
+  rankedPageIds: string[],
   sample: RetrievalTemporalCase,
 ): string[] {
-  return rankedPages
-    .filter((page) => pageQualifies(page, sample))
-    .map((page) => page.id);
+  const pageById = new Map(sample.pages.map((page) => [page.id, page]));
+  return rankedPageIds.filter((pageId) => {
+    const page = pageById.get(pageId);
+    return page ? pageQualifies(page, sample) : false;
+  });
 }
 
-function tokenize(value: string): Set<string> {
-  return new Set(
-    value
-      .toLowerCase()
-      .split(/[^a-z0-9]+/g)
-      .map((token) => token.trim())
-      .filter((token) => token.length >= 3 || (token.length >= 2 && /\d/.test(token))),
-  );
+function buildTemporalMessages(pages: SchemaTierPage[]): Message[] {
+  return pages.map((page) => ({
+    role: "user",
+    timestamp: page.createdAt,
+    content: [
+      `page_id: ${page.id}`,
+      `owner: ${page.owner}`,
+      `namespace: ${page.namespace}`,
+      `title: ${page.title}`,
+      `canonical_title: ${page.canonicalTitle}`,
+      `type: ${page.type}`,
+      `created_at: ${page.createdAt}`,
+      `aliases: ${page.aliases.join(", ")}`,
+      `timeline: ${page.timeline.join(" | ")}`,
+      `see_also: ${page.seeAlso.join(", ")}`,
+      `body: ${page.body}`,
+      page.dirtySignals.length > 0
+        ? `dirty_signals: ${page.dirtySignals.join(" | ")}`
+        : undefined,
+    ].filter((line): line is string => Boolean(line)).join("\n"),
+  }));
+}
+
+function extractRankedPageIds(recallText: string, pages: SchemaTierPage[]): string[] {
+  const matches: Array<{ id: string; index: number }> = [];
+  const lowerRecallText = recallText.toLowerCase();
+
+  for (const page of pages) {
+    const marker = `page_id: ${page.id.toLowerCase()}`;
+    const index = lowerRecallText.indexOf(marker);
+    if (index >= 0) {
+      matches.push({ id: page.id, index });
+    }
+  }
+
+  matches.sort((left, right) => {
+    if (left.index !== right.index) {
+      return left.index - right.index;
+    }
+    return left.id.localeCompare(right.id);
+  });
+
+  return matches.map((match) => match.id);
 }

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -1,13 +1,26 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import type { BenchMemoryAdapter, SearchResult, Message } from "../packages/bench/src/index.js";
+import type {
+  BenchMemoryAdapter,
+  BenchRecallOptions,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
 import { runBenchmark } from "../packages/bench/src/index.js";
-import { RETRIEVAL_TEMPORAL_FIXTURE } from "../packages/bench/src/benchmarks/remnic/retrieval-temporal/fixture.js";
+import {
+  RETRIEVAL_TEMPORAL_FIXTURE,
+  type RetrievalTemporalCase,
+} from "../packages/bench/src/benchmarks/remnic/retrieval-temporal/fixture.js";
 
 class NoopMemoryAdapter implements BenchMemoryAdapter {
   async store(_sessionId: string, _messages: Message[]): Promise<void> {}
 
-  async recall(_sessionId: string, _query: string): Promise<string> {
+  async recall(
+    _sessionId: string,
+    _query: string,
+    _budgetChars?: number,
+    _options?: BenchRecallOptions,
+  ): Promise<string> {
     return "";
   }
 
@@ -33,6 +46,47 @@ class NoopMemoryAdapter implements BenchMemoryAdapter {
 }
 
 const adapter = new NoopMemoryAdapter();
+
+class RetrievalTemporalFixtureAdapter extends NoopMemoryAdapter {
+  constructor(
+    private readonly pageIdsForCase: (sample: RetrievalTemporalCase) => string[],
+  ) {
+    super();
+  }
+
+  override async recall(
+    sessionId: string,
+    query: string,
+    budgetChars?: number,
+    options?: BenchRecallOptions,
+  ): Promise<string> {
+    const sample = retrievalTemporalCaseForSession(sessionId);
+    assert.equal(query, sample.query);
+    assert.equal(budgetChars, 12_000);
+    assert.equal(options?.asOf, sample.window.end);
+
+    return this.pageIdsForCase(sample)
+      .map((pageId) => `page_id: ${pageId}`)
+      .join("\n");
+  }
+}
+
+function cleanTemporalHitsOnly(): RetrievalTemporalFixtureAdapter {
+  return new RetrievalTemporalFixtureAdapter((sample) =>
+    sample.tier === "clean" ? sample.expectedPageIds : [],
+  );
+}
+
+function expectedTemporalHits(): RetrievalTemporalFixtureAdapter {
+  return new RetrievalTemporalFixtureAdapter((sample) => sample.expectedPageIds);
+}
+
+function retrievalTemporalCaseForSession(sessionId: string): RetrievalTemporalCase {
+  const sampleId = sessionId.replace(/^retrieval-temporal:/, "");
+  const sample = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === sampleId);
+  assert.ok(sample, `unexpected retrieval-temporal session ${sessionId}`);
+  return sample;
+}
 
 test("runBenchmark executes taxonomy-accuracy in quick mode", async () => {
   const result = await runBenchmark("taxonomy-accuracy", {
@@ -126,7 +180,7 @@ test("runBenchmark treats retrospective decision questions as non-initiating pro
 test("runBenchmark executes retrieval-temporal in quick mode", async () => {
   const result = await runBenchmark("retrieval-temporal", {
     mode: "quick",
-    system: adapter,
+    system: cleanTemporalHitsOnly(),
   });
 
   assert.equal(result.meta.benchmark, "retrieval-temporal");
@@ -141,7 +195,7 @@ test("runBenchmark applies retrieval-temporal limit as an exact task cap", async
   const result = await runBenchmark("retrieval-temporal", {
     mode: "quick",
     limit: 1,
-    system: adapter,
+    system: cleanTemporalHitsOnly(),
   });
 
   assert.equal(result.results.tasks.length, 1);
@@ -149,10 +203,14 @@ test("runBenchmark applies retrieval-temporal limit as an exact task cap", async
   assert.equal(result.results.aggregates["dirty_penalty.qrel_at_1"], undefined);
 });
 
-test("runBenchmark preserves quarter tokens for full retrieval-temporal cases", async () => {
+test("runBenchmark records adapter-returned page order for full retrieval-temporal cases", async () => {
   const result = await runBenchmark("retrieval-temporal", {
     mode: "full",
-    system: adapter,
+    system: new RetrievalTemporalFixtureAdapter((sample) =>
+      sample.id === "clean:morgan-q3-commitments"
+        ? ["morgan-q3-training-plan", "morgan-coffee-preferences"]
+        : sample.expectedPageIds,
+    ),
   });
 
   const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
@@ -171,22 +229,25 @@ test("runBenchmark rejects overflowed timeline dates in retrieval-temporal evide
   const targetPage = temporalCase.pages.find((page) => page.id === "morgan-q3-training-plan");
   assert.ok(targetPage);
 
+  const originalCreatedAt = targetPage.createdAt;
   const originalCreated = targetPage.frontmatter.created;
   const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
 
   try {
+    targetPage.createdAt = "2026-06-30T23:59:59.000Z";
     targetPage.frontmatter.created = undefined;
     targetPage.frontmatter.timeline = ["2026-08-32 impossible training block"];
 
     const result = await runBenchmark("retrieval-temporal", {
       mode: "full",
-      system: adapter,
+      system: expectedTemporalHits(),
     });
 
     const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
     assert.ok(task);
     assert.equal(task.scores.qrel_at_1, 0);
   } finally {
+    targetPage.createdAt = originalCreatedAt;
     targetPage.frontmatter.created = originalCreated;
     targetPage.frontmatter.timeline = originalTimeline;
   }
@@ -265,22 +326,25 @@ test("runBenchmark rejects overflowed created timestamps in retrieval-temporal e
   const targetPage = temporalCase.pages.find((page) => page.id === "morgan-q3-training-plan");
   assert.ok(targetPage);
 
+  const originalCreatedAt = targetPage.createdAt;
   const originalCreated = targetPage.frontmatter.created;
   const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
 
   try {
+    targetPage.createdAt = "2026-06-31T07:00:00.000Z";
     targetPage.frontmatter.created = "2026-06-31T07:00:00.000Z";
     targetPage.frontmatter.timeline = [];
 
     const result = await runBenchmark("retrieval-temporal", {
       mode: "full",
-      system: adapter,
+      system: expectedTemporalHits(),
     });
 
     const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
     assert.ok(task);
     assert.equal(task.scores.qrel_at_1, 0);
   } finally {
+    targetPage.createdAt = originalCreatedAt;
     targetPage.frontmatter.created = originalCreated;
     targetPage.frontmatter.timeline = originalTimeline;
   }
@@ -293,22 +357,25 @@ test("runBenchmark rejects timeline entries with extra day digits in retrieval-t
   const targetPage = temporalCase.pages.find((page) => page.id === "morgan-q3-training-plan");
   assert.ok(targetPage);
 
+  const originalCreatedAt = targetPage.createdAt;
   const originalCreated = targetPage.frontmatter.created;
   const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
 
   try {
+    targetPage.createdAt = "2026-06-30T23:59:59.000Z";
     targetPage.frontmatter.created = undefined;
     targetPage.frontmatter.timeline = ["2026-08-032 malformed day"];
 
     const result = await runBenchmark("retrieval-temporal", {
       mode: "full",
-      system: adapter,
+      system: expectedTemporalHits(),
     });
 
     const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
     assert.ok(task);
     assert.equal(task.scores.qrel_at_1, 0);
   } finally {
+    targetPage.createdAt = originalCreatedAt;
     targetPage.frontmatter.created = originalCreated;
     targetPage.frontmatter.timeline = originalTimeline;
   }
@@ -321,22 +388,25 @@ test("runBenchmark rejects timeline entries with trailing alpha suffixes in retr
   const targetPage = temporalCase.pages.find((page) => page.id === "morgan-q3-training-plan");
   assert.ok(targetPage);
 
+  const originalCreatedAt = targetPage.createdAt;
   const originalCreated = targetPage.frontmatter.created;
   const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
 
   try {
+    targetPage.createdAt = "2026-06-30T23:59:59.000Z";
     targetPage.frontmatter.created = undefined;
     targetPage.frontmatter.timeline = ["2026-08-03x malformed day token"];
 
     const result = await runBenchmark("retrieval-temporal", {
       mode: "full",
-      system: adapter,
+      system: expectedTemporalHits(),
     });
 
     const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
     assert.ok(task);
     assert.equal(task.scores.qrel_at_1, 0);
   } finally {
+    targetPage.createdAt = originalCreatedAt;
     targetPage.frontmatter.created = originalCreated;
     targetPage.frontmatter.timeline = originalTimeline;
   }


### PR DESCRIPTION
Fixes clawpatch finding `fnd_sig-feat-library-0ca7d8ea6f-6e40_ad528849f1`.

This keeps the PR intentionally narrow:
- `retrieval-temporal` now resets, seeds, drains, and recalls through the supplied `BenchMemoryAdapter`.
- Temporal queries pass the fixture `asOf` value into the adapter.
- qrel scores are based on page IDs returned by adapter recall output and the existing half-open temporal evidence window.
- Added spy-adapter regression coverage so quick mode cannot pass without exercising the adapter.

Verification:
- `pnpm exec tsx --test packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts`
- `pnpm run check-types`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `retrieval-temporal` benchmark execution/scoring to depend on adapter reset/store/recall output, which can alter reported metrics and may surface adapter integration issues, but is limited to benchmark/test code.
> 
> **Overview**
> `retrieval-temporal` no longer uses an internal deterministic ranking; it now **resets a per-case session, seeds pages via `store`, optionally `drain`s, and calls `recall` with the case `asOf` timestamp** to obtain results.
> 
> Scoring and task details are now derived from **page IDs extracted from adapter `recall` output** (including returned ordering), and temporal evidence checks now also consider `page.createdAt`. New/updated tests add spy/fixture adapters to ensure quick/full runs actually exercise the adapter path and fail on reset errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e6eb748bca6a70e592e351f5727fa079ddf4539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->