### PR TITLE
fix(build): route make lint to typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 	npm test
 
 lint:
-	npm run lint
+	npm run check-types
 
 preflight:
 	npm run preflight

--- a/tests/makefile-lint-target.test.ts
+++ b/tests/makefile-lint-target.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("make lint delegates to an existing type-check script", () => {
+  const dryRun = spawnSync("make", ["-n", "lint"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(dryRun.status, 0, dryRun.stderr);
+  assert.match(dryRun.stdout, /\bnpm run check-types\b/);
+  assert.doesNotMatch(dryRun.stdout, /\bnpm run lint\b/);
+
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  assert.equal(typeof pkg.scripts?.["check-types"], "string");
+});


### PR DESCRIPTION
## Summary
- update `make lint` to call the existing root `check-types` script
- add a regression test that dry-runs the Makefile target and verifies the delegated script exists

## Verification
- `pnpm install --frozen-lockfile`
- `make -n lint`
- `pnpm exec tsx --test tests/makefile-lint-target.test.ts`
- `git diff --check`
- `make lint`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build/test harness change: updates the `make lint` target to run type-checking and adds a small regression test to ensure the Makefile delegates to an existing npm script.
> 
> **Overview**
> **`make lint` no longer calls `npm run lint`; it now delegates to the existing `check-types` script.**
> 
> Adds `tests/makefile-lint-target.test.ts`, which dry-runs `make -n lint` to assert the Makefile invokes `npm run check-types` (and not `npm run lint`) and verifies `package.json` defines the `check-types` script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5ba6572201136c859d6a03b9653ec96144bc9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->