### PR TITLE
test(cli): include linked root tests

### DIFF
--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -28,7 +28,7 @@
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "precheck-types": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/*.test.ts ../../tests/remnic-cli-bin-wrapper.test.ts",
+    "test": "tsx --test src/*.test.ts ../../tests/remnic-cli-bin-wrapper.test.ts ../../tests/evals-engram-adapter-buffering.test.ts ../../tests/shim-openclaw-engram-package.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/tests/remnic-cli-bin-wrapper.test.ts
+++ b/tests/remnic-cli-bin-wrapper.test.ts
@@ -2,15 +2,34 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { constants } from "node:fs";
-import { chmod, copyFile, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { constants as osConstants, tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const packageBinDir = join(repoRoot, "packages", "remnic-cli", "bin");
+const remnicCliPackageJson = join(repoRoot, "packages", "remnic-cli", "package.json");
 const remnicBin = join(packageBinDir, "remnic.cjs");
 const engramBin = join(packageBinDir, "engram.cjs");
+
+test("@remnic/cli package test script includes linked root tests", async () => {
+  const raw = await readFile(remnicCliPackageJson, "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+  assert.equal(typeof parsed, "object");
+  assert.notEqual(parsed, null);
+  assert.equal(Array.isArray(parsed), false);
+
+  const scripts = (parsed as Record<string, unknown>).scripts;
+  assert.equal(typeof scripts, "object");
+  assert.notEqual(scripts, null);
+  assert.equal(Array.isArray(scripts), false);
+
+  const testScript = (scripts as Record<string, unknown>).test;
+  assert.equal(typeof testScript, "string");
+  assert.match(testScript, /\.\.\/\.\.\/tests\/evals-engram-adapter-buffering\.test\.ts/);
+  assert.match(testScript, /\.\.\/\.\.\/tests\/shim-openclaw-engram-package\.test\.ts/);
+});
 
 test("remnic package bins are executable on POSIX checkouts", async () => {
   if (process.platform === "win32") {


### PR DESCRIPTION
## Summary
- Add the two feature-linked root tests to @remnic/cli's package test script so `pnpm turbo run test --filter @remnic/cli` actually runs them.
- Add a guard in the already-included bin-wrapper test to fail if that package script drops the linked root test paths again.

## Verification
- pnpm install --frozen-lockfile --prefer-offline
- pnpm turbo run test --filter @remnic/cli --output-logs=errors-only
- pnpm --filter @remnic/cli check-types
- node packages/remnic-core/scripts/ensure-better-sqlite3.mjs
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test wiring and adds a guard test to prevent regression, with no runtime/production code changes.
> 
> **Overview**
> Ensures `@remnic/cli` runs two linked root-level tests when invoked via package-scoped test runs by extending the package `test` script to include `tests/evals-engram-adapter-buffering.test.ts` and `tests/shim-openclaw-engram-package.test.ts`.
> 
> Adds a new assertion in `tests/remnic-cli-bin-wrapper.test.ts` that reads `packages/remnic-cli/package.json` and fails if those root test paths are removed from the package `test` script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c2ac943675fc6783c9cdb483937b1a5f4d90744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->