### PR TITLE
fix(build): typecheck workspace packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo ""
 	@echo "  make build           Compile TypeScript to dist/"
 	@echo "  make test            Run full test suite"
-	@echo "  make lint            TypeScript type check (tsc --noEmit)"
+	@echo "  make lint            TypeScript type check (root + workspace packages)"
 	@echo "  make preflight       Full pre-PR gate (types + contract + tests + build)"
 	@echo "  make preflight-quick Fast pre-PR gate (types + contract + key tests)"
 	@echo "  make clean           Remove dist/ and build artifacts"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "check:openclaw-sdk-surface:required": "node scripts/check-openclaw-sdk-surface.mjs --require",
     "build": "pnpm --filter @remnic/core build && pnpm run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
     "dev": "tsup --watch",
-    "check-types": "tsc --noEmit",
+    "check-types": "pnpm --filter @remnic/core build && tsc --noEmit && pnpm --recursive --if-present --filter=\"./packages/*\" run check-types",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
     "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts' 'packages/export-weclone/src/**/*.test.ts' 'packages/import-weclone/src/**/*.test.ts'",
     "test:openclaw-scenarios": "pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",

--- a/packages/bench-ui/package.json
+++ b/packages/bench-ui/package.json
@@ -6,6 +6,7 @@
   "description": "Minimal local UI shell for browsing Remnic benchmark result summaries.",
   "scripts": {
     "dev": "vite",
+    "check-types": "tsc --noEmit",
     "build": "vite build"
   },
   "dependencies": {

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "prebuild": "node ../../scripts/ensure-bench-build-deps.mjs",
     "build": "tsup --config tsup.config.ts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/packages/connector-weclone/package.json
+++ b/packages/connector-weclone/package.json
@@ -17,6 +17,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts src/cli.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
     "test": "tsx --test src/*.test.ts",
     "prepublishOnly": "npm run build"
   },

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -1134,7 +1134,9 @@ describe("WeCloneProxy", () => {
 
     assert.equal(res.status, 200);
     assert.ok(recallCalled, "Recall must be invoked for chat URLs with query strings");
-    const msgs = (receivedBody as Record<string, unknown>).messages as Array<{
+    const forwardedBody = receivedBody as unknown as Record<string, unknown> | null;
+    assert.ok(forwardedBody, "WeClone should have received a request");
+    const msgs = forwardedBody.messages as Array<{
       role: string;
       content: string;
     }>;

--- a/packages/export-weclone/package.json
+++ b/packages/export-weclone/package.json
@@ -14,6 +14,8 @@
   "files": ["dist", "README.md"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-types": "tsc --noEmit",
     "test": "tsx --test 'src/**/*.test.ts'",
     "prepublishOnly": "npm run build"
   },

--- a/packages/hermes-provider/package.json
+++ b/packages/hermes-provider/package.json
@@ -14,6 +14,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/import-chatgpt/package.json
+++ b/packages/import-chatgpt/package.json
@@ -14,6 +14,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test src/adapter.test.ts src/parser.test.ts src/transform.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/import-claude/package.json
+++ b/packages/import-claude/package.json
@@ -14,6 +14,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test src/adapter.test.ts src/parser.test.ts src/transform.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/import-gemini/package.json
+++ b/packages/import-gemini/package.json
@@ -14,6 +14,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test src/adapter.test.ts src/parser.test.ts src/transform.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/import-lossless-claw/package.json
+++ b/packages/import-lossless-claw/package.json
@@ -14,6 +14,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test src/transform.test.ts src/source.test.ts src/importer.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/import-mem0/package.json
+++ b/packages/import-mem0/package.json
@@ -14,6 +14,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test src/adapter.test.ts src/parser.test.ts src/transform.test.ts src/client.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/import-supermemory/package.json
+++ b/packages/import-supermemory/package.json
@@ -14,6 +14,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test src/parser.test.ts src/transform.test.ts src/adapter.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/import-supermemory/src/adapter.test.ts
+++ b/packages/import-supermemory/src/adapter.test.ts
@@ -5,7 +5,7 @@ import { adapter } from "./adapter.js";
 describe("adapter", () => {
   it("parses and transforms", async () => {
     const parsed = await adapter.parse({ memories: [{ id: "x", content: "y" }] });
-    const out = adapter.transform(parsed);
+    const out = await adapter.transform(parsed);
     assert.equal(out.length, 1);
   });
 });

--- a/packages/import-weclone/package.json
+++ b/packages/import-weclone/package.json
@@ -14,6 +14,8 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-types": "tsc --noEmit",
     "test": "tsx --test 'src/**/*.test.ts'",
     "prepublishOnly": "npm run build"
   },

--- a/packages/import-weclone/src/adapter.test.ts
+++ b/packages/import-weclone/src/adapter.test.ts
@@ -15,7 +15,7 @@ describe("wecloneImportAdapter", () => {
     assert.equal(wecloneImportAdapter.name, "weclone");
   });
 
-  it("parse delegates to parseWeCloneExport and returns valid result", () => {
+  it("parse delegates to parseWeCloneExport and returns valid result", async () => {
     const input = {
       platform: "telegram",
       messages: [
@@ -31,7 +31,7 @@ describe("wecloneImportAdapter", () => {
         },
       ],
     };
-    const result = wecloneImportAdapter.parse(input);
+    const result = await wecloneImportAdapter.parse(input);
     assert.equal(typeof result, "object");
     assert.ok(Array.isArray(result.turns));
     assert.equal(result.turns.length, 2);
@@ -52,7 +52,7 @@ describe("wecloneImportAdapter", () => {
     );
   });
 
-  it("parse works without options", () => {
+  it("parse works without options", async () => {
     const input = {
       messages: [
         {
@@ -62,11 +62,11 @@ describe("wecloneImportAdapter", () => {
         },
       ],
     };
-    const result = wecloneImportAdapter.parse(input);
+    const result = await wecloneImportAdapter.parse(input);
     assert.equal(result.turns.length, 1);
   });
 
-  it("parse forwards platform option to parser", () => {
+  it("parse forwards platform option to parser", async () => {
     const input = {
       messages: [
         {
@@ -76,7 +76,7 @@ describe("wecloneImportAdapter", () => {
         },
       ],
     };
-    const result = wecloneImportAdapter.parse(input, { platform: "discord" });
+    const result = await wecloneImportAdapter.parse(input, { platform: "discord" });
     assert.equal(result.metadata.source, "weclone-discord");
   });
 

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -71,7 +71,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node scripts/clean-clawhub-artifact.mjs",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc -p tsconfig.check.json",
     "plugin:inspect": "plugin-inspector check --config plugin-inspector.config.json --no-openclaw",
     "plugin:inspect:runtime": "pnpm run build && PLUGIN_INSPECTOR_EXECUTE_ISOLATED=1 plugin-inspector check --config plugin-inspector.config.json --no-openclaw --runtime --mock-sdk",
     "prepublishOnly": "npm run build"

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -10,7 +10,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { Worker } from "node:worker_threads";
+import { Worker, type WorkerOptions } from "node:worker_threads";
 
 export type BridgeMode = "embedded" | "delegate";
 
@@ -154,7 +154,7 @@ function checkDaemonHealthSync(host: string, port: number, timeoutMs = SYNC_HEAL
     const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
     const view = new Int32Array(state);
     const workerUrl = new URL(`data:text/javascript,${encodeURIComponent(HEALTH_WORKER_SOURCE)}`);
-    worker = new Worker(workerUrl, {
+    const workerOptions: WorkerOptions & { type: "module" } = {
       type: "module",
       workerData: {
         host,
@@ -164,7 +164,8 @@ function checkDaemonHealthSync(host: string, port: number, timeoutMs = SYNC_HEAL
         timeoutMs,
         state,
       },
-    });
+    };
+    worker = new Worker(workerUrl, workerOptions);
 
     Atomics.wait(view, 0, 0, timeoutMs + 250);
     const status = Atomics.load(view, 0);

--- a/packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.test.ts
+++ b/packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.test.ts
@@ -36,7 +36,7 @@ test("memory-search tool uses ctx session key and returns a structured JSON payl
     {
       snippetMaxChars: 120,
       recallForActiveMemory: async (_orchestrator, params) => {
-        received = params as Record<string, unknown>;
+        received = params as unknown as Record<string, unknown>;
         return {
           results: [
             {
@@ -81,7 +81,7 @@ test("memory-search tool ignores explicit sessionKey overrides when runtime cont
     {} as never,
     {
       recallForActiveMemory: async (_orchestrator, params) => {
-        received = params as Record<string, unknown>;
+        received = params as unknown as Record<string, unknown>;
         return {
           results: [],
           truncated: false,
@@ -97,12 +97,14 @@ test("memory-search tool ignores explicit sessionKey overrides when runtime cont
     { sessionKey: "ctx-session" },
   );
 
-  assert.equal(received?.sessionKey, "ctx-session");
+  const ctxReceived = received as unknown as Record<string, unknown> | null;
+  assert.equal(ctxReceived?.sessionKey, "ctx-session");
 
   await tool.execute(
     "tc-memory-search-param-fallback",
     { query: "preferences", sessionKey: "param-session" },
   );
 
-  assert.equal(received?.sessionKey, "param-session");
+  const paramReceived = received as unknown as Record<string, unknown> | null;
+  assert.equal(paramReceived?.sessionKey, "param-session");
 });

--- a/packages/plugin-openclaw/src/runtime-surfaces.test.ts
+++ b/packages/plugin-openclaw/src/runtime-surfaces.test.ts
@@ -5,7 +5,7 @@ import type {
   ConsolidationObservation,
   MemoryFile,
   MemoryFrontmatter,
-} from "../../../remnic-core/src/types.js";
+} from "@remnic/core/types";
 import {
   parseDreamNarrativeResponse,
   planDreamEntryFromConsolidation,

--- a/packages/plugin-openclaw/src/session-command-descriptors.test.ts
+++ b/packages/plugin-openclaw/src/session-command-descriptors.test.ts
@@ -35,9 +35,13 @@ test("buildSessionCommandDescriptors wires toggle and status handlers", async ()
     getLastRecall(sessionKey: string) {
       recallCalls.push(sessionKey);
       return {
+        sessionKey,
+        recordedAt: "2026-04-12T12:00:00.000Z",
+        queryHash: "test-query",
+        queryLen: 12,
         memoryIds: ["mem-1", "mem-2"],
         latencyMs: 33,
-        plannerMode: "minimal",
+        plannerMode: "minimal" as const,
       };
     },
     getLastRecallSummary(sessionKey: string) {

--- a/packages/plugin-openclaw/src/slot-validator.test.ts
+++ b/packages/plugin-openclaw/src/slot-validator.test.ts
@@ -13,8 +13,8 @@ function buildLogger() {
     logger: {
       debug() {},
       info() {},
-      warn(message: string) {
-        warnings.push(message);
+      warn(...args: unknown[]) {
+        warnings.push(String(args[0] ?? ""));
       },
       error() {},
     },

--- a/packages/plugin-openclaw/tsconfig.check.json
+++ b/packages/plugin-openclaw/tsconfig.check.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "noEmit": true,
+    "paths": {
+      "@remnic/core": [
+        "packages/remnic-core/src/index.ts"
+      ],
+      "@remnic/core/*": [
+        "packages/remnic-core/src/*.ts"
+      ]
+    },
+    "rootDir": "../.."
+  },
+  "include": [
+    "src",
+    "../../src/**/*.d.ts"
+  ]
+}

--- a/packages/plugin-pi/package.json
+++ b/packages/plugin-pi/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts src/publisher.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test 'src/**/*.test.ts'",
     "prepublishOnly": "npm run build"

--- a/packages/remnic-server/package.json
+++ b/packages/remnic-server/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --target es2022 --platform node --outDir dist && node scripts/verify-bin.mjs",
     "verify:bin": "node scripts/verify-bin.mjs",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -49,6 +49,7 @@
   },
   "scripts": {
     "build": "node ./scripts/sync-openclaw-plugin.mjs && tsup --config tsup.config.ts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "postinstall": "node ./scripts/postinstall-banner.mjs",
     "prepack": "npm run build",

--- a/tests/root-typecheck-coverage.test.ts
+++ b/tests/root-typecheck-coverage.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  name?: string;
+  peerDependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+};
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+test("root typecheck covers package tsconfigs", () => {
+  const rootPkg = readJson<PackageJson>(join(repoRoot, "package.json"));
+  const rootCheckTypes = rootPkg.scripts?.["check-types"] ?? "";
+
+  assert.match(rootCheckTypes, /\bpnpm --filter @remnic\/core build\b/);
+  assert.match(rootCheckTypes, /\btsc --noEmit\b/);
+  assert.match(rootCheckTypes, /\bpnpm --recursive\b/);
+  assert.match(rootCheckTypes, /--if-present/);
+  assert.match(rootCheckTypes, /--filter="\.\/packages\/\*"/);
+  assert.doesNotMatch(rootCheckTypes, /--filter '\.\/packages\/\*'/);
+  assert.match(rootCheckTypes, /\brun check-types\b/);
+
+  const packagesDir = join(repoRoot, "packages");
+  const packageNamesWithTsconfig = readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(join(packagesDir, name, "tsconfig.json")))
+    .sort();
+
+  const packagesMissingCheckTypes = packageNamesWithTsconfig
+    .filter((name) => {
+      const pkg = readJson<PackageJson>(join(packagesDir, name, "package.json"));
+      return !pkg.scripts?.["check-types"];
+    })
+    .sort();
+
+  assert.deepEqual(packagesMissingCheckTypes, []);
+
+  const packagesMissingCorePrecheck = packageNamesWithTsconfig
+    .filter((name) => {
+      const pkg = readJson<PackageJson>(join(packagesDir, name, "package.json"));
+      const usesCore =
+        Boolean(pkg.dependencies?.["@remnic/core"]) ||
+        Boolean(pkg.devDependencies?.["@remnic/core"]) ||
+        Boolean(pkg.peerDependencies?.["@remnic/core"]);
+      return (
+        usesCore &&
+        pkg.name !== "@remnic/plugin-openclaw" &&
+        !pkg.scripts?.["precheck-types"]
+      );
+    })
+    .sort();
+
+  assert.deepEqual(packagesMissingCorePrecheck, []);
+});


### PR DESCRIPTION
## Summary
- expand root `check-types` so it runs package-level typechecks across the workspace
- add `check-types` scripts for TS packages that had tsconfigs but were skipped
- add a regression test that fails when package tsconfigs lack typecheck coverage
- fix type errors surfaced in previously skipped package test files

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test tests/root-typecheck-coverage.test.ts packages/import-supermemory/src/adapter.test.ts packages/import-weclone/src/adapter.test.ts packages/connector-weclone/src/proxy.test.ts packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.test.ts packages/plugin-openclaw/src/session-command-descriptors.test.ts packages/plugin-openclaw/src/slot-validator.test.ts packages/plugin-openclaw/src/runtime-surfaces.test.ts`
- `npm run check-types`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to build/typecheck scripts and test-only TypeScript fixes, with no runtime logic changes beyond typecheck configuration.
> 
> **Overview**
> **Expands workspace typechecking** by updating root `check-types` (and `make lint`) to run `tsc` at the root *and* recursively run each package’s `check-types` script.
> 
> Adds missing per-package `check-types`/`precheck-types` scripts across several workspace packages and introduces `tests/root-typecheck-coverage.test.ts` to enforce that all packages with a `tsconfig.json` are covered (and that `@remnic/core`-dependent packages run the required precheck).
> 
> Fixes newly-surfaced type errors in previously un-typechecked tests (e.g., async adapter methods, safer `unknown` casts) and tightens `@remnic/plugin-openclaw` typechecking via a new `tsconfig.check.json` plus minor test/import typing adjustments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1f54eddfb2335ae74dc6d1f53d0ce1290aaa99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->