### PR TITLE
fix(bench): reject partial MemBench datasets

### DIFF
--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -295,18 +295,18 @@ async function loadDataset(
     const cases: MemBenchCase[] = [];
     let remainingLimit = normalizedLimit;
     for (const filename of filenames) {
-      if (remainingLimit === 0) {
-        break;
-      }
-
       try {
         const raw = await readFile(path.join(datasetDir, filename), "utf8");
         const parsed = filename.endsWith(".jsonl")
           ? parseJsonlDataset(raw, filename)
           : parseJsonDataset(raw, filename);
-        const limitedCases = applyLimit(parsed, remainingLimit);
-        cases.push(...limitedCases);
-        if (remainingLimit !== undefined) {
+        const limitedCases = remainingLimit === 0
+          ? []
+          : applyLimit(parsed, remainingLimit);
+        if (limitedCases.length > 0) {
+          cases.push(...limitedCases);
+        }
+        if (remainingLimit !== undefined && limitedCases.length > 0) {
           remainingLimit = Math.max(remainingLimit - limitedCases.length, 0);
         }
       } catch (error) {
@@ -316,11 +316,15 @@ async function loadDataset(
       }
     }
 
+    if (datasetErrors.length > 0) {
+      throw new Error(buildDatasetLoadError(datasetDir, datasetErrors));
+    }
+
     if (cases.length > 0) {
       return ensureDatasetCases(cases);
     }
 
-    throw new Error(buildDatasetNotFoundError(datasetDir, undefined, datasetErrors));
+    throw new Error(buildDatasetNotFoundError(datasetDir, undefined, []));
   }
 
   if (mode === "full") {
@@ -522,6 +526,16 @@ function buildDatasetNotFoundError(
   return details.length > 0
     ? `MemBench dataset not found under ${datasetDir}. Tried ${tried}. Errors: ${details}`
     : `MemBench dataset not found under ${datasetDir}. Tried ${tried}.`;
+}
+
+function buildDatasetLoadError(
+  datasetDir: string,
+  datasetErrors: string[],
+): string {
+  return [
+    `MemBench dataset under ${datasetDir} has invalid recognized shard(s).`,
+    `Errors: ${datasetErrors.join(" | ")}`,
+  ].join(" ");
 }
 
 function normalizePublishedDataset(

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
   BenchResponder,
@@ -464,6 +464,71 @@ test("runBenchmark accepts upstream MemBench export filenames in full mode", asy
   assert.equal(result.results.tasks[0]?.expected, "Lisbon");
   assert.equal(result.results.tasks[0]?.details.memoryType, "factual");
   assert.equal(result.results.tasks[0]?.details.scenario, "participant");
+});
+
+test("runBenchmark rejects partial MemBench datasets when a recognized shard fails", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-partial-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+
+  try {
+    await mkdir(datasetDir, { recursive: true });
+    await writeFile(
+      path.join(datasetDir, "membench.json"),
+      JSON.stringify(createDatasetCases()),
+      "utf8",
+    );
+    await writeFile(
+      path.join(datasetDir, "FirstAgentDataHighLevel.jsonl"),
+      "{not json}\n",
+      "utf8",
+    );
+
+    await assert.rejects(
+      () =>
+        runBenchmark("membench", {
+          mode: "full",
+          datasetDir,
+          system: adapter,
+        }),
+      /MemBench dataset under .* has invalid recognized shard\(s\).*FirstAgentDataHighLevel\.jsonl/,
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("runBenchmark validates later recognized shards after the limit is reached", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-limited-partial-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+
+  try {
+    await mkdir(datasetDir, { recursive: true });
+    await writeFile(
+      path.join(datasetDir, "membench.json"),
+      JSON.stringify(createDatasetCases()),
+      "utf8",
+    );
+    await writeFile(
+      path.join(datasetDir, "ThirdAgentDataHighLevel.jsonl"),
+      "{not json}\n",
+      "utf8",
+    );
+
+    await assert.rejects(
+      () =>
+        runBenchmark("membench", {
+          mode: "full",
+          datasetDir,
+          limit: 1,
+          system: adapter,
+        }),
+      /MemBench dataset under .* has invalid recognized shard\(s\).*ThirdAgentDataHighLevel\.jsonl/,
+    );
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test("runBenchmark normalizes nested published MemBench trajectory and qa structures", async () => {


### PR DESCRIPTION
## Summary

This fixes a clawpatch finding where MemBench could silently score a partial dataset if one recognized shard failed to parse after another shard had already loaded successfully.

The loader now records parse/load failures for recognized MemBench files and rejects the dataset if any recognized shard is invalid, instead of returning partial cases. A regression test covers a valid shard plus an invalid recognized JSONL shard.

## Verification

- `pnpm exec tsx --test tests/bench-membench-runner.test.ts`
- `pnpm --filter @remnic/bench exec tsx --test src/benchmarks/published/membench/runner.test.ts`
- `pnpm --filter @remnic/bench run build`
- `pnpm --filter @remnic/bench run check-types`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

Clawpatch finding: `fnd_sig-feat-library-14187c8876-e889_57fd68979c`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MemBench dataset loading to fail hard when any recognized shard cannot be parsed, which can change benchmark runs from partial results to errors (including when `limit` is reached). Risk is limited to benchmark execution paths but may impact existing workflows relying on best-effort loading.
> 
> **Overview**
> **MemBench dataset loading is now strict about recognized shard failures.** When loading from `datasetDir`, the runner continues scanning all recognized files (even after `limit` is reached) and records parse/load errors.
> 
> If *any* recognized shard fails, the run now throws a new `MemBench dataset ... has invalid recognized shard(s)` error rather than returning whatever cases were successfully parsed. Tests add coverage for rejecting mixed valid/invalid shard directories and for validating shards that appear after the requested `limit` is satisfied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc53443b20904c88a005141cca106c0b7dbdb689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->