### PR TITLE
Scope Remnic bench adapter resets

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { Orchestrator, parseConfig } from "@remnic/core";
+import { Orchestrator, parseConfig, parseEntityFile, StorageManager } from "@remnic/core";
 
 import {
   buildBenchAdapterConfig,
@@ -19,8 +20,55 @@ const BASE_CONFIG = {
   lcmEnabled: true as const,
 };
 
+function benchReplaySourceForTest(sessionId: string): string {
+  return `bench-replay-${createHash("sha256").update(sessionId).digest("hex").slice(0, 16)}`;
+}
+
+function createDeferredForTest(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function shellQuoteForTest(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function hourlySummarySnapshotForTest(sessionKey: string, bullet: string): string {
+  const generatedAt = "2026-05-17T10:00:00.000Z";
+  return JSON.stringify(
+    {
+      schemaVersion: 1,
+      sessionKey,
+      generatedAt,
+      summaries: [
+        {
+          hour: "2026-05-17T10:00:00.000Z",
+          sessionKey,
+          bullets: [bullet],
+          turnCount: 1,
+          generatedAt,
+        },
+      ],
+    },
+    null,
+    2,
+  );
+}
+
+async function assertPathMissingForTest(filePath: string): Promise<void> {
+  await assert.rejects(
+    () => stat(filePath),
+    (err: unknown) =>
+      !!err &&
+      typeof err === "object" &&
+      (err as { code?: unknown }).code === "ENOENT",
+  );
 }
 
 test("direct adapter keeps its recall-friendly defaults without overrides", () => {
@@ -160,7 +208,27 @@ test("direct adapter can use a caller-owned memory directory", async () => {
 
 test("direct adapter reset clears caller-owned memory directory", async () => {
   const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-owned-"));
-  const adapter = await createRemnicAdapter({ memoryDir });
+  const sentinelPath = path.join(memoryDir, "caller-owned-sentinel.txt");
+  const threadPath = path.join(memoryDir, "threads", "stale-thread.json");
+  const summaryPath = path.join(
+    memoryDir,
+    "summaries",
+    "hourly",
+    "owned-reset-session",
+    "2026-05-17.md",
+  );
+  await writeFile(sentinelPath, "do not remove");
+  await mkdir(path.dirname(threadPath), { recursive: true });
+  await writeFile(threadPath, "{}");
+  await mkdir(path.dirname(summaryPath), { recursive: true });
+  await writeFile(summaryPath, "stale hourly summary");
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
 
   try {
     await adapter.store("owned-reset-session", [
@@ -179,12 +247,1123 @@ test("direct adapter reset clears caller-owned memory directory", async () => {
 
     await adapter.reset?.();
     assert.equal((await stat(memoryDir)).isDirectory(), true);
+    assert.equal(await readFile(sentinelPath, "utf8"), "do not remove");
+    await assertPathMissingForTest(threadPath);
+    await assertPathMissingForTest(summaryPath);
 
     const afterReset = await adapter.recall(
       "owned-reset-session",
       "What is the caller-owned reset code?",
     );
     assert.doesNotMatch(afterReset, /violet-19/);
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset preserves other caller-owned sessions", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-session-"));
+  const sentinelPath = path.join(memoryDir, "caller-owned-sentinel.txt");
+  await writeFile(sentinelPath, "preserve caller data");
+  const adapter = await createRemnicAdapter({ memoryDir });
+
+  try {
+    await adapter.store("owned-reset-session-a", [
+      {
+        role: "user",
+        content: "Remember the session-a reset code is indigo-41.",
+      },
+    ]);
+    await adapter.store("owned-reset-session-b", [
+      {
+        role: "user",
+        content: "Remember the session-b reset code is copper-82.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    assert.match(
+      await adapter.recall(
+        "owned-reset-session-a",
+        "What is the session-a reset code?",
+      ),
+      /indigo-41/,
+    );
+    assert.match(
+      await adapter.recall(
+        "owned-reset-session-b",
+        "What is the session-b reset code?",
+      ),
+      /copper-82/,
+    );
+
+    await adapter.reset?.("owned-reset-session-a");
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve caller data");
+
+    assert.doesNotMatch(
+      await adapter.recall(
+        "owned-reset-session-a",
+        "What is the session-a reset code?",
+      ),
+      /indigo-41/,
+    );
+    assert.match(
+      await adapter.recall(
+        "owned-reset-session-b",
+        "What is the session-b reset code?",
+      ),
+      /copper-82/,
+    );
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset clears caller-owned hourly summaries", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-summary-"));
+  const resetSession = "owned-summary-reset-session";
+  const otherSession = "owned-summary-other-session";
+  const resetSummaryPath = path.join(
+    memoryDir,
+    "summaries",
+    "hourly",
+    resetSession,
+    "2026-05-17.md",
+  );
+  const otherSummaryPath = path.join(
+    memoryDir,
+    "summaries",
+    "hourly",
+    otherSession,
+    "2026-05-17.md",
+  );
+  const resetSnapshotPath = path.join(
+    memoryDir,
+    "state",
+    "summaries",
+    `${resetSession}.json`,
+  );
+  const otherSnapshotPath = path.join(
+    memoryDir,
+    "state",
+    "summaries",
+    `${otherSession}.json`,
+  );
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    configOverrides: {
+      hourlySummariesEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await mkdir(path.dirname(resetSummaryPath), { recursive: true });
+    await mkdir(path.dirname(otherSummaryPath), { recursive: true });
+    await mkdir(path.dirname(resetSnapshotPath), { recursive: true });
+    await writeFile(resetSummaryPath, "stale reset hourly summary");
+    await writeFile(otherSummaryPath, "preserve other hourly summary");
+    await writeFile(
+      resetSnapshotPath,
+      hourlySummarySnapshotForTest(resetSession, "stale reset snapshot"),
+    );
+    await writeFile(
+      otherSnapshotPath,
+      hourlySummarySnapshotForTest(otherSession, "preserve other snapshot"),
+    );
+
+    await adapter.reset?.(resetSession);
+
+    await assertPathMissingForTest(resetSummaryPath);
+    await assertPathMissingForTest(resetSnapshotPath);
+    assert.equal(await readFile(otherSummaryPath, "utf8"), "preserve other hourly summary");
+    assert.equal(
+      await readFile(otherSnapshotPath, "utf8"),
+      hourlySummarySnapshotForTest(otherSession, "preserve other snapshot"),
+    );
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset rejects summary path traversal", async () => {
+  const parentDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-reset-summary-traversal-"),
+  );
+  const memoryDir = path.join(parentDir, "memory");
+  const outsideDir = path.join(parentDir, "outside");
+  const outsidePath = path.join(outsideDir, "sentinel.txt");
+  await mkdir(memoryDir, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+  await writeFile(outsidePath, "preserve caller data");
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    configOverrides: {
+      hourlySummariesEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("../../../outside", [
+      {
+        role: "user",
+        content: "Remember the traversal reset code is calendula-91.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    await assert.rejects(
+      () => adapter.reset?.("../../../outside"),
+      /benchmark sessionId resolves outside Remnic benchmark state/,
+    );
+    assert.equal(await readFile(outsidePath, "utf8"), "preserve caller data");
+    assert.match(
+      await adapter.recall("../../../outside", "What is the traversal reset code?"),
+      /calendula-91/,
+    );
+  } finally {
+    await adapter.destroy();
+    await rm(parentDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset clears caller-owned core replay state", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-core-session-"));
+  const sentinelPath = path.join(memoryDir, "caller-owned-sentinel.txt");
+  await writeFile(sentinelPath, "preserve caller data");
+  const adapterOptions = {
+    memoryDir,
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  };
+  let adapter = await createRemnicAdapter(adapterOptions);
+
+  try {
+    await adapter.store("owned-core-reset-session", [
+      {
+        role: "user",
+        content: "Remember the old core reset code is orchid-17.",
+      },
+    ]);
+    await adapter.store("owned-core-reset-other-session", [
+      {
+        role: "user",
+        content: "Remember the other core reset code is cedar-29.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    assert.match(
+      await adapter.recall(
+        "owned-core-reset-session",
+        "What is the core reset code?",
+      ),
+      /orchid-17/,
+    );
+    assert.match(
+      await adapter.recall(
+        "owned-core-reset-other-session",
+        "What is the other core reset code?",
+      ),
+      /cedar-29/,
+    );
+
+    await adapter.destroy();
+    adapter = await createRemnicAdapter(adapterOptions);
+
+    await adapter.reset?.("owned-core-reset-session");
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve caller data");
+
+    await adapter.store("owned-core-reset-session", [
+      {
+        role: "user",
+        content: "Remember the new core reset code is willow-83.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "owned-core-reset-session",
+      "What is the core reset code?",
+    );
+    assert.doesNotMatch(recalled, /orchid-17/);
+    assert.match(recalled, /willow-83/);
+    assert.match(
+      await adapter.recall(
+        "owned-core-reset-other-session",
+        "What is the other core reset code?",
+      ),
+      /cedar-29/,
+    );
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset clears caller-owned verbatim artifacts", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-artifacts-"));
+  const resetSession = "owned-artifact-reset-session";
+  const otherSession = "owned-artifact-other-session";
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    configOverrides: {
+      transcriptEnabled: true,
+      verbatimArtifactsEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    const storage = new StorageManager(memoryDir);
+    const resetMemoryId = await storage.writeMemory(
+      "fact",
+      "Remember the stale artifact reset code is hibiscus-57.",
+      { source: benchReplaySourceForTest(resetSession) },
+    );
+    const otherMemoryId = await storage.writeMemory(
+      "fact",
+      "Remember the other artifact code is juniper-68.",
+      { source: benchReplaySourceForTest(otherSession) },
+    );
+    await storage.writeArtifact(
+      "Verbatim stale artifact quote: hibiscus-57.",
+      { sourceMemoryId: resetMemoryId },
+    );
+    await storage.writeArtifact(
+      "Verbatim other artifact quote: juniper-68.",
+      { sourceMemoryId: otherMemoryId },
+    );
+
+    const resetArtifact = (await storage.searchArtifacts("hibiscus-57", 10))
+      .find((artifact) => artifact.frontmatter.sourceMemoryId === resetMemoryId);
+    const otherArtifact = (await storage.searchArtifacts("juniper-68", 10))
+      .find((artifact) => artifact.frontmatter.sourceMemoryId === otherMemoryId);
+    assert.ok(resetArtifact);
+    assert.ok(otherArtifact);
+
+    await adapter.reset?.(resetSession);
+
+    await assertPathMissingForTest(resetArtifact.path);
+    assert.match(await readFile(otherArtifact.path, "utf8"), /juniper-68/);
+    const remainingArtifacts = await new StorageManager(memoryDir).searchArtifacts(
+      "juniper-68",
+      10,
+    );
+    assert.equal(
+      remainingArtifacts.some(
+        (artifact) => artifact.frontmatter.sourceMemoryId === otherMemoryId,
+      ),
+      true,
+    );
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset clears caller-owned entity timeline state", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-entities-"));
+  const resetSession = "owned-entity-reset-session";
+  const otherSession = "owned-entity-other-session";
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    configOverrides: {
+      entityRetrievalEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    const storage = new StorageManager(memoryDir);
+    const sharedEntityName = await storage.writeEntity(
+      "Shared Reset Entity",
+      "project",
+      ["Remember the stale entity reset code is camellia-33."],
+      { source: "extraction", sessionKey: resetSession },
+    );
+    await storage.writeEntity(
+      "Shared Reset Entity",
+      "project",
+      ["Remember the other entity code is fern-44."],
+      { source: "extraction", sessionKey: otherSession },
+    );
+    const resetOnlyEntityName = await storage.writeEntity(
+      "Reset Only Entity",
+      "project",
+      ["Remember the reset-only entity code is moss-13."],
+      { source: "extraction", sessionKey: resetSession },
+    );
+    const whitespaceEntityName = await storage.writeEntity(
+      "Whitespace Entity",
+      "project",
+      [
+        "Keep the alpha  beta spacing variant.",
+        "Keep the alpha beta spacing variant.",
+      ],
+      { source: "extraction", sessionKey: otherSession },
+    );
+    await storage.writeEntity(
+      "Whitespace Entity",
+      "project",
+      ["Remember the reset whitespace code is lichen-92."],
+      { source: "extraction", sessionKey: resetSession },
+    );
+    const preexistingStructuredEntityName = await storage.writeEntity(
+      "Preexisting Structured Entity",
+      "project",
+      [],
+      {
+        structuredSections: [
+          {
+            key: "details",
+            title: "Details",
+            facts: ["Preserve the preexisting structured code agate-64."],
+          },
+        ],
+      },
+    );
+    await storage.writeEntity(
+      "Preexisting Structured Entity",
+      "project",
+      ["Remember the reset-only timeline code is basalt-29."],
+      { source: "extraction", sessionKey: resetSession },
+    );
+
+    await adapter.reset?.(resetSession);
+
+    const sharedEntity = await storage.readEntity(sharedEntityName);
+    assert.doesNotMatch(sharedEntity, /camellia-33/);
+    assert.match(sharedEntity, /fern-44/);
+    assert.equal(sharedEntity.includes(`[session=${resetSession}]`), false);
+    assert.equal(sharedEntity.includes(`[session=${otherSession}]`), true);
+    await assertPathMissingForTest(
+      path.join(memoryDir, "entities", `${resetOnlyEntityName}.md`),
+    );
+    const whitespaceEntity = parseEntityFile(await storage.readEntity(whitespaceEntityName));
+    assert.deepEqual(
+      whitespaceEntity.facts.filter((fact) => fact.includes("alpha")),
+      [
+        "Keep the alpha  beta spacing variant.",
+        "Keep the alpha beta spacing variant.",
+      ],
+    );
+    const preexistingStructuredEntity = await storage.readEntity(
+      preexistingStructuredEntityName,
+    );
+    assert.match(preexistingStructuredEntity, /agate-64/);
+    assert.doesNotMatch(preexistingStructuredEntity, /basalt-29/);
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset clears replay structured entity facts", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-reset-structured-entities-"),
+  );
+  const resetSession = "structured-entity-reset-session";
+  const otherSession = "structured-entity-other-session";
+  const originalIngestReplayBatch = Orchestrator.prototype.ingestReplayBatch;
+  let adapter: Awaited<ReturnType<typeof createRemnicAdapter>> | undefined;
+  let sharedEntityName = "";
+  let duplicateEntityName = "";
+
+  Orchestrator.prototype.ingestReplayBatch = async function (
+    this: Orchestrator,
+    turns: Parameters<Orchestrator["ingestReplayBatch"]>[0],
+  ): Promise<void> {
+    const sessionKey = turns[0]?.sessionKey ?? "";
+    const code = sessionKey === resetSession ? "iris-41" : "cedar-52";
+    sharedEntityName = await this.storage.writeEntity(
+      "Shared Structured Entity",
+      "project",
+      [`Remember the structured entity timeline code is ${code}.`],
+      {
+        source: "extraction",
+        sessionKey,
+        structuredSections: [
+          {
+            key: "details",
+            title: "Details",
+            facts: [`Remember the structured entity section code is ${code}.`],
+          },
+        ],
+      },
+    );
+    if (sessionKey === resetSession) {
+      await this.storage.writeEntity(
+        "Duplicate Structured Entity",
+        "project",
+        ["Remember the duplicate structured reset timeline code is quartz-18."],
+        {
+          source: "extraction",
+          sessionKey,
+          structuredSections: [
+            {
+              key: "details",
+              title: "Details",
+              facts: ["Preserve the duplicate structured code opal-73."],
+            },
+          ],
+        },
+      );
+    }
+  };
+
+  try {
+    adapter = await createRemnicAdapter({
+      memoryDir,
+      configOverrides: {
+        entityRetrievalEnabled: true,
+        extractionMinUserTurns: 999,
+      },
+    });
+    const storage = new StorageManager(memoryDir);
+    duplicateEntityName = await storage.writeEntity(
+      "Duplicate Structured Entity",
+      "project",
+      [],
+      {
+        structuredSections: [
+          {
+            key: "details",
+            title: "Details",
+            facts: ["Preserve the duplicate structured code opal-73."],
+          },
+        ],
+      },
+    );
+    await adapter.store(resetSession, [
+      {
+        role: "user",
+        content: "Remember the structured entity reset code is iris-41.",
+      },
+    ]);
+    await adapter.store(otherSession, [
+      {
+        role: "user",
+        content: "Remember the structured entity other code is cedar-52.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    const beforeReset = await storage.readEntity(sharedEntityName);
+    assert.match(beforeReset, /iris-41/);
+    assert.match(beforeReset, /cedar-52/);
+
+    await adapter.reset?.(resetSession);
+
+    const afterReset = await storage.readEntity(sharedEntityName);
+    assert.doesNotMatch(afterReset, /iris-41/);
+    assert.match(afterReset, /cedar-52/);
+    const duplicateAfterReset = await storage.readEntity(duplicateEntityName);
+    assert.match(duplicateAfterReset, /opal-73/);
+    assert.doesNotMatch(duplicateAfterReset, /quartz-18/);
+  } finally {
+    Orchestrator.prototype.ingestReplayBatch = originalIngestReplayBatch;
+    await adapter?.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter scoped reset waits for background core replay", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-reset-background-replay-"),
+  );
+  const releaseReplay = createDeferredForTest();
+  const originalIngestReplayBatch = Orchestrator.prototype.ingestReplayBatch;
+  Orchestrator.prototype.ingestReplayBatch = async function (
+    this: Orchestrator,
+    turns: Parameters<Orchestrator["ingestReplayBatch"]>[0],
+    options?: Parameters<Orchestrator["ingestReplayBatch"]>[1],
+  ): Promise<void> {
+    const sessionKey = turns[0]?.sessionKey;
+    if (sessionKey !== "background-reset-session") {
+      return originalIngestReplayBatch.call(this, turns, options);
+    }
+
+    await releaseReplay.promise;
+    await this.storage.writeMemory(
+      "fact",
+      "Remember the background reset replay code is azalea-24.",
+      { source: "unclaimed-test-source" },
+    );
+  };
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    replayExtractionMode: "background",
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("background-reset-session", [
+      {
+        role: "user",
+        content: "Remember the background reset replay code is azalea-24.",
+      },
+    ]);
+
+    let resetSettled = false;
+    const resetPromise = adapter.reset?.("background-reset-session").then(() => {
+      resetSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(resetSettled, false);
+
+    releaseReplay.resolve();
+    await resetPromise;
+
+    const memories = await new StorageManager(memoryDir).readAllMemories();
+    assert.equal(
+      memories.some((memory) => memory.content.includes("azalea-24")),
+      false,
+    );
+  } finally {
+    releaseReplay.resolve();
+    Orchestrator.prototype.ingestReplayBatch = originalIngestReplayBatch;
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter scoped reset marks partial replay writes after rejection", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-reset-partial-replay-"),
+  );
+  const originalIngestReplayBatch = Orchestrator.prototype.ingestReplayBatch;
+  Orchestrator.prototype.ingestReplayBatch = async function (
+    this: Orchestrator,
+    turns: Parameters<Orchestrator["ingestReplayBatch"]>[0],
+    options?: Parameters<Orchestrator["ingestReplayBatch"]>[1],
+  ): Promise<void> {
+    const sessionKey = turns[0]?.sessionKey;
+    if (sessionKey !== "partial-replay-reset-session") {
+      return originalIngestReplayBatch.call(this, turns, options);
+    }
+
+    await this.storage.writeMemory(
+      "fact",
+      "Remember the partial replay reset code is primrose-12.",
+      { source: "unclaimed-test-source" },
+    );
+    throw new Error("simulated partial replay failure");
+  };
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    replayExtractionMode: "background",
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("partial-replay-reset-session", [
+      {
+        role: "user",
+        content: "Remember the partial replay reset code is primrose-12.",
+      },
+    ]);
+
+    await adapter.reset?.("partial-replay-reset-session");
+
+    const memories = await new StorageManager(memoryDir).readAllMemories();
+    assert.equal(
+      memories.some((memory) => memory.content.includes("primrose-12")),
+      false,
+    );
+  } finally {
+    Orchestrator.prototype.ingestReplayBatch = originalIngestReplayBatch;
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter drain checks extraction idle after background replay completes", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-drain-background-replay-"),
+  );
+  const releaseReplay = createDeferredForTest();
+  const originalIngestReplayBatch = Orchestrator.prototype.ingestReplayBatch;
+  const originalWaitForExtractionIdle = Orchestrator.prototype.waitForExtractionIdle;
+  const originalWaitForConsolidationIdle = Orchestrator.prototype.waitForConsolidationIdle;
+  let replayCompleted = false;
+  let extractionIdleCallCount = 0;
+  let extractionIdleBeforeReplay = false;
+  Orchestrator.prototype.ingestReplayBatch = async function (
+    this: Orchestrator,
+    turns: Parameters<Orchestrator["ingestReplayBatch"]>[0],
+    options?: Parameters<Orchestrator["ingestReplayBatch"]>[1],
+  ): Promise<void> {
+    const sessionKey = turns[0]?.sessionKey;
+    if (sessionKey !== "drain-background-replay-session") {
+      return originalIngestReplayBatch.call(this, turns, options);
+    }
+
+    await releaseReplay.promise;
+    replayCompleted = true;
+  };
+  Orchestrator.prototype.waitForExtractionIdle = async function (): Promise<boolean> {
+    extractionIdleCallCount += 1;
+    if (!replayCompleted) {
+      extractionIdleBeforeReplay = true;
+    }
+    return true;
+  };
+  Orchestrator.prototype.waitForConsolidationIdle = async function (): Promise<boolean> {
+    return true;
+  };
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    replayExtractionMode: "background",
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("drain-background-replay-session", [
+      {
+        role: "user",
+        content: "Remember the drain background replay code is anise-27.",
+      },
+    ]);
+
+    let drainSettled = false;
+    const drainPromise = adapter.drain?.().then(() => {
+      drainSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(drainSettled, false);
+    assert.equal(extractionIdleCallCount, 0);
+
+    releaseReplay.resolve();
+    await drainPromise;
+
+    assert.equal(replayCompleted, true);
+    assert.equal(extractionIdleBeforeReplay, false);
+    assert.equal(extractionIdleCallCount, 1);
+  } finally {
+    releaseReplay.resolve();
+    Orchestrator.prototype.ingestReplayBatch = originalIngestReplayBatch;
+    Orchestrator.prototype.waitForExtractionIdle = originalWaitForExtractionIdle;
+    Orchestrator.prototype.waitForConsolidationIdle = originalWaitForConsolidationIdle;
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter full reset waits for background core replay before rebuild", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-reset-background-full-"),
+  );
+  const sentinelPath = path.join(memoryDir, "caller-owned-sentinel.txt");
+  await writeFile(sentinelPath, "preserve caller data");
+  const releaseReplay = createDeferredForTest();
+  const originalIngestReplayBatch = Orchestrator.prototype.ingestReplayBatch;
+  Orchestrator.prototype.ingestReplayBatch = async function (
+    this: Orchestrator,
+    turns: Parameters<Orchestrator["ingestReplayBatch"]>[0],
+    options?: Parameters<Orchestrator["ingestReplayBatch"]>[1],
+  ): Promise<void> {
+    const sessionKey = turns[0]?.sessionKey;
+    if (sessionKey !== "background-full-reset-session") {
+      return originalIngestReplayBatch.call(this, turns, options);
+    }
+
+    await releaseReplay.promise;
+    await this.storage.writeMemory(
+      "fact",
+      "Remember the background full reset replay code is marigold-64.",
+      { source: "unclaimed-test-source" },
+    );
+  };
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    replayExtractionMode: "background",
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("background-full-reset-session", [
+      {
+        role: "user",
+        content: "Remember the background full reset replay code is marigold-64.",
+      },
+    ]);
+
+    let resetSettled = false;
+    const resetPromise = adapter.reset?.().then(() => {
+      resetSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(resetSettled, false);
+
+    releaseReplay.resolve();
+    await resetPromise;
+
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve caller data");
+    const memories = await new StorageManager(memoryDir).readAllMemories();
+    assert.equal(
+      memories.some((memory) => memory.content.includes("marigold-64")),
+      false,
+    );
+  } finally {
+    releaseReplay.resolve();
+    Orchestrator.prototype.ingestReplayBatch = originalIngestReplayBatch;
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter attributes concurrent background replay memories by session", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-background-attribution-"),
+  );
+  const releaseFirstReplay = createDeferredForTest();
+  const originalIngestReplayBatch = Orchestrator.prototype.ingestReplayBatch;
+  Orchestrator.prototype.ingestReplayBatch = async function (
+    this: Orchestrator,
+    turns: Parameters<Orchestrator["ingestReplayBatch"]>[0],
+    options?: Parameters<Orchestrator["ingestReplayBatch"]>[1],
+  ): Promise<void> {
+    const sessionKey = turns[0]?.sessionKey;
+    if (
+      sessionKey !== "background-attribution-a" &&
+      sessionKey !== "background-attribution-b"
+    ) {
+      return originalIngestReplayBatch.call(this, turns, options);
+    }
+
+    if (sessionKey === "background-attribution-a") {
+      await releaseFirstReplay.promise;
+    }
+    const code = sessionKey === "background-attribution-a"
+      ? "iris-31"
+      : "lotus-52";
+    await this.storage.writeMemory(
+      "fact",
+      `Remember the ${sessionKey} replay code is ${code}.`,
+      { source: "unclaimed-test-source" },
+    );
+  };
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    replayExtractionMode: "background",
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("background-attribution-a", [
+      {
+        role: "user",
+        content: "Remember the background-attribution-a replay code is iris-31.",
+      },
+    ]);
+    await adapter.store("background-attribution-b", [
+      {
+        role: "user",
+        content: "Remember the background-attribution-b replay code is lotus-52.",
+      },
+    ]);
+
+    releaseFirstReplay.resolve();
+    await adapter.drain?.();
+    await adapter.reset?.("background-attribution-a");
+
+    const memories = await new StorageManager(memoryDir).readAllMemories();
+    assert.equal(
+      memories.some((memory) => memory.content.includes("iris-31")),
+      false,
+    );
+    assert.equal(
+      memories.some((memory) => memory.content.includes("lotus-52")),
+      true,
+    );
+  } finally {
+    releaseFirstReplay.resolve();
+    Orchestrator.prototype.ingestReplayBatch = originalIngestReplayBatch;
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter normalizes session IDs for scoped reset", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-reset-normalized-session-"),
+  );
+  const adapterOptions = {
+    memoryDir,
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  };
+  const adapter = await createRemnicAdapter(adapterOptions);
+
+  try {
+    await adapter.store("  owned-normalized-reset-session  ", [
+      {
+        role: "user",
+        content: "Remember the normalized reset code is pearl-44.",
+      },
+    ]);
+    await adapter.store("owned-normalized-other-session", [
+      {
+        role: "user",
+        content: "Remember the normalized other code is granite-55.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    assert.match(
+      await adapter.recall(
+        "owned-normalized-reset-session",
+        "What is the normalized reset code?",
+      ),
+      /pearl-44/,
+    );
+    assert.match(
+      await adapter.recall(
+        "owned-normalized-other-session",
+        "What is the normalized other code?",
+      ),
+      /granite-55/,
+    );
+
+    await assert.rejects(
+      async () => {
+        await adapter.reset?.("   ");
+      },
+      /benchmark sessionId must be non-empty/,
+    );
+    assert.match(
+      await adapter.recall(
+        "owned-normalized-other-session",
+        "What is the normalized other code?",
+      ),
+      /granite-55/,
+    );
+
+    await adapter.reset?.("  owned-normalized-reset-session  ");
+    await adapter.store("owned-normalized-reset-session", [
+      {
+        role: "user",
+        content: "Remember the replacement normalized code is quartz-66.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "  owned-normalized-reset-session  ",
+      "What is the normalized reset code?",
+    );
+    assert.doesNotMatch(recalled, /pearl-44/);
+    assert.match(recalled, /quartz-66/);
+    assert.match(
+      await adapter.recall(
+        "owned-normalized-other-session",
+        "What is the normalized other code?",
+      ),
+      /granite-55/,
+    );
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset clears caller-owned cold replay state", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-cold-session-"));
+  const adapterOptions = {
+    memoryDir,
+    configOverrides: {
+      qmdColdTierEnabled: true,
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  };
+  const adapter = await createRemnicAdapter(adapterOptions);
+
+  try {
+    const coldStorage = new StorageManager(path.join(memoryDir, "cold"));
+    const resetColdId = await coldStorage.writeMemory(
+      "fact",
+      "Remember the stale cold reset code is frost-77.",
+      { source: benchReplaySourceForTest("owned-cold-reset-session") },
+    );
+    const otherColdId = await coldStorage.writeMemory(
+      "fact",
+      "Remember the other cold reset code is ember-88.",
+      { source: benchReplaySourceForTest("owned-cold-other-session") },
+    );
+
+    await adapter.reset?.("owned-cold-reset-session");
+
+    const coldMemories = await new StorageManager(memoryDir).readAllColdMemories();
+    assert.equal(
+      coldMemories.some((memory) => memory.frontmatter.id === resetColdId),
+      false,
+    );
+    assert.equal(
+      coldMemories.some((memory) => memory.frontmatter.id === otherColdId),
+      true,
+    );
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter session reset tracks replay-created cold memories", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(tmpdir(), "remnic-bench-reset-replay-cold-session-"),
+  );
+  const resetSession = "replay-cold-reset-session";
+  const otherSession = "replay-cold-other-session";
+  const originalIngestReplayBatch = Orchestrator.prototype.ingestReplayBatch;
+  let adapter: Awaited<ReturnType<typeof createRemnicAdapter>> | undefined;
+
+  Orchestrator.prototype.ingestReplayBatch = async function (
+    this: Orchestrator,
+    turns: Parameters<Orchestrator["ingestReplayBatch"]>[0],
+  ): Promise<void> {
+    const content = turns.map((turn) => turn.content).join("\n");
+    const code = content.includes("glacier-31") ? "glacier-31" : "lantern-46";
+    const memoryId = await this.storage.writeMemory(
+      "fact",
+      `Remember the replay-created cold reset code is ${code}.`,
+    );
+    const memory = (await this.storage.readAllMemories())
+      .find((candidate) => candidate.frontmatter.id === memoryId);
+    assert.ok(memory);
+    await this.storage.migrateMemoryToTier(memory, "cold");
+  };
+
+  try {
+    adapter = await createRemnicAdapter({
+      memoryDir,
+      configOverrides: {
+        qmdColdTierEnabled: true,
+        transcriptEnabled: true,
+        extractionMinUserTurns: 999,
+      },
+    });
+    await adapter.store(resetSession, [
+      {
+        role: "user",
+        content: "Remember the replay-created cold reset code is glacier-31.",
+      },
+    ]);
+    await adapter.store(otherSession, [
+      {
+        role: "user",
+        content: "Remember the replay-created cold other code is lantern-46.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    const beforeReset = await new StorageManager(memoryDir).readAllColdMemories();
+    assert.equal(beforeReset.some((memory) => memory.content.includes("glacier-31")), true);
+    assert.equal(beforeReset.some((memory) => memory.content.includes("lantern-46")), true);
+
+    await adapter.reset?.(resetSession);
+
+    const afterReset = await new StorageManager(memoryDir).readAllColdMemories();
+    assert.equal(afterReset.some((memory) => memory.content.includes("glacier-31")), false);
+    assert.equal(afterReset.some((memory) => memory.content.includes("lantern-46")), true);
+  } finally {
+    Orchestrator.prototype.ingestReplayBatch = originalIngestReplayBatch;
+    await adapter?.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter full reset clears caller-owned core state when replay is skipped", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-skip-full-"));
+  const sentinelPath = path.join(memoryDir, "caller-owned-sentinel.txt");
+  await writeFile(sentinelPath, "preserve caller data");
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    replayExtractionMode: "skip",
+    configOverrides: {
+      transcriptEnabled: true,
+    },
+  });
+
+  try {
+    const staleId = await new StorageManager(memoryDir).writeMemory(
+      "fact",
+      "Remember the stale skip full reset code is saffron-18.",
+      { source: benchReplaySourceForTest("skip-full-reset-session") },
+    );
+
+    await adapter.reset?.();
+
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve caller data");
+    const memories = await new StorageManager(memoryDir).readAllMemories();
+    assert.equal(
+      memories.some((memory) => memory.frontmatter.id === staleId),
+      false,
+    );
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter scoped reset clears caller-owned core state when replay is skipped", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-skip-session-"));
+  const adapter = await createRemnicAdapter({
+    memoryDir,
+    replayExtractionMode: "skip",
+    configOverrides: {
+      transcriptEnabled: true,
+    },
+  });
+
+  try {
+    const storage = new StorageManager(memoryDir);
+    const resetId = await storage.writeMemory(
+      "fact",
+      "Remember the stale skip session reset code is topaz-74.",
+      { source: benchReplaySourceForTest("skip-reset-session") },
+    );
+    const otherId = await storage.writeMemory(
+      "fact",
+      "Remember the other skip session code is opal-36.",
+      { source: benchReplaySourceForTest("skip-other-session") },
+    );
+
+    await adapter.reset?.("skip-reset-session");
+
+    const memories = await new StorageManager(memoryDir).readAllMemories();
+    assert.equal(
+      memories.some((memory) => memory.frontmatter.id === resetId),
+      false,
+    );
+    assert.equal(
+      memories.some((memory) => memory.frontmatter.id === otherId),
+      true,
+    );
   } finally {
     await adapter.destroy();
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -4,7 +4,17 @@
 
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -18,7 +28,10 @@ import {
   Orchestrator,
   parseFlexibleIsoTimestamp,
   parseConfig,
+  parseEntityFile,
+  serializeEntityFile,
 } from "@remnic/core";
+import type { EntityStructuredSection, MemoryFile } from "@remnic/core";
 import type {
   BenchJudge,
   BenchMemoryAdapter,
@@ -158,6 +171,8 @@ type BenchRecallEngine = {
     maxDepth: number;
     maxTurnIndex?: number;
   }>;
+  clearSession?(sessionId: string): Promise<void>;
+  clearAll?(): Promise<void>;
 };
 
 const BENCH_TEARDOWN_DEFERRED_READY_WAIT_MS = 500;
@@ -166,7 +181,61 @@ const CORE_EXPLICIT_CUE_MAX_CHARS = 18_000;
 const CORE_EXPLICIT_CUE_MAX_ITEM_CHARS = 2_400;
 const CORE_EXPLICIT_CUE_MAX_REFERENCES = 24;
 const CORE_TRAJECTORY_ANALYSIS_MAX_CHARS = 18_000;
+const BENCH_REMNIC_STATE_CHILDREN = [
+  "archive",
+  "artifacts",
+  "cold",
+  "conversation-index",
+  "corrections",
+  "entities",
+  "facts",
+  "identity",
+  "profiling",
+  "procedures",
+  "qmd-bench",
+  "qmd-cache",
+  "qmd-config",
+  "questions",
+  "reasoning-traces",
+  "state",
+  "summaries",
+  "threads",
+  "transcripts",
+] as const;
 const execFileAsync = promisify(execFile);
+
+type BenchCoreMemoryTier = "hot" | "cold";
+
+type BenchQmdIndex = {
+  isAvailable(): boolean;
+  update(): Promise<void>;
+  updateCollection?(collection: string): Promise<void>;
+  updateCollectionStrict?(collection: string): Promise<void>;
+};
+
+type BenchArtifactStorageView = {
+  artifactIndexCache?: unknown;
+  bumpArtifactWriteVersion?: () => number;
+};
+
+type BenchEntityStructuredFactSources = Map<string, Map<string, Set<string>>>;
+
+type BenchEntityStructuredFactSourceFile = {
+  version: 1;
+  sessionId: string;
+  entries: Array<{
+    entityName: string;
+    sectionKey: string;
+    facts: string[];
+  }>;
+};
+
+type BenchEntityStorageView = {
+  entitySchemas?: Parameters<typeof parseEntityFile>[1];
+  writeStorageSecureFile?: (filePath: string, content: string) => Promise<void>;
+  invalidateKnowledgeIndexCache?: () => void;
+  bumpMemoryStatusVersion?: () => void;
+};
 
 function normalizeReplaySourceValidAtMode(
   value: RemnicAdapterOptions["replaySourceValidAtMode"],
@@ -446,6 +515,21 @@ function resolveConfiguredBenchDir(options: RemnicAdapterOptions): string | unde
   return sandboxDir ?? memoryDir;
 }
 
+function normalizeBenchSessionId(sessionId: string): string {
+  const normalized = sessionId.trim();
+  if (!normalized) {
+    throw new Error("benchmark sessionId must be non-empty.");
+  }
+  return normalized;
+}
+
+function normalizeOptionalBenchSessionId(sessionId?: string): string | undefined {
+  if (sessionId === undefined) {
+    return undefined;
+  }
+  return normalizeBenchSessionId(sessionId);
+}
+
 async function removeBenchQmdSandbox(sandbox: BenchQmdSandbox): Promise<void> {
   if (!sandbox.indexName.startsWith("remnic-bench-")) {
     return;
@@ -453,6 +537,785 @@ async function removeBenchQmdSandbox(sandbox: BenchQmdSandbox): Promise<void> {
   await Promise.all([
     rm(sandbox.cacheDir, { recursive: true, force: true }),
     rm(sandbox.configDir, { recursive: true, force: true }),
+  ]);
+}
+
+async function clearCallerOwnedBenchState(memoryDir: string): Promise<void> {
+  await Promise.all(
+    BENCH_REMNIC_STATE_CHILDREN.map((entry) =>
+      rm(path.join(memoryDir, entry), { recursive: true, force: true }),
+    ),
+  );
+}
+
+async function readBenchCoreMemories(
+  orchestrator: Orchestrator,
+): Promise<MemoryFile[]> {
+  return [
+    ...await orchestrator.storage.readAllMemories(),
+    ...await orchestrator.storage.readAllColdMemories(),
+  ];
+}
+
+async function readBenchCoreMemoryIds(
+  orchestrator: Orchestrator,
+): Promise<Set<string>> {
+  const memories = await readBenchCoreMemories(orchestrator);
+  return new Set(memories.map((memory) => memory.frontmatter.id));
+}
+
+function isErrnoCode(err: unknown, code: string): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    (err as { code?: unknown }).code === code
+  );
+}
+
+function benchCoreMemoryTier(memory: MemoryFile): BenchCoreMemoryTier {
+  return memory.path.includes(`${path.sep}cold${path.sep}`) ? "cold" : "hot";
+}
+
+function benchCoreMemorySource(sessionId: string): string {
+  return `bench-replay-${createHash("sha256").update(sessionId).digest("hex").slice(0, 16)}`;
+}
+
+function benchEntityStructuredFactSourceDir(memoryDir: string): string {
+  return path.join(memoryDir, "state", "bench-entity-structured-facts");
+}
+
+function benchEntityStructuredFactSourcePath(
+  memoryDir: string,
+  sessionId: string,
+): string {
+  return path.join(
+    benchEntityStructuredFactSourceDir(memoryDir),
+    `${benchCoreMemorySource(sessionId)}.json`,
+  );
+}
+
+function normalizeBenchEntityStructuredFact(fact: string): string {
+  return fact.replace(/\s+/g, " ").trim();
+}
+
+function addBenchEntityStructuredFactSource(
+  sources: BenchEntityStructuredFactSources,
+  entityName: string,
+  sectionKey: string,
+  fact: string,
+): void {
+  const normalizedFact = normalizeBenchEntityStructuredFact(fact);
+  if (!entityName || !sectionKey || !normalizedFact) return;
+  let entitySources = sources.get(entityName);
+  if (!entitySources) {
+    entitySources = new Map<string, Set<string>>();
+    sources.set(entityName, entitySources);
+  }
+  let sectionFacts = entitySources.get(sectionKey);
+  if (!sectionFacts) {
+    sectionFacts = new Set<string>();
+    entitySources.set(sectionKey, sectionFacts);
+  }
+  sectionFacts.add(normalizedFact);
+}
+
+function mergeBenchEntityStructuredFactSources(
+  target: BenchEntityStructuredFactSources,
+  source: BenchEntityStructuredFactSources,
+): void {
+  for (const [entityName, sections] of source) {
+    for (const [sectionKey, facts] of sections) {
+      for (const fact of facts) {
+        addBenchEntityStructuredFactSource(target, entityName, sectionKey, fact);
+      }
+    }
+  }
+}
+
+function serializeBenchEntityStructuredFactSources(
+  sessionId: string,
+  sources: BenchEntityStructuredFactSources,
+): BenchEntityStructuredFactSourceFile {
+  return {
+    version: 1,
+    sessionId,
+    entries: Array.from(sources.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .flatMap(([entityName, sections]) =>
+        Array.from(sections.entries())
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([sectionKey, facts]) => ({
+            entityName,
+            sectionKey,
+            facts: Array.from(facts).sort(),
+          })),
+      ),
+  };
+}
+
+async function readBenchEntityStructuredFactSourceFile(
+  filePath: string,
+  expectedSessionId?: string,
+): Promise<{
+  sessionId: string | undefined;
+  sources: BenchEntityStructuredFactSources;
+}> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(filePath, "utf8"));
+  } catch {
+    return { sessionId: undefined, sources: new Map() };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { sessionId: undefined, sources: new Map() };
+  }
+  const file = parsed as {
+    version?: unknown;
+    sessionId?: unknown;
+    entries?: unknown;
+  };
+  const sessionId = typeof file.sessionId === "string" ? file.sessionId : undefined;
+  if (
+    file.version !== 1 ||
+    !Array.isArray(file.entries) ||
+    (expectedSessionId !== undefined && sessionId !== expectedSessionId)
+  ) {
+    return { sessionId, sources: new Map() };
+  }
+
+  const sources: BenchEntityStructuredFactSources = new Map();
+  for (const entry of file.entries) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const candidate = entry as {
+      entityName?: unknown;
+      sectionKey?: unknown;
+      facts?: unknown;
+    };
+    if (
+      typeof candidate.entityName !== "string" ||
+      typeof candidate.sectionKey !== "string" ||
+      !Array.isArray(candidate.facts)
+    ) {
+      continue;
+    }
+    for (const fact of candidate.facts) {
+      if (typeof fact !== "string") continue;
+      addBenchEntityStructuredFactSource(
+        sources,
+        candidate.entityName,
+        candidate.sectionKey,
+        fact,
+      );
+    }
+  }
+  return { sessionId, sources };
+}
+
+async function readBenchEntityStructuredFactSources(
+  memoryDir: string,
+  sessionId: string,
+): Promise<BenchEntityStructuredFactSources> {
+  return (
+    await readBenchEntityStructuredFactSourceFile(
+      benchEntityStructuredFactSourcePath(memoryDir, sessionId),
+      sessionId,
+    )
+  ).sources;
+}
+
+async function readOtherBenchEntityStructuredFactSources(
+  memoryDir: string,
+  sessionId: string,
+): Promise<BenchEntityStructuredFactSources> {
+  const sourceDir = benchEntityStructuredFactSourceDir(memoryDir);
+  const excludedPath = benchEntityStructuredFactSourcePath(memoryDir, sessionId);
+  let entries;
+  try {
+    entries = await readdir(sourceDir, { withFileTypes: true });
+  } catch {
+    return new Map();
+  }
+
+  const merged: BenchEntityStructuredFactSources = new Map();
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const filePath = path.join(sourceDir, entry.name);
+    if (path.resolve(filePath) === path.resolve(excludedPath)) continue;
+    const sourceFile = await readBenchEntityStructuredFactSourceFile(filePath);
+    if (sourceFile.sessionId === sessionId) continue;
+    mergeBenchEntityStructuredFactSources(merged, sourceFile.sources);
+  }
+  return merged;
+}
+
+async function writeBenchEntityStructuredFactSources(
+  memoryDir: string,
+  sessionId: string,
+  sources: BenchEntityStructuredFactSources,
+): Promise<void> {
+  if (sources.size === 0) return;
+
+  const sourcePath = benchEntityStructuredFactSourcePath(memoryDir, sessionId);
+  const merged = await readBenchEntityStructuredFactSources(memoryDir, sessionId);
+  mergeBenchEntityStructuredFactSources(merged, sources);
+  await mkdir(path.dirname(sourcePath), { recursive: true });
+  const tempPath = `${sourcePath}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(
+    tempPath,
+    `${JSON.stringify(
+      serializeBenchEntityStructuredFactSources(sessionId, merged),
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  await rename(tempPath, sourcePath);
+}
+
+async function removeBenchEntityStructuredFactSources(
+  memoryDir: string,
+  sessionId: string,
+): Promise<void> {
+  await unlink(benchEntityStructuredFactSourcePath(memoryDir, sessionId)).catch((err) => {
+    if (!isErrnoCode(err, "ENOENT")) {
+      throw err;
+    }
+  });
+}
+
+async function captureBenchEntityStructuredFactWrite(
+  orchestrator: Orchestrator,
+  sources: BenchEntityStructuredFactSources,
+  entityName: string,
+  structuredSections: EntityStructuredSection[] | undefined,
+  beforeSources: BenchEntityStructuredFactSources,
+): Promise<void> {
+  const incomingFacts = new Set<string>();
+  for (const section of structuredSections ?? []) {
+    for (const fact of section.facts ?? []) {
+      if (typeof fact !== "string") continue;
+      const normalizedFact = normalizeBenchEntityStructuredFact(fact);
+      if (normalizedFact) incomingFacts.add(normalizedFact);
+    }
+  }
+  if (!entityName || incomingFacts.size === 0) return;
+
+  const entityStorage = orchestrator.storage as unknown as BenchEntityStorageView;
+  const raw = await orchestrator.storage.readEntity(entityName);
+  if (!raw) return;
+  const entity = parseEntityFile(raw, entityStorage.entitySchemas);
+  for (const section of entity.structuredSections ?? []) {
+    for (const fact of section.facts) {
+      const normalizedFact = normalizeBenchEntityStructuredFact(fact);
+      if (!incomingFacts.has(normalizedFact)) continue;
+      if (beforeSources.get(entityName)?.get(section.key)?.has(normalizedFact)) {
+        continue;
+      }
+      addBenchEntityStructuredFactSource(
+        sources,
+        entityName,
+        section.key,
+        normalizedFact,
+      );
+    }
+  }
+}
+
+async function readBenchEntityStructuredFactSnapshot(
+  orchestrator: Orchestrator,
+): Promise<BenchEntityStructuredFactSources> {
+  const storage = orchestrator.storage;
+  const entityStorage = storage as unknown as BenchEntityStorageView;
+  const sources: BenchEntityStructuredFactSources = new Map();
+  for (const entityName of await storage.listEntityNames()) {
+    const raw = await storage.readEntity(entityName);
+    if (!raw) continue;
+    const entity = parseEntityFile(raw, entityStorage.entitySchemas);
+    for (const section of entity.structuredSections ?? []) {
+      for (const fact of section.facts) {
+        addBenchEntityStructuredFactSource(sources, entityName, section.key, fact);
+      }
+    }
+  }
+  return sources;
+}
+
+function hasBenchEntityStructuredFacts(
+  structuredSections: EntityStructuredSection[] | undefined,
+): boolean {
+  return (structuredSections ?? []).some((section) =>
+    (section.facts ?? []).some((fact) =>
+      typeof fact === "string" &&
+      normalizeBenchEntityStructuredFact(fact).length > 0,
+    ),
+  );
+}
+
+async function withBenchEntityStructuredFactCapture(
+  orchestrator: Orchestrator,
+  sessionId: string,
+  task: () => Promise<void>,
+): Promise<void> {
+  type BenchWriteEntity = (
+    name: string,
+    type: string,
+    facts: string[],
+    options?: { structuredSections?: EntityStructuredSection[] },
+  ) => Promise<string>;
+  const storage = orchestrator.storage as unknown as { writeEntity: BenchWriteEntity };
+  const originalWriteEntity = storage.writeEntity;
+  const writeEntity = originalWriteEntity.bind(orchestrator.storage);
+  const captured: BenchEntityStructuredFactSources = new Map();
+
+  storage.writeEntity = async (...args: Parameters<BenchWriteEntity>): Promise<string> => {
+    const structuredSections = args[3]?.structuredSections;
+    const beforeSources = hasBenchEntityStructuredFacts(structuredSections)
+      ? await readBenchEntityStructuredFactSnapshot(orchestrator)
+      : new Map<string, Map<string, Set<string>>>();
+    const entityName = await writeEntity(...args);
+    await captureBenchEntityStructuredFactWrite(
+      orchestrator,
+      captured,
+      entityName,
+      structuredSections,
+      beforeSources,
+    );
+    return entityName;
+  };
+
+  let taskError: unknown;
+  try {
+    await task();
+  } catch (err) {
+    taskError = err;
+    throw err;
+  } finally {
+    storage.writeEntity = originalWriteEntity;
+    try {
+      await writeBenchEntityStructuredFactSources(
+        orchestrator.storage.dir,
+        sessionId,
+        captured,
+      );
+    } catch (err) {
+      if (taskError === undefined) {
+        throw err;
+      }
+    }
+  }
+}
+
+async function rememberNewBenchCoreMemories(
+  orchestrator: Orchestrator,
+  sessionMemoryIds: Map<string, Set<string>>,
+  sessionId: string,
+  beforeIds: Set<string>,
+): Promise<void> {
+  const after = await readBenchCoreMemories(orchestrator);
+  const remembered = sessionMemoryIds.get(sessionId) ?? new Set<string>();
+  const source = benchCoreMemorySource(sessionId);
+  for (const memory of after) {
+    if (!beforeIds.has(memory.frontmatter.id)) {
+      await orchestrator.storage.writeMemoryFrontmatter(memory, { source });
+      remembered.add(memory.frontmatter.id);
+    }
+  }
+  if (remembered.size > 0) {
+    sessionMemoryIds.set(sessionId, remembered);
+  }
+}
+
+async function clearBenchCoreSessionMemories(
+  orchestrator: Orchestrator,
+  sessionId: string,
+  memoryIds: Set<string> | undefined,
+  coldCollection: string,
+): Promise<void> {
+  const memories = [
+    ...await orchestrator.storage.readAllMemories(),
+    ...await orchestrator.storage.readAllColdMemories(),
+  ];
+  const trackedIds = memoryIds ?? new Set<string>();
+  const source = benchCoreMemorySource(sessionId);
+  const targets = memories
+    .filter((memory) =>
+      trackedIds.has(memory.frontmatter.id) ||
+      memory.frontmatter.source === source,
+    )
+    .map((memory) => ({ memory, tier: benchCoreMemoryTier(memory) }));
+  const targetMemoryIds = new Set(trackedIds);
+  for (const target of targets) {
+    targetMemoryIds.add(target.memory.frontmatter.id);
+  }
+
+  await clearBenchCoreArtifactsForMemoryIds(orchestrator, targetMemoryIds);
+  await clearBenchCoreEntitiesForSession(orchestrator, sessionId);
+  if (targets.length === 0) return;
+
+  await orchestrator.storage.removeFactContentHashesForMemories(
+    targets.map((target) => target.memory),
+  );
+
+  const changedTiers = new Set<BenchCoreMemoryTier>();
+  for (const { memory, tier } of targets) {
+    if (tier === "cold") {
+      try {
+        await unlink(memory.path);
+      } catch (err) {
+        if (!isErrnoCode(err, "ENOENT")) {
+          throw err;
+        }
+      }
+      changedTiers.add("cold");
+      continue;
+    }
+
+    await orchestrator.storage.invalidateMemory(memory.frontmatter.id);
+    changedTiers.add("hot");
+  }
+
+  const invalidateTierCaches = (
+    orchestrator.storage as unknown as {
+      invalidateMemoryCachesForTiers?: (
+        tiers: Iterable<"hot" | "cold" | "archive">,
+      ) => void;
+    }
+  ).invalidateMemoryCachesForTiers;
+  if (typeof invalidateTierCaches === "function") {
+    invalidateTierCaches.call(orchestrator.storage, changedTiers);
+  } else {
+    orchestrator.storage.invalidateAllMemoriesCacheForDir();
+  }
+
+  const qmd = orchestrator.qmd as BenchQmdIndex;
+  if (!qmd.isAvailable()) {
+    return;
+  }
+  if (changedTiers.has("hot")) {
+    await qmd.update();
+  }
+  if (changedTiers.has("cold")) {
+    if (typeof qmd.updateCollectionStrict === "function") {
+      await qmd.updateCollectionStrict(coldCollection);
+    } else if (typeof qmd.updateCollection === "function") {
+      await qmd.updateCollection(coldCollection);
+    } else {
+      await qmd.update();
+    }
+  }
+}
+
+function compileBenchEntityFacts(entity: ReturnType<typeof parseEntityFile>): string[] {
+  const facts: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of entity.timeline) {
+    const fact = entry.text.trim();
+    if (!fact || seen.has(fact)) continue;
+    seen.add(fact);
+    facts.push(fact);
+  }
+  for (const section of entity.structuredSections ?? []) {
+    for (const rawFact of section.facts) {
+      const fact = rawFact.replace(/\s+/g, " ").trim();
+      if (!fact || seen.has(fact)) continue;
+      seen.add(fact);
+      facts.push(fact);
+    }
+  }
+  return facts;
+}
+
+function hasBenchEntityState(entity: ReturnType<typeof parseEntityFile>): boolean {
+  return entity.timeline.length > 0 ||
+    (entity.structuredSections ?? []).some((section) => section.facts.length > 0) ||
+    entity.relationships.length > 0 ||
+    entity.activity.length > 0 ||
+    entity.aliases.length > 0 ||
+    (entity.extraSections ?? []).some((section) =>
+      section.lines.some((line) => line.trim().length > 0),
+    ) ||
+    (entity.preSectionLines ?? []).some((line) => line.trim().length > 0);
+}
+
+function pruneBenchEntityStructuredFacts(
+  structuredSections: EntityStructuredSection[] | undefined,
+  targetSources: Map<string, Set<string>> | undefined,
+  protectedSources: Map<string, Set<string>> | undefined,
+): { changed: boolean; structuredSections: EntityStructuredSection[] } {
+  const sections = structuredSections ?? [];
+  if (sections.length === 0) {
+    return { changed: false, structuredSections: [] };
+  }
+  if (!targetSources || targetSources.size === 0) {
+    return { changed: false, structuredSections: sections };
+  }
+
+  let changed = false;
+  const nextSections: EntityStructuredSection[] = [];
+  for (const section of sections) {
+    const targetFacts = targetSources?.get(section.key);
+    const protectedFacts = protectedSources?.get(section.key);
+    const nextFacts = section.facts.filter((fact) => {
+      const normalizedFact = normalizeBenchEntityStructuredFact(fact);
+      if (!targetFacts?.has(normalizedFact)) {
+        return true;
+      }
+      return protectedFacts?.has(normalizedFact) === true;
+    });
+    if (nextFacts.length !== section.facts.length) {
+      changed = true;
+    }
+    if (nextFacts.length === 0) {
+      continue;
+    }
+    nextSections.push({ ...section, facts: nextFacts });
+  }
+
+  return { changed, structuredSections: nextSections };
+}
+
+async function clearBenchCoreEntitiesForSession(
+  orchestrator: Orchestrator,
+  sessionId: string,
+): Promise<void> {
+  const storage = orchestrator.storage;
+  const entityStorage = storage as unknown as BenchEntityStorageView;
+  const entitySchemas = entityStorage.entitySchemas;
+  const targetStructuredSources = await readBenchEntityStructuredFactSources(
+    storage.dir,
+    sessionId,
+  );
+  const protectedStructuredSources = await readOtherBenchEntityStructuredFactSources(
+    storage.dir,
+    sessionId,
+  );
+  const entityNames = await storage.listEntityNames();
+  let changedAny = false;
+
+  for (const entityName of entityNames) {
+    const raw = await storage.readEntity(entityName);
+    if (!raw) continue;
+
+    const entity = parseEntityFile(raw, entitySchemas);
+    const nextTimeline = entity.timeline.filter((entry) => entry.sessionKey !== sessionId);
+    const timelineChanged = nextTimeline.length !== entity.timeline.length;
+    const prunedStructured = pruneBenchEntityStructuredFacts(
+      entity.structuredSections,
+      targetStructuredSources.get(entityName),
+      protectedStructuredSources.get(entityName),
+    );
+    if (!timelineChanged && !prunedStructured.changed) {
+      continue;
+    }
+
+    entity.timeline = nextTimeline;
+    entity.structuredSections = prunedStructured.structuredSections;
+    entity.facts = compileBenchEntityFacts(entity);
+    entity.summary = undefined;
+    entity.synthesis = undefined;
+    entity.synthesisUpdatedAt = undefined;
+    entity.synthesisTimelineCount = undefined;
+    entity.synthesisStructuredFactCount = undefined;
+    entity.synthesisStructuredFactDigest = undefined;
+    entity.updated = new Date().toISOString();
+
+    const entityPath = path.join(storage.dir, "entities", `${entityName}.md`);
+    if (!hasBenchEntityState(entity)) {
+      await unlink(entityPath).catch((err) => {
+        if (!isErrnoCode(err, "ENOENT")) {
+          throw err;
+        }
+      });
+      await storage.removeEntitySynthesisQueueEntries([entityName]).catch(() => undefined);
+      changedAny = true;
+      continue;
+    }
+
+    const serialized = serializeEntityFile(entity, entitySchemas);
+    if (typeof entityStorage.writeStorageSecureFile === "function") {
+      await entityStorage.writeStorageSecureFile.call(storage, entityPath, serialized);
+    } else {
+      await writeFile(entityPath, serialized, "utf8");
+    }
+    await storage.removeEntitySynthesisQueueEntries([entityName]).catch(() => undefined);
+    changedAny = true;
+  }
+
+  if (targetStructuredSources.size > 0) {
+    await removeBenchEntityStructuredFactSources(storage.dir, sessionId);
+  }
+
+  if (!changedAny) return;
+  entityStorage.invalidateKnowledgeIndexCache?.call(storage);
+  entityStorage.bumpMemoryStatusVersion?.call(storage);
+}
+
+async function listBenchArtifactMarkdownFiles(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listBenchArtifactMarkdownFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function clearBenchCoreArtifactsForMemoryIds(
+  orchestrator: Orchestrator,
+  memoryIds: Set<string>,
+): Promise<void> {
+  if (memoryIds.size === 0) return;
+
+  const artifactFiles = await listBenchArtifactMarkdownFiles(
+    path.join(orchestrator.storage.dir, "artifacts"),
+  );
+  let removedAny = false;
+  for (const filePath of artifactFiles) {
+    const artifact = await orchestrator.storage.readMemoryByPath(filePath);
+    const sourceMemoryId = artifact?.frontmatter.sourceMemoryId;
+    if (typeof sourceMemoryId !== "string" || !memoryIds.has(sourceMemoryId)) {
+      continue;
+    }
+    try {
+      await unlink(filePath);
+      removedAny = true;
+    } catch (err) {
+      if (!isErrnoCode(err, "ENOENT")) {
+        throw err;
+      }
+    }
+  }
+
+  if (!removedAny) return;
+  const artifactStorage = orchestrator.storage as unknown as BenchArtifactStorageView;
+  artifactStorage.artifactIndexCache = null;
+  artifactStorage.bumpArtifactWriteVersion?.call(orchestrator.storage);
+}
+
+async function listTranscriptJsonlFiles(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listTranscriptJsonlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function clearBenchTranscriptSession(
+  memoryDir: string,
+  sessionId: string,
+): Promise<void> {
+  const transcriptFiles = await listTranscriptJsonlFiles(path.join(memoryDir, "transcripts"));
+  for (const filePath of transcriptFiles) {
+    let content: string;
+    try {
+      content = await readFile(filePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    let removed = false;
+    const kept: string[] = [];
+    for (const line of content.split("\n")) {
+      if (line.trim().length === 0) {
+        kept.push(line);
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line) as { sessionKey?: unknown };
+        if (parsed.sessionKey === sessionId) {
+          removed = true;
+          continue;
+        }
+      } catch {
+        // Preserve malformed lines; reset should only remove known session entries.
+      }
+      kept.push(line);
+    }
+    if (!removed) continue;
+
+    const nonEmptyLines = kept.filter((line) => line.trim().length > 0);
+    if (nonEmptyLines.length === 0) {
+      await unlink(filePath).catch(() => undefined);
+      continue;
+    }
+
+    const nextContent = kept.join("\n");
+    const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+    await writeFile(
+      tempPath,
+      nextContent.endsWith("\n") ? nextContent : `${nextContent}\n`,
+      "utf8",
+    );
+    await rename(tempPath, filePath);
+  }
+}
+
+function resolveBenchChildPath(root: string, ...segments: string[]): string {
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(resolvedRoot, ...segments);
+  const relative = path.relative(resolvedRoot, resolvedPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("benchmark sessionId resolves outside Remnic benchmark state.");
+  }
+  return resolvedPath;
+}
+
+function resolveBenchSummarySessionPaths(
+  memoryDir: string,
+  sessionId: string,
+): {
+  hourlyDir: string;
+  snapshotPath: string;
+  lockPath: string;
+} {
+  const hourlyRoot = path.join(memoryDir, "summaries", "hourly");
+  const snapshotRoot = path.join(memoryDir, "state", "summaries");
+  return {
+    hourlyDir: resolveBenchChildPath(hourlyRoot, sessionId),
+    snapshotPath: resolveBenchChildPath(snapshotRoot, `${sessionId}.json`),
+    lockPath: resolveBenchChildPath(snapshotRoot, `${sessionId}.lock`),
+  };
+}
+
+async function clearBenchSummarySession(
+  memoryDir: string,
+  sessionId: string,
+): Promise<void> {
+  const summaryPaths = resolveBenchSummarySessionPaths(memoryDir, sessionId);
+  await Promise.all([
+    rm(summaryPaths.hourlyDir, {
+      recursive: true,
+      force: true,
+    }),
+    rm(summaryPaths.snapshotPath, {
+      force: true,
+    }),
+    rm(summaryPaths.lockPath, {
+      force: true,
+    }),
   ]);
 }
 
@@ -467,6 +1330,9 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
     );
     const drainTimeoutMs = normalizeDrainTimeoutMs(options.drainTimeoutMs);
     const configuredBenchDir = resolveConfiguredBenchDir(options);
+    const coreSessionMemoryIds = new Map<string, Set<string>>();
+    const coreReplaySessionChains = new Map<string, Promise<void>>();
+    let coreReplayChain: Promise<void> = Promise.resolve();
     let state = await createBenchOrchestrator(
       mode,
       options.configOverrides,
@@ -474,6 +1340,32 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       configuredBenchDir,
     );
     const sessionTurnCounters = new Map<string, number>();
+
+    const queueBenchCoreReplay = (
+      sessionId: string,
+      task: () => Promise<void>,
+    ): Promise<void> => {
+      const queued = coreReplayChain.catch(() => undefined).then(task);
+      let tracked: Promise<void>;
+      tracked = queued.finally(() => {
+        if (coreReplaySessionChains.get(sessionId) === tracked) {
+          coreReplaySessionChains.delete(sessionId);
+        }
+      });
+      coreReplaySessionChains.set(sessionId, tracked);
+      coreReplayChain = tracked.catch(() => undefined);
+      return queued;
+    };
+
+    const waitForBenchCoreReplaySession = async (
+      sessionId: string,
+    ): Promise<void> => {
+      await coreReplaySessionChains.get(sessionId)?.catch(() => undefined);
+    };
+
+    const waitForAllBenchCoreReplay = async (): Promise<void> => {
+      await coreReplayChain.catch(() => undefined);
+    };
 
     const getEngine = () => {
       const engine = state.orchestrator.lcmEngine;
@@ -484,6 +1376,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
     };
 
     const cleanup = async (): Promise<void> => {
+      await waitForAllBenchCoreReplay();
       const orchestrator = state.orchestrator as unknown as OrchestratorTeardownView;
 
       orchestrator.abortDeferredInit();
@@ -512,12 +1405,15 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       }
     };
 
-    const rebuild = async (): Promise<void> => {
-      const shouldClearCallerOwnedMemoryDir = !state.ownsTempDir;
+    const rebuild = async (
+      rebuildOptions: { clearCallerOwnedBenchState?: boolean } = {},
+    ): Promise<void> => {
+      const shouldClearCallerOwnedBenchState =
+        !state.ownsTempDir && rebuildOptions.clearCallerOwnedBenchState === true;
       const callerOwnedMemoryDir = state.tempDir;
       await cleanup();
-      if (shouldClearCallerOwnedMemoryDir) {
-        await rm(callerOwnedMemoryDir, { recursive: true, force: true });
+      if (shouldClearCallerOwnedBenchState) {
+        await clearCallerOwnedBenchState(callerOwnedMemoryDir);
       }
       state = await createBenchOrchestrator(
         mode,
@@ -526,10 +1422,12 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         configuredBenchDir,
       );
       sessionTurnCounters.clear();
+      coreSessionMemoryIds.clear();
     };
 
     return {
       async store(sessionId: string, messages: Message[]): Promise<void> {
+        sessionId = normalizeBenchSessionId(sessionId);
         const timestampedMessages = messages.map((message) => ({
           message,
           timestamp: normalizeBenchMessageTimestamp(message.timestamp),
@@ -551,6 +1449,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           return;
         }
 
+        const replayOrchestrator = state.orchestrator;
         const batchStartMs = Date.now();
         const conversationalMessages = timestampedMessages.filter(
           (
@@ -579,7 +1478,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
             sessionId,
             turn,
           );
-          await state.orchestrator.transcript.append({
+          await replayOrchestrator.transcript.append({
             timestamp: turn.timestamp,
             role: turn.role,
             content: turn.content,
@@ -588,8 +1487,24 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           });
         }
 
-        const replayExtraction = state.orchestrator.ingestReplayBatch(replayTurns, {
-          archiveLcm: false,
+        const replayExtraction = queueBenchCoreReplay(sessionId, async () => {
+          const beforeCoreMemoryIds = await readBenchCoreMemoryIds(replayOrchestrator);
+          try {
+            await withBenchEntityStructuredFactCapture(
+              replayOrchestrator,
+              sessionId,
+              () => replayOrchestrator.ingestReplayBatch(replayTurns, {
+                archiveLcm: false,
+              }),
+            );
+          } finally {
+            await rememberNewBenchCoreMemories(
+              replayOrchestrator,
+              coreSessionMemoryIds,
+              sessionId,
+              beforeCoreMemoryIds,
+            );
+          }
         });
         if (replayExtractionMode === "background") {
           void replayExtraction.catch(() => undefined);
@@ -604,6 +1519,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         budgetChars?: number,
         recallOptions: BenchRecallOptions = {},
       ): Promise<string> {
+        sessionId = normalizeBenchSessionId(sessionId);
         const engine = getEngine();
         const budget = budgetChars ?? DEFAULT_BENCH_RECALL_BUDGET_CHARS;
         if (budget <= 0) {
@@ -1036,7 +1952,8 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       },
 
       async search(query: string, limit: number, sessionId?: string): Promise<SearchResult[]> {
-        const results = await getEngine().searchContext(query, limit, sessionId);
+        const normalizedSessionId = normalizeOptionalBenchSessionId(sessionId);
+        const results = await getEngine().searchContext(query, limit, normalizedSessionId);
         return results.map((result) => ({
           turnIndex: result.turn_index,
           role: result.role,
@@ -1045,8 +1962,51 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         }));
       },
 
-      async reset(_sessionId?: string): Promise<void> {
-        await rebuild();
+      async reset(sessionId?: string): Promise<void> {
+        const normalizedSessionId = normalizeOptionalBenchSessionId(sessionId);
+        if (normalizedSessionId !== undefined) {
+          if (useCoreMemoryPipeline) {
+            resolveBenchSummarySessionPaths(state.tempDir, normalizedSessionId);
+          }
+          if (useCoreMemoryPipeline && replayExtractionMode !== "skip") {
+            await waitForBenchCoreReplaySession(normalizedSessionId);
+          }
+          const engine = getEngine();
+          if (typeof engine.clearSession !== "function") {
+            throw new Error("Remnic benchmark adapter does not support session-scoped reset for this engine.");
+          }
+          await engine.clearSession(normalizedSessionId);
+          if (useCoreMemoryPipeline) {
+            await clearBenchCoreSessionMemories(
+              state.orchestrator,
+              normalizedSessionId,
+              coreSessionMemoryIds.get(normalizedSessionId),
+              state.qmdSandbox.coldCollection,
+            );
+            coreSessionMemoryIds.delete(normalizedSessionId);
+            await clearBenchTranscriptSession(state.tempDir, normalizedSessionId);
+            await clearBenchSummarySession(state.tempDir, normalizedSessionId);
+          }
+          sessionTurnCounters.delete(normalizedSessionId);
+          return;
+        }
+
+        if (state.ownsTempDir) {
+          await rebuild();
+          return;
+        }
+
+        if (useCoreMemoryPipeline) {
+          await rebuild({ clearCallerOwnedBenchState: true });
+          return;
+        }
+
+        const engine = getEngine();
+        if (typeof engine.clearAll !== "function") {
+          throw new Error("Remnic benchmark adapter cannot safely reset a caller-owned memory directory.");
+        }
+        await engine.clearAll();
+        sessionTurnCounters.clear();
       },
 
       async drain(): Promise<void> {
@@ -1066,16 +2026,17 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         try {
           await Promise.race([
             (async () => {
-              const [, extractionIdle, consolidationIdle] = await Promise.all([
-                engine.waitForObserveQueueIdle(),
-                state.orchestrator.waitForExtractionIdle(drainTimeoutMs),
-                state.orchestrator.waitForConsolidationIdle(drainTimeoutMs),
-              ]);
+              await engine.waitForObserveQueueIdle();
+              await waitForAllBenchCoreReplay();
+              const extractionIdle =
+                await state.orchestrator.waitForExtractionIdle(drainTimeoutMs);
               if (!extractionIdle) {
                 throw new Error(
                   `drain() timed out waiting for extraction idle (${describeDrainState(state.orchestrator)})`,
                 );
               }
+              const consolidationIdle =
+                await state.orchestrator.waitForConsolidationIdle(drainTimeoutMs);
               if (!consolidationIdle) {
                 throw new Error(
                   `drain() timed out waiting for consolidation idle (${describeDrainState(state.orchestrator)})`,
@@ -1093,7 +2054,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       },
 
       async getStats(sessionId?: string): Promise<MemoryStats> {
-        return getEngine().getStats(sessionId);
+        return getEngine().getStats(normalizeOptionalBenchSessionId(sessionId));
       },
 
       async destroy(): Promise<void> {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -96,7 +96,11 @@ export {
 // Storage
 // ---------------------------------------------------------------------------
 
-export { StorageManager } from "./storage.js";
+export {
+  StorageManager,
+  parseEntityFile,
+  serializeEntityFile,
+} from "./storage.js";
 
 // ---------------------------------------------------------------------------
 // Extraction
@@ -1125,6 +1129,8 @@ export type {
 export type {
   PluginConfig,
   GatewayConfig,
+  EntityFile,
+  EntityStructuredSection,
   MemoryFile,
   MemoryObservation,
   ExtractedFact,

--- a/packages/remnic-core/src/lcm-engine.test.ts
+++ b/packages/remnic-core/src/lcm-engine.test.ts
@@ -412,6 +412,54 @@ test("waitForSessionObserveIdle resolves once the target session drains even if 
   }
 });
 
+test("LCM normalizes session IDs across observe, stats, and clear", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-lcm-session-normalize-"),
+  );
+
+  try {
+    const engine = new LcmEngine(createPluginConfig(memoryDir), async () => {
+      return "summary";
+    });
+
+    await engine.observeMessages("  session-normalized  ", [
+      { role: "user", content: "normalization marker alpha" },
+    ]);
+    await engine.waitForSessionObserveIdle("session-normalized");
+
+    assert.equal((await engine.getStats("session-normalized")).totalMessages, 1);
+    assert.equal((await engine.getStats("  session-normalized  ")).totalMessages, 1);
+    assert.equal(
+      (await engine.searchContextFull(
+        "normalization",
+        10,
+        "session-normalized",
+      )).length,
+      1,
+    );
+
+    await engine.clearSession("  session-normalized  ");
+
+    assert.equal((await engine.getStats("session-normalized")).totalMessages, 0);
+    assert.equal(
+      (await engine.searchContextFull(
+        "normalization",
+        10,
+        "session-normalized",
+      )).length,
+      0,
+    );
+
+    await engine.observeMessages("   ", [
+      { role: "user", content: "blank session should be ignored" },
+    ]);
+    await engine.waitForObserveQueueIdle();
+    assert.equal((await engine.getStats()).totalMessages, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("close prevents deferred observe work from reinitializing the engine", async () => {
   const memoryDir = await mkdtemp(
     path.join(os.tmpdir(), "engram-lcm-engine-close-"),

--- a/packages/remnic-core/src/lcm/archive.ts
+++ b/packages/remnic-core/src/lcm/archive.ts
@@ -395,6 +395,38 @@ export class LcmArchive {
     return row.cnt;
   }
 
+  /** Delete all archived messages for one session. */
+  deleteSession(sessionId: string): number {
+    const txn = this.db.transaction(() => {
+      this.db
+        .prepare(
+          "DELETE FROM lcm_messages_fts WHERE rowid IN (SELECT id FROM lcm_messages WHERE session_id = ?)",
+        )
+        .run(sessionId);
+      this.db
+        .prepare(
+          "DELETE FROM lcm_message_parts WHERE message_id IN (SELECT id FROM lcm_messages WHERE session_id = ?)",
+        )
+        .run(sessionId);
+      const result = this.db
+        .prepare("DELETE FROM lcm_messages WHERE session_id = ?")
+        .run(sessionId);
+      return result.changes;
+    });
+    return txn();
+  }
+
+  /** Delete all archived messages. */
+  deleteAll(): number {
+    const txn = this.db.transaction(() => {
+      this.db.prepare("DELETE FROM lcm_messages_fts").run();
+      this.db.prepare("DELETE FROM lcm_message_parts").run();
+      const result = this.db.prepare("DELETE FROM lcm_messages").run();
+      return result.changes;
+    });
+    return txn();
+  }
+
   /** Prune messages older than retentionDays. */
   pruneOldMessages(retentionDays: number): number {
     const cutoff = new Date(Date.now() - retentionDays * 86400_000).toISOString();

--- a/packages/remnic-core/src/lcm/dag.ts
+++ b/packages/remnic-core/src/lcm/dag.ts
@@ -123,6 +123,36 @@ export class LcmDag {
     return row.cnt;
   }
 
+  /** Delete all summary and compaction state for one session. */
+  deleteSession(sessionId: string): number {
+    const txn = this.db.transaction(() => {
+      this.db
+        .prepare(
+          "DELETE FROM lcm_summaries_fts WHERE rowid IN (SELECT rowid FROM lcm_summary_nodes WHERE session_id = ?)",
+        )
+        .run(sessionId);
+      this.db
+        .prepare("DELETE FROM lcm_compaction_events WHERE session_id = ?")
+        .run(sessionId);
+      const result = this.db
+        .prepare("DELETE FROM lcm_summary_nodes WHERE session_id = ?")
+        .run(sessionId);
+      return result.changes;
+    });
+    return txn();
+  }
+
+  /** Delete all summary and compaction state. */
+  deleteAll(): number {
+    const txn = this.db.transaction(() => {
+      this.db.prepare("DELETE FROM lcm_summaries_fts").run();
+      this.db.prepare("DELETE FROM lcm_compaction_events").run();
+      const result = this.db.prepare("DELETE FROM lcm_summary_nodes").run();
+      return result.changes;
+    });
+    return txn();
+  }
+
   /** Set parent_id for a list of child node IDs. */
   setParent(childIds: string[], parentId: string): void {
     const stmt = this.db.prepare(

--- a/packages/remnic-core/src/lcm/engine.ts
+++ b/packages/remnic-core/src/lcm/engine.ts
@@ -47,6 +47,24 @@ export function extractLcmConfig(cfg: PluginConfig): LcmEngineConfig {
   };
 }
 
+function normalizeLcmSessionId(sessionId: string): string {
+  return sessionId.trim();
+}
+
+function normalizeOptionalLcmSessionId(sessionId?: string): string | undefined {
+  if (sessionId === undefined) {
+    return undefined;
+  }
+  const normalized = normalizeLcmSessionId(sessionId);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+const EMPTY_LCM_STATS = {
+  totalMessages: 0,
+  totalSummaryNodes: 0,
+  maxDepth: -1,
+} as const;
+
 export class LcmEngine {
   private db: Database.Database | null = null;
   private archive: LcmArchive | null = null;
@@ -161,7 +179,9 @@ export class LcmEngine {
     sessionId: string,
     messages: LcmObserveMessage[],
   ): Promise<void> {
-    this.enqueueObserveMessages(sessionId, messages);
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return;
+    this.enqueueObserveMessages(normalizedSessionId, messages);
   }
 
   /** Enqueue an observe job without waiting for worker completion. */
@@ -170,16 +190,18 @@ export class LcmEngine {
     messages: LcmObserveMessage[],
   ): void {
     if (!this.config.enabled || this.closed) return;
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return;
     if (messages.length === 0) return;
 
-    this.reservePendingObserveInit(sessionId);
+    this.reservePendingObserveInit(normalizedSessionId);
 
     void this.ensureInitialized()
       .then(() => {
         if (this.closed || !this.observeQueue) return;
-        this.observeQueue.enqueue(sessionId, messages);
+        this.observeQueue.enqueue(normalizedSessionId, messages);
         log.debug(
-          `LCM observe enqueued: session=${sessionId}, depth=${this.observeQueue.depth}, inFlight=${this.observeQueue.inFlightCount}`,
+          `LCM observe enqueued: session=${normalizedSessionId}, depth=${this.observeQueue.depth}, inFlight=${this.observeQueue.inFlightCount}`,
         );
       })
       .catch((err) => {
@@ -187,7 +209,7 @@ export class LcmEngine {
         log.error(`LCM observe enqueue initialization error: ${err}`);
       })
       .finally(() => {
-        this.releasePendingObserveInit(sessionId);
+        this.releasePendingObserveInit(normalizedSessionId);
       });
   }
 
@@ -241,10 +263,12 @@ export class LcmEngine {
 
   async waitForSessionObserveIdle(sessionId: string): Promise<void> {
     if (!this.config.enabled || this.closed) return;
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return;
     await this.ensureInitialized();
     if (this.closed) return;
-    await this.waitForPendingObserveInitIdle(sessionId);
-    await this.observeQueue?.whenSessionIdle(sessionId);
+    await this.waitForPendingObserveInitIdle(normalizedSessionId);
+    await this.observeQueue?.whenSessionIdle(normalizedSessionId);
   }
 
   private reservePendingObserveInit(sessionId: string): void {
@@ -297,6 +321,8 @@ export class LcmEngine {
     budgetChars: number,
   ): Promise<string> {
     if (!this.config.enabled) return "";
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return "";
     await this.ensureInitialized();
 
     const effectiveBudget = Math.ceil(
@@ -304,7 +330,7 @@ export class LcmEngine {
     );
     if (effectiveBudget <= 0) return "";
 
-    return assembleCompressedHistory(this.dag!, this.archive!, sessionId, {
+    return assembleCompressedHistory(this.dag!, this.archive!, normalizedSessionId, {
       freshTailTurns: this.config.freshTailTurns,
       budgetChars: effectiveBudget,
     });
@@ -316,9 +342,11 @@ export class LcmEngine {
     limit = this.config.messagePartsRecallMaxResults,
   ): Promise<LcmStructuredRecallMatch[]> {
     if (!this.config.enabled || !this.config.messagePartsEnabled) return [];
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return [];
     await this.ensureInitialized();
     if (!this.archive) return [];
-    return this.archive.searchStructuredParts(query, limit, sessionId);
+    return this.archive.searchStructuredParts(query, limit, normalizedSessionId);
   }
 
   formatStructuredRecall(
@@ -346,10 +374,12 @@ export class LcmEngine {
   /** Flush pending summaries before compaction (called from before_compaction hook). */
   async preCompactionFlush(sessionId: string): Promise<void> {
     if (!this.config.enabled) return;
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return;
     await this.ensureInitialized();
 
     try {
-      await this.summarizer!.summarizeIncremental(sessionId);
+      await this.summarizer!.summarizeIncremental(normalizedSessionId);
     } catch (err) {
       log.debug(`LCM pre-compaction flush error: ${err}`);
     }
@@ -362,25 +392,29 @@ export class LcmEngine {
     tokensAfter: number,
   ): Promise<void> {
     if (!this.config.enabled) return;
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return;
     await this.ensureInitialized();
 
-    const maxTurn = this.archive!.getMaxTurnIndex(sessionId);
+    const maxTurn = this.archive!.getMaxTurnIndex(normalizedSessionId);
 
-    this.dag!.recordCompaction(sessionId, maxTurn, tokensBefore, tokensAfter);
+    this.dag!.recordCompaction(normalizedSessionId, maxTurn, tokensBefore, tokensAfter);
     log.info(
-      `LCM compaction recorded: session=${sessionId}, turn=${maxTurn}, tokens ${tokensBefore}→${tokensAfter}`,
+      `LCM compaction recorded: session=${normalizedSessionId}, turn=${maxTurn}, tokens ${tokensBefore}→${tokensAfter}`,
     );
   }
 
   /** Verify archive coverage after compaction. */
   async verifyPostCompaction(sessionId: string): Promise<void> {
     if (!this.config.enabled) return;
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return;
     await this.ensureInitialized();
 
-    const msgCount = this.archive!.getMessageCount(sessionId);
-    const nodeCount = this.dag!.getNodeCount(sessionId);
+    const msgCount = this.archive!.getMessageCount(normalizedSessionId);
+    const nodeCount = this.dag!.getNodeCount(normalizedSessionId);
     log.debug(
-      `LCM post-compaction verify: session=${sessionId}, messages=${msgCount}, summaryNodes=${nodeCount}`,
+      `LCM post-compaction verify: session=${normalizedSessionId}, messages=${msgCount}, summaryNodes=${nodeCount}`,
     );
   }
 
@@ -400,8 +434,10 @@ export class LcmEngine {
     }>
   > {
     if (!this.config.enabled) return [];
+    const normalizedSessionId = normalizeOptionalLcmSessionId(sessionId);
+    if (sessionId !== undefined && !normalizedSessionId) return [];
     await this.ensureInitialized();
-    return this.archive!.search(query, limit, sessionId);
+    return this.archive!.search(query, limit, normalizedSessionId);
   }
 
   /** Search via FTS returning full message content (not snippets). */
@@ -420,8 +456,10 @@ export class LcmEngine {
     }>
   > {
     if (!this.config.enabled) return [];
+    const normalizedSessionId = normalizeOptionalLcmSessionId(sessionId);
+    if (sessionId !== undefined && !normalizedSessionId) return [];
     await this.ensureInitialized();
-    return this.archive!.searchWithContent(query, limit, sessionId);
+    return this.archive!.searchWithContent(query, limit, normalizedSessionId);
   }
 
   /** Get a compressed summary of a turn range. */
@@ -431,12 +469,14 @@ export class LcmEngine {
     toTurn: number,
   ): Promise<{ summary: string; turn_count: number; depth: number } | null> {
     if (!this.config.enabled) return null;
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return null;
     await this.ensureInitialized();
 
-    const nodes = this.dag!.getCoveringNodes(sessionId, fromTurn, toTurn);
+    const nodes = this.dag!.getCoveringNodes(normalizedSessionId, fromTurn, toTurn);
     if (nodes.length === 0) {
       // No summary exists — build a description from raw messages
-      const messages = this.archive!.getMessages(sessionId, fromTurn, toTurn);
+      const messages = this.archive!.getMessages(normalizedSessionId, fromTurn, toTurn);
       if (messages.length === 0) return null;
       const preview = messages
         .slice(0, 5)
@@ -466,9 +506,11 @@ export class LcmEngine {
     maxTokens: number,
   ): Promise<Array<{ turn_index: number; role: string; content: string }>> {
     if (!this.config.enabled) return [];
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return [];
     await this.ensureInitialized();
 
-    const messages = this.archive!.getMessages(sessionId, fromTurn, toTurn);
+    const messages = this.archive!.getMessages(normalizedSessionId, fromTurn, toTurn);
     if (messages.length === 0) return [];
 
     // Enforce token budget — keep first and last, truncate middle
@@ -529,14 +571,18 @@ export class LcmEngine {
   }> {
     if (!this.config.enabled)
       return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: -1 };
+    const normalizedSessionId = normalizeOptionalLcmSessionId(sessionId);
+    if (sessionId !== undefined && !normalizedSessionId) {
+      return { ...EMPTY_LCM_STATS };
+    }
     await this.ensureInitialized();
 
-    if (sessionId) {
+    if (normalizedSessionId) {
       return {
-        totalMessages: this.archive!.getMessageCount(sessionId),
-        totalSummaryNodes: this.dag!.getNodeCount(sessionId),
-        maxDepth: this.dag!.getMaxDepth(sessionId),
-        maxTurnIndex: this.archive!.getMaxTurnIndex(sessionId),
+        totalMessages: this.archive!.getMessageCount(normalizedSessionId),
+        totalSummaryNodes: this.dag!.getNodeCount(normalizedSessionId),
+        maxDepth: this.dag!.getMaxDepth(normalizedSessionId),
+        maxTurnIndex: this.archive!.getMaxTurnIndex(normalizedSessionId),
       };
     }
 
@@ -545,6 +591,28 @@ export class LcmEngine {
       totalSummaryNodes: 0, // Would need a global count query
       maxDepth: -1,
     };
+  }
+
+  /** Clear all LCM archive and summary state for one session. */
+  async clearSession(sessionId: string): Promise<void> {
+    if (!this.config.enabled || this.closed) return;
+    const normalizedSessionId = normalizeLcmSessionId(sessionId);
+    if (!normalizedSessionId) return;
+    await this.ensureInitialized();
+    if (this.closed || !this.archive || !this.dag) return;
+    await this.waitForSessionObserveIdle(normalizedSessionId);
+    this.dag.deleteSession(normalizedSessionId);
+    this.archive.deleteSession(normalizedSessionId);
+  }
+
+  /** Clear all LCM archive and summary state without closing the engine. */
+  async clearAll(): Promise<void> {
+    if (!this.config.enabled || this.closed) return;
+    await this.ensureInitialized();
+    if (this.closed || !this.archive || !this.dag) return;
+    await this.waitForObserveQueueIdle();
+    this.dag.deleteAll();
+    this.archive.deleteAll();
   }
 
   /** Prune old data beyond retention period. */


### PR DESCRIPTION
## Summary
- add LCM clear APIs for session-scoped and caller-owned global benchmark resets
- make Remnic bench reset(sessionId) clear only that session instead of rebuilding the backing store
- keep caller-owned memory directories intact during global reset and cover sentinel/session isolation regressions

## Verification
- pnpm exec tsx --test packages/bench/src/adapters/remnic-adapter.test.ts
- pnpm exec tsx --test packages/remnic-core/src/lcm-engine.test.ts
- pnpm run check-types
- git diff --check
- node /Users/joshuawarren/src/clawpatch/dist/cli.js --state-dir /tmp/remnic-clawpatch-main-20260517-after-1028 revalidate --finding fnd_sig-feat-library-0c857094a2-924b_2ea8ed7abe
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark reset/cleanup paths that delete on-disk state and adds new LCM DB deletion APIs; mistakes could cause data loss or incomplete cleanup, especially with background replay concurrency.
> 
> **Overview**
> **Remnic bench resets are now session-scoped and caller-owned safe.** `reset(sessionId)` no longer rebuilds the backing store; it clears only that session’s LCM state (via new engine hooks) plus associated core replay outputs (memories in hot/cold tiers, verbatim artifacts, entity timeline + structured facts, transcripts, and hourly summary files/snapshots).
> 
> **Global reset behavior changes for caller-owned directories.** Full `reset()` now preserves the root directory and non-Remnic files while removing known Remnic benchmark subtrees; it refuses to reset caller-owned dirs unless the engine supports `clearAll`. Background replay work is queued/tracked so `drain()` and resets wait for in-flight replay, and both bench + LCM normalize/validate session IDs and reject path traversal for summary cleanup.
> 
> **Core LCM adds deletion APIs.** `LcmEngine` gains `clearSession`/`clearAll`, session-id normalization across observe/search/stats/clear, and underlying `LcmArchive`/`LcmDag` add `deleteSession`/`deleteAll` to remove FTS and related rows; core exports `parseEntityFile`/`serializeEntityFile` for the adapter’s entity cleanup. Extensive new tests cover isolation, traversal rejection, background replay ordering, and cold-tier cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81430307bf87e0b0bd59ce87abc7b28f25fafebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->