### PR TITLE
fix(core): guard markdown import target symlinks

### DIFF
--- a/packages/remnic-core/src/transfer/import-md.ts
+++ b/packages/remnic-core/src/transfer/import-md.ts
@@ -1,6 +1,12 @@
 import path from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { fileExists, listFilesRecursive, toPosixRelPath, fromPosixRelPath } from "./fs-utils.js";
+import {
+  fileExists,
+  listFilesRecursive,
+  prepareSafeArchiveRoot,
+  resolveSafeArchiveTarget,
+  toPosixRelPath,
+} from "./fs-utils.js";
 import { parseConflictPolicy, type ConflictPolicy } from "./conflict-policy.js";
 
 export type { ConflictPolicy };
@@ -20,6 +26,11 @@ export async function importMarkdownBundle(opts: ImportMdOptions): Promise<{ wri
   const conflict = parseConflictPolicy(opts.conflict, "importMarkdownBundle");
   const fromAbs = path.resolve(opts.fromDir);
   const targetAbs = path.resolve(opts.targetMemoryDir);
+  const targetRoot = await prepareSafeArchiveRoot(
+    targetAbs,
+    "importMarkdownBundle",
+    "targetMemoryDir",
+  );
 
   const filesAbs = await listFilesRecursive(fromAbs);
   const writes: Array<{ abs: string; content: string }> = [];
@@ -28,7 +39,7 @@ export async function importMarkdownBundle(opts: ImportMdOptions): Promise<{ wri
   for (const abs of filesAbs) {
     const relPosix = toPosixRelPath(abs, fromAbs);
     if (relPosix === "manifest.json") continue;
-    const dstAbs = path.join(targetAbs, fromPosixRelPath(relPosix));
+    const dstAbs = await resolveSafeArchiveTarget(targetRoot, relPosix);
     const content = await readFile(abs, "utf-8");
 
     const exists = await fileExists(dstAbs);

--- a/tests/export-import-md.test.ts
+++ b/tests/export-import-md.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { importMarkdownBundle } from "../src/transfer/import-md.js";
@@ -22,4 +22,64 @@ test("markdown import rejects invalid conflict policy without overwriting existi
     /invalid conflict policy/i,
   );
   assert.equal(await readFile(targetPath, "utf-8"), "original profile\n");
+});
+
+test("markdown import rejects target subdirectory symlinks outside the memory root", async () => {
+  const fromDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-outside-"));
+
+  try {
+    await mkdir(path.join(fromDir, "facts"), { recursive: true });
+    await writeFile(path.join(fromDir, "facts", "a.md"), "incoming fact\n", "utf-8");
+    await symlink(outsideDir, path.join(targetDir, "facts"), "dir");
+
+    await assert.rejects(
+      importMarkdownBundle({
+        targetMemoryDir: targetDir,
+        fromDir,
+        conflict: "overwrite",
+      }),
+      /escapes target root via symlink|targets a symlink/,
+    );
+
+    await assert.rejects(
+      readFile(path.join(outsideDir, "a.md"), "utf-8"),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(fromDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("markdown import rejects symlinked target memory roots", async () => {
+  const fromDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const parentDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-parent-"));
+  const targetLink = path.join(parentDir, "target-link");
+
+  try {
+    await writeFile(path.join(fromDir, "profile.md"), "incoming profile\n", "utf-8");
+    await symlink(targetDir, targetLink, "dir");
+
+    await assert.rejects(
+      importMarkdownBundle({
+        targetMemoryDir: targetLink,
+        fromDir,
+        conflict: "overwrite",
+      }),
+      /targetMemoryDir' must not be a symlink/,
+    );
+
+    await assert.rejects(
+      readFile(path.join(targetDir, "profile.md"), "utf-8"),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(fromDir, { recursive: true, force: true });
+    await rm(parentDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- route Markdown import target paths through the shared symlink-aware archive target resolver
- reject symlinked target roots and target subdirectories before writing imported Markdown
- add regression tests that prove outside targets are not written

## Clawpatch finding
- Fixes `fnd_sig-feat-library-326e848962-15bd_8421638e34`: Markdown import writes through target symlinks outside the memory root

## Verification
- `pnpm exec tsx --test tests/export-import-md.test.ts`
- `pnpm exec tsx --test tests/import-autodetect.test.ts tests/export-import-md.test.ts`
- `npm run check-types`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens path resolution for filesystem writes during markdown import, which is security-sensitive and could affect where data is written. Behavior changes may surface new import-time errors for previously accepted (but unsafe) directory layouts.
> 
> **Overview**
> Markdown bundle import now resolves all destination paths via the shared `prepareSafeArchiveRoot`/`resolveSafeArchiveTarget` helpers, rejecting symlinked `targetMemoryDir` and any symlinked subpaths that would escape the memory root before any writes occur.
> 
> Adds tests covering invalid conflict policy non-overwrite behavior plus two new regressions ensuring imports fail when the target root or a target subdirectory is a symlink, and that no files are written outside the intended directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d6c45ee986f2f4e6b9940180f33d108ff4a68d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->