### PR TITLE
Fix causal trajectory store path resolution

### DIFF
--- a/packages/remnic-core/src/causal-behavior.ts
+++ b/packages/remnic-core/src/causal-behavior.ts
@@ -9,7 +9,7 @@
  * Key insight: "Preferences are recurring causal pathways."
  */
 
-import type { CausalTrajectoryRecord } from "./causal-trajectory.js";
+import { resolveCausalTrajectoryStoreDir, type CausalTrajectoryRecord } from "./causal-trajectory.js";
 import type { CausalChainIndex } from "./causal-chain.js";
 import { readChainIndex, resolveChainsDir } from "./causal-chain.js";
 import { normalizeRecallTokens } from "./recall-tokenization.js";
@@ -270,9 +270,7 @@ export async function extractCausalBehaviorSignals(options: {
     const { memoryDir, causalTrajectoryStoreDir, config: behaviorConfig } = options;
 
     // Read all trajectories
-    const root = causalTrajectoryStoreDir
-      ? path.join(memoryDir, causalTrajectoryStoreDir)
-      : path.join(memoryDir, "state", "causal-trajectories");
+    const root = resolveCausalTrajectoryStoreDir(memoryDir, causalTrajectoryStoreDir);
     const trajectoriesDir = path.join(root, "trajectories");
     const files = await listJsonFiles(trajectoriesDir).catch(() => [] as string[]);
 

--- a/packages/remnic-core/src/causal-chain.ts
+++ b/packages/remnic-core/src/causal-chain.ts
@@ -10,7 +10,7 @@ import path from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { listJsonFiles, readJsonFile } from "./json-store.js";
-import type { CausalTrajectoryRecord } from "./causal-trajectory.js";
+import { resolveCausalTrajectoryStoreDir, type CausalTrajectoryRecord } from "./causal-trajectory.js";
 import { topicOverlapScore } from "./boxes.js";
 import { countRecallTokenOverlap, normalizeRecallTokens } from "./recall-tokenization.js";
 import {
@@ -118,9 +118,7 @@ export function makeEdgeId(fromId: string, toId: string): string {
 // ─── Storage Paths ───────────────────────────────────────────────────────────
 
 export function resolveChainsDir(memoryDir: string, causalTrajectoryStoreDir?: string): string {
-  const root = causalTrajectoryStoreDir
-    ? path.join(memoryDir, causalTrajectoryStoreDir)
-    : path.join(memoryDir, "state", "causal-trajectories");
+  const root = resolveCausalTrajectoryStoreDir(memoryDir, causalTrajectoryStoreDir);
   return path.join(root, "chains");
 }
 
@@ -312,9 +310,7 @@ async function readRecentTrajectories(
   currentSessionKey: string,
   lookbackDays: number,
 ): Promise<CausalTrajectoryRecord[]> {
-  const root = causalTrajectoryStoreDir
-    ? path.join(memoryDir, causalTrajectoryStoreDir)
-    : path.join(memoryDir, "state", "causal-trajectories");
+  const root = resolveCausalTrajectoryStoreDir(memoryDir, causalTrajectoryStoreDir);
   const trajectoriesDir = path.join(root, "trajectories");
 
   const files = await listJsonFiles(trajectoriesDir).catch(() => [] as string[]);

--- a/packages/remnic-core/src/causal-consolidation.ts
+++ b/packages/remnic-core/src/causal-consolidation.ts
@@ -13,7 +13,7 @@
  */
 
 import { createHash } from "node:crypto";
-import type { CausalTrajectoryRecord } from "./causal-trajectory.js";
+import { resolveCausalTrajectoryStoreDir, type CausalTrajectoryRecord } from "./causal-trajectory.js";
 import { readChainIndex, resolveChainsDir, type CausalChainIndex, type CausalEdge } from "./causal-chain.js";
 import { listJsonFiles, readJsonFile } from "./json-store.js";
 import { isRecord } from "./store-contract.js";
@@ -67,9 +67,7 @@ async function readAllTrajectories(
   memoryDir: string,
   causalTrajectoryStoreDir?: string,
 ): Promise<CausalTrajectoryRecord[]> {
-  const root = causalTrajectoryStoreDir
-    ? path.join(memoryDir, causalTrajectoryStoreDir)
-    : path.join(memoryDir, "state", "causal-trajectories");
+  const root = resolveCausalTrajectoryStoreDir(memoryDir, causalTrajectoryStoreDir);
   const trajectoriesDir = path.join(root, "trajectories");
 
   const files = await listJsonFiles(trajectoriesDir).catch(() => [] as string[]);

--- a/tests/causal-behavior.test.ts
+++ b/tests/causal-behavior.test.ts
@@ -9,6 +9,7 @@ import {
   extractCausalBehaviorSignals,
   type CausalBehaviorSignal,
 } from "../src/causal-behavior.js";
+import { parseConfig } from "../src/config.js";
 import { recordCausalTrajectory } from "../src/causal-trajectory.js";
 import { writeChainIndex, resolveChainsDir, type CausalChainIndex, type CausalEdge } from "../src/causal-chain.js";
 
@@ -159,6 +160,43 @@ test("extractCausalBehaviorSignals detects topic revisitation", async () => {
   const topicSignals = signals.filter((s) => s.signalType === "topic_revisitation");
   assert.ok(topicSignals.length > 0, "Expected topic revisitation signal");
   assert.ok(topicSignals[0].frequency >= 3);
+});
+
+test("extractCausalBehaviorSignals reads trajectories from parsed config store dir", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-behavior-config-dir-"));
+  const cfg = parseConfig({ memoryDir });
+
+  for (let i = 0; i < 3; i++) {
+    await recordCausalTrajectory({
+      memoryDir: cfg.memoryDir,
+      causalTrajectoryStoreDir: cfg.causalTrajectoryStoreDir,
+      record: {
+        schemaVersion: 1,
+        trajectoryId: `traj-config-topic-${i}`,
+        recordedAt: new Date(Date.UTC(2026, 4, i + 1, 10)).toISOString(),
+        sessionKey: `session-config-${i}`,
+        goal: "Fix authentication error handling",
+        actionSummary: "Patched login handler",
+        observationSummary: "Tests pass",
+        outcomeKind: "success",
+        outcomeSummary: "Auth fixed",
+      },
+    });
+  }
+
+  const signals = await extractCausalBehaviorSignals({
+    memoryDir: cfg.memoryDir,
+    causalTrajectoryStoreDir: cfg.causalTrajectoryStoreDir,
+    config: { minFrequency: 3, minSessions: 2, confidenceThreshold: 0.6 },
+  });
+
+  const topicSignals = signals.filter((s) => s.signalType === "topic_revisitation");
+  assert.equal(topicSignals.length, 1);
+  assert.deepEqual(topicSignals[0].trajectoryIds, [
+    "traj-config-topic-0",
+    "traj-config-topic-1",
+    "traj-config-topic-2",
+  ]);
 });
 
 test("extractCausalBehaviorSignals detects action patterns", async () => {

--- a/tests/causal-chain.test.ts
+++ b/tests/causal-chain.test.ts
@@ -239,9 +239,9 @@ test("resolveChainsDir uses default path", () => {
   assert.equal(dir, path.join("/tmp/engram", "state", "causal-trajectories", "chains"));
 });
 
-test("resolveChainsDir uses custom store dir", () => {
+test("resolveChainsDir treats custom store dir as the resolved store root", () => {
   const dir = resolveChainsDir("/tmp/engram", "custom/store");
-  assert.equal(dir, path.join("/tmp/engram", "custom/store", "chains"));
+  assert.equal(dir, path.join("custom/store", "chains"));
 });
 
 // ─── End-to-end stitching ────────────────────────────────────────────────────

--- a/tests/causal-consolidation.test.ts
+++ b/tests/causal-consolidation.test.ts
@@ -7,7 +7,35 @@ import {
   deriveCausalPromotionCandidates,
   synthesizeCausalPreferencesViaLlm,
 } from "../src/causal-consolidation.js";
+import { parseConfig } from "../src/config.js";
 import { recordCausalTrajectory, type CausalTrajectoryRecord } from "../src/causal-trajectory.js";
+import type { GatewayConfig } from "../src/types.js";
+
+type ChatCompletionRequest = {
+  messages: Array<{ role: string; content: string }>;
+};
+
+function testGatewayConfig(): GatewayConfig {
+  return {
+    agents: {
+      defaults: {
+        model: {
+          primary: "test-provider/test-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        "test-provider": {
+          baseUrl: "http://llm.test/v1",
+          api: "openai-completions",
+          apiKey: "test-key",
+          models: [],
+        },
+      },
+    },
+  };
+}
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -72,6 +100,97 @@ test("deriveCausalPromotionCandidates returns empty without LLM when trajectorie
     config: { minRecurrence: 3, minSessions: 2, successThreshold: 0.7 },
   });
   assert.equal(candidates.length, 0, "Without LLM, should return empty");
+});
+
+test("deriveCausalPromotionCandidates reads trajectories from parsed config store dir", async (t) => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-consol-config-dir-"));
+  const cfg = parseConfig({ memoryDir });
+  assert.equal(
+    cfg.causalTrajectoryStoreDir,
+    path.join(memoryDir, "state", "causal-trajectories"),
+  );
+
+  await recordCausalTrajectory({
+    memoryDir: cfg.memoryDir,
+    causalTrajectoryStoreDir: cfg.causalTrajectoryStoreDir,
+    record: {
+      schemaVersion: 1,
+      trajectoryId: "traj-config-a",
+      recordedAt: new Date("2026-05-01T10:00:00.000Z").toISOString(),
+      sessionKey: "session-a",
+      goal: "Fix authentication regression",
+      actionSummary: "Added regression tests before refactoring the handler",
+      observationSummary: "The focused test caught the stale branch",
+      outcomeKind: "success",
+      outcomeSummary: "Authentication regression fixed",
+    },
+  });
+
+  await recordCausalTrajectory({
+    memoryDir: cfg.memoryDir,
+    causalTrajectoryStoreDir: cfg.causalTrajectoryStoreDir,
+    record: {
+      schemaVersion: 1,
+      trajectoryId: "traj-config-b",
+      recordedAt: new Date("2026-05-02T10:00:00.000Z").toISOString(),
+      sessionKey: "session-b",
+      goal: "Fix authentication follow-up",
+      actionSummary: "Kept the regression test while simplifying the handler",
+      observationSummary: "The second pass stayed green",
+      outcomeKind: "success",
+      outcomeSummary: "Follow-up authentication fix landed",
+    },
+  });
+
+  const requests: ChatCompletionRequest[] = [];
+  const originalFetch = globalThis.fetch;
+  const mockFetch: typeof fetch = async (_input, init) => {
+    if (typeof init?.body === "string") {
+      requests.push(JSON.parse(init.body) as ChatCompletionRequest);
+    }
+    return new Response(
+      JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                rules: [
+                  {
+                    content: "When fixing auth bugs, add regression tests before refactoring.",
+                    category: "rule",
+                    confidence: 0.92,
+                    evidence: ["traj-config-a", "traj-config-b"],
+                  },
+                ],
+                preferences: [],
+              }),
+            },
+          },
+        ],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  };
+  globalThis.fetch = mockFetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const candidates = await deriveCausalPromotionCandidates({
+    memoryDir: cfg.memoryDir,
+    causalTrajectoryStoreDir: cfg.causalTrajectoryStoreDir,
+    config: { minRecurrence: 2, minSessions: 1, successThreshold: 0.7 },
+    gatewayConfig: testGatewayConfig(),
+  });
+
+  assert.equal(requests.length, 1, "expected consolidation to call the LLM with recorded trajectories");
+  assert.match(requests[0].messages[1].content, /Fix authentication regression/);
+  assert.match(requests[0].messages[1].content, /Fix authentication follow-up/);
+  assert.equal(candidates.length, 1);
+  assert.deepEqual(candidates[0].provenance, ["traj-config-a", "traj-config-b"]);
 });
 
 test("synthesizeCausalPreferencesViaLlm returns null for empty store", async () => {


### PR DESCRIPTION
## Summary
- route causal consolidation, chain stitching, and behavior extraction through the shared trajectory store resolver
- align the chain helper test with the resolver contract for custom store roots
- add parsed-config regression coverage for consolidation and behavior extraction

## Verification
- pnpm exec tsx --test tests/causal-consolidation.test.ts tests/causal-behavior.test.ts tests/causal-chain.test.ts
- pnpm run check-types
- git diff --check
- node /Users/joshuawarren/src/clawpatch/dist/cli.js --state-dir /tmp/remnic-clawpatch-main-20260517-after-1028 revalidate --finding fnd_sig-feat-library-2da00b2b0e-9086_43779ad1b0
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes filesystem path resolution for causal trajectory reading and chain storage; misconfigured/custom paths could alter where data is read/written, but changes are localized and covered by new tests.
> 
> **Overview**
> **Unifies causal-trajectory store path resolution** by routing causal behavior extraction, causal chain stitching (`resolveChainsDir`/trajectory reads), and causal consolidation through `resolveCausalTrajectoryStoreDir` instead of manually `path.join`-ing against `memoryDir`.
> 
> **Aligns and expands test coverage** to match the resolver contract for custom store roots (custom dir treated as already-resolved root), and adds regression tests ensuring behavior extraction and LLM consolidation read trajectories correctly when using `parseConfig`-derived `causalTrajectoryStoreDir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3005e30eec37b2db1b9c175a33214c07aa9482a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->