### PR TITLE
fix(weclone): honor legacy home fallback

### DIFF
--- a/packages/connector-weclone/src/cli.test.ts
+++ b/packages/connector-weclone/src/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import * as net from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -25,6 +25,18 @@ function runCliWithConfig(config: unknown) {
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
+}
+
+function runCliWithoutConfig(env: NodeJS.ProcessEnv) {
+  return spawnSync(process.execPath, [tsxCli, cliPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+    },
+    timeout: 5_000,
+  });
 }
 
 function listenOnEphemeralPort(): Promise<{ server: net.Server; port: number }> {
@@ -61,6 +73,38 @@ describe("remnic-weclone-proxy CLI", () => {
     assert.match(result.stderr, /Invalid config at .*weclone\.json:/);
     assert.match(result.stderr, /wecloneApiUrl/);
     assert.doesNotMatch(result.stderr, /at parseConfig/);
+  });
+
+  it("falls back to ENGRAM_HOME when REMNIC_HOME is empty", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-env-"));
+    const remnicHome = join(tempDir, "legacy-home");
+    const configDir = join(remnicHome, "connectors");
+    const configPath = join(configDir, "weclone.json");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        proxyPort: 8100,
+        remnicDaemonUrl: "http://127.0.0.1:4318",
+      }),
+      { mode: 0o600 },
+    );
+
+    try {
+      const result = runCliWithoutConfig({
+        REMNIC_HOME: "",
+        ENGRAM_HOME: remnicHome,
+        HOME: join(tempDir, "home"),
+      });
+
+      assert.ifError(result.error);
+      assert.equal(result.status, 1);
+      assert.ok(result.stderr.includes(`Invalid config at ${configPath}:`));
+      assert.match(result.stderr, /wecloneApiUrl/);
+      assert.doesNotMatch(result.stderr, /Config not found/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("prints a controlled error when proxy startup fails", async () => {

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -33,7 +33,10 @@ import { homedir } from "node:os";
  * substitute it).
  */
 function defaultConfigPath(): string {
-  const override = process.env.REMNIC_HOME ?? process.env.ENGRAM_HOME;
+  const override =
+    process.env.REMNIC_HOME && process.env.REMNIC_HOME.length > 0
+      ? process.env.REMNIC_HOME
+      : process.env.ENGRAM_HOME;
   if (override && override.length > 0) {
     return resolve(override, "connectors", "weclone.json");
   }

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -2998,7 +2998,8 @@ const WECLONE_PROXY_CONFIG_FILENAME = "weclone.json";
  * `os.homedir()` in both places — the same rule the proxy CLI follows.
  */
 export function resolveWeCloneProxyConfigPath(): string {
-  const override = readEnvVar("REMNIC_HOME") ?? readEnvVar("ENGRAM_HOME");
+  const remnicHome = readEnvVar("REMNIC_HOME");
+  const override = remnicHome && remnicHome.length > 0 ? remnicHome : readEnvVar("ENGRAM_HOME");
   if (override && override.length > 0) {
     return path.resolve(override, "connectors", WECLONE_PROXY_CONFIG_FILENAME);
   }

--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -146,6 +146,33 @@ test("installConnector weclone writes registry config AND proxy config with defa
   );
 });
 
+test("installConnector weclone falls back to ENGRAM_HOME when REMNIC_HOME is empty", async (t) => {
+  const sandbox = makeSandbox(t);
+  const legacyHome = path.join(sandbox.root, "legacy-remnic-home");
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: "",
+      ENGRAM_HOME: legacyHome,
+    },
+    () => {
+      const result = installConnector({ connectorId: "weclone" });
+      assert.equal(result.status, "installed", `expected installed, got: ${result.status} — ${result.message}`);
+
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      assert.equal(proxyConfigPath, path.join(legacyHome, "connectors", "weclone.json"));
+      assert.ok(fs.existsSync(proxyConfigPath), "proxy config must be written under legacy ENGRAM_HOME");
+
+      const registryConfig = JSON.parse(
+        fs.readFileSync(result.configPath as string, "utf8"),
+      ) as Record<string, unknown>;
+      assert.equal(registryConfig.proxyConfigPath, proxyConfigPath);
+    },
+  );
+});
+
 test("installConnector weclone honours user-supplied overrides", async (t) => {
   const sandbox = makeSandbox(t);
   await withEnv(


### PR DESCRIPTION
## Summary
- Treat empty REMNIC_HOME as absent so ENGRAM_HOME can still supply the default WeClone connector config path.
- Add a spawn-level CLI regression that runs without --config and verifies the legacy path is used before config validation.

## Verification
- pnpm install --frozen-lockfile --prefer-offline
- pnpm exec tsx --test packages/connector-weclone/src/cli.test.ts
- pnpm --filter @remnic/connector-weclone check-types
- node packages/remnic-core/scripts/ensure-better-sqlite3.mjs
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small env-var resolution tweak plus regression tests; behavior change is limited to default config-path selection when `REMNIC_HOME` is set to an empty string.
> 
> **Overview**
> Fixes WeClone proxy config path resolution so **an empty `REMNIC_HOME` no longer blocks the legacy `ENGRAM_HOME` fallback**, keeping install/run behavior consistent.
> 
> Adds regression coverage: the `remnic-weclone-proxy` CLI is now tested when run *without* `--config` under `REMNIC_HOME=""`, and core `installConnector("weclone")` gets an integration test ensuring the proxy config is written under `ENGRAM_HOME/connectors/weclone.json` in that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a7ffa1f045113e89ee90dcd660f98ac0bb0c97c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->