### PR TITLE
test(contradiction): cover actionable cooldown refresh

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -395,6 +395,11 @@ test("writePair refreshes expired independent verdicts with actionable lower-con
     assert.equal(refreshed.resolution, undefined);
     assert.equal(refreshed.lastReviewedAt, undefined);
     assert.equal(readPair(dir, dormant.pairId)?.verdict, "contradicts");
+
+    const unresolved = listPairs(dir, { filter: "unresolved" });
+    assert.equal(unresolved.total, 1);
+    assert.equal(unresolved.pairs[0]?.pairId, dormant.pairId);
+    assert.equal(unresolved.pairs[0]?.verdict, "contradicts");
   } finally {
     await cleanup();
   }


### PR DESCRIPTION
## Summary
- add regression coverage that expired independent contradiction-review entries can be replaced by lower-confidence actionable verdicts
- assert the refreshed actionable pair is returned by unresolved review queue listing

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts`
- `pnpm --filter @remnic/core check-types`
- `node scripts/ensure-better-sqlite3.mjs`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that tightens regression coverage around `writePair` cooldown refresh behavior and `listPairs` unresolved filtering.
> 
> **Overview**
> Adds regression coverage ensuring that when `writePair` replaces an *expired* dormant `independent` review with a lower-confidence actionable verdict, the refreshed pair also appears in the `listPairs(..., { filter: "unresolved" })` review queue.
> 
> No production logic changes; this PR only strengthens the contradiction review test suite around cooldown refresh + unresolved listing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10a0c7c89caccfd6f54fcf785b14e2962066a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->