### PR TITLE
fix(cli): reject unsupported fallback bench options

### DIFF
--- a/packages/remnic-cli/src/bench-fallback.test.ts
+++ b/packages/remnic-cli/src/bench-fallback.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   buildBenchRunnerArgs,
   createFallbackBenchOutputDir,
+  findUnsupportedFallbackBenchOptions,
   resolveFallbackBenchResultPath,
 } from "./bench-fallback.js";
 import type { ParsedBenchArgs } from "./bench-args.js";
@@ -45,6 +46,18 @@ test("buildBenchRunnerArgs forwards a run-scoped output directory", () => {
     "/tmp/datasets/longmemeval",
     "--output-dir",
     "/tmp/remnic-bench/fallback-runs/longmemeval-1710000000000-123",
+  ]);
+});
+
+test("findUnsupportedFallbackBenchOptions rejects package-only timeout options", () => {
+  const parsed = createParsedBenchArgs({
+    drainTimeout: 1,
+    max429WaitMs: 2,
+  });
+
+  assert.deepEqual(findUnsupportedFallbackBenchOptions(parsed), [
+    "--drain-timeout",
+    "--max-429-wait",
   ]);
 });
 

--- a/packages/remnic-cli/src/bench-fallback.ts
+++ b/packages/remnic-cli/src/bench-fallback.ts
@@ -23,6 +23,47 @@ export function buildBenchRunnerArgs(
   return args;
 }
 
+export function findUnsupportedFallbackBenchOptions(parsed: ParsedBenchArgs): string[] {
+  const unsupported: string[] = [];
+  const add = (condition: boolean, flag: string) => {
+    if (condition) unsupported.push(flag);
+  };
+
+  add(parsed.modelSource !== undefined, "--model-source");
+  add(parsed.gatewayAgentId !== undefined, "--gateway-agent-id");
+  add(parsed.fastGatewayAgentId !== undefined, "--fast-gateway-agent-id");
+  add(parsed.systemProvider !== undefined, "--system-provider/--provider");
+  add(parsed.systemModel !== undefined, "--system-model/--model");
+  add(parsed.systemBaseUrl !== undefined, "--system-base-url/--base-url");
+  add(parsed.systemApiKey !== undefined, "--system-api-key");
+  add(parsed.systemCodexReasoningEffort !== undefined, "--system-codex-reasoning-effort");
+  add(parsed.systemResponderContextBudgetChars !== undefined, "--system-responder-context-budget-chars");
+  add(parsed.systemResponderPromptBudgetChars !== undefined, "--system-responder-prompt-budget-chars");
+  add(parsed.judgeProvider !== undefined, "--judge-provider");
+  add(parsed.judgeModel !== undefined, "--judge-model");
+  add(parsed.judgeBaseUrl !== undefined, "--judge-base-url");
+  add(parsed.judgeApiKey !== undefined, "--judge-api-key");
+  add(parsed.judgeCodexReasoningEffort !== undefined, "--judge-codex-reasoning-effort");
+  add(parsed.internalProvider !== undefined, "--internal-provider");
+  add(parsed.internalModel !== undefined, "--internal-model");
+  add(parsed.internalBaseUrl !== undefined, "--internal-base-url");
+  add(parsed.internalApiKey !== undefined, "--internal-api-key");
+  add(parsed.internalDisableThinking === true, "--internal-disable-thinking");
+  add(parsed.internalCodexReasoningEffort !== undefined, "--internal-codex-reasoning-effort");
+  add(parsed.amaBenchJudgeProtocol !== undefined, "--ama-bench-judge-protocol");
+  add(parsed.amaBenchCrossJudgeProvider !== undefined, "--ama-bench-cross-judge-provider");
+  add(parsed.amaBenchCrossJudgeModel !== undefined, "--ama-bench-cross-judge-model");
+  add(parsed.amaBenchCrossJudgeBaseUrl !== undefined, "--ama-bench-cross-judge-base-url");
+  add(parsed.amaBenchCrossJudgeApiKey !== undefined, "--ama-bench-cross-judge-api-key");
+  add(parsed.amaBenchCrossJudgeCodexReasoningEffort !== undefined, "--ama-bench-cross-judge-codex-reasoning-effort");
+  add(parsed.disableThinking === true, "--disable-thinking");
+  add(parsed.requestTimeout !== undefined, "--request-timeout");
+  add(parsed.drainTimeout !== undefined, "--drain-timeout");
+  add(parsed.max429WaitMs !== undefined, "--max-429-wait");
+
+  return unsupported;
+}
+
 export function createFallbackBenchOutputDir(
   resultsDir: string,
   benchmarkId: string,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -194,6 +194,7 @@ import {
 import {
   buildBenchRunnerArgs,
   createFallbackBenchOutputDir,
+  findUnsupportedFallbackBenchOptions,
   resolveFallbackBenchResultPath,
 } from "./bench-fallback.js";
 import {
@@ -1125,32 +1126,10 @@ async function runBenchViaFallback(
       'Fallback benchmark runner does not support --runtime-profile "openclaw-chain". Build/install @remnic/bench to use package-backed runtime profiles.',
     );
   }
-  if (
-    parsed.modelSource !== undefined ||
-    parsed.gatewayAgentId !== undefined ||
-    parsed.fastGatewayAgentId !== undefined ||
-    parsed.systemProvider !== undefined ||
-    parsed.systemModel !== undefined ||
-    parsed.systemBaseUrl !== undefined ||
-    parsed.judgeProvider !== undefined ||
-    parsed.judgeModel !== undefined ||
-    parsed.judgeBaseUrl !== undefined ||
-    parsed.internalProvider !== undefined ||
-    parsed.internalModel !== undefined ||
-    parsed.internalBaseUrl !== undefined ||
-    parsed.internalApiKey !== undefined ||
-    parsed.internalDisableThinking === true ||
-    parsed.internalCodexReasoningEffort !== undefined ||
-    parsed.amaBenchJudgeProtocol !== undefined ||
-    parsed.amaBenchCrossJudgeProvider !== undefined ||
-    parsed.amaBenchCrossJudgeModel !== undefined ||
-    parsed.amaBenchCrossJudgeBaseUrl !== undefined ||
-    parsed.amaBenchCrossJudgeApiKey !== undefined ||
-    parsed.disableThinking === true ||
-    parsed.requestTimeout !== undefined
-  ) {
+  const unsupportedOptions = findUnsupportedFallbackBenchOptions(parsed);
+  if (unsupportedOptions.length > 0) {
     throw new Error(
-      "Fallback benchmark runner does not support provider-backed, gateway, or thinking/timeout flags. Build/install @remnic/bench to use those options.",
+      `Fallback benchmark runner does not support provider-backed, gateway, or thinking/timeout flags (${unsupportedOptions.join(", ")}). Build/install @remnic/bench to use those options.`,
     );
   }
   if (!fs.existsSync(EVAL_RUNNER_PATH)) {


### PR DESCRIPTION
## Summary
- centralize unsupported-option detection for the eval fallback benchmark runner
- reject fallback-only omissions like `--drain-timeout` and `--max-429-wait` instead of silently dropping them
- add focused fallback coverage for those timeout options

## Verification
- `pnpm exec tsx --test packages/remnic-cli/src/bench-fallback.test.ts`
- `pnpm --filter @remnic/cli check-types`
- `node packages/remnic-core/scripts/ensure-better-sqlite3.mjs`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI behavior for the fallback benchmark runner by actively rejecting additional flags that were previously silently ignored, which may break existing scripts relying on the old behavior. Scope is limited to argument validation and error messaging.
> 
> **Overview**
> The fallback benchmark runner now centralizes unsupported-flag detection via `findUnsupportedFallbackBenchOptions`, and `runBenchViaFallback` throws an error that lists the specific rejected flags.
> 
> This expands rejection to include additional timeout-related options (e.g. `--drain-timeout`, `--max-429-wait`) and adds a focused unit test covering these newly unsupported fallback options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f78249366c257f95a13876198ffbc26d6d6e441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->