### PR TITLE
fix(cli): render query results from recall response

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3845,6 +3845,30 @@ async function cmdStatus(json: boolean): Promise<void> {
   }
 }
 
+interface QueryRenderableResult {
+  content?: string;
+  preview?: string;
+  context?: string;
+}
+
+export function renderQueryTextLines(result: {
+  results?: QueryRenderableResult[];
+  context?: string;
+}): string[] {
+  const results = Array.isArray(result.results) ? result.results : [];
+  if (results.length === 0) return ["No results."];
+
+  return results.map((memory) => {
+    const text =
+      memory.content?.trim()
+      || memory.preview?.trim()
+      || memory.context?.trim()
+      || result.context?.trim()
+      || "(no preview available)";
+    return `- ${text}`;
+  });
+}
+
 async function cmdQuery(queryText: string, json: boolean, explain: boolean): Promise<void> {
   if (!queryText) {
     console.error("Usage: remnic query <text>");
@@ -3921,13 +3945,8 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
     if (json) {
       console.log(JSON.stringify(result, null, 2));
     } else {
-      const memories = (result as { memories?: Array<{ content: string }> }).memories ?? [];
-      if (memories.length === 0) {
-        console.log("No results.");
-        return;
-      }
-      for (const m of memories) {
-        console.log(`- ${m.content}`);
+      for (const line of renderQueryTextLines(result)) {
+        console.log(line);
       }
     }
   } finally {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3863,7 +3863,6 @@ export function renderQueryTextLines(result: {
       memory.content?.trim()
       || memory.preview?.trim()
       || memory.context?.trim()
-      || result.context?.trim()
       || "(no preview available)";
     return `- ${text}`;
   });

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3868,6 +3868,18 @@ export function renderQueryTextLines(result: {
   });
 }
 
+export function buildQueryRecallRequest(queryText: string): {
+  query: string;
+  mode: "auto";
+  sessionKey: string;
+} {
+  return {
+    query: queryText,
+    mode: "auto",
+    sessionKey: `remnic-cli:query:${process.pid}`,
+  };
+}
+
 async function cmdQuery(queryText: string, json: boolean, explain: boolean): Promise<void> {
   if (!queryText) {
     console.error("Usage: remnic query <text>");
@@ -3884,6 +3896,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
   const service = new EngramAccessService(orchestrator);
+  const recallRequest = buildQueryRecallRequest(queryText);
 
   try {
     if (explain) {
@@ -3909,7 +3922,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
       }
 
       const explainStart = Date.now();
-      const recallResult = await service.recall({ query: queryText, mode: "auto" });
+      const recallResult = await service.recall(recallRequest);
       const totalDurationMs = Date.now() - explainStart;
       // recall() returns { count, results, memoryIds, ... } (see
       // EngramAccessRecallResponse). A prior version of this fallback
@@ -3940,7 +3953,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
       return;
     }
 
-    const result = await service.recall({ query: queryText, mode: "auto" });
+    const result = await service.recall(recallRequest);
     if (json) {
       console.log(JSON.stringify(result, null, 2));
     } else {

--- a/packages/remnic-cli/src/query-render.test.ts
+++ b/packages/remnic-cli/src/query-render.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { renderQueryTextLines } from "./index.js";
+
+test("plain text query output renders recall results content", () => {
+  const lines = renderQueryTextLines({
+    results: [{ content: "known fact" }],
+  });
+
+  assert.deepEqual(lines, ["- known fact"]);
+});
+
+test("plain text query output falls back to preview and context", () => {
+  assert.deepEqual(
+    renderQueryTextLines({
+      results: [{ preview: "short preview" }],
+    }),
+    ["- short preview"],
+  );
+  assert.deepEqual(
+    renderQueryTextLines({
+      context: "recall context",
+      results: [{}],
+    }),
+    ["- recall context"],
+  );
+});
+
+test("plain text query output reports no results when recall results are empty", () => {
+  assert.deepEqual(renderQueryTextLines({ results: [] }), ["No results."]);
+  assert.deepEqual(renderQueryTextLines({}), ["No results."]);
+});

--- a/packages/remnic-cli/src/query-render.test.ts
+++ b/packages/remnic-cli/src/query-render.test.ts
@@ -11,7 +11,7 @@ test("plain text query output renders recall results content", () => {
   assert.deepEqual(lines, ["- known fact"]);
 });
 
-test("plain text query output falls back to preview and context", () => {
+test("plain text query output falls back to preview and per-result context", () => {
   assert.deepEqual(
     renderQueryTextLines({
       results: [{ preview: "short preview" }],
@@ -20,14 +20,23 @@ test("plain text query output falls back to preview and context", () => {
   );
   assert.deepEqual(
     renderQueryTextLines({
-      context: "recall context",
-      results: [{}],
+      results: [{ context: "memory context" }],
     }),
-    ["- recall context"],
+    ["- memory context"],
   );
 });
 
 test("plain text query output reports no results when recall results are empty", () => {
   assert.deepEqual(renderQueryTextLines({ results: [] }), ["No results."]);
   assert.deepEqual(renderQueryTextLines({}), ["No results."]);
+});
+
+test("plain text query output does not use aggregate recall context as item text", () => {
+  assert.deepEqual(
+    renderQueryTextLines({
+      context: "first memory\n\nsecond memory",
+      results: [{}],
+    }),
+    ["- (no preview available)"],
+  );
 });

--- a/packages/remnic-cli/src/query-render.test.ts
+++ b/packages/remnic-cli/src/query-render.test.ts
@@ -1,7 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { renderQueryTextLines } from "./index.js";
+import { buildQueryRecallRequest, renderQueryTextLines } from "./index.js";
+
+test("query recall requests include a one-shot CLI session key", () => {
+  const request = buildQueryRecallRequest("known fact");
+
+  assert.equal(request.query, "known fact");
+  assert.equal(request.mode, "auto");
+  assert.equal(request.sessionKey, `remnic-cli:query:${process.pid}`);
+});
 
 test("plain text query output renders recall results content", () => {
   const lines = renderQueryTextLines({


### PR DESCRIPTION
## Summary
- render non-JSON `remnic query` output from `recall().results` instead of the non-existent `memories` field
- add a small renderer covering content, preview/context fallback, and no-results output

## Verification
- `pnpm exec tsx --test packages/remnic-cli/src/query-render.test.ts`
- `pnpm --filter @remnic/cli check-types`
- `pnpm --filter @remnic/cli test`
- `npm run preflight:quick`

Clawpatch finding: `medium: Plain-text query output reads a non-existent recall field`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to `remnic query` CLI formatting and recall request metadata, with added unit tests to lock output behavior.
> 
> **Overview**
> Fixes non-JSON `remnic query` output to render from `recall().results` (with `content` → `preview` → per-item `context` fallbacks) instead of a non-existent `memories` field, and returns "No results." when empty.
> 
> Adds `buildQueryRecallRequest()` to include a per-process `sessionKey` in recall calls (used for both normal and `--explain` paths) and introduces `query-render.test.ts` to cover request shape and text rendering edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f483c720cd0a2a920ddcaa3dfec91432250e6b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->