### PR TITLE
Stabilize active benchmark ETA after restart

### DIFF
--- a/scripts/bench/public-sota/check-active-public-run.mjs
+++ b/scripts/bench/public-sota/check-active-public-run.mjs
@@ -189,7 +189,7 @@ function newestDiagnostics(diagDir, count, lifecycleStart) {
         name: record.name,
         startedAt: record.startedAt,
         ageSeconds: record.startedAt
-          ? Math.round((Date.now() - Date.parse(record.startedAt)) / 1000)
+          ? Math.round((checkedAtMs - Date.parse(record.startedAt)) / 1000)
           : undefined,
         provider: record.provider,
         model: record.model,

--- a/scripts/bench/public-sota/check-active-public-run.mjs
+++ b/scripts/bench/public-sota/check-active-public-run.mjs
@@ -7,6 +7,19 @@ import path from 'node:path';
 const defaultRunId = process.env.DEFAULT_PUBLIC_RUN_ID ?? 'public-matrix-codex-bf9b2643-20260515T052919Z';
 const defaultResultsRoot = process.env.RESULTS_ROOT ?? path.join(os.homedir(), '.remnic/bench/results');
 const [resultsDir = path.join(defaultResultsRoot, defaultRunId)] = process.argv.slice(2);
+const checkedAtMs = parseNowMs();
+
+function parseNowMs() {
+  const override = process.env.CHECK_ACTIVE_PUBLIC_RUN_NOW;
+  if (!override) {
+    return Date.now();
+  }
+  const parsed = Date.parse(override);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid CHECK_ACTIVE_PUBLIC_RUN_NOW: ${override}`);
+  }
+  return parsed;
+}
 
 function hasTmuxSession(name) {
   try {
@@ -212,7 +225,7 @@ function newestDiagnostics(diagDir, count, lifecycleStart) {
   };
 }
 
-function parseBenchmarkProgress(lines, benchmark) {
+function parseBenchmarkProgress(lines, benchmark, lifecycleStart) {
   if (!benchmark) {
     return null;
   }
@@ -229,7 +242,15 @@ function parseBenchmarkProgress(lines, benchmark) {
   const completed = Number(match[2]);
   const total = Number(match[3]);
   const elapsedSeconds = Number(match[4]);
-  const remainingSeconds = Number(match[5]);
+  const remainingSecondsAtCheckpoint = Number(match[5]);
+  const checkpointAtMs = lifecycleStart
+    ? lifecycleStart.timestampMs + (elapsedSeconds * 1000)
+    : checkedAtMs;
+  const estimatedFinishAtMs = checkpointAtMs + (remainingSecondsAtCheckpoint * 1000);
+  const remainingSeconds = Math.max(
+    0,
+    Math.round((estimatedFinishAtMs - checkedAtMs) / 1000),
+  );
   return {
     line: latest,
     benchmark: match[1],
@@ -238,8 +259,11 @@ function parseBenchmarkProgress(lines, benchmark) {
     remaining: total - completed,
     percent: total > 0 ? Math.round((completed / total) * 10000) / 100 : 0,
     elapsedSeconds,
+    checkpointAt: new Date(checkpointAtMs).toISOString(),
+    checkpointAgeSeconds: Math.max(0, Math.round((checkedAtMs - checkpointAtMs) / 1000)),
+    remainingSecondsAtCheckpoint,
     remainingSeconds,
-    estimatedFinishAt: new Date(Date.now() + remainingSeconds * 1000).toISOString(),
+    estimatedFinishAt: new Date(estimatedFinishAtMs).toISOString(),
   };
 }
 
@@ -300,7 +324,7 @@ const summary = {
     : [],
   memoryArenaResultFiles: jsonFiles.filter((name) => name.startsWith('memory-arena-')),
   runLogTail: runLogTail.slice(-12),
-  progress: parseBenchmarkProgress(progressLines.lines, benchmark),
+  progress: parseBenchmarkProgress(progressLines.lines, benchmark, lifecycleStart),
   progressSource: {
     mode: progressLines.mode,
     markerFound: progressLines.markerFound,
@@ -310,12 +334,12 @@ const summary = {
   monitor: monitorStat
     ? {
         mtime: monitorStat.mtime.toISOString(),
-        ageSeconds: Math.round((Date.now() - monitorStat.mtimeMs) / 1000),
+        ageSeconds: Math.round((checkedAtMs - monitorStat.mtimeMs) / 1000),
         tail: readLines(monitorPath, 12),
       }
     : null,
   diagnostics: newestDiagnostics(path.join(resultsDir, 'codex-cli-diagnostics'), 30, lifecycleStart),
-  checkedAt: new Date().toISOString(),
+  checkedAt: new Date(checkedAtMs).toISOString(),
 };
 
 console.log(JSON.stringify(summary, null, 2));

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -1871,6 +1871,15 @@ test("active public run progress ignores pre-restart checkpoints", async () => {
       new Date("2026-05-17T03:50:00.000Z"),
       new Date("2026-05-17T03:50:00.000Z"),
     );
+    const diagnosticsDir = path.join(runDir, "codex-cli-diagnostics");
+    await mkdir(diagnosticsDir, { recursive: true });
+    await writeJson(path.join(diagnosticsDir, "in-flight.json"), {
+      startedAt: "2026-05-17T03:55:00.000Z",
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      serviceTier: "fast",
+    });
     await writeFile(
       path.join(runDir, "run.log"),
       [
@@ -1890,6 +1899,7 @@ test("active public run progress ignores pre-restart checkpoints", async () => {
     assert.equal(beforeStatus.progress, null);
     assert.equal(beforeStatus.checkedAt, "2026-05-17T04:00:00.000Z");
     assert.equal(beforeStatus.monitor.ageSeconds, 600);
+    assert.equal(beforeStatus.diagnostics.inFlightRecords[0].ageSeconds, 300);
     assert.equal(beforeStatus.progressSource.mode, "run-log-lines-since-lifecycle-start");
     assert.equal(beforeStatus.progressSource.markerFound, true);
     assert.equal(beforeStatus.progressSource.scannedLines, 0);

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -1860,6 +1860,17 @@ test("active public run progress ignores pre-restart checkpoints", async () => {
       ].join("\n"),
       "utf8",
     );
+    const activeRunEnv = {
+      ...process.env,
+      CHECK_ACTIVE_PUBLIC_RUN_NOW: "2026-05-17T04:00:00.000Z",
+    };
+    const monitorPath = path.join(runDir, "monitor-30m.log");
+    await writeFile(monitorPath, "status monitor\n", "utf8");
+    await utimes(
+      monitorPath,
+      new Date("2026-05-17T03:50:00.000Z"),
+      new Date("2026-05-17T03:50:00.000Z"),
+    );
     await writeFile(
       path.join(runDir, "run.log"),
       [
@@ -1873,10 +1884,12 @@ test("active public run progress ignores pre-restart checkpoints", async () => {
     const beforeCheckpoint = await execFileAsync(
       process.execPath,
       [path.join("scripts", "bench", "public-sota", "check-active-public-run.mjs"), runDir],
-      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+      { cwd: process.cwd(), env: activeRunEnv, maxBuffer: 1024 * 1024 },
     );
     const beforeStatus = JSON.parse(beforeCheckpoint.stdout);
     assert.equal(beforeStatus.progress, null);
+    assert.equal(beforeStatus.checkedAt, "2026-05-17T04:00:00.000Z");
+    assert.equal(beforeStatus.monitor.ageSeconds, 600);
     assert.equal(beforeStatus.progressSource.mode, "run-log-lines-since-lifecycle-start");
     assert.equal(beforeStatus.progressSource.markerFound, true);
     assert.equal(beforeStatus.progressSource.scannedLines, 0);
@@ -1895,12 +1908,17 @@ test("active public run progress ignores pre-restart checkpoints", async () => {
     const afterCheckpoint = await execFileAsync(
       process.execPath,
       [path.join("scripts", "bench", "public-sota", "check-active-public-run.mjs"), runDir],
-      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+      { cwd: process.cwd(), env: activeRunEnv, maxBuffer: 1024 * 1024 },
     );
     const afterStatus = JSON.parse(afterCheckpoint.stdout);
     assert.equal(afterStatus.progress.completed, 50);
     assert.equal(afterStatus.progress.total, 4209);
     assert.equal(afterStatus.progress.remaining, 4159);
+    assert.equal(afterStatus.progress.checkpointAt, "2026-05-17T02:40:00.000Z");
+    assert.equal(afterStatus.progress.checkpointAgeSeconds, 4800);
+    assert.equal(afterStatus.progress.remainingSecondsAtCheckpoint, 199632);
+    assert.equal(afterStatus.progress.remainingSeconds, 194832);
+    assert.equal(afterStatus.progress.estimatedFinishAt, "2026-05-19T10:07:12.000Z");
     assert.equal(afterStatus.progressSource.scannedLines, 1);
     assert.doesNotMatch(afterStatus.progress.line, /1850\/4209/);
 
@@ -1919,11 +1937,16 @@ test("active public run progress ignores pre-restart checkpoints", async () => {
     const longLogCheckpoint = await execFileAsync(
       process.execPath,
       [path.join("scripts", "bench", "public-sota", "check-active-public-run.mjs"), runDir],
-      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+      { cwd: process.cwd(), env: activeRunEnv, maxBuffer: 1024 * 1024 },
     );
     const longLogStatus = JSON.parse(longLogCheckpoint.stdout);
     assert.equal(longLogStatus.progress.completed, 100);
     assert.equal(longLogStatus.progress.total, 4209);
+    assert.equal(longLogStatus.progress.checkpointAt, "2026-05-17T03:20:00.000Z");
+    assert.equal(longLogStatus.progress.checkpointAgeSeconds, 2400);
+    assert.equal(longLogStatus.progress.remainingSecondsAtCheckpoint, 197232);
+    assert.equal(longLogStatus.progress.remainingSeconds, 194832);
+    assert.equal(longLogStatus.progress.estimatedFinishAt, "2026-05-19T10:07:12.000Z");
     assert.equal(longLogStatus.progressSource.markerFound, true);
     assert.equal(longLogStatus.progressSource.scannedLines, 5002);
   } finally {


### PR DESCRIPTION
## Summary
- add a deterministic CHECK_ACTIVE_PUBLIC_RUN_NOW override to active public-run status checks
- anchor progress ETA to the benchmark checkpoint timestamp instead of letting it drift with monitor age
- cover restart-scoped progress, checkpoint age, remaining time, monitor age, and in-flight diagnostic age in diagnostics tests

## Verification
- node --check scripts/bench/public-sota/check-active-public-run.mjs
- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts
- node scripts/bench/public-sota/check-active-public-run.mjs /Users/joshuawarren/.remnic/bench/results/public-matrix-codex-bf9b2643-20260515T052919Z
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes time/ETA calculations and JSON output fields used to monitor active public benchmark runs; mistakes could misreport progress or remaining time after restarts. Scope is limited to a CLI status script plus test coverage.
> 
> **Overview**
> Makes `check-active-public-run.mjs` deterministic and restart-stable by introducing a `CHECK_ACTIVE_PUBLIC_RUN_NOW` time override and using it consistently for `checkedAt`, monitor/diagnostic ages, and in-flight record age calculations.
> 
> Reworks progress parsing so ETA is anchored to the benchmark checkpoint time (derived from the latest lifecycle start + elapsed seconds) rather than drifting with wall-clock checks; exposes new progress fields (`checkpointAt`, `checkpointAgeSeconds`, `remainingSecondsAtCheckpoint`) and updates tests to validate these values and restart-scoped behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2619b518a9e490e125c27c9faac63271e9f8a18f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->