### PR TITLE
Ship shim postinstall banner in package

### DIFF
--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -18,7 +18,8 @@
   "files": [
     "dist",
     "bin/engram-access.js",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "scripts/postinstall-banner.mjs"
   ],
   "publishConfig": {
     "access": "public",

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -117,6 +117,24 @@ test("@remnic/server build verifies declared bin artifacts", async () => {
   assert.equal(packageJson.scripts["verify:bin"], "node scripts/verify-bin.mjs");
 });
 
+test("legacy OpenClaw Engram shim package ships its postinstall script", async () => {
+  const packageJson = JSON.parse(
+    await readFile("packages/shim-openclaw-engram/package.json", "utf8"),
+  ) as {
+    files?: string[];
+    scripts?: Record<string, string>;
+  };
+
+  assert.equal(
+    packageJson.scripts?.postinstall,
+    "node ./scripts/postinstall-banner.mjs",
+  );
+  assert.ok(
+    packageJson.files?.includes("scripts/postinstall-banner.mjs"),
+    "postinstall-banner.mjs must be included in the packed shim package",
+  );
+});
+
 test("@remnic/server bin verifier accepts Node executable bin targets", async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-server-bin-ok-"));
   try {


### PR DESCRIPTION
## Summary
- include scripts/postinstall-banner.mjs in the legacy shim package files whitelist
- add a release-surface test that keeps the shim postinstall script and packlist aligned

## Verification
- pnpm exec tsx --test tests/release-workflow-public-packages.test.ts
- npm pack --dry-run --json from packages/shim-openclaw-engram confirms scripts/postinstall-banner.mjs is present
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging metadata tweak plus a release-surface test to prevent accidentally omitting the shim’s postinstall script from published artifacts.
> 
> **Overview**
> Ensures the legacy `@joshuaswarren/openclaw-engram` shim actually ships its `postinstall` banner by adding `scripts/postinstall-banner.mjs` to the package `files` whitelist.
> 
> Adds a release-surface test that asserts the shim’s `postinstall` script and pack list stay aligned so future changes don’t silently drop the script from the published tarball.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c9f0f7fc959da6cc747185ff58a2af13181065e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->