### PR TITLE
fix(weclone): expand proxy config tilde paths

### DIFF
--- a/packages/connector-weclone/src/cli.test.ts
+++ b/packages/connector-weclone/src/cli.test.ts
@@ -12,31 +12,48 @@ const repoRoot = resolve(__dirname, "../../..");
 const tsxCli = join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
 const cliPath = join(__dirname, "cli.ts");
 
+function mergeEnv(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function runCli(args: string[], envOverrides: Record<string, string | undefined> = {}) {
+  return spawnSync(process.execPath, [tsxCli, cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 5_000,
+    env: mergeEnv(envOverrides),
+  });
+}
+
 function runCliWithConfig(config: unknown) {
   const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-cli-"));
   const configPath = join(tempDir, "weclone.json");
   writeFileSync(configPath, JSON.stringify(config), { mode: 0o600 });
   try {
-    return spawnSync(process.execPath, [tsxCli, cliPath, "--config", configPath], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      timeout: 5_000,
-    });
+    return runCli(["--config", configPath]);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
 }
 
-function runCliWithoutConfig(env: NodeJS.ProcessEnv) {
-  return spawnSync(process.execPath, [tsxCli, cliPath], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      ...env,
-    },
-    timeout: 5_000,
-  });
+function writeInvalidConfig(configPath: string): void {
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      proxyPort: 8100,
+      remnicDaemonUrl: "http://127.0.0.1:4318",
+    }),
+    { mode: 0o600 },
+  );
 }
 
 function listenOnEphemeralPort(): Promise<{ server: net.Server; port: number }> {
@@ -78,20 +95,11 @@ describe("remnic-weclone-proxy CLI", () => {
   it("falls back to ENGRAM_HOME when REMNIC_HOME is empty", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-env-"));
     const remnicHome = join(tempDir, "legacy-home");
-    const configDir = join(remnicHome, "connectors");
-    const configPath = join(configDir, "weclone.json");
-    mkdirSync(configDir, { recursive: true });
-    writeFileSync(
-      configPath,
-      JSON.stringify({
-        proxyPort: 8100,
-        remnicDaemonUrl: "http://127.0.0.1:4318",
-      }),
-      { mode: 0o600 },
-    );
+    const configPath = join(remnicHome, "connectors", "weclone.json");
+    writeInvalidConfig(configPath);
 
     try {
-      const result = runCliWithoutConfig({
+      const result = runCli([], {
         REMNIC_HOME: "",
         ENGRAM_HOME: remnicHome,
         HOME: join(tempDir, "home"),
@@ -122,6 +130,31 @@ describe("remnic-weclone-proxy CLI", () => {
       assert.match(result.stderr, /EADDRINUSE|address already in use/i);
     } finally {
       await closeServer(server);
+    }
+  });
+
+  it("expands tilde in explicit --config paths", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-cli-"));
+    const home = join(tempDir, "home");
+    const configPath = join(home, ".remnic", "connectors", "weclone.json");
+    writeInvalidConfig(configPath);
+
+    try {
+      const result = runCli(["--config", "~/.remnic/connectors/weclone.json"], {
+        HOME: home,
+        USERPROFILE: home,
+        REMNIC_HOME: undefined,
+        ENGRAM_HOME: undefined,
+      });
+
+      assert.ifError(result.error);
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /Invalid config at /);
+      assert.ok(result.stderr.includes(configPath), result.stderr);
+      assert.match(result.stderr, /wecloneApiUrl/);
+      assert.doesNotMatch(result.stderr, /Config not found/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -11,8 +11,31 @@
 import { createWeCloneProxy } from "./proxy.js";
 import { parseConfig, type WeCloneConnectorConfig } from "./config.js";
 import { readFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { homedir } from "node:os";
+
+function firstNonEmptyEnv(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveHomeDir(): string {
+  const envHome = process.env.HOME;
+  return envHome && envHome.length > 0 ? envHome : homedir();
+}
+
+function expandTildePath(input: string): string {
+  if (input === "~") return resolveHomeDir();
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return join(resolveHomeDir(), input.slice(2));
+  }
+  return input;
+}
 
 /**
  * Resolve the default proxy config path. Kept in lockstep with
@@ -33,16 +56,11 @@ import { homedir } from "node:os";
  * substitute it).
  */
 function defaultConfigPath(): string {
-  const override =
-    process.env.REMNIC_HOME && process.env.REMNIC_HOME.length > 0
-      ? process.env.REMNIC_HOME
-      : process.env.ENGRAM_HOME;
-  if (override && override.length > 0) {
-    return resolve(override, "connectors", "weclone.json");
+  const override = firstNonEmptyEnv("REMNIC_HOME", "ENGRAM_HOME");
+  if (override) {
+    return resolve(expandTildePath(override), "connectors", "weclone.json");
   }
-  const envHome = process.env.HOME;
-  const home = envHome && envHome.length > 0 ? envHome : homedir();
-  return resolve(home, ".remnic", "connectors", "weclone.json");
+  return resolve(expandTildePath(resolveHomeDir()), ".remnic", "connectors", "weclone.json");
 }
 
 function errorMessage(err: unknown): string {
@@ -65,7 +83,7 @@ async function main(): Promise<void> {
         console.error("Error: --config requires a path argument");
         process.exit(1);
       }
-      configPath = resolve(args[i + 1]);
+      configPath = resolve(expandTildePath(args[i + 1]));
       i++;
     }
   }

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from "node:url";
 import { generateToken, revokeToken, buildTokenEntry, commitTokenEntry, loadTokenStore, saveTokenStore } from "../tokens.js";
 import { launchProcessSync } from "../runtime/child-process.js";
 import { mergeEnv, readEnvVar, resolveHomeDir } from "../runtime/env.js";
+import { expandTildePath } from "../utils/path.js";
 import { coerceInstallExtension } from "./coerce.js";
 
 // Native memory artifact materialization for Codex CLI (#378). Surfaced here
@@ -2979,6 +2980,16 @@ function getConnectorsDir(): string {
 const WECLONE_PROXY_CONFIG_DIRNAME = ".remnic";
 const WECLONE_PROXY_CONFIG_FILENAME = "weclone.json";
 
+function readFirstNonEmptyEnvVar(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Resolve the path to ~/.remnic/connectors/weclone.json for the current user.
  * Honours REMNIC_HOME / ENGRAM_HOME env overrides so tests can point the
@@ -2998,15 +3009,14 @@ const WECLONE_PROXY_CONFIG_FILENAME = "weclone.json";
  * `os.homedir()` in both places — the same rule the proxy CLI follows.
  */
 export function resolveWeCloneProxyConfigPath(): string {
-  const remnicHome = readEnvVar("REMNIC_HOME");
-  const override = remnicHome && remnicHome.length > 0 ? remnicHome : readEnvVar("ENGRAM_HOME");
-  if (override && override.length > 0) {
-    return path.resolve(override, "connectors", WECLONE_PROXY_CONFIG_FILENAME);
+  const override = readFirstNonEmptyEnvVar("REMNIC_HOME", "ENGRAM_HOME");
+  if (override) {
+    return path.resolve(expandTildePath(override), "connectors", WECLONE_PROXY_CONFIG_FILENAME);
   }
   const envHome = readEnvVar("HOME");
   const home = envHome && envHome.length > 0 ? envHome : os.homedir();
   return path.resolve(
-    home,
+    expandTildePath(home),
     WECLONE_PROXY_CONFIG_DIRNAME,
     "connectors",
     WECLONE_PROXY_CONFIG_FILENAME,

--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -805,6 +805,26 @@ test("resolveWeCloneProxyConfigPath treats empty HOME as absent (aligns with os.
   );
 });
 
+test("resolveWeCloneProxyConfigPath expands tilde home overrides", async (t) => {
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: "~/custom-remnic",
+      ENGRAM_HOME: undefined,
+    },
+    () => {
+      const resolved = resolveWeCloneProxyConfigPath();
+      assert.equal(
+        resolved,
+        path.resolve(sandbox.home, "custom-remnic", "connectors", "weclone.json"),
+      );
+    },
+  );
+});
+
 test("buildWeCloneProxyConfig merges memoryInjection partials", () => {
   const config = buildWeCloneProxyConfig({
     userConfig: { memoryInjection: { maxTokens: 2500 } },


### PR DESCRIPTION
## Summary
- expand `~` in WeClone proxy config path resolution for `REMNIC_HOME` / `ENGRAM_HOME` overrides
- expand `~` in explicit `remnic-weclone-proxy --config` paths
- keep the installer and proxy CLI path resolution in lockstep after #1087 landed the empty-home fallback fix

## Verification
- `pnpm exec tsx --test packages/connector-weclone/src/cli.test.ts packages/remnic-core/src/connectors/weclone-installer.test.ts`
- `pnpm --filter @remnic/connector-weclone check-types && pnpm --filter @remnic/core check-types`
- `git diff --check`
- `npm run preflight:quick`