### PR TITLE
fix(core): validate access browse options

### DIFF
--- a/packages/remnic-core/src/access-cli.test.ts
+++ b/packages/remnic-core/src/access-cli.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { main } from "./access-cli.js";
+import { main, runCli } from "./access-cli.js";
 
 async function rejectsUsage(argv: string[]): Promise<void> {
   await assert.rejects(
@@ -10,6 +10,33 @@ async function rejectsUsage(argv: string[]): Promise<void> {
     },
     /invalid access-cli arguments/,
   );
+}
+
+async function captureRunCliFailure(argv: string[]): Promise<string> {
+  let output = "";
+  const originalStdoutWrite = process.stdout.write;
+  const originalExit = process.exit;
+
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.exit = ((code?: string | number | null | undefined): never => {
+    throw new Error(`process.exit:${code ?? 0}`);
+  }) as typeof process.exit;
+
+  try {
+    await assert.rejects(
+      async () => {
+        await runCli(argv);
+      },
+      /process\.exit:1/,
+    );
+    return output;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.exit = originalExit;
+  }
 }
 
 test("access-cli rejects malformed dry-run values before store can run", async () => {
@@ -62,6 +89,30 @@ test("access-cli rejects partial numeric values", async () => {
     "--confidence",
     "0.5x",
   ]);
+});
+
+test("access-cli rejects invalid browse sort and pagination before runtime initialization", async () => {
+  await rejectsUsage(["browse", "--sort", "udpated_desc"]);
+  await rejectsUsage(["browse", "--limit", "0"]);
+  await rejectsUsage(["browse", "--limit", "-1"]);
+  await rejectsUsage(["browse", "--offset", "-1"]);
+});
+
+test("access-cli browse sort error lists accepted values", async () => {
+  const output = await captureRunCliFailure(["browse", "--sort", "udpated_desc"]);
+
+  assert.match(output, /invalid value for --sort/);
+  assert.match(output, /Accepted: updated_desc, updated_asc, created_desc, created_asc\./);
+});
+
+test("access-cli browse pagination bound errors list accepted ranges", async () => {
+  const limitOutput = await captureRunCliFailure(["browse", "--limit", "0"]);
+  const offsetOutput = await captureRunCliFailure(["browse", "--offset", "-1"]);
+
+  assert.match(limitOutput, /invalid value for --limit/);
+  assert.match(limitOutput, /Accepted: integer >= 1\./);
+  assert.match(offsetOutput, /invalid value for --offset/);
+  assert.match(offsetOutput, /Accepted: integer >= 0\./);
 });
 
 test("access-cli rejects confidence outside the documented range", async () => {

--- a/packages/remnic-core/src/access-cli.ts
+++ b/packages/remnic-core/src/access-cli.ts
@@ -40,6 +40,7 @@ type UsageErrorKind =
   | "unsupported-command"
   | "unexpected-positional"
   | "unknown-option"
+  | "invalid-option"
   | "option-does-not-take-value"
   | "missing-option"
   | "missing-content"
@@ -50,6 +51,7 @@ class UsageError extends Error {
   constructor(
     readonly kind: UsageErrorKind,
     readonly optionName?: string,
+    readonly acceptedValues?: readonly string[],
   ) {
     super("invalid access-cli arguments");
   }
@@ -63,6 +65,10 @@ function formatUsageError(error: UsageError): string {
       return "unexpected positional argument";
     case "unknown-option":
       return `unknown option: --${error.optionName ?? "unknown"}`;
+    case "invalid-option": {
+      const accepted = error.acceptedValues?.length ? `. Accepted: ${error.acceptedValues.join(", ")}.` : "";
+      return `invalid value for --${error.optionName ?? "unknown"}${accepted}`;
+    }
     case "option-does-not-take-value":
       return `option does not accept a value: --${error.optionName ?? "unknown"}`;
     case "missing-option":
@@ -142,6 +148,15 @@ const COMMAND_SPECS: Record<CommandName, CommandSpec> = {
     flagOptions: new Set(["dry-run"]),
   },
 };
+
+const BROWSE_SORT_VALUES = Object.freeze([
+  "updated_desc",
+  "updated_asc",
+  "created_desc",
+  "created_asc",
+] as const);
+
+type BrowseSort = (typeof BROWSE_SORT_VALUES)[number];
 
 function parseArgs(argv: string[]): ParsedArgs {
   const [commandRaw, ...rest] = argv;
@@ -229,7 +244,11 @@ function requireOption(args: ParsedArgs, name: string): string {
   return value;
 }
 
-function parseIntegerOption(args: ParsedArgs, name: string): number | undefined {
+function parseIntegerOption(
+  args: ParsedArgs,
+  name: string,
+  options: { min?: number } = {},
+): number | undefined {
   const raw = getLastOption(args, name);
   if (!raw) return undefined;
   const trimmed = raw.trim();
@@ -240,7 +259,19 @@ function parseIntegerOption(args: ParsedArgs, name: string): number | undefined 
   if (!Number.isSafeInteger(value)) {
     throw new UsageError("invalid-integer", name);
   }
+  if (options.min !== undefined && value < options.min) {
+    throw new UsageError("invalid-option", name, [`integer >= ${options.min}`]);
+  }
   return value;
+}
+
+function parseBrowseSortOption(args: ParsedArgs, name: string): BrowseSort | undefined {
+  const raw = getLastOption(args, name);
+  if (!raw) return undefined;
+  if ((BROWSE_SORT_VALUES as readonly string[]).includes(raw)) {
+    return raw as BrowseSort;
+  }
+  throw new UsageError("invalid-option", name, BROWSE_SORT_VALUES);
 }
 
 function parseFloatOption(
@@ -296,9 +327,9 @@ async function runBrowse(args: ParsedArgs, preferredId?: string): Promise<void> 
     query: getLastOption(args, "query"),
     category: getLastOption(args, "category"),
     status: getLastOption(args, "status"),
-    sort: getLastOption(args, "sort") as "updated_desc" | "updated_asc" | "created_desc" | "created_asc" | undefined,
-    limit: parseIntegerOption(args, "limit"),
-    offset: parseIntegerOption(args, "offset"),
+    sort: parseBrowseSortOption(args, "sort"),
+    limit: parseIntegerOption(args, "limit", { min: 1 }),
+    offset: parseIntegerOption(args, "offset", { min: 0 }),
   };
   const { service } = buildRuntime(preferredId);
   const result = await service.memoryBrowse(request);


### PR DESCRIPTION
## Summary
- reject unsupported `access-cli browse --sort` values before runtime initialization
- reject invalid browse pagination bounds (`--limit < 1`, `--offset < 0`) in the CLI parser
- add regression coverage for bad sort and pagination inputs

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/access-cli.test.ts`
- `pnpm --filter @remnic/core check-types`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI argument validation/error messaging and add tests, with no runtime/service behavior changes beyond rejecting invalid `browse` inputs earlier.
> 
> **Overview**
> **Tightens `engram-access browse` CLI input validation** by rejecting unsupported `--sort` values and enforcing pagination bounds (`--limit >= 1`, `--offset >= 0`) during argument parsing (before runtime initialization).
> 
> Improves usage errors with a new `invalid-option` kind that can include *accepted values/ranges* in the message, and adds regression tests that assert both early rejection and the printed "Accepted:" guidance via `runCli` output capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cbca865ee741d1626c54b8c2bcd116dbd83ba69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->