### PR TITLE
fix: encode summary snapshot session paths

### DIFF
--- a/packages/remnic-core/src/summary-snapshot.test.ts
+++ b/packages/remnic-core/src/summary-snapshot.test.ts
@@ -62,6 +62,87 @@ test("summary snapshot helpers round-trip summaries in descending hour order", a
   assert.deepEqual(loaded, [summaries[1], summaries[0]]);
 });
 
+test("summary snapshot paths encode traversal-looking session keys", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-snapshot-traversal-"),
+  );
+  const sessionKey = "../meta";
+  const summary = {
+    hour: "2026-03-26T08:00:00.000Z",
+    sessionKey,
+    bullets: ["safe bullet"],
+    turnCount: 1,
+    generatedAt: "2026-03-26T08:15:00.000Z",
+  };
+
+  await writeSummarySnapshot(memoryDir, sessionKey, [summary]);
+
+  const snapshotRoot = path.join(memoryDir, "state", "summaries");
+  const snapshotPath = summarySnapshotPath(memoryDir, sessionKey);
+  assert.equal(path.dirname(snapshotPath), snapshotRoot);
+  assert.match(path.basename(snapshotPath), /^%2E%2E%2Fmeta\.json$/);
+  await assert.rejects(
+    readFile(path.join(memoryDir, "state", "meta.json"), "utf-8"),
+    /ENOENT/,
+  );
+  assert.deepEqual(await readSummarySnapshot(memoryDir, sessionKey), [summary]);
+});
+
+test("summary snapshot helpers round-trip slash-containing session keys", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-snapshot-slash-"),
+  );
+  const sessionKey = "thread/a";
+  const summary = {
+    hour: "2026-03-26T08:00:00.000Z",
+    sessionKey,
+    bullets: ["slash bullet"],
+    turnCount: 1,
+    generatedAt: "2026-03-26T08:15:00.000Z",
+  };
+
+  await upsertSummarySnapshot(memoryDir, summary);
+
+  const snapshotRoot = path.join(memoryDir, "state", "summaries");
+  const snapshotPath = summarySnapshotPath(memoryDir, sessionKey);
+  assert.equal(path.dirname(snapshotPath), snapshotRoot);
+  assert.match(path.basename(snapshotPath), /^thread%2Fa\.json$/);
+  assert.deepEqual(await readSummarySnapshot(memoryDir, sessionKey), [summary]);
+});
+
+test("readSummarySnapshot keeps a safe nested legacy raw-path fallback", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-snapshot-legacy-"),
+  );
+  const sessionKey = "thread/a.with.dots";
+  const summary = {
+    hour: "2026-03-26T08:00:00.000Z",
+    sessionKey,
+    bullets: ["legacy bullet"],
+    turnCount: 1,
+    generatedAt: "2026-03-26T08:15:00.000Z",
+  };
+  const snapshotRoot = path.join(memoryDir, "state", "summaries");
+  const legacyPath = path.join(snapshotRoot, `${sessionKey}.json`);
+  await mkdir(path.dirname(legacyPath), { recursive: true });
+  await writeFile(
+    legacyPath,
+    JSON.stringify({
+      schemaVersion: 1,
+      sessionKey,
+      generatedAt: "2026-03-26T08:20:00.000Z",
+      summaries: [summary],
+    }),
+    "utf-8",
+  );
+
+  assert.notEqual(
+    summarySnapshotPath(memoryDir, sessionKey),
+    legacyPath,
+  );
+  assert.deepEqual(await readSummarySnapshot(memoryDir, sessionKey), [summary]);
+});
+
 test("readRecent prefers the materialized summary snapshot over markdown fallback", async () => {
   const memoryDir = await mkdtemp(
     path.join(os.tmpdir(), "engram-summary-prefers-snapshot-"),

--- a/packages/remnic-core/src/summary-snapshot.ts
+++ b/packages/remnic-core/src/summary-snapshot.ts
@@ -9,6 +9,10 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
+import {
+  encodeStoragePathSegment,
+  resolvePathInsideStorageRoot,
+} from "./storage-paths.js";
 import type { HourlySummary } from "./types.js";
 
 const summarySnapshotSchemaVersion = 1;
@@ -42,19 +46,64 @@ export function summarySnapshotPath(
   memoryDir: string,
   sessionKey: string,
 ): string {
-  return path.join(memoryDir, "state", "summaries", `${sessionKey}.json`);
+  return resolveSummarySnapshotPath(memoryDir, sessionKey, "json");
 }
 
 function summarySnapshotLockPath(memoryDir: string, sessionKey: string): string {
-  return path.join(memoryDir, "state", "summaries", `${sessionKey}.lock`);
+  return resolveSummarySnapshotPath(memoryDir, sessionKey, "lock");
+}
+
+function summarySnapshotRoot(memoryDir: string): string {
+  return resolvePathInsideStorageRoot(memoryDir, "state", "summaries");
+}
+
+function resolveSummarySnapshotPath(
+  memoryDir: string,
+  sessionKey: string,
+  extension: "json" | "lock",
+): string {
+  const safeSessionKey = encodeStoragePathSegment(sessionKey, "session");
+  return resolvePathInsideStorageRoot(
+    summarySnapshotRoot(memoryDir),
+    `${safeSessionKey}.${extension}`,
+  );
+}
+
+function legacySummarySnapshotPath(
+  memoryDir: string,
+  sessionKey: string,
+): string | null {
+  if (sessionKey.includes("\0")) {
+    return null;
+  }
+  try {
+    return resolvePathInsideStorageRoot(
+      summarySnapshotRoot(memoryDir),
+      `${sessionKey}.json`,
+    );
+  } catch {
+    return null;
+  }
 }
 
 export async function readSummarySnapshot(
   memoryDir: string,
   sessionKey: string,
 ): Promise<HourlySummary[] | null> {
+  const filePath = summarySnapshotPath(memoryDir, sessionKey);
+  const snapshot = await readSummarySnapshotFile(filePath, sessionKey);
+  if (snapshot !== null) return snapshot;
+
+  const legacyPath = legacySummarySnapshotPath(memoryDir, sessionKey);
+  if (legacyPath === null || legacyPath === filePath) return null;
+  return readSummarySnapshotFile(legacyPath, sessionKey);
+}
+
+async function readSummarySnapshotFile(
+  filePath: string,
+  sessionKey: string,
+): Promise<HourlySummary[] | null> {
   try {
-    const filePath = summarySnapshotPath(memoryDir, sessionKey);
     const raw = await readFile(filePath, "utf-8");
     const data = SummarySnapshotSchema.parse(JSON.parse(raw));
     if (data.sessionKey !== sessionKey) return null;


### PR DESCRIPTION
## Summary
- encode summary snapshot and lock filenames with the shared storage path segment encoder
- resolve snapshot paths under memoryDir/state/summaries before use
- keep a read-only fallback for safe legacy raw snapshot filenames

## Verification
- pnpm exec tsx --test packages/remnic-core/src/summary-snapshot.test.ts
- pnpm rebuild better-sqlite3 && npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk filename scheme for summary snapshots/locks and adds legacy-read fallback, which could affect snapshot persistence/lookup across upgrades. Limited scope to local file storage and covered by new traversal/slash/legacy tests.
> 
> **Overview**
> **Hardens summary snapshot file handling against path traversal and unsafe session keys.** Snapshot and lock paths are now built via `encodeStoragePathSegment` and `resolvePathInsideStorageRoot`, ensuring filenames stay within `memoryDir/state/summaries` even when `sessionKey` contains `..` or `/`.
> 
> `readSummarySnapshot` now attempts the new encoded path first, then falls back to a *read-only* legacy raw-path location (when safely resolvable) for backwards compatibility. Tests were expanded to cover traversal-looking keys, slash-containing keys, and legacy nested snapshot reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4c567f6c2f1a3f233e8aff31f4bc094b4d10420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->