### PR TITLE
Scope active run diagnostics after restart

### DIFF
--- a/scripts/bench/public-sota/check-active-public-run.mjs
+++ b/scripts/bench/public-sota/check-active-public-run.mjs
@@ -56,10 +56,39 @@ function benchmarkFromRun(runId, statusRows) {
   return match?.[1] ?? null;
 }
 
-function newestDiagnostics(diagDir, count) {
+function latestLifecycleStart(statusRows, benchmark) {
+  let latest;
+  for (const line of statusRows) {
+    const [rowBenchmark, status, timestamp] = line.split('\t');
+    if (rowBenchmark !== benchmark) {
+      continue;
+    }
+    if (status !== 'start' && !status?.startsWith('restart')) {
+      continue;
+    }
+    const timestampMs = Date.parse(timestamp);
+    if (!Number.isFinite(timestampMs)) {
+      continue;
+    }
+    if (!latest || timestampMs > latest.timestampMs) {
+      latest = { status, timestamp, timestampMs };
+    }
+  }
+  return latest;
+}
+
+function newestDiagnostics(diagDir, count, lifecycleStart) {
   if (!fs.existsSync(diagDir)) {
     return {
       total: 0,
+      allDiagnostics: 0,
+      beforeLifecycleStart: 0,
+      lifecycleStart: lifecycleStart
+        ? {
+            status: lifecycleStart.status,
+            timestamp: lifecycleStart.timestamp,
+          }
+        : null,
       sampleSize: 0,
       errors: 0,
       nonzero: 0,
@@ -82,9 +111,19 @@ function newestDiagnostics(diagDir, count) {
   let errors = 0;
   let nonzero = 0;
   let inFlight = 0;
-  const parsedRecords = records.map((entry) => {
+  let beforeLifecycleStart = 0;
+  const parsedRecords = records.flatMap((entry) => {
     try {
       const record = { ...JSON.parse(fs.readFileSync(entry.file, 'utf8')), name: entry.name };
+      const startedAtMs = Date.parse(record.startedAt);
+      if (
+        lifecycleStart
+        && Number.isFinite(startedAtMs)
+        && startedAtMs < lifecycleStart.timestampMs
+      ) {
+        beforeLifecycleStart += 1;
+        return [];
+      }
       if (record.error || record.parseError) {
         errors += 1;
       }
@@ -94,10 +133,10 @@ function newestDiagnostics(diagDir, count) {
       if (!record.finishedAt) {
         inFlight += 1;
       }
-      return record;
+      return [record];
     } catch (error) {
       errors += 1;
-      return { name: entry.name, parseError: String(error) };
+      return [{ name: entry.name, parseError: String(error) }];
     }
   });
   const sample = parsedRecords.slice(0, count);
@@ -106,9 +145,17 @@ function newestDiagnostics(diagDir, count) {
     .sort((left, right) => String(right.finishedAt).localeCompare(String(left.finishedAt)))
     .slice(0, 5);
   return {
-    total: records.length,
+    total: parsedRecords.length,
+    allDiagnostics: records.length,
+    beforeLifecycleStart,
+    lifecycleStart: lifecycleStart
+      ? {
+          status: lifecycleStart.status,
+          timestamp: lifecycleStart.timestamp,
+        }
+      : null,
     scanned: parsedRecords.length,
-    countsMode: 'all-diagnostics',
+    countsMode: lifecycleStart ? 'diagnostics-since-lifecycle-start' : 'all-diagnostics',
     sampleSize: sample.length,
     errors,
     nonzero,
@@ -191,6 +238,7 @@ function parseBenchmarkProgress(lines, benchmark) {
 const runId = path.basename(resultsDir);
 const statusRows = readStatusRows(path.join(resultsDir, 'status.tsv'));
 const benchmark = benchmarkFromRun(runId, statusRows);
+const lifecycleStart = latestLifecycleStart(statusRows, benchmark);
 const monitorSessionName = runId === 'public-matrix-codex-bf9b2643-20260515T052919Z'
   ? 'public-matrix-codex-monitor-bf9b2643'
   : `${runId}-monitor`;
@@ -222,7 +270,7 @@ const summary = {
         tail: readLines(monitorPath, 12),
       }
     : null,
-  diagnostics: newestDiagnostics(path.join(resultsDir, 'codex-cli-diagnostics'), 30),
+  diagnostics: newestDiagnostics(path.join(resultsDir, 'codex-cli-diagnostics'), 30, lifecycleStart),
   checkedAt: new Date().toISOString(),
 };
 

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -1787,6 +1787,64 @@ test("active public run diagnostics picks latest finished record from full scan"
   }
 });
 
+test("active public run diagnostics ignore records before latest lifecycle start", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-public-sota-active-run-restart-"));
+  try {
+    const runDir = path.join(root, "public-memory-arena-codex-20260517T000000Z");
+    const diagnosticsDir = path.join(runDir, "codex-cli-diagnostics");
+    await mkdir(diagnosticsDir, { recursive: true });
+    await writeFile(
+      path.join(runDir, "status.tsv"),
+      [
+        "benchmark\tstatus\ttimestamp",
+        "memory-arena\tstart\t2026-05-17T00:00:00Z",
+        "memory-arena\trestart-after-reboot\t2026-05-17T02:00:00Z",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeJson(path.join(diagnosticsDir, "pre-restart-failed.json"), {
+      runId: path.basename(runDir),
+      startedAt: "2026-05-17T01:59:00.000Z",
+      finishedAt: "2026-05-17T01:59:30.000Z",
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      serviceTier: "fast",
+      error: "Codex CLI completion failed (signal SIGTERM)",
+    });
+    await writeJson(path.join(diagnosticsDir, "post-restart-ok.json"), {
+      runId: path.basename(runDir),
+      startedAt: "2026-05-17T02:00:10.000Z",
+      finishedAt: "2026-05-17T02:00:20.000Z",
+      durationMs: 10_000,
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      serviceTier: "fast",
+      result: { status: 0 },
+    });
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [path.join("scripts", "bench", "public-sota", "check-active-public-run.mjs"), runDir],
+      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+    );
+    const status = JSON.parse(stdout);
+    assert.equal(status.diagnostics.countsMode, "diagnostics-since-lifecycle-start");
+    assert.equal(status.diagnostics.lifecycleStart.status, "restart-after-reboot");
+    assert.equal(status.diagnostics.lifecycleStart.timestamp, "2026-05-17T02:00:00Z");
+    assert.equal(status.diagnostics.allDiagnostics, 2);
+    assert.equal(status.diagnostics.beforeLifecycleStart, 1);
+    assert.equal(status.diagnostics.total, 1);
+    assert.equal(status.diagnostics.errors, 0);
+    assert.equal(status.diagnostics.nonzero, 0);
+    assert.equal(status.diagnostics.latestFinished[0].name, "post-restart-ok.json");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("public SOTA evidence scripts share manifest hash identity helpers", async () => {
   const files = [
     path.join("scripts", "bench", "public-sota", "package-public-benchmark-evidence.mjs"),


### PR DESCRIPTION
## Summary
- filter active-run diagnostic counts to records after the latest benchmark lifecycle start or restart marker
- expose lifecycle-scoped diagnostic metadata so reboot SIGTERM records do not poison the resumed run status
- add regression coverage for restart-after-reboot diagnostic scoping

## Verification
- node --check scripts/bench/public-sota/check-active-public-run.mjs
- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes how an active-run status script filters and reports diagnostics, plus adds a regression test; no production runtime or security-critical logic is affected.
> 
> **Overview**
> Active public-run status reporting now *scopes diagnostics to the latest benchmark lifecycle start* (either `start` or a `restart*` marker from `status.tsv`), so pre-restart failures don’t skew the resumed run’s health/progress.
> 
> `scripts/bench/public-sota/check-active-public-run.mjs` adds `latestLifecycleStart()` and filters out diagnostics whose `startedAt` predates that marker, while exposing new metadata (`countsMode`, `allDiagnostics`, `beforeLifecycleStart`, and `lifecycleStart`) in the JSON summary. Tests add coverage ensuring pre-restart SIGTERM diagnostics are ignored and the post-restart record is treated as the latest finished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ed7ca86ded3cadf65d3c1e7152a56c6ba50820d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->