### PR TITLE
fix(core): scope contradiction scans by namespace

### DIFF
--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { EngramAccessHttpServer } from "./access-http.js";
+import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
+import { parseConfig } from "./config.js";
+import { readPair, writePair } from "./contradiction/contradiction-review.js";
+import type { StorageManager } from "./storage.js";
+
+test("HTTP contradiction scan uses writable namespace resolver", async () => {
+  const resolverCalls: Array<{ namespace: string | undefined; principal: string | undefined }> = [];
+  const storage = {
+    readAllMemories: async () => [],
+  } as unknown as StorageManager;
+  const service = {
+    storageRef: storage,
+    configRef: parseConfig({
+      memoryDir: "/tmp/remnic-http-contradiction-scan-test",
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+      },
+    }),
+    memoryDir: "/tmp/remnic-http-contradiction-scan-test",
+    embeddingLookupFactoryRef: undefined,
+    localLlmRef: null,
+    fallbackLlmRef: null,
+    getReadableStorageForNamespace: async () => {
+      throw new Error("readable resolver must not authorize contradiction scan writes");
+    },
+    getWritableStorageForNamespace: async (namespace: string | undefined, principal: string | undefined) => {
+      resolverCalls.push({ namespace, principal });
+      return { namespace: namespace ?? "default", storage };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "writer",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/contradiction-scan`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ namespace: "team" }),
+    });
+    const body = await response.json() as { scanned?: number };
+
+    assert.equal(response.status, 200);
+    assert.equal(body.scanned, 0);
+    assert.deepEqual(resolverCalls, [{ namespace: "team", principal: "writer" }]);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP review list uses readable namespace resolver", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-http-review-list-"));
+  const resolverCalls: Array<{ namespace: string | undefined; principal: string | undefined }> = [];
+  const service = {
+    configRef: parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    }),
+    memoryDir: dir,
+    getReadableStorageForNamespace: async (namespace: string | undefined, principal: string | undefined) => {
+      resolverCalls.push({ namespace, principal });
+      throw new EngramAccessInputError(`namespace is not readable: ${namespace}`);
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/review/contradictions?namespace=team`, {
+      headers: { authorization: "Bearer test-token" },
+    });
+    const body = await response.json() as { error?: string };
+
+    assert.equal(response.status, 400);
+    assert.match(body.error ?? "", /namespace is not readable: team/);
+    assert.deepEqual(resolverCalls, [{ namespace: "team", principal: "reader" }]);
+  } finally {
+    await server.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("HTTP default review list includes legacy unscoped pairs without mutating storage", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-http-review-list-default-"));
+  const legacy = writePair(dir, {
+    memoryIds: ["legacy-a", "legacy-b"],
+    verdict: "contradicts",
+    rationale: "legacy pending pair",
+    confidence: 0.9,
+    detectedAt: new Date().toISOString(),
+  });
+  const resolverCalls: Array<{ namespace: string | undefined; principal: string | undefined }> = [];
+  const storage = {
+    readAllMemories: async () => [],
+  } as unknown as StorageManager;
+  const service = {
+    configRef: parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    }),
+    memoryDir: dir,
+    getReadableStorageForNamespace: async (namespace: string | undefined, principal: string | undefined) => {
+      resolverCalls.push({ namespace, principal });
+      return { namespace: namespace ?? "default", storage };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/review/contradictions`, {
+      headers: { authorization: "Bearer test-token" },
+    });
+    const body = await response.json() as {
+      total?: number;
+      pairs?: Array<{ pairId?: string; namespace?: string }>;
+    };
+    assert.equal(response.status, 200);
+    assert.equal(body.total, 1);
+    assert.equal(body.pairs?.[0]?.pairId, legacy.pairId);
+    assert.equal(body.pairs?.[0]?.namespace, undefined);
+    assert.equal(readPair(dir, legacy.pairId)?.namespace, undefined);
+    assert.deepEqual(resolverCalls, [{ namespace: undefined, principal: "reader" }]);
+  } finally {
+    await server.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("HTTP review show hides namespace denial as pair_not_found", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-http-review-show-"));
+  const pair = writePair(dir, {
+    namespace: "team",
+    memoryIds: ["team-a", "team-b"],
+    verdict: "contradicts",
+    rationale: "synthetic",
+    confidence: 0.9,
+    detectedAt: new Date().toISOString(),
+  });
+  const resolverCalls: Array<{ namespace: string | undefined; principal: string | undefined }> = [];
+  const service = {
+    configRef: parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    }),
+    memoryDir: dir,
+    getReadableStorageForNamespace: async (namespace: string | undefined, principal: string | undefined) => {
+      resolverCalls.push({ namespace, principal });
+      throw new EngramAccessInputError(`namespace is not readable: ${namespace}`);
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/review/contradictions/${pair.pairId}`, {
+      headers: { authorization: "Bearer test-token" },
+    });
+    const body = await response.json() as { error?: string };
+
+    assert.equal(response.status, 404);
+    assert.equal(body.error, "pair_not_found");
+    assert.deepEqual(resolverCalls, [{ namespace: "team", principal: "reader" }]);
+  } finally {
+    await server.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1128,10 +1128,20 @@ export class EngramAccessHttpServer {
       }
       const namespace = parsed.searchParams.get("namespace") ?? undefined;
       const limitRaw = parseInt(parsed.searchParams.get("limit") ?? "50", 10);
-      const { listPairs } = await import("./contradiction/contradiction-review.js");
+      const {
+        isDefaultReviewNamespace,
+        listPairs,
+      } = await import("./contradiction/contradiction-review.js");
+      const principal = this.resolveRequestPrincipal(req);
+      const resolved = await this.service.getReadableStorageForNamespace(namespace, principal);
+      const reviewNamespace = this.service.configRef.namespacesEnabled ? resolved.namespace : undefined;
+      const includeUnscopedForNamespace = Boolean(
+        reviewNamespace && isDefaultReviewNamespace(this.service.configRef.defaultNamespace, namespace, reviewNamespace),
+      );
       const result = listPairs(this.service.memoryDir, {
         filter: rawFilter as "all" | "unresolved" | "contradicts" | "independent" | "duplicates" | "needs-user",
-        namespace,
+        namespace: reviewNamespace,
+        includeUnscopedForNamespace,
         limit: Number.isFinite(limitRaw) ? limitRaw : 50,
       });
       this.respondJson(res, 200, result);
@@ -1143,6 +1153,12 @@ export class EngramAccessHttpServer {
       const { readPair } = await import("./contradiction/contradiction-review.js");
       const pair = readPair(this.service.memoryDir, pairId);
       if (!pair) {
+        this.respondJson(res, 404, { error: "pair_not_found" });
+        return;
+      }
+      try {
+        await this.service.getReadableStorageForNamespace(pair.namespace, this.resolveRequestPrincipal(req));
+      } catch {
         this.respondJson(res, 404, { error: "pair_not_found" });
         return;
       }
@@ -1163,9 +1179,14 @@ export class EngramAccessHttpServer {
         this.respondJson(res, 400, { error: `Invalid verb: ${verb}. Must be one of: keep-a, keep-b, merge, both-valid, needs-more-context` });
         return;
       }
+      const principal = this.resolveRequestPrincipal(req);
       const result = await executeResolution(this.service.memoryDir, this.service.storageRef, pairId, verb, {
         mergedMemoryId: typeof body.mergedMemoryId === "string" ? body.mergedMemoryId : undefined,
         mergedContent: typeof body.mergedContent === "string" ? body.mergedContent : undefined,
+        storageForNamespace: async (namespace) => {
+          const resolved = await this.service.getWritableStorageForNamespace(namespace, principal);
+          return resolved.storage;
+        },
       });
       this.respondJson(res, 200, result);
       return;
@@ -1267,11 +1288,14 @@ export class EngramAccessHttpServer {
     if (req.method === "POST" && pathname === "/engram/v1/contradiction-scan") {
       const body = await this.readJsonBody(req) as Record<string, unknown>;
       const { runContradictionScan } = await import("./contradiction/contradiction-scan.js");
+      const principal = this.resolveRequestPrincipal(req);
       const result = await runContradictionScan({
         storage: this.service.storageRef,
         config: this.service.configRef,
         memoryDir: this.service.memoryDir,
         embeddingLookupFactory: this.service.embeddingLookupFactoryRef,
+        storageForNamespace: (namespace) =>
+          this.service.getWritableStorageForNamespace(namespace, principal),
         localLlm: this.service.localLlmRef,
         fallbackLlm: this.service.fallbackLlmRef,
         namespace: typeof body.namespace === "string" ? body.namespace : undefined,

--- a/packages/remnic-core/src/access-mcp.test.ts
+++ b/packages/remnic-core/src/access-mcp.test.ts
@@ -7,10 +7,16 @@
  */
 
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import { EngramMcpServer } from "./access-mcp.js";
-import type { EngramAccessService } from "./access-service.js";
+import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
+import { parseConfig } from "./config.js";
+import { readPair, writePair } from "./contradiction/contradiction-review.js";
+import type { StorageManager } from "./storage.js";
 
 // ──────────────────────────────────────────────────────────────────────────
 // Stub service — only implements the members EngramMcpServer actually touches.
@@ -173,6 +179,133 @@ test("MCP maintenance: hourly summarization dispatches to the access service", a
 
   assert.equal(called, true, "memorySummarizeHourly should be dispatched");
   assert.equal((response as Record<string, unknown> & { result?: { isError?: boolean } }).result?.isError, false);
+});
+
+test("MCP contradiction scan uses writable namespace resolver", async () => {
+  const resolverCalls: Array<{ namespace: string | undefined; principal: string | undefined }> = [];
+  const storage = {
+    readAllMemories: async () => [],
+  } as unknown as StorageManager;
+  const service = {
+    ...makeMockService(),
+    storageRef: storage,
+    configRef: parseConfig({
+      memoryDir: "/tmp/remnic-mcp-contradiction-scan-test",
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+      },
+    }),
+    memoryDir: "/tmp/remnic-mcp-contradiction-scan-test",
+    embeddingLookupFactoryRef: undefined,
+    localLlmRef: null,
+    fallbackLlmRef: null,
+    getReadableStorageForNamespace: async () => {
+      throw new Error("readable resolver must not authorize contradiction scan writes");
+    },
+    getWritableStorageForNamespace: async (namespace: string | undefined, principal: string | undefined) => {
+      resolverCalls.push({ namespace, principal });
+      return { namespace: namespace ?? "default", storage };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service, { principal: "writer" });
+
+  const response = await server.handleRequest(
+    makeToolRequest("engram.contradiction_scan_run", { namespace: "team" }),
+  );
+
+  const result = (response as Record<string, unknown> & {
+    result?: { isError?: boolean; structuredContent?: { scanned?: number } };
+  }).result;
+  assert.equal(result?.isError, false);
+  assert.equal(result?.structuredContent?.scanned, 0);
+  assert.deepEqual(resolverCalls, [{ namespace: "team", principal: "writer" }]);
+});
+
+test("MCP review list uses readable namespace resolver", async () => {
+  const resolverCalls: Array<{ namespace: string | undefined; principal: string | undefined }> = [];
+  const storage = {
+    readAllMemories: async () => [],
+  } as unknown as StorageManager;
+  const service = {
+    ...makeMockService(),
+    configRef: parseConfig({
+      memoryDir: "/tmp/remnic-mcp-review-list-test",
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    }),
+    memoryDir: "/tmp/remnic-mcp-review-list-test",
+    getReadableStorageForNamespace: async (namespace: string | undefined, principal: string | undefined) => {
+      resolverCalls.push({ namespace, principal });
+      throw new EngramAccessInputError(`namespace is not readable: ${namespace}`);
+    },
+    storageRef: storage,
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service, { principal: "reader" });
+
+  const response = await server.handleRequest(
+    makeToolRequest("engram.review_list", { namespace: "team" }),
+  );
+
+  const result = (response as Record<string, unknown> & {
+    result?: { isError?: boolean; content?: Array<{ text?: string }> };
+  }).result;
+  assert.equal(result?.isError, true);
+  assert.match(result?.content?.[0]?.text ?? "", /namespace is not readable: team/);
+  assert.deepEqual(resolverCalls, [{ namespace: "team", principal: "reader" }]);
+});
+
+test("MCP default review list includes legacy unscoped pairs without mutating storage", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mcp-review-list-default-"));
+  try {
+    const legacy = writePair(dir, {
+      memoryIds: ["legacy-a", "legacy-b"],
+      verdict: "contradicts",
+      rationale: "legacy pending pair",
+      confidence: 0.9,
+      detectedAt: new Date().toISOString(),
+    });
+    const resolverCalls: Array<{ namespace: string | undefined; principal: string | undefined }> = [];
+    const storage = {
+      readAllMemories: async () => [],
+    } as unknown as StorageManager;
+    const service = {
+      ...makeMockService(),
+      configRef: parseConfig({
+        memoryDir: dir,
+        namespacesEnabled: true,
+        defaultNamespace: "default",
+      }),
+      memoryDir: dir,
+      getReadableStorageForNamespace: async (namespace: string | undefined, principal: string | undefined) => {
+        resolverCalls.push({ namespace, principal });
+        return { namespace: namespace ?? "default", storage };
+      },
+      storageRef: storage,
+    } as unknown as EngramAccessService;
+    const server = new EngramMcpServer(service, { principal: "reader" });
+
+    const response = await server.handleRequest(makeToolRequest("engram.review_list"));
+    const result = (response as Record<string, unknown> & {
+      result?: {
+        isError?: boolean;
+        structuredContent?: {
+          total?: number;
+          pairs?: Array<{ pairId?: string; namespace?: string }>;
+        };
+      };
+    }).result;
+    assert.equal(result?.isError, false);
+    assert.equal(result?.structuredContent?.total, 1);
+    assert.equal(result?.structuredContent?.pairs?.[0]?.pairId, legacy.pairId);
+    assert.equal(result?.structuredContent?.pairs?.[0]?.namespace, undefined);
+    assert.equal(readPair(dir, legacy.pairId)?.namespace, undefined);
+    assert.deepEqual(resolverCalls, [{ namespace: undefined, principal: "reader" }]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("MCP maintenance: conversation index update sanitizes optional args", async () => {

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2795,7 +2795,10 @@ export class EngramMcpServer {
       // ── Contradiction Review (issue #520) ──────────────────────────────────
       case "engram.review_list":
       case "remnic.review_list": {
-        const { listPairs } = await import("./contradiction/contradiction-review.js");
+        const {
+          isDefaultReviewNamespace,
+          listPairs,
+        } = await import("./contradiction/contradiction-review.js");
         const VALID_REVIEW_FILTERS = new Set(["all", "unresolved", "contradicts", "independent", "duplicates", "needs-user"]);
         const rawFilter = typeof args.filter === "string" ? args.filter : "unresolved";
         if (!VALID_REVIEW_FILTERS.has(rawFilter)) {
@@ -2804,7 +2807,17 @@ export class EngramMcpServer {
         const filter = rawFilter as "all" | "unresolved" | "contradicts" | "independent" | "duplicates" | "needs-user";
         const ns = typeof args.namespace === "string" ? args.namespace : undefined;
         const limit = typeof args.limit === "number" ? args.limit : 50;
-        return listPairs(this.service.memoryDir, { filter, namespace: ns, limit });
+        const resolved = await this.service.getReadableStorageForNamespace(ns, effectivePrincipal);
+        const reviewNamespace = this.service.configRef.namespacesEnabled ? resolved.namespace : undefined;
+        const includeUnscopedForNamespace = Boolean(
+          reviewNamespace && isDefaultReviewNamespace(this.service.configRef.defaultNamespace, ns, reviewNamespace),
+        );
+        return listPairs(this.service.memoryDir, {
+          filter,
+          namespace: reviewNamespace,
+          includeUnscopedForNamespace,
+          limit,
+        });
       }
       case "engram.review_resolve":
       case "remnic.review_resolve": {
@@ -2818,6 +2831,10 @@ export class EngramMcpServer {
         return executeResolution(this.service.memoryDir, this.service.storageRef, pairId, verb, {
           mergedMemoryId: typeof args.mergedMemoryId === "string" ? args.mergedMemoryId : undefined,
           mergedContent: typeof args.mergedContent === "string" ? args.mergedContent : undefined,
+          storageForNamespace: async (namespace) => {
+            const resolved = await this.service.getWritableStorageForNamespace(namespace, effectivePrincipal);
+            return resolved.storage;
+          },
         });
       }
       case "engram.contradiction_scan_run":
@@ -2828,6 +2845,8 @@ export class EngramMcpServer {
           config: this.service.configRef,
           memoryDir: this.service.memoryDir,
           embeddingLookupFactory: this.service.embeddingLookupFactoryRef,
+          storageForNamespace: (namespace) =>
+            this.service.getWritableStorageForNamespace(namespace, effectivePrincipal),
           localLlm: this.service.localLlmRef,
           fallbackLlm: this.service.fallbackLlmRef,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramAccessService } from "./access-service.js";
+import type { StorageManager } from "./storage.js";
+import type { PluginConfig } from "./types.js";
+
+function makeConfig(): PluginConfig {
+  return {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      { name: "team", readPrincipals: ["reader", "writer"], writePrincipals: ["writer"] },
+    ],
+    memoryDir: "/synthetic/mem",
+    defaultRecallNamespaces: ["self", "shared"],
+    principalFromSessionKeyMode: "disabled",
+    principalFromSessionKeyRules: [],
+    briefing: { enabled: false, defaultWindow: "yesterday" },
+    daySum: { enabled: false },
+    searchBackend: "orama",
+    qmd: { enabled: false },
+    nativeKnowledge: { enabled: false },
+    recall: { budget: {} },
+    consolidation: { enabled: false },
+    extraction: { enabled: false },
+    lcm: { enabled: false },
+  } as unknown as PluginConfig;
+}
+
+function makeService(): {
+  service: EngramAccessService;
+  storage: StorageManager;
+  getStorageCalls: string[];
+} {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const storage = { marker: "team-storage" } as unknown as StorageManager;
+  const getStorageCalls: string[] = [];
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: makeConfig(),
+    async getStorage(namespace: string): Promise<StorageManager> {
+      getStorageCalls.push(namespace);
+      return storage;
+    },
+  };
+
+  return { service, storage, getStorageCalls };
+}
+
+test("getWritableStorageForNamespace denies read-only principals before storage lookup", async () => {
+  const { service, getStorageCalls } = makeService();
+
+  await assert.rejects(
+    () => service.getWritableStorageForNamespace("team", "reader"),
+    /namespace is not writable: team/,
+  );
+  assert.deepEqual(getStorageCalls, []);
+});
+
+test("getWritableStorageForNamespace denies missing principals before storage lookup", async () => {
+  const { service, getStorageCalls } = makeService();
+
+  await assert.rejects(
+    () => service.getWritableStorageForNamespace("team", undefined),
+    /authentication required/,
+  );
+  assert.deepEqual(getStorageCalls, []);
+});
+
+test("getWritableStorageForNamespace resolves namespace storage for write principals", async () => {
+  const { service, storage, getStorageCalls } = makeService();
+
+  const resolved = await service.getWritableStorageForNamespace("team", "writer");
+
+  assert.equal(resolved.namespace, "team");
+  assert.equal(resolved.storage, storage);
+  assert.deepEqual(getStorageCalls, ["team"]);
+});

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5130,6 +5130,29 @@ export class EngramAccessService {
     return storage.dir;
   }
 
+  async getReadableStorageForNamespace(namespace?: string, principal?: string): Promise<{
+    namespace: string;
+    storage: StorageManager;
+  }> {
+    const resolved = this.resolveReadableNamespace(namespace, principal);
+    const storage = await this.orchestrator.getStorage(resolved);
+    return { namespace: resolved, storage };
+  }
+
+  async getWritableStorageForNamespace(namespace?: string, principal?: string): Promise<{
+    namespace: string;
+    storage: StorageManager;
+  }> {
+    if (this.orchestrator.config.namespacesEnabled && !principal?.trim()) {
+      throw new EngramAccessInputError(
+        "authentication required: namespaces are enabled and no principal was supplied",
+      );
+    }
+    const resolved = this.resolveWritableNamespace(namespace, undefined, principal);
+    const storage = await this.orchestrator.getStorage(resolved);
+    return { namespace: resolved, storage };
+  }
+
   get storageRef(): StorageManager {
     return this.orchestrator.storage;
   }

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -8545,6 +8545,16 @@ export function registerCli(
           const result = await executeResolution(orchestrator.config.memoryDir, orchestrator.storage, pairId, verb, {
             mergedMemoryId: cmdOpts.mergedMemoryId,
             mergedContent: cmdOpts.mergedContent,
+            storageForNamespace: (namespace) => {
+              const requested = namespace?.trim();
+              if (!orchestrator.config.namespacesEnabled) {
+                if (requested && requested !== orchestrator.config.defaultNamespace) {
+                  throw new Error(`unsupported namespace: ${requested}`);
+                }
+                return orchestrator.storage;
+              }
+              return orchestrator.getStorageForNamespace(requested || orchestrator.config.defaultNamespace);
+            },
           });
           console.log(result.message);
           if (result.affectedIds.length > 0) {
@@ -8573,6 +8583,13 @@ export function registerCli(
                   return [];
                 }
               };
+            },
+            storageForNamespace: async (namespace) => {
+              const resolvedNamespace =
+                namespace?.trim() ||
+                (orchestrator.config.namespacesEnabled ? orchestrator.config.defaultNamespace : undefined);
+              const storage = await orchestrator.getStorageForNamespace(resolvedNamespace);
+              return { storage, namespace: resolvedNamespace };
             },
             localLlm: orchestrator.localLlm ?? null,
             fallbackLlm: orchestrator.fastGatewayLlm ?? null,

--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -2,7 +2,7 @@
  * Contradiction Review Queue — storage for detected contradiction pairs (issue #520).
  *
  * Stores candidate pairs as JSON files under `memoryDir/.review/contradictions/`.
- * Pair IDs are deterministic (sha256 of sorted memory IDs) so reruns are idempotent.
+ * Pair IDs are deterministic (sha256 of sorted memory IDs plus namespace when scoped) so reruns are idempotent.
  *
  * Lifecycle:
  *   - `contradicts` → awaiting user review
@@ -20,7 +20,7 @@ import type { ContradictionVerdict } from "./contradiction-judge.js";
 export type ResolutionVerb = "keep-a" | "keep-b" | "merge" | "both-valid" | "needs-more-context";
 
 export interface ContradictionPair {
-  /** Deterministic pair ID: sha256(sorted(memoryIdA, memoryIdB)). */
+  /** Deterministic pair ID: sha256(sorted(memoryIdA, memoryIdB) plus namespace when scoped). */
   pairId: string;
   /** Memory IDs (sorted). */
   memoryIds: [string, string];
@@ -54,12 +54,25 @@ export interface WritePairOptions {
   cooldownDays?: number;
 }
 const NEEDS_MORE_CONTEXT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const UNSCOPED_MIGRATION_MARKER_PREFIX = ".unscoped-migrated-";
+const UNSCOPED_MIGRATION_MARKER_SUFFIX = ".done";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-export function computePairId(memoryIdA: string, memoryIdB: string): string {
+export function computePairId(memoryIdA: string, memoryIdB: string, namespace?: string): string {
   const sorted = [memoryIdA, memoryIdB].sort();
-  return createHash("sha256").update(sorted.join("::")).digest("hex").slice(0, 24);
+  const normalizedNamespace = namespace?.trim();
+  const scope = normalizedNamespace ? `ns:${normalizedNamespace}::` : "";
+  return createHash("sha256").update(`${scope}${sorted.join("::")}`).digest("hex").slice(0, 24);
+}
+
+export function isDefaultReviewNamespace(
+  defaultNamespace: string,
+  requestedNamespace: string | undefined,
+  resolvedNamespace: string,
+): boolean {
+  const requested = requestedNamespace?.trim();
+  return !requested || requested === defaultNamespace || resolvedNamespace === defaultNamespace;
 }
 
 function isTerminalResolution(resolution: ResolutionVerb | undefined): boolean {
@@ -72,6 +85,17 @@ function preservesDirectResolution(resolution: ResolutionVerb | undefined): bool
 
 function isDormantReviewedPair(pair: ContradictionPair): boolean {
   return pair.verdict === "independent" || pair.resolution === "both-valid";
+}
+
+function reviewStateRank(pair: ContradictionPair, cooldownDays?: number): number {
+  if (isTerminalResolution(pair.resolution)) return 5;
+  if (pair.resolution === "both-valid") return 4;
+  if (isDeferralActive(pair)) return 3;
+  if (isDormantReviewedPair(pair)) {
+    if (cooldownDays === undefined) return 2;
+    return isCoolingDown(pair, cooldownDays) ? 2 : 0;
+  }
+  return 1;
 }
 
 function parseIsoMillis(value: string | undefined): number | null {
@@ -101,8 +125,54 @@ function isDeferralActive(pair: ContradictionPair): boolean {
   return deferredUntil !== null && Date.now() < deferredUntil;
 }
 
+function reviewStateMillis(pair: ContradictionPair): number {
+  return Math.max(
+    parseIsoMillis(pair.deferredUntil) ?? Number.NEGATIVE_INFINITY,
+    parseIsoMillis(pair.lastReviewedAt) ?? Number.NEGATIVE_INFINITY,
+    parseIsoMillis(pair.detectedAt) ?? Number.NEGATIVE_INFINITY,
+  );
+}
+
+function mergeMigratedPair(existing: ContradictionPair, migrated: ContradictionPair, options: WritePairOptions): ContradictionPair {
+  const existingRank = reviewStateRank(existing, options.cooldownDays);
+  const migratedRank = reviewStateRank(migrated, options.cooldownDays);
+  const selected = migratedRank > existingRank
+    ? migrated
+    : migratedRank < existingRank
+      ? existing
+      : reviewStateMillis(migrated) > reviewStateMillis(existing)
+        ? migrated
+        : existing;
+
+  return {
+    ...selected,
+    pairId: migrated.pairId,
+    namespace: migrated.namespace,
+  };
+}
+
 function reviewDir(memoryDir: string): string {
   return path.join(memoryDir, ".review", "contradictions");
+}
+
+function migrationMarkerPath(memoryDir: string, namespace: string): string {
+  const namespaceKey = createHash("sha256").update(namespace).digest("hex").slice(0, 16);
+  return path.join(reviewDir(memoryDir), `${UNSCOPED_MIGRATION_MARKER_PREFIX}${namespaceKey}${UNSCOPED_MIGRATION_MARKER_SUFFIX}`);
+}
+
+function clearUnscopedMigrationMarkers(memoryDir: string): void {
+  const dir = reviewDir(memoryDir);
+  if (!fs.existsSync(dir)) return;
+
+  try {
+    for (const entry of fs.readdirSync(dir)) {
+      if (entry.startsWith(UNSCOPED_MIGRATION_MARKER_PREFIX) && entry.endsWith(UNSCOPED_MIGRATION_MARKER_SUFFIX)) {
+        fs.rmSync(path.join(dir, entry), { force: true });
+      }
+    }
+  } catch {
+    // Marker cleanup is best-effort. The next migration/list call can recover.
+  }
 }
 
 function pairPath(memoryDir: string, pairId: string): string {
@@ -151,7 +221,10 @@ export function writePair(
   options: WritePairOptions = {},
 ): ContradictionPair {
   ensureDir(memoryDir);
-  const pairId = computePairId(pair.memoryIds[0], pair.memoryIds[1]);
+  if (pair.namespace === undefined) {
+    clearUnscopedMigrationMarkers(memoryDir);
+  }
+  const pairId = computePairId(pair.memoryIds[0], pair.memoryIds[1], pair.namespace);
   const existing = readPair(memoryDir, pairId);
 
   // Preserve terminal user resolutions if already reviewed.
@@ -220,7 +293,7 @@ export function writePairs(
   const results: ContradictionPair[] = [];
 
   for (const pair of pairs) {
-    const key = computePairId(pair.memoryIds[0], pair.memoryIds[1]);
+    const key = computePairId(pair.memoryIds[0], pair.memoryIds[1], pair.namespace);
     if (seen.has(key)) continue;
     seen.add(key);
     results.push(writePair(memoryDir, pair, options));
@@ -256,12 +329,13 @@ export function listPairs(
   options?: {
     filter?: ContradictionFilter;
     namespace?: string;
+    includeUnscopedForNamespace?: boolean;
     limit?: number;
   },
 ): ContradictionListResult {
   const startTime = Date.now();
   const dir = reviewDir(memoryDir);
-  const { filter = "all", namespace, limit = 50 } = options ?? {};
+  const { filter = "all", namespace, includeUnscopedForNamespace = false, limit = 50 } = options ?? {};
   const pairs: ContradictionPair[] = [];
   let total = 0;
 
@@ -280,7 +354,7 @@ export function listPairs(
       if (!Array.isArray(pair.memoryIds)) continue;
 
       // Namespace filter
-      if (namespace && pair.namespace !== namespace) continue;
+      if (namespace && pair.namespace !== namespace && !(includeUnscopedForNamespace && pair.namespace === undefined)) continue;
 
       // Verdict filter
       if (filter === "unresolved") {
@@ -300,6 +374,55 @@ export function listPairs(
   }
 
   return { pairs, total, durationMs: Date.now() - startTime };
+}
+
+export function migrateUnscopedPairsToNamespace(memoryDir: string, namespace: string, options: WritePairOptions = {}): number {
+  const resolvedNamespace = namespace.trim();
+  if (!resolvedNamespace) return 0;
+
+  const dir = reviewDir(memoryDir);
+  if (!fs.existsSync(dir)) return 0;
+  const markerPath = migrationMarkerPath(memoryDir, resolvedNamespace);
+  if (fs.existsSync(markerPath)) return 0;
+
+  let migrated = 0;
+  for (const entry of fs.readdirSync(dir)) {
+    if (!entry.endsWith(".json")) continue;
+    const filePath = path.join(dir, entry);
+
+    try {
+      const raw = fs.readFileSync(filePath, "utf-8");
+      const pair = JSON.parse(raw) as ContradictionPair;
+      if (typeof pair !== "object" || pair === null) continue;
+      if (!Array.isArray(pair.memoryIds)) continue;
+      if (pair.namespace !== undefined) continue;
+
+      const pairId = computePairId(pair.memoryIds[0], pair.memoryIds[1], resolvedNamespace);
+      const migratedPair = { ...pair, namespace: resolvedNamespace, pairId };
+      const targetPath = pairPath(memoryDir, pairId);
+      if (targetPath === filePath) {
+        writePairFile(filePath, migratedPair);
+      } else if (!fs.existsSync(targetPath)) {
+        writePairFile(targetPath, migratedPair);
+        fs.rmSync(filePath, { force: true });
+      } else {
+        const existing = readPair(memoryDir, pairId);
+        writePairFile(targetPath, existing ? mergeMigratedPair(existing, migratedPair, options) : migratedPair);
+        fs.rmSync(filePath, { force: true });
+      }
+      migrated += 1;
+    } catch {
+      continue;
+    }
+  }
+
+  try {
+    fs.writeFileSync(markerPath, `${new Date().toISOString()}\n`, { encoding: "utf-8", flag: "wx" });
+  } catch {
+    // Another caller may have completed the same one-shot migration first.
+  }
+
+  return migrated;
 }
 
 // ── Cooldown ───────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/contradiction/contradiction-scan.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-scan.ts
@@ -24,6 +24,7 @@ import {
   listPairs,
   isCoolingDown,
   computePairId,
+  migrateUnscopedPairsToNamespace,
   type ContradictionPair,
 } from "./contradiction-review.js";
 import type { LocalLlmClient } from "../local-llm.js";
@@ -59,6 +60,11 @@ export interface ScanResult {
   elapsedMs: number;
 }
 
+export interface ScanStorageResolution {
+  storage: StorageManager;
+  namespace?: string;
+}
+
 export interface ScanDependencies {
   storage: StorageManager;
   config: PluginConfig;
@@ -71,6 +77,10 @@ export interface ScanDependencies {
    * The scan driver passes its own `storage` so the lookup queries the correct index.
    */
   embeddingLookupFactory?: (storage: StorageManager) => SemanticDedupLookup | undefined;
+  /** Resolver for namespace-scoped storage. Required for scans when namespaces are enabled. */
+  storageForNamespace?: (
+    namespace: string | undefined,
+  ) => StorageManager | ScanStorageResolution | Promise<StorageManager | ScanStorageResolution>;
   localLlm: LocalLlmClient | null;
   fallbackLlm: FallbackLlmClient | null;
   namespace?: string;
@@ -85,22 +95,31 @@ export interface ScanDependencies {
  */
 export async function runContradictionScan(deps: ScanDependencies): Promise<ScanResult> {
   const startTime = Date.now();
-  const { storage, config, memoryDir, embeddingLookup, embeddingLookupFactory, localLlm, fallbackLlm, namespace } = deps;
+  const { config, memoryDir, embeddingLookup, embeddingLookupFactory, localLlm, fallbackLlm } = deps;
+  const requestedNamespace = normalizeScanNamespace(deps.namespace);
   const scanConfig = config.contradictionScan;
-
-  // Prefer the factory (which uses the scan's own storage for correct namespace scoping)
-  // over a pre-built lookup (which may use default-namespace storage).
-  const scopedEmbeddingLookup = embeddingLookupFactory
-    ? embeddingLookupFactory(storage)
-    : embeddingLookup;
 
   if (!scanConfig.enabled) {
     log.info("[contradiction-scan] disabled by config");
     return { scanned: 0, candidates: 0, judged: 0, queued: 0, cooledDown: 0, elapsedMs: 0 };
   }
 
+  const { storage: scanStorage, namespace } = await resolveScanStorage(deps, requestedNamespace);
+  if (config.namespacesEnabled && namespace !== undefined && isDefaultNamespaceScan(config, requestedNamespace, namespace)) {
+    const migrated = migrateUnscopedPairsToNamespace(memoryDir, namespace, { cooldownDays: scanConfig.cooldownDays });
+    if (migrated > 0) {
+      log.info("[contradiction-scan] migrated %d legacy unscoped review pairs to namespace %s", migrated, namespace);
+    }
+  }
+
+  // Prefer the factory (which uses the scan's own storage for correct namespace scoping)
+  // over a pre-built lookup (which may use default-namespace storage).
+  const scopedEmbeddingLookup = embeddingLookupFactory
+    ? embeddingLookupFactory(scanStorage)
+    : embeddingLookup;
+
   // 1. Load active memories in scan categories
-  const memories = await loadEligibleMemories(storage, namespace);
+  const memories = await loadEligibleMemories(scanStorage);
   log.info("[contradiction-scan] loaded %d eligible memories", memories.length);
 
   if (memories.length < 2) {
@@ -115,7 +134,7 @@ export async function runContradictionScan(deps: ScanDependencies): Promise<Scan
   }
 
   // 3. Generate candidate pairs
-  const candidates = await generatePairs(memories, existingMap, scanConfig, scopedEmbeddingLookup);
+  const candidates = await generatePairs(memories, existingMap, scanConfig, namespace, scopedEmbeddingLookup);
   const cooledDown = candidates.skipped;
   log.info("[contradiction-scan] generated %d candidates (%d cooled down)", candidates.pairs.length, cooledDown);
 
@@ -132,7 +151,7 @@ export async function runContradictionScan(deps: ScanDependencies): Promise<Scan
 
   // 4. Cap at maxPairsPerRun (deterministic selection by pairId)
   const capped = candidates.pairs
-    .sort((a, b) => computePairId(a.idA, a.idB).localeCompare(computePairId(b.idA, b.idB)))
+    .sort((a, b) => computePairId(a.idA, a.idB, namespace).localeCompare(computePairId(b.idA, b.idB, namespace)))
     .slice(0, scanConfig.maxPairsPerRun);
 
   // 5. Build judge inputs
@@ -199,6 +218,7 @@ async function generatePairs(
   memories: MemoryFile[],
   existingPairs: Map<string, ContradictionPair>,
   scanConfig: PluginConfig["contradictionScan"],
+  namespace: string | undefined,
   embeddingLookup?: SemanticDedupLookup,
 ): Promise<PairGenResult> {
   const pairs: CandidatePair[] = [];
@@ -224,7 +244,7 @@ async function generatePairs(
       for (let j = i + 1; j < group.length; j++) {
         const a = group[i];
         const b = group[j];
-        const pairId = computePairId(a.frontmatter.id!, b.frontmatter.id!);
+        const pairId = computePairId(a.frontmatter.id!, b.frontmatter.id!, namespace);
 
         if (seen.has(pairId)) continue;
         seen.add(pairId);
@@ -261,7 +281,7 @@ async function generatePairs(
 
       if (overlap < scanConfig.topicOverlapFloor) continue;
 
-      const pairId = computePairId(a.frontmatter.id!, b.frontmatter.id!);
+      const pairId = computePairId(a.frontmatter.id!, b.frontmatter.id!, namespace);
       if (seen.has(pairId)) continue;
       seen.add(pairId);
 
@@ -295,7 +315,7 @@ async function generatePairs(
           const peer = memoryById.get(hit.id);
           if (!peer) continue;
 
-          const pairId = computePairId(id, hit.id);
+          const pairId = computePairId(id, hit.id, namespace);
           if (seen.has(pairId)) continue;
           seen.add(pairId);
 
@@ -329,7 +349,73 @@ async function generatePairs(
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-async function loadEligibleMemories(storage: StorageManager, namespace?: string): Promise<MemoryFile[]> {
+function normalizeScanNamespace(namespace: string | undefined): string | undefined {
+  const trimmed = namespace?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+async function resolveScanStorage(
+  deps: ScanDependencies,
+  namespace: string | undefined,
+): Promise<ScanStorageResolution> {
+  if (!deps.config.namespacesEnabled) {
+    const defaultNamespace = normalizeScanNamespace(deps.config.defaultNamespace);
+    if (namespace && namespace !== defaultNamespace) {
+      throw new Error(`unsupported namespace: ${namespace}`);
+    }
+    return { storage: deps.storage, namespace: undefined };
+  }
+
+  if (deps.storageForNamespace) {
+    const resolved = await deps.storageForNamespace(namespace);
+    if (isScanStorageResolution(resolved)) {
+      return {
+        storage: resolved.storage,
+        namespace: normalizeScanNamespace(resolved.namespace) ?? fallbackResolvedNamespace(deps, namespace),
+      };
+    }
+    if (!isStorageManagerLike(resolved)) {
+      throw new Error("storageForNamespace must return a StorageManager or { storage: StorageManager, namespace?: string }");
+    }
+    return {
+      storage: resolved,
+      namespace: fallbackResolvedNamespace(deps, namespace),
+    };
+  }
+
+  throw new Error(
+    "contradiction scans require storageForNamespace when namespaces are enabled so callers can enforce namespace access",
+  );
+}
+
+function isScanStorageResolution(value: StorageManager | ScanStorageResolution): value is ScanStorageResolution {
+  if (isStorageManagerLike(value)) return false;
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { storage?: unknown };
+  return isStorageManagerLike(candidate.storage);
+}
+
+function isStorageManagerLike(value: unknown): value is StorageManager {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { readAllMemories?: unknown };
+  return typeof candidate.readAllMemories === "function";
+}
+
+function fallbackResolvedNamespace(deps: ScanDependencies, namespace: string | undefined): string | undefined {
+  if (namespace) return namespace;
+  return deps.config.namespacesEnabled ? deps.config.defaultNamespace : undefined;
+}
+
+function isDefaultNamespaceScan(
+  config: PluginConfig,
+  requestedNamespace: string | undefined,
+  resolvedNamespace: string,
+): boolean {
+  if (requestedNamespace === undefined) return true;
+  return requestedNamespace === config.defaultNamespace || resolvedNamespace === config.defaultNamespace;
+}
+
+async function loadEligibleMemories(storage: StorageManager): Promise<MemoryFile[]> {
   let all: MemoryFile[];
   try {
     all = await storage.readAllMemories();
@@ -352,10 +438,6 @@ async function loadEligibleMemories(storage: StorageManager, namespace?: string)
 
     // Must have an ID
     if (!fm.id) return false;
-
-    // Namespace scoping is handled at the storage layer — memoryDir is
-    // already namespace-scoped, so readAllMemories() returns only memories
-    // within the requested namespace.
 
     return true;
   });

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -14,11 +14,13 @@ import {
   isCoolingDown,
   resolvePair,
   deferPair,
+  migrateUnscopedPairsToNamespace,
   type ContradictionPair,
 } from "./contradiction-review.js";
 import { _pairKey, _contentHash } from "./contradiction-judge.js";
 import { executeResolution, isValidResolutionVerb } from "./resolution.js";
-import { ACTIVE_STATUSES } from "./contradiction-scan.js";
+import { ACTIVE_STATUSES, runContradictionScan } from "./contradiction-scan.js";
+import { parseConfig } from "../config.js";
 import type { StorageManager } from "../storage.js";
 import type { MemoryCategory, MemoryFile, MemoryFrontmatter } from "../types.js";
 
@@ -175,6 +177,20 @@ function makeResolutionStorage(options: {
   return storage as typeof storage & StorageManager;
 }
 
+function makeScanStorage(memories: MemoryFile[]) {
+  let readCount = 0;
+  const storage = {
+    get readCount() {
+      return readCount;
+    },
+    async readAllMemories() {
+      readCount += 1;
+      return memories.map(cloneMemory);
+    },
+  };
+  return storage as typeof storage & StorageManager;
+}
+
 // ── Pair ID determinism ────────────────────────────────────────────────────────
 
 test("computePairId is deterministic and order-independent", () => {
@@ -187,6 +203,18 @@ test("computePairId produces different IDs for different pairs", () => {
   const ab = computePairId("a", "b");
   const ac = computePairId("a", "c");
   assert.notEqual(ab, ac);
+});
+
+test("computePairId includes namespace scope when present", () => {
+  const unscoped = computePairId("a", "b");
+  const ns1 = computePairId("a", "b", "ns1");
+  const ns1Reversed = computePairId("b", "a", "ns1");
+  const ns2 = computePairId("a", "b", "ns2");
+
+  assert.notEqual(ns1, unscoped);
+  assert.equal(ns1, ns1Reversed);
+  assert.notEqual(ns1, ns2);
+  assert.equal(computePairId("a", "b", "  "), unscoped);
 });
 
 // ── Review queue write/read ────────────────────────────────────────────────────
@@ -215,6 +243,20 @@ test("writePair is idempotent", async () => {
     const first = writePair(dir, pair);
     const second = writePair(dir, pair);
     assert.equal(first.pairId, second.pairId);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("writePair stores identical memory id pairs separately per namespace", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const ns1 = writePair(dir, makePair({ namespace: "ns1" }));
+    const ns2 = writePair(dir, makePair({ namespace: "ns2" }));
+
+    assert.notEqual(ns1.pairId, ns2.pairId);
+    assert.equal(listPairs(dir, { namespace: "ns1" }).pairs[0]?.pairId, ns1.pairId);
+    assert.equal(listPairs(dir, { namespace: "ns2" }).pairs[0]?.pairId, ns2.pairId);
   } finally {
     await cleanup();
   }
@@ -444,6 +486,652 @@ test("listPairs filters by namespace", async () => {
     const ns1 = listPairs(dir, { namespace: "ns1" });
     assert.equal(ns1.pairs.length, 1);
     assert.equal(ns1.pairs[0].namespace, "ns1");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("listPairs can include legacy unscoped pairs for a namespace filter", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const legacy = writePair(dir, makePair({ memoryIds: ["legacy-a", "legacy-b"] }));
+    writePair(dir, makePair({ namespace: "other", memoryIds: ["other-a", "other-b"] }));
+
+    const result = listPairs(dir, { namespace: "default", includeUnscopedForNamespace: true });
+
+    assert.equal(result.total, 1);
+    assert.equal(result.pairs[0]?.pairId, legacy.pairId);
+    assert.equal(result.pairs[0]?.namespace, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("migrateUnscopedPairsToNamespace adopts legacy unscoped review pairs", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const legacy = writePair(dir, makePair({ memoryIds: ["legacy-a", "legacy-b"] }));
+    writePair(dir, makePair({ namespace: "other", memoryIds: ["other-a", "other-b"] }));
+
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+
+    const migrated = listPairs(dir, { filter: "all", namespace: "default" }).pairs;
+    assert.equal(migrated.length, 1);
+    assert.equal(migrated[0]!.namespace, "default");
+    assert.equal(migrated[0]!.pairId, computePairId("legacy-a", "legacy-b", "default"));
+    assert.equal(readPair(dir, legacy.pairId), null);
+
+    const other = listPairs(dir, { filter: "all", namespace: "other" }).pairs;
+    assert.equal(other.length, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("migrateUnscopedPairsToNamespace skips review directory scan after completion marker", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    writePair(dir, makePair({ memoryIds: ["legacy-a", "legacy-b"] }));
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+
+    const reviewPath = path.join(dir, ".review", "contradictions");
+    const originalReaddirSync = fs.readdirSync;
+    const callOriginalReaddirSync = originalReaddirSync as unknown as (...args: unknown[]) => unknown;
+    const fsMutable = fs as unknown as { readdirSync: typeof fs.readdirSync };
+    let reviewDirScans = 0;
+    try {
+      fsMutable.readdirSync = ((...args: unknown[]) => {
+        if (String(args[0]) === reviewPath) reviewDirScans += 1;
+        return callOriginalReaddirSync(...args);
+      }) as typeof fs.readdirSync;
+
+      assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 0);
+      assert.equal(reviewDirScans, 0);
+    } finally {
+      fsMutable.readdirSync = originalReaddirSync;
+    }
+
+    const lateLegacy = writePair(dir, makePair({ memoryIds: ["late-a", "late-b"] }));
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+    assert.equal(readPair(dir, lateLegacy.pairId), null);
+    assert.equal(readPair(dir, computePairId("late-a", "late-b", "default"))?.namespace, "default");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("migrateUnscopedPairsToNamespace preserves legacy both-valid state on scoped collisions", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const scoped = writePair(dir, makePair({
+      namespace: "default",
+      memoryIds: ["shared-a", "shared-b"],
+      verdict: "contradicts",
+      confidence: 0.95,
+      detectedAt: "2026-01-01T00:00:00.000Z",
+    }));
+    const legacy: ContradictionPair = {
+      ...makePair({
+        memoryIds: ["shared-a", "shared-b"],
+        verdict: "independent",
+        resolution: "both-valid",
+        lastReviewedAt: "2026-02-01T00:00:00.000Z",
+        detectedAt: "2026-01-15T00:00:00.000Z",
+      }),
+      pairId: computePairId("shared-a", "shared-b"),
+    };
+    await writeStoredPair(dir, legacy);
+
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+
+    const migrated = readPair(dir, scoped.pairId);
+    assert.ok(migrated);
+    assert.equal(migrated.namespace, "default");
+    assert.equal(migrated.resolution, "both-valid");
+    assert.equal(migrated.verdict, "independent");
+    assert.equal(migrated.lastReviewedAt, "2026-02-01T00:00:00.000Z");
+    assert.equal(readPair(dir, legacy.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("migrateUnscopedPairsToNamespace preserves legacy cooldown state on scoped collisions", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const scoped = writePair(dir, makePair({
+      namespace: "default",
+      memoryIds: ["shared-a", "shared-b"],
+      verdict: "contradicts",
+      confidence: 0.95,
+      detectedAt: "2026-01-01T00:00:00.000Z",
+    }));
+    const legacy: ContradictionPair = {
+      ...makePair({
+        memoryIds: ["shared-a", "shared-b"],
+        verdict: "independent",
+        lastReviewedAt: "2026-02-01T00:00:00.000Z",
+        detectedAt: "2026-01-15T00:00:00.000Z",
+      }),
+      pairId: computePairId("shared-a", "shared-b"),
+    };
+    await writeStoredPair(dir, legacy);
+
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+
+    const migrated = readPair(dir, scoped.pairId);
+    assert.ok(migrated);
+    assert.equal(migrated.namespace, "default");
+    assert.equal(migrated.verdict, "independent");
+    assert.equal(migrated.lastReviewedAt, "2026-02-01T00:00:00.000Z");
+    assert.equal(readPair(dir, legacy.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("migrateUnscopedPairsToNamespace preserves scoped conflicts over expired legacy cooldowns", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const scoped = writePair(dir, makePair({
+      namespace: "default",
+      memoryIds: ["shared-a", "shared-b"],
+      verdict: "contradicts",
+      confidence: 0.95,
+      detectedAt: "2026-04-01T00:00:00.000Z",
+    }));
+    const legacy: ContradictionPair = {
+      ...makePair({
+        memoryIds: ["shared-a", "shared-b"],
+        verdict: "independent",
+        lastReviewedAt: "2020-01-01T00:00:00.000Z",
+        detectedAt: "2020-01-01T00:00:00.000Z",
+      }),
+      pairId: computePairId("shared-a", "shared-b"),
+    };
+    await writeStoredPair(dir, legacy);
+
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default", { cooldownDays: 14 }), 1);
+
+    const migrated = readPair(dir, scoped.pairId);
+    assert.ok(migrated);
+    assert.equal(migrated.namespace, "default");
+    assert.equal(migrated.verdict, "contradicts");
+    assert.equal(migrated.resolution, undefined);
+    assert.equal(readPair(dir, legacy.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("migrateUnscopedPairsToNamespace preserves existing terminal scoped state on collisions", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const scoped: ContradictionPair = {
+      ...makePair({
+        namespace: "default",
+        memoryIds: ["shared-a", "shared-b"],
+        verdict: "contradicts",
+        resolution: "keep-a",
+        lastReviewedAt: "2026-01-01T00:00:00.000Z",
+      }),
+      pairId: computePairId("shared-a", "shared-b", "default"),
+    };
+    await writeStoredPair(dir, scoped);
+    const legacy: ContradictionPair = {
+      ...makePair({
+        memoryIds: ["shared-a", "shared-b"],
+        verdict: "independent",
+        resolution: "both-valid",
+        lastReviewedAt: "2026-02-01T00:00:00.000Z",
+      }),
+      pairId: computePairId("shared-a", "shared-b"),
+    };
+    await writeStoredPair(dir, legacy);
+
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+
+    const migrated = readPair(dir, scoped.pairId);
+    assert.ok(migrated);
+    assert.equal(migrated.namespace, "default");
+    assert.equal(migrated.resolution, "keep-a");
+    assert.equal(migrated.verdict, "contradicts");
+    assert.equal(readPair(dir, legacy.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("migrateUnscopedPairsToNamespace keeps selected memory order on scoped collisions", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const scoped: ContradictionPair = {
+      ...makePair({
+        namespace: "default",
+        memoryIds: ["shared-b", "shared-a"],
+        verdict: "contradicts",
+        resolution: "keep-a",
+        lastReviewedAt: "2026-01-01T00:00:00.000Z",
+      }),
+      pairId: computePairId("shared-a", "shared-b", "default"),
+    };
+    await writeStoredPair(dir, scoped);
+    const legacy: ContradictionPair = {
+      ...makePair({
+        memoryIds: ["shared-a", "shared-b"],
+        verdict: "independent",
+        resolution: "both-valid",
+        lastReviewedAt: "2026-02-01T00:00:00.000Z",
+      }),
+      pairId: computePairId("shared-a", "shared-b"),
+    };
+    await writeStoredPair(dir, legacy);
+
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+
+    const migrated = readPair(dir, scoped.pairId);
+    assert.ok(migrated);
+    assert.equal(migrated.resolution, "keep-a");
+    assert.deepEqual(migrated.memoryIds, ["shared-b", "shared-a"]);
+    assert.equal(readPair(dir, legacy.pairId), null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan loads memories from namespace-scoped storage", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const ns1A = makeMemory("ns1-a");
+    ns1A.frontmatter.entityRef = "entity:shared";
+    const ns1B = makeMemory("ns1-b");
+    ns1B.frontmatter.entityRef = "entity:shared";
+    const ns2A = makeMemory("ns2-a");
+    ns2A.frontmatter.entityRef = "entity:shared";
+
+    const rootStorage = makeScanStorage([ns1A, ns1B, ns2A]);
+    const ns1Storage = makeScanStorage([ns1A, ns1B]);
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+        topicOverlapFloor: 0,
+        similarityFloor: 0,
+      },
+    });
+
+    const result = await runContradictionScan({
+      storage: rootStorage,
+      storageForNamespace(namespace) {
+        assert.equal(namespace, "ns1");
+        return ns1Storage;
+      },
+      config,
+      memoryDir: dir,
+      localLlm: null,
+      fallbackLlm: null,
+      namespace: "ns1",
+    });
+
+    assert.equal(rootStorage.readCount, 0);
+    assert.equal(ns1Storage.readCount, 1);
+    assert.equal(result.scanned, 2);
+    assert.equal(result.judged, 1);
+    assert.equal(result.queued, 1);
+
+    const queued = listPairs(dir, { filter: "all", namespace: "ns1" }).pairs;
+    assert.equal(queued.length, 1);
+    assert.deepEqual([...queued[0]!.memoryIds].sort(), ["ns1-a", "ns1-b"]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan resolves default namespace scans through namespace storage resolver", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const defaultA = makeMemory("default-a");
+    defaultA.frontmatter.entityRef = "entity:shared";
+    const defaultB = makeMemory("default-b");
+    defaultB.frontmatter.entityRef = "entity:shared";
+    const rootOnly = makeMemory("root-only");
+    rootOnly.frontmatter.entityRef = "entity:shared";
+
+    const rootStorage = makeScanStorage([rootOnly]);
+    const defaultStorage = makeScanStorage([defaultA, defaultB]);
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "configured-default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+        topicOverlapFloor: 0,
+        similarityFloor: 0,
+      },
+    });
+
+    const result = await runContradictionScan({
+      storage: rootStorage,
+      storageForNamespace(namespace) {
+        assert.equal(namespace, undefined);
+        return { storage: defaultStorage, namespace: "resolved-default" };
+      },
+      config,
+      memoryDir: dir,
+      localLlm: null,
+      fallbackLlm: null,
+    });
+
+    assert.equal(rootStorage.readCount, 0);
+    assert.equal(defaultStorage.readCount, 1);
+    assert.equal(result.scanned, 2);
+
+    const queued = listPairs(dir, { filter: "all", namespace: "resolved-default" }).pairs;
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0]!.namespace, "resolved-default");
+    assert.deepEqual([...queued[0]!.memoryIds].sort(), ["default-a", "default-b"]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan treats StorageManager with storage property as raw storage", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const defaultA = makeMemory("default-a");
+    defaultA.frontmatter.entityRef = "entity:shared";
+    const defaultB = makeMemory("default-b");
+    defaultB.frontmatter.entityRef = "entity:shared";
+    const nestedOnly = makeMemory("nested-only");
+    nestedOnly.frontmatter.entityRef = "entity:shared";
+
+    const rawStorage = makeScanStorage([defaultA, defaultB]) as ReturnType<typeof makeScanStorage> & {
+      storage: ReturnType<typeof makeScanStorage>;
+    };
+    rawStorage.storage = makeScanStorage([nestedOnly]);
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "configured-default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+        topicOverlapFloor: 0,
+        similarityFloor: 0,
+      },
+    });
+
+    const result = await runContradictionScan({
+      storage: makeScanStorage([]),
+      storageForNamespace() {
+        return rawStorage;
+      },
+      config,
+      memoryDir: dir,
+      localLlm: null,
+      fallbackLlm: null,
+    });
+
+    assert.equal(rawStorage.readCount, 1);
+    assert.equal(rawStorage.storage.readCount, 0);
+    assert.equal(result.scanned, 2);
+
+    const queued = listPairs(dir, { filter: "all", namespace: "configured-default" }).pairs;
+    assert.equal(queued.length, 1);
+    assert.deepEqual([...queued[0]!.memoryIds].sort(), ["default-a", "default-b"]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan migrates legacy unscoped cooldown pairs for default namespace scans", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const defaultA = makeMemory("default-a");
+    defaultA.frontmatter.entityRef = "entity:shared";
+    const defaultB = makeMemory("default-b");
+    defaultB.frontmatter.entityRef = "entity:shared";
+    writePair(dir, makePair({
+      memoryIds: ["default-a", "default-b"],
+      verdict: "independent",
+      lastReviewedAt: new Date().toISOString(),
+    }));
+
+    const defaultStorage = makeScanStorage([defaultA, defaultB]);
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "configured-default",
+      contradictionScan: {
+        enabled: true,
+        cooldownDays: 14,
+        maxPairsPerRun: 10,
+        topicOverlapFloor: 0,
+        similarityFloor: 0,
+      },
+    });
+
+    const result = await runContradictionScan({
+      storage: makeScanStorage([]),
+      storageForNamespace(namespace) {
+        assert.equal(namespace, undefined);
+        return { storage: defaultStorage, namespace: "resolved-default" };
+      },
+      config,
+      memoryDir: dir,
+      localLlm: null,
+      fallbackLlm: null,
+    });
+
+    assert.equal(result.cooledDown, 1);
+    assert.equal(result.judged, 0);
+    assert.equal(result.queued, 0);
+
+    const queued = listPairs(dir, { filter: "all", namespace: "resolved-default" }).pairs;
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0]!.namespace, "resolved-default");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan migrates legacy unscoped cooldown pairs for explicit default namespace scans", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const defaultA = makeMemory("default-a");
+    defaultA.frontmatter.entityRef = "entity:shared";
+    const defaultB = makeMemory("default-b");
+    defaultB.frontmatter.entityRef = "entity:shared";
+    writePair(dir, makePair({
+      memoryIds: ["default-a", "default-b"],
+      verdict: "independent",
+      lastReviewedAt: new Date().toISOString(),
+    }));
+
+    const defaultStorage = makeScanStorage([defaultA, defaultB]);
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "configured-default",
+      contradictionScan: {
+        enabled: true,
+        cooldownDays: 14,
+        maxPairsPerRun: 10,
+        topicOverlapFloor: 0,
+        similarityFloor: 0,
+      },
+    });
+
+    const result = await runContradictionScan({
+      storage: makeScanStorage([]),
+      storageForNamespace(namespace) {
+        assert.equal(namespace, "configured-default");
+        return { storage: defaultStorage, namespace: "configured-default" };
+      },
+      config,
+      memoryDir: dir,
+      localLlm: null,
+      fallbackLlm: null,
+      namespace: "configured-default",
+    });
+
+    assert.equal(result.cooledDown, 1);
+    assert.equal(result.judged, 0);
+    assert.equal(result.queued, 0);
+
+    const queued = listPairs(dir, { filter: "all", namespace: "configured-default" }).pairs;
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0]!.namespace, "configured-default");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan rejects namespace scans without an access-checked storage resolver", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const rootStorage = makeScanStorage([makeMemory("root-a"), makeMemory("root-b")]);
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+      },
+    });
+
+    await assert.rejects(
+      runContradictionScan({
+        storage: rootStorage,
+        config,
+        memoryDir: dir,
+        localLlm: null,
+        fallbackLlm: null,
+        namespace: "ns1",
+      }),
+      /storageForNamespace/,
+    );
+
+    assert.equal(rootStorage.readCount, 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan rejects default scans without an access-checked storage resolver when namespaces are enabled", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const rootStorage = makeScanStorage([makeMemory("root-a"), makeMemory("root-b")]);
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+      },
+    });
+
+    await assert.rejects(
+      runContradictionScan({
+        storage: rootStorage,
+        config,
+        memoryDir: dir,
+        localLlm: null,
+        fallbackLlm: null,
+      }),
+      /storageForNamespace/,
+    );
+
+    assert.equal(rootStorage.readCount, 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan rejects unsupported explicit namespaces when namespaces are disabled", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const rootStorage = makeScanStorage([makeMemory("root-a"), makeMemory("root-b")]);
+    let resolverCalls = 0;
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: false,
+      defaultNamespace: "default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+      },
+    });
+
+    await assert.rejects(
+      runContradictionScan({
+        storage: rootStorage,
+        storageForNamespace() {
+          resolverCalls += 1;
+          return makeScanStorage([]);
+        },
+        config,
+        memoryDir: dir,
+        localLlm: null,
+        fallbackLlm: null,
+        namespace: "typo",
+      }),
+      /unsupported namespace: typo/,
+    );
+
+    assert.equal(resolverCalls, 0);
+    assert.equal(rootStorage.readCount, 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan ignores explicit default namespace when namespaces are disabled", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const rootA = makeMemory("root-a");
+    rootA.frontmatter.entityRef = "entity:shared";
+    const rootB = makeMemory("root-b");
+    rootB.frontmatter.entityRef = "entity:shared";
+    const rootStorage = makeScanStorage([rootA, rootB]);
+    let resolverCalls = 0;
+    const config = parseConfig({
+      memoryDir: dir,
+      namespacesEnabled: false,
+      defaultNamespace: "default",
+      contradictionScan: {
+        enabled: true,
+        maxPairsPerRun: 10,
+        topicOverlapFloor: 0,
+        similarityFloor: 0,
+      },
+    });
+
+    const result = await runContradictionScan({
+      storage: rootStorage,
+      storageForNamespace() {
+        resolverCalls += 1;
+        return makeScanStorage([]);
+      },
+      config,
+      memoryDir: dir,
+      localLlm: null,
+      fallbackLlm: null,
+      namespace: "default",
+    });
+
+    assert.equal(resolverCalls, 0);
+    assert.equal(rootStorage.readCount, 1);
+    assert.equal(result.scanned, 2);
+    assert.equal(result.queued, 1);
+    assert.equal(listPairs(dir, { filter: "all", namespace: "default" }).pairs.length, 0);
+    assert.equal(listPairs(dir, { filter: "all" }).pairs.length, 1);
   } finally {
     await cleanup();
   }
@@ -789,6 +1477,112 @@ test("executeResolution keep-a does not supersede when the kept memory is missin
     assert.deepEqual(storage.supersedeCalls, []);
     assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, undefined);
     assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution resolves namespaced pairs against namespace storage", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const rootStorage = makeResolutionStorage();
+    rootStorage.memories.clear();
+    const nsStorage = makeResolutionStorage();
+    const written = writePair(dir, makePair({ namespace: "ns1" }));
+
+    const result = await executeResolution(dir, rootStorage, written.pairId, "keep-a", {
+      storageForNamespace(namespace) {
+        assert.equal(namespace, "ns1");
+        return nsStorage;
+      },
+    });
+
+    assert.deepEqual(result.affectedIds, ["mem-b-002"]);
+    assert.equal(rootStorage.supersedeCalls.length, 0);
+    assert.deepEqual(nsStorage.supersedeCalls, [{
+      oldId: "mem-b-002",
+      newId: "mem-a-001",
+      reason: "contradiction-resolution:keep-a",
+    }]);
+    assert.equal(readPair(dir, written.pairId)?.resolution, "keep-a");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution rejects namespaced pairs without a storage resolver", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const rootStorage = makeResolutionStorage();
+    const written = writePair(dir, makePair({ namespace: "ns1" }));
+
+    await assert.rejects(
+      () => executeResolution(dir, rootStorage, written.pairId, "keep-a"),
+      /storageForNamespace/,
+    );
+    assert.equal(rootStorage.supersedeCalls.length, 0);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution checks namespace resolver before reporting already resolved pairs", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const pair: ContradictionPair = {
+      ...makePair({
+        namespace: "team",
+        resolution: "both-valid",
+        lastReviewedAt: "2026-01-01T00:00:00.000Z",
+      }),
+      pairId: computePairId("mem-a-001", "mem-b-002", "team"),
+    };
+    await writeStoredPair(dir, pair);
+    const storage = makeResolutionStorage();
+    let resolverCalls = 0;
+
+    await assert.rejects(
+      () => executeResolution(dir, storage, pair.pairId, "keep-a", {
+        storageForNamespace(namespace) {
+          resolverCalls += 1;
+          assert.equal(namespace, "team");
+          throw new Error("namespace denied");
+        },
+      }),
+      /namespace denied/,
+    );
+
+    assert.equal(resolverCalls, 1);
+    assert.equal(storage.supersedeCalls.length, 0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("executeResolution resolves legacy unscoped pairs through default namespace storage", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const rootStorage = makeResolutionStorage();
+    rootStorage.memories.clear();
+    const defaultStorage = makeResolutionStorage();
+    const written = writePair(dir, makePair());
+
+    const result = await executeResolution(dir, rootStorage, written.pairId, "keep-a", {
+      storageForNamespace(namespace) {
+        assert.equal(namespace, undefined);
+        return defaultStorage;
+      },
+    });
+
+    assert.deepEqual(result.affectedIds, ["mem-b-002"]);
+    assert.equal(rootStorage.supersedeCalls.length, 0);
+    assert.deepEqual(defaultStorage.supersedeCalls, [{
+      oldId: "mem-b-002",
+      newId: "mem-a-001",
+      reason: "contradiction-resolution:keep-a",
+    }]);
+    assert.equal(readPair(dir, written.pairId)?.resolution, "keep-a");
   } finally {
     await cleanup();
   }

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -27,6 +27,8 @@ export interface ExecuteResolutionOptions {
   mergedContent?: string;
   /** Category for a newly created merged memory. Defaults to the shared source category, or fact. */
   mergedCategory?: MemoryCategory;
+  /** Resolve storage for the pair namespace, or the default namespace for legacy unscoped pairs. */
+  storageForNamespace?: (namespace: string | undefined) => StorageManager | Promise<StorageManager>;
 }
 
 const VALID_VERBS: ResolutionVerb[] = ["keep-a", "keep-b", "merge", "both-valid", "needs-more-context"];
@@ -56,6 +58,16 @@ export async function executeResolution(
     return { pairId, verb, affectedIds: [], message: `Pair ${pairId} not found` };
   }
 
+  if (pair.namespace && !options.storageForNamespace) {
+    throw new Error(
+      "contradiction resolution requires storageForNamespace for namespaced pairs so callers resolve the correct namespace storage",
+    );
+  }
+
+  const resolutionStorage = options.storageForNamespace
+    ? await options.storageForNamespace(pair.namespace)
+    : storage;
+
   if (pair.resolution && pair.resolution !== "needs-more-context") {
     return { pairId, verb, affectedIds: [], message: `Pair already resolved with verb "${pair.resolution}"` };
   }
@@ -67,21 +79,21 @@ export async function executeResolution(
 
   switch (verb) {
     case "keep-a": {
-      const keepTarget = await validateKeepTarget(storage, pairId, idA);
+      const keepTarget = await validateKeepTarget(resolutionStorage, pairId, idA);
       if (!keepTarget.ok) {
         supersedeFailed = true;
         message = keepTarget.message;
         break;
       }
-      const sourceB = await loadSourceSnapshot(storage, idB);
+      const sourceB = await loadSourceSnapshot(resolutionStorage, idB);
       const ok = sourceB
-        ? await supersedeSafe(storage, idB, idA, "contradiction-resolution:keep-a")
+        ? await supersedeSafe(resolutionStorage, idB, idA, "contradiction-resolution:keep-a")
         : false;
       if (ok) { affectedIds.push(idB); message = `Kept ${idA}, superseded ${idB}`; }
       else {
         supersedeFailed = true;
         const rolledBack = sourceB
-          ? await restoreMemorySnapshot(storage, sourceB, "contradiction-resolution:keep-a-rollback")
+          ? await restoreMemorySnapshot(resolutionStorage, sourceB, "contradiction-resolution:keep-a-rollback")
           : false;
         message = rolledBack
           ? `Supersede failed for ${idB}; restored ${idB} and did not resolve`
@@ -90,21 +102,21 @@ export async function executeResolution(
       break;
     }
     case "keep-b": {
-      const keepTarget = await validateKeepTarget(storage, pairId, idB);
+      const keepTarget = await validateKeepTarget(resolutionStorage, pairId, idB);
       if (!keepTarget.ok) {
         supersedeFailed = true;
         message = keepTarget.message;
         break;
       }
-      const sourceA = await loadSourceSnapshot(storage, idA);
+      const sourceA = await loadSourceSnapshot(resolutionStorage, idA);
       const ok = sourceA
-        ? await supersedeSafe(storage, idA, idB, "contradiction-resolution:keep-b")
+        ? await supersedeSafe(resolutionStorage, idA, idB, "contradiction-resolution:keep-b")
         : false;
       if (ok) { affectedIds.push(idA); message = `Kept ${idB}, superseded ${idA}`; }
       else {
         supersedeFailed = true;
         const rolledBack = sourceA
-          ? await restoreMemorySnapshot(storage, sourceA, "contradiction-resolution:keep-b-rollback")
+          ? await restoreMemorySnapshot(resolutionStorage, sourceA, "contradiction-resolution:keep-b-rollback")
           : false;
         message = rolledBack
           ? `Supersede failed for ${idA}; restored ${idA} and did not resolve`
@@ -113,31 +125,31 @@ export async function executeResolution(
       break;
     }
     case "merge": {
-      const replacement = await prepareMergeReplacement(storage, pairId, idA, idB, options);
+      const replacement = await prepareMergeReplacement(resolutionStorage, pairId, idA, idB, options);
       if (!replacement.ok) {
         supersedeFailed = true;
         message = replacement.message;
         break;
       }
 
-      const okA = await supersedeSafe(storage, idA, replacement.mergedId, "contradiction-resolution:merge");
+      const okA = await supersedeSafe(resolutionStorage, idA, replacement.mergedId, "contradiction-resolution:merge");
       if (!okA) {
         supersedeFailed = true;
-        const rolledBackA = await restoreMemorySnapshot(storage, replacement.sourceA);
+        const rolledBackA = await restoreMemorySnapshot(resolutionStorage, replacement.sourceA);
         message = rolledBackA
           ? `Merge failed for ${idA}; restored ${idA} and did not resolve`
           : `Merge failed for ${idA}; rollback incomplete for ${idA} and pair is not resolved`;
         if (rolledBackA) {
-          await cleanupCreatedReplacement(storage, replacement);
+          await cleanupCreatedReplacement(resolutionStorage, replacement);
         }
         break;
       }
 
-      const okB = await supersedeSafe(storage, idB, replacement.mergedId, "contradiction-resolution:merge");
+      const okB = await supersedeSafe(resolutionStorage, idB, replacement.mergedId, "contradiction-resolution:merge");
       if (!okB) {
         supersedeFailed = true;
-        const rolledBackA = await restoreMemorySnapshot(storage, replacement.sourceA);
-        const rolledBackB = await restoreMemorySnapshot(storage, replacement.sourceB);
+        const rolledBackA = await restoreMemorySnapshot(resolutionStorage, replacement.sourceA);
+        const rolledBackB = await restoreMemorySnapshot(resolutionStorage, replacement.sourceB);
         message = rolledBackA && rolledBackB
           ? `Merge failed for ${idB}; restored ${idA} and ${idB} and did not resolve`
           : `Merge failed for ${idB}; rollback incomplete for ${[
@@ -145,7 +157,7 @@ export async function executeResolution(
             rolledBackB ? undefined : idB,
           ].filter(Boolean).join(", ")} and pair is not resolved`;
         if (rolledBackA && rolledBackB) {
-          await cleanupCreatedReplacement(storage, replacement);
+          await cleanupCreatedReplacement(resolutionStorage, replacement);
         }
         break;
       }


### PR DESCRIPTION
## Summary
- resolve namespace-scoped storage before contradiction pair generation
- pass that scoped storage into embedding lookup construction
- keep review queue namespace filtering while preventing cross-namespace candidate pairs
- add regression coverage proving scans for `ns1` ignore memories returned only by root storage

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `pnpm --filter @remnic/core build`
- `npm run test:entity-hardening`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace authorization and storage selection for contradiction scan/review/resolve across HTTP, MCP, CLI, and persistence; mistakes could leak cross-namespace data or write to the wrong tenant, though changes are covered by extensive new tests.
> 
> **Overview**
> **Namespaces are now enforced end-to-end for contradiction scanning and review.** `runContradictionScan` requires a caller-provided `storageForNamespace` resolver when namespaces are enabled, uses the resolved namespace-scoped storage (including for embedding lookups), and computes pair IDs with namespace scope to prevent cross-namespace collisions.
> 
> **Review queue handling is updated for legacy unscoped pairs.** Pair IDs now incorporate namespace; `listPairs` can optionally include unscoped legacy pairs for the default namespace, and a one-shot `migrateUnscopedPairsToNamespace` flow promotes legacy pairs (with collision/precedence rules) during default-namespace scans.
> 
> **HTTP/MCP/CLI wiring now routes reads vs writes through the correct namespace resolvers.** Review-list/show endpoints validate readable access (and hide denials as `pair_not_found` on show), scans and resolutions use writable storage resolution, and `executeResolution` gains `storageForNamespace` so namespaced pairs are resolved against the correct storage. Regression tests are added for these behaviors and for `EngramAccessService.getWritableStorageForNamespace` auth checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2671e2a082c6aeeccb299ab685e3c93fae5f50eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->