### PR TITLE
Fix migrate source argument parsing

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -39,9 +39,71 @@ const SUPERMEMORY_DIR = path.join(
 );
 
 const args = process.argv.slice(2);
-const dryRun = args.includes("--dry-run");
-const sourceArg = args.find((a) => a.startsWith("--source="));
-const source = sourceArg ? sourceArg.split("=")[1] : "all";
+type MigrationSource = "context" | "supermemory" | "honcho" | "all";
+
+const VALID_SOURCES = new Set<MigrationSource>([
+  "context",
+  "supermemory",
+  "honcho",
+  "all",
+]);
+
+function parseSource(value: string | undefined): MigrationSource {
+  if (!value || value.startsWith("--")) {
+    throw new Error("--source requires a value: context|supermemory|honcho|all");
+  }
+  if (!VALID_SOURCES.has(value as MigrationSource)) {
+    throw new Error(
+      `--source must be one of context|supermemory|honcho|all; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value as MigrationSource;
+}
+
+function parseArgs(rawArgs: string[]): { dryRun: boolean; source: MigrationSource } {
+  let dryRun = false;
+  let source: MigrationSource = "all";
+  let sawSource = false;
+
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--source") {
+      if (sawSource) throw new Error("--source may only be provided once");
+      source = parseSource(rawArgs[i + 1]);
+      sawSource = true;
+      i++;
+      continue;
+    }
+    if (arg.startsWith("--source=")) {
+      if (sawSource) throw new Error("--source may only be provided once");
+      source = parseSource(arg.slice("--source=".length));
+      sawSource = true;
+      continue;
+    }
+
+    throw new Error(
+      arg.startsWith("--")
+        ? `Unknown argument: ${arg}`
+        : `Unexpected argument: ${arg}`,
+    );
+  }
+
+  return { dryRun, source };
+}
+
+let parsedArgs: { dryRun: boolean; source: MigrationSource };
+try {
+  parsedArgs = parseArgs(args);
+} catch (err) {
+  console.error(`Invalid arguments: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+}
+
+const { dryRun, source } = parsedArgs;
 
 interface MigrationStats {
   contextFiles: number;

--- a/tests/migrate-source-cli.test.ts
+++ b/tests/migrate-source-cli.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const tsxCli = path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
+
+function runMigrate(args: string[], homeDir: string) {
+  return spawnSync(process.execPath, [tsxCli, "scripts/migrate.ts", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      HONCHO_API_KEY: "",
+    },
+    timeout: 30_000,
+  });
+}
+
+test("migrate accepts --source as a separate argument and limits selected sources", async () => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "remnic-migrate-home-"));
+  try {
+    const result = runMigrate(["--dry-run", "--source", "context"], homeDir);
+
+    assert.equal(
+      result.status,
+      0,
+      `expected migrate to succeed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert.match(result.stdout, /Source:\s+context/);
+    assert.match(result.stdout, /Migrating context files/);
+    assert.doesNotMatch(result.stdout, /Migrating Supermemory daily logs/);
+    assert.doesNotMatch(result.stdout, /Migrating Honcho conclusions/);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("migrate rejects invalid --source values before creating migration directories", async () => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "remnic-migrate-home-"));
+  try {
+    const result = runMigrate(["--source", "bogus"], homeDir);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--source must be one of context\|supermemory\|honcho\|all/);
+    assert.equal(existsSync(path.join(homeDir, ".openclaw")), false);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("migrate rejects --source with no value", async () => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "remnic-migrate-home-"));
+  try {
+    const result = runMigrate(["--source", "--dry-run"], homeDir);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--source requires a value/);
+    assert.equal(existsSync(path.join(homeDir, ".openclaw")), false);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("migrate rejects unknown arguments instead of defaulting to all sources", async () => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), "remnic-migrate-home-"));
+  try {
+    const result = runMigrate(["--sourc", "context"], homeDir);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Unknown argument: --sourc/);
+    assert.equal(existsSync(path.join(homeDir, ".openclaw")), false);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- parse both `--source=value` and `--source value` in `scripts/migrate.ts`
- reject missing, duplicate, and unknown source values before migration directories are created
- add CLI regression coverage for scoped context migration and invalid source inputs

## Finding
- Fixes clawpatch finding `fnd_sig-feat-library-32b0f83226-d1f8_49dcb23b70`

## Verification
- `pnpm exec tsx --test tests/migrate-source-cli.test.ts`
- `git diff --check`
- `npm run check-types`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `scripts/migrate.ts` argument parsing and add CLI tests, with no impact to migration logic beyond earlier validation and stricter rejection of invalid flags.
> 
> **Overview**
> **Fixes `scripts/migrate.ts` CLI parsing for `--source`** by supporting both `--source=value` and `--source value`, validating allowed sources, and failing fast on missing/duplicate/unknown arguments.
> 
> Adds a `node:test` CLI regression suite (`tests/migrate-source-cli.test.ts`) to confirm scoped source runs (e.g., context-only) and to ensure invalid inputs exit non-zero *before* creating `~/.openclaw` migration directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0497749308596becf9870790c327d04d07030d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->