### PR TITLE
fix(package): expose root cli subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     },
     "./access-cli": {
       "import": "./dist/access-cli.js"
+    },
+    "./cli": {
+      "import": "./dist/cli.js"
     }
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
 import { registerTools } from "./tools.js";
 import { registerLcmTools } from "./lcm/index.js";
 import { estimateTokens as estimateLcmTokens } from "./lcm/archive.js";
-import { registerCli } from "./cli.js";
+import { registerCli } from "@remnic/core/cli";
 import { objectiveStateStoreOverrideForNamespace } from "./objective-state.js";
 import { recordObjectiveStateSnapshotsFromAgentMessages } from "./objective-state-writers.js";
 import { probeQmdAvailability } from "./qmd-availability-probe.js";

--- a/tests/root-cli-package-boundary.test.ts
+++ b/tests/root-cli-package-boundary.test.ts
@@ -42,4 +42,31 @@ describe("root CLI package boundaries", () => {
       "root build should prepare @remnic/core dist before running root tsup",
     );
   });
+
+  it("root package exposes each CLI shim through package exports and build entries", () => {
+    const manifest = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as {
+      exports?: Record<string, { import?: string }>;
+    };
+    const tsupConfig = readFileSync(resolve("tsup.config.ts"), "utf8");
+
+    for (const [filePath] of ROOT_CLI_SHIMS) {
+      const subpath = `./${filePath
+        .replace(/^src\//, "")
+        .replace(/\.ts$/, "")}`;
+      const distPath = `./dist/${filePath
+        .replace(/^src\//, "")
+        .replace(/\.ts$/, ".js")}`;
+
+      assert.equal(
+        manifest.exports?.[subpath]?.import,
+        distPath,
+        `${subpath} must resolve to ${distPath} through package exports`,
+      );
+      assert.ok(
+        tsupConfig.includes(`"${filePath}"`) ||
+          tsupConfig.includes(`'${filePath}'`),
+        `${filePath} must be a root tsup entry so ${distPath} exists after build`,
+      );
+    }
+  });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/access-cli.ts"],
+  entry: ["src/index.ts", "src/access-cli.ts", "src/cli.ts"],
   format: ["esm"],
   target: "es2022",
   platform: "node",


### PR DESCRIPTION
## Summary
- expose the root CLI shim as `remnic-workspace/cli` in package exports
- add `src/cli.ts` to the root tsup entries so `dist/cli.js` is emitted
- make `registerCli` an explicit re-export for the root shim and cover CLI shim package boundaries

## Verification
- pnpm exec tsx --test tests/root-cli-package-boundary.test.ts
- pnpm run build
- node --input-type=module -e "const mod = await import('remnic-workspace/cli'); if (typeof mod.registerCli !== 'function') throw new Error('registerCli export missing'); console.log('ok')"
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging/build wiring changes to expose a new `./cli` export and ensure `dist/cli.js` is produced; minimal runtime behavior change aside from sourcing `registerCli` from `@remnic/core`.
> 
> **Overview**
> Exposes the root CLI shim as a first-class package export by adding `./cli` → `./dist/cli.js` to `package.json` exports and ensuring `tsup` emits `dist/cli.js`.
> 
> Updates `src/index.ts` to import `registerCli` from the public `@remnic/core/cli` subpath (instead of a local module) and adds tests that enforce CLI shims use public core exports and are included in root exports/build entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e88855816f0ab717fa4abe8a424696f69dda483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->