### PR TITLE
fix(connector-weclone): handle cli startup errors

### DIFF
--- a/packages/connector-weclone/src/cli.test.ts
+++ b/packages/connector-weclone/src/cli.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as net from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+const tsxCli = join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const cliPath = join(__dirname, "cli.ts");
+
+function runCliWithConfig(config: unknown) {
+  const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-cli-"));
+  const configPath = join(tempDir, "weclone.json");
+  writeFileSync(configPath, JSON.stringify(config), { mode: 0o600 });
+  try {
+    return spawnSync(process.execPath, [tsxCli, cliPath, "--config", configPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function listenOnEphemeralPort(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolveServer, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, () => {
+      server.off("error", reject);
+      const address = server.address();
+      assert.ok(address && typeof address === "object");
+      resolveServer({ server, port: address.port });
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolveClose, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolveClose();
+    });
+  });
+}
+
+describe("remnic-weclone-proxy CLI", () => {
+  it("prints a controlled error for semantically invalid config", () => {
+    const result = runCliWithConfig({
+      proxyPort: 8100,
+      remnicDaemonUrl: "http://127.0.0.1:4318",
+    });
+
+    assert.ifError(result.error);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Invalid config at .*weclone\.json:/);
+    assert.match(result.stderr, /wecloneApiUrl/);
+    assert.doesNotMatch(result.stderr, /at parseConfig/);
+  });
+
+  it("prints a controlled error when proxy startup fails", async () => {
+    const { server, port } = await listenOnEphemeralPort();
+    try {
+      const result = runCliWithConfig({
+        wecloneApiUrl: "http://127.0.0.1:8000/v1",
+        proxyPort: port,
+        remnicDaemonUrl: "http://127.0.0.1:4318",
+      });
+
+      assert.ifError(result.error);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /Failed to start WeClone proxy:/);
+      assert.match(result.stderr, /EADDRINUSE|address already in use/i);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -9,7 +9,7 @@
  */
 
 import { createWeCloneProxy } from "./proxy.js";
-import { parseConfig } from "./config.js";
+import { parseConfig, type WeCloneConnectorConfig } from "./config.js";
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { homedir } from "node:os";
@@ -42,63 +42,83 @@ function defaultConfigPath(): string {
   return resolve(home, ".remnic", "connectors", "weclone.json");
 }
 
-// Parse --config first so an explicit path takes precedence over env-var
-// resolution. Only fall back to defaultConfigPath() when the user has not
-// supplied an explicit --config flag. This lets `remnic-weclone-proxy
-// --config /abs/path` work even in environments where REMNIC_HOME is
-// misconfigured, without defaultConfigPath() (and any env-var validation
-// it contains) running unnecessarily.
-const args = process.argv.slice(2);
-let configPath: string | null = null;
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
-for (let i = 0; i < args.length; i++) {
-  if (args[i] === "--config") {
-    if (!args[i + 1]) {
-      console.error("Error: --config requires a path argument");
-      process.exit(1);
+async function main(): Promise<void> {
+  // Parse --config first so an explicit path takes precedence over env-var
+  // resolution. Only fall back to defaultConfigPath() when the user has not
+  // supplied an explicit --config flag. This lets `remnic-weclone-proxy
+  // --config /abs/path` work even in environments where REMNIC_HOME is
+  // misconfigured, without defaultConfigPath() (and any env-var validation
+  // it contains) running unnecessarily.
+  const args = process.argv.slice(2);
+  let configPath: string | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--config") {
+      if (!args[i + 1]) {
+        console.error("Error: --config requires a path argument");
+        process.exit(1);
+      }
+      configPath = resolve(args[i + 1]);
+      i++;
     }
-    configPath = resolve(args[i + 1]);
-    i++;
   }
-}
 
-if (configPath === null) {
-  configPath = defaultConfigPath();
-}
+  if (configPath === null) {
+    configPath = defaultConfigPath();
+  }
 
-if (!existsSync(configPath)) {
-  console.error(`Config not found: ${configPath}`);
-  console.error("Run: remnic connectors install weclone");
-  process.exit(1);
-}
+  if (!existsSync(configPath)) {
+    console.error(`Config not found: ${configPath}`);
+    console.error("Run: remnic connectors install weclone");
+    process.exit(1);
+  }
 
-let raw: unknown;
-try {
-  raw = JSON.parse(readFileSync(configPath, "utf-8"));
-} catch (err) {
-  console.error(`Failed to parse config at ${configPath}: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
-}
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    console.error(`Failed to parse config at ${configPath}: ${errorMessage(err)}`);
+    process.exit(1);
+  }
 
-if (typeof raw !== "object" || raw === null) {
-  console.error(`Config at ${configPath} must be a JSON object`);
-  process.exit(1);
-}
+  if (typeof raw !== "object" || raw === null) {
+    console.error(`Config at ${configPath} must be a JSON object`);
+    process.exit(1);
+  }
 
-const config = parseConfig(raw);
-const proxy = createWeCloneProxy(config);
+  let config: WeCloneConnectorConfig;
+  try {
+    config = parseConfig(raw);
+  } catch (err) {
+    console.error(`Invalid config at ${configPath}: ${errorMessage(err)}`);
+    process.exit(1);
+  }
 
-proxy.start().then(() => {
+  const proxy = createWeCloneProxy(config);
+  try {
+    await proxy.start();
+  } catch (err) {
+    console.error(`Failed to start WeClone proxy: ${errorMessage(err)}`);
+    process.exit(1);
+  }
+
   console.log(`WeClone memory proxy listening on :${config.proxyPort}`);
   console.log(`  WeClone API: ${config.wecloneApiUrl}`);
   console.log(`  Remnic daemon: ${config.remnicDaemonUrl}`);
-});
 
-process.on("SIGINT", () => {
-  proxy.stop();
-  process.exit(0);
-});
-process.on("SIGTERM", () => {
-  proxy.stop();
-  process.exit(0);
+  const stopAndExit = () => {
+    void proxy.stop();
+    process.exit(0);
+  };
+  process.on("SIGINT", stopAndExit);
+  process.on("SIGTERM", stopAndExit);
+}
+
+void main().catch((err) => {
+  console.error(`Failed to start WeClone proxy: ${errorMessage(err)}`);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- wrap WeClone proxy semantic config validation in controlled CLI stderr/exit handling
- report proxy startup failures, including occupied ports, as deterministic CLI errors
- add entrypoint tests for invalid config and listen failure paths

## Finding addressed
- `fnd_sig-feat-cli-command-aeb69150ee-_bdb295d7f6`

## Verification
- `pnpm --filter @remnic/connector-weclone test`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the CLI entrypoint’s error handling and add tests; core proxy behavior is unchanged.
> 
> **Overview**
> **Improves `remnic-weclone-proxy` CLI error handling** by wrapping config validation (`parseConfig`) and proxy startup (`proxy.start()`) in `try/catch`, emitting controlled stderr messages and exiting with status `1` instead of leaking stack traces.
> 
> Adds a new `cli.test.ts` that spawns the CLI with a temp config to assert deterministic output for *semantically invalid config* and *startup failure (e.g., `EADDRINUSE` when the port is occupied)*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73eac152a7cbf0055249937886dfbe9d7a1342e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->