### PR TITLE
fix(core): keep conversation chunks inside index root

### DIFF
--- a/packages/remnic-core/src/conversation-index/indexer.test.ts
+++ b/packages/remnic-core/src/conversation-index/indexer.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { ConversationChunk } from "./chunker.js";
+import { sanitizeSessionKey, writeConversationChunks } from "./indexer.js";
+
+function sampleChunk(overrides: Partial<ConversationChunk> = {}): ConversationChunk {
+  return {
+    id: "2026-05-17T00-00-00-000Z-0",
+    sessionKey: "agent:main",
+    startTs: "2026-05-17T00:00:00.000Z",
+    endTs: "2026-05-17T00:01:00.000Z",
+    text: "hello",
+    ...overrides,
+  };
+}
+
+function assertInsideRoot(root: string, candidate: string): void {
+  const relative = path.relative(root, candidate);
+  assert.ok(relative.length > 0);
+  assert.notEqual(relative, "..", `${candidate} escaped ${root}`);
+  assert.ok(!relative.startsWith(`..${path.sep}`), `${candidate} escaped ${root}`);
+  assert.ok(!path.isAbsolute(relative), `${candidate} escaped ${root}`);
+}
+
+test("sanitizeSessionKey rejects dot-only path components", () => {
+  assert.equal(sanitizeSessionKey("."), "unknown-session");
+  assert.equal(sanitizeSessionKey(".."), "unknown-session");
+  assert.equal(sanitizeSessionKey(""), "unknown-session");
+});
+
+test("writeConversationChunks keeps adversarial path components inside root", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
+  try {
+    const written = await writeConversationChunks(root, [
+      sampleChunk({
+        id: "../../outside",
+        sessionKey: "..",
+      }),
+    ]);
+
+    assert.equal(written.length, 1);
+    assertInsideRoot(root, written[0]!);
+    assert.equal(path.basename(written[0]!), ".._.._outside.md");
+    assert.match(await readFile(written[0]!, "utf-8"), /kind: conversation_chunk/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("writeConversationChunks accepts safe dot-prefixed path components", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
+  try {
+    const written = await writeConversationChunks(root, [
+      sampleChunk({
+        id: "..chunk",
+        sessionKey: "..abc",
+      }),
+    ]);
+
+    assert.equal(written.length, 1);
+    assertInsideRoot(root, written[0]!);
+    assert.equal(path.basename(written[0]!), "..chunk.md");
+    assert.equal(path.basename(path.dirname(path.dirname(written[0]!))), "..abc");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("writeConversationChunks rejects invalid chunk timestamps before deriving paths", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
+  try {
+    await assert.rejects(
+      writeConversationChunks(root, [
+        sampleChunk({
+          startTs: "../2026-05-17",
+        }),
+      ]),
+      /invalid conversation chunk start timestamp/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("writeConversationChunks rejects a symlinked index root", async () => {
+  const temp = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
+  const target = path.join(temp, "outside");
+  const root = path.join(temp, "index-root");
+  try {
+    await mkdir(target);
+    await symlink(target, root);
+
+    await assert.rejects(
+      writeConversationChunks(root, [sampleChunk()]),
+      /conversation chunk path contains symlink/,
+    );
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+});
+
+test("writeConversationChunks rejects symlinked root ancestors before mkdir", async () => {
+  const temp = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
+  const memoryDir = path.join(temp, "memory");
+  const stateTarget = path.join(temp, "outside-state");
+  const root = path.join(memoryDir, "state", "conversation-index");
+  try {
+    await mkdir(memoryDir);
+    await mkdir(stateTarget);
+    await symlink(stateTarget, path.join(memoryDir, "state"));
+
+    await assert.rejects(
+      writeConversationChunks(root, [sampleChunk()]),
+      /conversation chunk path contains symlink/,
+    );
+    await assert.rejects(access(path.join(stateTarget, "conversation-index")), {
+      code: "ENOENT",
+    });
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+});
+
+test("writeConversationChunks rejects symlinked intermediate directories", async () => {
+  const temp = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
+  const root = path.join(temp, "root");
+  const outside = path.join(temp, "outside");
+  try {
+    await mkdir(root);
+    await mkdir(outside);
+    await symlink(outside, path.join(root, "agent_main"));
+
+    await assert.rejects(
+      writeConversationChunks(root, [sampleChunk({ sessionKey: "agent:main" })]),
+      /conversation chunk path contains symlink/,
+    );
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+});
+
+test("writeConversationChunks rejects symlinked target files", async () => {
+  const temp = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
+  const root = path.join(temp, "root");
+  const outside = path.join(temp, "outside.md");
+  const chunk = sampleChunk({ id: "chunk-1" });
+  try {
+    const dir = path.join(root, "agent_main", "2026-05-17");
+    await mkdir(dir, { recursive: true });
+    await writeFile(outside, "outside", "utf-8");
+    await symlink(outside, path.join(dir, "chunk-1.md"));
+
+    await assert.rejects(
+      writeConversationChunks(root, [chunk]),
+      /conversation chunk path contains symlink/,
+    );
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/conversation-index/indexer.ts
+++ b/packages/remnic-core/src/conversation-index/indexer.ts
@@ -1,14 +1,115 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { lstat, mkdir, writeFile } from "node:fs/promises";
+import type { Stats } from "node:fs";
 import path from "node:path";
 import { log } from "../logger.js";
 import type { FaissConversationIndexAdapter } from "./faiss-adapter.js";
 import type { ConversationChunk } from "./chunker.js";
 
+const MAX_PATH_COMPONENT_LENGTH = 200;
+
+function sanitizePathComponent(
+  value: string,
+  fallback: string,
+  opts: { lowercase?: boolean } = {},
+): string {
+  const raw = typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : fallback;
+  const normalized = opts.lowercase ? raw.toLowerCase() : raw;
+  const sanitized = normalized
+    .replace(/[^a-zA-Z0-9._-]+/g, "_")
+    .slice(0, MAX_PATH_COMPONENT_LENGTH);
+  if (!sanitized || sanitized === "." || sanitized === "..") {
+    return fallback;
+  }
+  return sanitized;
+}
+
 export function sanitizeSessionKey(sessionKey: string): string {
-  const raw = typeof sessionKey === "string" && sessionKey.trim().length > 0
-    ? sessionKey
-    : "unknown-session";
-  return raw.toLowerCase().replace(/[^a-z0-9._-]+/g, "_").slice(0, 200);
+  return sanitizePathComponent(sessionKey, "unknown-session", { lowercase: true });
+}
+
+function sanitizeChunkId(id: string): string {
+  return sanitizePathComponent(id, "chunk");
+}
+
+function datePathComponent(startTs: string): string {
+  if (typeof startTs !== "string" || !/^\d{4}-\d{2}-\d{2}T/.test(startTs)) {
+    throw new Error("invalid conversation chunk start timestamp");
+  }
+  const date = new Date(startTs);
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error("invalid conversation chunk start timestamp");
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+function resolveInsideRoot(rootDir: string, candidate: string): string {
+  const root = path.resolve(rootDir);
+  const resolved = path.resolve(candidate);
+  const rel = path.relative(root, resolved);
+  if (
+    rel === "" ||
+    (rel !== ".." && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel))
+  ) {
+    return resolved;
+  }
+  throw new Error("conversation chunk path escapes index root");
+}
+
+async function lstatIfExists(candidate: string): Promise<Stats | undefined> {
+  try {
+    return await lstat(candidate);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+async function rejectSymlinkIfExists(candidate: string): Promise<void> {
+  const stat = await lstatIfExists(candidate);
+  if (stat?.isSymbolicLink()) {
+    throw new Error("conversation chunk path contains symlink");
+  }
+}
+
+async function rejectExistingSymlinksInPath(baseDir: string, candidate: string): Promise<void> {
+  const base = path.resolve(baseDir);
+  const resolved = path.resolve(candidate);
+
+  let current = base;
+  while (current !== path.dirname(current)) {
+    const stat = await lstatIfExists(current);
+    if (stat) {
+      if (stat.isSymbolicLink()) {
+        throw new Error("conversation chunk path contains symlink");
+      }
+      break;
+    }
+    current = path.dirname(current);
+  }
+
+  const relative = path.relative(base, resolved);
+  if (relative === "") return;
+
+  current = base;
+  for (const part of relative.split(path.sep)) {
+    current = path.join(current, part);
+    const stat = await lstatIfExists(current);
+    if (!stat) return;
+    if (stat.isSymbolicLink()) {
+      throw new Error("conversation chunk path contains symlink");
+    }
+  }
+}
+
+async function rejectExistingSymlinkAncestors(
+  rootDir: string,
+  candidate: string,
+): Promise<void> {
+  const root = path.resolve(rootDir);
+  const resolved = resolveInsideRoot(root, candidate);
+  await rejectExistingSymlinksInPath(root, resolved);
 }
 
 export async function writeConversationChunks(
@@ -16,12 +117,21 @@ export async function writeConversationChunks(
   chunks: ConversationChunk[],
 ): Promise<string[]> {
   const written: string[] = [];
+  const root = path.resolve(rootDir);
+  await rejectExistingSymlinksInPath(root, root);
+  await mkdir(root, { recursive: true });
+  await rejectExistingSymlinksInPath(root, root);
+
   for (const c of chunks) {
     const safe = sanitizeSessionKey(c.sessionKey);
-    const date = c.startTs.slice(0, 10);
-    const dir = path.join(rootDir, safe, date);
+    const date = datePathComponent(c.startTs);
+    const dir = resolveInsideRoot(root, path.join(root, safe, date));
+    await rejectExistingSymlinkAncestors(root, dir);
     await mkdir(dir, { recursive: true });
-    const fp = path.join(dir, `${c.id}.md`);
+    await rejectExistingSymlinkAncestors(root, dir);
+    const fp = resolveInsideRoot(root, path.join(dir, `${sanitizeChunkId(c.id)}.md`));
+    await rejectExistingSymlinkAncestors(root, path.dirname(fp));
+    await rejectSymlinkIfExists(fp);
     const content =
       `---\n` +
       `kind: conversation_chunk\n` +


### PR DESCRIPTION
## Summary
- Sanitize conversation-index session and chunk id path components
- Validate chunk start timestamps before deriving date directories
- Assert resolved write paths stay inside the configured conversation-index root
- Add focused traversal regressions

Clawpatch finding: `fnd_sig-feat-library-41e0d2eb4b-d55c_f813af6f29`

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/conversation-index/indexer.test.ts`
- `pnpm --filter @remnic/core run check-types`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem path construction and adds symlink/path-escape enforcement in `writeConversationChunks`, which could affect where/when chunk files are written and cause new write failures in edge cases.
> 
> **Overview**
> Hardens conversation chunk persistence to ensure all derived paths stay **inside the configured conversation-index root**.
> 
> This tightens path handling by sanitizing `sessionKey` and chunk `id` components (rejecting `.`/`..`), validating `startTs` before using it for date directories, resolving/validating computed paths against the root, and rejecting writes through existing symlinks (root, ancestors, intermediate dirs, and target files).
> 
> Adds a new `indexer.test.ts` suite covering path traversal attempts, invalid timestamps, and multiple symlink-escape scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634eaf24da0b7395e3ee9f65406e12514532dcc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->