### PR TITLE
Fix public benchmark launch root fallback

### DIFF
--- a/scripts/bench/public-sota/launch-next-public-benchmark.sh
+++ b/scripts/bench/public-sota/launch-next-public-benchmark.sh
@@ -7,18 +7,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT_DEFAULT="$(git -C "${SCRIPT_DIR}/../../.." rev-parse --show-toplevel 2>/dev/null || (cd "${SCRIPT_DIR}/../../.." && pwd))"
 
 REPO_ROOT="${REPO_ROOT:-${REPO_ROOT_DEFAULT}}"
-LAUNCH_REPO_ROOT="${LAUNCH_REPO_ROOT:-${REPO_ROOT}}"
+EXPLICIT_LAUNCH_REPO_ROOT="${LAUNCH_REPO_ROOT:-}"
+BASE_BRANCH="${BASE_BRANCH:-bench/public-matrix-codex}"
 RESULTS_ROOT="${RESULTS_ROOT:-${HOME}/.remnic/bench/results}"
 OUT_ROOT="${OUT_ROOT:-${RESULTS_ROOT}}"
-
-active_scoring_session="$(tmux list-sessions -F '#S' 2>/dev/null \
-  | grep -E '^public-.*-codex-.*[0-9]{8}T[0-9]{6}Z$' \
-  | head -1 || true)"
-
-if [[ -n "${active_scoring_session}" ]]; then
-  echo "Refusing to launch: active public benchmark scoring session ${active_scoring_session} is still running." >&2
-  exit 3
-fi
 
 benchmark="${1:-amemgym}"
 case "${benchmark}" in
@@ -28,6 +20,50 @@ case "${benchmark}" in
     exit 2
     ;;
 esac
+
+resolve_launch_repo_root() {
+  if [[ -n "${EXPLICIT_LAUNCH_REPO_ROOT}" ]]; then
+    printf '%s\n' "${EXPLICIT_LAUNCH_REPO_ROOT}"
+    return
+  fi
+
+  if [[ -d "${REPO_ROOT}/evals/datasets/${benchmark}" ]]; then
+    printf '%s\n' "${REPO_ROOT}"
+    return
+  fi
+
+  local worktree=""
+  local branch=""
+  local line=""
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    case "${line}" in
+      worktree\ *)
+        worktree="${line#worktree }"
+        branch=""
+        ;;
+      branch\ *)
+        branch="${line#branch }"
+        if [[ "${branch}" == "refs/heads/${BASE_BRANCH}" && -d "${worktree}/evals/datasets/${benchmark}" ]]; then
+          printf '%s\n' "${worktree}"
+          return
+        fi
+        ;;
+    esac
+  done < <(git -C "${REPO_ROOT}" worktree list --porcelain 2>/dev/null || true)
+
+  printf '%s\n' "${REPO_ROOT}"
+}
+
+LAUNCH_REPO_ROOT="$(resolve_launch_repo_root)"
+
+active_scoring_session="$(tmux list-sessions -F '#S' 2>/dev/null \
+  | grep -E '^public-.*-codex-.*[0-9]{8}T[0-9]{6}Z$' \
+  | head -1 || true)"
+
+if [[ -n "${active_scoring_session}" ]]; then
+  echo "Refusing to launch: active public benchmark scoring session ${active_scoring_session} is still running." >&2
+  exit 3
+fi
 
 if ! git -C "${LAUNCH_REPO_ROOT}" rev-parse --show-toplevel >/dev/null 2>&1; then
   echo "Launch repo is not a git checkout: ${LAUNCH_REPO_ROOT}" >&2

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -1617,6 +1617,24 @@ test("MemoryArena transition helper retries active-session launch collisions", a
   assert.match(source, /exit 0[\s\S]*if \[\[ "\$\{launch_status\}" -ne 0 \]\]; then/);
 });
 
+test("next public benchmark launcher falls back to a base-branch worktree with datasets", async () => {
+  const source = await readFile(
+    path.join("scripts", "bench", "public-sota", "launch-next-public-benchmark.sh"),
+    "utf8",
+  );
+
+  assert.match(source, /EXPLICIT_LAUNCH_REPO_ROOT="\$\{LAUNCH_REPO_ROOT:-\}"/);
+  assert.match(source, /BASE_BRANCH="\$\{BASE_BRANCH:-bench\/public-matrix-codex\}"/);
+  assert.match(source, /resolve_launch_repo_root\(\)/);
+  assert.match(source, /if \[\[ -n "\$\{EXPLICIT_LAUNCH_REPO_ROOT\}" \]\]; then[\s\S]*printf '%s\\n' "\$\{EXPLICIT_LAUNCH_REPO_ROOT\}"/);
+  assert.match(source, /if \[\[ -d "\$\{REPO_ROOT\}\/evals\/datasets\/\$\{benchmark\}" \]\]; then[\s\S]*printf '%s\\n' "\$\{REPO_ROOT\}"/);
+  assert.match(source, /git -C "\$\{REPO_ROOT\}" worktree list --porcelain/);
+  assert.match(source, /"\$\{branch\}" == "refs\/heads\/\$\{BASE_BRANCH\}"/);
+  assert.match(source, /-d "\$\{worktree\}\/evals\/datasets\/\$\{benchmark\}"/);
+  assert.match(source, /LAUNCH_REPO_ROOT="\$\(resolve_launch_repo_root\)"/);
+  assert.doesNotMatch(source, /LAUNCH_REPO_ROOT="\$\{LAUNCH_REPO_ROOT:-\$\{REPO_ROOT\}\}"/);
+});
+
 test("MemoryArena publish watcher ignores derived evidence JSON files", async () => {
   const source = await readFile(
     path.join("scripts", "bench", "public-sota", "memoryarena", "watch-and-publish-memoryarena.sh"),


### PR DESCRIPTION
## Summary
- make downstream public benchmark launches fall back to a base-branch worktree that has the requested dataset when the automation checkout does not
- preserve explicit LAUNCH_REPO_ROOT overrides and current-repo launches when datasets are present
- add regression coverage for the fallback wiring

## Verification
- bash -n scripts/bench/public-sota/launch-next-public-benchmark.sh
- node --check scripts/bench/public-sota/check-active-public-run.mjs
- node --check scripts/bench/public-sota/status-public-sota-pipeline.mjs
- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts
- dry-run with stubbed tmux resolved launch_repo_root=/Users/joshuawarren/src/remnic-public-matrix-codex
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the repo-root selection logic for launching benchmark runs, which can affect where jobs execute and which datasets are used. Risk is limited to benchmark automation scripts and is covered by a new regression test.
> 
> **Overview**
> **Public benchmark launches now resolve `LAUNCH_REPO_ROOT` more robustly.** `launch-next-public-benchmark.sh` keeps honoring an explicit `LAUNCH_REPO_ROOT`, otherwise uses the current repo if the dataset exists, and otherwise searches `git worktree list --porcelain` for a `BASE_BRANCH` (default `bench/public-matrix-codex`) worktree that contains the requested `evals/datasets/<benchmark>`.
> 
> Adds a regression test in `public-sota-diagnostics.test.ts` to assert the new fallback wiring and ensure the old `LAUNCH_REPO_ROOT=${LAUNCH_REPO_ROOT:-${REPO_ROOT}}` behavior is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5939e5d05ecb127ecdf873231aac9c4c6f3532be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->