### PR TITLE
fix(codex): surface materialize read failures

### DIFF
--- a/packages/remnic-core/src/connectors/codex-materialize-runner.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize-runner.ts
@@ -16,6 +16,7 @@ import { log } from "../logger.js";
 import { StorageManager } from "../storage.js";
 import type { PluginConfig, MemoryFile } from "../types.js";
 import {
+  hasCodexMaterializeSentinel,
   materializeForNamespace,
   type MaterializeResult,
   type RolloutSummaryInput,
@@ -88,18 +89,19 @@ export async function runCodexMaterialize(
   if (options.memories) {
     memories = options.memories;
   } else {
+    if (!hasCodexMaterializeSentinel(options.codexHome)) {
+      return materializeForNamespace(namespace, {
+        memories: [],
+        codexHome: options.codexHome,
+        maxSummaryTokens: cfg.codexMaterializeMaxSummaryTokens,
+        rolloutRetentionDays: cfg.codexMaterializeRolloutRetentionDays,
+        rolloutSummaries: options.rolloutSummaries,
+        now: options.now,
+      });
+    }
     const nsDir = resolveNamespaceDir(memoryDir, namespace, cfg);
     const storage = new StorageManager(nsDir);
-    try {
-      memories = await storage.readAllMemories();
-    } catch (error) {
-      log.warn(
-        `[codex-materialize] skipped — failed to read memories from ${nsDir}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      return null;
-    }
+    memories = await storage.readAllMemories();
   }
 
   // Intentionally NOT catching here: per the JSDoc contract above,

--- a/packages/remnic-core/src/connectors/codex-materialize.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize.ts
@@ -156,8 +156,7 @@ export function materializeForNamespace(
     warn: (msg) => log.warn(`[codex-materialize] ${msg}`),
     debug: (msg) => log.debug(`[codex-materialize] ${msg}`),
   };
-  const codexHome = resolveCodexHome(options.codexHome);
-  const memoriesDir = path.join(codexHome, "memories");
+  const memoriesDir = resolveCodexMemoriesDir(options.codexHome);
   const now = options.now ?? new Date();
   // Honor `0` as "no summary budget" — parseConfig already clamps to non-
   // negative integers, so any provided number is meaningful. Only fall back
@@ -753,6 +752,14 @@ function resolveCodexHome(override?: string): string {
   const fromEnv = readEnvVar("CODEX_HOME");
   if (fromEnv && fromEnv.trim().length > 0) return fromEnv;
   return path.join(resolveHomeDir(), ".codex");
+}
+
+export function resolveCodexMemoriesDir(codexHome?: string): string {
+  return path.join(resolveCodexHome(codexHome), "memories");
+}
+
+export function hasCodexMaterializeSentinel(codexHome?: string): boolean {
+  return readSentinel(path.join(resolveCodexMemoriesDir(codexHome), SENTINEL_FILE)) !== null;
 }
 
 function readSentinel(sentinelPath: string): SentinelFile | null {

--- a/tests/codex-materialize-runner.test.ts
+++ b/tests/codex-materialize-runner.test.ts
@@ -22,9 +22,16 @@ import { mkdtempSync, mkdirSync, existsSync, readdirSync, rmSync } from "node:fs
 import os from "node:os";
 import path from "node:path";
 
-import { runCodexMaterialize } from "../src/connectors/codex-materialize-runner.js";
+import {
+  runCodexMaterialize,
+  runPostConsolidationMaterialize,
+} from "../src/connectors/codex-materialize-runner.js";
 import { ensureSentinel, SENTINEL_FILE } from "../src/connectors/codex-materialize.js";
 import { parseConfig } from "../src/config.js";
+import {
+  SecureStoreLockedError,
+  writeMaybeEncryptedFile,
+} from "../src/secure-store/index.js";
 import { StorageManager } from "../src/storage.js";
 
 function makeTempDir(prefix: string): string {
@@ -233,6 +240,92 @@ test("runner propagates schema errors instead of silently returning null", async
       }),
       /EISDIR|ENOTEMPTY|EEXIST|EPERM|EACCES|is a directory|directory not empty|file already exists/iu,
     );
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("runner skips before reading locked memories when Codex sentinel is missing", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-nosentinel-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-nosentinel-workspace-");
+  const { root: codexHome } = makeCodexHome();
+
+  try {
+    const lockedMemoryPath = path.join(memoryDir, "facts", "2026-04-02", "locked.md");
+    await writeMaybeEncryptedFile(
+      lockedMemoryPath,
+      "---\nid: locked-test-memory\ncategory: fact\n---\nsynthetic locked memory",
+      Buffer.alloc(32, 0x42),
+      {},
+      memoryDir,
+    );
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      codexMaterializeMemories: true,
+    });
+
+    const result = await runCodexMaterialize({
+      config,
+      codexHome,
+      reason: "manual",
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.ok(result, "missing sentinel should return an expected skip result");
+    assert.equal(result.skippedNoSentinel, true);
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("runner propagates opted-in storage read failures while post-consolidation catches them", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-readfail-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-readfail-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    const lockedMemoryPath = path.join(memoryDir, "facts", "2026-04-02", "locked.md");
+    await writeMaybeEncryptedFile(
+      lockedMemoryPath,
+      "---\nid: locked-test-memory\ncategory: fact\n---\nsynthetic locked memory",
+      Buffer.alloc(32, 0x42),
+      {},
+      memoryDir,
+    );
+    ensureSentinel(memoriesDir, "default", new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      codexMaterializeMemories: true,
+    });
+
+    await assert.rejects(
+      runCodexMaterialize({
+        config,
+        codexHome,
+        reason: "manual",
+        now: new Date("2026-04-02T00:00:00Z"),
+      }),
+      (error) => error instanceof SecureStoreLockedError,
+    );
+
+    const postConsolidationResult = await runPostConsolidationMaterialize("[test]", {
+      config,
+      codexHome,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    assert.equal(postConsolidationResult, null);
   } finally {
     rmSync(memoryDir, { recursive: true, force: true });
     rmSync(workspaceDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- let `runCodexMaterialize` propagate storage read failures instead of reporting successful skips
- keep `runPostConsolidationMaterialize` non-fatal by relying on its scoped catch
- add locked encrypted-store regression coverage for both caller policies

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test tests/codex-materialize-runner.test.ts`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runner control-flow and error propagation for Codex materialization; callers may now see new thrown errors instead of silent skips when opted in, which could affect CLI/session workflows if not handled.
> 
> **Overview**
> **Codex materialization runner now distinguishes opt-in skips from real I/O failures.** `runCodexMaterialize` checks for the Codex sentinel *before* reading memories; when missing it returns the normal `skippedNoSentinel` result without touching storage (avoids triggering encrypted-store lock errors).
> 
> **Storage read errors are no longer swallowed.** The runner no longer catches `StorageManager.readAllMemories()` failures, so opted-in runs fail loudly, while `runPostConsolidationMaterialize` remains non-fatal by catching and logging.
> 
> Adds regression tests covering (1) skipping before reading locked memories when the sentinel is absent and (2) propagating locked-store read failures for manual runs while consolidation hooks still return `null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1abf2f19654ca07e2b603be1a66aa3c88255dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->