### PR TITLE
fix(cli): reject malformed connector config flags

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5393,15 +5393,30 @@ function snapshotConnectorTokenEntry(connectorId: string): TokenEntry | null {
 // ── M5 connectors command ────────────────────────────────────────────────────
 
 async function cmdConnectors(action: string, rest: string[], json: boolean): Promise<void> {
-  // For install/remove/doctor, the connector ID is the first non-flag positional
-  // arg. We must strip the value tokens consumed by split-form `--config key=value`
-  // flags BEFORE filtering for non-flags, otherwise `installExtension=false`
-  // (the value of `--config installExtension=false`) would be mistaken for the
-  // connector ID when the user writes:
-  //   remnic connectors install --config installExtension=false codex-cli
-  const strippedRest = stripConfigArgv(rest);
-  const nonFlagArgs = strippedRest.filter((a) => !a.startsWith("--"));
-  const connectorId = nonFlagArgs[0];
+  const rawNonFlagArgs = rest.filter((a) => !a.startsWith("--"));
+  const resolveConfigStrippedNonFlagArgs = (): string[] => {
+    // Connector actions that resolve a connector id/name must strip split-form
+    // `--config key=value` values before filtering for positionals; otherwise
+    // `installExtension=false` can be mistaken for the connector name. Keep
+    // this out of the marketplace path because marketplace uses
+    // `--config <path>` with file-path semantics.
+    let strippedRest: string[];
+    try {
+      strippedRest = stripConfigArgv(rest);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    return strippedRest.filter((a) => !a.startsWith("--"));
+  };
+  const resolveConnectorId = (usage: string): string => {
+    const connectorId = resolveConfigStrippedNonFlagArgs()[0];
+    if (!connectorId) {
+      console.error(usage);
+      process.exit(1);
+    }
+    return connectorId;
+  };
 
   if (action === "list") {
     const { installed, available } = listConnectors();
@@ -5415,11 +5430,14 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       }
     }
   } else if (action === "install") {
-    if (!connectorId) {
-      console.error("Usage: remnic connectors install <id>");
+    const connectorId = resolveConnectorId("Usage: remnic connectors install <id>");
+    let connectorConfig: Record<string, unknown>;
+    try {
+      connectorConfig = parseConnectorConfig(rest);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     }
-    const connectorConfig = parseConnectorConfig(rest);
     const preInstallTokenEntry = snapshotConnectorTokenEntry(connectorId);
     const result = installConnector({
       connectorId,
@@ -5478,10 +5496,7 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       console.log("  Memory extension publish skipped via installExtension=false");
     }
   } else if (action === "remove") {
-    if (!connectorId) {
-      console.error("Usage: remnic connectors remove <id>");
-      process.exit(1);
-    }
+    const connectorId = resolveConnectorId("Usage: remnic connectors remove <id>");
     const connectorBeforeRemoval = listConnectors().installed.find(
       (connector) => connector.connectorId === connectorId,
     );
@@ -5520,10 +5535,7 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       process.exit(1);
     }
   } else if (action === "doctor") {
-    if (!connectorId) {
-      console.error("Usage: remnic connectors doctor <id>");
-      process.exit(1);
-    }
+    const connectorId = resolveConnectorId("Usage: remnic connectors doctor <id>");
     const result = await doctorConnector(connectorId);
 
     // Append memory extension publisher health only for the requested
@@ -5591,7 +5603,7 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       console.log(healthy ? "\nConnector healthy" : "\nConnector has issues");
     }
   } else if (action === "marketplace") {
-    const subAction = nonFlagArgs[0];
+    const subAction = rawNonFlagArgs[0];
     // Use the original `rest` (not strippedRest) because marketplace uses
     // `--config <path>` for a file path, not `--config key=value` pairs.
     // `stripConfigArgv` would silently remove that flag, breaking config
@@ -5676,7 +5688,7 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       runConnectorPollOnce: pollOnce,
     } = await import("@remnic/core" as string);
 
-    const rawName = nonFlagArgs[0];
+    const rawName = resolveConfigStrippedNonFlagArgs()[0];
     let connectorName: string;
     try {
       connectorName = parseRunName(rawName);

--- a/packages/remnic-cli/src/parse-connector-config.test.ts
+++ b/packages/remnic-cli/src/parse-connector-config.test.ts
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseConnectorConfig,
+  stripConfigArgv,
+} from "./parse-connector-config.js";
+
+test("parseConnectorConfig accepts joined and split key=value config", () => {
+  assert.deepEqual(
+    parseConnectorConfig([
+      "--config=codexHome=/tmp/remnic",
+      "--config",
+      "installExtension=false",
+    ]),
+    {
+      codexHome: "/tmp/remnic",
+      installExtension: "false",
+    },
+  );
+});
+
+test("parseConnectorConfig preserves values containing equals signs", () => {
+  assert.deepEqual(parseConnectorConfig(["--config", "token=a=b"]), {
+    token: "a=b",
+  });
+});
+
+test("parseConnectorConfig rejects missing split values", () => {
+  assert.throws(
+    () => parseConnectorConfig(["--config"]),
+    /--config requires key=value/,
+  );
+  assert.throws(
+    () => parseConnectorConfig(["--config", "--force"]),
+    /--config requires key=value/,
+  );
+});
+
+test("parseConnectorConfig rejects config values without an assignment", () => {
+  assert.throws(
+    () => parseConnectorConfig(["--config=installExtension"]),
+    /--config requires key=value/,
+  );
+  assert.throws(
+    () => parseConnectorConfig(["--config", "installExtension"]),
+    /--config requires key=value/,
+  );
+});
+
+test("parseConnectorConfig rejects empty config keys", () => {
+  assert.throws(
+    () => parseConnectorConfig(["--config==false"]),
+    /--config requires a non-empty key/,
+  );
+  assert.throws(
+    () => parseConnectorConfig(["--config", "=false"]),
+    /--config requires a non-empty key/,
+  );
+});
+
+test("stripConfigArgv removes valid config args before connector id resolution", () => {
+  assert.deepEqual(
+    stripConfigArgv([
+      "--config=codexHome=/tmp/remnic",
+      "--config",
+      "installExtension=false",
+      "--force",
+      "codex-cli",
+    ]),
+    ["--force", "codex-cli"],
+  );
+});
+
+test("stripConfigArgv rejects malformed config args instead of hiding them", () => {
+  assert.throws(
+    () => stripConfigArgv(["--config=installExtension", "codex-cli"]),
+    /--config requires key=value/,
+  );
+  assert.throws(
+    () => stripConfigArgv(["--config", "--force", "codex-cli"]),
+    /--config requires key=value/,
+  );
+});
+
+test("marketplace --config file paths are not connector key=value assignments", () => {
+  const marketplaceRest = [
+    "validate",
+    "--config",
+    "./remnic.json",
+    "./marketplace.json",
+  ];
+
+  assert.equal(
+    marketplaceRest.filter((arg) => !arg.startsWith("--"))[0],
+    "validate",
+  );
+  assert.throws(
+    () => stripConfigArgv(marketplaceRest),
+    /--config requires key=value/,
+  );
+});

--- a/packages/remnic-cli/src/parse-connector-config.ts
+++ b/packages/remnic-cli/src/parse-connector-config.ts
@@ -11,6 +11,18 @@
  *
  * Values may themselves contain "=", so we split on the first "=" only.
  */
+function parseConfigAssignment(raw: string, flag: string): [string, string] {
+  const eqIdx = raw.indexOf("=");
+  if (eqIdx === -1) {
+    throw new Error(`${flag} requires key=value`);
+  }
+  const key = raw.slice(0, eqIdx);
+  if (!key) {
+    throw new Error(`${flag} requires a non-empty key`);
+  }
+  return [key, raw.slice(eqIdx + 1)];
+}
+
 export function parseConnectorConfig(args: string[]): Record<string, unknown> {
   const config: Record<string, unknown> = {};
   for (let i = 0; i < args.length; i++) {
@@ -18,26 +30,17 @@ export function parseConnectorConfig(args: string[]): Record<string, unknown> {
     if (arg.startsWith("--config=")) {
       // Joined form: --config=key=value  (value may itself contain "=")
       const rest = arg.slice("--config=".length);
-      const eqIdx = rest.indexOf("=");
-      if (eqIdx !== -1) {
-        const key = rest.slice(0, eqIdx);
-        const value = rest.slice(eqIdx + 1);
-        if (key) config[key] = value;
-      }
+      const [key, value] = parseConfigAssignment(rest, "--config");
+      config[key] = value;
     } else if (arg === "--config") {
       // Split form: --config key=value
       const next = args[i + 1];
-      if (next !== undefined) {
-        const eqIdx = next.indexOf("=");
-        if (eqIdx !== -1) {
-          const key = next.slice(0, eqIdx);
-          const value = next.slice(eqIdx + 1);
-          if (key) {
-            config[key] = value;
-            i++; // consume the next token
-          }
-        }
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error("--config requires key=value");
       }
+      const [key, value] = parseConfigAssignment(next, "--config");
+      config[key] = value;
+      i++; // consume the next token
     }
   }
   return config;
@@ -64,15 +67,17 @@ export function stripConfigArgv(args: string[]): string[] {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg.startsWith("--config=")) {
-      // Joined form: the flag+value is a single token — skip it.
+      // Joined form: the flag+value is a single token - validate then skip it.
+      parseConfigAssignment(arg.slice("--config=".length), "--config");
       continue;
     } else if (arg === "--config") {
-      // Split form: peek at the next token. If it looks like key=value, skip
-      // both the flag and its value; otherwise skip only the flag (malformed).
+      // Split form: validate and skip both the flag and its value.
       const next = args[i + 1];
-      if (next !== undefined && next.includes("=") && !next.startsWith("--")) {
-        i++; // skip value token too
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error("--config requires key=value");
       }
+      parseConfigAssignment(next, "--config");
+      i++; // skip value token too
       continue;
     }
     result.push(arg);

--- a/tests/cli-connector-id-resolution.test.ts
+++ b/tests/cli-connector-id-resolution.test.ts
@@ -72,10 +72,7 @@ test("stripConfigArgv: split-form --config with value containing = signs", () =>
   assert.deepEqual(stripped, ["codex-cli"]);
 });
 
-test("stripConfigArgv: split-form --config followed by another flag (malformed) — flag only removed", () => {
-  // --config followed by --force (no = in next token) — should only skip the --config token.
+test("stripConfigArgv: split-form --config followed by another flag rejects malformed input", () => {
   const argv = ["--config", "--force", "codex-cli"];
-  const stripped = stripConfigArgv(argv);
-  // --force is NOT a config value (starts with --), so it is kept. --config is removed.
-  assert.deepEqual(stripped, ["--force", "codex-cli"]);
+  assert.throws(() => stripConfigArgv(argv), /--config requires key=value/);
 });

--- a/tests/cli-parse-connector-config.test.ts
+++ b/tests/cli-parse-connector-config.test.ts
@@ -54,8 +54,27 @@ test("parseConnectorConfig: no --config flags yields empty object", () => {
   assert.deepEqual(result, {});
 });
 
-test("parseConnectorConfig: split form does not consume non-kv next arg", () => {
-  // --config followed by something without = should be ignored
-  const result = parseConnectorConfig(["--config", "--force"]);
-  assert.deepEqual(result, {});
+test("parseConnectorConfig: split form rejects missing key=value", () => {
+  assert.throws(
+    () => parseConnectorConfig(["--config", "--force"]),
+    /--config requires key=value/,
+  );
+  assert.throws(
+    () => parseConnectorConfig(["--config", "codex-cli"]),
+    /--config requires key=value/,
+  );
+});
+
+test("parseConnectorConfig: joined form rejects missing key=value", () => {
+  assert.throws(
+    () => parseConnectorConfig(["--config=installExtension"]),
+    /--config requires key=value/,
+  );
+});
+
+test("parseConnectorConfig: rejects empty keys", () => {
+  assert.throws(
+    () => parseConnectorConfig(["--config==false"]),
+    /--config requires a non-empty key/,
+  );
 });


### PR DESCRIPTION
## Summary
- validate connector `--config` flags as `key=value` in joined and split forms
- reject missing values, missing assignments, and empty keys before connector install runs
- keep `stripConfigArgv` strict so malformed config tokens cannot be silently removed
- add package-local and root regression coverage

Closes clawpatch finding `fnd_sig-feat-cli-command-fdb2abc43c-_7d87c216cd`.

## Verification
- `pnpm exec tsx --test packages/remnic-cli/src/parse-connector-config.test.ts tests/cli-parse-connector-config.test.ts tests/cli-connector-id-resolution.test.ts`
- `pnpm --filter @remnic/core build`
- `pnpm --filter @remnic/cli test`
- `pnpm --filter @remnic/cli check-types`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI argument parsing to hard-fail on malformed `--config` usage and to resolve connector IDs differently across subcommands, which can break existing scripts that relied on previously-tolerated inputs.
> 
> **Overview**
> **Tightens validation of connector `--config` flags** so both joined (`--config=key=value`) and split (`--config key=value`) forms must include a non-empty key and an `=` assignment, while still allowing values containing additional `=`.
> 
> Updates `cmdConnectors` positional parsing to avoid misidentifying split `--config` values as connector IDs for `install`/`remove`/`doctor`/`run`, adds explicit error handling (exit non-zero) on bad `--config`, and expands regression tests to cover these stricter failure cases (including keeping marketplace `--config <path>` semantics separate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7a6263508ff717acd9e70809de29bbf04e12558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->