### PR TITLE
fix(package): publish root postinstall helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dist",
     "bin/engram-access.js",
     "openclaw.plugin.json",
-    "packages/remnic-core/scripts/ensure-better-sqlite3.mjs"
+    "scripts/ensure-better-sqlite3.mjs"
   ],
   "dependencies": {
     "@remnic/core": "workspace:^",
@@ -116,7 +116,7 @@
     "review:patterns": "bash scripts/check-review-patterns.sh",
     "hooks:install": "bash scripts/install-git-hooks.sh",
     "migrate": "tsx scripts/migrate.ts",
-    "postinstall": "node packages/remnic-core/scripts/ensure-better-sqlite3.mjs",
+    "postinstall": "node scripts/ensure-better-sqlite3.mjs",
     "prepack": "npm run build"
   },
   "devDependencies": {

--- a/scripts/ensure-better-sqlite3.mjs
+++ b/scripts/ensure-better-sqlite3.mjs
@@ -1,0 +1,124 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+if (process.env.REMNIC_SKIP_BETTER_SQLITE3_VERIFY === "1") {
+  console.log("[remnic] Skipping better-sqlite3 verification by request.");
+  process.exit(0);
+}
+
+try {
+  verifyBetterSqlite3();
+  console.log("[remnic] better-sqlite3 native binding verified.");
+  process.exit(0);
+} catch (error) {
+  console.warn(`[remnic] better-sqlite3 verification failed: ${errorMessage(error)}`);
+}
+
+const packageDir = betterSqlite3PackageDir();
+if (!packageDir) {
+  console.error("[remnic] Could not resolve better-sqlite3/package.json.");
+  process.exit(1);
+}
+
+const rebuild = rebuildBetterSqlite3(packageDir);
+if (!rebuild.ok) {
+  console.error("[remnic] better-sqlite3 native rebuild failed.");
+  if (rebuild.output) console.error(rebuild.output);
+  console.error(
+    `[remnic] Try manually from this install directory: npx node-gyp rebuild --directory=${packageDir}`,
+  );
+  process.exit(rebuild.status ?? 1);
+}
+
+try {
+  clearBetterSqlite3RequireCache(packageDir);
+  verifyBetterSqlite3();
+  console.log("[remnic] better-sqlite3 native binding rebuilt and verified.");
+} catch (error) {
+  console.error(
+    `[remnic] better-sqlite3 rebuild completed but the binding still does not load: ${errorMessage(error)}`,
+  );
+  process.exit(1);
+}
+
+function verifyBetterSqlite3() {
+  const loaded = require("better-sqlite3");
+  const Database = typeof loaded === "function" ? loaded : loaded?.default;
+  if (typeof Database !== "function") {
+    throw new Error("module did not export a constructor");
+  }
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = MEMORY");
+  db.close();
+}
+
+function betterSqlite3PackageDir() {
+  try {
+    return path.dirname(require.resolve("better-sqlite3/package.json"));
+  } catch {
+    return null;
+  }
+}
+
+function rebuildBetterSqlite3(cwd) {
+  const localNodeGyp = resolveOptional("node-gyp/bin/node-gyp.js");
+  if (localNodeGyp) {
+    return runRebuild(process.execPath, [localNodeGyp, "rebuild", "--release"], cwd);
+  }
+
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  return runRebuild(
+    npm,
+    ["exec", "--yes", "node-gyp", "--", "rebuild", "--release"],
+    cwd,
+  );
+}
+
+function resolveOptional(specifier) {
+  try {
+    return require.resolve(specifier);
+  } catch {
+    return null;
+  }
+}
+
+function runRebuild(command, args, cwd) {
+  console.log(`[remnic] Rebuilding better-sqlite3 native binding in ${cwd}`);
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      npm_config_build_from_source: "true",
+    },
+    windowsHide: true,
+  });
+
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    output: [
+      result.error ? String(result.error) : "",
+      result.stdout ?? "",
+      result.stderr ?? "",
+    ]
+      .filter((part) => part.trim().length > 0)
+      .join("\n")
+      .trim(),
+  };
+}
+
+function clearBetterSqlite3RequireCache(packageDir) {
+  for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(packageDir)) {
+      delete require.cache[key];
+    }
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tests/root-cli-package-boundary.test.ts
+++ b/tests/root-cli-package-boundary.test.ts
@@ -69,4 +69,36 @@ describe("root CLI package boundaries", () => {
       );
     }
   });
+
+  it("root postinstall runs a root-level script included in the package files", () => {
+    const manifest = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as {
+      files?: string[];
+      scripts?: { postinstall?: string };
+    };
+    const postinstall = manifest.scripts?.postinstall ?? "";
+    const postinstallHelper = readFileSync(
+      resolve("scripts/ensure-better-sqlite3.mjs"),
+      "utf8",
+    );
+
+    assert.equal(
+      postinstall,
+      "node scripts/ensure-better-sqlite3.mjs",
+      "root postinstall should not depend on workspace-internal package paths",
+    );
+    assert.ok(
+      manifest.files?.includes("scripts/ensure-better-sqlite3.mjs"),
+      "root package files must include the postinstall helper",
+    );
+    assert.doesNotMatch(
+      postinstall,
+      /packages\/remnic-core\//,
+      "root postinstall must use a stable root-level published path",
+    );
+    assert.doesNotMatch(
+      postinstallHelper,
+      /packages\/remnic-core\//,
+      "root postinstall helper must not delegate through workspace-internal paths",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- move the root package postinstall path to a root-level published helper
- include that helper in the root package files allow-list
- add a package boundary regression that prevents root postinstall from depending on workspace-internal paths

## Verification
- `pnpm exec tsx --test tests/root-cli-package-boundary.test.ts`
- `node scripts/ensure-better-sqlite3.mjs`
- `pnpm pack --pack-destination <tmp> && npm install <tmp>/remnic-workspace-9.3.464.tgz`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install-time `postinstall` behavior by moving and publishing the better-sqlite3 verification/rebuild helper; failures here can break consumer installs across environments. Code changes are small but run during dependency installation and invoke native rebuild tooling.
> 
> **Overview**
> Updates the root package `postinstall` to run a **root-level, published** `scripts/ensure-better-sqlite3.mjs` helper (and adds it to the root `files` allow-list) so installs no longer depend on workspace-internal paths.
> 
> Adds the new `scripts/ensure-better-sqlite3.mjs` helper that verifies `better-sqlite3` loads and, if not, attempts a `node-gyp rebuild` then re-verifies.
> 
> Extends `tests/root-cli-package-boundary.test.ts` with a regression check ensuring the root `postinstall` and helper don’t reference `packages/remnic-core` and that the helper is included in published files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9341c9eddfad87758a60ec3eefc25cd585138f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->