### PR TITLE
fix(cli): validate taxonomy resolve flags

### DIFF
--- a/packages/remnic-cli/src/cli-args.ts
+++ b/packages/remnic-cli/src/cli-args.ts
@@ -26,32 +26,76 @@ export function hasFlag(args: string[], flag: string): boolean {
 }
 
 /**
- * Set of flags for `taxonomy resolve` that are boolean (no trailing value).
- * Key-value flags (like `--category`) consume the next token as their value.
+ * Flag spec for `taxonomy resolve`.
  */
 export const TAXONOMY_RESOLVE_BOOLEAN_FLAGS = new Set(["--json"]);
+export const TAXONOMY_RESOLVE_VALUE_FLAGS = new Set(["--category"]);
+
+export interface TaxonomyResolveArgs {
+  textParts: string[];
+  values: Record<string, string>;
+  booleans: Set<string>;
+}
 
 /**
  * Strip CLI flags from `taxonomy resolve` argument tokens, returning only
  * the text parts. Boolean flags (e.g. `--json`) skip only the flag itself;
  * key-value flags (e.g. `--category preference`) skip the flag and its
  * following value token.
+ *
+ * Use `--` before literal text that starts with `--`.
  */
 export function stripResolveFlags(
   args: string[],
   booleanFlags: ReadonlySet<string> = TAXONOMY_RESOLVE_BOOLEAN_FLAGS,
+  valueFlags: ReadonlySet<string> = TAXONOMY_RESOLVE_VALUE_FLAGS,
 ): string[] {
+  return parseTaxonomyResolveArgs(args, booleanFlags, valueFlags).textParts;
+}
+
+export function parseTaxonomyResolveArgs(
+  args: string[],
+  booleanFlags: ReadonlySet<string> = TAXONOMY_RESOLVE_BOOLEAN_FLAGS,
+  valueFlags: ReadonlySet<string> = TAXONOMY_RESOLVE_VALUE_FLAGS,
+): TaxonomyResolveArgs {
   const textParts: string[] = [];
+  const values: Record<string, string> = {};
+  const booleans = new Set<string>();
+  let literalText = false;
+
   for (let i = 0; i < args.length; i++) {
-    if (args[i].startsWith("--")) {
-      // Boolean flags have no trailing value — skip only the flag itself
-      if (!booleanFlags.has(args[i])) {
-        // Key-value flag: skip the flag and its value (next token)
-        i++;
-      }
+    const arg = args[i];
+    if (literalText) {
+      textParts.push(arg);
       continue;
     }
-    textParts.push(args[i]);
+
+    if (arg === "--") {
+      literalText = true;
+      continue;
+    }
+
+    if (arg.startsWith("--")) {
+      if (booleanFlags.has(arg)) {
+        booleans.add(arg);
+        continue;
+      }
+
+      if (valueFlags.has(arg)) {
+        const value = args[i + 1];
+        if (value === undefined || value.startsWith("--")) {
+          throw new Error(`${arg} requires a value`);
+        }
+        values[arg] = value;
+        i++;
+        continue;
+      }
+
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+
+    textParts.push(arg);
   }
-  return textParts;
+
+  return { textParts, values, booleans };
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -211,8 +211,19 @@ import {
   resolveServerBin,
   resolveServerBinDetails,
 } from "./daemon-service.js";
-export { hasFlag, resolveFlag, stripResolveFlags, TAXONOMY_RESOLVE_BOOLEAN_FLAGS } from "./cli-args.js";
-import { hasFlag, resolveFlag, stripResolveFlags, TAXONOMY_RESOLVE_BOOLEAN_FLAGS } from "./cli-args.js";
+export {
+  hasFlag,
+  parseTaxonomyResolveArgs,
+  resolveFlag,
+  stripResolveFlags,
+  TAXONOMY_RESOLVE_BOOLEAN_FLAGS,
+  TAXONOMY_RESOLVE_VALUE_FLAGS,
+} from "./cli-args.js";
+import {
+  hasFlag,
+  parseTaxonomyResolveArgs,
+  resolveFlag,
+} from "./cli-args.js";
 import { parseConnectorConfig, stripConfigArgv } from "./parse-connector-config.js";
 // `remnic import` top-level command (issue #568 slice 1). The adapter packages
 // are optional à-la-carte installs loaded via computed-specifier dynamic
@@ -7710,22 +7721,26 @@ async function cmdTaxonomy(rest: string[]): Promise<void> {
     }
 
     case "resolve": {
-      // Strip --flag and its following value token together so flag values
-      // (e.g. "preference" in `--category preference`) don't leak into text.
-      // Boolean flags (like --json) don't consume a following value token.
       const resolveArgs = rest.slice(1);
-      const textParts = stripResolveFlags(resolveArgs, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
+      let parsedResolveArgs: ReturnType<typeof parseTaxonomyResolveArgs>;
+      try {
+        parsedResolveArgs = parseTaxonomyResolveArgs(resolveArgs);
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      const textParts = parsedResolveArgs.textParts;
       const text = textParts.join(" ");
       if (!text) {
         console.error("Usage: remnic taxonomy resolve <text>");
         process.exit(1);
       }
 
-      const categoryFlag = resolveFlag(rest, "--category") as MemoryCategory | undefined;
+      const categoryFlag = parsedResolveArgs.values["--category"] as MemoryCategory | undefined;
       const memoryCategory: MemoryCategory = categoryFlag ?? "fact";
       const taxonomy = await loadTaxonomy(config.memoryDir);
       const decision = resolveCategory(text, memoryCategory, taxonomy);
-      const json = rest.includes("--json");
+      const json = parsedResolveArgs.booleans.has("--json");
 
       if (json) {
         console.log(JSON.stringify(decision, null, 2));

--- a/tests/taxonomy-cli-boolean-flag.test.ts
+++ b/tests/taxonomy-cli-boolean-flag.test.ts
@@ -12,6 +12,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { coerceBool, coerceInstallExtension } from "../packages/remnic-core/src/connectors/coerce.js";
 import {
+  parseTaxonomyResolveArgs,
   stripResolveFlags,
   TAXONOMY_RESOLVE_BOOLEAN_FLAGS,
 } from "../packages/remnic-cli/src/cli-args.js";
@@ -57,6 +58,38 @@ describe("taxonomy resolve flag stripping", () => {
     const args = ["--json"];
     const result = stripResolveFlags(args, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
     assert.deepStrictEqual(result, []);
+  });
+
+  it("rejects unknown option-looking tokens instead of dropping following text", () => {
+    assert.throws(
+      () => stripResolveFlags(["remember", "--jsoon", "the", "thing"]),
+      /Unknown flag: --jsoon/,
+    );
+  });
+
+  it("rejects --category with no value", () => {
+    assert.throws(
+      () => stripResolveFlags(["remember", "--category"]),
+      /--category requires a value/,
+    );
+  });
+
+  it("rejects --category followed by another flag", () => {
+    assert.throws(
+      () => stripResolveFlags(["remember", "--category", "--json"]),
+      /--category requires a value/,
+    );
+  });
+
+  it("allows literal option-looking text after -- delimiter", () => {
+    const result = stripResolveFlags(["--json", "--", "--literal", "text"]);
+    assert.deepStrictEqual(result, ["--literal", "text"]);
+  });
+
+  it("does not treat --category after -- delimiter as a flag value", () => {
+    const result = parseTaxonomyResolveArgs(["--category", "fact", "--", "--category", "literal"]);
+    assert.deepStrictEqual(result.textParts, ["--category", "literal"]);
+    assert.equal(result.values["--category"], "fact");
   });
 });
 


### PR DESCRIPTION
## Summary
- parse `taxonomy resolve` arguments with explicit boolean/value flag sets
- reject unknown `--...` tokens and malformed `--category` values instead of dropping user text
- support `--` so literal option-looking resolve text can still be passed intentionally

## Finding addressed
- `fnd_sig-feat-cli-command-a009cd200b-_5d0a16b6d8`

## Verification
- `pnpm exec tsx --test tests/taxonomy-cli-boolean-flag.test.ts`
- `pnpm --filter @remnic/cli run check-types`
- `pnpm --filter @remnic/cli test`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `taxonomy resolve` argument parsing to error on unknown/malformed flags and introduces `--` literal-text handling, which can break existing invocations that relied on previous permissive behavior.
> 
> **Overview**
> Tightens `remnic taxonomy resolve` CLI parsing by introducing `parseTaxonomyResolveArgs` with explicit boolean/value flag specs (e.g. `--json`, `--category`).
> 
> The command now **rejects unknown `--...` tokens** and **errors when `--category` is missing/has an invalid value**, instead of silently treating them as text; it also supports `--` to pass option-looking text literally. Tests are expanded to cover the new validation and delimiter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb0f96e5b32d85e5c82d1a2f63d10aabcba0491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->