### PR TITLE
fix(core): parse Anthropic kind aliases

### DIFF
--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -196,7 +196,7 @@ export function parseAnthropicMessageParts(
   );
   const parts: LcmMessagePartInput[] = [];
   for (const block of blocks) {
-    const type = asNonEmptyString(block.type);
+    const type = asNonEmptyString(block.type ?? block.kind);
     if (type === "text") {
       const text = asNonEmptyString(block.text);
       if (text) parts.push(makePart("text", { type, text }, { filePath: firstFilePath(text) }));

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -183,6 +183,26 @@ describe("message-parts parsers", () => {
     assert.equal(parts[1]!.filePath, "packages/core/src/config.ts");
   });
 
+  it("extracts Anthropic kind aliases as structured parts", () => {
+    const parts = parseAnthropicMessageParts({
+      content: [
+        { kind: "text", text: "I will edit packages/core/src/aliases.ts" },
+        {
+          kind: "tool_use",
+          id: "toolu_kind",
+          name: "Edit",
+          input: { path: "packages/core/src/aliases.ts", old_string: "a", new_string: "b" },
+        },
+      ],
+    });
+
+    assert.equal(parts.length, 2);
+    assert.equal(parts[0]!.kind, "text");
+    assert.equal(parts[0]!.filePath, "packages/core/src/aliases.ts");
+    assert.equal(parts[1]!.kind, "file_write");
+    assert.equal(parts[1]!.filePath, "packages/core/src/aliases.ts");
+  });
+
   it("preserves Anthropic tool_result error flags", () => {
     const parts = parseAnthropicMessageParts({
       content: [
@@ -216,6 +236,24 @@ describe("message-parts parsers", () => {
     assert.equal(parts.length, 1);
     assert.equal(parts[0]!.kind, "tool_result");
     assert.equal(parts[0]!.payload.id, "toolu_inferred");
+  });
+
+  it("infers Anthropic kind alias blocks before Pi source format", () => {
+    const parts = parseMessageParts({
+      role: "user",
+      content: [
+        {
+          kind: "tool_result",
+          tool_use_id: "toolu_kind_inferred",
+          content: [{ kind: "text", text: "Updated src/aliases.ts" }],
+        },
+      ],
+    });
+
+    assert.equal(parts.length, 1);
+    assert.equal(parts[0]!.kind, "tool_result");
+    assert.equal(parts[0]!.payload.id, "toolu_kind_inferred");
+    assert.equal(parts[0]!.filePath, "src/aliases.ts");
   });
 
   it("normalizes explicit Remnic parts and redacts secrets", () => {


### PR DESCRIPTION
## Summary
- use the same `type ?? kind` discriminator inside the Anthropic parser that source-format inference already accepts
- preserve kind-shaped Anthropic `tool_use` blocks as structured tool/file parts
- cover inferred kind-shaped `tool_result` blocks so they are not dropped

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test packages/remnic-core/src/message-parts/message-parts.test.ts`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `pnpm --filter @remnic/core build`
- `npm run test:entity-hardening`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core message-part parsing logic for Anthropic inputs, which could change how tool/text blocks are classified and how file paths are extracted for some payload shapes.
> 
> **Overview**
> Updates the Anthropic message-parts parser to treat `kind` as an alias for `type` (using `type ?? kind`) so kind-shaped Anthropic blocks are parsed instead of ignored.
> 
> Adds tests covering `kind`-based `text`, `tool_use`, and `tool_result` blocks, including a case ensuring kind-alias Anthropic `tool_result` inference happens before Pi-shaped source-format detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9898ae482707f6239971d48fc72b4deedb4774d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->