### PR TITLE
fix(bench): reject unsafe adapter memory dirs

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -262,6 +262,21 @@ test("direct adapter reset clears caller-owned memory directory", async () => {
   }
 });
 
+test("direct adapter rejects unsafe caller-owned memory directories before initialization", async () => {
+  const sentinelPath = path.join(tmpdir(), `remnic-bench-unsafe-sentinel-${process.pid}.txt`);
+  await writeFile(sentinelPath, "preserve temp root data");
+
+  try {
+    await assert.rejects(
+      () => createRemnicAdapter({ memoryDir: tmpdir() }),
+      /must not be a root, home, temp, cwd, or repository ancestor path/,
+    );
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve temp root data");
+  } finally {
+    await rm(sentinelPath, { force: true });
+  }
+});
+
 test("direct adapter session reset preserves other caller-owned sessions", async () => {
   const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-reset-session-"));
   const sentinelPath = path.join(memoryDir, "caller-owned-sentinel.txt");

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -15,7 +15,7 @@ import {
   unlink,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import {
@@ -332,7 +332,7 @@ async function createBenchOrchestrator(
   configuredMemoryDir?: string,
 ): Promise<BenchOrchestratorState> {
   const tempDir = configuredMemoryDir
-    ? path.resolve(expandTildePath(configuredMemoryDir))
+    ? assertSafeConfiguredBenchDir(configuredMemoryDir)
     : await mkdtemp(path.join(tmpdir(), `remnic-bench-${mode}-`));
   const ownsTempDir = !configuredMemoryDir;
   await mkdir(tempDir, { recursive: true });
@@ -513,6 +513,31 @@ function resolveConfiguredBenchDir(options: RemnicAdapterOptions): string | unde
   const memoryDir = normalizeConfiguredBenchDir(options.memoryDir);
   const sandboxDir = normalizeConfiguredBenchDir(options.sandboxDir);
   return sandboxDir ?? memoryDir;
+}
+
+function assertSafeConfiguredBenchDir(configuredDir: string): string {
+  const resolved = path.resolve(expandTildePath(configuredDir));
+  const root = path.parse(resolved).root;
+  const dangerousDirs = [
+    root,
+    path.resolve(homedir()),
+    path.resolve(tmpdir()),
+    path.resolve(process.cwd()),
+  ];
+  if (
+    dangerousDirs.includes(resolved) ||
+    isPathAncestorOf(resolved, path.resolve(process.cwd()))
+  ) {
+    throw new Error(
+      `Remnic benchmark memoryDir/sandboxDir must not be a root, home, temp, cwd, or repository ancestor path: ${resolved}`,
+    );
+  }
+  return resolved;
+}
+
+function isPathAncestorOf(candidate: string, child: string): boolean {
+  const relative = path.relative(candidate, child);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
 }
 
 function normalizeBenchSessionId(sessionId: string): string {


### PR DESCRIPTION
## Summary
- reject dangerous caller-provided Remnic benchmark memory/sandbox directories before adapter initialization
- block root, home, temp root, current workspace, and workspace ancestor paths while preserving caller-owned benchmark subdirectories
- add a sentinel regression proving unsafe temp-root initialization rejects without deleting unrelated files

## Verification
- `pnpm install --frozen-lockfile --prefer-offline`
- `node scripts/ensure-better-sqlite3.mjs`
- `pnpm exec tsx --test packages/bench/src/adapters/remnic-adapter.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds stricter validation for caller-supplied `memoryDir`/`sandboxDir`, which could break existing benchmark setups that pointed at shared locations like `tmpdir()` or the repo root.
> 
> **Overview**
> **Prevents unsafe benchmark directory usage.** `createRemnicAdapter`/`createBenchOrchestrator` now validates caller-provided `memoryDir`/`sandboxDir` via `assertSafeConfiguredBenchDir`, rejecting paths that resolve to *root, home, temp root, cwd,* or any *ancestor of the repository*.
> 
> Adds a regression test that attempts to initialize with `memoryDir=tmpdir()` and asserts it fails *before* initialization/cleanup can delete unrelated temp-root files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f67f7009cfc0eba04a3d0fdff19ac10c6d3310c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->