### PR TITLE
Scope active run progress after restart

### DIFF
--- a/scripts/bench/public-sota/check-active-public-run.mjs
+++ b/scripts/bench/public-sota/check-active-public-run.mjs
@@ -30,6 +30,14 @@ function readLines(file, count) {
   return fs.readFileSync(file, 'utf8').trim().split(/\r?\n/).slice(-count);
 }
 
+function readAllLines(file) {
+  if (!fs.existsSync(file)) {
+    return [];
+  }
+  const content = fs.readFileSync(file, 'utf8').trim();
+  return content ? content.split(/\r?\n/) : [];
+}
+
 function readStatusRows(file) {
   if (!fs.existsSync(file)) {
     return [];
@@ -235,6 +243,34 @@ function parseBenchmarkProgress(lines, benchmark) {
   };
 }
 
+function linesSinceLifecycleStart(lines, lifecycleStart) {
+  if (!lifecycleStart || lifecycleStart.status === 'start') {
+    return {
+      lines,
+      mode: 'all-run-log-lines',
+      markerFound: false,
+    };
+  }
+
+  const marker = `=== ${lifecycleStart.status} ${lifecycleStart.timestamp} ===`;
+  const markerIndex = lines.findLastIndex((line) => line.trim() === marker);
+  if (markerIndex < 0) {
+    return {
+      lines: [],
+      mode: 'run-log-lines-since-lifecycle-start',
+      markerFound: false,
+      marker,
+    };
+  }
+
+  return {
+    lines: lines.slice(markerIndex + 1),
+    mode: 'run-log-lines-since-lifecycle-start',
+    markerFound: true,
+    marker,
+  };
+}
+
 const runId = path.basename(resultsDir);
 const statusRows = readStatusRows(path.join(resultsDir, 'status.tsv'));
 const benchmark = benchmarkFromRun(runId, statusRows);
@@ -245,7 +281,9 @@ const monitorSessionName = runId === 'public-matrix-codex-bf9b2643-20260515T0529
 const jsonFiles = fs.existsSync(resultsDir)
   ? fs.readdirSync(resultsDir).filter((name) => name.endsWith('.json')).sort()
   : [];
-const runLogTail = readLines(path.join(resultsDir, 'run.log'), 500);
+const runLogLines = readAllLines(path.join(resultsDir, 'run.log'));
+const runLogTail = runLogLines.slice(-500);
+const progressLines = linesSinceLifecycleStart(runLogLines, lifecycleStart);
 const monitorPath = path.join(resultsDir, 'monitor-30m.log');
 const monitorStat = fs.existsSync(monitorPath) ? fs.statSync(monitorPath) : undefined;
 const summary = {
@@ -262,7 +300,13 @@ const summary = {
     : [],
   memoryArenaResultFiles: jsonFiles.filter((name) => name.startsWith('memory-arena-')),
   runLogTail: runLogTail.slice(-12),
-  progress: parseBenchmarkProgress(runLogTail, benchmark),
+  progress: parseBenchmarkProgress(progressLines.lines, benchmark),
+  progressSource: {
+    mode: progressLines.mode,
+    markerFound: progressLines.markerFound,
+    marker: progressLines.marker,
+    scannedLines: progressLines.lines.length,
+  },
   monitor: monitorStat
     ? {
         mtime: monitorStat.mtime.toISOString(),

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -1845,6 +1845,92 @@ test("active public run diagnostics ignore records before latest lifecycle start
   }
 });
 
+test("active public run progress ignores pre-restart checkpoints", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-public-sota-active-run-restart-progress-"));
+  try {
+    const runDir = path.join(root, "public-memory-arena-codex-20260517T000000Z");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      path.join(runDir, "status.tsv"),
+      [
+        "benchmark\tstatus\ttimestamp",
+        "memory-arena\tstart\t2026-05-17T00:00:00Z",
+        "memory-arena\trestart-after-reboot\t2026-05-17T02:00:00Z",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(
+      path.join(runDir, "run.log"),
+      [
+        "  [memory-arena] 1850/4209 tasks (142365s elapsed, ~181535s remaining)",
+        "=== restart-after-reboot 2026-05-17T02:00:00Z ===",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const beforeCheckpoint = await execFileAsync(
+      process.execPath,
+      [path.join("scripts", "bench", "public-sota", "check-active-public-run.mjs"), runDir],
+      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+    );
+    const beforeStatus = JSON.parse(beforeCheckpoint.stdout);
+    assert.equal(beforeStatus.progress, null);
+    assert.equal(beforeStatus.progressSource.mode, "run-log-lines-since-lifecycle-start");
+    assert.equal(beforeStatus.progressSource.markerFound, true);
+    assert.equal(beforeStatus.progressSource.scannedLines, 0);
+
+    await writeFile(
+      path.join(runDir, "run.log"),
+      [
+        "  [memory-arena] 1850/4209 tasks (142365s elapsed, ~181535s remaining)",
+        "=== restart-after-reboot 2026-05-17T02:00:00Z ===",
+        "  [memory-arena] 50/4209 tasks (2400s elapsed, ~199632s remaining)",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const afterCheckpoint = await execFileAsync(
+      process.execPath,
+      [path.join("scripts", "bench", "public-sota", "check-active-public-run.mjs"), runDir],
+      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+    );
+    const afterStatus = JSON.parse(afterCheckpoint.stdout);
+    assert.equal(afterStatus.progress.completed, 50);
+    assert.equal(afterStatus.progress.total, 4209);
+    assert.equal(afterStatus.progress.remaining, 4159);
+    assert.equal(afterStatus.progressSource.scannedLines, 1);
+    assert.doesNotMatch(afterStatus.progress.line, /1850\/4209/);
+
+    await writeFile(
+      path.join(runDir, "run.log"),
+      [
+        "  [memory-arena] 1850/4209 tasks (142365s elapsed, ~181535s remaining)",
+        "=== restart-after-reboot 2026-05-17T02:00:00Z ===",
+        ...Array.from({ length: 5001 }, (_, index) => `post-restart detail ${index}`),
+        "  [memory-arena] 100/4209 tasks (4800s elapsed, ~197232s remaining)",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const longLogCheckpoint = await execFileAsync(
+      process.execPath,
+      [path.join("scripts", "bench", "public-sota", "check-active-public-run.mjs"), runDir],
+      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+    );
+    const longLogStatus = JSON.parse(longLogCheckpoint.stdout);
+    assert.equal(longLogStatus.progress.completed, 100);
+    assert.equal(longLogStatus.progress.total, 4209);
+    assert.equal(longLogStatus.progressSource.markerFound, true);
+    assert.equal(longLogStatus.progressSource.scannedLines, 5002);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("public SOTA evidence scripts share manifest hash identity helpers", async () => {
   const files = [
     path.join("scripts", "bench", "public-sota", "package-public-benchmark-evidence.mjs"),


### PR DESCRIPTION
## Summary
- parse active-run progress only from run log lines after the latest lifecycle restart marker
- expose progress source metadata so stale or missing post-restart checkpoints are visible
- add regression coverage for pre-restart checkpoints and first post-restart checkpoint handling

## Verification
- node --check scripts/bench/public-sota/check-active-public-run.mjs
- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how active-run progress is computed and reported after restarts, which may affect monitoring output for long-running benchmarks. Logic is well-covered by new regression tests but relies on correct restart marker formatting in `run.log`.
> 
> **Overview**
> Active-run progress reporting in `check-active-public-run.mjs` now **ignores stale pre-restart checkpoints** by parsing progress only from `run.log` lines after the latest lifecycle restart marker derived from `status.tsv`.
> 
> The script now emits `progressSource` metadata (mode, whether the marker was found, marker text, and scanned line count) to make missing/stale post-restart progress explicit. Adds a regression test covering pre-restart checkpoint suppression and first post-restart checkpoint handling (including long logs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f70260110628b01eb997ab79278ed743d47ebeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->