### PR TITLE
fix(cli): reject bare marketplace value flags

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3436,9 +3436,19 @@ function resolveMemoryDir(): string {
  */
 function resolveFlagStrict(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
-  if (idx === -1 || idx + 1 >= args.length) return undefined;
+  if (idx === -1) return undefined;
+  if (idx + 1 >= args.length) {
+    throw new Error(
+      `${flag} requires a value. Provide it as \`${flag} <value>\`, not as a bare flag.`,
+    );
+  }
   const next = args[idx + 1];
-  return next.startsWith("-") ? undefined : next;
+  if (next.startsWith("-")) {
+    throw new Error(
+      `${flag} requires a value. Provide it as \`${flag} <value>\`, not as a bare flag.`,
+    );
+  }
+  return next;
 }
 // ── OpenClaw config helpers ───────────────────────────────────────────────────
 
@@ -5637,7 +5647,16 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       renderConnectorsList: renderLiveList,
     } = await import("@remnic/core" as string);
 
-    const formatFlag = resolveFlagStrict(rest, "--format");
+    let formatFlag: string | undefined;
+    try {
+      formatFlag = resolveFlagStrict(rest, "--format");
+    } catch (err) {
+      process.stderr.write(
+        `connectors status: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exitCode = 2;
+      return;
+    }
     let parsed: { format: string };
     try {
       parsed = parseStatusOpts({ format: formatFlag });
@@ -5699,7 +5718,16 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       process.exitCode = 2;
       return;
     }
-    const formatFlag = resolveFlagStrict(rest, "--format");
+    let formatFlag: string | undefined;
+    try {
+      formatFlag = resolveFlagStrict(rest, "--format");
+    } catch (err) {
+      process.stderr.write(
+        `connectors run: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exitCode = 2;
+      return;
+    }
     let format: string;
     try {
       format = parseListOpts({ format: formatFlag }).format;
@@ -5846,7 +5874,13 @@ async function cmdConnectorsMarketplace(
   rest: string[],
   json: boolean,
 ): Promise<void> {
-  const configPath = resolveConfigPath(resolveFlagStrict(rest, "--config"));
+  let configPath: string;
+  try {
+    configPath = resolveConfigPath(resolveFlagStrict(rest, "--config"));
+  } catch (err) {
+    console.error(`connectors marketplace: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
   const rawConfig = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
@@ -5857,7 +5891,13 @@ async function cmdConnectorsMarketplace(
   const config = parseConfig(pluginConfig);
 
   if (subAction === "generate") {
-    const outputDir = resolveFlagStrict(rest, "--output") ?? process.cwd();
+    let outputDir: string;
+    try {
+      outputDir = resolveFlagStrict(rest, "--output") ?? process.cwd();
+    } catch (err) {
+      console.error(`connectors marketplace generate: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
     const manifest = generateMarketplaceManifest();
     await writeMarketplaceManifest(outputDir, manifest);
     const outPath = path.join(outputDir, "marketplace.json");
@@ -5910,9 +5950,10 @@ async function cmdConnectorsMarketplace(
     // CLAUDE.md gotcha #14 & #51: reject --type without a value instead of
     // silently defaulting to "github".
     const validTypes = new Set(["github", "git", "local", "url"]);
-    const hasTypeFlag = rest.includes("--type");
-    const typeFlag = resolveFlagStrict(rest, "--type") ?? (hasTypeFlag ? undefined : "github");
-    if (typeFlag === undefined) {
+    let typeFlag: string;
+    try {
+      typeFlag = resolveFlagStrict(rest, "--type") ?? "github";
+    } catch {
       console.error(`--type requires a value. Must be one of: ${[...validTypes].join(", ")}`);
       process.exit(1);
     }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3435,20 +3435,26 @@ function resolveMemoryDir(): string {
  * config path. Use this variant only for flags that require a value argument.
  */
 function resolveFlagStrict(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1) return undefined;
-  if (idx + 1 >= args.length) {
-    throw new Error(
-      `${flag} requires a value. Provide it as \`${flag} <value>\`, not as a bare flag.`,
-    );
+  let value: string | undefined;
+  for (let idx = 0; idx < args.length; idx++) {
+    if (args[idx] !== flag) continue;
+
+    if (idx + 1 >= args.length) {
+      throw new Error(
+        `${flag} requires a value. Provide it as \`${flag} <value>\`, not as a bare flag.`,
+      );
+    }
+    const next = args[idx + 1];
+    if (next.startsWith("-")) {
+      throw new Error(
+        `${flag} requires a value. Provide it as \`${flag} <value>\`, not as a bare flag.`,
+      );
+    }
+
+    value ??= next;
+    idx++;
   }
-  const next = args[idx + 1];
-  if (next.startsWith("-")) {
-    throw new Error(
-      `${flag} requires a value. Provide it as \`${flag} <value>\`, not as a bare flag.`,
-    );
-  }
-  return next;
+  return value;
 }
 // ── OpenClaw config helpers ───────────────────────────────────────────────────
 

--- a/packages/remnic-cli/src/marketplace-cli.test.ts
+++ b/packages/remnic-cli/src/marketplace-cli.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+import test, { before } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { access, mkdir, mkdtemp, rm } from "node:fs/promises";
@@ -29,6 +29,20 @@ function toTextResult(result: ReturnType<typeof spawnSync>): SpawnTextResult {
     stderr: typeof result.stderr === "string" ? result.stderr : result.stderr?.toString("utf8") ?? "",
   };
 }
+
+before(() => {
+  const result = toTextResult(
+    spawnSync(process.execPath, [path.join(repoRoot, "scripts", "ensure-cli-bench-build-deps.mjs")], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+  );
+  assert.equal(
+    result.status,
+    0,
+    `failed to prepare CLI build dependencies\n${result.stdout}\n${result.stderr}`,
+  );
+});
 
 async function pathExists(candidate: string): Promise<boolean> {
   try {

--- a/packages/remnic-cli/src/marketplace-cli.test.ts
+++ b/packages/remnic-cli/src/marketplace-cli.test.ts
@@ -121,3 +121,39 @@ test("connectors marketplace rejects a bare --config flag before using defaults"
     await rm(home, { recursive: true, force: true });
   }
 });
+
+test("connectors marketplace generate rejects a duplicate bare --output flag", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-marketplace-cli-"));
+  const outputDir = path.join(home, "out");
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        tsxCli,
+        cliPath,
+        "connectors",
+        "marketplace",
+        "generate",
+        "--output",
+        outputDir,
+        "--output",
+      ],
+      {
+        cwd: home,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: home,
+          REMNIC_HOME: home,
+        },
+      },
+    );
+
+    const textResult = toTextResult(result);
+    assert.notEqual(textResult.status, 0);
+    assert.match(textResult.stderr, /connectors marketplace generate: --output requires a value/);
+    assert.equal(await pathExists(path.join(outputDir, "marketplace.json")), false);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-cli/src/marketplace-cli.test.ts
+++ b/packages/remnic-cli/src/marketplace-cli.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { access, mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const srcDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(srcDir, "../../..");
+const cliPath = path.join(srcDir, "index.ts");
+const tsxCli = path.join(
+  repoRoot,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
+
+interface SpawnTextResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function toTextResult(result: ReturnType<typeof spawnSync>): SpawnTextResult {
+  return {
+    status: result.status,
+    stdout: typeof result.stdout === "string" ? result.stdout : result.stdout?.toString("utf8") ?? "",
+    stderr: typeof result.stderr === "string" ? result.stderr : result.stderr?.toString("utf8") ?? "",
+  };
+}
+
+async function pathExists(candidate: string): Promise<boolean> {
+  try {
+    await access(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runMarketplace(args: string[]): Promise<SpawnTextResult> {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-marketplace-cli-"));
+  const cwd = path.join(home, "cwd");
+  await mkdir(cwd);
+
+  const result = spawnSync(process.execPath, [tsxCli, cliPath, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: home,
+      REMNIC_HOME: home,
+      OPENCLAW_CONFIG_PATH: path.join(home, "openclaw.json"),
+    },
+  });
+
+  await rm(home, { recursive: true, force: true });
+  return toTextResult(result);
+}
+
+test("connectors marketplace generate rejects a bare --output flag", async () => {
+  const result = await runMarketplace([
+    "connectors",
+    "marketplace",
+    "generate",
+    "--output",
+  ]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /connectors marketplace generate: --output requires a value/);
+  assert.doesNotMatch(result.stdout, /Generated marketplace\.json/);
+});
+
+test("connectors marketplace rejects a bare --config flag before using defaults", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-marketplace-cli-"));
+  const outputDir = path.join(home, "out");
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        tsxCli,
+        cliPath,
+        "connectors",
+        "marketplace",
+        "generate",
+        "--config",
+        "--output",
+        outputDir,
+      ],
+      {
+        cwd: home,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: home,
+          REMNIC_HOME: home,
+        },
+      },
+    );
+
+    const textResult = toTextResult(result);
+    assert.notEqual(textResult.status, 0);
+    assert.match(textResult.stderr, /connectors marketplace: --config requires a value/);
+    assert.equal(await pathExists(path.join(outputDir, "marketplace.json")), false);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- make strict value-flag parsing throw when a value-taking flag is present without a value
- handle malformed marketplace --config/--output and connector --format flags with scoped CLI errors
- add regression coverage for bare marketplace --output and --config flags

## Verification
- pnpm exec tsx --test packages/remnic-cli/src/marketplace-cli.test.ts
- pnpm --filter @remnic/cli check-types
- pnpm --filter @remnic/cli test
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to CLI argument validation/error reporting for value-taking flags, plus new regression tests; no core data/auth logic touched.
> 
> **Overview**
> **Tightens CLI parsing for value-taking flags** by making `resolveFlagStrict` throw when a flag like `--config`, `--output`, `--type`, or `--format` is provided without a value (or followed by another flag), instead of silently treating it as missing.
> 
> Updates `connectors status/run` and `connectors marketplace` subcommands to catch these errors and emit scoped, user-friendly messages with appropriate non-zero exit codes, and adds `marketplace-cli.test.ts` regression coverage for bare/duplicate `--output` and bare `--config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68ed292e277274a4df9485892d8c70ce6a59fa8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->