### PR TITLE
fix(importers): publish core peer ranges

### DIFF
--- a/packages/import-chatgpt/package.json
+++ b/packages/import-chatgpt/package.json
@@ -23,7 +23,7 @@
     "provenance": true
   },
   "peerDependencies": {
-    "@remnic/core": "workspace:^"
+    "@remnic/core": "^1.1.12"
   },
   "devDependencies": {
     "@remnic/core": "workspace:*",

--- a/packages/import-supermemory/package.json
+++ b/packages/import-supermemory/package.json
@@ -23,7 +23,7 @@
     "provenance": true
   },
   "peerDependencies": {
-    "@remnic/core": "workspace:^"
+    "@remnic/core": "^1.1.12"
   },
   "devDependencies": {
     "@remnic/core": "workspace:*",


### PR DESCRIPTION
## Summary
- replace the published @remnic/core peer dependency range for the ChatGPT importer with a concrete semver range
- replace the published @remnic/core peer dependency range for the Supermemory importer with the same semver range
- keep local workspace devDependencies so monorepo development still links the local core package

Fixes clawpatch findings:
- `fnd_sig-feat-library-3eb8d0e76b-af62_e9d79f191e`
- `fnd_sig-feat-library-4b03088982-8e41_f6a0882480`

## Verification
- pnpm --filter @remnic/core run build
- pnpm --filter @remnic/import-chatgpt test
- pnpm --filter @remnic/import-chatgpt run build
- pnpm --filter @remnic/import-chatgpt pack --pack-destination /tmp/remnic-import-chatgpt-pack
- tar -xOf /tmp/remnic-import-chatgpt-pack/remnic-import-chatgpt-0.1.0.tgz package/package.json | jq ' .peerDependencies,.devDependencies '\n- pnpm --filter @remnic/import-supermemory test\n- pnpm --filter @remnic/import-supermemory run build\n- pnpm --filter @remnic/import-supermemory pack --pack-destination /tmp/remnic-import-supermemory-pack\n- tar -xOf /tmp/remnic-import-supermemory-pack/remnic-import-supermemory-0.1.2.tgz package/package.json | jq ' .peerDependencies,.devDependencies '\n- git diff --check\n- pnpm rebuild better-sqlite3\n- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts published peer dependency ranges for two importer packages, with no runtime code changes; main risk is unintended incompatibility if consumers rely on older `@remnic/core` versions.
> 
> **Overview**
> Updates `@remnic/import-chatgpt` and `@remnic/import-supermemory` to publish `@remnic/core` as a real semver peer dependency (`^1.1.12`) rather than `workspace:^`, while keeping `@remnic/core` as a `workspace:*` devDependency for local monorepo development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf880ad4d5efb06948bd6ce63dced092edd0d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->