### PR TITLE
Preserve corrupt routing rule state on writes

### DIFF
--- a/packages/remnic-core/src/routing/store.ts
+++ b/packages/remnic-core/src/routing/store.ts
@@ -69,6 +69,10 @@ function normalizeRule(rule: RouteRule, options?: RoutingEngineOptions): RouteRu
   };
 }
 
+function isEnoent(err: unknown): boolean {
+  return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
 export class RoutingRulesStore {
   private readonly memoryRoot: string;
   private readonly statePath: string;
@@ -135,18 +139,37 @@ export class RoutingRulesStore {
   }
 
   private async readPersistedRules(): Promise<RouteRule[]> {
+    await this.assertStatePathScoped();
+    let raw: string;
     try {
-      await this.assertStatePathScoped();
-      const raw = await readFile(this.statePath, "utf-8");
-      const parsed = JSON.parse(raw) as Partial<RoutingRulesState>;
-      if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.rules)) return [];
-      const normalized = parsed.rules
-        .map((rule) => normalizeRule(rule))
-        .filter((rule): rule is RouteRule => rule !== null);
-      return this.dedupeById(normalized);
-    } catch {
-      return [];
+      raw = await readFile(this.statePath, "utf-8");
+    } catch (err) {
+      if (isEnoent(err)) {
+        return [];
+      }
+      throw err;
     }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(
+        `failed to parse routing rules state at ${this.statePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`invalid routing rules state at ${this.statePath}: expected object`);
+    }
+    const state = parsed as Partial<RoutingRulesState>;
+    if (!Array.isArray(state.rules)) {
+      throw new Error(`invalid routing rules state at ${this.statePath}: rules must be an array`);
+    }
+    const normalized = state.rules
+      .map((rule) => normalizeRule(rule))
+      .filter((rule): rule is RouteRule => rule !== null);
+    return this.dedupeById(normalized);
   }
 
   private async writeNormalized(rules: RouteRule[], options?: RoutingEngineOptions): Promise<RouteRule[]> {

--- a/tests/routing-store.test.ts
+++ b/tests/routing-store.test.ts
@@ -46,6 +46,45 @@ test("routing store fail-opens malformed file", async () => {
   }
 });
 
+test("routing store upsert rejects malformed state without overwriting it", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-routing-store-malformed-upsert-"));
+  try {
+    const statePath = path.join(memoryDir, "state", "routing-rules.json");
+    await mkdir(path.dirname(statePath), { recursive: true });
+    await writeFile(statePath, "{bad-json", "utf-8");
+
+    const store = new RoutingRulesStore(memoryDir);
+    await assert.rejects(
+      async () => store.upsert(sampleRule({ id: "new-rule", pattern: "new incident" })),
+      /failed to parse routing rules state/,
+    );
+
+    assert.equal(await readFile(statePath, "utf-8"), "{bad-json");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("routing store upsert rejects invalid state shape without overwriting it", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-routing-store-invalid-shape-upsert-"));
+  try {
+    const statePath = path.join(memoryDir, "state", "routing-rules.json");
+    await mkdir(path.dirname(statePath), { recursive: true });
+    const invalidState = JSON.stringify({ version: 1, updatedAt: new Date().toISOString() }, null, 2);
+    await writeFile(statePath, invalidState, "utf-8");
+
+    const store = new RoutingRulesStore(memoryDir);
+    await assert.rejects(
+      async () => store.upsert(sampleRule({ id: "new-rule", pattern: "new incident" })),
+      /rules must be an array/,
+    );
+
+    assert.equal(await readFile(statePath, "utf-8"), invalidState);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("routing store skips invalid rule entries on read", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-routing-store-invalid-"));
   try {
@@ -89,6 +128,21 @@ test("routing store upsert replaces by id", async () => {
     assert.equal(rules.length, 1);
     assert.equal(rules[0].pattern, "outage");
     assert.equal(rules[0].priority, 9);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("routing store upsert treats missing state file as empty", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-routing-store-upsert-missing-"));
+  try {
+    const store = new RoutingRulesStore(memoryDir);
+    const rules = await store.upsert(sampleRule({ id: "r1", pattern: "incident" }));
+    assert.equal(rules.length, 1);
+    assert.equal(rules[0].id, "r1");
+
+    const raw = await readFile(path.join(memoryDir, "state", "routing-rules.json"), "utf-8");
+    assert.match(raw, /"incident"/);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- treat only missing routing rule state files as empty during write operations
- surface corrupt JSON and invalid top-level state shapes instead of overwriting them
- add regression coverage for malformed, invalid-shape, and missing-file upserts

## Verification
- pnpm exec tsx --test tests/routing-store.test.ts
- npm_config_workspace_concurrency=1 npm run preflight:quick

Addresses clawpatch finding fnd_sig-feat-library-3e55154249-0f42_2c7fe7d9f3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence error-handling so `upsert` now fails on malformed/invalid state instead of silently treating it as empty, which could surface new errors in environments with corrupt state files. Behavior is otherwise localized to routing-rule storage and covered by new regression tests.
> 
> **Overview**
> **Routing rule persistence now preserves corrupt state during writes.** `RoutingRulesStore.readPersistedRules` distinguishes missing state files (`ENOENT`) from malformed JSON or invalid top-level shapes, returning empty only for missing files and throwing descriptive errors for parse/shape failures.
> 
> **Write paths that depend on persisted state (notably `upsert`) will now reject corrupt state instead of overwriting it**, and tests add coverage for malformed JSON, invalid state shape, and missing-file upserts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00dcf322cb86dbd69aa26b791569e75c1274426d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->