### PR TITLE
fix(core): isolate contradiction review temp writes

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -12,8 +12,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { createHash } from "node:crypto";
-import { log } from "../logger.js";
+import { createHash, randomUUID } from "node:crypto";
 import type { ContradictionVerdict } from "./contradiction-judge.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -120,6 +119,25 @@ function ensureDir(memoryDir: string): void {
   }
 }
 
+function uniqueTempPath(filePath: string): string {
+  return `${filePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
+}
+
+function writePairFile(filePath: string, pair: ContradictionPair): void {
+  const tmpPath = uniqueTempPath(filePath);
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(pair, null, 2), "utf-8");
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      // Best-effort cleanup only; preserve the original write failure.
+    }
+    throw error;
+  }
+}
+
 // ── Write ──────────────────────────────────────────────────────────────────────
 
 /**
@@ -185,11 +203,7 @@ export function writePair(
   };
 
   const filePath = pairPath(memoryDir, pairId);
-  const tmpPath = `${filePath}.tmp`;
-
-  // Atomic write: temp then rename (rule 54)
-  fs.writeFileSync(tmpPath, JSON.stringify(full, null, 2), "utf-8");
-  fs.renameSync(tmpPath, filePath);
+  writePairFile(filePath, full);
 
   return full;
 }
@@ -334,10 +348,7 @@ export function resolvePair(
   };
 
   const filePath = pairPath(memoryDir, pairId);
-  const tmpPath = `${filePath}.tmp`;
-
-  fs.writeFileSync(tmpPath, JSON.stringify(updated, null, 2), "utf-8");
-  fs.renameSync(tmpPath, filePath);
+  writePairFile(filePath, updated);
 
   return updated;
 }
@@ -362,10 +373,7 @@ export function deferPair(
   };
 
   const filePath = pairPath(memoryDir, pairId);
-  const tmpPath = `${filePath}.tmp`;
-
-  fs.writeFileSync(tmpPath, JSON.stringify(updated, null, 2), "utf-8");
-  fs.renameSync(tmpPath, filePath);
+  writePairFile(filePath, updated);
 
   return updated;
 }

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -215,6 +216,63 @@ test("writePair is idempotent", async () => {
     const second = writePair(dir, pair);
     assert.equal(first.pairId, second.pairId);
   } finally {
+    await cleanup();
+  }
+});
+
+test("review queue writes use unique temporary paths", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  const tempPaths: string[] = [];
+  const originalWriteFileSync = fs.writeFileSync;
+
+  (fs as any).writeFileSync = (file: unknown, ...args: unknown[]) => {
+    const filePath = String(file);
+    if (filePath.includes(`${path.sep}.review${path.sep}contradictions${path.sep}`)) {
+      tempPaths.push(filePath);
+    }
+    return (originalWriteFileSync as any).call(fs, file, ...args);
+  };
+
+  try {
+    const first = writePair(dir, makePair({ memoryIds: ["mem-a-001", "mem-b-002"] }));
+    const second = writePair(dir, makePair({ memoryIds: ["mem-a-003", "mem-b-004"] }));
+    resolvePair(dir, first.pairId, "both-valid");
+    deferPair(dir, second.pairId);
+
+    assert.equal(tempPaths.length, 4);
+    assert.equal(new Set(tempPaths).size, tempPaths.length);
+    for (const tempPath of tempPaths) {
+      assert.match(tempPath, /\.json\.\d+\.\d+\.[0-9a-f-]+\.tmp$/);
+      assert.equal(tempPath.endsWith(".json.tmp"), false);
+    }
+  } finally {
+    fs.writeFileSync = originalWriteFileSync;
+    await cleanup();
+  }
+});
+
+test("review queue write failures clean up unique temporary files", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  const originalRenameSync = fs.renameSync;
+  let attemptedTempPath: string | null = null;
+
+  (fs as any).renameSync = (oldPath: unknown, newPath: unknown) => {
+    if (String(newPath).includes(`${path.sep}.review${path.sep}contradictions${path.sep}`)) {
+      attemptedTempPath = String(oldPath);
+      throw new Error("simulated rename failure");
+    }
+    return (originalRenameSync as any).call(fs, oldPath, newPath);
+  };
+
+  try {
+    assert.throws(
+      () => writePair(dir, makePair()),
+      /simulated rename failure/,
+    );
+    assert.ok(attemptedTempPath);
+    assert.equal(fs.existsSync(attemptedTempPath), false);
+  } finally {
+    fs.renameSync = originalRenameSync;
     await cleanup();
   }
 });


### PR DESCRIPTION
## Summary
- route contradiction review pair writes through one atomic-write helper
- use a unique sibling temp path per write instead of shared `<pair>.json.tmp`
- clean up the unique temp file when write or rename fails
- add regression coverage for unique temp paths and failed-rename cleanup

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `pnpm --filter @remnic/core build`
- `npm run test:entity-hardening`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk write path for contradiction review queue entries; bugs here could drop or corrupt queued review items, but the change is localized and covered by new tests.
> 
> **Overview**
> Routes all contradiction review queue writes through a shared `writePairFile` helper that performs an atomic temp-write+rename using a **unique temp filename per write** (PID/time/UUID) instead of a shared `*.json.tmp`.
> 
> Adds best-effort cleanup of the temp file on write/rename failure, and introduces regression tests verifying unique temp paths across `writePair`/`resolvePair`/`deferPair` and that failed renames don’t leave temp files behind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57410f486c27fdb8e407f8bc9cb1a05417f203db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->