### PR TITLE
Fix review approval collision handling

### DIFF
--- a/packages/remnic-core/src/review/index.test.ts
+++ b/packages/remnic-core/src/review/index.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { TestContext } from "node:test";
+import { performReview } from "./index.js";
+
+async function makeMemoryDir(t: TestContext): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-review-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function reviewMarkdown(id: string): string {
+  return `---
+id: ${id}
+category: fact
+confidence: 0.4
+confidenceTier: low
+source: test
+created: 2026-05-17T00:00:00.000Z
+reviewReason: low_confidence
+---
+Candidate memory.`;
+}
+
+test("approve promotes to the source basename when no target exists", async (t) => {
+  const memoryDir = await makeMemoryDir(t);
+  const reviewDir = path.join(memoryDir, "review");
+  await mkdir(reviewDir, { recursive: true });
+  const reviewPath = path.join(reviewDir, "candidate.md");
+  await writeFile(reviewPath, reviewMarkdown("review-no-collision"), "utf8");
+
+  const result = performReview(memoryDir, "review-no-collision", "approve");
+
+  const today = new Date().toISOString().split("T")[0];
+  const expectedPath = path.join(memoryDir, "facts", today, "candidate.md");
+  assert.equal(result.updatedPath, expectedPath);
+  assert.match(await readFile(expectedPath, "utf8"), /confidence: 0\.9/);
+  await assert.rejects(stat(reviewPath), /ENOENT/);
+});
+
+test("approve does not overwrite an existing promoted memory with the same basename", async (t) => {
+  const memoryDir = await makeMemoryDir(t);
+  const reviewDir = path.join(memoryDir, "review");
+  await mkdir(reviewDir, { recursive: true });
+  const reviewPath = path.join(reviewDir, "candidate.md");
+  await writeFile(reviewPath, reviewMarkdown("review/collision"), "utf8");
+
+  const today = new Date().toISOString().split("T")[0];
+  const targetDir = path.join(memoryDir, "facts", today);
+  await mkdir(targetDir, { recursive: true });
+  const collisionPath = path.join(targetDir, "candidate.md");
+  await writeFile(collisionPath, "original promoted memory", "utf8");
+
+  const result = performReview(memoryDir, "review/collision", "approve");
+
+  assert.notEqual(result.updatedPath, collisionPath);
+  assert.match(path.basename(result.updatedPath ?? ""), /^candidate-review-collision(?:-\d+)?\.md$/);
+  assert.equal(await readFile(collisionPath, "utf8"), "original promoted memory");
+
+  const promotedContent = await readFile(result.updatedPath!, "utf8");
+  assert.match(promotedContent, /confidence: 0\.9/);
+  assert.match(promotedContent, /confidenceTier: high/);
+  await assert.rejects(stat(reviewPath), /ENOENT/);
+});

--- a/packages/remnic-core/src/review/index.ts
+++ b/packages/remnic-core/src/review/index.ts
@@ -211,7 +211,6 @@ function approveItem(memoryDir: string, itemId: string): ReviewResult {
 
     const content = fs.readFileSync(found, "utf8");
     const fm = parseFrontmatter(content);
-    const body = extractBody(content);
     if (!fm) return { itemId, action: "approve", message: "Could not parse frontmatter" };
 
     // Promote to facts/ with boosted confidence
@@ -226,7 +225,7 @@ function approveItem(memoryDir: string, itemId: string): ReviewResult {
       .replace(/confidenceTier: \w+/, "confidenceTier: high");
 
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-    fs.writeFileSync(outputPath, updatedContent);
+    const promotedPath = writeFileWithoutClobber(outputPath, updatedContent, itemId);
 
     // Remove from review
     fs.unlinkSync(found);
@@ -234,7 +233,7 @@ function approveItem(memoryDir: string, itemId: string): ReviewResult {
     return {
       itemId,
       action: "approve",
-      updatedPath: outputPath,
+      updatedPath: promotedPath,
       message: `Promoted to ${category} with confidence 0.9`,
     };
   }
@@ -308,6 +307,64 @@ function readFileSafe(filePath: string): string | null {
   } catch {
     return null;
   }
+}
+
+function writeFileWithoutClobber(basePath: string, content: string, discriminator: string): string {
+  const parsed = path.parse(basePath);
+  const safeDiscriminator = sanitizeFilePart(discriminator);
+
+  for (let attempt = 0; attempt < 1000; attempt++) {
+    const candidate = attempt === 0
+      ? basePath
+      : path.join(
+        parsed.dir,
+        `${parsed.name}-${safeDiscriminator}${attempt === 1 ? "" : `-${attempt}`}${parsed.ext || ".md"}`,
+      );
+
+    try {
+      fs.writeFileSync(candidate, content, { encoding: "utf8", flag: "wx" });
+      return candidate;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") continue;
+      throw error;
+    }
+  }
+
+  throw new Error(`Could not find a free review promotion path for ${basePath}`);
+}
+
+function sanitizeFilePart(value: string): string {
+  const chars: string[] = [];
+  let previousWasDash = false;
+
+  for (const char of value) {
+    const next = isSafeFilePartChar(char) ? char : "-";
+    if (next === "-" && previousWasDash) continue;
+    chars.push(next);
+    previousWasDash = next === "-";
+    if (chars.length >= 64) break;
+  }
+
+  let start = 0;
+  let end = chars.length;
+  while (start < end && chars[start] === "-") start++;
+  while (end > start && chars[end - 1] === "-") end--;
+
+  const sanitized = chars.slice(start, end).join("");
+  return sanitized || "review-item";
+}
+
+function isSafeFilePartChar(value: string): boolean {
+  if (value.length !== 1) return false;
+  const code = value.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    value === "." ||
+    value === "_" ||
+    value === "-"
+  );
 }
 
 function parseFrontmatter(content: string): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary
- prevent review approval from overwriting an existing promoted memory with the same basename
- use exclusive file creation and an ID-suffixed fallback path on collision
- add regression coverage for normal approval and collision preservation

## Verification
- pnpm exec tsx --test packages/remnic-core/src/review/index.test.ts
- pnpm run check-types
- git diff --check
- node /Users/joshuawarren/src/clawpatch/dist/cli.js --state-dir /tmp/remnic-clawpatch-main-20260517-after-1028 revalidate --finding fnd_sig-feat-library-0cbdccb48f-f43c_8186b0aa83
- npm run preflight:quick

Clawpatch finding fixed: fnd_sig-feat-library-0cbdccb48f-f43c_8186b0aa83

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `approve` promotion path to use exclusive file creation with fallback filenames, which affects how reviewed items are persisted and could surface new edge cases in file naming/collision handling. Scope is limited to local filesystem writes and is covered by new regression tests.
> 
> **Overview**
> Fixes review approval so promoting an item to the dated category directory no longer overwrites an existing file with the same basename.
> 
> `approve` now writes via `writeFileWithoutClobber`, using exclusive create (`wx`) and generating an ID-suffixed fallback filename (with sanitization) on collisions; `updatedPath` returns the actual promoted path. Adds node tests covering the no-collision case and verifying collision preservation plus confidence boosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf2a79f4bc2f1ce1fa6766b9871a9ea339054ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->