### PR TITLE
fix(core): validate capsule export options

### DIFF
--- a/packages/remnic-core/src/capsule-cli.ts
+++ b/packages/remnic-core/src/capsule-cli.ts
@@ -201,29 +201,32 @@ export function parseCapsuleIncludeKinds(raw: unknown): string[] | undefined {
 }
 
 /**
- * Parse a comma-separated `--peers` value into an array of peer ids.
+ * Parse a comma-separated peer id value into an array of peer ids.
  */
-export function parseCapsulePeers(raw: unknown): string[] | undefined {
+export function parseCapsulePeers(
+  raw: unknown,
+  optionName = "--peers",
+): string[] | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== "string") {
     throw new Error(
-      `--peers expects a comma-separated list of peer ids; got ${JSON.stringify(raw)}`,
+      `${optionName} expects a comma-separated list of peer ids; got ${JSON.stringify(raw)}`,
     );
   }
   if (raw.trim() === "") {
-    throw new Error(`--peers expects at least one non-empty peer id`);
+    throw new Error(`${optionName} expects at least one non-empty peer id`);
   }
   const parts = raw
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
   if (parts.length === 0) {
-    throw new Error(`--peers expects at least one non-empty peer id`);
+    throw new Error(`${optionName} expects at least one non-empty peer id`);
   }
   for (const p of parts) {
     if (p.includes("/") || p.includes("\\") || p === "." || p === "..") {
       throw new Error(
-        `--peers entries must be plain id tokens (no path separators): ${p}`,
+        `${optionName} entries must be plain id tokens (no path separators): ${p}`,
       );
     }
   }
@@ -237,10 +240,10 @@ export function parseCapsulePeers(raw: unknown): string[] | undefined {
 
 export interface CapsuleExportOptions {
   name: string;
-  out: string | undefined;
+  outDir: string | undefined;
   since: string | undefined;
   includeKinds: string[] | undefined;
-  peers: string[] | undefined;
+  peerIds: string[] | undefined;
 }
 
 export interface CapsuleImportOptions {
@@ -274,21 +277,21 @@ export function parseCapsuleExportOptions(
 ): CapsuleExportOptions {
   if (typeof nameArg !== "string" || nameArg.trim() === "") {
     throw new Error(
-      `capsule export: <name> is required (e.g. "remnic capsule export my-capsule")`,
+      `capsule export: --name is required (e.g. "remnic capsule export --name my-capsule")`,
     );
   }
   const name = nameArg.trim();
 
-  const out =
-    typeof opts.out === "string" && opts.out.trim() !== ""
-      ? opts.out.trim()
+  const outDir =
+    typeof opts.outDir === "string" && opts.outDir.trim() !== ""
+      ? opts.outDir.trim()
       : undefined;
 
   const since = parseCapsuleSince(opts.since);
   const includeKinds = parseCapsuleIncludeKinds(opts.includeKinds);
-  const peers = parseCapsulePeers(opts.peers);
+  const peerIds = parseCapsulePeers(opts.peerIds, "--peer-ids");
 
-  return { name, out, since, includeKinds, peers };
+  return { name, outDir, since, includeKinds, peerIds };
 }
 
 export function parseCapsuleImportOptions(

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4265,28 +4265,17 @@ export function registerCli(
         .option("--namespace <ns>", "Namespace (v3.0+, default: config defaultNamespace)", "")
         .action(async (...args: unknown[]) => {
           const options = (args[0] ?? {}) as Record<string, unknown>;
-          const name = options.name ? String(options.name) : "";
-          if (!name) {
-            console.error("--name is required. Example: remnic capsule export --name my-capsule");
+          const { parseCapsuleExportOptions } = await import("./capsule-cli.js");
+          let parsed: ReturnType<typeof parseCapsuleExportOptions>;
+          try {
+            parsed = parseCapsuleExportOptions(options.name, options);
+          } catch (err) {
+            console.error(err instanceof Error ? err.message : String(err));
             process.exitCode = 1;
             return;
           }
           const namespace = options.namespace ? String(options.namespace) : "";
           const doEncrypt = options.encrypt === true;
-          const outDir = options.outDir ? String(options.outDir) : undefined;
-          const since = options.since ? String(options.since) : undefined;
-          const includeKinds = options.includeKinds
-            ? String(options.includeKinds)
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean)
-            : undefined;
-          const peerIds = options.peerIds
-            ? String(options.peerIds)
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean)
-            : undefined;
           const includeTranscripts = options.includeTranscripts === true;
 
           const pluginVersion = await getPluginVersion();
@@ -4296,19 +4285,19 @@ export function registerCli(
 
           const { exportCapsule } = await import("./transfer/capsule-export.js");
           const result = await exportCapsule({
-            name,
+            name: parsed.name,
             root: memoryDir,
-            since,
+            since: parsed.since,
             // Pass `includeKinds` only when the user explicitly provided it.
             // Do NOT merge transcripts into an explicit list here: doing so would
             // produce a hard-coded allow-list that silently drops other valid
             // memory dirs (peers/, forks/, etc.). Instead, use `includeTranscripts`
             // so the exporter adds transcripts while keeping the default "all dirs"
             // walk. (Cursor / #747)
-            includeKinds,
+            includeKinds: parsed.includeKinds,
             includeTranscripts,
-            peerIds,
-            outDir,
+            peerIds: parsed.peerIds,
+            outDir: parsed.outDir,
             pluginVersion,
             encrypt: doEncrypt,
             memoryDir: doEncrypt ? memoryDir : undefined,

--- a/tests/cli/capsule.test.ts
+++ b/tests/cli/capsule.test.ts
@@ -44,6 +44,90 @@ import {
   type CapsuleInspectData,
   type CapsuleListEntry,
 } from "../../packages/remnic-core/src/capsule-cli.js";
+import { registerCli } from "../../packages/remnic-core/src/cli.js";
+
+class MockCommand {
+  children = new Map<string, MockCommand>();
+  actionHandler?: (...args: unknown[]) => Promise<void> | void;
+
+  constructor(readonly name: string) {}
+
+  command(name: string): MockCommand {
+    const child = new MockCommand(name);
+    this.children.set(name, child);
+    return child;
+  }
+
+  description(): MockCommand {
+    return this;
+  }
+
+  option(): MockCommand {
+    return this;
+  }
+
+  requiredOption(): MockCommand {
+    return this;
+  }
+
+  argument(): MockCommand {
+    return this;
+  }
+
+  action(handler: (...args: unknown[]) => Promise<void> | void): MockCommand {
+    this.actionHandler = handler;
+    return this;
+  }
+}
+
+function getCapsuleExportAction(): (...args: unknown[]) => Promise<void> | void {
+  const root = new MockCommand("root");
+  registerCli(
+    {
+      registerCli(handler: (opts: { program: MockCommand }) => void): void {
+        handler({ program: root });
+      },
+    },
+    {
+      config: {
+        memoryDir: "/tmp/remnic-capsule-cli-test",
+      },
+    } as never,
+  );
+
+  const action = root.children
+    .get("engram")
+    ?.children.get("capsule")
+    ?.children.get("export")
+    ?.actionHandler;
+  assert.equal(typeof action, "function");
+  return action;
+}
+
+async function captureCapsuleExportError(options: Record<string, unknown>): Promise<{
+  exitCode: string | number | undefined;
+  stderr: string;
+}> {
+  const action = getCapsuleExportAction();
+  const originalError = console.error;
+  const originalExitCode = process.exitCode;
+  const messages: string[] = [];
+  process.exitCode = undefined;
+  console.error = (...args: unknown[]) => {
+    messages.push(args.map(String).join(" "));
+  };
+
+  try {
+    await action(options);
+    return {
+      exitCode: process.exitCode,
+      stderr: messages.join("\n"),
+    };
+  } finally {
+    console.error = originalError;
+    process.exitCode = originalExitCode;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Suite 1 — parseCapsuleOutputFormat
@@ -248,41 +332,71 @@ test("parseCapsulePeers rejects . and ..", () => {
 
 test("parseCapsuleExportOptions assembles option bag from valid inputs", () => {
   const result = parseCapsuleExportOptions("my-capsule", {
-    out: "/tmp/caps",
+    outDir: "/tmp/caps",
     since: "2026-04-01T00:00:00Z",
     includeKinds: "facts,entities",
-    peers: "peer-a",
+    peerIds: "peer-a",
   });
   assert.equal(result.name, "my-capsule");
-  assert.equal(result.out, "/tmp/caps");
+  assert.equal(result.outDir, "/tmp/caps");
   assert.ok(typeof result.since === "string");
   assert.deepEqual(result.includeKinds, ["facts", "entities"]);
-  assert.deepEqual(result.peers, ["peer-a"]);
+  assert.deepEqual(result.peerIds, ["peer-a"]);
 });
 
 test("parseCapsuleExportOptions uses defaults when optional flags absent", () => {
   const result = parseCapsuleExportOptions("my-capsule", {});
   assert.equal(result.name, "my-capsule");
-  assert.equal(result.out, undefined);
+  assert.equal(result.outDir, undefined);
   assert.equal(result.since, undefined);
   assert.equal(result.includeKinds, undefined);
-  assert.equal(result.peers, undefined);
+  assert.equal(result.peerIds, undefined);
 });
 
 test("parseCapsuleExportOptions rejects missing name", () => {
   assert.throws(
     () => parseCapsuleExportOptions("", {}),
-    /capsule export: <name> is required/,
+    /capsule export: --name is required/,
   );
   assert.throws(
     () => parseCapsuleExportOptions(undefined, {}),
-    /capsule export: <name> is required/,
+    /capsule export: --name is required/,
   );
 });
 
 test("parseCapsuleExportOptions trims whitespace from name", () => {
   const result = parseCapsuleExportOptions("  my-capsule  ", {});
   assert.equal(result.name, "my-capsule");
+});
+
+test("parseCapsuleExportOptions rejects empty include kind and peer id lists", () => {
+  assert.throws(
+    () => parseCapsuleExportOptions("my-capsule", { includeKinds: "," }),
+    /--include-kinds expects at least one non-empty kind name/,
+  );
+  assert.throws(
+    () => parseCapsuleExportOptions("my-capsule", { peerIds: "," }),
+    /--peer-ids expects at least one non-empty peer id/,
+  );
+});
+
+test("capsule export CLI wiring rejects empty include kind and peer id lists before export", async () => {
+  const includeKindsResult = await captureCapsuleExportError({
+    name: "backup",
+    includeKinds: ",",
+  });
+  const peerIdsResult = await captureCapsuleExportError({
+    name: "backup",
+    peerIds: ",",
+  });
+
+  assert.equal(includeKindsResult.exitCode, 1);
+  assert.match(
+    includeKindsResult.stderr,
+    /--include-kinds expects at least one non-empty kind name/,
+  );
+  assert.equal(peerIdsResult.exitCode, 1);
+  assert.match(peerIdsResult.stderr, /--peer-ids expects at least one non-empty peer id/);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route `remnic capsule export` through the strict capsule export option parser
- align the parser with shipped Commander option keys (`outDir`, `peerIds`)
- reject empty `--include-kinds` and `--peer-ids` lists before capsule export runs

## Verification
- `pnpm install --frozen-lockfile --prefer-offline`
- `node packages/remnic-core/scripts/ensure-better-sqlite3.mjs`
- `pnpm exec tsx --test tests/cli/capsule.test.ts`
- `pnpm --filter @remnic/core check-types`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: tightens `capsule export` CLI option parsing/validation and aligns option keys, which may surface previously-silent misconfigurations but doesn’t alter export internals.
> 
> **Overview**
> Routes `remnic capsule export` through the shared strict `parseCapsuleExportOptions` helper instead of ad-hoc string parsing, so invalid flags fail early with consistent error messages.
> 
> Aligns the export option bag with Commander flag names (`outDir`, `peerIds`) and updates `parseCapsulePeers` to accept a configurable option name for accurate errors. Adds tests (including CLI wiring via a mock Commander) to ensure empty `--include-kinds`/`--peer-ids` lists are rejected before running the export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587dabba320732e44936405216e2b68d5c3b9e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->