### PR TITLE
Use restart window for public evidence diagnostics

### DIFF
--- a/scripts/bench/public-sota/evidence-run-utils.mjs
+++ b/scripts/bench/public-sota/evidence-run-utils.mjs
@@ -355,13 +355,18 @@ export function assertCodexDiagnostics(diagnostics, taskCount) {
 export function statusTimes(resultsDir, benchmark, fallback) {
   const statusPath = path.join(resultsDir, 'status.tsv');
   if (!fs.existsSync(statusPath)) {
-    return { startedAt: fallback, successAt: fallback };
+    return { startedAt: fallback, lifecycleStartedAt: fallback, successAt: fallback };
   }
   const body = fs.readFileSync(statusPath, 'utf8').trim();
   const rows = body ? body.split(/\r?\n/).slice(1).map((line) => line.split('\t')) : [];
   const matching = rows.filter(([name]) => name === benchmark);
+  const startedAt = matching.find(([, status]) => status === 'start')?.[2] ?? fallback;
+  const lifecycleStart = [...matching]
+    .reverse()
+    .find(([, status]) => status === 'start' || String(status).startsWith('restart'));
   return {
-    startedAt: matching.find(([, status]) => status === 'start')?.[2] ?? fallback,
+    startedAt,
+    lifecycleStartedAt: lifecycleStart?.[2] ?? startedAt,
     successAt: [...matching].reverse().find(([, status]) => status === 'success')?.[2] ?? fallback,
   };
 }

--- a/scripts/bench/public-sota/memoryarena/package-memoryarena-evidence.mjs
+++ b/scripts/bench/public-sota/memoryarena/package-memoryarena-evidence.mjs
@@ -153,7 +153,7 @@ async function main() {
   const comparison = compareMemoryArenaSota(result, targetMap);
   const dataset = await scanDataset(args['dataset-dir'], repoRoot, 'memory-arena', replacements);
   assertDatasetMatchesRunManifest(baseManifest, 'memory-arena', dataset);
-  const times = statusTimes(resultsDir, 'memory-arena');
+  const times = statusTimes(resultsDir, 'memory-arena', result.meta.timestamp);
   const startedAt = times.startedAt ?? result.meta.timestamp;
   const finishedAt = result.meta.timestamp;
   const generatedAt = new Date().toISOString();
@@ -224,7 +224,14 @@ async function main() {
   const manifestPath = path.join(outDir, 'MANIFEST.memory-arena.json');
   await fsp.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
 
-  const diagnostics = buildDiagnosticsSummary(resultsDir, manifest.run.id, 'memory-arena', startedAt, finishedAt, generatedAt);
+  const diagnostics = buildDiagnosticsSummary(
+    resultsDir,
+    manifest.run.id,
+    'memory-arena',
+    times.lifecycleStartedAt,
+    finishedAt,
+    generatedAt,
+  );
   assertCodexDiagnostics(diagnostics, result.results.tasks.length);
   const diagnosticsPath = path.join(outDir, 'memory-arena-diagnostics-summary.json');
   await fsp.writeFile(diagnosticsPath, `${JSON.stringify(diagnostics, null, 2)}\n`, 'utf8');

--- a/scripts/bench/public-sota/package-public-benchmark-evidence.mjs
+++ b/scripts/bench/public-sota/package-public-benchmark-evidence.mjs
@@ -268,7 +268,14 @@ async function main() {
   await fsp.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
   const comparisonPath = path.join(outDir, `${benchmark}-sota-comparison.json`);
   await fsp.writeFile(comparisonPath, `${JSON.stringify(comparison, null, 2)}\n`, 'utf8');
-  const diagnostics = buildDiagnosticsSummary(resultsDir, manifest.run.id, benchmark, times.startedAt, result.meta.timestamp, generatedAt);
+  const diagnostics = buildDiagnosticsSummary(
+    resultsDir,
+    manifest.run.id,
+    benchmark,
+    times.lifecycleStartedAt,
+    result.meta.timestamp,
+    generatedAt,
+  );
   assertCodexDiagnostics(diagnostics, result.results.tasks.length);
   const diagnosticsPath = path.join(outDir, `${benchmark}-diagnostics-summary.json`);
   await fsp.writeFile(diagnosticsPath, `${JSON.stringify(diagnostics, null, 2)}\n`, 'utf8');

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -11,7 +11,7 @@ import {
   roundedJsonNumberReplacer,
 } from "../scripts/bench/public-sota/compare-public-benchmark-sota.mjs";
 import { manifestArtifactHashIdentity } from "../scripts/bench/public-sota/evidence-integrity.mjs";
-import { buildDiagnosticsSummary } from "../scripts/bench/public-sota/evidence-run-utils.mjs";
+import { buildDiagnosticsSummary, statusTimes } from "../scripts/bench/public-sota/evidence-run-utils.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -325,6 +325,21 @@ async function writeValidDiagnostics(diagnosticsDir: string, count = 1): Promise
   }
 }
 
+async function writeInstantDiagnostics(diagnosticsDir: string, timestamp: string, count: number): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await writeJson(path.join(diagnosticsDir, `instant-${String(index + 1).padStart(2, "0")}.json`), {
+      runId: RUN_ID,
+      startedAt: timestamp,
+      finishedAt: timestamp,
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      serviceTier: "fast",
+      result: { status: 0 },
+    });
+  }
+}
+
 async function assertRejectsInvalidDiagnostics(
   script: string,
   args: string[],
@@ -614,6 +629,116 @@ test("diagnostics summary excludes records that started before benchmark start",
     assert.equal(summary?.checked, 1);
     assert.equal(summary?.providers["codex-cli"], 1);
     assert.equal(summary?.minStartedAt, "2026-05-16T00:00:10.000Z");
+  } finally {
+    await rm(dirs.root, { recursive: true, force: true });
+  }
+});
+
+test("public evidence diagnostics use the latest restart lifecycle start", async () => {
+  const dirs = await createRunDirs("remnic-public-sota-diagnostics-restart-window-");
+  try {
+    await writeFile(
+      path.join(dirs.resultsDir, "status.tsv"),
+      [
+        "benchmark\tstatus\ttimestamp",
+        "memory-arena\tstart\t2026-05-17T00:00:00.000Z",
+        "memory-arena\trestart-after-reboot\t2026-05-17T02:00:00.000Z",
+        "memory-arena\tsuccess\t2026-05-17T03:00:00.000Z",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeJson(path.join(dirs.diagnosticsDir, "pre-restart-failed.json"), {
+      runId: RUN_ID,
+      startedAt: "2026-05-17T01:59:00.000Z",
+      finishedAt: "2026-05-17T01:59:30.000Z",
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      serviceTier: "fast",
+      error: "Codex CLI completion failed (signal SIGTERM)",
+    });
+    await writeJson(path.join(dirs.diagnosticsDir, "post-restart-ok.json"), {
+      runId: RUN_ID,
+      startedAt: "2026-05-17T02:00:10.000Z",
+      finishedAt: "2026-05-17T02:00:20.000Z",
+      provider: "codex-cli",
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      serviceTier: "fast",
+      result: { status: 0 },
+    });
+
+    const times = statusTimes(dirs.resultsDir, "memory-arena", FINISHED_AT);
+    assert.equal(times.startedAt, "2026-05-17T00:00:00.000Z");
+    assert.equal(times.lifecycleStartedAt, "2026-05-17T02:00:00.000Z");
+    assert.equal(times.successAt, "2026-05-17T03:00:00.000Z");
+
+    const summary = buildDiagnosticsSummary(
+      dirs.resultsDir,
+      RUN_ID,
+      "memory-arena",
+      times.lifecycleStartedAt,
+      times.successAt,
+      "2026-05-17T03:01:00.000Z",
+    );
+    assert.equal(summary?.beforeStart, 1);
+    assert.equal(summary?.checked, 1);
+    assert.equal(summary?.errored, 0);
+    assert.equal(summary?.complete, 1);
+  } finally {
+    await rm(dirs.root, { recursive: true, force: true });
+  }
+});
+
+test("public evidence packagers keep artifact start separate from diagnostics restart window", async () => {
+  const generic = await readFile(
+    path.join("scripts", "bench", "public-sota", "package-public-benchmark-evidence.mjs"),
+    "utf8",
+  );
+  const memoryArena = await readFile(
+    path.join("scripts", "bench", "public-sota", "memoryarena", "package-memoryarena-evidence.mjs"),
+    "utf8",
+  );
+
+  assert.match(generic, /const artifact = buildArtifact\(result, dataset, comparison, times\.startedAt\)/);
+  assert.match(generic, /const filename = `\$\{times\.startedAt\.slice\(0, 10\)\}-\$\{benchmark\}-gpt-5\.5-real-/);
+  assert.match(generic, /buildDiagnosticsSummary\([\s\S]*times\.lifecycleStartedAt[\s\S]*result\.meta\.timestamp/);
+
+  assert.match(memoryArena, /const times = statusTimes\(resultsDir, 'memory-arena', result\.meta\.timestamp\)/);
+  assert.match(memoryArena, /const startedAt = times\.startedAt \?\? result\.meta\.timestamp/);
+  assert.match(memoryArena, /buildPublicArtifact\(result, dataset, derived, comparison, startedAt\)/);
+  assert.match(memoryArena, /buildDiagnosticsSummary\([\s\S]*times\.lifecycleStartedAt[\s\S]*finishedAt/);
+});
+
+test("MemoryArena public SOTA packager falls back when status.tsv is missing", async () => {
+  const dirs = await createRunDirs("remnic-public-sota-memoryarena-no-status-");
+  try {
+    await writeInstantDiagnostics(dirs.diagnosticsDir, FINISHED_AT, 5);
+    const resultPath = path.join(dirs.resultsDir, "memory-arena-result.json");
+    await writeMemoryArenaResult(resultPath);
+    await writeBaseManifest(dirs.resultsDir, "memory-arena", resultPath);
+
+    await execFileAsync(
+      process.execPath,
+      [
+        path.join("scripts", "bench", "public-sota", "memoryarena", "package-memoryarena-evidence.mjs"),
+        "--result", resultPath,
+        "--results-dir", dirs.resultsDir,
+        "--dataset-dir", dirs.datasetDir,
+        "--repo-root", process.cwd(),
+        "--out-dir", dirs.outDir,
+      ],
+      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+    );
+
+    const manifest = JSON.parse(await readFile(path.join(dirs.outDir, "MANIFEST.memory-arena.json"), "utf8"));
+    const artifact = JSON.parse(await readFile(path.join(dirs.outDir, manifest.publicArtifacts[0].path), "utf8"));
+    const diagnostics = JSON.parse(await readFile(path.join(dirs.outDir, "memory-arena-diagnostics-summary.json"), "utf8"));
+
+    assert.equal(artifact.startedAt, FINISHED_AT);
+    assert.equal(diagnostics.checked, 5);
+    assert.equal(diagnostics.minStartedAt, FINISHED_AT);
   } finally {
     await rm(dirs.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- make public evidence packaging use the latest lifecycle start, including restart markers, when deriving benchmark start time
- prevent pre-reboot failed diagnostics from being counted against a restarted public benchmark result
- add regression coverage for restart-aware diagnostics windows

## Verification
- node --check scripts/bench/public-sota/evidence-run-utils.mjs
- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts
- live diagnostic-window probe on public-matrix-codex-bf9b2643: beforeStart=14726, checked=911, errored=0, nonzero=0, all codex-cli/gpt-5.5/xhigh/fast
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how public evidence diagnostics are time-windowed, which can alter pass/fail counts and published diagnostics summaries for restarted runs. Moderate risk due to impact on benchmark evidence generation and regression coverage, but scope is limited to bench packaging utilities and tests.
> 
> **Overview**
> Public evidence packaging now distinguishes the *artifact start time* from the *diagnostics lifecycle start*, using the latest `start`/`restart*` marker in `status.tsv` to window `codex-cli` diagnostics and avoid counting pre-restart failures against a restarted run.
> 
> `statusTimes()` now returns `lifecycleStartedAt` (with robust fallback behavior when `status.tsv` is missing), and both the generic and MemoryArena packagers feed `times.lifecycleStartedAt` into `buildDiagnosticsSummary` while still using `times.startedAt` for artifact timestamps/filenames.
> 
> Tests add restart-window and missing-`status.tsv` regression coverage, plus assertions that packagers keep artifact start separate from the diagnostics restart window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206c6084c1224dc88139d4c0a17b923f0a761cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->