### PR TITLE
test(contradiction): cover missing merge replacement

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -1327,6 +1327,26 @@ test("executeResolution merge requires a real merged memory", async () => {
   }
 });
 
+test("executeResolution merge rejects missing replacement before superseding sources", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage();
+
+    const result = await executeResolution(dir, storage, written.pairId, "merge", {
+      mergedMemoryId: "missing-merged-memory",
+    });
+
+    assert.deepEqual(storage.supersedeCalls, []);
+    assert.match(result.message, /Merged memory missing-merged-memory not found/);
+    assert.equal(storage.memories.get("mem-a-001")?.frontmatter.status, undefined);
+    assert.equal(storage.memories.get("mem-b-002")?.frontmatter.status, undefined);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("executeResolution merge supersedes both sources to a verified merged memory", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {


### PR DESCRIPTION
## Summary
- add regression coverage that merge resolution rejects a missing explicit replacement memory before superseding either source
- assert the pair remains unresolved and both source memories remain active when replacement verification fails

## Verification
- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts`
- `pnpm --filter @remnic/core check-types`
- `git diff --check`
- `node scripts/ensure-better-sqlite3.mjs`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a regression test around `executeResolution` merge failure ordering; no production logic changes, so risk is low aside from potentially tightening expected behavior in tests.
> 
> **Overview**
> Adds a regression test ensuring `executeResolution(..., "merge", { mergedMemoryId })` **fails fast** when the specified merged replacement memory does not exist.
> 
> The new coverage asserts no `supersedeMemory` calls occur, both source memories remain active, and the contradiction pair stays unresolved when replacement verification fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b003723265727d89510cf661b82b3f9a6f3146ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->