### PR TITLE
fix(weclone): redact contiguous card numbers

### DIFF
--- a/packages/export-weclone/src/privacy.test.ts
+++ b/packages/export-weclone/src/privacy.test.ts
@@ -73,6 +73,50 @@ describe("sweepPii", () => {
     assert.equal(result.redactedCount, 1);
   });
 
+  it("redacts contiguous credit card numbers that pass Luhn", () => {
+    const records = [
+      makeRecord({ output: "Card: 4111111111111111." }),
+    ];
+    const result = sweepPii(records);
+
+    assert.equal(result.cleanRecords[0].output, "Card: [REDACTED].");
+    assert.equal(result.redactedCount, 1);
+    assert.equal(result.redactionDetails[0].pattern, "credit_card");
+  });
+
+  it("redacts card numbers followed by adjacent numeric metadata", () => {
+    const records = [
+      makeRecord({ output: "Card: 4111 1111 1111 1111 123." }),
+    ];
+    const result = sweepPii(records);
+
+    assert.equal(result.cleanRecords[0].output, "Card: [REDACTED] 123.");
+    assert.equal(result.redactedCount, 1);
+    assert.equal(result.redactionDetails[0].pattern, "credit_card");
+  });
+
+  it("redacts valid 19-digit card candidates without truncating them", () => {
+    const records = [
+      makeRecord({ output: "Card: 4000000000000000006." }),
+    ];
+    const result = sweepPii(records);
+
+    assert.equal(result.cleanRecords[0].output, "Card: [REDACTED].");
+    assert.equal(result.redactedCount, 1);
+    assert.equal(result.redactionDetails[0].pattern, "credit_card");
+  });
+
+  it("does not redact non-card digit runs that fail Luhn", () => {
+    const records = [
+      makeRecord({ output: "Reference number: 1234567890123456." }),
+    ];
+    const result = sweepPii(records);
+
+    assert.equal(result.cleanRecords[0].output, "Reference number: 1234567890123456.");
+    assert.equal(result.redactedCount, 0);
+    assert.equal(result.redactionDetails.length, 0);
+  });
+
   it("redacts IP addresses", () => {
     const records = [makeRecord({ output: "Server is at 192.168.1.100 on port 80." })];
     const result = sweepPii(records);
@@ -125,6 +169,22 @@ describe("sweepPii", () => {
     assert.equal(result.redactedCount, 1);
     assert.equal(result.redactionDetails[0].index, 1);
     assert.equal(result.redactionDetails[0].field, "output");
+  });
+
+  it("records one redaction detail for each repeated match in a field", () => {
+    const records = [
+      makeRecord({ output: "Email a@example.com and b@example.com." }),
+    ];
+    const result = sweepPii(records);
+
+    assert.equal(result.cleanRecords[0].output, "Email [REDACTED] and [REDACTED].");
+    assert.equal(result.redactedCount, 1);
+    assert.equal(
+      result.redactionDetails.filter(
+        (detail) => detail.field === "output" && detail.pattern === "email",
+      ).length,
+      2,
+    );
   });
 
   it("handles multiple PII types in a single record", () => {

--- a/packages/export-weclone/src/privacy.ts
+++ b/packages/export-weclone/src/privacy.ts
@@ -18,7 +18,43 @@ export interface PrivacySweepResult {
 interface PiiPattern {
   name: string;
   regex: RegExp;
+  validate?: (match: string) => boolean;
 }
+
+function normalizeCardCandidate(value: string): string {
+  return value.replace(/[-\s]/g, "");
+}
+
+function passesLuhn(value: string): boolean {
+  let sum = 0;
+  let doubleDigit = false;
+
+  for (let i = value.length - 1; i >= 0; i -= 1) {
+    let digit = Number(value[i]);
+    if (!Number.isInteger(digit)) return false;
+    if (doubleDigit) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+    doubleDigit = !doubleDigit;
+  }
+
+  return sum > 0 && sum % 10 === 0;
+}
+
+function isCreditCardCandidate(match: string): boolean {
+  const digits = normalizeCardCandidate(match);
+  return digits.length >= 13 && digits.length <= 19 && passesLuhn(digits);
+}
+
+const CREDIT_CARD_PATTERNS: PiiPattern[] = [19, 18, 17, 16, 15, 14, 13].map(
+  (digitCount) => ({
+    name: "credit_card",
+    regex: new RegExp(`\\b\\d(?:[-\\s]?\\d){${digitCount - 1}}\\b`, "g"),
+    validate: isCreditCardCandidate,
+  }),
+);
 
 /**
  * Ordered list of PII patterns.
@@ -37,11 +73,10 @@ const PII_PATTERNS: PiiPattern[] = [
     name: "ssn",
     regex: /\b\d{3}-\d{2}-\d{4}\b/g,
   },
-  {
-    // Credit card: 4 groups of 4 digits separated by dashes or spaces
-    name: "credit_card",
-    regex: /\b\d{4}[-\s]\d{4}[-\s]\d{4}[-\s]\d{4}\b/g,
-  },
+  // Credit card: 13-19 digits, optionally separated by dashes or spaces.
+  // Try longest candidates first so valid 19-digit cards are preserved while
+  // shorter cards next to numeric metadata can still be reconsidered.
+  ...CREDIT_CARD_PATTERNS,
   {
     // IP address: four octets 0-255
     name: "ip_address",
@@ -83,16 +118,16 @@ export function sweepPii(records: TrainingExportRecord[]): PrivacySweepResult {
       for (const pattern of PII_PATTERNS) {
         // Reset lastIndex for global regex reuse
         pattern.regex.lastIndex = 0;
-        if (pattern.regex.test(value)) {
-          pattern.regex.lastIndex = 0;
-          value = value.replace(pattern.regex, "[REDACTED]");
+        value = value.replace(pattern.regex, (match) => {
+          if (pattern.validate && !pattern.validate(match)) return match;
           recordHasRedaction.add(idx);
           redactionDetails.push({
             index: idx,
             field,
             pattern: pattern.name,
           });
-        }
+          return "[REDACTED]";
+        });
       }
 
       cleaned[field] = value;


### PR DESCRIPTION
## Summary
- detect 13-19 digit card candidates with optional spaces/dashes and Luhn validation
- redact contiguous card numbers such as `4111111111111111` without broadly redacting invalid digit runs
- record redaction details per accepted match while redacting

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test packages/export-weclone/src/privacy.test.ts`
- `pnpm --filter @remnic/core build`
- `pnpm --filter @remnic/export-weclone test`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PII redaction logic for credit cards and how matches are recorded; mistakes could cause under-redaction of sensitive data or over-redaction of benign numeric strings.
> 
> **Overview**
> Improves `sweepPii` credit-card detection by expanding it from a single spaced/dashed 16-digit pattern to **13–19 digit candidates** (contiguous or with spaces/dashes) and validating matches with a **Luhn check** before redacting.
> 
> Updates redaction processing to use a `replace` callback so `redactionDetails` are emitted **per accepted match** (including repeated matches in the same field), and adds tests covering contiguous cards, 19-digit cards, cards adjacent to numeric metadata, and non-card digit runs that fail Luhn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62032a5d9e783109362487ce9674e0b7d409a103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->