### PR TITLE
fix(package): expose connector subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,21 @@
     },
     "./cli": {
       "import": "./dist/cli.js"
+    },
+    "./connectors": {
+      "import": "./dist/connectors/index.js"
+    },
+    "./connectors/codex-materialize": {
+      "import": "./dist/connectors/codex-materialize.js"
+    },
+    "./connectors/codex-materialize.js": {
+      "import": "./dist/connectors/codex-materialize.js"
+    },
+    "./connectors/codex-materialize-runner": {
+      "import": "./dist/connectors/codex-materialize-runner.js"
+    },
+    "./connectors/codex-materialize-runner.js": {
+      "import": "./dist/connectors/codex-materialize-runner.js"
     }
   },
   "files": [

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -17,6 +17,26 @@
     "./cli": {
       "import": "./dist/cli.js",
       "types": "./dist/cli.d.ts"
+    },
+    "./connectors": {
+      "import": "./dist/connectors/index.js",
+      "types": "./dist/connectors/index.d.ts"
+    },
+    "./connectors/codex-materialize": {
+      "import": "./dist/connectors/codex-materialize.js",
+      "types": "./dist/connectors/codex-materialize.d.ts"
+    },
+    "./connectors/codex-materialize.js": {
+      "import": "./dist/connectors/codex-materialize.js",
+      "types": "./dist/connectors/codex-materialize.d.ts"
+    },
+    "./connectors/codex-materialize-runner": {
+      "import": "./dist/connectors/codex-materialize-runner.js",
+      "types": "./dist/connectors/codex-materialize-runner.d.ts"
+    },
+    "./connectors/codex-materialize-runner.js": {
+      "import": "./dist/connectors/codex-materialize-runner.js",
+      "types": "./dist/connectors/codex-materialize-runner.d.ts"
     }
   },
   "files": [

--- a/packages/remnic-core/tsup.config.ts
+++ b/packages/remnic-core/tsup.config.ts
@@ -8,8 +8,14 @@ const srcFiles = readdirSync(join(__dirname, "src"))
   .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts") && !f.endsWith(".d.ts"))
   .map((f) => `src/${f}`);
 
+const connectorEntryFiles = [
+  "src/connectors/index.ts",
+  "src/connectors/codex-materialize.ts",
+  "src/connectors/codex-materialize-runner.ts",
+];
+
 export default defineConfig({
-  entry: srcFiles,
+  entry: [...srcFiles, ...connectorEntryFiles],
   format: ["esm"],
   target: "es2022",
   platform: "node",

--- a/src/connectors/codex-materialize-runner.ts
+++ b/src/connectors/codex-materialize-runner.ts
@@ -1,1 +1,1 @@
-export * from "../../packages/remnic-core/src/connectors/codex-materialize-runner.js";
+export * from "@remnic/core/connectors/codex-materialize-runner";

--- a/src/connectors/codex-materialize.ts
+++ b/src/connectors/codex-materialize.ts
@@ -1,1 +1,1 @@
-export * from "../../packages/remnic-core/src/connectors/codex-materialize.js";
+export * from "@remnic/core/connectors/codex-materialize";

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,1 +1,1 @@
-export * from "../../packages/remnic-core/src/connectors/index.js";
+export * from "@remnic/core/connectors";

--- a/tests/root-cli-package-boundary.test.ts
+++ b/tests/root-cli-package-boundary.test.ts
@@ -8,8 +8,22 @@ const ROOT_CLI_SHIMS = [
   ["src/cli.ts", "@remnic/core/cli"],
 ] as const;
 
+const ROOT_CONNECTOR_SHIMS = [
+  ["src/connectors/index.ts", "@remnic/core/connectors"],
+  [
+    "src/connectors/codex-materialize.ts",
+    "@remnic/core/connectors/codex-materialize",
+  ],
+  [
+    "src/connectors/codex-materialize-runner.ts",
+    "@remnic/core/connectors/codex-materialize-runner",
+  ],
+] as const;
+
+const ROOT_PACKAGE_ENTRIES = [...ROOT_CLI_SHIMS, ...ROOT_CONNECTOR_SHIMS] as const;
+
 describe("root CLI package boundaries", () => {
-  for (const [filePath, publicSpecifier] of ROOT_CLI_SHIMS) {
+  for (const [filePath, publicSpecifier] of ROOT_PACKAGE_ENTRIES) {
     it(`${filePath} uses the public @remnic/core package export`, () => {
       const source = readFileSync(resolve(filePath), "utf8");
 
@@ -49,9 +63,10 @@ describe("root CLI package boundaries", () => {
     };
     const tsupConfig = readFileSync(resolve("tsup.config.ts"), "utf8");
 
-    for (const [filePath] of ROOT_CLI_SHIMS) {
+    for (const [filePath] of ROOT_PACKAGE_ENTRIES) {
       const subpath = `./${filePath
         .replace(/^src\//, "")
+        .replace(/\/index\.ts$/, "")
         .replace(/\.ts$/, "")}`;
       const distPath = `./dist/${filePath
         .replace(/^src\//, "")
@@ -66,6 +81,43 @@ describe("root CLI package boundaries", () => {
         tsupConfig.includes(`"${filePath}"`) ||
           tsupConfig.includes(`'${filePath}'`),
         `${filePath} must be a root tsup entry so ${distPath} exists after build`,
+      );
+    }
+  });
+
+  it("core package exposes connector shims through public exports and build entries", () => {
+    const manifest = JSON.parse(
+      readFileSync(resolve("packages/remnic-core/package.json"), "utf8"),
+    ) as {
+      exports?: Record<string, { import?: string; types?: string }>;
+    };
+    const tsupConfig = readFileSync(resolve("packages/remnic-core/tsup.config.ts"), "utf8");
+
+    for (const [rootFilePath, publicSpecifier] of ROOT_CONNECTOR_SHIMS) {
+      const coreFilePath = rootFilePath.replace(
+        /^src\/connectors\//,
+        "src/connectors/",
+      );
+      const subpath = publicSpecifier.replace(/^@remnic\/core/, ".");
+      const distPath = `./dist/${coreFilePath
+        .replace(/^src\//, "")
+        .replace(/\.ts$/, ".js")}`;
+      const typesPath = distPath.replace(/\.js$/, ".d.ts");
+
+      assert.equal(
+        manifest.exports?.[subpath]?.import,
+        distPath,
+        `${subpath} must resolve to ${distPath} through @remnic/core exports`,
+      );
+      assert.equal(
+        manifest.exports?.[subpath]?.types,
+        typesPath,
+        `${subpath} must publish declarations at ${typesPath}`,
+      );
+      assert.ok(
+        tsupConfig.includes(`"${coreFilePath}"`) ||
+          tsupConfig.includes(`'${coreFilePath}'`),
+        `${coreFilePath} must be a core tsup entry so ${distPath} exists after build`,
       );
     }
   });

--- a/tests/root-cli-package-boundary.test.ts
+++ b/tests/root-cli-package-boundary.test.ts
@@ -93,11 +93,7 @@ describe("root CLI package boundaries", () => {
     };
     const tsupConfig = readFileSync(resolve("packages/remnic-core/tsup.config.ts"), "utf8");
 
-    for (const [rootFilePath, publicSpecifier] of ROOT_CONNECTOR_SHIMS) {
-      const coreFilePath = rootFilePath.replace(
-        /^src\/connectors\//,
-        "src/connectors/",
-      );
+    for (const [coreFilePath, publicSpecifier] of ROOT_CONNECTOR_SHIMS) {
       const subpath = publicSpecifier.replace(/^@remnic\/core/, ".");
       const distPath = `./dist/${coreFilePath
         .replace(/^src\//, "")

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/access-cli.ts", "src/cli.ts"],
+  entry: [
+    "src/index.ts",
+    "src/access-cli.ts",
+    "src/cli.ts",
+    "src/connectors/index.ts",
+    "src/connectors/codex-materialize.ts",
+    "src/connectors/codex-materialize-runner.ts",
+  ],
   format: ["esm"],
   target: "es2022",
   platform: "node",


### PR DESCRIPTION
## Summary
- expose connector subpaths from both `@remnic/core` and the root package export maps
- build connector shims as package entrypoints instead of source-only files
- route root connector shims through public `@remnic/core` exports rather than private source paths

## Verification
- `pnpm exec tsx --test tests/root-cli-package-boundary.test.ts`
- `pnpm --filter @remnic/core build`
- `pnpm run build`
- connector subpath import smoke for `@remnic/core/connectors*` and `remnic-workspace/connectors*`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk packaging/build-surface change: adjusts export maps and build entrypoints so connector subpath imports resolve correctly, with added tests to prevent regressions.
> 
> **Overview**
> **Exposes connector subpath entrypoints** from both the root package and `@remnic/core` by extending `package.json` `exports` to include `./connectors` and the Codex connector modules.
> 
> Updates both `tsup.config.ts` builds to emit these connector shims as explicit entrypoints, and switches root `src/connectors/*` shims to re-export via the public `@remnic/core/connectors*` specifiers instead of private workspace paths.
> 
> Extends `root-cli-package-boundary.test.ts` to cover connector shims, verify export-map/build-entry consistency (including `index.ts` subpath normalization), and assert `@remnic/core` also publishes the connector subpaths with typings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5963ae159e2255feceb9ec15862c3d674cb276b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->