### PR TITLE
fix(core): validate contradiction keep targets

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -775,6 +775,53 @@ test("executeResolution merge keeps created replacement when rollback fails", as
   }
 });
 
+test("executeResolution keep-a does not supersede when the kept memory is missing", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage();
+    storage.memories.delete("mem-a-001");
+
+    const result = await executeResolution(dir, storage, written.pairId, "keep-a");
+
+    assert.match(result.message, /Kept memory mem-a-001 not found/);
+    assert.deepEqual(result.affectedIds, []);
+    assert.deepEqual(storage.supersedeCalls, []);
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, undefined);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution keep-b does not supersede when the kept memory is inactive", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage();
+    const keepB = storage.memories.get("mem-b-002");
+    assert.ok(keepB);
+    storage.memories.set("mem-b-002", {
+      ...keepB,
+      frontmatter: {
+        ...keepB.frontmatter,
+        status: "superseded",
+        supersededBy: "replacement",
+      },
+    });
+
+    const result = await executeResolution(dir, storage, written.pairId, "keep-b");
+
+    assert.match(result.message, /Kept memory mem-b-002 is superseded/);
+    assert.deepEqual(result.affectedIds, []);
+    assert.deepEqual(storage.supersedeCalls, []);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.status, undefined);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("executeResolution keep-a restores source after partial supersede failure", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -67,6 +67,12 @@ export async function executeResolution(
 
   switch (verb) {
     case "keep-a": {
+      const keepTarget = await validateKeepTarget(storage, pairId, idA);
+      if (!keepTarget.ok) {
+        supersedeFailed = true;
+        message = keepTarget.message;
+        break;
+      }
       const sourceB = await loadSourceSnapshot(storage, idB);
       const ok = sourceB
         ? await supersedeSafe(storage, idB, idA, "contradiction-resolution:keep-a")
@@ -84,6 +90,12 @@ export async function executeResolution(
       break;
     }
     case "keep-b": {
+      const keepTarget = await validateKeepTarget(storage, pairId, idB);
+      if (!keepTarget.ok) {
+        supersedeFailed = true;
+        message = keepTarget.message;
+        break;
+      }
       const sourceA = await loadSourceSnapshot(storage, idA);
       const ok = sourceA
         ? await supersedeSafe(storage, idA, idB, "contradiction-resolution:keep-b")
@@ -244,6 +256,28 @@ function mergedMemoryCategory(sourceA: MemoryFile, sourceB: MemoryFile): MemoryC
   return sourceA.frontmatter.category === sourceB.frontmatter.category
     ? sourceA.frontmatter.category
     : "fact";
+}
+
+type KeepTargetValidation =
+  | { ok: true }
+  | { ok: false; message: string };
+
+async function validateKeepTarget(
+  storage: StorageManager,
+  pairId: string,
+  keepId: string,
+): Promise<KeepTargetValidation> {
+  const target = await loadSourceSnapshot(storage, keepId);
+  if (!target) {
+    return { ok: false, message: `Kept memory ${keepId} not found; not resolving ${pairId}` };
+  }
+
+  const status = target.frontmatter.status ?? "active";
+  if (status !== "active") {
+    return { ok: false, message: `Kept memory ${keepId} is ${status}; not resolving ${pairId}` };
+  }
+
+  return { ok: true };
 }
 
 async function loadSourceSnapshot(storage: StorageManager, memoryId: string): Promise<MemoryFile | null> {


### PR DESCRIPTION
## Summary
- validate `keep-a` and `keep-b` targets exist before superseding the opposite memory
- reject inactive kept memories instead of superseding to stale targets
- leave the review pair unresolved and avoid supersede calls when validation fails

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `pnpm --filter @remnic/core build`
- `npm run test:entity-hardening`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `executeResolution` behavior for `keep-a`/`keep-b` to bail out before superseding when the keep target is missing or not `active`, which could alter resolution outcomes and leave more pairs unresolved. Risk is moderate because it touches memory lifecycle/supersession logic, but the change is small and covered by new tests.
> 
> **Overview**
> Prevents contradiction `keep-a`/`keep-b` resolutions from superseding the opposite memory when the *kept* memory is missing or not `active` (e.g., already `superseded`), and leaves the pair unresolved in those cases.
> 
> Adds `validateKeepTarget` to `resolution.ts` and new tests asserting **no supersede calls** and **no pair resolution write** when validation fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f369a3e6c3d7ec72222b5b8f6078e7fc6f9ddab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->