### PR TITLE
fix(cli): align importer and bench type contracts

### DIFF
--- a/packages/remnic-cli/src/import-bundle-detect.test.ts
+++ b/packages/remnic-cli/src/import-bundle-detect.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  BUNDLE_SUPPORTED_IMPORTERS,
   detectBundleEntries,
   type BundleDetectOptions,
 } from "./import-bundle-detect.js";
+import { SUPPORTED_IMPORTERS } from "./optional-importer.js";
 
 /**
  * Build a fake filesystem map that the detect helpers can query through
@@ -46,6 +48,22 @@ function makeFs(
 }
 
 describe("detectBundleEntries", () => {
+  it("keeps bundle-supported importers intentionally narrower than optional importers", () => {
+    assert.deepEqual([...BUNDLE_SUPPORTED_IMPORTERS], [
+      "chatgpt",
+      "claude",
+      "gemini",
+      "mem0",
+    ]);
+    for (const name of BUNDLE_SUPPORTED_IMPORTERS) {
+      assert.ok(SUPPORTED_IMPORTERS.includes(name));
+    }
+    assert.equal(
+      (BUNDLE_SUPPORTED_IMPORTERS as readonly string[]).includes("supermemory"),
+      false,
+    );
+  });
+
   it("finds a ChatGPT saved-memories file at the bundle root", () => {
     const fs = makeFs(
       { "/bundle/memory.json": "{}" },

--- a/packages/remnic-cli/src/import-bundle-detect.ts
+++ b/packages/remnic-cli/src/import-bundle-detect.ts
@@ -23,8 +23,16 @@ import path from "node:path";
 
 import type { SupportedImporterName } from "./optional-importer.js";
 
+export const BUNDLE_SUPPORTED_IMPORTERS = [
+  "chatgpt",
+  "claude",
+  "gemini",
+  "mem0",
+] as const satisfies readonly SupportedImporterName[];
+export type BundleSupportedImporterName = (typeof BUNDLE_SUPPORTED_IMPORTERS)[number];
+
 export interface DetectedBundleEntry {
-  adapter: SupportedImporterName;
+  adapter: BundleSupportedImporterName;
   filePath: string;
   /**
    * Optional transform hint — e.g. a ChatGPT `conversations.json` should
@@ -48,8 +56,8 @@ export interface BundleDetectOptions {
 
 /**
  * Walk `bundleDir` (one level deep, plus one nested directory layer) and
- * return the list of importer entries to run. The order is stable
- * (chatgpt, claude, gemini, mem0) so re-scans produce identical output.
+ * return the list of importer entries to run. The order is stable across
+ * BUNDLE_SUPPORTED_IMPORTERS so re-scans produce identical output.
  *
  * Returns an empty array when no known files are found. Callers are
  * responsible for surfacing "bundle was empty" to the user.
@@ -116,12 +124,12 @@ export function detectBundleEntries(
   }
 
   // Stable sort by (adapter preference order, file path).
-  const adapterOrder: Record<SupportedImporterName, number> = {
+  const adapterOrder = {
     chatgpt: 0,
     claude: 1,
     gemini: 2,
     mem0: 3,
-  };
+  } satisfies Record<BundleSupportedImporterName, number>;
   entries.sort((a, b) => {
     const delta = adapterOrder[a.adapter] - adapterOrder[b.adapter];
     if (delta !== 0) return delta;
@@ -210,7 +218,7 @@ function classifyFile(
 function disambiguateConversations(
   filePath: string,
   readFileImpl: (p: string) => string,
-): SupportedImporterName {
+): BundleSupportedImporterName {
   try {
     const content = readFileImpl(filePath);
     const parsed = JSON.parse(content);

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -95,12 +95,18 @@ describe("parseImportArgs", () => {
   it("rejects an unknown adapter with the valid list", () => {
     assert.throws(
       () => parseImportArgs(["--adapter", "bogus"]),
-      /chatgpt, claude, gemini, mem0/,
+      /chatgpt, claude, gemini, mem0, supermemory/,
     );
   });
 
-  it("accepts the four canonical adapters", () => {
-    for (const name of ["chatgpt", "claude", "gemini", "mem0"] as const) {
+  it("accepts the canonical adapters", () => {
+    for (const name of [
+      "chatgpt",
+      "claude",
+      "gemini",
+      "mem0",
+      "supermemory",
+    ] as const) {
       const parsed = parseImportArgs(["--adapter", name]);
       assert.equal(parsed.adapter, name);
     }

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -2,9 +2,9 @@
 // `remnic import` command dispatcher (issue #568, slice 1)
 // ---------------------------------------------------------------------------
 //
-// This module is the top-level CLI entry for the four memory importers
-// (ChatGPT, Claude, Gemini, Mem0). Slice 1 wires ONLY the infrastructure —
-// actual source adapters land in slices 2-5 and are discovered via the
+// This module is the top-level CLI entry for optional memory importers
+// (ChatGPT, Claude, Gemini, Mem0, Supermemory). Slice 1 wires ONLY the infrastructure —
+// actual source adapters land in follow-up slices and are discovered via the
 // computed-specifier loader in `optional-importer.ts`. Running
 // `remnic import --adapter chatgpt ...` today will therefore surface a clean
 // "optional package not installed" hint rather than a bare MODULE_NOT_FOUND.
@@ -13,7 +13,7 @@
 //   `--flag` without a following value; rule 51 — reject invalid input with
 //   a list of valid options instead of silently defaulting):
 //
-//   --adapter <name>       Required. One of chatgpt|claude|gemini|mem0.
+//   --adapter <name>       Required. One of the supported optional importers.
 //   --file <path>          Required unless the adapter accepts an API-only
 //                          input (mem0). Expanded via ~.
 //   --dry-run              Parse + transform only; no writes, no API calls.
@@ -92,7 +92,7 @@ export interface ImportDispatchIO {
   stderr: (line: string) => void;
 }
 
-export const IMPORT_USAGE = `remnic import — Bring memory from ChatGPT, Claude, Gemini, or Mem0 (issue #568)
+export const IMPORT_USAGE = `remnic import — Bring memory from ChatGPT, Claude, Gemini, Mem0, or Supermemory (issue #568)
 
 Usage:
   remnic import --adapter <name> --file <path> [options]
@@ -116,14 +116,16 @@ Bulk mode (slice 7):
                               mem0 exports inside <dir> and run each
                               matching adapter. Replaces --adapter/--file.
 
-Slice 1 ships infrastructure only. The four adapter packages
+Slice 1 ships infrastructure only. Adapter packages
 (@remnic/import-chatgpt, @remnic/import-claude, @remnic/import-gemini,
-@remnic/import-mem0) land in slices 2-5. Install whichever you need:
+@remnic/import-mem0, @remnic/import-supermemory) land in follow-up slices.
+Install whichever you need:
 
   npm install -g @remnic/import-chatgpt
   npm install -g @remnic/import-claude
   npm install -g @remnic/import-gemini
   npm install -g @remnic/import-mem0
+  npm install -g @remnic/import-supermemory
 `;
 
 /**

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -422,6 +422,7 @@ type PackageBenchModule = {
     amaBenchJudgeProtocol?: "default" | "recommended";
     amaBenchCrossJudge?: unknown;
     amaBenchCrossJudgeProvider?: PackageBenchProviderConfig | null;
+    drainTimeoutMs?: number;
     system: {
       destroy(): Promise<void>;
     };
@@ -701,7 +702,9 @@ interface ResolveBenchRuntimeProfileOptions {
   amaBenchCrossJudgeBaseUrl?: string;
   amaBenchCrossJudgeApiKey?: string;
   amaBenchCrossJudgeCodexReasoningEffort?: "low" | "medium" | "high" | "xhigh";
+  lcmObserveConcurrency?: number;
   requestTimeout?: number;
+  drainTimeout?: number;
   max429WaitMs?: number;
   disableThinking?: boolean;
 }
@@ -715,6 +718,7 @@ interface ResolvedBenchRuntimeProfile {
     preserveRuntimeDefaults?: boolean;
     responder?: unknown;
     judge?: unknown;
+    drainTimeoutMs?: number;
   };
   systemProvider: BenchProviderConfig | null;
   judgeProvider: BenchProviderConfig | null;
@@ -8552,8 +8556,9 @@ Other:
     }
 
     case "import": {
-      // Infrastructure-only in slice 1 (#568). The four adapter packages
-      // (@remnic/import-chatgpt/claude/gemini/mem0) land in slices 2-5 and
+      // Infrastructure-only in slice 1 (#568). The optional adapter packages
+      // (@remnic/import-chatgpt/claude/gemini/mem0/supermemory) land in
+      // follow-up slices and
       // are loaded via computed-specifier dynamic import — running
       // `remnic import --adapter chatgpt` today surfaces a clean install
       // hint rather than MODULE_NOT_FOUND.

--- a/packages/remnic-cli/src/optional-import-lossless-claw.ts
+++ b/packages/remnic-cli/src/optional-import-lossless-claw.ts
@@ -8,14 +8,13 @@
 // type-checks even when the optional package is not yet linked into
 // node_modules — same pattern as optional-importer.ts.
 
+import type { openLcmDatabase } from "@remnic/core";
+
 import { isSpecifierNotFoundError } from "./optional-module-loader.js";
 
 const SPECIFIER = "@remnic/" + "import-lossless-claw";
 
-interface BetterSqlite3DatabaseLike {
-  prepare(sql: string): unknown;
-  close(): void;
-}
+type BetterSqlite3DatabaseLike = ReturnType<typeof openLcmDatabase>;
 
 export interface ImportLosslessClawModule {
   openSourceDatabase(filePath: string): BetterSqlite3DatabaseLike;
@@ -32,6 +31,8 @@ export interface ImportLosslessClawModule {
     sessionsTouched: string[];
     messagesInserted: number;
     messagesSkipped: number;
+    messagePartsInserted: number;
+    messagePartsSkipped: number;
     summariesInserted: number;
     summariesSkipped: number;
     summariesMultiParentCollapsed: number;

--- a/packages/remnic-cli/src/optional-importer.ts
+++ b/packages/remnic-cli/src/optional-importer.ts
@@ -1,8 +1,8 @@
 // Lazy loader for optional @remnic/import-<source> packages (issue #568).
 //
-// Each supported source (chatgpt, claude, gemini, mem0) ships as its own
-// optional workspace package so the CLI stays à la carte — users who only
-// need one importer should not have to install the other three. Loading goes
+// Each supported source (chatgpt, claude, gemini, mem0, supermemory) ships as
+// its own optional workspace package so the CLI stays à la carte — users who only
+// need one importer should not have to install the others. Loading goes
 // through this helper so the bundler cannot statically resolve the specifier
 // (computed-string-concatenation import) and so every importer gets the same
 // "install hint on miss, re-throw on every other error" treatment as the


### PR DESCRIPTION
## Summary
- split bundle auto-detect support from the full optional importer union so Supermemory remains supported without forcing a fake bundle order
- mirror bench drain timeout and LCM observe concurrency fields in the CLI package-backed bench contract
- update the lossless-claw optional loader contract with message-part counters and the core LCM database type

## Clawpatch findings
- fnd_sig-feat-cli-command-72fd8b2e72-_254b074819
- fnd_sig-feat-cli-command-7a2b4279cc-_48e1d06aff
- fnd_sig-feat-cli-command-fdb2abc43c-_0a8320b0d9

## Verification
- pnpm --filter @remnic/cli run check-types
- pnpm --filter @remnic/cli test
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly type/contract alignment and help/test updates; behavior change is limited to narrowing bundle auto-detect to a fixed importer subset while keeping `supermemory` available via explicit `--adapter`.
> 
> **Overview**
> **Importer/bundle detection contracts were split.** Bundle auto-detect now uses a dedicated `BUNDLE_SUPPORTED_IMPORTERS` subset and `DetectedBundleEntry.adapter` is narrowed to that union, with tests asserting `supermemory` remains *optional* but is not part of bundle ordering.
> 
> **`remnic import` now includes `supermemory` in the supported adapter list and help/validation output**, updating usage text and tests accordingly.
> 
> **CLI package-backed contracts were refreshed to match upstream types:** the bench-facing config/types add `lcmObserveConcurrency` and drain-timeout fields, and the optional lossless-claw loader’s type shape now uses the core LCM DB type and includes message-part insert/skip counters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba3cd34652885b0727b361465c7cb5fb89b53b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->