### PR TITLE
Fail bench command on partial failures

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -6429,9 +6429,7 @@ async function cmdBench(rest: string[]): Promise<void> {
   });
   if (failures.size > 0) {
     console.error(`\nFailed benchmarks: ${[...failures].join(", ")}`);
-    if (failures.size === selectedBenchmarks.length) {
-      process.exit(1);
-    }
+    process.exitCode = 1;
   }
 }
 

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
@@ -358,6 +359,56 @@ test("bench providers discovery is exposed as a package-backed CLI surface", asy
   assert.match(parserSource, /first === "providers"/);
   assert.match(parserSource, /const providerAction =[\s\S]*args\[0\] === "discover"/);
   assert.match(readme, /remnic bench providers discover/);
+});
+
+test("bench run exits non-zero after a mixed success/failure run", async () => {
+  const { mkdtemp } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(__dirname, "..");
+  const datasetDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-empty-locomo-dataset-"),
+  );
+  const resultsDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-mixed-bench-results-"),
+  );
+
+  try {
+    const result = spawnSync(
+      "pnpm",
+      [
+        "exec",
+        "tsx",
+        "packages/remnic-cli/src/index.ts",
+        "bench",
+        "run",
+        "taxonomy-accuracy",
+        "locomo",
+        "--dataset-dir",
+        datasetDir,
+        "--results-dir",
+        resultsDir,
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        timeout: 30_000,
+      },
+    );
+
+    assert.equal(
+      result.status,
+      1,
+      `expected mixed benchmark run to exit 1\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert.match(result.stdout, /Benchmark: taxonomy-accuracy/);
+    assert.match(result.stderr, /benchmark "locomo" failed/);
+    assert.match(result.stderr, /Failed benchmarks: locomo/);
+  } finally {
+    rmSync(datasetDir, { recursive: true, force: true });
+    rmSync(resultsDir, { recursive: true, force: true });
+  }
 });
 
 test("bench surface retains local UI compatibility alongside providers discovery", async () => {


### PR DESCRIPTION
## Summary
- mark remnic bench run as failed whenever any selected benchmark fails
- keep attempting all selected benchmarks and writing the repro manifest before returning
- add a subprocess regression for one passing benchmark plus one failing benchmark returning exit code 1

## Verification
- pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI process exit behavior for mixed benchmark outcomes, which can affect CI/pipeline gating and downstream automation. Logic change is small and covered by a new subprocess regression test.
> 
> **Overview**
> `remnic bench run` now returns a failing exit status when **any** selected benchmark fails, instead of only when *all* benchmarks fail.
> 
> Adds a subprocess regression test that runs one passing and one failing benchmark and asserts exit code `1` plus expected stdout/stderr messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5983a59abc6d640e674f7fb21e21138fcdfaae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->