### PR TITLE
fix(weclone): expand tilde config paths

### DIFF
--- a/packages/connector-weclone/src/cli.test.ts
+++ b/packages/connector-weclone/src/cli.test.ts
@@ -12,6 +12,27 @@ const repoRoot = resolve(__dirname, "../../..");
 const tsxCli = join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
 const cliPath = join(__dirname, "cli.ts");
 
+function buildCliEnv(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+function runCliWithArgs(args: string[], env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(process.execPath, [tsxCli, cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: buildCliEnv(env),
+    timeout: 5_000,
+  });
+}
+
 function runCliWithConfig(config: unknown) {
   const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-cli-"));
   const configPath = join(tempDir, "weclone.json");
@@ -31,10 +52,7 @@ function runCliWithoutConfig(env: NodeJS.ProcessEnv) {
   return spawnSync(process.execPath, [tsxCli, cliPath], {
     cwd: repoRoot,
     encoding: "utf8",
-    env: {
-      ...process.env,
-      ...env,
-    },
+    env: buildCliEnv(env),
     timeout: 5_000,
   });
 }
@@ -95,6 +113,70 @@ describe("remnic-weclone-proxy CLI", () => {
         REMNIC_HOME: "",
         ENGRAM_HOME: remnicHome,
         HOME: join(tempDir, "home"),
+      });
+
+      assert.ifError(result.error);
+      assert.equal(result.status, 1);
+      assert.ok(result.stderr.includes(`Invalid config at ${configPath}:`));
+      assert.match(result.stderr, /wecloneApiUrl/);
+      assert.doesNotMatch(result.stderr, /Config not found/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("expands tilde in --config paths", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-tilde-config-"));
+    const home = join(tempDir, "home");
+    const configDir = join(home, ".remnic", "connectors");
+    const configPath = join(configDir, "weclone.json");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        proxyPort: 8100,
+        remnicDaemonUrl: "http://127.0.0.1:4318",
+      }),
+      { mode: 0o600 },
+    );
+
+    try {
+      const result = runCliWithArgs(["--config", "~/.remnic/connectors/weclone.json"], {
+        HOME: home,
+        REMNIC_HOME: undefined,
+        ENGRAM_HOME: undefined,
+      });
+
+      assert.ifError(result.error);
+      assert.equal(result.status, 1);
+      assert.ok(result.stderr.includes(`Invalid config at ${configPath}:`));
+      assert.match(result.stderr, /wecloneApiUrl/);
+      assert.doesNotMatch(result.stderr, /Config not found/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("expands tilde in REMNIC_HOME default config paths", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-tilde-home-"));
+    const home = join(tempDir, "home");
+    const configDir = join(home, "remnic-home", "connectors");
+    const configPath = join(configDir, "weclone.json");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        proxyPort: 8100,
+        remnicDaemonUrl: "http://127.0.0.1:4318",
+      }),
+      { mode: 0o600 },
+    );
+
+    try {
+      const result = runCliWithoutConfig({
+        HOME: home,
+        REMNIC_HOME: "~/remnic-home",
+        ENGRAM_HOME: undefined,
       });
 
       assert.ifError(result.error);

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -11,7 +11,7 @@
 import { createWeCloneProxy } from "./proxy.js";
 import { parseConfig, type WeCloneConnectorConfig } from "./config.js";
 import { readFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 
 /**
@@ -32,17 +32,28 @@ import { homedir } from "node:os";
  * cleared (empty string is not nullish, so `?? os.homedir()` does NOT
  * substitute it).
  */
+function homeDir(): string {
+  const envHome = process.env.HOME;
+  return envHome && envHome.length > 0 ? envHome : homedir();
+}
+
+function expandTildePath(input: string): string {
+  if (input === "~") return homeDir();
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return join(homeDir(), input.slice(2));
+  }
+  return input;
+}
+
 function defaultConfigPath(): string {
   const override =
     process.env.REMNIC_HOME && process.env.REMNIC_HOME.length > 0
       ? process.env.REMNIC_HOME
       : process.env.ENGRAM_HOME;
   if (override && override.length > 0) {
-    return resolve(override, "connectors", "weclone.json");
+    return resolve(expandTildePath(override), "connectors", "weclone.json");
   }
-  const envHome = process.env.HOME;
-  const home = envHome && envHome.length > 0 ? envHome : homedir();
-  return resolve(home, ".remnic", "connectors", "weclone.json");
+  return resolve(homeDir(), ".remnic", "connectors", "weclone.json");
 }
 
 function errorMessage(err: unknown): string {
@@ -65,7 +76,7 @@ async function main(): Promise<void> {
         console.error("Error: --config requires a path argument");
         process.exit(1);
       }
-      configPath = resolve(args[i + 1]);
+      configPath = resolve(expandTildePath(args[i + 1]));
       i++;
     }
   }

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from "node:url";
 import { generateToken, revokeToken, buildTokenEntry, commitTokenEntry, loadTokenStore, saveTokenStore } from "../tokens.js";
 import { launchProcessSync } from "../runtime/child-process.js";
 import { mergeEnv, readEnvVar, resolveHomeDir } from "../runtime/env.js";
+import { expandTildePath } from "../utils/path.js";
 import { coerceInstallExtension } from "./coerce.js";
 
 // Native memory artifact materialization for Codex CLI (#378). Surfaced here
@@ -3001,7 +3002,7 @@ export function resolveWeCloneProxyConfigPath(): string {
   const remnicHome = readEnvVar("REMNIC_HOME");
   const override = remnicHome && remnicHome.length > 0 ? remnicHome : readEnvVar("ENGRAM_HOME");
   if (override && override.length > 0) {
-    return path.resolve(override, "connectors", WECLONE_PROXY_CONFIG_FILENAME);
+    return path.resolve(expandTildePath(override), "connectors", WECLONE_PROXY_CONFIG_FILENAME);
   }
   const envHome = readEnvVar("HOME");
   const home = envHome && envHome.length > 0 ? envHome : os.homedir();

--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -173,6 +173,32 @@ test("installConnector weclone falls back to ENGRAM_HOME when REMNIC_HOME is emp
   );
 });
 
+test("installConnector weclone expands tilde in REMNIC_HOME", async (t) => {
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: "~/remnic-home",
+      ENGRAM_HOME: undefined,
+    },
+    () => {
+      const result = installConnector({ connectorId: "weclone" });
+      assert.equal(result.status, "installed", `expected installed, got: ${result.status} — ${result.message}`);
+
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      assert.equal(proxyConfigPath, path.join(sandbox.home, "remnic-home", "connectors", "weclone.json"));
+      assert.ok(fs.existsSync(proxyConfigPath), "proxy config must be written under expanded REMNIC_HOME");
+
+      const registryConfig = JSON.parse(
+        fs.readFileSync(result.configPath as string, "utf8"),
+      ) as Record<string, unknown>;
+      assert.equal(registryConfig.proxyConfigPath, proxyConfigPath);
+    },
+  );
+});
+
 test("installConnector weclone honours user-supplied overrides", async (t) => {
   const sandbox = makeSandbox(t);
   await withEnv(


### PR DESCRIPTION
## Summary
- Expand literal tilde prefixes for remnic-weclone-proxy --config paths.
- Expand tilde prefixes in REMNIC_HOME/ENGRAM_HOME before resolving the default WeClone proxy config path.
- Keep the core installer resolver aligned with the standalone connector CLI and add regressions for both surfaces.

## Verification
- pnpm install --frozen-lockfile --prefer-offline
- pnpm exec tsx --test packages/connector-weclone/src/cli.test.ts
- pnpm exec tsx --test packages/remnic-core/src/connectors/weclone-installer.test.ts
- pnpm --filter @remnic/connector-weclone check-types
- pnpm --filter @remnic/core check-types
- node packages/remnic-core/scripts/ensure-better-sqlite3.mjs
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to path resolution for WeClone proxy config locations, with added regression tests to reduce chance of breaking config discovery across environments.
> 
> **Overview**
> Fixes WeClone proxy config discovery when paths include a literal `~`. The standalone `remnic-weclone-proxy` CLI now expands `~` in both explicit `--config` arguments and env-derived default paths (`REMNIC_HOME`/`ENGRAM_HOME`) before resolving to an absolute path.
> 
> `@remnic/core`’s `resolveWeCloneProxyConfigPath()` is kept in sync by expanding `~` on overrides as well, and new tests cover tilde expansion plus env-var deletion semantics in CLI test harnesses to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84adc2b0ef39e20287130546ccbafeec17d74af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->