### PR TITLE
fix(core): encode hourly summary session paths

### DIFF
--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -9,6 +9,13 @@ import { extractJsonCandidates } from "./json-extract.js";
 import type { HourlySummary, TranscriptEntry, PluginConfig, GatewayConfig } from "./types.js";
 import type { TranscriptManager } from "./transcript.js";
 import { readSummarySnapshot, upsertSummarySnapshot, writeSummarySnapshot } from "./summary-snapshot.js";
+import {
+  encodeStoragePathSegment,
+  encodeStoragePathSegmentWithHash,
+  isSafeLegacyPathSegment,
+  resolveSafeStoragePath,
+  storagePathHash,
+} from "./storage-paths.js";
 
 // Schema for LLM summary output
 const HourlySummarySchema = z.object({
@@ -79,6 +86,30 @@ export class HourlySummarizer {
   async initialize(): Promise<void> {
     await mkdir(this.summariesDir, { recursive: true });
     log.info("hourly summarizer initialized");
+  }
+
+  private async summarySessionDir(sessionKey: string): Promise<string> {
+    return resolveSafeStoragePath(
+      this.summariesDir,
+      encodeStoragePathSegment(sessionKey, "session"),
+    );
+  }
+
+  private async legacySummarySessionDir(sessionKey: string): Promise<string | null> {
+    if (sessionKey.includes("\0")) return null;
+    try {
+      return await resolveSafeStoragePath(this.summariesDir, sessionKey);
+    } catch {
+      return null;
+    }
+  }
+
+  private summaryDateString(hour: string): string {
+    const dateStr = hour.slice(0, 10);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+      throw new Error(`invalid hourly summary timestamp: ${hour}`);
+    }
+    return dateStr;
   }
 
   // Generate summary for a specific hour and session
@@ -365,12 +396,12 @@ Respond with valid JSON matching this schema:
 
   // Save summary to file
   async saveSummary(summary: HourlySummary): Promise<void> {
-    const sessionDir = path.join(this.summariesDir, summary.sessionKey);
+    const sessionDir = await this.summarySessionDir(summary.sessionKey);
     await mkdir(sessionDir, { recursive: true });
 
     // Format date as YYYY-MM-DD for the filename
-    const dateStr = summary.hour.slice(0, 10);
-    const filePath = path.join(sessionDir, `${dateStr}.md`);
+    const dateStr = this.summaryDateString(summary.hour);
+    const filePath = await resolveSafeStoragePath(sessionDir, `${dateStr}.md`);
 
     // Format hour as HH:00 for display
     const hourStr = summary.hour.slice(11, 13);
@@ -482,22 +513,24 @@ Respond with valid JSON matching this schema:
           .sort((a, b) => new Date(b.hour).getTime() - new Date(a.hour).getTime());
       }
 
-      const sessionDir = path.join(this.summariesDir, sessionKey);
-      const files = await readdir(sessionDir);
-      const mdFiles = files.filter((f) => f.endsWith(".md"));
-
       const summaries: HourlySummary[] = [];
+      const encodedDir = await this.summarySessionDir(sessionKey);
+      const legacyDir = await this.legacySummarySessionDir(sessionKey);
+      const seenDirs = new Set<string>();
 
-      for (const file of mdFiles) {
-        const filePath = path.join(sessionDir, file);
-        const content = await readFile(filePath, "utf-8");
-
-        // Parse the markdown file
-        const parsed = this.parseSummaryFile(content, sessionKey, file);
+      for (const sessionDir of [encodedDir, legacyDir]) {
+        if (!sessionDir || seenDirs.has(sessionDir)) continue;
+        seenDirs.add(sessionDir);
+        const parsed = await this.readSummaryDir(sessionDir, sessionKey);
         summaries.push(...parsed);
       }
 
-      const sortedSummaries = summaries.sort(
+      const byHour = new Map<string, HourlySummary>();
+      for (const summary of summaries) {
+        if (!byHour.has(summary.hour)) byHour.set(summary.hour, summary);
+      }
+
+      const sortedSummaries = Array.from(byHour.values()).sort(
         (a, b) => new Date(b.hour).getTime() - new Date(a.hour).getTime(),
       );
 
@@ -525,6 +558,34 @@ Respond with valid JSON matching this schema:
       // Directory doesn't exist or error reading
       return [];
     }
+  }
+
+  private async readSummaryDir(
+    sessionDir: string,
+    sessionKey: string,
+  ): Promise<HourlySummary[]> {
+    let files: string[];
+    try {
+      files = await readdir(sessionDir);
+    } catch {
+      return [];
+    }
+
+    const summaries: HourlySummary[] = [];
+    const mdFiles = files.filter((f) => f.endsWith(".md"));
+    for (const file of mdFiles) {
+      const filePath = await resolveSafeStoragePath(sessionDir, file).catch(() => null);
+      if (filePath === null) continue;
+
+      try {
+        const content = await readFile(filePath, "utf-8");
+        summaries.push(...this.parseSummaryFile(content, sessionKey, file));
+      } catch {
+        // Skip unreadable summary files.
+      }
+    }
+
+    return summaries;
   }
 
   private parseSummaryFile(
@@ -695,36 +756,63 @@ Respond with valid JSON matching this schema:
       }
     }
 
-    const transcriptDir = path.join(this.config.memoryDir, "transcripts", channelType, channelId);
-
     try {
-      // Read all daily transcript files in the directory
-      const files = await readdir(transcriptDir);
+      const transcriptRoot = path.join(this.config.memoryDir, "transcripts");
+      const encodedDir = path.join(
+        encodeStoragePathSegment(channelType),
+        encodeStoragePathSegment(channelId),
+      );
+      const alternateDir = path.join(
+        encodeStoragePathSegmentWithHash(channelType),
+        `${encodeStoragePathSegmentWithHash(channelId)}--session-${storagePathHash(sessionKey)}`,
+      );
+      const legacyDir =
+        isSafeLegacyPathSegment(channelType) && isSafeLegacyPathSegment(channelId)
+          ? path.join(channelType, channelId)
+          : undefined;
+      const candidateDirs = new Set(
+        [encodedDir, alternateDir, legacyDir].filter(
+          (dir): dir is string => typeof dir === "string" && dir.length > 0,
+        ),
+      );
       const entries: TranscriptEntry[] = [];
 
-      for (const file of files) {
-        if (!file.endsWith(".jsonl")) continue;
+      // Read all daily transcript files in the directory
+      for (const candidateDir of candidateDirs) {
+        const transcriptDir = await resolveSafeStoragePath(transcriptRoot, candidateDir).catch(() => null);
+        if (transcriptDir === null) continue;
 
-        const transcriptPath = path.join(transcriptDir, file);
-        try {
-          const content = await readFile(transcriptPath, "utf-8");
-          const lines = content.trim().split("\n");
+        const files = await readdir(transcriptDir).catch(() => []);
+        for (const file of files) {
+          if (!file.endsWith(".jsonl")) continue;
 
-          for (const line of lines) {
-            if (!line.trim()) continue;
-            try {
-              const entry = JSON.parse(line) as TranscriptEntry;
-              const entryTime = new Date(entry.timestamp).getTime();
+          const transcriptPath = await resolveSafeStoragePath(transcriptDir, file).catch(() => null);
+          if (transcriptPath === null) continue;
 
-              if (entryTime >= startTime.getTime() && entryTime < endTime.getTime()) {
-                entries.push(entry);
+          try {
+            const content = await readFile(transcriptPath, "utf-8");
+            const lines = content.trim().split("\n");
+
+            for (const line of lines) {
+              if (!line.trim()) continue;
+              try {
+                const entry = JSON.parse(line) as TranscriptEntry;
+                const entryTime = new Date(entry.timestamp).getTime();
+
+                if (
+                  entry.sessionKey === sessionKey &&
+                  entryTime >= startTime.getTime() &&
+                  entryTime < endTime.getTime()
+                ) {
+                  entries.push(entry);
+                }
+              } catch {
+                // Skip malformed lines
               }
-            } catch {
-              // Skip malformed lines
             }
+          } catch {
+            // Skip unreadable files
           }
-        } catch {
-          // Skip unreadable files
         }
       }
 

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -697,37 +697,57 @@ Respond with valid JSON matching this schema:
 
   // Get list of active sessions from transcript directory
   private async getActiveSessions(): Promise<string[]> {
-    const transcriptDir = path.join(this.config.memoryDir, "transcripts");
+    const transcriptDir = await resolveSafeStoragePath(
+      this.config.memoryDir,
+      "transcripts",
+    ).catch(() => null);
+    if (transcriptDir === null) return [];
 
     try {
       const sessionKeys = new Set<string>();
       const typeEntries = await readdir(transcriptDir, { withFileTypes: true });
       for (const typeEnt of typeEntries) {
         if (!typeEnt.isDirectory()) continue;
-        const typeDir = path.join(transcriptDir, typeEnt.name);
+        const typeDir = await resolveSafeStoragePath(transcriptDir, typeEnt.name).catch(() => null);
+        if (typeDir === null) continue;
         const idEntries = await readdir(typeDir, { withFileTypes: true });
         for (const idEnt of idEntries) {
           if (!idEnt.isDirectory()) continue;
-          const chanDir = path.join(typeDir, idEnt.name);
+          const chanDir = await resolveSafeStoragePath(typeDir, idEnt.name).catch(() => null);
+          if (chanDir === null) continue;
           const files = (await readdir(chanDir)).filter((f) => f.endsWith(".jsonl")).sort();
-          const last = files[files.length - 1];
-          if (!last) continue;
-          try {
-            const raw = await readFile(path.join(chanDir, last), "utf-8");
-            const firstLine = raw.split("\n").find((l) => l.trim().length > 0);
-            if (!firstLine) continue;
-            const entry = JSON.parse(firstLine) as TranscriptEntry;
-            if (typeof entry.sessionKey === "string" && entry.sessionKey.length > 0) {
-              sessionKeys.add(entry.sessionKey);
-            }
-          } catch {
-            // ignore
+          for (const file of files) {
+            const transcriptPath = await resolveSafeStoragePath(chanDir, file).catch(() => null);
+            if (transcriptPath === null) continue;
+            await this.collectTranscriptSessionKeys(transcriptPath, sessionKeys);
           }
         }
       }
       return Array.from(sessionKeys);
     } catch {
       return [];
+    }
+  }
+
+  private async collectTranscriptSessionKeys(
+    transcriptPath: string,
+    sessionKeys: Set<string>,
+  ): Promise<void> {
+    try {
+      const raw = await readFile(transcriptPath, "utf-8");
+      for (const line of raw.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const entry = JSON.parse(line) as TranscriptEntry;
+          if (typeof entry.sessionKey === "string" && entry.sessionKey.length > 0) {
+            sessionKeys.add(entry.sessionKey);
+          }
+        } catch {
+          // ignore malformed transcript lines
+        }
+      }
+    } catch {
+      // ignore unreadable transcript files
     }
   }
 

--- a/packages/remnic-core/src/summary-snapshot.test.ts
+++ b/packages/remnic-core/src/summary-snapshot.test.ts
@@ -10,6 +10,7 @@ import {
   summarySnapshotPath,
   writeSummarySnapshot,
 } from "./summary-snapshot.js";
+import { encodeStoragePathSegment } from "./storage-paths.js";
 import type { PluginConfig } from "./types.js";
 
 function makeConfig(memoryDir: string): PluginConfig {
@@ -189,6 +190,79 @@ test("readRecent prefers the materialized summary snapshot over markdown fallbac
   );
 });
 
+test("saveSummary encodes traversal-looking session keys before writing markdown", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-markdown-traversal-"),
+  );
+  const summarizer = new HourlySummarizer(makeConfig(memoryDir));
+  await summarizer.initialize();
+
+  const sessionKey = "../escape";
+  const dateStr = "2026-03-26";
+  const summary = {
+    hour: `${dateStr}T08:00:00.000Z`,
+    sessionKey,
+    bullets: ["safe markdown bullet"],
+    turnCount: 1,
+    generatedAt: "2026-03-26T08:15:00.000Z",
+  };
+
+  await summarizer.saveSummary(summary);
+
+  const encodedPath = path.join(
+    memoryDir,
+    "summaries",
+    "hourly",
+    encodeStoragePathSegment(sessionKey, "session"),
+    `${dateStr}.md`,
+  );
+  const unsafePath = path.join(memoryDir, "summaries", "escape", `${dateStr}.md`);
+
+  const markdown = await readFile(encodedPath, "utf-8");
+  assert.match(markdown, /safe markdown bullet/);
+  await assert.rejects(readFile(unsafePath, "utf-8"), /ENOENT/);
+});
+
+test("saveSummary encodes slash-containing session keys before writing markdown", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-markdown-slash-"),
+  );
+  const summarizer = new HourlySummarizer(makeConfig(memoryDir));
+  await summarizer.initialize();
+
+  const sessionKey = "thread/a";
+  const dateStr = "2026-03-26";
+  const summary = {
+    hour: `${dateStr}T08:00:00.000Z`,
+    sessionKey,
+    bullets: ["slash markdown bullet"],
+    turnCount: 1,
+    generatedAt: "2026-03-26T08:15:00.000Z",
+  };
+
+  await summarizer.saveSummary(summary);
+
+  const encodedPath = path.join(
+    memoryDir,
+    "summaries",
+    "hourly",
+    encodeStoragePathSegment(sessionKey, "session"),
+    `${dateStr}.md`,
+  );
+  const legacyPath = path.join(
+    memoryDir,
+    "summaries",
+    "hourly",
+    "thread",
+    "a",
+    `${dateStr}.md`,
+  );
+
+  const markdown = await readFile(encodedPath, "utf-8");
+  assert.match(markdown, /slash markdown bullet/);
+  await assert.rejects(readFile(legacyPath, "utf-8"), /ENOENT/);
+});
+
 test("readRecent backfills a summary snapshot from the full parsed markdown history", async () => {
   const memoryDir = await mkdtemp(
     path.join(os.tmpdir(), "engram-summary-backfill-"),
@@ -237,6 +311,99 @@ test("readRecent backfills a summary snapshot from the full parsed markdown hist
   assert.deepEqual(
     widerRecent.map((summary) => summary.bullets),
     [["newer markdown bullet"], ["older markdown bullet"]],
+  );
+});
+
+test("readRecent keeps a safe nested legacy markdown fallback", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-markdown-legacy-"),
+  );
+  const summarizer = new HourlySummarizer(makeConfig(memoryDir));
+  await summarizer.initialize();
+
+  const sessionKey = "thread/a";
+  const dateStr = "2026-03-24";
+  const mdDir = path.join(memoryDir, "summaries", "hourly", "thread", "a");
+  await mkdir(mdDir, { recursive: true });
+
+  await writeFile(
+    path.join(mdDir, `${dateStr}.md`),
+    [
+      `# Hourly Summaries — ${dateStr}`,
+      "",
+      `*Session: ${sessionKey}*`,
+      "",
+      "## 14:00",
+      "",
+      "- legacy slash markdown bullet",
+      "  *(4 turns)*",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  assert.equal(await readSummarySnapshot(memoryDir, sessionKey), null);
+
+  const recent = await summarizer.readRecent(sessionKey, 9999);
+  assert.deepEqual(
+    recent.map((summary) => summary.bullets),
+    [["legacy slash markdown bullet"]],
+  );
+  assert.deepEqual(
+    (await readSummarySnapshot(memoryDir, sessionKey))?.map(
+      (summary) => summary.bullets,
+    ),
+    [["legacy slash markdown bullet"]],
+  );
+});
+
+test("readRecent does not duplicate hours during encoded markdown migration", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-markdown-migration-"),
+  );
+  const summarizer = new HourlySummarizer(makeConfig(memoryDir));
+  await summarizer.initialize();
+
+  const sessionKey = "thread/a";
+  const dateStr = "2026-03-24";
+  const encodedDir = path.join(
+    memoryDir,
+    "summaries",
+    "hourly",
+    encodeStoragePathSegment(sessionKey, "session"),
+  );
+  const legacyDir = path.join(memoryDir, "summaries", "hourly", "thread", "a");
+  await mkdir(encodedDir, { recursive: true });
+  await mkdir(legacyDir, { recursive: true });
+
+  const markdown = (bullet: string) =>
+    [
+      `# Hourly Summaries — ${dateStr}`,
+      "",
+      `*Session: ${sessionKey}*`,
+      "",
+      "## 14:00",
+      "",
+      `- ${bullet}`,
+      "  *(4 turns)*",
+      "",
+    ].join("\n");
+
+  await writeFile(
+    path.join(encodedDir, `${dateStr}.md`),
+    markdown("encoded markdown bullet"),
+    "utf-8",
+  );
+  await writeFile(
+    path.join(legacyDir, `${dateStr}.md`),
+    markdown("legacy markdown bullet"),
+    "utf-8",
+  );
+
+  const recent = await summarizer.readRecent(sessionKey, 9999);
+  assert.deepEqual(
+    recent.map((summary) => summary.bullets),
+    [["encoded markdown bullet"]],
   );
 });
 
@@ -404,5 +571,75 @@ test("runHourly keeps processing later sessions when snapshot upsert fails after
       (summary) => summary.bullets,
     ),
     [[`summary for ${succeedingSession}`]],
+  );
+});
+
+test("hourly transcript lookup ignores traversal channel paths", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-transcript-traversal-"),
+  );
+  const summarizer = new HourlySummarizer(makeConfig(memoryDir));
+  await summarizer.initialize();
+
+  const sessionKey = "agent:worker:..:escape";
+  const timestamp = "2026-03-26T08:15:00.000Z";
+  const escapedDir = path.join(memoryDir, "escape");
+  await mkdir(escapedDir, { recursive: true });
+  await writeFile(
+    path.join(escapedDir, "2026-03-26.jsonl"),
+    JSON.stringify({
+      role: "user",
+      content: "escaped transcript",
+      timestamp,
+      sessionKey,
+    }) + "\n",
+    "utf-8",
+  );
+
+  const entries = await (summarizer as any).getTranscriptEntries(
+    sessionKey,
+    new Date("2026-03-26T08:00:00.000Z"),
+    new Date("2026-03-26T09:00:00.000Z"),
+  );
+
+  assert.deepEqual(entries, []);
+});
+
+test("hourly transcript lookup reads encoded transcript channel directories", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-transcript-encoded-"),
+  );
+  const summarizer = new HourlySummarizer(makeConfig(memoryDir));
+  await summarizer.initialize();
+
+  const sessionKey = "agent:worker:discord:channel:a/b";
+  const timestamp = "2026-03-26T08:15:00.000Z";
+  const transcriptDir = path.join(
+    memoryDir,
+    "transcripts",
+    encodeStoragePathSegment("discord"),
+    encodeStoragePathSegment("a/b"),
+  );
+  await mkdir(transcriptDir, { recursive: true });
+  await writeFile(
+    path.join(transcriptDir, "2026-03-26.jsonl"),
+    JSON.stringify({
+      role: "user",
+      content: "encoded transcript",
+      timestamp,
+      sessionKey,
+    }) + "\n",
+    "utf-8",
+  );
+
+  const entries = await (summarizer as any).getTranscriptEntries(
+    sessionKey,
+    new Date("2026-03-26T08:00:00.000Z"),
+    new Date("2026-03-26T09:00:00.000Z"),
+  );
+
+  assert.deepEqual(
+    entries.map((entry: any) => entry.content),
+    ["encoded transcript"],
   );
 });

--- a/packages/remnic-core/src/summary-snapshot.test.ts
+++ b/packages/remnic-core/src/summary-snapshot.test.ts
@@ -574,6 +574,42 @@ test("runHourly keeps processing later sessions when snapshot upsert fails after
   );
 });
 
+test("hourly active session discovery reads every session key in a transcript file", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-summary-active-sessions-"),
+  );
+  const summarizer = new HourlySummarizer(makeConfig(memoryDir));
+  await summarizer.initialize();
+
+  const transcriptDir = path.join(memoryDir, "transcripts", "other", "default");
+  await mkdir(transcriptDir, { recursive: true });
+  await writeFile(
+    path.join(transcriptDir, "2026-03-26.jsonl"),
+    [
+      JSON.stringify({
+        role: "user",
+        content: "first session",
+        timestamp: "2026-03-26T08:15:00.000Z",
+        sessionKey: "agent:first:main",
+      }),
+      JSON.stringify({
+        role: "user",
+        content: "second session",
+        timestamp: "2026-03-26T08:16:00.000Z",
+        sessionKey: "agent:second:main",
+      }),
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const sessions = await (summarizer as any).getActiveSessions();
+  assert.deepEqual(
+    [...sessions].sort(),
+    ["agent:first:main", "agent:second:main"],
+  );
+});
+
 test("hourly transcript lookup ignores traversal channel paths", async () => {
   const memoryDir = await mkdtemp(
     path.join(os.tmpdir(), "engram-summary-transcript-traversal-"),


### PR DESCRIPTION
## Summary
- encode hourly summary markdown directories from session keys before writing
- keep safe legacy markdown reads while avoiding duplicate hours during migration
- align hourly transcript lookup with encoded transcript storage paths and exact session filtering

## Verification
- pnpm exec tsx --test packages/remnic-core/src/summary-snapshot.test.ts
- git diff --check
- npm run preflight:quick

Clawpatch finding addressed: hourly summaries used raw session keys as filesystem paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem read/write paths for hourly summaries and transcript discovery/lookup; mistakes could cause missed summaries or failure to find transcript entries. Changes are security-motivated (path traversal/symlink safety) but alter storage layout and migration behavior.
> 
> **Overview**
> **Hourly summary markdown storage is now path-safe.** `saveSummary` writes to an encoded per-session directory and resolves files via `resolveSafeStoragePath`, with basic date validation to avoid malformed filenames.
> 
> **Markdown reads support migration without duplication.** `readRecent` now reads from both encoded and safe legacy session directories, de-duplicates summaries by hour, and factors directory/file reads into a helper that skips unsafe/unreadable files.
> 
> **Transcript scanning/lookup is hardened and aligned with encoded storage.** Active-session discovery now safely walks transcript directories and collects *all* `sessionKey`s from each `.jsonl` file, while transcript lookup searches encoded/hashed/legacy channel directories and only returns entries whose `entry.sessionKey` exactly matches the requested session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637c12477208a818aa584df87dba3ac461836fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->