### PR TITLE
Redact explicit capture review metadata

### DIFF
--- a/packages/remnic-core/src/explicit-capture.ts
+++ b/packages/remnic-core/src/explicit-capture.ts
@@ -103,6 +103,42 @@ function redactSecrets(value: string): string {
   return redacted;
 }
 
+function containsSecretLikeValue(value: string): boolean {
+  return SECRET_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function assertNoSecretLikeMetadata(field: string, value: string | undefined): void {
+  const trimmed = asTrimmed(value);
+  if (trimmed && containsSecretLikeValue(trimmed)) {
+    throw new Error(`${field} appears to contain a secret or credential`);
+  }
+}
+
+function assertNoSecretLikeMetadataList(field: string, values: string[] | undefined): void {
+  for (const value of values ?? []) {
+    assertNoSecretLikeMetadata(field, value);
+  }
+}
+
+function sanitizeReviewText(value: string | undefined, fallback: string): string {
+  const redacted = redactSecrets(asTrimmed(value) ?? fallback);
+  const sanitized = sanitizeMemoryContent(redacted);
+  const safe = sanitized.text.trim();
+  return safe.length > 0 ? safe : fallback;
+}
+
+function sanitizeReviewMetadata(value: string | undefined): string | undefined {
+  const trimmed = asTrimmed(value);
+  if (!trimmed) return undefined;
+  return sanitizeReviewText(trimmed, "[redacted]");
+}
+
+function sanitizeReviewTags(tags: string[] | undefined): string[] {
+  return Array.from(new Set((tags ?? [])
+    .map((tag) => sanitizeReviewMetadata(tag))
+    .filter((tag): tag is string => typeof tag === "string" && tag.length > 0)));
+}
+
 function normalizeExplicitCaptureError(error: unknown): string {
   if (error instanceof Error && error.message.trim().length > 0) return error.message.trim();
   const rendered = String(error).trim();
@@ -285,6 +321,10 @@ export function validateExplicitCaptureInput(
       throw new Error("content appears to contain a secret or credential");
     }
   }
+  assertNoSecretLikeMetadata("sourceReason", input.sourceReason);
+  assertNoSecretLikeMetadata("entityRef", input.entityRef);
+  assertNoSecretLikeMetadata("ttl", input.ttl);
+  assertNoSecretLikeMetadataList("tags", input.tags);
 
   const confidence = Number.isFinite(input.confidence) ? Number(input.confidence) : 0.95;
   if (confidence < 0 || confidence > 1) {
@@ -384,8 +424,13 @@ export async function persistExplicitCapture(
 
 function buildExplicitCaptureReviewContent(input: ExplicitCaptureInput, reason: string): string {
   const requestedContent = asTrimmed(input.content);
-  const sanitized = sanitizeMemoryContent(redactSecrets(requestedContent ?? "[empty explicit capture]"));
-  const safeContent = sanitized.text.trim().length > 0 ? sanitized.text.trim() : "[empty explicit capture]";
+  const safeContent = sanitizeReviewText(requestedContent, "[empty explicit capture]");
+  const safeCategory = sanitizeReviewMetadata(input.category);
+  const safeNamespace = sanitizeReviewMetadata(input.namespace);
+  const safeEntityRef = sanitizeReviewMetadata(input.entityRef);
+  const safeTtl = sanitizeReviewMetadata(input.ttl);
+  const safeSourceReason = sanitizeReviewMetadata(input.sourceReason);
+  const safeTags = sanitizeReviewTags(input.tags);
   const lines = [
     "Explicit capture queued for review.",
     "",
@@ -395,12 +440,12 @@ function buildExplicitCaptureReviewContent(input: ExplicitCaptureInput, reason: 
     safeContent,
   ];
   const metadata = [
-    input.category ? `Requested category: ${input.category}` : undefined,
-    input.namespace ? `Requested namespace: ${input.namespace}` : undefined,
-    input.entityRef ? `Requested entityRef: ${input.entityRef}` : undefined,
-    input.ttl ? `Requested ttl: ${input.ttl}` : undefined,
-    input.sourceReason ? `Requested sourceReason: ${input.sourceReason}` : undefined,
-    input.tags && input.tags.length > 0 ? `Requested tags: ${input.tags.join(", ")}` : undefined,
+    safeCategory ? `Requested category: ${safeCategory}` : undefined,
+    safeNamespace ? `Requested namespace: ${safeNamespace}` : undefined,
+    safeEntityRef ? `Requested entityRef: ${safeEntityRef}` : undefined,
+    safeTtl ? `Requested ttl: ${safeTtl}` : undefined,
+    safeSourceReason ? `Requested sourceReason: ${safeSourceReason}` : undefined,
+    safeTags.length > 0 ? `Requested tags: ${safeTags.join(", ")}` : undefined,
   ].filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
   if (metadata.length > 0) {
     lines.push("", ...metadata);
@@ -431,7 +476,7 @@ export async function queueExplicitCaptureForReview(
   source: ExplicitCaptureSource,
   error: unknown,
 ): Promise<{ id: string; duplicateOf?: string }> {
-  const reason = normalizeExplicitCaptureError(error);
+  const reason = sanitizeReviewText(normalizeExplicitCaptureError(error), "explicit capture failed");
   const requestedNamespace = asTrimmed(input.namespace);
   const queueNamespace = resolveExplicitCaptureReviewNamespace(orchestrator, requestedNamespace);
   const content = buildExplicitCaptureReviewContent(input, reason);
@@ -444,14 +489,12 @@ export async function queueExplicitCaptureForReview(
   const reviewCategory = requestedCategory && INLINE_ALLOWED_CATEGORIES.has(requestedCategory as MemoryCategory)
     ? requestedCategory as MemoryCategory
     : "fact";
-  const requestedTags = Array.isArray(input.tags)
-    ? input.tags.map((tag) => tag.trim()).filter(Boolean)
-    : [];
+  const requestedTags = sanitizeReviewTags(input.tags);
   const storage = await orchestrator.getStorage(queueNamespace);
   const id = await storage.writeMemory(reviewCategory, content, {
     confidence: 0.2,
     tags: Array.from(new Set([...EXPLICIT_CAPTURE_REVIEW_TAGS, ...requestedTags])),
-    entityRef: asTrimmed(input.entityRef),
+    entityRef: sanitizeReviewMetadata(input.entityRef),
     source: source === "inline" ? "explicit-inline-review" : "explicit-review",
   });
   const created = await storage.getMemoryById(id);

--- a/tests/explicit-capture.test.ts
+++ b/tests/explicit-capture.test.ts
@@ -98,6 +98,27 @@ test("explicit capture validation rejects likely secrets", () => {
   );
 });
 
+test("explicit capture validation rejects credential-like metadata", () => {
+  const tagName = ["api", "key"].join("_");
+  const tagValue = ["tag", "Secret", "12345"].join("");
+  const unsafeTag = [tagName, tagValue].join("=");
+  for (const [field, input] of [
+    ["sourceReason", { sourceReason: "token=sourceReasonSecret12345" }],
+    ["entityRef", { entityRef: "secret=entitySecret12345" }],
+    ["ttl", { ttl: "password=ttlSecret12345" }],
+    ["tags", { tags: ["operator-review", unsafeTag] }],
+  ] as const) {
+    assert.throws(
+      () =>
+        validateExplicitCaptureInput({
+          content: "This safe explicit capture has unsafe metadata.",
+          ...input,
+        }),
+      new RegExp(`${field} appears to contain a secret or credential`),
+    );
+  }
+});
+
 test("explicit capture validation rejects invalid ttl values before persistence", () => {
   assert.throws(
     () =>
@@ -282,6 +303,107 @@ test("queueExplicitCaptureForReview stores a pending-review memory and lifecycle
   assert.doesNotMatch(memories[0]?.content ?? "", /supersecretvalue123/);
   assert.match(memories[0]?.content ?? "", /\[redacted credential\]/);
   assert.equal(lifecycleEvents.some((event) => event.eventType === "explicit_capture_queued"), true);
+});
+
+test("queueExplicitCaptureForReview redacts credential-like review metadata", async () => {
+  const tagName = ["api", "key"].join("_");
+  const tagValue = ["tag", "Secret", "12345"].join("");
+  const unsafeTag = [tagName, tagValue].join("=");
+  const memories: Array<{
+    frontmatter: { id: string; status?: string; tags?: string[]; category?: string; entityRef?: string };
+    content: string;
+    path: string;
+  }> = [];
+  const frontmatterReasons: string[] = [];
+  const lifecycleReasons: string[] = [];
+  const storage = {
+    readAllMemories: async () => memories,
+    writeMemory: async (
+      category: string,
+      content: string,
+      options: { tags?: string[]; entityRef?: string },
+    ) => {
+      memories.push({
+        frontmatter: {
+          id: "fact-1",
+          category,
+          tags: options.tags,
+          entityRef: options.entityRef,
+          status: "active",
+        },
+        content,
+        path: "/tmp/fact-1.md",
+      });
+      return "fact-1";
+    },
+    getMemoryById: async (id: string) => memories.find((memory) => memory.frontmatter.id === id) ?? null,
+    writeMemoryFrontmatter: async (
+      memory: { frontmatter: { status?: string } },
+      patch: { status: string },
+      options: { reasonCode?: string },
+    ) => {
+      memory.frontmatter.status = patch.status;
+      frontmatterReasons.push(options.reasonCode ?? "");
+      return memory;
+    },
+    appendMemoryLifecycleEvents: async (events: Array<{ reasonCode?: string }>) => {
+      lifecycleReasons.push(...events.map((event) => event.reasonCode ?? ""));
+      return events.length;
+    },
+  };
+
+  await queueExplicitCaptureForReview(
+    {
+      config: {
+        defaultNamespace: "default",
+        sharedNamespace: "shared",
+        namespacesEnabled: false,
+        namespacePolicies: [],
+      },
+      getStorage: async () => storage,
+    } as never,
+    {
+      content: "This safe explicit capture should be queued for manual review.",
+      category: "fact",
+      tags: ["operator-review", unsafeTag],
+      entityRef: "secret=entitySecret12345",
+      ttl: "password=ttlSecret12345",
+      sourceReason: "token=sourceReasonSecret12345",
+    },
+    "memory_capture",
+    new Error("Bearer abcdefghijklmnop"),
+  );
+
+  assert.equal(memories.length, 1);
+  const persisted = [
+    memories[0]?.content ?? "",
+    ...(memories[0]?.frontmatter.tags ?? []),
+    memories[0]?.frontmatter.entityRef ?? "",
+    ...frontmatterReasons,
+    ...lifecycleReasons,
+  ].join("\n");
+
+  for (const secret of [
+    "tagSecret12345",
+    "entitySecret12345",
+    "ttlSecret12345",
+    "sourceReasonSecret12345",
+    "abcdefghijklmnop",
+  ]) {
+    assert.equal(persisted.includes(secret), false, `review record leaked ${secret}`);
+  }
+  assert.match(memories[0]?.content ?? "", /Reason: Bearer \[redacted token\]/);
+  assert.match(memories[0]?.content ?? "", /Requested sourceReason: \[redacted credential\]/);
+  assert.match(memories[0]?.content ?? "", /Requested ttl: \[redacted credential\]/);
+  assert.deepEqual(memories[0]?.frontmatter.tags, [
+    "explicit-capture",
+    "queued-review",
+    "operator-review",
+    "[redacted credential]",
+  ]);
+  assert.equal(memories[0]?.frontmatter.entityRef, "[redacted credential]");
+  assert.deepEqual(frontmatterReasons, ["Bearer [redacted token]"]);
+  assert.deepEqual(lifecycleReasons, ["Bearer [redacted token]"]);
 });
 
 test("queueExplicitCaptureForReview preserves requested namespace isolation when namespaces are enabled", async () => {


### PR DESCRIPTION
## Summary
- reject credential-like explicit capture metadata before accepted persistence
- redact queued review reasons, metadata, tags, and entity refs before writing review records
- add regression coverage for validation and queued review persistence

## Verification
- pnpm exec tsx --test tests/explicit-capture.test.ts
- pnpm run check-types
- git diff --check
- node /Users/joshuawarren/src/clawpatch/dist/cli.js --state-dir /tmp/remnic-clawpatch-main-20260517-after-1028 revalidate --finding fnd_sig-feat-library-0dfe449a13-ae8e_39993e23cb
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens validation and sanitization around explicit-capture review queuing to prevent secret leakage in persisted review records; changes affect what gets rejected vs queued and how review content/metadata is stored.
> 
> **Overview**
> Prevents secrets from leaking via explicit-capture *review queue* records by adding secret-like detection/redaction for queued review `reason`, metadata fields, `entityRef`, and `tags` before persistence.
> 
> `validateExplicitCaptureInput` now rejects credential-like values not just in `content` but also in metadata (`sourceReason`, `entityRef`, `ttl`, `tags`). Tests add coverage for metadata validation failures and for ensuring queued review persistence/frontmatter/lifecycle reasons are properly redacted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a78e7ec992929bf480d1e62e0e5c44a9d18f904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->