### PR TITLE
fix(contradiction): make context deferrals non-terminal

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -37,6 +37,8 @@ export interface ContradictionPair {
   lastReviewedAt?: string;
   /** Resolution verb applied by user. */
   resolution?: ResolutionVerb;
+  /** ISO timestamp until which a non-terminal deferral remains hidden from review. */
+  deferredUntil?: string;
   /** Namespace scope. */
   namespace?: string;
 }
@@ -48,12 +50,44 @@ export interface ContradictionListResult {
 }
 
 export type ContradictionFilter = ContradictionVerdict | "all" | "unresolved";
+const NEEDS_MORE_CONTEXT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
 export function computePairId(memoryIdA: string, memoryIdB: string): string {
   const sorted = [memoryIdA, memoryIdB].sort();
   return createHash("sha256").update(sorted.join("::")).digest("hex").slice(0, 24);
+}
+
+function isTerminalResolution(resolution: ResolutionVerb | undefined): boolean {
+  return Boolean(resolution && resolution !== "needs-more-context");
+}
+
+function parseIsoMillis(value: string | undefined): number | null {
+  if (!value) return null;
+  const millis = new Date(value).getTime();
+  return Number.isFinite(millis) ? millis : null;
+}
+
+function isDeferred(pair: Pick<ContradictionPair, "resolution" | "deferredUntil">): boolean {
+  return pair.resolution === "needs-more-context" || Boolean(pair.deferredUntil);
+}
+
+function deferralUntilMillis(pair: ContradictionPair): number | null {
+  const deferredUntil = parseIsoMillis(pair.deferredUntil);
+  if (deferredUntil !== null) return deferredUntil;
+
+  if (pair.resolution === "needs-more-context") {
+    const lastReviewed = parseIsoMillis(pair.lastReviewedAt);
+    return lastReviewed === null ? null : lastReviewed + NEEDS_MORE_CONTEXT_COOLDOWN_MS;
+  }
+
+  return null;
+}
+
+function isDeferralActive(pair: ContradictionPair): boolean {
+  const deferredUntil = deferralUntilMillis(pair);
+  return deferredUntil !== null && Date.now() < deferredUntil;
 }
 
 function reviewDir(memoryDir: string): string {
@@ -86,21 +120,28 @@ export function writePair(memoryDir: string, pair: Omit<ContradictionPair, "pair
   const pairId = computePairId(pair.memoryIds[0], pair.memoryIds[1]);
   const existing = readPair(memoryDir, pairId);
 
-  // Preserve user resolution if already reviewed
-  if (existing?.resolution) {
+  // Preserve terminal user resolutions if already reviewed.
+  if (isTerminalResolution(existing?.resolution)) {
+    return existing!;
+  }
+
+  // Preserve active deferrals, but allow expired deferrals to be refreshed.
+  const existingDeferralExpired = Boolean(existing && isDeferred(existing) && !isDeferralActive(existing));
+  if (existing && isDeferralActive(existing)) {
     return existing;
   }
 
   // Preserve cooldown: don't overwrite a cooled-down entry with lower confidence
-  if (existing && existing.confidence >= pair.confidence) {
+  if (existing && !existingDeferralExpired && existing.confidence >= pair.confidence) {
     return existing;
   }
 
   const full: ContradictionPair = {
     ...pair,
     pairId,
-    lastReviewedAt: existing?.lastReviewedAt,
-    resolution: existing?.resolution,
+    lastReviewedAt: existingDeferralExpired ? pair.lastReviewedAt : (existing?.lastReviewedAt ?? pair.lastReviewedAt),
+    resolution: undefined,
+    deferredUntil: existingDeferralExpired ? undefined : existing?.deferredUntil,
   };
 
   const filePath = pairPath(memoryDir, pairId);
@@ -185,7 +226,8 @@ export function listPairs(
 
       // Verdict filter
       if (filter === "unresolved") {
-        if (pair.resolution) continue;
+        if (isTerminalResolution(pair.resolution)) continue;
+        if (isDeferralActive(pair)) continue;
         if (pair.verdict === "independent") continue;
       } else if (filter !== "all" && pair.verdict !== filter) {
         continue;
@@ -209,23 +251,33 @@ export function listPairs(
  */
 export function isCoolingDown(pair: ContradictionPair, cooldownDays: number): boolean {
   if (cooldownDays <= 0) return false; // rule 27: guard against 0
+
+  const deferredUntil = deferralUntilMillis(pair);
+  if (deferredUntil !== null) {
+    return Date.now() < deferredUntil;
+  }
+
   if (!pair.lastReviewedAt) return false;
 
-  const lastReviewed = new Date(pair.lastReviewedAt).getTime();
-  if (!Number.isFinite(lastReviewed)) return false;
+  const lastReviewed = parseIsoMillis(pair.lastReviewedAt);
+  if (lastReviewed === null) return false;
 
   const cooldownMs = cooldownDays * 24 * 60 * 60 * 1000;
   return Date.now() < lastReviewed + cooldownMs;
 }
 
 /**
- * Mark a pair as reviewed (sets lastReviewedAt and resolution).
+ * Mark a pair as reviewed (sets lastReviewedAt and, for terminal verbs, resolution).
  */
 export function resolvePair(
   memoryDir: string,
   pairId: string,
   verb: ResolutionVerb,
 ): ContradictionPair | null {
+  if (verb === "needs-more-context") {
+    return deferPair(memoryDir, pairId);
+  }
+
   const existing = readPair(memoryDir, pairId);
   if (!existing) return null;
 
@@ -233,6 +285,35 @@ export function resolvePair(
     ...existing,
     lastReviewedAt: new Date().toISOString(),
     resolution: verb,
+    deferredUntil: undefined,
+  };
+
+  const filePath = pairPath(memoryDir, pairId);
+  const tmpPath = `${filePath}.tmp`;
+
+  fs.writeFileSync(tmpPath, JSON.stringify(updated, null, 2), "utf-8");
+  fs.renameSync(tmpPath, filePath);
+
+  return updated;
+}
+
+/**
+ * Defer a pair without terminally resolving it.
+ */
+export function deferPair(
+  memoryDir: string,
+  pairId: string,
+  deferredUntil = new Date(Date.now() + NEEDS_MORE_CONTEXT_COOLDOWN_MS).toISOString(),
+): ContradictionPair | null {
+  const existing = readPair(memoryDir, pairId);
+  if (!existing) return null;
+  if (isTerminalResolution(existing.resolution)) return existing;
+
+  const updated: ContradictionPair = {
+    ...existing,
+    lastReviewedAt: new Date().toISOString(),
+    resolution: undefined,
+    deferredUntil,
   };
 
   const filePath = pairPath(memoryDir, pairId);

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -12,6 +12,7 @@ import {
   listPairs,
   isCoolingDown,
   resolvePair,
+  deferPair,
   type ContradictionPair,
 } from "./contradiction-review.js";
 import { _pairKey, _contentHash } from "./contradiction-judge.js";
@@ -41,6 +42,12 @@ function makePair(overrides?: Partial<ContradictionPair>): Omit<ContradictionPai
     detectedAt: new Date().toISOString(),
     ...overrides,
   };
+}
+
+async function writeStoredPair(dir: string, pair: ContradictionPair): Promise<void> {
+  const reviewDir = path.join(dir, ".review", "contradictions");
+  await mkdir(reviewDir, { recursive: true });
+  await writeFile(path.join(reviewDir, `${pair.pairId}.json`), JSON.stringify(pair, null, 2), "utf-8");
 }
 
 function makeMemory(id: string, category: MemoryCategory = "fact"): MemoryFile {
@@ -351,6 +358,38 @@ test("isCoolingDown returns false when cooldownDays is 0 (rule 27)", () => {
     lastReviewedAt: new Date().toISOString(),
   };
   assert.equal(isCoolingDown(pair, 0), false, "0 cooldownDays should disable cooldown");
+  assert.equal(
+    isCoolingDown({ ...pair, pairId: "deferred", deferredUntil: new Date(Date.now() + 60_000).toISOString() }, 0),
+    false,
+    "0 cooldownDays should disable explicit deferral cooldown",
+  );
+  assert.equal(
+    isCoolingDown({ ...pair, pairId: "legacy-deferred", resolution: "needs-more-context" }, 0),
+    false,
+    "0 cooldownDays should disable legacy deferral cooldown",
+  );
+});
+
+test("isCoolingDown uses deferredUntil instead of generic cooldown for deferrals", () => {
+  const now = Date.now();
+  const active: ContradictionPair = {
+    pairId: "active-deferral",
+    memoryIds: ["a", "b"],
+    verdict: "contradicts",
+    rationale: "",
+    confidence: 0.8,
+    detectedAt: new Date(now).toISOString(),
+    lastReviewedAt: new Date(now).toISOString(),
+    deferredUntil: new Date(now + 60_000).toISOString(),
+  };
+  const expired: ContradictionPair = {
+    ...active,
+    pairId: "expired-deferral",
+    deferredUntil: new Date(now - 60_000).toISOString(),
+  };
+
+  assert.equal(isCoolingDown(active, 14), true);
+  assert.equal(isCoolingDown(expired, 14), false);
 });
 
 // ── Resolution verbs ───────────────────────────────────────────────────────────
@@ -582,6 +621,82 @@ test("executeResolution merge keeps created replacement when rollback fails", as
   }
 });
 
+test("executeResolution needs-more-context defers without terminal resolution", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage();
+
+    const result = await executeResolution(dir, storage, written.pairId, "needs-more-context");
+    const deferred = readPair(dir, written.pairId);
+
+    assert.deepEqual(result.affectedIds, []);
+    assert.match(result.message, /Deferred/);
+    assert.ok(deferred?.lastReviewedAt);
+    assert.ok(deferred?.deferredUntil);
+    assert.equal(deferred?.resolution, undefined);
+    assert.equal(listPairs(dir, { filter: "unresolved" }).total, 0);
+    assert.equal(listPairs(dir, { filter: "all" }).total, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("expired needs-more-context deferral returns to unresolved and can be refreshed", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ confidence: 0.95 }));
+    const deferred = resolvePair(dir, written.pairId, "needs-more-context");
+    assert.ok(deferred);
+
+    const expiredAt = new Date(Date.now() - 60_000).toISOString();
+    await writeStoredPair(dir, {
+      ...deferred!,
+      lastReviewedAt: expiredAt,
+      deferredUntil: expiredAt,
+    });
+
+    assert.equal(listPairs(dir, { filter: "unresolved" }).total, 1);
+
+    const refreshed = writePair(dir, makePair({
+      confidence: 0.5,
+      verdict: "duplicates",
+      rationale: "Fresh judge result after deferral expiry",
+    }));
+
+    assert.equal(refreshed.confidence, 0.5);
+    assert.equal(refreshed.verdict, "duplicates");
+    assert.equal(refreshed.resolution, undefined);
+    assert.equal(refreshed.deferredUntil, undefined);
+    assert.equal(readPair(dir, written.pairId)?.deferredUntil, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("legacy needs-more-context resolutions honor cooldown before returning to unresolved", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+
+    await writeStoredPair(dir, {
+      ...written,
+      lastReviewedAt: new Date().toISOString(),
+      resolution: "needs-more-context",
+    });
+    assert.equal(listPairs(dir, { filter: "unresolved" }).total, 0);
+
+    await writeStoredPair(dir, {
+      ...written,
+      lastReviewedAt: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+      resolution: "needs-more-context",
+    });
+    assert.equal(listPairs(dir, { filter: "unresolved" }).total, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
 // ── resolvePair ────────────────────────────────────────────────────────────────
 
 test("resolvePair sets resolution and lastReviewedAt", async () => {
@@ -592,6 +707,26 @@ test("resolvePair sets resolution and lastReviewedAt", async () => {
     assert.ok(resolved);
     assert.equal(resolved!.resolution, "both-valid");
     assert.ok(resolved!.lastReviewedAt);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("needs-more-context deferral does not clear terminal resolutions", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const resolved = resolvePair(dir, written.pairId, "keep-a");
+    assert.equal(resolved?.resolution, "keep-a");
+
+    const deferredViaResolve = resolvePair(dir, written.pairId, "needs-more-context");
+    assert.equal(deferredViaResolve?.resolution, "keep-a");
+    assert.equal(deferredViaResolve?.deferredUntil, undefined);
+
+    const deferredDirectly = deferPair(dir, written.pairId);
+    assert.equal(deferredDirectly?.resolution, "keep-a");
+    assert.equal(deferredDirectly?.deferredUntil, undefined);
+    assert.equal(listPairs(dir, { filter: "unresolved" }).total, 0);
   } finally {
     await cleanup();
   }

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -56,7 +56,7 @@ export async function executeResolution(
     return { pairId, verb, affectedIds: [], message: `Pair ${pairId} not found` };
   }
 
-  if (pair.resolution) {
+  if (pair.resolution && pair.resolution !== "needs-more-context") {
     return { pairId, verb, affectedIds: [], message: `Pair already resolved with verb "${pair.resolution}"` };
   }
 


### PR DESCRIPTION
## Summary
- Treat `needs-more-context` as a temporary deferral instead of a persisted terminal contradiction resolution.
- Add `deferredUntil` handling so active deferrals stay out of unresolved review, while expired deferrals re-enter the queue and can be refreshed.
- Add regression coverage for execution, unresolved listing, cooldown handling, and refresh after deferral expiry.

## Clawpatch
- Fixes `fnd_sig-feat-library-058376cb2a-d68a_9ab85617dc` (`Deferred contradiction resolutions are treated as permanent resolutions`).

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts`
- `pnpm run check-types`
- `git diff --check`
- `npm run preflight:quick`
- `node /Users/joshuawarren/src/clawpatch/dist/cli.js --state-dir /tmp/remnic-clawpatch-current-local-20260517 revalidate --finding fnd_sig-feat-library-058376cb2a-d68a_9ab85617dc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes contradiction review queue persistence and filtering semantics by introducing time-based deferrals, which can affect what items appear for user review and when entries are overwritten/refreshed.
> 
> **Overview**
> Treats `needs-more-context` as a *non-terminal deferral* rather than a persisted resolution by introducing `deferredUntil` and deferral-aware helpers in `contradiction-review.ts`.
> 
> Updates queue behavior so **unresolved listings hide active deferrals**, `isCoolingDown` uses deferral timing when present, and `writePair` preserves terminal resolutions while allowing **expired deferrals to re-enter the queue and be refreshed**. Adds `deferPair` (and routes `resolvePair("needs-more-context")` through it) plus new tests covering deferral execution, listing behavior, expiry/refresh, and legacy `needs-more-context` handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986e70cfd28e95c5d4fa912fcce72f5abc20d7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->