### PR TITLE
Harden token store mutations

### DIFF
--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -650,7 +650,7 @@ test("removeConnector weclone error message reflects token-revocation status tru
       // Fail both: proxy-config unlink AND the revokeToken path (via
       // saveTokenStore throwing when it tries to persist the revocation).
       const originalUnlink = fs.unlinkSync.bind(fs);
-      const originalWrite = fs.writeFileSync.bind(fs);
+      const originalRename = fs.renameSync.bind(fs);
       const unlinkMock = t.mock.method(fs, "unlinkSync", (target: fs.PathLike) => {
         if (String(target) === proxyConfigPath) {
           throw new Error("EPERM: proxy unlink failed (simulated)");
@@ -658,16 +658,16 @@ test("removeConnector weclone error message reflects token-revocation status tru
         return originalUnlink(target);
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const writeMock = t.mock.method(fs, "writeFileSync", (...args: [any, any, any?]) => {
-        if (String(args[0] ?? "").endsWith("tokens.json")) {
-          throw new Error("EPERM: tokens.json write failed (simulated)");
+      const renameMock = t.mock.method(fs, "renameSync", (...args: [any, any]) => {
+        if (String(args[1] ?? "").endsWith("tokens.json")) {
+          throw new Error("EPERM: tokens.json rename failed (simulated)");
         }
-        return originalWrite(...args);
+        return originalRename(...args);
       });
 
       const removeResult = removeConnector("weclone");
       unlinkMock.mock.restore();
-      writeMock.mock.restore();
+      renameMock.mock.restore();
 
       assert.equal(removeResult.status, "error");
       // Must mention token revocation failure, not claim success.

--- a/packages/remnic-core/src/tokens.test.ts
+++ b/packages/remnic-core/src/tokens.test.ts
@@ -1,0 +1,178 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { chmod, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  buildTokenEntry,
+  commitTokenEntry,
+  generateToken,
+  loadTokenStore,
+  revokeToken,
+  saveTokenStore,
+} from "./tokens.js";
+
+async function makeTempTokenPath(): Promise<{ dir: string; tokensPath: string }> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-tokens-"));
+  return { dir, tokensPath: path.join(dir, "tokens.json") };
+}
+
+test("token mutations reject corrupt stores without overwriting them", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    await writeFile(tokensPath, "{not json", "utf8");
+
+    assert.throws(
+      () => generateToken("codex", tokensPath),
+      /failed to parse token store/,
+    );
+    assert.equal(await readFile(tokensPath, "utf8"), "{not json");
+
+    assert.throws(
+      () => revokeToken("codex", tokensPath),
+      /failed to parse token store/,
+    );
+    assert.equal(await readFile(tokensPath, "utf8"), "{not json");
+
+    assert.throws(
+      () => commitTokenEntry(buildTokenEntry("codex"), tokensPath),
+      /failed to parse token store/,
+    );
+    assert.equal(await readFile(tokensPath, "utf8"), "{not json");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadTokenStore validates token entry shape before returning tokens", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    await writeFile(
+      tokensPath,
+      JSON.stringify({ tokens: [{ token: "remnic_cx_bad", connector: "" }] }),
+      "utf8",
+    );
+
+    assert.throws(
+      () => loadTokenStore(tokensPath),
+      /connector must be a non-empty string/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadTokenStore accepts timestamp-less legacy token entries", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    await writeFile(
+      tokensPath,
+      JSON.stringify({
+        tokens: [
+          { token: "remnic_hm_manual", connector: "hermes" },
+        ],
+      }),
+      "utf8",
+    );
+
+    const store = loadTokenStore(tokensPath);
+
+    assert.deepEqual(store.tokens, [
+      {
+        token: "remnic_hm_manual",
+        connector: "hermes",
+        createdAt: "1970-01-01T00:00:00.000Z",
+      },
+    ]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("saveTokenStore preserves the prior file when atomic rename fails", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  const original = {
+    tokens: [{
+      token: "remnic_cx_original",
+      connector: "codex",
+      createdAt: "2026-05-18T00:00:00.000Z",
+    }],
+  };
+  const replacement = {
+    tokens: [{
+      token: "remnic_cx_replacement",
+      connector: "codex",
+      createdAt: "2026-05-18T00:01:00.000Z",
+    }],
+  };
+  await writeFile(tokensPath, `${JSON.stringify(original, null, 2)}\n`, "utf8");
+  await chmod(tokensPath, 0o600);
+
+  const renameSync = fs.renameSync;
+  (fs as unknown as { renameSync: typeof fs.renameSync }).renameSync = () => {
+    throw new Error("simulated rename failure");
+  };
+  try {
+    assert.throws(
+      () => saveTokenStore(replacement, tokensPath),
+      /simulated rename failure/,
+    );
+  } finally {
+    (fs as unknown as { renameSync: typeof fs.renameSync }).renameSync = renameSync;
+  }
+
+  assert.deepEqual(JSON.parse(await readFile(tokensPath, "utf8")), original);
+  const leftovers = (await readdir(dir)).filter((name) => name.includes(".tmp"));
+  assert.deepEqual(leftovers, []);
+  assert.equal((await stat(tokensPath)).mode & 0o777, 0o600);
+});
+
+test("legacy flat token stores migrate without dropping tokens", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    await writeFile(
+      tokensPath,
+      JSON.stringify({
+        codex: "remnic_cx_legacy",
+        hermes: "remnic_hm_legacy",
+      }),
+      "utf8",
+    );
+
+    const store = loadTokenStore(tokensPath);
+    assert.deepEqual(
+      store.tokens.map((entry) => [entry.connector, entry.token]).sort(),
+      [
+        ["codex", "remnic_cx_legacy"],
+        ["hermes", "remnic_hm_legacy"],
+      ],
+    );
+
+    const migrated = JSON.parse(await readFile(tokensPath, "utf8"));
+    assert.equal(Array.isArray(migrated.tokens), true);
+    assert.equal(migrated.tokens.length, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("legacy flat token stores reject empty connector keys before returning tokens", async () => {
+  const { dir, tokensPath } = await makeTempTokenPath();
+  try {
+    await writeFile(
+      tokensPath,
+      JSON.stringify({
+        "": "remnic_cx_invalid",
+      }),
+      "utf8",
+    );
+
+    assert.throws(
+      () => loadTokenStore(tokensPath),
+      /connector must be a non-empty string/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/tokens.ts
+++ b/packages/remnic-core/src/tokens.ts
@@ -7,7 +7,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { resolveHomeDir } from "./runtime/env.js";
 
 export interface TokenEntry {
@@ -58,45 +58,138 @@ function ensureDir(filePath: string): void {
   fs.mkdirSync(dir, { recursive: true });
 }
 
+function isEnoent(error: unknown): boolean {
+  return error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function validateTokenEntry(raw: unknown, index: number): TokenEntry {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error(`invalid token entry at index ${index}: expected object`);
+  }
+  const entry = raw as Record<string, unknown>;
+  if (typeof entry.token !== "string" || entry.token.length === 0) {
+    throw new Error(`invalid token entry at index ${index}: token must be a non-empty string`);
+  }
+  if (typeof entry.connector !== "string" || entry.connector.length === 0) {
+    throw new Error(`invalid token entry at index ${index}: connector must be a non-empty string`);
+  }
+  return {
+    token: entry.token,
+    connector: entry.connector,
+    createdAt:
+      typeof entry.createdAt === "string" && entry.createdAt.length > 0
+        ? entry.createdAt
+        : new Date(0).toISOString(),
+  };
+}
+
+function parseTokenStore(rawText: string, filePath: string): { store: TokenStore; migratedLegacy: boolean } {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(rawText);
+  } catch (error) {
+    throw new Error(
+      `failed to parse token store at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+    const record = raw as Record<string, unknown>;
+    if (record.tokens !== undefined) {
+      if (!Array.isArray(record.tokens)) {
+        throw new Error(`invalid token store at ${filePath}: tokens must be an array`);
+      }
+      return {
+        store: {
+          tokens: record.tokens.map((entry, index) => validateTokenEntry(entry, index)),
+        },
+        migratedLegacy: false,
+      };
+    }
+
+    // Migrate legacy flat-map format: { "connector": "token_value", ... }
+    const migrated: TokenEntry[] = [];
+    for (const [key, value] of Object.entries(record)) {
+      if (typeof value === "string" && value.length > 0) {
+        migrated.push(
+          validateTokenEntry(
+            { token: value, connector: key, createdAt: new Date().toISOString() },
+            migrated.length,
+          ),
+        );
+      }
+    }
+    if (migrated.length > 0) {
+      return { store: { tokens: migrated }, migratedLegacy: true };
+    }
+  }
+
+  throw new Error(`invalid token store at ${filePath}: expected token array or legacy connector map`);
+}
+
 export function loadTokenStore(tokensPath?: string): TokenStore {
   const p = resolveReadPath(tokensPath);
   try {
-    const raw = JSON.parse(fs.readFileSync(p, "utf8"));
-    if (Array.isArray(raw.tokens)) {
-      return { tokens: raw.tokens };
-    }
-    // Migrate legacy flat-map format: { "connector": "token_value", ... }
-    if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
-      const migrated: TokenEntry[] = [];
-      for (const [key, value] of Object.entries(raw)) {
-        if (key === "tokens") continue; // skip if tokens key exists but isn't array
-        if (typeof value === "string" && value.length > 0) {
-          migrated.push({ token: value, connector: key, createdAt: new Date().toISOString() });
-        }
-      }
-      if (migrated.length > 0) {
-        const store: TokenStore = { tokens: migrated };
-        // Auto-migrate: rewrite in new format (best-effort, don't lose tokens on write failure)
-        try {
-          saveTokenStore(store, tokensPath);
-        } catch {
-          // Migration write failed (e.g., read-only fs) — still return parsed tokens
-        }
-        return store;
+    const rawText = fs.readFileSync(p, "utf8");
+    const { store, migratedLegacy } = parseTokenStore(rawText, p);
+    if (migratedLegacy) {
+      // Auto-migrate legacy flat-map stores in new format. This is best-effort:
+      // a migration write failure must not hide the successfully parsed tokens.
+      try {
+        saveTokenStore(store, tokensPath);
+      } catch {
+        // Migration write failed (e.g., read-only fs) — still return parsed tokens.
       }
     }
-    return { tokens: [] };
+    return store;
+  } catch (error) {
+    if (isEnoent(error)) {
+      return { tokens: [] };
+    }
+    throw error;
+  }
+}
+
+function fsyncDirectoryBestEffort(dirPath: string): void {
+  let dirFd: number | null = null;
+  try {
+    dirFd = fs.openSync(dirPath, "r");
+    fs.fsyncSync(dirFd);
   } catch {
-    return { tokens: [] };
+    // Directory fsync is not supported on every platform/filesystem.
+  } finally {
+    if (dirFd !== null) {
+      try { fs.closeSync(dirFd); } catch { /* ignore */ }
+    }
   }
 }
 
 export function saveTokenStore(store: TokenStore, tokensPath?: string): void {
   const p = tokensPath ?? defaultTokensPath();
   ensureDir(p);
-  fs.writeFileSync(p, JSON.stringify(store, null, 2) + "\n", { mode: 0o600 });
-  // Tighten permissions on pre-existing files (writeFileSync mode only applies to new files)
-  try { fs.chmodSync(p, 0o600); } catch { /* ignore on platforms without chmod */ }
+  const validated: TokenStore = {
+    tokens: store.tokens.map((entry, index) => validateTokenEntry(entry, index)),
+  };
+  const dir = path.dirname(p);
+  const tmpPath = path.join(dir, `.${path.basename(p)}.${process.pid}.${randomUUID()}.tmp`);
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(tmpPath, "w", 0o600);
+    fs.writeFileSync(fd, JSON.stringify(validated, null, 2) + "\n", "utf8");
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(tmpPath, p);
+    // Tighten permissions on pre-existing files after atomic replacement.
+    try { fs.chmodSync(p, 0o600); } catch { /* ignore on platforms without chmod */ }
+    fsyncDirectoryBestEffort(dir);
+  } catch (error) {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* ignore */ }
+    }
+    try { fs.rmSync(tmpPath, { force: true }); } catch { /* ignore cleanup failure */ }
+    throw error;
+  }
 }
 
 /**

--- a/tests/integration/connectors-hermes.test.ts
+++ b/tests/integration/connectors-hermes.test.ts
@@ -135,6 +135,24 @@ function withTempHome(fn: (tmpHome: string) => void): void {
   }
 }
 
+function withTokenStoreRenameFailure(tokensPath: string, fn: () => void): void {
+  const originalRename = fs.renameSync.bind(fs);
+  // saveTokenStore writes to a temp file and atomically renames over tokens.json.
+  // Mock that final replace boundary so the test remains independent of
+  // platform-specific chmod behavior.
+  fs.renameSync = ((oldPath: fs.PathLike, newPath: fs.PathLike) => {
+    if (String(newPath) === tokensPath) {
+      throw new Error("EPERM: tokens.json rename failed (simulated)");
+    }
+    return originalRename(oldPath, newPath);
+  }) as typeof fs.renameSync;
+  try {
+    fn();
+  } finally {
+    fs.renameSync = originalRename;
+  }
+}
+
 test("upsertHermesConfig creates config.yaml when profile dir exists but file does not", () => {
   withTempHome((tmpHome) => {
     const profileDir = path.join(tmpHome, ".hermes", "profiles", "default");
@@ -1773,9 +1791,7 @@ test("atomic flow: commitTokenEntry failure rolls back YAML and preserves old to
         }).tokens.find((t) => t.connector === "hermes")?.token;
         assert.ok(originalToken, "Baseline token must be present");
 
-        // Make tokens.json read-only to simulate commitTokenEntry failure.
-        fs.chmodSync(tokensPath, 0o444);
-        try {
+        withTokenStoreRenameFailure(tokensPath, () => {
           // Force reinstall — YAML write will succeed, but token commit must fail.
           const install2 = mod.installConnector({
             connectorId: "hermes",
@@ -1799,10 +1815,7 @@ test("atomic flow: commitTokenEntry failure rolls back YAML and preserves old to
             yamlBefore,
             "config.yaml must be rolled back to prior content when commitTokenEntry fails",
           );
-        } finally {
-          // Restore write permission so the temp dir can be cleaned up.
-          try { fs.chmodSync(tokensPath, 0o600); } catch { /* ignore */ }
-        }
+        });
       });
       resolve();
     } catch (err) {
@@ -2540,9 +2553,9 @@ test("atomic flow: commitTokenEntry throw during saveTokenStore still preserves 
         assert.ok(originalToken, "Initial install must produce a hermes token");
         assert.ok(originalToken.startsWith("remnic_hm_"), "Prior token must have hermes prefix");
 
-        // Step 2: Make tokens.json read-only so commitTokenEntry's saveTokenStore throws.
-        fs.chmodSync(tokensPath, 0o444);
-        try {
+        // Step 2: make the atomic token-store replacement fail so
+        // commitTokenEntry's saveTokenStore throws.
+        withTokenStoreRenameFailure(tokensPath, () => {
           const install2 = mod.installConnector({
             connectorId: "hermes",
             force: true,
@@ -2557,10 +2570,7 @@ test("atomic flow: commitTokenEntry throw during saveTokenStore still preserves 
             install2.message.toLowerCase().includes("commit"),
             `Error message must explain the commit failure, got: ${install2.message}`,
           );
-        } finally {
-          // Restore write permission before assertions.
-          try { fs.chmodSync(tokensPath, 0o600); } catch { /* ignore */ }
-        }
+        });
 
         // Step 3: The ORIGINAL hermes token must still be in tokens.json.
         // Without the UXJI fix (pre-commit snapshot), priorTokenEntry would be null

--- a/tests/integration/token-management.test.ts
+++ b/tests/integration/token-management.test.ts
@@ -54,7 +54,11 @@ test("tokens.ts uses remnic_ prefix convention for known connectors", () => {
 
 test("tokens.ts writes file with 0o600 permissions", () => {
   const content = fs.readFileSync(TOKENS_SRC, "utf-8");
-  assert.ok(content.includes("mode: 0o600"), "Must set file mode to 0o600 (owner-only)");
+  assert.ok(content.includes("0o600"), "Must set file mode to 0o600 (owner-only)");
+  assert.ok(
+    content.includes("fs.openSync(tmpPath") || content.includes("fs.chmodSync(p, 0o600"),
+    "Must apply owner-only permissions while writing the token store",
+  );
 });
 
 test("tokens.ts default path is ~/.remnic/tokens.json with legacy Engram fallback", () => {
@@ -84,7 +88,7 @@ test("tokens.ts handles legacy flat-map token format migration", () => {
     "Must handle legacy { connector: token } format",
   );
   assert.ok(
-    content.includes("Auto-migrate: rewrite in new format"),
+    content.includes("Auto-migrate legacy flat-map stores in new format"),
     "Must auto-migrate legacy format to new format",
   );
 });


### PR DESCRIPTION
## Summary
- fail closed on corrupt or invalid token stores instead of treating them as empty
- validate token entries before reads/writes and keep legacy flat-map migration
- write token stores atomically via temp file, fsync, rename, and owner-only permissions

## Verification
- pnpm exec tsx --test packages/remnic-core/src/tokens.test.ts tests/integration/token-management.test.ts
- npm_config_workspace_concurrency=1 npm run preflight:quick

Addresses clawpatch finding fnd_sig-feat-library-359f87bed6-70c4_92a4179fcb.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core token persistence semantics (fail-closed parsing + atomic replace via `renameSync`) which can affect all connectors’ auth flows and rollback paths if edge cases were missed, but scope is contained to token store I/O and tests cover key failure modes.
> 
> **Overview**
> **Token store hardening:** `loadTokenStore` now *fails closed* on corrupt/invalid JSON and validates token entry shape (including accepting legacy entries missing `createdAt`), while still best-effort migrating the legacy flat-map format.
> 
> **Safer persistence:** `saveTokenStore` now performs an atomic write via temp file + `fsync` + `renameSync`, enforces `0o600` permissions post-replace, and best-effort fsyncs the directory; tests are updated/added to simulate rename failures (instead of chmod-based failures) and to ensure corrupt stores are not overwritten and atomic-write failures preserve the prior file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb9f3e05120d53dc3a6f718cddf5e9621f4355f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->