### PR TITLE
Declare plugin-openclaw acorn build dependency

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -83,6 +83,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-inspector": "0.3.10",
+    "acorn": "^8.16.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       '@openclaw/plugin-inspector':
         specifier: 0.3.10
         version: 0.3.10
+      acorn:
+        specifier: ^8.16.0
+        version: 8.16.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
- add `acorn` as an explicit devDependency of `@remnic/plugin-openclaw`
- update the workspace lockfile importer entry so the ClawHub cleanup script does not rely on transitive installs

## Finding
- Fixes clawpatch finding `fnd_sig-feat-library-3a8302610c-20ae_44345e958f`

## Verification
- `pnpm --filter @remnic/plugin-openclaw run build`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `@remnic/plugin-openclaw` dependency metadata/lockfile to ensure a build-time script can resolve `acorn`, with no runtime or logic changes.
> 
> **Overview**
> Ensures `@remnic/plugin-openclaw` declares `acorn` explicitly as a `devDependency` so the build/cleanup script that imports `acorn` doesn’t rely on transitive installs.
> 
> Updates the workspace lockfile accordingly to include `acorn@8.16.0` for this package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5c28fd56d0d54292f29f6f19703f140620009b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->