### PR TITLE
fix(cli): avoid shelling launchctl plist paths

### DIFF
--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -5,6 +5,8 @@ import { pathToFileURL } from "node:url";
 
 import {
   inspectLaunchdPlist,
+  launchdLoadPlist,
+  launchdUnloadPlist,
   readLaunchdProgramArguments,
   resolveServerBinDetails,
 } from "./daemon-service.js";
@@ -185,6 +187,46 @@ test("readLaunchdProgramArguments parses plist string entries", () => {
   assert.deepEqual(args, [
     "/usr/local/bin/node",
     "/Users/test/Remnic & Server/dist/index.js",
+  ]);
+});
+
+test("launchdLoadPlist invokes launchctl with argv instead of a shell command", () => {
+  const calls: Array<{ command: string; args: string[]; options: unknown }> = [];
+  const hostilePath = `/Users/test"$(touch injected)"/Library/LaunchAgents/ai.remnic.daemon.plist`;
+
+  launchdLoadPlist(hostilePath, {
+    execFileSync: (command, args, options) => {
+      calls.push({ command, args: [...args], options });
+      return Buffer.alloc(0);
+    },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: "launchctl",
+      args: ["load", "-w", hostilePath],
+      options: { stdio: "pipe" },
+    },
+  ]);
+});
+
+test("launchdUnloadPlist invokes launchctl with argv instead of a shell command", () => {
+  const calls: Array<{ command: string; args: string[]; options: unknown }> = [];
+  const hostilePath = `/Users/test"; touch injected; echo "/Library/LaunchAgents/ai.remnic.daemon.plist`;
+
+  launchdUnloadPlist(hostilePath, {
+    execFileSync: (command, args, options) => {
+      calls.push({ command, args: [...args], options });
+      return Buffer.alloc(0);
+    },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: "launchctl",
+      args: ["unload", hostilePath],
+      options: { stdio: "pipe" },
+    },
   ]);
 });
 

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import * as childProcess from "node:child_process";
 import { fileURLToPath } from "node:url";
 import {
   findCommandOnPath as findCommandOnPathDefault,
@@ -43,7 +44,29 @@ export interface InspectLaunchdPlistOptions {
   readFileSync?: (file: string, encoding: BufferEncoding) => string;
 }
 
+export interface LaunchctlProcess {
+  execFileSync: (
+    command: string,
+    args: string[],
+    options: childProcess.ExecFileSyncOptions,
+  ) => Buffer | string;
+}
+
 const thisModuleDir = path.dirname(fileURLToPath(import.meta.url));
+
+export function launchdLoadPlist(
+  plistPath: string,
+  processApi: LaunchctlProcess = childProcess,
+): void {
+  processApi.execFileSync("launchctl", ["load", "-w", plistPath], { stdio: "pipe" });
+}
+
+export function launchdUnloadPlist(
+  plistPath: string,
+  processApi: LaunchctlProcess = childProcess,
+): void {
+  processApi.execFileSync("launchctl", ["unload", plistPath], { stdio: "pipe" });
+}
 
 export function resolveServerBinDetails(options: ResolveServerBinOptions = {}): ServerBinResolution {
   const existsSync = options.existsSync ?? fs.existsSync;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -206,6 +206,8 @@ import {
 import { expandTilde, resolveHomeDir } from "./path-utils.js";
 import {
   inspectLaunchdPlist,
+  launchdLoadPlist,
+  launchdUnloadPlist,
   resolveServerBin,
   resolveServerBinDetails,
 } from "./daemon-service.js";
@@ -6661,8 +6663,7 @@ function daemonInstall(): void {
     fs.mkdirSync(path.dirname(LAUNCHD_PLIST_PATH), { recursive: true });
     fs.writeFileSync(LAUNCHD_PLIST_PATH, plist);
     try {
-
-      childProcess.execSync(`launchctl load -w "${LAUNCHD_PLIST_PATH}"`, { stdio: "pipe" });
+      launchdLoadPlist(LAUNCHD_PLIST_PATH);
     } catch {
       // May already be loaded
     }
@@ -6698,7 +6699,7 @@ function daemonUninstall(): void {
     let removed = false;
     for (const plistPath of LAUNCHD_PLIST_PATHS) {
       try {
-        childProcess.execSync(`launchctl unload "${plistPath}"`, { stdio: "pipe" });
+        launchdUnloadPlist(plistPath);
       } catch {
         // May not be loaded
       }


### PR DESCRIPTION
## Summary
- route launchd load/unload through execFileSync argv helpers instead of shell command strings
- keep daemon install/uninstall best-effort behavior while removing plist path interpolation
- add hostile-path regression tests for both launchctl load and unload

Finding addressed:
- fnd_sig-feat-cli-command-7a2b4279cc-_4b0322dbcb

## Verification
- pnpm exec tsx --test packages/remnic-cli/src/daemon-service.test.ts
- pnpm --filter @remnic/cli run check-types
- pnpm --filter @remnic/cli test
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CLI installs/uninstalls the macOS launchd daemon by switching from shell command strings to `execFileSync` argv calls, which is security-sensitive and could impact daemon management behavior. Scope is small and covered by targeted regression tests for hostile plist paths.
> 
> **Overview**
> Updates the macOS daemon install/uninstall flow to **stop interpolating launchd plist paths into shell commands** and instead route `launchctl load`/`unload` through new `launchdLoadPlist`/`launchdUnloadPlist` helpers that use `execFileSync` with an argv array.
> 
> Adds regression tests using intentionally hostile plist paths to ensure `launchctl` is invoked with argv (not a shell), preserving the existing best-effort behavior around already-loaded/not-loaded services.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5c9278a9ab6e1205e039d3a8b7655a65c451a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->