### PR TITLE
fix(build): route root cli shims through core exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "check:openclaw-plugin-sync": "node scripts/check-openclaw-plugin-sync.mjs",
     "check:openclaw-sdk-surface": "node scripts/check-openclaw-sdk-surface.mjs",
     "check:openclaw-sdk-surface:required": "node scripts/check-openclaw-sdk-surface.mjs --require",
-    "build": "pnpm run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
+    "build": "pnpm --filter @remnic/core build && pnpm run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
     "dev": "tsup --watch",
     "check-types": "tsc --noEmit",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -13,6 +13,10 @@
     "./access-cli": {
       "import": "./dist/access-cli.js",
       "types": "./dist/access-cli.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
     }
   },
   "files": [

--- a/src/access-cli.ts
+++ b/src/access-cli.ts
@@ -1,1 +1,1 @@
-export * from "../packages/remnic-core/src/access-cli.js";
+export * from "@remnic/core/access-cli";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,1 +1,1 @@
-export * from "../packages/remnic-core/src/cli.js";
+export * from "@remnic/core/cli";

--- a/tests/root-cli-package-boundary.test.ts
+++ b/tests/root-cli-package-boundary.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT_CLI_SHIMS = [
+  ["src/access-cli.ts", "@remnic/core/access-cli"],
+  ["src/cli.ts", "@remnic/core/cli"],
+] as const;
+
+describe("root CLI package boundaries", () => {
+  for (const [filePath, publicSpecifier] of ROOT_CLI_SHIMS) {
+    it(`${filePath} uses the public @remnic/core package export`, () => {
+      const source = readFileSync(resolve(filePath), "utf8");
+
+      assert.ok(
+        source.includes(`from "${publicSpecifier}"`),
+        `${filePath} should import ${publicSpecifier}`,
+      );
+      assert.doesNotMatch(
+        source,
+        /packages\/remnic-core\/src/,
+        `${filePath} must not import core private source paths`,
+      );
+    });
+  }
+
+  it("root build prepares core public subpath artifacts before bundling shims", () => {
+    const manifest = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as {
+      scripts?: { build?: string };
+    };
+    const buildScript = manifest.scripts?.build ?? "";
+    const coreBuild = "pnpm --filter @remnic/core build";
+    const rootBundle = "tsup";
+
+    assert.ok(
+      buildScript.includes(coreBuild),
+      "root build should build @remnic/core before relying on its public subpath exports",
+    );
+    assert.ok(
+      buildScript.indexOf(coreBuild) < buildScript.indexOf(rootBundle),
+      "root build should prepare @remnic/core dist before running root tsup",
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
     "paths": {
       "@remnic/core": [
         "./packages/remnic-core/src/index.ts"
+      ],
+      "@remnic/core/*": [
+        "./packages/remnic-core/src/*.ts"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- route root CLI shims through public `@remnic/core/*` package exports instead of `packages/remnic-core/src/*`
- add a public `@remnic/core/cli` subpath export for the shared core CLI surface
- add a regression test that blocks private core source imports in the root CLI shim files

## Finding addressed
- `fnd_sig-feat-cli-command-c708252bd0-_e3c65ee34f`

## Verification
- `pnpm exec tsx --test tests/root-cli-package-boundary.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `pnpm --filter @remnic/core build`
- `npm run build`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to package exports, TypeScript path mapping, and build/test wiring, with no runtime logic changes beyond how CLI entrypoints are resolved/bundled.
> 
> **Overview**
> Root CLI shim modules now re-export via public `@remnic/core/*` subpath exports instead of importing `packages/remnic-core/src` directly, and `@remnic/core` publishes a new `./cli` export to support this.
> 
> The root `build` script is updated to build `@remnic/core` first, `tsconfig.json` adds `@remnic/core/*` path mapping, and a new test (`root-cli-package-boundary.test.ts`) prevents regressions by asserting both the shim import specifiers and build ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9f87d1672831010b4605519d46afa8dfdc3c4a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->