### PR TITLE
Fix root engram-access legacy config routing

### DIFF
--- a/bin/engram-access.js
+++ b/bin/engram-access.js
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 
+// This root bin keeps the legacy `engram-access` command alive for workspace
+// users. Identify it as the legacy OpenClaw plugin id so access-cli targets
+// plugins.entries["openclaw-engram"] before falling through to the canonical
+// Remnic entry when both config blocks exist.
 import("../dist/access-cli.js")
-  .then(({ runCli }) => runCli(process.argv.slice(2)))
+  .then(({ runCli }) =>
+    runCli(process.argv.slice(2), { preferredId: "openclaw-engram" }),
+  )
   .catch((error) => {
     const message = error instanceof Error ? error.message : "unknown load error";
     console.error(`access-cli failed to load dist/access-cli.js: ${message}`);

--- a/tests/resolve-remnic-plugin-entry.test.ts
+++ b/tests/resolve-remnic-plugin-entry.test.ts
@@ -45,6 +45,12 @@ const SHIM_BIN_PATH = path.resolve(
   "bin",
   "engram-access.js",
 );
+const ROOT_ENGRAM_ACCESS_BIN_PATH = path.resolve(
+  __dirname,
+  "..",
+  "bin",
+  "engram-access.js",
+);
 
 function configWithBothEntries() {
   return {
@@ -173,5 +179,19 @@ test("shim engram-access bin wrapper passes preferredId='openclaw-engram' to run
     src,
     /runCli\s*\(\s*process\.argv\.slice\(2\)\s*,/,
     "shim bin wrapper must forward process.argv AND options to runCli",
+  );
+});
+
+test("root engram-access bin wrapper passes preferredId='openclaw-engram'", () => {
+  const src = fs.readFileSync(ROOT_ENGRAM_ACCESS_BIN_PATH, "utf8");
+  assert.match(
+    src,
+    /preferredId:\s*"openclaw-engram"/,
+    "root engram-access bin must identify itself as the legacy caller so mixed canonical/legacy configs target the legacy entry",
+  );
+  assert.match(
+    src,
+    /runCli\s*\(\s*process\.argv\.slice\(2\)\s*,/,
+    "root engram-access bin wrapper must forward process.argv AND options to runCli",
   );
 });


### PR DESCRIPTION
## Summary
- pass the legacy `openclaw-engram` preferred id from the root `engram-access` bin wrapper
- add regression coverage so the root wrapper cannot call `runCli` without options

## Finding
- fixes clawpatch high data-loss finding `fnd_sig-feat-cli-command-362ce05acf-_12153e3998`

## Verification
- `pnpm exec tsx --test tests/resolve-remnic-plugin-entry.test.ts`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the root `engram-access` CLI selects a plugin config entry by forcing `preferredId: "openclaw-engram"`, which can affect which `memoryDir` is read/written when both legacy and canonical configs exist. Low code churn, but it touches config resolution paths that previously led to data-loss scenarios if misrouted.
> 
> **Overview**
> Ensures the root `bin/engram-access.js` wrapper identifies itself as the legacy caller by passing `preferredId: "openclaw-engram"` into `runCli`, so mixed legacy/canonical plugin configs resolve to the intended legacy entry.
> 
> Adds regression coverage in `tests/resolve-remnic-plugin-entry.test.ts` that asserts the root wrapper forwards both argv and options (including `preferredId`), preventing future regressions where the root command would silently target the canonical config block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4da3b03ba42fe2d0c9a1d5ab257d915e41a69869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->