### PR TITLE
fix(build): include postinstall helper in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "files": [
     "dist",
     "bin/engram-access.js",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "packages/remnic-core/scripts/ensure-better-sqlite3.mjs"
   ],
   "dependencies": {
     "@remnic/core": "workspace:^",

--- a/tests/package-lifecycle-files.test.ts
+++ b/tests/package-lifecycle-files.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, posix } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const lifecycleScriptNames = new Set(["preinstall", "install", "postinstall"]);
+
+type PackageJson = {
+  files?: string[];
+  scripts?: Record<string, string>;
+};
+
+function readPackageJson(): PackageJson {
+  return JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as PackageJson;
+}
+
+function nodeScriptTarget(command: string): string | null {
+  const match = command.match(/^node\s+(\S+)/);
+  return match ? normalizePackagePath(match[1]) : null;
+}
+
+function normalizePackagePath(value: string): string {
+  return value.replace(/^\.\//, "").split(posix.sep).join(posix.sep);
+}
+
+function filesInclude(target: string, files: string[]): boolean {
+  return files.some((entry) => {
+    const normalizedEntry = normalizePackagePath(entry).replace(/\/$/, "");
+    return target === normalizedEntry || target.startsWith(`${normalizedEntry}/`);
+  });
+}
+
+test("root lifecycle script targets are included in packed files", () => {
+  const pkg = readPackageJson();
+  const files = pkg.files ?? [];
+  const missingTargets: string[] = [];
+
+  for (const [scriptName, command] of Object.entries(pkg.scripts ?? {})) {
+    if (!lifecycleScriptNames.has(scriptName)) continue;
+    const target = nodeScriptTarget(command);
+    if (!target) continue;
+
+    assert.equal(
+      existsSync(join(repoRoot, target)),
+      true,
+      `${scriptName} target ${target} must exist in the repository`,
+    );
+    if (!filesInclude(target, files)) {
+      missingTargets.push(target);
+    }
+  }
+
+  assert.deepEqual(missingTargets, []);
+});


### PR DESCRIPTION
## Summary
- include the root `postinstall` helper in the package `files` whitelist
- add a regression test that checks lifecycle script targets exist and are packed

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test tests/package-lifecycle-files.test.ts`
- `npm pack --dry-run --json --ignore-scripts` manifest check for `packages/remnic-core/scripts/ensure-better-sqlite3.mjs`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging whitelist and a small test addition; main risk is unintended npm pack contents or CI failures if lifecycle scripts change format.
> 
> **Overview**
> Ensures the `postinstall` helper (`packages/remnic-core/scripts/ensure-better-sqlite3.mjs`) is included in the root package publish whitelist by adding it to `package.json` `files`.
> 
> Adds a regression test (`tests/package-lifecycle-files.test.ts`) that verifies any root `preinstall`/`install`/`postinstall` scripts that invoke `node <path>` both exist in-repo and are covered by the `files` list so they’ll be present in `npm pack` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73b2d3dfd42b4fd4293913a0c30fdf622b4aff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->