### PR TITLE
Fix replay timestamp normalization

### DIFF
--- a/packages/remnic-core/src/replay/normalizers/shared.ts
+++ b/packages/remnic-core/src/replay/normalizers/shared.ts
@@ -1,4 +1,4 @@
-import { isReplayRole, type ReplayRole } from "../types.js";
+import { isReplayRole, parseIsoTimestamp, type ReplayRole } from "../types.js";
 
 type NormalizeRoleOptions = {
   assistantAliases?: string[];
@@ -64,5 +64,6 @@ export function normalizeReplayTimestamp(value: unknown, options: NormalizeTimes
   if (typeof value !== "string") return null;
   const raw = options.trimString === false ? value : value.trim();
   if (raw.length === 0) return null;
-  return toIso(Date.parse(raw));
+  const millis = parseIsoTimestamp(raw);
+  return millis === null ? null : toIso(millis);
 }

--- a/tests/replay-normalizers.test.ts
+++ b/tests/replay-normalizers.test.ts
@@ -271,3 +271,35 @@ test("normalizers skip out-of-range numeric timestamps instead of throwing", asy
   assert.equal(claude.warnings.length > 0, true);
   assert.equal(chatgpt.warnings.length > 0, true);
 });
+
+test("normalizers reject overflowed string timestamps instead of rewriting them", async () => {
+  const openclaw = await openclawReplayNormalizer.parse(
+    [{ role: "user", content: "x", timestamp: "2024-02-31T10:00:00Z" }],
+    {},
+  );
+  const claude = await claudeReplayNormalizer.parse(
+    { chat_messages: [{ sender: "human", text: "x", created_at: "2024-02-31T10:00:00Z" }] },
+    {},
+  );
+
+  assert.equal(openclaw.turns.length, 0);
+  assert.equal(claude.turns.length, 0);
+  assert.equal(openclaw.warnings.length > 0, true);
+  assert.equal(claude.warnings.length > 0, true);
+});
+
+test("normalizers reject non-UTC string timestamps instead of Date.parse coercion", async () => {
+  const openclaw = await openclawReplayNormalizer.parse(
+    [{ role: "user", content: "x", timestamp: "February 25, 2026 10:00 AM" }],
+    {},
+  );
+  const claude = await claudeReplayNormalizer.parse(
+    { chat_messages: [{ sender: "human", text: "x", created_at: "2026-02-25T10:00:00-05:00" }] },
+    {},
+  );
+
+  assert.equal(openclaw.turns.length, 0);
+  assert.equal(claude.turns.length, 0);
+  assert.equal(openclaw.warnings.length > 0, true);
+  assert.equal(claude.warnings.length > 0, true);
+});


### PR DESCRIPTION
## Summary
- Use the replay pipeline's strict ISO timestamp parser for string timestamp normalization.
- Reject overflowed or non-UTC string timestamps instead of allowing `Date.parse` to rewrite them.
- Add replay normalizer regressions for overflowed dates and Date.parse-only strings.

## Verification
- `pnpm exec tsx --test tests/replay-normalizers.test.ts`
- `npm_config_workspace_concurrency=1 npm run preflight:quick`

This is a focused fix from a clawpatch finding against replay import timestamp handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replay import behavior by rejecting string timestamps that `Date.parse` previously coerced (overflowed dates, non-UTC/offset formats), which could drop turns for some inputs. Scope is limited to timestamp normalization plus regression tests.
> 
> **Overview**
> Switches string replay timestamp normalization to use the replay pipeline’s strict `parseIsoTimestamp` instead of `Date.parse`, so invalid/overflowed ISO strings and non-UTC/offset timestamps are rejected rather than coerced into different dates.
> 
> Adds regression tests ensuring OpenClaw and Claude normalizers skip turns (with warnings) for overflowed dates (e.g. Feb 31) and non-UTC string formats that `Date.parse` would otherwise accept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7cd7d4f4064d229f6063081089532b7651c3df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->