### PR TITLE
fix(core): validate capsule export options

### DIFF
--- a/packages/remnic-core/src/capsule-cli.ts
+++ b/packages/remnic-core/src/capsule-cli.ts
@@ -201,34 +201,36 @@ export function parseCapsuleIncludeKinds(raw: unknown): string[] | undefined {
 }
 
 /**
- * Parse a comma-separated `--peers` value into an array of peer ids.
+ * Parse a comma-separated `--peer-ids` value into an array of peer ids.
  */
-export function parseCapsulePeers(raw: unknown): string[] | undefined {
+export function parseCapsulePeerIds(raw: unknown): string[] | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== "string") {
     throw new Error(
-      `--peers expects a comma-separated list of peer ids; got ${JSON.stringify(raw)}`,
+      `--peer-ids expects a comma-separated list of peer ids; got ${JSON.stringify(raw)}`,
     );
   }
   if (raw.trim() === "") {
-    throw new Error(`--peers expects at least one non-empty peer id`);
+    throw new Error(`--peer-ids expects at least one non-empty peer id`);
   }
   const parts = raw
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
   if (parts.length === 0) {
-    throw new Error(`--peers expects at least one non-empty peer id`);
+    throw new Error(`--peer-ids expects at least one non-empty peer id`);
   }
   for (const p of parts) {
     if (p.includes("/") || p.includes("\\") || p === "." || p === "..") {
       throw new Error(
-        `--peers entries must be plain id tokens (no path separators): ${p}`,
+        `--peer-ids entries must be plain id tokens (no path separators): ${p}`,
       );
     }
   }
   return [...new Set(parts)];
 }
+
+export const parseCapsulePeers = parseCapsulePeerIds;
 
 // ---------------------------------------------------------------------------
 // Parsed option bags (returned by the parse helpers below and consumed by
@@ -237,10 +239,10 @@ export function parseCapsulePeers(raw: unknown): string[] | undefined {
 
 export interface CapsuleExportOptions {
   name: string;
-  out: string | undefined;
+  outDir: string | undefined;
   since: string | undefined;
   includeKinds: string[] | undefined;
-  peers: string[] | undefined;
+  peerIds: string[] | undefined;
 }
 
 export interface CapsuleImportOptions {
@@ -279,16 +281,16 @@ export function parseCapsuleExportOptions(
   }
   const name = nameArg.trim();
 
-  const out =
-    typeof opts.out === "string" && opts.out.trim() !== ""
-      ? opts.out.trim()
+  const outDir =
+    typeof opts.outDir === "string" && opts.outDir.trim() !== ""
+      ? opts.outDir.trim()
       : undefined;
 
   const since = parseCapsuleSince(opts.since);
   const includeKinds = parseCapsuleIncludeKinds(opts.includeKinds);
-  const peers = parseCapsulePeers(opts.peers);
+  const peerIds = parseCapsulePeerIds(opts.peerIds);
 
-  return { name, out, since, includeKinds, peers };
+  return { name, outDir, since, includeKinds, peerIds };
 }
 
 export function parseCapsuleImportOptions(

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4265,28 +4265,18 @@ export function registerCli(
         .option("--namespace <ns>", "Namespace (v3.0+, default: config defaultNamespace)", "")
         .action(async (...args: unknown[]) => {
           const options = (args[0] ?? {}) as Record<string, unknown>;
-          const name = options.name ? String(options.name) : "";
-          if (!name) {
-            console.error("--name is required. Example: remnic capsule export --name my-capsule");
+          const { parseCapsuleExportOptions } = await import("./capsule-cli.js");
+          let parsed;
+          try {
+            parsed = parseCapsuleExportOptions(options.name, options);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.error(message);
             process.exitCode = 1;
             return;
           }
           const namespace = options.namespace ? String(options.namespace) : "";
           const doEncrypt = options.encrypt === true;
-          const outDir = options.outDir ? String(options.outDir) : undefined;
-          const since = options.since ? String(options.since) : undefined;
-          const includeKinds = options.includeKinds
-            ? String(options.includeKinds)
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean)
-            : undefined;
-          const peerIds = options.peerIds
-            ? String(options.peerIds)
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean)
-            : undefined;
           const includeTranscripts = options.includeTranscripts === true;
 
           const pluginVersion = await getPluginVersion();
@@ -4296,19 +4286,19 @@ export function registerCli(
 
           const { exportCapsule } = await import("./transfer/capsule-export.js");
           const result = await exportCapsule({
-            name,
+            name: parsed.name,
             root: memoryDir,
-            since,
+            since: parsed.since,
             // Pass `includeKinds` only when the user explicitly provided it.
             // Do NOT merge transcripts into an explicit list here: doing so would
             // produce a hard-coded allow-list that silently drops other valid
             // memory dirs (peers/, forks/, etc.). Instead, use `includeTranscripts`
             // so the exporter adds transcripts while keeping the default "all dirs"
             // walk. (Cursor / #747)
-            includeKinds,
+            includeKinds: parsed.includeKinds,
             includeTranscripts,
-            peerIds,
-            outDir,
+            peerIds: parsed.peerIds,
+            outDir: parsed.outDir,
             pluginVersion,
             encrypt: doEncrypt,
             memoryDir: doEncrypt ? memoryDir : undefined,

--- a/tests/cli/capsule.test.ts
+++ b/tests/cli/capsule.test.ts
@@ -24,8 +24,11 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
 import path from "node:path";
 
+import { registerCli } from "../../packages/remnic-core/src/cli.js";
+import { parseConfig } from "../../packages/remnic-core/src/config.js";
 import {
   defaultCapsulesDir,
   parseCapsuleConflictMode,
@@ -44,6 +47,105 @@ import {
   type CapsuleInspectData,
   type CapsuleListEntry,
 } from "../../packages/remnic-core/src/capsule-cli.js";
+
+class MockCommand {
+  readonly children = new Map<string, MockCommand>();
+  actionHandler?: (...args: unknown[]) => Promise<void> | void;
+
+  constructor(readonly name: string) {}
+
+  command(name: string): MockCommand {
+    const child = new MockCommand(name);
+    this.children.set(name, child);
+    return child;
+  }
+
+  description(): MockCommand {
+    return this;
+  }
+
+  option(): MockCommand {
+    return this;
+  }
+
+  requiredOption(): MockCommand {
+    return this;
+  }
+
+  argument(): MockCommand {
+    return this;
+  }
+
+  action(handler: (...args: unknown[]) => Promise<void> | void): MockCommand {
+    this.actionHandler = handler;
+    return this;
+  }
+}
+
+function registerCapsuleCliFixture(): MockCommand {
+  const root = new MockCommand("root");
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir: path.join(os.tmpdir(), "remnic-capsule-cli-test", "memory"),
+    workspaceDir: path.join(os.tmpdir(), "remnic-capsule-cli-test", "workspace"),
+    qmdEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    identityEnabled: false,
+    identityContinuityEnabled: false,
+    sharedContextEnabled: false,
+    captureMode: "implicit",
+  });
+
+  registerCli(
+    {
+      registerCli(handler: (opts: { program: MockCommand }) => void): void {
+        handler({ program: root });
+      },
+    },
+    { config } as never,
+  );
+  return root;
+}
+
+function getAction(root: MockCommand, segments: string[]): (...args: unknown[]) => Promise<void> | void {
+  let current: MockCommand | undefined = root;
+  for (const segment of segments) {
+    current = current?.children.get(segment);
+  }
+  assert.equal(typeof current?.actionHandler, "function");
+  return current!.actionHandler!;
+}
+
+async function captureAction(
+  action: (...args: unknown[]) => Promise<void> | void,
+  options: Record<string, unknown>,
+): Promise<{ exitCode: number | string | undefined; stderr: string; stdout: string }> {
+  const errors: string[] = [];
+  const logs: string[] = [];
+  const originalError = console.error;
+  const originalLog = console.log;
+  const originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+  console.error = (...args: unknown[]) => {
+    errors.push(args.map((value) => String(value)).join(" "));
+  };
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((value) => String(value)).join(" "));
+  };
+  try {
+    await action(options);
+    return {
+      exitCode: process.exitCode,
+      stderr: errors.join("\n"),
+      stdout: logs.join("\n"),
+    };
+  } finally {
+    console.error = originalError;
+    console.log = originalLog;
+    process.exitCode = originalExitCode;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Suite 1 — parseCapsuleOutputFormat
@@ -230,7 +332,7 @@ test("parseCapsulePeers deduplicates", () => {
 });
 
 test("parseCapsulePeers rejects empty string", () => {
-  assert.throws(() => parseCapsulePeers(""), /--peers/);
+  assert.throws(() => parseCapsulePeers(""), /--peer-ids/);
 });
 
 test("parseCapsulePeers rejects entries with path separators", () => {
@@ -248,25 +350,25 @@ test("parseCapsulePeers rejects . and ..", () => {
 
 test("parseCapsuleExportOptions assembles option bag from valid inputs", () => {
   const result = parseCapsuleExportOptions("my-capsule", {
-    out: "/tmp/caps",
+    outDir: "/tmp/caps",
     since: "2026-04-01T00:00:00Z",
     includeKinds: "facts,entities",
-    peers: "peer-a",
+    peerIds: "peer-a",
   });
   assert.equal(result.name, "my-capsule");
-  assert.equal(result.out, "/tmp/caps");
+  assert.equal(result.outDir, "/tmp/caps");
   assert.ok(typeof result.since === "string");
   assert.deepEqual(result.includeKinds, ["facts", "entities"]);
-  assert.deepEqual(result.peers, ["peer-a"]);
+  assert.deepEqual(result.peerIds, ["peer-a"]);
 });
 
 test("parseCapsuleExportOptions uses defaults when optional flags absent", () => {
   const result = parseCapsuleExportOptions("my-capsule", {});
   assert.equal(result.name, "my-capsule");
-  assert.equal(result.out, undefined);
+  assert.equal(result.outDir, undefined);
   assert.equal(result.since, undefined);
   assert.equal(result.includeKinds, undefined);
-  assert.equal(result.peers, undefined);
+  assert.equal(result.peerIds, undefined);
 });
 
 test("parseCapsuleExportOptions rejects missing name", () => {
@@ -283,6 +385,32 @@ test("parseCapsuleExportOptions rejects missing name", () => {
 test("parseCapsuleExportOptions trims whitespace from name", () => {
   const result = parseCapsuleExportOptions("  my-capsule  ", {});
   assert.equal(result.name, "my-capsule");
+});
+
+test("capsule export action rejects empty include-kinds before export runs", async () => {
+  const root = registerCapsuleCliFixture();
+  const action = getAction(root, ["engram", "capsule", "export"]);
+  const result = await captureAction(action, {
+    name: "backup",
+    includeKinds: ",",
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.match(result.stderr, /--include-kinds expects at least one non-empty kind name/);
+  assert.equal(result.stdout, "");
+});
+
+test("capsule export action rejects empty peer-ids before export runs", async () => {
+  const root = registerCapsuleCliFixture();
+  const action = getAction(root, ["engram", "capsule", "export"]);
+  const result = await captureAction(action, {
+    name: "backup",
+    peerIds: ",",
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.match(result.stderr, /--peer-ids expects at least one non-empty peer id/);
+  assert.equal(result.stdout, "");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route `remnic capsule export` through the strict capsule export option parser
- align the export parser with the shipped `--out-dir` and `--peer-ids` option names
- reject comma-only `--include-kinds` and `--peer-ids` before export can create an empty capsule

## Verification
- `pnpm exec tsx --test tests/cli/capsule.test.ts packages/remnic-core/src/capsule-cli.test.ts`
- `pnpm --filter @remnic/core check-types`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `remnic capsule export` CLI path and its flag parsing, which can change behavior and error messages for existing scripts. Risk is limited to option validation/wiring; no core data logic changes.
> 
> **Overview**
> **`remnic capsule export` now uses `parseCapsuleExportOptions` for all inputs** instead of ad-hoc string splitting, so invalid `--include-kinds`/`--peer-ids` values fail fast with consistent errors before any export work runs.
> 
> Renames the export option bag fields from `out`→`outDir` and `peers`→`peerIds`, introduces `parseCapsulePeerIds` (with `parseCapsulePeers` kept as an alias), and adds CLI-level tests that exercise the `capsule export` action error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf02651d62b4ddc8af25fb4ade17c6266066bb3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->