### PR TITLE
fix(core): harden contradiction resolution refresh

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -67,6 +67,10 @@ function isTerminalResolution(resolution: ResolutionVerb | undefined): boolean {
   return resolution === "keep-a" || resolution === "keep-b" || resolution === "merge";
 }
 
+function preservesDirectResolution(resolution: ResolutionVerb | undefined): boolean {
+  return isTerminalResolution(resolution) || resolution === "both-valid";
+}
+
 function isDormantReviewedPair(pair: ContradictionPair): boolean {
   return pair.verdict === "independent" || pair.resolution === "both-valid";
 }
@@ -348,7 +352,7 @@ export function deferPair(
 ): ContradictionPair | null {
   const existing = readPair(memoryDir, pairId);
   if (!existing) return null;
-  if (isTerminalResolution(existing.resolution)) return existing;
+  if (preservesDirectResolution(existing.resolution)) return existing;
 
   const updated: ContradictionPair = {
     ...existing,

--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -50,6 +50,10 @@ export interface ContradictionListResult {
 }
 
 export type ContradictionFilter = ContradictionVerdict | "all" | "unresolved";
+export interface WritePairOptions {
+  /** Cooldown used by scan callers to preserve still-dormant reviewed pairs. */
+  cooldownDays?: number;
+}
 const NEEDS_MORE_CONTEXT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -60,7 +64,11 @@ export function computePairId(memoryIdA: string, memoryIdB: string): string {
 }
 
 function isTerminalResolution(resolution: ResolutionVerb | undefined): boolean {
-  return Boolean(resolution && resolution !== "needs-more-context");
+  return resolution === "keep-a" || resolution === "keep-b" || resolution === "merge";
+}
+
+function isDormantReviewedPair(pair: ContradictionPair): boolean {
+  return pair.verdict === "independent" || pair.resolution === "both-valid";
 }
 
 function parseIsoMillis(value: string | undefined): number | null {
@@ -115,7 +123,11 @@ function ensureDir(memoryDir: string): void {
  * Idempotent: if the pair already exists with a higher or equal confidence,
  * the existing entry is preserved.
  */
-export function writePair(memoryDir: string, pair: Omit<ContradictionPair, "pairId"> & { memoryIds: [string, string] }): ContradictionPair {
+export function writePair(
+  memoryDir: string,
+  pair: Omit<ContradictionPair, "pairId"> & { memoryIds: [string, string] },
+  options: WritePairOptions = {},
+): ContradictionPair {
   ensureDir(memoryDir);
   const pairId = computePairId(pair.memoryIds[0], pair.memoryIds[1]);
   const existing = readPair(memoryDir, pairId);
@@ -124,6 +136,9 @@ export function writePair(memoryDir: string, pair: Omit<ContradictionPair, "pair
   if (isTerminalResolution(existing?.resolution)) {
     return existing!;
   }
+  if (existing?.resolution === "both-valid" && options.cooldownDays === undefined) {
+    return existing;
+  }
 
   // Preserve active deferrals, but allow expired deferrals to be refreshed.
   const existingDeferralExpired = Boolean(existing && isDeferred(existing) && !isDeferralActive(existing));
@@ -131,17 +146,38 @@ export function writePair(memoryDir: string, pair: Omit<ContradictionPair, "pair
     return existing;
   }
 
-  // Preserve cooldown: don't overwrite a cooled-down entry with lower confidence
-  if (existing && !existingDeferralExpired && existing.confidence >= pair.confidence) {
+  // Preserve same-verdict or still-cooling entries, but let expired dormant
+  // verdicts refresh when the judge now finds an actionable conflict.
+  const existingDormantCooldownActive = Boolean(
+    existing
+    && isDormantReviewedPair(existing)
+    && options.cooldownDays !== undefined
+    && isCoolingDown(existing, options.cooldownDays),
+  );
+  const existingDormantExpired = Boolean(
+    existing
+    && isDormantReviewedPair(existing)
+    && options.cooldownDays !== undefined
+    && !existingDormantCooldownActive,
+  );
+  if (
+    existing
+    && !existingDeferralExpired
+    && (existingDormantCooldownActive || (!existingDormantExpired && existing.confidence >= pair.confidence))
+  ) {
     return existing;
   }
 
   const full: ContradictionPair = {
     ...pair,
     pairId,
-    lastReviewedAt: existingDeferralExpired ? pair.lastReviewedAt : (existing?.lastReviewedAt ?? pair.lastReviewedAt),
+    lastReviewedAt: (existingDeferralExpired || existingDormantExpired)
+      ? pair.lastReviewedAt
+      : (existing?.lastReviewedAt ?? pair.lastReviewedAt),
     resolution: undefined,
-    deferredUntil: existingDeferralExpired ? undefined : existing?.deferredUntil,
+    deferredUntil: (existingDeferralExpired || existingDormantExpired)
+      ? undefined
+      : existing?.deferredUntil,
   };
 
   const filePath = pairPath(memoryDir, pairId);
@@ -157,7 +193,11 @@ export function writePair(memoryDir: string, pair: Omit<ContradictionPair, "pair
 /**
  * Write multiple pairs, deduplicating inputs first (rule 49).
  */
-export function writePairs(memoryDir: string, pairs: Array<Omit<ContradictionPair, "pairId"> & { memoryIds: [string, string] }>): ContradictionPair[] {
+export function writePairs(
+  memoryDir: string,
+  pairs: Array<Omit<ContradictionPair, "pairId"> & { memoryIds: [string, string] }>,
+  options: WritePairOptions = {},
+): ContradictionPair[] {
   const seen = new Set<string>();
   const results: ContradictionPair[] = [];
 
@@ -165,7 +205,7 @@ export function writePairs(memoryDir: string, pairs: Array<Omit<ContradictionPai
     const key = computePairId(pair.memoryIds[0], pair.memoryIds[1]);
     if (seen.has(key)) continue;
     seen.add(key);
-    results.push(writePair(memoryDir, pair));
+    results.push(writePair(memoryDir, pair, options));
   }
 
   return results;
@@ -228,6 +268,7 @@ export function listPairs(
       if (filter === "unresolved") {
         if (isTerminalResolution(pair.resolution)) continue;
         if (isDeferralActive(pair)) continue;
+        if (pair.resolution === "both-valid") continue;
         if (pair.verdict === "independent") continue;
       } else if (filter !== "all" && pair.verdict !== filter) {
         continue;

--- a/packages/remnic-core/src/contradiction/contradiction-scan.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-scan.ts
@@ -165,7 +165,7 @@ export async function runContradictionScan(deps: ScanDependencies): Promise<Scan
     });
   }
 
-  const written = writePairs(memoryDir, queueEntries);
+  const written = writePairs(memoryDir, queueEntries, { cooldownDays: scanConfig.cooldownDays });
   const elapsed = Date.now() - startTime;
   log.info("[contradiction-scan] complete: %d queued in %dms", written.length, elapsed);
 

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -233,6 +233,102 @@ test("writePair preserves user resolution", async () => {
   }
 });
 
+test("writePair preserves both-valid resolutions without scan cooldown context", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair({ confidence: 0.5 }));
+    resolvePair(dir, written.pairId, "both-valid");
+
+    const updated = writePair(dir, makePair({ confidence: 0.95 }));
+    assert.equal(updated.resolution, "both-valid");
+    assert.equal(updated.confidence, 0.5);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("writePair preserves dormant independent verdicts during cooldown", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const now = new Date().toISOString();
+    const dormant = writePair(dir, makePair({
+      verdict: "independent",
+      confidence: 0.95,
+      lastReviewedAt: now,
+    }));
+
+    const refreshed = writePair(dir, makePair({
+      verdict: "contradicts",
+      confidence: 1,
+      rationale: "Fresh actionable judge result during cooldown",
+    }), { cooldownDays: 14 });
+
+    assert.equal(refreshed.pairId, dormant.pairId);
+    assert.equal(refreshed.verdict, "independent");
+    assert.equal(refreshed.confidence, 0.95);
+    assert.equal(refreshed.lastReviewedAt, now);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("writePair refreshes expired independent verdicts with actionable lower-confidence results", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const expiredAt = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
+    const dormant = writePair(dir, makePair({
+      verdict: "independent",
+      confidence: 0.95,
+      detectedAt: expiredAt,
+      lastReviewedAt: expiredAt,
+    }));
+
+    const refreshed = writePair(dir, makePair({
+      verdict: "contradicts",
+      confidence: 0.5,
+      rationale: "Fresh actionable judge result after cooldown",
+    }), { cooldownDays: 14 });
+
+    assert.equal(refreshed.pairId, dormant.pairId);
+    assert.equal(refreshed.verdict, "contradicts");
+    assert.equal(refreshed.confidence, 0.5);
+    assert.equal(refreshed.resolution, undefined);
+    assert.equal(refreshed.lastReviewedAt, undefined);
+    assert.equal(readPair(dir, dormant.pairId)?.verdict, "contradicts");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("writePair refreshes expired both-valid resolutions with actionable results", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const expiredAt = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
+    const written = writePair(dir, makePair({ confidence: 0.95 }));
+    const resolved = resolvePair(dir, written.pairId, "both-valid");
+    assert.ok(resolved);
+    await writeStoredPair(dir, {
+      ...resolved,
+      lastReviewedAt: expiredAt,
+    });
+
+    const refreshed = writePair(dir, makePair({
+      verdict: "contradicts",
+      confidence: 0.5,
+      rationale: "Fresh actionable judge result after both-valid cooldown",
+    }), { cooldownDays: 14 });
+
+    assert.equal(refreshed.pairId, written.pairId);
+    assert.equal(refreshed.verdict, "contradicts");
+    assert.equal(refreshed.confidence, 0.5);
+    assert.equal(refreshed.resolution, undefined);
+    assert.equal(refreshed.lastReviewedAt, undefined);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
 // ── Batch dedup (rule 49) ──────────────────────────────────────────────────────
 
 test("writePairs deduplicates batch inputs", async () => {
@@ -615,6 +711,74 @@ test("executeResolution merge keeps created replacement when rollback fails", as
     assert.equal(storage.memories.get("mem-a-001")?.frontmatter.supersededBy, mergedId);
     assert.equal(storage.memories.get(mergedId)?.content, "merged canonical fact");
     assert.deepEqual(storage.removedFactHashIds, []);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution keep-a restores source after partial supersede failure", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage({ partialSupersedeBeforeFailureFor: "mem-b-002" });
+
+    const result = await executeResolution(dir, storage, written.pairId, "keep-a");
+
+    assert.match(result.message, /restored mem-b-002/);
+    assert.deepEqual(result.affectedIds, []);
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, undefined);
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.supersededBy, undefined);
+    assert.deepEqual(
+      storage.frontmatterWrites.map(({ memoryId, beforeStatus, lifecycle }) => ({
+        memoryId,
+        beforeStatus,
+        actor: lifecycle?.actor,
+        reasonCode: lifecycle?.reasonCode,
+      })),
+      [
+        {
+          memoryId: "mem-b-002",
+          beforeStatus: "superseded",
+          actor: "contradiction-resolution",
+          reasonCode: "contradiction-resolution:keep-a-rollback",
+        },
+      ],
+    );
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution keep-b restores source after partial supersede failure", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage({ partialSupersedeBeforeFailureFor: "mem-a-001" });
+
+    const result = await executeResolution(dir, storage, written.pairId, "keep-b");
+
+    assert.match(result.message, /restored mem-a-001/);
+    assert.deepEqual(result.affectedIds, []);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.status, undefined);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.supersededBy, undefined);
+    assert.deepEqual(
+      storage.frontmatterWrites.map(({ memoryId, beforeStatus, lifecycle }) => ({
+        memoryId,
+        beforeStatus,
+        actor: lifecycle?.actor,
+        reasonCode: lifecycle?.reasonCode,
+      })),
+      [
+        {
+          memoryId: "mem-a-001",
+          beforeStatus: "superseded",
+          actor: "contradiction-resolution",
+          reasonCode: "contradiction-resolution:keep-b-rollback",
+        },
+      ],
+    );
     assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
   } finally {
     await cleanup();

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -879,17 +879,29 @@ test("resolvePair sets resolution and lastReviewedAt", async () => {
 test("needs-more-context deferral does not clear terminal resolutions", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {
-    const written = writePair(dir, makePair());
-    const resolved = resolvePair(dir, written.pairId, "keep-a");
-    assert.equal(resolved?.resolution, "keep-a");
+    const keepPair = writePair(dir, makePair());
+    const keepResolved = resolvePair(dir, keepPair.pairId, "keep-a");
+    assert.equal(keepResolved?.resolution, "keep-a");
 
-    const deferredViaResolve = resolvePair(dir, written.pairId, "needs-more-context");
-    assert.equal(deferredViaResolve?.resolution, "keep-a");
-    assert.equal(deferredViaResolve?.deferredUntil, undefined);
+    const deferredKeepViaResolve = resolvePair(dir, keepPair.pairId, "needs-more-context");
+    assert.equal(deferredKeepViaResolve?.resolution, "keep-a");
+    assert.equal(deferredKeepViaResolve?.deferredUntil, undefined);
 
-    const deferredDirectly = deferPair(dir, written.pairId);
-    assert.equal(deferredDirectly?.resolution, "keep-a");
-    assert.equal(deferredDirectly?.deferredUntil, undefined);
+    const deferredKeepDirectly = deferPair(dir, keepPair.pairId);
+    assert.equal(deferredKeepDirectly?.resolution, "keep-a");
+    assert.equal(deferredKeepDirectly?.deferredUntil, undefined);
+
+    const bothValidPair = writePair(dir, makePair({ memoryIds: ["mem-a-003", "mem-b-004"] }));
+    const bothValidResolved = resolvePair(dir, bothValidPair.pairId, "both-valid");
+    assert.equal(bothValidResolved?.resolution, "both-valid");
+
+    const deferredBothValidViaResolve = resolvePair(dir, bothValidPair.pairId, "needs-more-context");
+    assert.equal(deferredBothValidViaResolve?.resolution, "both-valid");
+    assert.equal(deferredBothValidViaResolve?.deferredUntil, undefined);
+
+    const deferredBothValidDirectly = deferPair(dir, bothValidPair.pairId);
+    assert.equal(deferredBothValidDirectly?.resolution, "both-valid");
+    assert.equal(deferredBothValidDirectly?.deferredUntil, undefined);
     assert.equal(listPairs(dir, { filter: "unresolved" }).total, 0);
   } finally {
     await cleanup();

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -67,15 +67,37 @@ export async function executeResolution(
 
   switch (verb) {
     case "keep-a": {
-      const ok = await supersedeSafe(storage, idB, idA, "contradiction-resolution:keep-a");
+      const sourceB = await loadSourceSnapshot(storage, idB);
+      const ok = sourceB
+        ? await supersedeSafe(storage, idB, idA, "contradiction-resolution:keep-a")
+        : false;
       if (ok) { affectedIds.push(idB); message = `Kept ${idA}, superseded ${idB}`; }
-      else { supersedeFailed = true; message = `Supersede failed for ${idB}; not resolving`; }
+      else {
+        supersedeFailed = true;
+        const rolledBack = sourceB
+          ? await restoreMemorySnapshot(storage, sourceB, "contradiction-resolution:keep-a-rollback")
+          : false;
+        message = rolledBack
+          ? `Supersede failed for ${idB}; restored ${idB} and did not resolve`
+          : `Supersede failed for ${idB}; rollback incomplete for ${idB} and pair is not resolved`;
+      }
       break;
     }
     case "keep-b": {
-      const ok = await supersedeSafe(storage, idA, idB, "contradiction-resolution:keep-b");
+      const sourceA = await loadSourceSnapshot(storage, idA);
+      const ok = sourceA
+        ? await supersedeSafe(storage, idA, idB, "contradiction-resolution:keep-b")
+        : false;
       if (ok) { affectedIds.push(idA); message = `Kept ${idB}, superseded ${idA}`; }
-      else { supersedeFailed = true; message = `Supersede failed for ${idA}; not resolving`; }
+      else {
+        supersedeFailed = true;
+        const rolledBack = sourceA
+          ? await restoreMemorySnapshot(storage, sourceA, "contradiction-resolution:keep-b-rollback")
+          : false;
+        message = rolledBack
+          ? `Supersede failed for ${idA}; restored ${idA} and did not resolve`
+          : `Supersede failed for ${idA}; rollback incomplete for ${idA} and pair is not resolved`;
+      }
       break;
     }
     case "merge": {
@@ -224,7 +246,24 @@ function mergedMemoryCategory(sourceA: MemoryFile, sourceB: MemoryFile): MemoryC
     : "fact";
 }
 
-async function restoreMemorySnapshot(storage: StorageManager, memory: MemoryFile): Promise<boolean> {
+async function loadSourceSnapshot(storage: StorageManager, memoryId: string): Promise<MemoryFile | null> {
+  try {
+    return await storage.getMemoryById(memoryId);
+  } catch (err) {
+    log.warn(
+      "[contradiction-resolution] source snapshot failed for %s: %s",
+      memoryId,
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}
+
+async function restoreMemorySnapshot(
+  storage: StorageManager,
+  memory: MemoryFile,
+  reasonCode = "contradiction-resolution:merge-rollback",
+): Promise<boolean> {
   try {
     const current = await storage.getMemoryById(memory.frontmatter.id);
     if (!current) return false;
@@ -236,7 +275,7 @@ async function restoreMemorySnapshot(storage: StorageManager, memory: MemoryFile
     };
     return await storage.writeMemoryFrontmatter(current, restoredFrontmatter, {
       actor: "contradiction-resolution",
-      reasonCode: "contradiction-resolution:merge-rollback",
+      reasonCode,
     });
   } catch (err) {
     log.warn(


### PR DESCRIPTION
## Summary
- roll back keep-a/keep-b partial supersede failures before leaving contradiction pairs unresolved
- let scan-driven expired independent/both-valid entries refresh with fresh judge results while preserving active cooldowns
- add regression coverage for both high clawpatch findings

## Clawpatch findings
- fnd_sig-feat-library-058376cb2a-28ce_875655e17c: keep-a and keep-b do not roll back partial supersede failures
- fnd_sig-feat-library-058376cb2a-a295_408ed244fe: Expired independent verdicts can permanently suppress later contradictions

## Tests
- pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contradiction scan queue persistence and resolution execution paths, which can affect whether contradictions resurface and how memory frontmatter is rolled back after failed supersedes. Logic is well-covered by new regression tests but could still change review/scan behavior in production.
> 
> **Overview**
> **Contradiction queue writes now respect scan cooldown context.** `writePair`/`writePairs` accept `cooldownDays` and treat `independent` verdicts and `both-valid` resolutions as *dormant*: they’re preserved while cooling down, but if the cooldown has expired they can be refreshed by new actionable judge results (clearing stale `lastReviewedAt`/`deferredUntil` as needed).
> 
> **Resolution execution is hardened against partial failures.** `executeResolution` for `keep-a`/`keep-b` now snapshots the source memory before attempting supersede, and on supersede failure attempts to restore the original frontmatter with verb-specific rollback reason codes; additional tests cover these rollback paths and the new dormant-refresh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9b51f2c52bbd99456698c010cef23ba8a4016b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->