### PR TITLE
fix(bench): normalize membench jsonl records

### DIFF
--- a/packages/bench/src/benchmarks/published/membench/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.test.ts
@@ -152,3 +152,83 @@ test("MemBench adds recommendation cues without exposing them to answer context"
     await rm(datasetDir, { recursive: true, force: true });
   }
 });
+
+test("MemBench normalizes upstream JSONL trajectory QA records", async () => {
+  const datasetDir = await mkdtemp(path.join(tmpdir(), "remnic-membench-jsonl-"));
+  const storedMessages: string[] = [];
+
+  try {
+    await writeFile(
+      path.join(datasetDir, "FirstAgentDataLowLevel.jsonl"),
+      `${JSON.stringify({
+        trajectory: ["I moved to Lisbon."],
+        qa: [
+          {
+            question: "Where did I move?",
+            answer: "Lisbon",
+          },
+        ],
+      })}\n`,
+      "utf8",
+    );
+
+    const result = await runMemBenchBenchmark({
+      benchmark: memBenchDefinition,
+      mode: "full",
+      datasetDir,
+      system: {
+        async reset() {
+          storedMessages.length = 0;
+        },
+        async store(_sessionId, messages) {
+          storedMessages.push(...messages.map((message) => message.content));
+        },
+        async recall() {
+          return storedMessages.join("\n\n");
+        },
+        async search() {
+          return [];
+        },
+        async destroy() {},
+        async getStats() {
+          return { totalMessages: storedMessages.length, totalSummaryNodes: 0, maxDepth: 0 };
+        },
+        responder: {
+          async respond() {
+            return {
+              text: "Lisbon",
+              tokens: { input: 1, output: 1 },
+              latencyMs: 1,
+              model: "membench-test-responder",
+            };
+          },
+        },
+        judge: {
+          async score() {
+            return 1;
+          },
+          async scoreWithMetrics() {
+            return {
+              score: 1,
+              tokens: { input: 0, output: 0 },
+              latencyMs: 0,
+              model: "membench-test-judge",
+            };
+          },
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks.length, 1);
+    const task = result.results.tasks[0]!;
+    assert.equal(task.question, "Where did I move?");
+    assert.equal(task.expected, "Lisbon");
+    assert.equal(task.details.memoryType, "factual");
+    assert.equal(task.details.scenario, "participant");
+    assert.equal(task.details.level, "low_level");
+    assert.match(storedMessages.join("\n"), /I moved to Lisbon/);
+    assert.equal(task.scores.membench_accuracy, 1);
+  } finally {
+    await rm(datasetDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -363,6 +363,7 @@ function parseJsonDataset(raw: string, filename: string): MemBenchCase[] {
 
 function parseJsonlDataset(raw: string, filename: string): MemBenchCase[] {
   const cases: MemBenchCase[] = [];
+  const hints = inferHintsFromLabel(filename, {});
   raw.split("\n").forEach((line, lineIndex) => {
     if (line.trim().length === 0) {
       return;
@@ -377,7 +378,14 @@ function parseJsonlDataset(raw: string, filename: string): MemBenchCase[] {
       );
     }
 
-    cases.push(parseCase(parsed, `${filename}:${lineIndex + 1}`));
+    const location = `${filename}:${lineIndex + 1}`;
+    const normalizedCases = normalizePublishedNode(parsed, hints, location);
+    if (normalizedCases.length > 0) {
+      cases.push(...normalizedCases);
+      return;
+    }
+
+    cases.push(parseCase(parsed, location));
   });
   return cases;
 }


### PR DESCRIPTION
Fixes clawpatch finding `fnd_sig-feat-library-14187c8876-1121_3903ae4bf6`.

This PR keeps the scope to MemBench dataset loading:
- JSONL lines now go through the published-shape normalizer before falling back to flat-case parsing.
- Filename-derived hints are preserved for upstream files like `FirstAgentDataLowLevel.jsonl`, so scenario/memoryType/level are inferred correctly.
- Adds a full-mode regression for an upstream `trajectory` + `qa` JSONL record.

Verification:
- `pnpm exec tsx --test packages/bench/src/benchmarks/published/membench/runner.test.ts`
- `pnpm run check-types`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MemBench JSONL ingestion to run records through the published-dataset normalizer with filename-derived hints, which can alter parsed task metadata and evaluation results for upstream datasets.
> 
> **Overview**
> MemBench now **normalizes JSONL dataset lines** using the published-shape normalizer (with filename-derived hints) before falling back to the flat `parseCase` path, aligning JSONL behavior with nested/official dataset structures.
> 
> Adds a full-mode regression test covering an upstream `trajectory` + `qa` JSONL record (e.g. `FirstAgentDataLowLevel.jsonl`) to ensure the loader correctly infers `memoryType`/`scenario`/`level` and produces a valid task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d008d082e877e9255e6ea7ccfb6fda17ce044a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->