### PR TITLE
test(cli): run full package test surface

### DIFF
--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -28,7 +28,7 @@
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "precheck-types": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/import-dispatch.test.ts src/import-bundle-detect.test.ts src/optional-importer.test.ts src/bench-args.test.ts src/daemon-service.test.ts src/xray.test.ts",
+    "test": "tsx --test src/*.test.ts ../../tests/remnic-cli-bin-wrapper.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/tests/remnic-cli-bin-wrapper.test.ts
+++ b/tests/remnic-cli-bin-wrapper.test.ts
@@ -3,10 +3,12 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { constants } from "node:fs";
 import { chmod, copyFile, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { constants as osConstants, tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 
-const packageBinDir = join(process.cwd(), "packages", "remnic-cli", "bin");
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageBinDir = join(repoRoot, "packages", "remnic-cli", "bin");
 const remnicBin = join(packageBinDir, "remnic.cjs");
 const engramBin = join(packageBinDir, "engram.cjs");
 


### PR DESCRIPTION
## Summary
- run the package-level CLI test script against every src/*.test.ts file so newly added CLI tests are not skipped
- include the root remnic-cli bin-wrapper contract test in the package test command
- resolve bin-wrapper fixture paths from the test file so the test also works when invoked from packages/remnic-cli

Findings addressed:
- fnd_sig-feat-cli-command-4da7701963-_c22e30c651
- fnd_sig-feat-cli-command-72fd8b2e72-_f7ca0971e5

## Verification
- pnpm --filter @remnic/cli test
- pnpm --filter @remnic/cli run check-types
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test execution wiring and path resolution for a CLI bin wrapper contract test.
> 
> **Overview**
> **Expands CLI test coverage and makes tests more robust.** The `@remnic/cli` `test` script now runs *all* `src/*.test.ts` files and also executes the shared `tests/remnic-cli-bin-wrapper.test.ts` contract test.
> 
> The bin-wrapper test now resolves the repo root from the test file location (via `import.meta.url`) instead of `process.cwd()`, so it works when invoked from within `packages/remnic-cli` as well as from the repo root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad6348d922d14c05debfbe349cf7e7b06d4930d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->