### PR TITLE
Expose active benchmark sessions in pipeline status

### DIFF
--- a/scripts/bench/public-sota/status-public-sota-pipeline.mjs
+++ b/scripts/bench/public-sota/status-public-sota-pipeline.mjs
@@ -152,6 +152,7 @@ console.log(JSON.stringify({
   activeRun: activeRunStatus ? {
     runId: activeRunStatus.runId,
     benchmark: activeRunStatus.benchmark,
+    benchmarkSession: activeRunStatus.benchmarkSession,
     progress: activeRunStatus.progress,
     resultFiles: activeRunStatus.benchmarkResultFiles,
     monitorSession: activeRunStatus.monitorSession,
@@ -165,6 +166,9 @@ console.log(JSON.stringify({
     },
   } : null,
   memoryArena: memoryArenaStatus ? {
+    benchmarkSession: memoryArenaStatus.benchmarkSession,
+    monitorSession: memoryArenaStatus.monitorSession,
+    monitorSessionName: memoryArenaStatus.monitorSessionName,
     progress: memoryArenaStatus.progress,
     resultFiles: memoryArenaStatus.memoryArenaResultFiles,
     diagnostics: {

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -1650,6 +1650,20 @@ test("public SOTA status maps MemoryArena publish watcher sessions with run suff
   assert.doesNotMatch(source, /publishWatcher: watcherSessions\.find\(\(session\) => session === `remnic-\$\{benchmark\}-publish-watcher`\)/);
 });
 
+test("public SOTA status exposes active run and MemoryArena session states", async () => {
+  const source = await readFile(
+    path.join("scripts", "bench", "public-sota", "status-public-sota-pipeline.mjs"),
+    "utf8",
+  );
+
+  assert.match(source, /benchmarkSession: activeRunStatus\.benchmarkSession/);
+  assert.match(source, /monitorSession: activeRunStatus\.monitorSession/);
+  assert.match(source, /monitorSessionName: activeRunStatus\.monitorSessionName/);
+  assert.match(source, /benchmarkSession: memoryArenaStatus\.benchmarkSession/);
+  assert.match(source, /monitorSession: memoryArenaStatus\.monitorSession/);
+  assert.match(source, /monitorSessionName: memoryArenaStatus\.monitorSessionName/);
+});
+
 test("generic public benchmark publish watcher keeps completion and staging evidence roots aligned", async () => {
   const source = await readFile(
     path.join("scripts", "bench", "public-sota", "watch-public-benchmark-publish.sh"),


### PR DESCRIPTION
## Summary
- include benchmark session state in the active-run pipeline status object
- include MemoryArena benchmark and monitor session state in the legacy MemoryArena status object
- add diagnostics coverage so status output stays unambiguous while public benchmark runs are active

## Verification
- node --check scripts/bench/public-sota/status-public-sota-pipeline.mjs
- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts
- node scripts/bench/public-sota/status-public-sota-pipeline.mjs
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds new fields to the public SOTA status JSON output plus a regression test, with no behavior changes to scoring or publishing logic.
> 
> **Overview**
> **Public SOTA pipeline status output is expanded to make active runs unambiguous.**
> 
> `scripts/bench/public-sota/status-public-sota-pipeline.mjs` now includes the active benchmark tmux session (`benchmarkSession`) and monitor session details (`monitorSession`, `monitorSessionName`) in the `activeRun` status, and exposes the same session metadata on the legacy `memoryArena` status object.
> 
> `tests/public-sota-diagnostics.test.ts` adds coverage asserting these session fields are present in the status script output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d67a93715dcdbd247d716edcb98ca01043640e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->