### PR TITLE
fix(core): fail connectors run on state write errors

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -229,6 +229,7 @@ import {
   renderConnectorsList,
   renderConnectorsRunResult,
   runConnectorPollOnce,
+  type ConnectorsOutputFormat,
   type ConnectorRow,
   type ConnectorRunResult,
 } from "./connectors-cli.js";
@@ -280,6 +281,14 @@ interface EngramMcpServerLike {
   runStdio(input: Readable, output: Writable): Promise<void>;
 }
 
+export interface ConnectorsRunCliOutputOptions {
+  connectorId: string;
+  result: ConnectorRunResult;
+  format: ConnectorsOutputFormat;
+  stdout?: (output: string) => void;
+  stderr?: (output: string) => void;
+}
+
 export interface DedupeCandidate {
   path: string;
   content: string;
@@ -289,6 +298,24 @@ export interface DedupeCandidate {
     updated?: string;
     created?: string;
   };
+}
+
+export function emitConnectorsRunCliResult({
+  connectorId,
+  result,
+  format,
+  stdout = (output) => process.stdout.write(output),
+  stderr = (output) => process.stderr.write(output),
+}: ConnectorsRunCliOutputOptions): number {
+  const output = renderConnectorsRunResult(connectorId, result, format);
+  const failed = result.error !== undefined || result.stateWriteError !== undefined;
+  if (failed) {
+    stderr(output + "\n");
+    return 1;
+  }
+
+  stdout(output + "\n");
+  return 0;
 }
 
 export interface ExactDedupePlan {
@@ -5688,13 +5715,12 @@ export function registerCli(
               return;
             }
 
-            const output = renderConnectorsRunResult(name, runResult, format);
-            if (runResult.error !== undefined) {
-              process.stderr.write(output + "\n");
-              process.exitCode = 1;
-            } else {
-              console.log(output);
-            }
+            const exitCode = emitConnectorsRunCliResult({
+              connectorId: name,
+              result: runResult,
+              format,
+            });
+            if (exitCode !== 0) process.exitCode = exitCode;
           });
       }
 

--- a/tests/cli/connectors-run-cli-action.test.ts
+++ b/tests/cli/connectors-run-cli-action.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { emitConnectorsRunCliResult } from "../../src/cli.js";
+
+test("connectors run CLI treats cursor persistence failure as a failed run", () => {
+  let stdout = "";
+  let stderr = "";
+  const exitCode = emitConnectorsRunCliResult({
+    connectorId: "google-drive",
+    result: {
+      docsImported: 2,
+      stateWriteError: "EACCES: permission denied, open state.json",
+    },
+    format: "json",
+    stdout: (output) => {
+      stdout += output;
+    },
+    stderr: (output) => {
+      stderr += output;
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.equal(stdout, "");
+  const parsed = JSON.parse(stderr) as Record<string, unknown>;
+  assert.equal(parsed.connector, "google-drive");
+  assert.equal(parsed.docsImported, 2);
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.error, null);
+  assert.equal(parsed.stateWriteError, "EACCES: permission denied, open state.json");
+});


### PR DESCRIPTION
## Summary
- treat connector state-write failures as failed CLI runs even when sync/ingest succeeded
- route connector run output through a small helper that returns the process exit code
- add a regression test asserting stateWriteError-only results go to stderr with exit code 1

Finding addressed:
- fnd_sig-feat-cli-command-97f5c550dc-_73b3252fa9

## Verification
- pnpm exec tsx --test tests/cli/connectors-run-cli-action.test.ts
- pnpm exec tsx --test tests/cli/connectors.test.ts tests/cli/connectors-run-ordering.test.ts
- pnpm exec tsc --noEmit
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `remnic connectors run` success/failure semantics by returning non-zero exit codes and emitting to stderr when cursor/error-state persistence fails, which may affect scripts relying on prior exit code/output streams.
> 
> **Overview**
> Updates `remnic connectors run` to treat `stateWriteError` (cursor/error-state persistence failures) as a failed run, not just sync/ingest errors.
> 
> Introduces `emitConnectorsRunCliResult()` to centralize rendering + stdout/stderr routing and return an exit code, and adds a regression test ensuring a state-write-only failure exits `1` and writes JSON output to stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0929c60b48be925e782443e90a725e11401b4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->