### PR TITLE
fix(config): coerce codex materialize options

### DIFF
--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -3196,21 +3196,25 @@ export function parseConfig(raw: unknown): PluginConfig {
     taxonomyAutoGenResolver: coerceBool(cfg.taxonomyAutoGenResolver) ?? true,
 
     // Codex CLI — native memory materialization (#378)
-    codexMaterializeMemories: cfg.codexMaterializeMemories !== false,
+    codexMaterializeMemories: coerceBool(cfg.codexMaterializeMemories) ?? true,
     codexMaterializeNamespace:
       typeof cfg.codexMaterializeNamespace === "string" && cfg.codexMaterializeNamespace.trim().length > 0
         ? cfg.codexMaterializeNamespace.trim()
         : "auto",
-    codexMaterializeMaxSummaryTokens:
-      typeof cfg.codexMaterializeMaxSummaryTokens === "number"
-        ? Math.max(0, Math.floor(cfg.codexMaterializeMaxSummaryTokens))
-        : 4500,
-    codexMaterializeRolloutRetentionDays:
-      typeof cfg.codexMaterializeRolloutRetentionDays === "number"
-        ? Math.max(0, Math.floor(cfg.codexMaterializeRolloutRetentionDays))
-        : 30,
-    codexMaterializeOnConsolidation: cfg.codexMaterializeOnConsolidation !== false,
-    codexMaterializeOnSessionEnd: cfg.codexMaterializeOnSessionEnd !== false,
+    codexMaterializeMaxSummaryTokens: parseIntegerAtLeast(
+      cfg.codexMaterializeMaxSummaryTokens,
+      4500,
+      0,
+      "codexMaterializeMaxSummaryTokens",
+    ),
+    codexMaterializeRolloutRetentionDays: parseIntegerAtLeast(
+      cfg.codexMaterializeRolloutRetentionDays,
+      30,
+      0,
+      "codexMaterializeRolloutRetentionDays",
+    ),
+    codexMaterializeOnConsolidation: coerceBool(cfg.codexMaterializeOnConsolidation) ?? true,
+    codexMaterializeOnSessionEnd: coerceBool(cfg.codexMaterializeOnSessionEnd) ?? true,
     // Codex CLI — marketplace integration (#418)
     codexMarketplaceEnabled: cfg.codexMarketplaceEnabled !== false, // default: true
 

--- a/tests/codex-materialize-runner.test.ts
+++ b/tests/codex-materialize-runner.test.ts
@@ -38,6 +38,33 @@ function makeCodexHome(): { root: string; memoriesDir: string } {
   return { root, memoriesDir };
 }
 
+test("parseConfig coerces string Codex materialization config values", () => {
+  const config = parseConfig({
+    codexMaterializeMemories: "false",
+    codexMaterializeOnSessionEnd: "false",
+    codexMaterializeOnConsolidation: "false",
+    codexMaterializeMaxSummaryTokens: "0",
+    codexMaterializeRolloutRetentionDays: "0",
+  });
+
+  assert.equal(config.codexMaterializeMemories, false);
+  assert.equal(config.codexMaterializeOnSessionEnd, false);
+  assert.equal(config.codexMaterializeOnConsolidation, false);
+  assert.equal(config.codexMaterializeMaxSummaryTokens, 0);
+  assert.equal(config.codexMaterializeRolloutRetentionDays, 0);
+});
+
+test("parseConfig rejects invalid Codex materialization numeric config values", () => {
+  assert.throws(
+    () => parseConfig({ codexMaterializeMaxSummaryTokens: "abc" }),
+    /codexMaterializeMaxSummaryTokens must be an integer greater than or equal to 0/,
+  );
+  assert.throws(
+    () => parseConfig({ codexMaterializeRolloutRetentionDays: "3.7" }),
+    /codexMaterializeRolloutRetentionDays must be an integer greater than or equal to 0/,
+  );
+});
+
 test("runner reads namespaced memories from memoryDir/namespaces/<ns> (P1 fix)", async () => {
   const memoryDir = makeTempDir("codex-materialize-runner-memdir-");
   const workspaceDir = makeTempDir("codex-materialize-runner-workspace-");


### PR DESCRIPTION
## Summary
- coerce Codex materialization booleans through the shared config helper
- coerce string numeric limits before applying the existing non-negative integer clamp
- add regression coverage for string opt-outs and zero values

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test tests/codex-materialize-runner.test.ts`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`
- `npm run test:entity-hardening`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config parsing for Codex materialization flags and numeric limits, which can alter materialization enablement/retention behavior based on CLI/env inputs; risk is moderate but scoped to config validation/coercion.
> 
> **Overview**
> **Codex materialization config parsing is hardened.** `parseConfig` now coerces `codexMaterialize*` booleans via `coerceBool` (so CLI strings like "false" actually disable) and routes the numeric limits through `parseIntegerAtLeast` to accept numeric strings while *rejecting* non-integer/invalid values.
> 
> Adds tests covering string opt-outs/zero values and ensuring invalid numeric inputs throw clear errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb929b9db6d117c315be1bfb23453b3f7a56a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->