### PR TITLE
fix(export-weclone): validate max pairs option

### DIFF
--- a/packages/export-weclone/src/synthesizer.test.ts
+++ b/packages/export-weclone/src/synthesizer.test.ts
@@ -367,6 +367,24 @@ describe("synthesizeTrainingPairs", () => {
     assert.equal(pairs.length, 1);
   });
 
+  it("rejects invalid maxPairsPerRecord values", () => {
+    const records = [
+      makeRecord({
+        instruction: "Recall a user preference (music)",
+        category: "preference",
+        output: "I enjoy jazz.",
+      }),
+    ];
+
+    for (const maxPairsPerRecord of [1.5, 0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      assert.throws(
+        () => synthesizeTrainingPairs(records, { maxPairsPerRecord }),
+        /maxPairsPerRecord must be a finite positive integer/,
+        `expected ${String(maxPairsPerRecord)} to be rejected`,
+      );
+    }
+  });
+
   it("applies style markers - lowercase output", () => {
     const records = [
       makeRecord({

--- a/packages/export-weclone/src/synthesizer.ts
+++ b/packages/export-weclone/src/synthesizer.ts
@@ -82,7 +82,7 @@ export function synthesizeTrainingPairs(
   records: TrainingExportRecord[],
   options?: SynthesizerOptions,
 ): TrainingExportRecord[] {
-  const maxPairs = options?.maxPairsPerRecord ?? DEFAULT_MAX_PAIRS;
+  const maxPairs = resolveMaxPairsPerRecord(options?.maxPairsPerRecord);
   const style = options?.styleMarkers;
   const result: TrainingExportRecord[] = [];
 
@@ -118,6 +118,18 @@ export function synthesizeTrainingPairs(
 }
 
 // ── Internals ────────────────────────────────────────────
+
+function resolveMaxPairsPerRecord(maxPairsPerRecord: number | undefined): number {
+  const maxPairs = maxPairsPerRecord ?? DEFAULT_MAX_PAIRS;
+  if (
+    !Number.isFinite(maxPairs) ||
+    !Number.isInteger(maxPairs) ||
+    maxPairs <= 0
+  ) {
+    throw new RangeError("maxPairsPerRecord must be a finite positive integer");
+  }
+  return maxPairs;
+}
 
 /**
  * Resolve a record's category field to a QUESTION_TEMPLATES key.


### PR DESCRIPTION
## Summary
- validate maxPairsPerRecord before synthesizing WeClone training pairs
- reject fractional, zero, negative, NaN, and infinite values with a clear RangeError
- add focused regression coverage for invalid numeric options

## Verification
- pnpm exec tsx --test packages/export-weclone/src/synthesizer.test.ts
- pnpm --filter @remnic/export-weclone check-types
- npm_config_workspace_concurrency=1 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds strict validation that throws a `RangeError` for non-integer/zero/negative/NaN/Infinity `maxPairsPerRecord`, which can break callers previously passing invalid numeric values.
> 
> **Overview**
> **Validates `maxPairsPerRecord` before generating training pairs.** `synthesizeTrainingPairs` now normalizes the option via `resolveMaxPairsPerRecord` and rejects non-finite, non-integer, or non-positive values with a clear `RangeError` message.
> 
> Adds a regression test ensuring fractional, zero, negative, `NaN`, and infinite `maxPairsPerRecord` inputs are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d2dfa83bb29afbdfe843312000e18c657af44c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->