### PR TITLE
fix(bench): restrict codex cli child env

### DIFF
--- a/packages/bench/src/providers/codex-cli.test.ts
+++ b/packages/bench/src/providers/codex-cli.test.ts
@@ -22,6 +22,7 @@ test("codex-cli provider invokes codex exec in an isolated benchmark mode", asyn
       provider: "codex-cli",
       model: "gpt-5.5",
       apiKey: "test-api-key",
+      baseUrl: "https://gateway.example/v1",
       reasoningEffort: "xhigh",
       retryOptions: { timeoutMs: 1234 },
     },
@@ -90,6 +91,155 @@ test("codex-cli provider invokes codex exec in an isolated benchmark mode", asyn
   assert.equal(captured.env?.ENGRAM_MEMORY_DIR, undefined);
   assert.equal(captured.env?.OPENCLAW_ENGRAM_ACCESS_TOKEN, undefined);
   assert.equal(captured.env?.OPENAI_API_KEY, "test-api-key");
+  assert.equal(captured.env?.OPENAI_BASE_URL, "https://gateway.example/v1");
+});
+
+test("codex-cli provider does not expose unrelated process secrets to the child", async () => {
+  const seededEnv = {
+    ANTHROPIC_API_KEY: "anthropic-secret",
+    AWS_SECRET_ACCESS_KEY: "aws-secret",
+    GITHUB_TOKEN: "github-secret",
+    NPM_TOKEN: "npm-secret",
+    OPENAI_API_KEY: "openai-secret",
+    REMNIC_MEMORY_DIR: "/tmp/remnic",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(seededEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  let capturedEnv: NodeJS.ProcessEnv | undefined;
+  try {
+    const provider = createCodexCliProvider(
+      { provider: "codex-cli", model: "gpt-5.5" },
+      {
+        async runCodexCli(request) {
+          capturedEnv = request.env;
+          return {
+            status: 0,
+            signal: null,
+            stdout: "",
+            stderr: "",
+            outputText: "ok",
+          };
+        },
+      },
+    );
+
+    await provider.complete("hello");
+
+    assert.equal(capturedEnv?.OPENAI_API_KEY, "openai-secret");
+    assert.equal(capturedEnv?.ANTHROPIC_API_KEY, undefined);
+    assert.equal(capturedEnv?.AWS_SECRET_ACCESS_KEY, undefined);
+    assert.equal(capturedEnv?.GITHUB_TOKEN, undefined);
+    assert.equal(capturedEnv?.NPM_TOKEN, undefined);
+    assert.equal(capturedEnv?.REMNIC_MEMORY_DIR, undefined);
+  } finally {
+    for (const key of Object.keys(seededEnv)) {
+      const previous = previousEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  }
+});
+
+test("codex-cli provider preserves mixed-case Windows runtime env keys", () => {
+  const seededEnv = {
+    Path: "C:\\tools\\bin",
+    SystemRoot: "C:\\Windows",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(seededEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  try {
+    const env = __codexCliProviderTestHooks.buildIsolatedCodexEnv("test-api-key");
+
+    assert.equal(env.Path, "C:\\tools\\bin");
+    assert.equal(env.SystemRoot, "C:\\Windows");
+    assert.equal(env.OPENAI_API_KEY, "test-api-key");
+  } finally {
+    for (const key of Object.keys(seededEnv)) {
+      const previous = previousEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  }
+});
+
+test("codex-cli provider preserves networking env required by the child", () => {
+  const seededEnv = {
+    CODEX_HOME: "/tmp/codex-home",
+    HTTPS_PROXY: "http://proxy.example:8080",
+    no_proxy: "localhost,127.0.0.1",
+    NODE_EXTRA_CA_CERTS: "/etc/company-ca.pem",
+    SSL_CERT_FILE: "/etc/ssl/cert.pem",
+    SSL_CERT_DIR: "/etc/ssl/certs",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(seededEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  try {
+    const env = __codexCliProviderTestHooks.buildIsolatedCodexEnv("test-api-key");
+
+    assert.equal(env.CODEX_HOME, "/tmp/codex-home");
+    assert.equal(env.HTTPS_PROXY, "http://proxy.example:8080");
+    assert.equal(env.no_proxy, "localhost,127.0.0.1");
+    assert.equal(env.NODE_EXTRA_CA_CERTS, "/etc/company-ca.pem");
+    assert.equal(env.SSL_CERT_FILE, "/etc/ssl/cert.pem");
+    assert.equal(env.SSL_CERT_DIR, "/etc/ssl/certs");
+  } finally {
+    for (const key of Object.keys(seededEnv)) {
+      const previous = previousEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  }
+});
+
+test("codex-cli provider preserves OpenAI scoping env required by the child", () => {
+  const seededEnv = {
+    OPENAI_BASE_URL: "https://gateway.example/v1",
+    OPENAI_ORGANIZATION: "org-example",
+    OPENAI_PROJECT: "proj-example",
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(seededEnv)) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+
+  try {
+    const env = __codexCliProviderTestHooks.buildIsolatedCodexEnv("test-api-key");
+
+    assert.equal(env.OPENAI_BASE_URL, "https://gateway.example/v1");
+    assert.equal(env.OPENAI_ORGANIZATION, "org-example");
+    assert.equal(env.OPENAI_PROJECT, "proj-example");
+  } finally {
+    for (const key of Object.keys(seededEnv)) {
+      const previous = previousEnv.get(key);
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    }
+  }
 });
 
 test("codex-cli provider defaults reasoning effort to xhigh", async () => {

--- a/packages/bench/src/providers/codex-cli.ts
+++ b/packages/bench/src/providers/codex-cli.ts
@@ -121,7 +121,53 @@ const CODEX_CLI_TRANSPORT_ENV = "REMNIC_BENCH_CODEX_CLI_TRANSPORT";
 const CODEX_CLI_VERSION_TIMEOUT_MS = 5_000;
 const CODEX_CLI_HEALTH_CACHE_TTL_MS = 30_000;
 const OPENAI_API_KEY_ENV = "OPENAI_API_KEY";
+const OPENAI_BASE_URL_ENV = "OPENAI_BASE_URL";
 const OPENAI_RESPONSES_BASE_URL = "https://api.openai.com/v1";
+const CODEX_CLI_RUNTIME_ENV_ALLOWLIST = new Set([
+  "ALL_PROXY",
+  "APPDATA",
+  "CODEX_HOME",
+  "COLORTERM",
+  "COMSPEC",
+  "FORCE_COLOR",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LANG",
+  "LOCALAPPDATA",
+  "LOGNAME",
+  "NO_COLOR",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "NUMBER_OF_PROCESSORS",
+  OPENAI_BASE_URL_ENV,
+  "OPENAI_ORGANIZATION",
+  "OPENAI_PROJECT",
+  "OS",
+  "PATH",
+  "PATHEXT",
+  "PROGRAMDATA",
+  "PROCESSOR_ARCHITECTURE",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "SHELL",
+  "SSL_CERT_DIR",
+  "SSL_CERT_FILE",
+  "SYSTEMDRIVE",
+  "SYSTEMROOT",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "USER",
+  "USERNAME",
+  "USERPROFILE",
+  "WINDIR",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_RUNTIME_DIR",
+]);
 
 const activeCodexCliChildPids = new Set<number>();
 let codexCliParentCleanupInstalled = false;
@@ -430,7 +476,7 @@ class CodexCliProvider implements LlmProvider {
       workspacePath,
       timeoutMs: this.config.retryOptions?.timeoutMs,
       signal: opts.signal,
-      env: buildIsolatedCodexEnv(this.config.apiKey),
+      env: buildIsolatedCodexEnv(this.config.apiKey, this.config.baseUrl),
     };
   }
 }
@@ -592,22 +638,32 @@ function buildCodexCompletionPrompt(
   ].join("\n");
 }
 
-function buildIsolatedCodexEnv(apiKey?: string): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env };
-  for (const key of Object.keys(env)) {
-    if (
-      key.startsWith("REMNIC_") ||
-      key.startsWith("ENGRAM_") ||
-      key.startsWith("OPENCLAW_") ||
-      key === "QMD_CONFIG_DIR"
-    ) {
-      delete env[key];
+function buildIsolatedCodexEnv(
+  apiKey?: string,
+  baseUrl?: string,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && isAllowedCodexRuntimeEnvKey(key)) {
+      env[key] = value;
     }
   }
-  if (apiKey) {
-    env.OPENAI_API_KEY = apiKey;
+
+  const resolvedApiKey = (apiKey ?? process.env[OPENAI_API_KEY_ENV] ?? "").trim();
+  if (resolvedApiKey.length > 0) {
+    env[OPENAI_API_KEY_ENV] = resolvedApiKey;
+  }
+  const resolvedBaseUrl = (baseUrl ?? process.env[OPENAI_BASE_URL_ENV] ?? "").trim();
+  if (resolvedBaseUrl.length > 0) {
+    env[OPENAI_BASE_URL_ENV] = resolvedBaseUrl;
   }
   return env;
+}
+
+function isAllowedCodexRuntimeEnvKey(key: string): boolean {
+  const normalized = key.toUpperCase();
+  return CODEX_CLI_RUNTIME_ENV_ALLOWLIST.has(normalized)
+    || normalized.startsWith("LC_");
 }
 
 async function startCodexCliDiagnostics(args: {


### PR DESCRIPTION
## Summary
- build Codex CLI subprocess environments from a runtime allowlist instead of cloning the parent process environment
- preserve only the selected OpenAI API key plus platform variables needed to launch the CLI
- add a regression test proving unrelated API keys, tokens, and cloud secrets are not exposed to the child process

Fixes clawpatch finding `fnd_sig-feat-library-4a29504070-2aae_820d8ae981`.

## Verification
- pnpm --filter @remnic/bench exec tsx --test src/providers/codex-cli.test.ts
- pnpm --filter @remnic/bench run build
- pnpm --filter @remnic/bench run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick
- after rebase onto latest main: pnpm --filter @remnic/bench exec tsx --test src/providers/codex-cli.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Codex CLI child process environment is constructed to prevent secret leakage; risk is moderate because missing/incorrectly-allowlisted env vars (PATH/proxy/certs) could break CLI execution on some platforms.
> 
> **Overview**
> Hardens the `codex-cli` benchmark provider by building the CLI subprocess environment from a runtime allowlist instead of inheriting the full parent `process.env`, preventing unrelated secrets (cloud creds, tokens, other provider keys) from being passed to the child.
> 
> Adds support for forwarding OpenAI scoping via `OPENAI_BASE_URL` (from config or env) and updates tests to cover secret non-leakage plus preservation of required runtime variables (Windows mixed-case keys, proxy/cert settings, and OpenAI org/project/base URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b10a2801225dd3b255a2e9b780e89f6d1cc7805d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->