### PR TITLE
fix(codex): resolve materialize config via shared plugin entry

### DIFF
--- a/packages/plugin-codex/bin/materialize.cjs
+++ b/packages/plugin-codex/bin/materialize.cjs
@@ -72,9 +72,25 @@ function isPlainRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+class MaterializeConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MaterializeConfigError";
+  }
+}
+
 function envValue(env, key) {
   const value = env[key];
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function safeErrorDetail(error) {
+  const raw = error instanceof Error ? error.message : String(error);
+  const cleaned = raw
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/[^\w .,:;()[\]{}'"!?/@+-]/g, "?")
+    .trim();
+  return cleaned.length > 240 ? `${cleaned.slice(0, 237)}...` : cleaned;
 }
 
 /**
@@ -84,18 +100,18 @@ function envValue(env, key) {
 function configCandidates(env = process.env) {
   const home = envValue(env, "HOME") || "";
   const openclawConfigPath =
-    envValue(env, "OPENCLAW_CONFIG_PATH") ||
     envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") ||
+    envValue(env, "OPENCLAW_CONFIG_PATH") ||
     path.join(home, ".openclaw", "openclaw.json");
   return [
     { path: envValue(env, "REMNIC_CONFIG"), label: "REMNIC_CONFIG" },
     {
       path: openclawConfigPath,
       label:
-        envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
-          ? "OPENCLAW_CONFIG_PATH"
-          : envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
-            ? "OPENCLAW_ENGRAM_CONFIG_PATH"
+        envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
+          ? "OPENCLAW_ENGRAM_CONFIG_PATH"
+          : envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
+            ? "OPENCLAW_CONFIG_PATH"
             : "default OpenClaw config",
     },
     path.join(home, ".config", "remnic", "config.json"),
@@ -143,14 +159,13 @@ function loadRawConfig(resolveEntry, env = process.env) {
     try {
       raw = JSON.parse(fs.readFileSync(candidate.path, "utf-8"));
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `Invalid JSON in ${candidate.label} (${candidate.path}): ${message}`,
+      throw new MaterializeConfigError(
+        `codex-materialize config error: invalid JSON in ${candidate.label} (${candidate.path}): ${safeErrorDetail(err)}`,
       );
     }
     if (!isPlainRecord(raw)) {
-      throw new Error(
-        `Invalid config in ${candidate.label} (${candidate.path}): expected a JSON object`,
+      throw new MaterializeConfigError(
+        `codex-materialize config error: invalid config in ${candidate.label} (${candidate.path}): expected a JSON object`,
       );
     }
     const resolved = extractRemnicConfigFromRaw(raw, resolveEntry);
@@ -202,7 +217,14 @@ async function main() {
   // Pass the shared resolver so loadRawConfig uses the same slot → id lookup
   // logic as all other config-loader sites (#403).
   const rawConfig = loadRawConfig(resolveRemnicPluginEntry);
-  const config = parseConfig(rawConfig);
+  let config;
+  try {
+    config = parseConfig(rawConfig);
+  } catch (err) {
+    throw new MaterializeConfigError(
+      `codex-materialize config error: parseConfig rejected the resolved config: ${safeErrorDetail(err)}`,
+    );
+  }
   if (args.memoryDir) {
     // parseConfig already locked in a memoryDir, but the CLI override wins.
     config.memoryDir = args.memoryDir;
@@ -243,13 +265,18 @@ module.exports = {
   loadRawConfig,
 };
 
+function formatFatalError(error) {
+  if (error instanceof MaterializeConfigError) {
+    return error.message;
+  }
+  return "codex-materialize failed; see logs for details";
+}
+
 if (require.main === module) {
   main().then(
     (code) => process.exit(code),
     (error) => {
-      console.error(
-        `codex-materialize failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      console.error(formatFatalError(error));
       process.exit(1);
     },
   );

--- a/packages/plugin-codex/bin/materialize.cjs
+++ b/packages/plugin-codex/bin/materialize.cjs
@@ -68,23 +68,62 @@ function parseArgs(argv) {
   return args;
 }
 
+function isPlainRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function envValue(env, key) {
+  const value = env[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 /**
  * Return candidate config file paths to search, in priority order.
  * The caller is responsible for parsing and entry-resolution.
  */
-function configCandidates() {
-  const home = process.env.HOME || "";
+function configCandidates(env = process.env) {
+  const home = envValue(env, "HOME") || "";
   const openclawConfigPath =
-    process.env.OPENCLAW_ENGRAM_CONFIG_PATH ||
-    process.env.OPENCLAW_CONFIG_PATH ||
+    envValue(env, "OPENCLAW_CONFIG_PATH") ||
+    envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") ||
     path.join(home, ".openclaw", "openclaw.json");
   return [
-    process.env.REMNIC_CONFIG,
-    openclawConfigPath,
+    { path: envValue(env, "REMNIC_CONFIG"), label: "REMNIC_CONFIG" },
+    {
+      path: openclawConfigPath,
+      label:
+        envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
+          ? "OPENCLAW_CONFIG_PATH"
+          : envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
+            ? "OPENCLAW_ENGRAM_CONFIG_PATH"
+            : "default OpenClaw config",
+    },
     path.join(home, ".config", "remnic", "config.json"),
     path.join(home, ".config", "engram", "config.json"),
     path.join(home, ".remnic", "config.json"),
-  ].filter((p) => typeof p === "string" && p.length > 0);
+  ]
+    .map((candidate) => {
+      return typeof candidate === "string"
+        ? { path: candidate, label: candidate }
+        : candidate;
+    })
+    .filter(
+      (candidate) =>
+        typeof candidate.path === "string" && candidate.path.length > 0,
+    );
+}
+
+function extractRemnicConfigFromRaw(raw, resolveEntry) {
+  const entry = resolveEntry(raw);
+  if (isPlainRecord(entry)) {
+    return isPlainRecord(entry.config) ? entry.config : entry;
+  }
+  // Legacy / developer config layout: the top-level object IS the config.
+  // Honour it only when the file is not an OpenClaw-shaped config.
+  if (!Object.prototype.hasOwnProperty.call(raw, "plugins")) {
+    return raw;
+  }
+  return undefined;
 }
 
 /**
@@ -95,31 +134,28 @@ function configCandidates() {
  * in exactly one place across all five config-loader sites (#403).
  *
  * @param {Function} resolveEntry - resolveRemnicPluginEntry from @remnic/core
+ * @param {NodeJS.ProcessEnv} env - environment override for tests
  */
-function loadRawConfig(resolveEntry) {
-  for (const candidate of configCandidates()) {
-    if (!fs.existsSync(candidate)) continue;
+function loadRawConfig(resolveEntry, env = process.env) {
+  for (const candidate of configCandidates(env)) {
+    if (!fs.existsSync(candidate.path)) continue;
+    let raw;
     try {
-      const raw = JSON.parse(fs.readFileSync(candidate, "utf-8"));
-      if (!raw || typeof raw !== "object") continue;
-      // Try the structured OpenClaw config layout first (plugins.entries).
-      // resolveEntry returns the full plugin entry (including .config).
-      const entry = resolveEntry(raw);
-      if (entry && typeof entry === "object") {
-        return entry.config && typeof entry.config === "object"
-          ? entry.config
-          : entry;
-      }
-      // Legacy / developer config layout: the top-level object IS the config.
-      // Honour it as long as it has no `plugins` subtree (so we don't
-      // accidentally treat a complete OpenClaw config with an unknown plugin
-      // slot as a flat Remnic config).
-      if (!raw.plugins) {
-        return raw;
-      }
-      // OpenClaw config but no Remnic entry found — skip to next candidate.
-    } catch (_err) {
-      // fall through to next candidate
+      raw = JSON.parse(fs.readFileSync(candidate.path, "utf-8"));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Invalid JSON in ${candidate.label} (${candidate.path}): ${message}`,
+      );
+    }
+    if (!isPlainRecord(raw)) {
+      throw new Error(
+        `Invalid config in ${candidate.label} (${candidate.path}): expected a JSON object`,
+      );
+    }
+    const resolved = extractRemnicConfigFromRaw(raw, resolveEntry);
+    if (resolved) {
+      return resolved;
     }
   }
   return {};
@@ -201,12 +237,20 @@ async function main() {
   return 0;
 }
 
-main().then(
-  (code) => process.exit(code),
-  (error) => {
-    console.error(
-      `codex-materialize failed: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    process.exit(1);
-  },
-);
+module.exports = {
+  configCandidates,
+  extractRemnicConfigFromRaw,
+  loadRawConfig,
+};
+
+if (require.main === module) {
+  main().then(
+    (code) => process.exit(code),
+    (error) => {
+      console.error(
+        `codex-materialize failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/codex-materialize.ts
+++ b/scripts/codex-materialize.ts
@@ -77,9 +77,25 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+class MaterializeConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MaterializeConfigError";
+  }
+}
+
 function envValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
   const value = env[key];
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function safeErrorDetail(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const cleaned = raw
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/[^\w .,:;()[\]{}'"!?/@+-]/g, "?")
+    .trim();
+  return cleaned.length > 240 ? `${cleaned.slice(0, 237)}...` : cleaned;
 }
 
 export function configCandidates(
@@ -87,18 +103,18 @@ export function configCandidates(
 ): ConfigCandidate[] {
   const home = envValue(env, "HOME") ?? "";
   const openclawConfigPath =
-    envValue(env, "OPENCLAW_CONFIG_PATH") ??
     envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") ??
+    envValue(env, "OPENCLAW_CONFIG_PATH") ??
     path.join(home, ".openclaw", "openclaw.json");
   return [
     { path: envValue(env, "REMNIC_CONFIG"), label: "REMNIC_CONFIG" },
     {
       path: openclawConfigPath,
       label:
-        envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
-          ? "OPENCLAW_CONFIG_PATH"
-          : envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
-            ? "OPENCLAW_ENGRAM_CONFIG_PATH"
+        envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
+          ? "OPENCLAW_ENGRAM_CONFIG_PATH"
+          : envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
+            ? "OPENCLAW_CONFIG_PATH"
             : "default OpenClaw config",
     },
     {
@@ -143,7 +159,7 @@ export function loadRawConfig(
   //
   // Order of precedence:
   //   1. `REMNIC_CONFIG` env var (developer escape hatch)
-  //   2. `OPENCLAW_CONFIG_PATH` / `OPENCLAW_ENGRAM_CONFIG_PATH` — the same
+  //   2. `OPENCLAW_ENGRAM_CONFIG_PATH` / `OPENCLAW_CONFIG_PATH` — the same
   //      env vars the Remnic plugin reads at runtime
   //   3. `~/.openclaw/openclaw.json` — standard OpenClaw install location
   //   4. Legacy `~/.config/remnic/config.json`, `~/.config/engram/config.json`,
@@ -156,14 +172,13 @@ export function loadRawConfig(
     try {
       raw = JSON.parse(fs.readFileSync(candidate.path, "utf-8"));
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `Invalid JSON in ${candidate.label} (${candidate.path}): ${message}`,
+      throw new MaterializeConfigError(
+        `codex-materialize config error: invalid JSON in ${candidate.label} (${candidate.path}): ${safeErrorDetail(err)}`,
       );
     }
     if (!isPlainRecord(raw)) {
-      throw new Error(
-        `Invalid config in ${candidate.label} (${candidate.path}): expected a JSON object`,
+      throw new MaterializeConfigError(
+        `codex-materialize config error: invalid config in ${candidate.label} (${candidate.path}): expected a JSON object`,
       );
     }
     const resolved = extractRemnicConfigFromRaw(raw);
@@ -197,7 +212,14 @@ async function main(): Promise<number> {
   }
 
   const rawConfig = loadRawConfig();
-  const config = parseConfig(rawConfig);
+  let config;
+  try {
+    config = parseConfig(rawConfig);
+  } catch (err) {
+    throw new MaterializeConfigError(
+      `codex-materialize config error: parseConfig rejected the resolved config: ${safeErrorDetail(err)}`,
+    );
+  }
   if (args.memoryDir) {
     // parseConfig already locked in a memoryDir, but the CLI override wins.
     (config as unknown as Record<string, unknown>).memoryDir = args.memoryDir;
@@ -243,14 +265,19 @@ function isCliEntrypoint(): boolean {
     : false;
 }
 
+function formatFatalError(error?: unknown): string {
+  if (error instanceof MaterializeConfigError) {
+    return error.message;
+  }
+  return "codex-materialize failed; see logs for details";
+}
+
 if (isCliEntrypoint()) {
   main().then(
     (code) => process.exit(code),
     (error) => {
       // eslint-disable-next-line no-console
-      console.error(
-        `codex-materialize failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      console.error(formatFatalError(error));
       process.exit(1);
     },
   );

--- a/scripts/codex-materialize.ts
+++ b/scripts/codex-materialize.ts
@@ -16,9 +16,11 @@
 
 import path from "node:path";
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 
 import { parseConfig } from "../packages/remnic-core/src/config.js";
 import { runCodexMaterialize } from "../packages/remnic-core/src/connectors/codex-materialize-runner.js";
+import { resolveRemnicPluginEntry } from "../packages/remnic-core/src/plugin-id.js";
 
 interface Args {
   namespace?: string;
@@ -66,64 +68,107 @@ function parseArgs(argv: string[]): Args {
   return args;
 }
 
-/**
- * Resolve a plugin config block from an OpenClaw-shaped config file.
- *
- * OpenClaw stores Remnic settings under
- * `plugins.entries["openclaw-engram"].config`; the legacy Remnic/Engram layouts
- * kept them at the top level. We accept both so we can run uniformly in
- * standard OpenClaw installs AND in developer sandboxes.
- */
-function unwrapOpenClawEntry(raw: unknown): Record<string, unknown> | null {
-  if (!raw || typeof raw !== "object") return null;
-  const obj = raw as Record<string, unknown>;
-  const entry = (obj.plugins as Record<string, unknown> | undefined)?.entries as
-    | Record<string, unknown>
-    | undefined;
-  const pluginConfig = (entry?.["openclaw-engram"] as Record<string, unknown> | undefined)
-    ?.config;
-  if (pluginConfig && typeof pluginConfig === "object") {
-    return pluginConfig as Record<string, unknown>;
-  }
-  // Legacy / developer config layout — the top-level object IS the plugin config.
-  return obj;
+interface ConfigCandidate {
+  path: string;
+  label: string;
 }
 
-function loadRawConfig(): Record<string, unknown> {
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function envValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function configCandidates(
+  env: NodeJS.ProcessEnv = process.env,
+): ConfigCandidate[] {
+  const home = envValue(env, "HOME") ?? "";
+  const openclawConfigPath =
+    envValue(env, "OPENCLAW_CONFIG_PATH") ??
+    envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") ??
+    path.join(home, ".openclaw", "openclaw.json");
+  return [
+    { path: envValue(env, "REMNIC_CONFIG"), label: "REMNIC_CONFIG" },
+    {
+      path: openclawConfigPath,
+      label:
+        envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
+          ? "OPENCLAW_CONFIG_PATH"
+          : envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
+            ? "OPENCLAW_ENGRAM_CONFIG_PATH"
+            : "default OpenClaw config",
+    },
+    {
+      path: path.join(home, ".config", "remnic", "config.json"),
+      label: "default Remnic config",
+    },
+    {
+      path: path.join(home, ".config", "engram", "config.json"),
+      label: "legacy Engram config",
+    },
+    {
+      path: path.join(home, ".remnic", "config.json"),
+      label: "legacy Remnic config",
+    },
+  ].filter((candidate): candidate is ConfigCandidate => {
+    return typeof candidate.path === "string" && candidate.path.length > 0;
+  });
+}
+
+export function extractRemnicConfigFromRaw(
+  raw: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const entry = resolveRemnicPluginEntry(raw);
+  if (isPlainRecord(entry)) {
+    const config = entry["config"];
+    return isPlainRecord(config) ? config : entry;
+  }
+  // Legacy / developer config layout: the top-level object IS the plugin
+  // config. Only accept it when this is not an OpenClaw-shaped config.
+  if (!Object.prototype.hasOwnProperty.call(raw, "plugins")) {
+    return raw;
+  }
+  return undefined;
+}
+
+export function loadRawConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, unknown> {
   // Try the common config locations without importing bootstrap.ts (which
   // pulls in the full orchestrator). A missing config is fine — parseConfig
   // produces sane defaults.
   //
   // Order of precedence:
   //   1. `REMNIC_CONFIG` env var (developer escape hatch)
-  //   2. `OPENCLAW_ENGRAM_CONFIG_PATH` / `OPENCLAW_CONFIG_PATH` — the same
+  //   2. `OPENCLAW_CONFIG_PATH` / `OPENCLAW_ENGRAM_CONFIG_PATH` — the same
   //      env vars the Remnic plugin reads at runtime
   //   3. `~/.openclaw/openclaw.json` — standard OpenClaw install location
   //   4. Legacy `~/.config/remnic/config.json`, `~/.config/engram/config.json`,
   //      `~/.remnic/config.json`
   //
-  // For (3) and (2) we unwrap `plugins.entries["openclaw-engram"].config`.
-  const home = process.env.HOME ?? "";
-  const openclawConfigPath =
-    process.env.OPENCLAW_ENGRAM_CONFIG_PATH ??
-    process.env.OPENCLAW_CONFIG_PATH ??
-    path.join(home, ".openclaw", "openclaw.json");
-  const candidates = [
-    process.env.REMNIC_CONFIG,
-    openclawConfigPath,
-    path.join(home, ".config", "remnic", "config.json"),
-    path.join(home, ".config", "engram", "config.json"),
-    path.join(home, ".remnic", "config.json"),
-  ].filter((p): p is string => typeof p === "string" && p.length > 0);
-
-  for (const candidate of candidates) {
-    if (!fs.existsSync(candidate)) continue;
+  // OpenClaw-shaped configs are resolved through the shared slot-aware helper.
+  for (const candidate of configCandidates(env)) {
+    if (!fs.existsSync(candidate.path)) continue;
+    let raw: unknown;
     try {
-      const raw = JSON.parse(fs.readFileSync(candidate, "utf-8"));
-      const unwrapped = unwrapOpenClawEntry(raw);
-      if (unwrapped) return unwrapped;
-    } catch {
-      // fall through to next candidate
+      raw = JSON.parse(fs.readFileSync(candidate.path, "utf-8"));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Invalid JSON in ${candidate.label} (${candidate.path}): ${message}`,
+      );
+    }
+    if (!isPlainRecord(raw)) {
+      throw new Error(
+        `Invalid config in ${candidate.label} (${candidate.path}): expected a JSON object`,
+      );
+    }
+    const resolved = extractRemnicConfigFromRaw(raw);
+    if (resolved) {
+      return resolved;
     }
   }
   return {};
@@ -192,13 +237,21 @@ async function main(): Promise<number> {
   return 0;
 }
 
-main().then(
-  (code) => process.exit(code),
-  (error) => {
-    // eslint-disable-next-line no-console
-    console.error(
-      `codex-materialize failed: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    process.exit(1);
-  },
-);
+function isCliEntrypoint(): boolean {
+  return process.argv[1] !== undefined
+    ? pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url
+    : false;
+}
+
+if (isCliEntrypoint()) {
+  main().then(
+    (code) => process.exit(code),
+    (error) => {
+      // eslint-disable-next-line no-console
+      console.error(
+        `codex-materialize failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      process.exit(1);
+    },
+  );
+}

--- a/tests/codex-materialize-config-resolution.test.ts
+++ b/tests/codex-materialize-config-resolution.test.ts
@@ -77,7 +77,7 @@ for (const [name, loadRawConfig] of loaders) {
     });
   });
 
-  test(`${name} prefers OPENCLAW_CONFIG_PATH over legacy OPENCLAW_ENGRAM_CONFIG_PATH`, () => {
+  test(`${name} keeps OPENCLAW_ENGRAM_CONFIG_PATH ahead of OPENCLAW_CONFIG_PATH`, () => {
     withTempDir((dir) => {
       const primaryPath = path.join(dir, "primary.json");
       const legacyPath = path.join(dir, "legacy.json");
@@ -89,8 +89,8 @@ for (const [name, loadRawConfig] of loaders) {
         OPENCLAW_CONFIG_PATH: primaryPath,
         OPENCLAW_ENGRAM_CONFIG_PATH: legacyPath,
       });
-      assert.equal(raw.marker, "primary");
-      assert.equal(raw.memoryDir, "/tmp/primary");
+      assert.equal(raw.marker, "legacy");
+      assert.equal(raw.memoryDir, "/tmp/legacy");
     });
   });
 
@@ -129,7 +129,7 @@ for (const [name, loadRawConfig] of loaders) {
             HOME: dir,
             REMNIC_CONFIG: configPath,
           }),
-        /Invalid JSON in REMNIC_CONFIG/u,
+        /codex-materialize config error: invalid JSON in REMNIC_CONFIG/u,
       );
     });
   });

--- a/tests/codex-materialize-config-resolution.test.ts
+++ b/tests/codex-materialize-config-resolution.test.ts
@@ -1,0 +1,136 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  loadRawConfig as loadDevRawConfig,
+} from "../scripts/codex-materialize.ts";
+import {
+  LEGACY_PLUGIN_ID,
+  PLUGIN_ID,
+  resolveRemnicPluginEntry,
+} from "../packages/remnic-core/src/plugin-id.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const packagedMaterialize = require(
+  path.resolve(__dirname, "..", "packages", "plugin-codex", "bin", "materialize.cjs"),
+) as {
+  loadRawConfig: (
+    resolveEntry: typeof resolveRemnicPluginEntry,
+    env?: NodeJS.ProcessEnv,
+  ) => Record<string, unknown>;
+};
+
+type Loader = (env: NodeJS.ProcessEnv) => Record<string, unknown>;
+
+const loaders: Array<[string, Loader]> = [
+  ["dev script", (env) => loadDevRawConfig(env)],
+  [
+    "packaged bin",
+    (env) => packagedMaterialize.loadRawConfig(resolveRemnicPluginEntry, env),
+  ],
+];
+
+function withTempDir<T>(fn: (dir: string) => T): T {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "codex-materialize-config-"));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeJson(file: string, value: unknown): void {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+for (const [name, loadRawConfig] of loaders) {
+  test(`${name} resolves the active OpenClaw Remnic slot`, () => {
+    withTempDir((dir) => {
+      const configPath = path.join(dir, "openclaw.json");
+      writeJson(configPath, {
+        plugins: {
+          slots: { memory: PLUGIN_ID },
+          entries: {
+            [PLUGIN_ID]: {
+              config: { memoryDir: "/tmp/canonical", marker: "canonical" },
+            },
+            [LEGACY_PLUGIN_ID]: {
+              config: { memoryDir: "/tmp/legacy", marker: "legacy" },
+            },
+          },
+        },
+      });
+
+      const raw = loadRawConfig({
+        HOME: dir,
+        OPENCLAW_CONFIG_PATH: configPath,
+      });
+      assert.equal(raw.marker, "canonical");
+      assert.equal(raw.memoryDir, "/tmp/canonical");
+    });
+  });
+
+  test(`${name} prefers OPENCLAW_CONFIG_PATH over legacy OPENCLAW_ENGRAM_CONFIG_PATH`, () => {
+    withTempDir((dir) => {
+      const primaryPath = path.join(dir, "primary.json");
+      const legacyPath = path.join(dir, "legacy.json");
+      writeJson(primaryPath, { memoryDir: "/tmp/primary", marker: "primary" });
+      writeJson(legacyPath, { memoryDir: "/tmp/legacy", marker: "legacy" });
+
+      const raw = loadRawConfig({
+        HOME: dir,
+        OPENCLAW_CONFIG_PATH: primaryPath,
+        OPENCLAW_ENGRAM_CONFIG_PATH: legacyPath,
+      });
+      assert.equal(raw.marker, "primary");
+      assert.equal(raw.memoryDir, "/tmp/primary");
+    });
+  });
+
+  test(`${name} skips OpenClaw configs without a Remnic entry instead of treating them as flat config`, () => {
+    withTempDir((dir) => {
+      const openclawPath = path.join(dir, "openclaw.json");
+      writeJson(openclawPath, {
+        memoryDir: "/tmp/should-not-be-used",
+        marker: "top-level-openclaw",
+        plugins: {
+          slots: { memory: "other-memory-plugin" },
+          entries: {
+            "other-memory-plugin": {
+              config: { memoryDir: "/tmp/foreign", marker: "foreign" },
+            },
+          },
+        },
+      });
+
+      const raw = loadRawConfig({
+        HOME: dir,
+        OPENCLAW_CONFIG_PATH: openclawPath,
+      });
+      assert.deepEqual(raw, {});
+    });
+  });
+
+  test(`${name} fails fast when an existing explicit config contains invalid JSON`, () => {
+    withTempDir((dir) => {
+      const configPath = path.join(dir, "broken.json");
+      writeFileSync(configPath, "{not json");
+
+      assert.throws(
+        () =>
+          loadRawConfig({
+            HOME: dir,
+            REMNIC_CONFIG: configPath,
+          }),
+        /Invalid JSON in REMNIC_CONFIG/u,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- make the dev `scripts/codex-materialize.ts` and packaged `materialize.cjs` resolve OpenClaw-shaped configs through `resolveRemnicPluginEntry`
- only allow flat config fallback when the file is not OpenClaw-shaped, so foreign plugin configs are skipped instead of misread
- fail fast on malformed existing config files and cover dev + packaged entrypoints with regression tests

Clawpatch: `fnd_sig-feat-library-32b0f83226-5c54_ba45230707`

## Verification
- `pnpm exec tsx --test tests/codex-materialize-config-resolution.test.ts`
- `pnpm exec tsx --test tests/resolve-remnic-plugin-entry.test.ts tests/codex-materialize-consolidation-wiring.test.ts`
- `pnpm exec tsx --test tests/codex-materialize.test.ts`
- `pnpm run check-types`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config discovery/parsing for `codex-materialize`, including stricter validation and new fail-fast errors, which could alter behavior for existing installs with malformed or unexpected config files. Impact is limited to the materialization CLI/bin path but affects both dev and packaged entrypoints.
> 
> **Overview**
> Aligns `codex-materialize` config resolution (dev script and packaged `materialize.cjs`) to use the shared `resolveRemnicPluginEntry` logic for OpenClaw-shaped configs, and only falls back to treating a file as flat Remnic config when it is *not* OpenClaw-shaped (avoiding misreading configs for other plugins).
> 
> Tightens error handling by validating parsed JSON is an object, failing fast with sanitized, user-facing `MaterializeConfigError` messages on invalid JSON or `parseConfig` rejection, and adjusts entrypoint wiring so the modules can be imported for testing. Adds regression tests that cover slot selection, env var precedence, skipping foreign OpenClaw configs, and invalid JSON for both dev + packaged loaders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8861c0f6cb736589a7112acd4a08c0f72d8868b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->