### PR TITLE
fix(core): reject unsafe commitment decay windows

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1346,7 +1346,8 @@
         "description": "Include the most relevant open question in generated memory context"
       },
       "commitmentDecayDays": {
-        "type": "number",
+        "type": "integer",
+        "minimum": 1,
         "default": 90,
         "description": "Days before fulfilled/expired commitments are removed"
       },
@@ -4936,7 +4937,8 @@
     "commitmentDecayDays": {
       "label": "Commitment Decay (days)",
       "advanced": true,
-      "placeholder": "90"
+      "placeholder": "90",
+      "help": "Positive integer days before fulfilled/expired commitments are removed."
     },
     "workspaceDir": {
       "label": "Workspace Directory",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1346,7 +1346,8 @@
         "description": "Include the most relevant open question in generated memory context"
       },
       "commitmentDecayDays": {
-        "type": "number",
+        "type": "integer",
+        "minimum": 1,
         "default": 90,
         "description": "Days before fulfilled/expired commitments are removed"
       },
@@ -4936,7 +4937,8 @@
     "commitmentDecayDays": {
       "label": "Commitment Decay (days)",
       "advanced": true,
-      "placeholder": "90"
+      "placeholder": "90",
+      "help": "Positive integer days before fulfilled/expired commitments are removed."
     },
     "workspaceDir": {
       "label": "Workspace Directory",

--- a/packages/remnic-core/src/commitment-ledger.test.ts
+++ b/packages/remnic-core/src/commitment-ledger.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { mkdtemp, stat, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  applyCommitmentLedgerLifecycle,
+  recordCommitmentLedgerEntry,
+  type CommitmentLedgerEntry,
+} from "./commitment-ledger.js";
+
+function makeEntry(overrides: Partial<CommitmentLedgerEntry> = {}): CommitmentLedgerEntry {
+  return {
+    schemaVersion: 1,
+    entryId: "commitment-1",
+    recordedAt: "2026-01-01T00:00:00.000Z",
+    sessionKey: "session-1",
+    source: "manual",
+    kind: "promise",
+    state: "fulfilled",
+    scope: "test",
+    summary: "ship the thing",
+    stateChangedAt: "2026-01-01T00:00:00.000Z",
+    resolvedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("commitment ledger lifecycle rejects invalid decayDays without deleting entries", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-commitment-decay-"));
+  try {
+    const filePath = await recordCommitmentLedgerEntry({
+      memoryDir,
+      entry: makeEntry(),
+    });
+
+    for (const decayDays of [-1, 0, 1.5, Number.NaN, Infinity]) {
+      await assert.rejects(
+        () =>
+          applyCommitmentLedgerLifecycle({
+            memoryDir,
+            enabled: true,
+            decayDays,
+            now: "2026-01-02T00:00:00.000Z",
+          }),
+        /decayDays must be an integer greater than or equal to 1/,
+        `invalid decayDays ${String(decayDays)} should throw`,
+      );
+      await assert.doesNotReject(() => stat(filePath));
+    }
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("commitment ledger lifecycle still deletes resolved entries past positive decayDays", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-commitment-decay-"));
+  try {
+    const filePath = await recordCommitmentLedgerEntry({
+      memoryDir,
+      entry: makeEntry(),
+    });
+
+    const result = await applyCommitmentLedgerLifecycle({
+      memoryDir,
+      enabled: true,
+      decayDays: 1,
+      now: "2026-01-03T00:00:00.000Z",
+    });
+
+    assert.equal(result.deletedResolved.length, 1);
+    assert.equal(result.deletedResolved[0]?.entryId, "commitment-1");
+    await assert.rejects(() => stat(filePath), /ENOENT/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/commitment-ledger.ts
+++ b/packages/remnic-core/src/commitment-ledger.ts
@@ -198,6 +198,13 @@ function isDecayEligibleResolvedEntry(entry: CommitmentLedgerEntry, nowMs: numbe
   return Date.parse(reference) < decayCutoff;
 }
 
+function assertPositiveIntegerDays(value: number, keyName: string): number {
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 1) {
+    throw new Error(`${keyName} must be an integer greater than or equal to 1; got ${String(value)}`);
+  }
+  return value;
+}
+
 async function findCommitmentLedgerEntryById(options: {
   memoryDir: string;
   commitmentLedgerDir?: string;
@@ -250,6 +257,7 @@ export async function applyCommitmentLedgerLifecycle(options: {
 
   const nowIso = assertIsoRecordedAt(options.now ?? new Date().toISOString(), "now");
   const nowMs = Date.parse(nowIso);
+  const decayDays = assertPositiveIntegerDays(options.decayDays, "decayDays");
   const { entryFiles } = await readCommitmentLedgerEntries(options);
 
   const transitionedToExpired: CommitmentLedgerEntry[] = [];
@@ -269,7 +277,7 @@ export async function applyCommitmentLedgerLifecycle(options: {
       continue;
     }
 
-    if (isDecayEligibleResolvedEntry(entry, nowMs, options.decayDays)) {
+    if (isDecayEligibleResolvedEntry(entry, nowMs, decayDays)) {
       await unlink(filePath);
       deletedResolved.push(entry);
     }

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -79,6 +79,20 @@ test("parseConfig activeRecallCacheTtlMs=500 preserves the explicit positive ttl
   assert.equal(result.activeRecallCacheTtlMs, 500);
 });
 
+test("parseConfig validates commitmentDecayDays as a positive integer", () => {
+  assert.equal(parseConfig({}).commitmentDecayDays, 90);
+  assert.equal(parseConfig({ commitmentDecayDays: 30 }).commitmentDecayDays, 30);
+  assert.equal(parseConfig({ commitmentDecayDays: "45" }).commitmentDecayDays, 45);
+
+  for (const value of [0, -1, 1.5, "1.5", "abc", Number.NaN, Infinity]) {
+    assert.throws(
+      () => parseConfig({ commitmentDecayDays: value }),
+      /commitmentDecayDays must be an integer greater than or equal to 1/,
+      `invalid commitmentDecayDays ${String(value)} should throw`,
+    );
+  }
+});
+
 test("parseConfig initGateTimeoutMs defaults to OpenClaw cold-start budget", () => {
   const result = parseConfig({});
   assert.equal(result.initGateTimeoutMs, 30_000);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1267,8 +1267,12 @@ export function parseConfig(raw: unknown): PluginConfig {
         : 120_000,
     sessionObserverBands,
     injectQuestions: cfg.injectQuestions === true,
-    commitmentDecayDays:
-      typeof cfg.commitmentDecayDays === "number" ? cfg.commitmentDecayDays : 90,
+    commitmentDecayDays: parseIntegerAtLeast(
+      cfg.commitmentDecayDays,
+      90,
+      1,
+      "commitmentDecayDays",
+    ),
     workspaceDir:
       typeof cfg.workspaceDir === "string" && cfg.workspaceDir.length > 0
         ? cfg.workspaceDir

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1346,7 +1346,8 @@
         "description": "Include the most relevant open question in generated memory context"
       },
       "commitmentDecayDays": {
-        "type": "number",
+        "type": "integer",
+        "minimum": 1,
         "default": 90,
         "description": "Days before fulfilled/expired commitments are removed"
       },
@@ -4936,7 +4937,8 @@
     "commitmentDecayDays": {
       "label": "Commitment Decay (days)",
       "advanced": true,
-      "placeholder": "90"
+      "placeholder": "90",
+      "help": "Positive integer days before fulfilled/expired commitments are removed."
     },
     "workspaceDir": {
       "label": "Workspace Directory",


### PR DESCRIPTION
## Summary
- reject `commitmentDecayDays` values below 1 or non-integer values during config parsing
- validate direct commitment-ledger lifecycle `decayDays` calls before deleting resolved entries
- update OpenClaw plugin manifests and add regression coverage for invalid decay windows

## Clawpatch finding
- Fixes `fnd_sig-feat-library-2da00b2b0e-3d62_277c909e3d`: Negative commitmentDecayDays can delete all resolved ledger entries

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/config.test.ts packages/remnic-core/src/commitment-ledger.test.ts`
- `npm run check:openclaw-plugin-sync`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches commitment-ledger retention/deletion behavior and config parsing; mistakes could unexpectedly retain or delete resolved commitments, but changes are narrowly scoped with new tests.
> 
> **Overview**
> Prevents unsafe commitment-ledger cleanup by requiring `commitmentDecayDays`/`decayDays` to be a *finite positive integer* before resolved entries can be deleted.
> 
> Updates config parsing (`parseConfig`) to reject non-integer or <1 decay windows (including numeric strings that don’t parse cleanly), adds lifecycle-level validation inside `applyCommitmentLedgerLifecycle`, and tightens plugin manifests (`openclaw.plugin.json` variants) to declare `commitmentDecayDays` as an integer with `minimum: 1` plus clearer UI help text. Adds regression tests covering invalid values and ensuring valid decay still deletes eligible resolved entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56611de9a775e60d57e3e20ee8d980d4139e701f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->