### PR TITLE
fix(cli): expand connector config paths

### DIFF
--- a/packages/remnic-cli/src/config-path.test.ts
+++ b/packages/remnic-cli/src/config-path.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveConfigPath } from "./index.js";
+
+const ORIGINAL_ENV = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE,
+  REMNIC_CONFIG_PATH: process.env.REMNIC_CONFIG_PATH,
+  ENGRAM_CONFIG_PATH: process.env.ENGRAM_CONFIG_PATH,
+};
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+test("resolveConfigPath expands home-relative CLI paths", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-config-home-"));
+  try {
+    process.env.HOME = home;
+    delete process.env.REMNIC_CONFIG_PATH;
+    delete process.env.ENGRAM_CONFIG_PATH;
+
+    assert.equal(
+      resolveConfigPath("~/remnic.json"),
+      path.join(home, "remnic.json"),
+    );
+    assert.equal(
+      resolveConfigPath("$HOME/remnic.json"),
+      path.join(home, "remnic.json"),
+    );
+    assert.equal(
+      resolveConfigPath("${HOME}/remnic.json"),
+      path.join(home, "remnic.json"),
+    );
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("resolveConfigPath expands home-relative env config paths", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-config-home-"));
+  try {
+    process.env.HOME = home;
+    process.env.REMNIC_CONFIG_PATH = "~/remnic.json";
+    delete process.env.ENGRAM_CONFIG_PATH;
+
+    assert.equal(resolveConfigPath(), path.join(home, "remnic.json"));
+
+    delete process.env.REMNIC_CONFIG_PATH;
+    process.env.ENGRAM_CONFIG_PATH = "${HOME}/engram.json";
+
+    assert.equal(resolveConfigPath(), path.join(home, "engram.json"));
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3264,10 +3264,10 @@ async function writeBenchReproManifestForPackageRun(args: {
 
 // ── Config helpers ───────────────────────────────────────────────────────────
 
-function resolveConfigPath(cliPath?: string): string {
-  if (cliPath) return path.resolve(cliPath);
+export function resolveConfigPath(cliPath?: string): string {
+  if (cliPath) return path.resolve(expandTilde(cliPath));
   const envPath = readCompatEnv("REMNIC_CONFIG_PATH", "ENGRAM_CONFIG_PATH");
-  if (envPath) return path.resolve(envPath);
+  if (envPath) return path.resolve(expandTilde(envPath));
 
   const candidates = [
     path.join(process.cwd(), "remnic.config.json"),


### PR DESCRIPTION
## Summary
- expand home-relative Remnic config paths in resolveConfigPath for CLI and env overrides
- cover CLI, REMNIC_CONFIG_PATH, and ENGRAM_CONFIG_PATH path expansion in focused tests

## Verification
- pnpm exec tsx --test packages/remnic-cli/src/config-path.test.ts
- pnpm exec tsx --test packages/remnic-cli/src/marketplace-cli.test.ts
- pnpm --filter @remnic/cli check-types
- pnpm --filter @remnic/cli test
- npm_config_workspace_concurrency=1 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to CLI config path resolution to expand home-relative paths, covered by new focused tests; main impact is on how file paths are interpreted from args/env.
> 
> **Overview**
> Fixes `resolveConfigPath` so config paths provided via CLI args or `REMNIC_CONFIG_PATH`/`ENGRAM_CONFIG_PATH` support home-relative forms (e.g. `~`, `$HOME`, `${HOME}`) before `path.resolve()`.
> 
> Adds `config-path.test.ts` to verify expansion behavior for both CLI-provided paths and env-var overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd194200d39d916c9d550f7f5f8f72119e01b236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->