### PR TITLE
Serialize concurrent memory state updates

### DIFF
--- a/packages/remnic-core/src/buffer-session.test.ts
+++ b/packages/remnic-core/src/buffer-session.test.ts
@@ -101,6 +101,83 @@ test("SmartBuffer clearAfterExtraction only clears the targeted logical session"
   assert.equal(buffer.getExtractionCount("thread-b"), 0);
 });
 
+test("SmartBuffer clearAfterExtraction preserves appends after queued snapshots", async () => {
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "first memory"));
+  const firstSnapshot = buffer.getTurns("thread-a");
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "second memory"));
+  const overlappingSnapshot = buffer.getTurns("thread-a");
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "third memory"));
+
+  await buffer.clearAfterExtraction("thread-a", firstSnapshot);
+  assert.deepEqual(
+    buffer.getTurns("thread-a").map((turn) => turn.content),
+    ["second memory", "third memory"],
+  );
+
+  await buffer.clearAfterExtraction("thread-a", overlappingSnapshot);
+  assert.deepEqual(
+    buffer.getTurns("thread-a").map((turn) => turn.content),
+    ["third memory"],
+  );
+});
+
+test("SmartBuffer clearAfterExtraction chooses the longest queued snapshot overlap", async () => {
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "repeat"));
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "middle"));
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "repeat"));
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "tail"));
+  const fullSnapshot = buffer.getTurns("thread-a");
+
+  await buffer.clearAfterExtraction("thread-a", fullSnapshot.slice(0, 2));
+  assert.deepEqual(
+    buffer.getTurns("thread-a").map((turn) => turn.content),
+    ["repeat", "tail"],
+  );
+
+  await buffer.clearAfterExtraction("thread-a", fullSnapshot);
+  assert.deepEqual(buffer.getTurns("thread-a"), []);
+});
+
+test("SmartBuffer clearAfterExtraction clears live copies of retained snapshots", async () => {
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "first memory"));
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "second memory"));
+  const extractionSnapshot = buffer.getTurns("thread-a");
+
+  await buffer.retainDeferredTurns("thread-a", extractionSnapshot, 2);
+  await buffer.clearAfterExtraction("thread-a", extractionSnapshot);
+
+  assert.deepEqual(
+    buffer.getTurns("thread-a").map((turn) => turn.content),
+    ["first memory", "second memory"],
+  );
+  assert.equal(
+    storage.saved?.entries?.["thread-a"]?.turns.length,
+    0,
+    "live turns must be cleared even when retained copies are preserved",
+  );
+});
+
 test("SmartBuffer read-only accessors do not persist phantom entries for unknown buffers", async () => {
   const storage = new FakeStorage({
     turns: [],

--- a/packages/remnic-core/src/buffer-surprise-report.ts
+++ b/packages/remnic-core/src/buffer-surprise-report.ts
@@ -74,10 +74,7 @@ export async function reportBufferSurpriseDistribution(
   readEvents: BufferSurpriseReader,
   options: BufferSurpriseReportOptions = {},
 ): Promise<BufferSurpriseDistribution> {
-  const limit =
-    typeof options.limit === "number" && options.limit > 0
-      ? Math.floor(options.limit)
-      : 200;
+  const limit = normalizeReportLimit(options.limit);
   const raw = await readEvents({ limit, since: options.since });
 
   // Filter for sanity: finite numeric scores in [0, 1], event tag match,
@@ -88,6 +85,8 @@ export async function reportBufferSurpriseDistribution(
       : Number.NaN;
   const rows = raw.filter((row): row is BufferSurpriseEvent => {
     if (!row || row.event !== "BUFFER_SURPRISE") return false;
+    const ts = Date.parse(row.timestamp);
+    if (!Number.isFinite(ts)) return false;
     if (typeof row.surpriseScore !== "number") return false;
     if (!Number.isFinite(row.surpriseScore)) return false;
     if (row.surpriseScore < 0 || row.surpriseScore > 1) return false;
@@ -98,13 +97,15 @@ export async function reportBufferSurpriseDistribution(
     // threshold from real traffic.
     if (typeof row.triggeredFlush !== "boolean") return false;
     if (Number.isFinite(sinceMs)) {
-      const ts = Date.parse(row.timestamp);
       if (!Number.isFinite(ts) || ts <= sinceMs) return false;
     }
     return true;
-  });
+  }).sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp));
 
-  if (rows.length === 0) {
+  const windowStart = Math.max(0, rows.length - limit);
+  const windowRows = rows.slice(windowStart);
+
+  if (windowRows.length === 0) {
     return {
       count: 0,
       triggeredCount: 0,
@@ -118,8 +119,8 @@ export async function reportBufferSurpriseDistribution(
     };
   }
 
-  const scores = rows.map((r) => r.surpriseScore).sort((a, b) => a - b);
-  const triggeredCount = rows.reduce(
+  const scores = windowRows.map((r) => r.surpriseScore).sort((a, b) => a - b);
+  const triggeredCount = windowRows.reduce(
     (acc, r) => acc + (r.triggeredFlush ? 1 : 0),
     0,
   );
@@ -134,7 +135,7 @@ export async function reportBufferSurpriseDistribution(
   // — not necessarily the one configured right now, but the value the
   // ledger rows were judged against. That's what operators need to reason
   // about the distribution.
-  const mostRecent = rows[rows.length - 1];
+  const mostRecent = windowRows[windowRows.length - 1];
   const currentThreshold =
     mostRecent && typeof mostRecent.threshold === "number"
       ? mostRecent.threshold
@@ -151,6 +152,13 @@ export async function reportBufferSurpriseDistribution(
     max: scores[scores.length - 1]!,
     currentThreshold,
   };
+}
+
+function normalizeReportLimit(limit: number | undefined): number {
+  if (limit === undefined) return 200;
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return 200;
+  const floored = Math.floor(limit);
+  return floored > 0 ? floored : 200;
 }
 
 /**

--- a/packages/remnic-core/src/buffer-surprise-telemetry.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-telemetry.test.ts
@@ -362,6 +362,49 @@ test("StorageManager.readBufferSurpriseEvents: non-positive limit returns empty"
   }
 });
 
+test("StorageManager.readBufferSurpriseEvents: sorts by event timestamp before limiting", async () => {
+  const { mkdtempSync, writeFileSync, mkdirSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const { StorageManager } = await import("./storage.js");
+
+  const dir = mkdtempSync(join(tmpdir(), "remnic-buffer-surprise-order-"));
+  const stateDir = join(dir, "state");
+  mkdirSync(stateDir, { recursive: true });
+  const ledgerPath = join(stateDir, "buffer-surprise-ledger.jsonl");
+  const newer = {
+    event: "BUFFER_SURPRISE",
+    timestamp: "2026-04-20T12:00:01.000Z",
+    bufferKey: "a",
+    sessionKey: "a",
+    turnRole: "user",
+    surpriseScore: 0.8,
+    threshold: 0.35,
+    triggeredFlush: true,
+    turnCountInWindow: 2,
+  };
+  const older = {
+    event: "BUFFER_SURPRISE",
+    timestamp: "2026-04-20T12:00:00.000Z",
+    bufferKey: "a",
+    sessionKey: "a",
+    turnRole: "user",
+    surpriseScore: 0.2,
+    threshold: 0.35,
+    triggeredFlush: false,
+    turnCountInWindow: 1,
+  };
+  writeFileSync(
+    ledgerPath,
+    `${JSON.stringify(newer)}\n${JSON.stringify(older)}\n`,
+  );
+
+  const storage = new StorageManager(dir);
+  const rows = await storage.readBufferSurpriseEvents({ limit: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]!.timestamp, newer.timestamp);
+});
+
 // ---------------------------------------------------------------------------
 // reportBufferSurpriseDistribution
 // ---------------------------------------------------------------------------
@@ -370,6 +413,7 @@ function syntheticRow(
   score: number,
   triggered: boolean,
   ts = "2026-04-20T12:00:00.000Z",
+  threshold = 0.35,
 ): BufferSurpriseEvent {
   return {
     event: "BUFFER_SURPRISE",
@@ -378,7 +422,7 @@ function syntheticRow(
     sessionKey: "sess-x",
     turnRole: "user",
     surpriseScore: score,
-    threshold: 0.35,
+    threshold,
     triggeredFlush: triggered,
     turnCountInWindow: 1,
   };
@@ -416,6 +460,21 @@ test("report: computes mean, median, p90 over recent rows", async () => {
   assert.equal(dist.min, 0.1);
   assert.equal(dist.max, 0.9);
   assert.equal(dist.currentThreshold, 0.35);
+});
+
+test("report: sorts by event timestamp for recent window and current threshold", async () => {
+  const rows: BufferSurpriseEvent[] = [
+    syntheticRow(0.9, true, "2026-04-20T12:00:02.000Z", 0.9),
+    syntheticRow(0.1, false, "2026-04-20T12:00:00.000Z", 0.1),
+    syntheticRow(0.5, true, "2026-04-20T12:00:01.000Z", 0.5),
+  ];
+  const dist = await reportBufferSurpriseDistribution(async () => rows, {
+    limit: 2,
+  });
+  assert.equal(dist.count, 2);
+  assert.equal(dist.min, 0.5);
+  assert.equal(dist.max, 0.9);
+  assert.equal(dist.currentThreshold, 0.9);
 });
 
 test("report: skips malformed rows (wrong event tag, non-finite score, out of range)", async () => {
@@ -467,6 +526,36 @@ test("report: defaults limit to 200 when omitted", async () => {
     },
   );
   assert.equal(seen, 200);
+});
+
+test("report: invalid limits default to the documented 200 row window", async () => {
+  const rows = [syntheticRow(0.7, false), syntheticRow(0.9, true)];
+  const seen: Array<number | undefined> = [];
+  const reader = async (options: { limit?: number }) => {
+    seen.push(options.limit);
+    return rows;
+  };
+
+  for (const limit of [0, -1, 0.5, Number.NaN]) {
+    const dist = await reportBufferSurpriseDistribution(reader, { limit });
+    assert.equal(dist.count, 2, `limit=${limit} should fall back to default`);
+    assert.equal(dist.currentThreshold, 0.35);
+  }
+  assert.deepEqual(seen, [200, 200, 200, 200]);
+});
+
+test("report: positive fractional limit floors to the recent row count", async () => {
+  const dist = await reportBufferSurpriseDistribution(
+    async () => [
+      syntheticRow(0.1, false, "2026-04-20T12:00:00.000Z"),
+      syntheticRow(0.8, true, "2026-04-20T12:00:01.000Z"),
+      syntheticRow(0.9, true, "2026-04-20T12:00:02.000Z"),
+    ],
+    { limit: 1.8 },
+  );
+  assert.equal(dist.count, 1);
+  assert.equal(dist.min, 0.9);
+  assert.equal(dist.currentThreshold, 0.35);
 });
 
 test("report: single-row ledger reports that row in every percentile", async () => {

--- a/packages/remnic-core/src/buffer-surprise-trigger.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-trigger.test.ts
@@ -500,3 +500,267 @@ test("flag on: probe that never resolves is timed out, turn is still saved", asy
     if (slowTimer) clearTimeout(slowTimer);
   }
 });
+
+test("flag on: slow probe does not hold the buffer mutation queue", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  let releaseSlowProbe: (() => void) | null = null;
+  let slowProbeStarted: (() => void) | null = null;
+  const slowProbeStartedPromise = new Promise<void>((resolve) => {
+    slowProbeStarted = resolve;
+  });
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn(key) {
+      if (key !== "sess-slow") return null;
+      slowProbeStarted?.();
+      return new Promise<number | null>((resolve) => {
+        releaseSlowProbe = () => resolve(null);
+      });
+    },
+  };
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferSurpriseProbeTimeoutMs: 1000,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const slowTurn = buffer.addTurn("sess-slow", makeTurn("sess-slow", "slow probe turn"));
+  await slowProbeStartedPromise;
+
+  const fastTurn = Promise.race([
+    buffer.addTurn("sess-fast", makeTurn("sess-fast", "fast probe turn")).then(() => "completed"),
+    new Promise<"blocked">((resolve) => setTimeout(() => resolve("blocked"), 100)),
+  ]);
+  assert.equal(
+    await fastTurn,
+    "completed",
+    "unrelated buffer writes must not wait for a slow surprise probe",
+  );
+  assert.equal(storage.saved?.entries?.["sess-fast"]?.turns.length, 1);
+
+  assert.ok(releaseSlowProbe);
+  (releaseSlowProbe as () => void)();
+  await slowTurn;
+});
+
+test("flag on: stale slow-probe promotion is ignored after buffer changes", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  let releaseOldProbe: (() => void) | null = null;
+  let oldProbeStarted: (() => void) | null = null;
+  const oldProbeStartedPromise = new Promise<void>((resolve) => {
+    oldProbeStarted = resolve;
+  });
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn(_key, turn) {
+      if (turn.content !== "old surprising turn") return null;
+      oldProbeStarted?.();
+      return new Promise<number | null>((resolve) => {
+        releaseOldProbe = () => resolve(0.99);
+      });
+    },
+  };
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferSurpriseProbeTimeoutMs: 1000,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const oldDecision = buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "old surprising turn"),
+  );
+  await oldProbeStartedPromise;
+
+  await buffer.clearAfterExtraction("sess-1");
+  const freshDecision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "fresh post-flush turn"),
+  );
+  assert.equal(freshDecision, "keep_buffering");
+
+  assert.ok(releaseOldProbe);
+  (releaseOldProbe as () => void)();
+  assert.equal(
+    await oldDecision,
+    "keep_buffering",
+    "late surprise score for a stale buffer entry must not flush newer turns",
+  );
+  const turns = buffer.getTurns("sess-1");
+  assert.equal(turns.length, 1);
+  assert.equal(turns[0]?.content, "fresh post-flush turn");
+});
+
+test("flag on: slow-probe promotion survives prefix clears before the scored turn", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  let releaseProbe: (() => void) | null = null;
+  let probeStarted: (() => void) | null = null;
+  const probeStartedPromise = new Promise<void>((resolve) => {
+    probeStarted = resolve;
+  });
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn(_key, turn) {
+      if (turn.content !== "surprising second turn") return null;
+      probeStarted?.();
+      return new Promise<number | null>((resolve) => {
+        releaseProbe = () => resolve(0.99);
+      });
+    },
+  };
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferSurpriseProbeTimeoutMs: 1000,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "ordinary first turn"));
+  const firstSnapshot = buffer.getTurns("sess-1");
+  const secondDecision = buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "surprising second turn"),
+  );
+  await probeStartedPromise;
+
+  await buffer.clearAfterExtraction("sess-1", firstSnapshot);
+  assert.deepEqual(
+    buffer.getTurns("sess-1").map((turn) => turn.content),
+    ["surprising second turn"],
+  );
+
+  assert.ok(releaseProbe);
+  (releaseProbe as () => void)();
+  assert.equal(
+    await secondDecision,
+    "extract_now",
+    "prefix clears must not suppress surprise flush for a still-live turn",
+  );
+});
+
+test("flag on: slow-probe promotion survives later appends to same buffer", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  let releaseOldProbe: (() => void) | null = null;
+  let oldProbeStarted: (() => void) | null = null;
+  const oldProbeStartedPromise = new Promise<void>((resolve) => {
+    oldProbeStarted = resolve;
+  });
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn(_key, turn) {
+      if (turn.content !== "old surprising turn") return null;
+      oldProbeStarted?.();
+      return new Promise<number | null>((resolve) => {
+        releaseOldProbe = () => resolve(0.99);
+      });
+    },
+  };
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferSurpriseProbeTimeoutMs: 1000,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const oldDecision = buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "old surprising turn"),
+  );
+  await oldProbeStartedPromise;
+
+  const newerDecision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "newer ordinary turn"),
+  );
+  assert.equal(newerDecision, "keep_buffering");
+
+  assert.ok(releaseOldProbe);
+  (releaseOldProbe as () => void)();
+  assert.equal(
+    await oldDecision,
+    "extract_now",
+    "a later append must not suppress a valid surprise flush for the older turn",
+  );
+  const turns = buffer.getTurns("sess-1");
+  assert.equal(turns.length, 2);
+  assert.equal(turns[0]?.content, "old surprising turn");
+  assert.equal(turns[1]?.content, "newer ordinary turn");
+});
+
+test("flag on: extraction clear preserves turns appended after the queued snapshot", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  let releaseOldProbe: (() => void) | null = null;
+  let oldProbeStarted: (() => void) | null = null;
+  const oldProbeStartedPromise = new Promise<void>((resolve) => {
+    oldProbeStarted = resolve;
+  });
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn(_key, turn) {
+      if (turn.content !== "old surprising turn") return null;
+      oldProbeStarted?.();
+      return new Promise<number | null>((resolve) => {
+        releaseOldProbe = () => resolve(0.99);
+      });
+    },
+  };
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferSurpriseProbeTimeoutMs: 1000,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const oldDecision = buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "old surprising turn"),
+  );
+  await oldProbeStartedPromise;
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "newer ordinary turn"));
+  assert.ok(releaseOldProbe);
+  (releaseOldProbe as () => void)();
+  assert.equal(await oldDecision, "extract_now");
+
+  const queuedSnapshot = buffer.getTurns("sess-1");
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "post-queue append"));
+  await buffer.clearAfterExtraction("sess-1", queuedSnapshot);
+
+  const remainingTurns = buffer.getTurns("sess-1");
+  assert.equal(remainingTurns.length, 1);
+  assert.equal(remainingTurns[0]?.content, "post-queue append");
+});
+
+test("flag on: stale snapshot clears do not mark live turns as freshly extracted", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(null));
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "processed turn"));
+  const processedSnapshot = buffer.getTurns("sess-1");
+  await buffer.clearAfterExtraction("sess-1", processedSnapshot);
+  assert.equal(buffer.getExtractionCount("sess-1"), 1);
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "live after reset"));
+  await buffer.clearAfterExtraction("sess-1", processedSnapshot);
+
+  const remainingTurns = buffer.getTurns("sess-1");
+  assert.equal(remainingTurns.length, 1);
+  assert.equal(remainingTurns[0]?.content, "live after reset");
+  assert.equal(
+    buffer.getExtractionCount("sess-1"),
+    1,
+    "a skipped stale-snapshot clear must not advance extraction metadata",
+  );
+});

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -12,6 +12,11 @@ import type {
 
 export type TriggerDecision = "extract_now" | "extract_batch" | "keep_buffering";
 
+export interface AddTurnOutcome {
+  decision: TriggerDecision;
+  extractionTurns?: BufferTurn[];
+}
+
 /**
  * Optional surprise probe injected into `SmartBuffer`.
  *
@@ -76,9 +81,18 @@ interface SurpriseTelemetryQueueEntry {
   threshold: number;
 }
 
+interface AddTurnMutationResult {
+  decision: TriggerDecision;
+  signalLevel: SignalLevel;
+  priorTurns: BufferTurn[];
+  turnSnapshot: BufferTurn;
+  turnCountInWindow: number;
+}
+
 export class SmartBuffer {
   private state: BufferState;
   private loaded = false;
+  private loadPromise: Promise<void> | null = null;
   private readonly surpriseProbe: BufferSurpriseProbe | null;
   private mutationChain: Promise<unknown> = Promise.resolve();
   /**
@@ -220,8 +234,17 @@ export class SmartBuffer {
 
   private async loadUnlocked(): Promise<void> {
     if (this.loaded) return;
-    this.state = this.normalizeState(await this.storage.loadBuffer());
-    this.loaded = true;
+    if (!this.loadPromise) {
+      this.loadPromise = this.storage.loadBuffer()
+        .then((state) => {
+          this.state = this.normalizeState(state);
+          this.loaded = true;
+        })
+        .finally(() => {
+          this.loadPromise = null;
+        });
+    }
+    await this.loadPromise;
   }
 
   async load(): Promise<void> {
@@ -247,19 +270,16 @@ export class SmartBuffer {
   }
 
   async addTurn(bufferKey: string, turn: BufferTurn): Promise<TriggerDecision> {
-    return this.enqueueMutation(async () => this.addTurnUnlocked(bufferKey, turn));
+    return (await this.addTurnWithOutcome(bufferKey, turn)).decision;
   }
 
-  private async addTurnUnlocked(bufferKey: string, turn: BufferTurn): Promise<TriggerDecision> {
-    await this.loadUnlocked();
-    const entry = this.entryFor(bufferKey);
-    entry.turns.push(turn);
-    if (bufferKey === "default") {
-      this.state.turns = entry.turns;
-    }
-
-    const signal = scanSignals(turn.content, this.config.highSignalPatterns);
-    let decision = this.evaluate(entry, signal.level);
+  async addTurnWithOutcome(
+    bufferKey: string,
+    turn: BufferTurn,
+  ): Promise<AddTurnOutcome> {
+    const mutation = await this.enqueueMutation(() => this.recordTurnUnlocked(bufferKey, turn));
+    let decision = mutation.decision;
+    let extractionTurns: BufferTurn[] | undefined;
 
     // Surprise-gated flush (issue #563). Additive only: if the probe is
     // disabled, unavailable, or the score is below threshold, the decision
@@ -275,16 +295,29 @@ export class SmartBuffer {
       // novelty signal that should not second-guess a high-signal hit
       // (which already flushes) or fight `every_n` / `time_based` modes.
       this.config.triggerMode === "smart" &&
-      signal.level !== "high"
+      mutation.signalLevel !== "high"
     ) {
-      const surprise = await this.computeSurpriseSafe(bufferKey, turn, entry);
+      const surprise = await this.computeSurpriseSafe(bufferKey, turn, mutation.priorTurns);
       if (surprise !== null) {
-        const triggered = surprise > this.config.bufferSurpriseThreshold;
-        if (triggered) {
-          log.debug(
-            `buffer[${bufferKey}]: surprise=${surprise.toFixed(3)} > threshold=${this.config.bufferSurpriseThreshold} → extract_now`,
+        const shouldPromote = surprise > this.config.bufferSurpriseThreshold;
+        let triggered = false;
+        if (shouldPromote) {
+          const currentTurns = await this.getExtractionTurnsIfTurnSnapshotStillCurrent(
+            bufferKey,
+            mutation.turnSnapshot,
           );
-          decision = "extract_now";
+          if (currentTurns) {
+            log.debug(
+              `buffer[${bufferKey}]: surprise=${surprise.toFixed(3)} > threshold=${this.config.bufferSurpriseThreshold} → extract_now`,
+            );
+            decision = "extract_now";
+            triggered = true;
+            extractionTurns = currentTurns;
+          } else {
+            log.debug(
+              `buffer[${bufferKey}]: surprise=${surprise.toFixed(3)} ignored because buffer changed before probe resolved`,
+            );
+          }
         }
         // Emit telemetry on every scored turn — both triggering and
         // non-triggering — so operators can fit the threshold to real
@@ -308,7 +341,7 @@ export class SmartBuffer {
             typeof turn.sessionKey === "string" ? turn.sessionKey : null,
           surpriseScore: surprise,
           triggered,
-          turnCountInWindow: entry.turns.length,
+          turnCountInWindow: mutation.turnCountInWindow,
           // Stamp at decision time so backpressure on the write chain
           // does not shift the event's apparent moment away from when
           // the turn was actually scored.
@@ -322,12 +355,51 @@ export class SmartBuffer {
     }
 
     log.debug(
-      `buffer[${bufferKey}]: ${entry.turns.length} turns, signal=${signal.level}, decision=${decision}`,
+      `buffer[${bufferKey}]: ${mutation.turnCountInWindow} turns, signal=${mutation.signalLevel}, decision=${decision}`,
     );
+    return extractionTurns ? { decision, extractionTurns } : { decision };
+  }
+
+  private async recordTurnUnlocked(bufferKey: string, turn: BufferTurn): Promise<AddTurnMutationResult> {
+    await this.loadUnlocked();
+    const entry = this.entryFor(bufferKey);
+    const priorTurns = entry.turns.slice();
+    entry.turns.push(turn);
+    const turnSnapshot = copyBufferTurn(turn);
+    if (bufferKey === "default") {
+      this.state.turns = entry.turns;
+    }
+
+    const signal = scanSignals(turn.content, this.config.highSignalPatterns);
+    const decision = this.evaluate(entry, signal.level);
+    const turnCountInWindow = entry.turns.length;
 
     this.pruneEntries([bufferKey]);
     await this.saveUnlocked();
-    return decision;
+    return {
+      decision,
+      signalLevel: signal.level,
+      priorTurns,
+      turnSnapshot,
+      turnCountInWindow,
+    };
+  }
+
+  private async getExtractionTurnsIfTurnSnapshotStillCurrent(
+    bufferKey: string,
+    turnSnapshot: BufferTurn,
+  ): Promise<BufferTurn[] | null> {
+    return this.enqueueMutation(async () => {
+      await this.loadUnlocked();
+      const entry = this.peekEntry(bufferKey);
+      if (!entry) return null;
+      const stillCurrent = entry.turns.some((turn) =>
+        bufferTurnsEqual(turn, turnSnapshot),
+      );
+      if (!stillCurrent) return null;
+      const retained = entry.retainedTurns ?? [];
+      return [...retained, ...entry.turns];
+    });
   }
 
   /**
@@ -415,14 +487,9 @@ export class SmartBuffer {
   private async computeSurpriseSafe(
     bufferKey: string,
     turn: BufferTurn,
-    entry: BufferEntryState,
+    priorTurns: readonly BufferTurn[],
   ): Promise<number | null> {
     if (!this.surpriseProbe) return null;
-    // The current turn was just pushed into entry.turns; exclude it from the
-    // corpus so the probe never compares a turn to itself.
-    const prior = entry.turns.length > 0
-      ? entry.turns.slice(0, -1)
-      : [];
     try {
       // Hard timeout around the probe so a hung embedder cannot stall
       // `addTurn()` before `save()`. A slow probe would otherwise
@@ -432,7 +499,7 @@ export class SmartBuffer {
       // "probe unavailable, fall through" rather than an error that
       // surfaces to the caller.
       const score = await probeWithTimeout(
-        this.surpriseProbe.scoreTurn(bufferKey, turn, prior),
+        this.surpriseProbe.scoreTurn(bufferKey, turn, priorTurns),
         this.config.bufferSurpriseProbeTimeoutMs,
       );
       if (score === null) return null;
@@ -611,11 +678,40 @@ export class SmartBuffer {
     return matches;
   }
 
-  async clearAfterExtraction(bufferKey = "default"): Promise<void> {
+  async clearAfterExtraction(
+    bufferKey = "default",
+    extractedTurns?: readonly BufferTurn[],
+  ): Promise<void> {
     await this.enqueueMutation(async () => {
       await this.loadUnlocked();
       const entry = this.entryFor(bufferKey);
-      entry.turns = [];
+      if (Array.isArray(extractedTurns)) {
+        const liveExtractedTurns = liveTurnsFromExtractionSnapshot(
+          entry,
+          extractedTurns,
+        );
+        let clearedLiveTurns = false;
+        if (liveExtractedTurns.length > 0) {
+          const matchedCount = matchingQueuedExtractionPrefixLength(
+            entry.turns,
+            liveExtractedTurns,
+          );
+          if (matchedCount > 0) {
+            entry.turns = entry.turns.slice(matchedCount);
+            clearedLiveTurns = true;
+          } else {
+            log.debug(
+              `buffer[${bufferKey}]: extraction clear skipped because live turns changed before clear`,
+            );
+          }
+        }
+        if (!clearedLiveTurns) {
+          await this.saveUnlocked();
+          return;
+        }
+      } else {
+        entry.turns = [];
+      }
       entry.lastExtractionAt = new Date().toISOString();
       entry.extractionCount += 1;
       if (bufferKey === "default") {
@@ -669,6 +765,101 @@ function describeError(err: unknown): string {
   } catch {
     return String(err);
   }
+}
+
+function copyBufferTurn(turn: BufferTurn): BufferTurn {
+  const copy: BufferTurn = {
+    role: turn.role,
+    content: turn.content,
+    timestamp: turn.timestamp,
+  };
+  if (typeof turn.sessionKey === "string") copy.sessionKey = turn.sessionKey;
+  if (typeof turn.logicalSessionKey === "string") {
+    copy.logicalSessionKey = turn.logicalSessionKey;
+  }
+  if (
+    turn.providerThreadId === null ||
+    typeof turn.providerThreadId === "string"
+  ) {
+    copy.providerThreadId = turn.providerThreadId;
+  }
+  if (typeof turn.turnFingerprint === "string") {
+    copy.turnFingerprint = turn.turnFingerprint;
+  }
+  if (typeof turn.persistProcessedFingerprint === "boolean") {
+    copy.persistProcessedFingerprint = turn.persistProcessedFingerprint;
+  }
+  return copy;
+}
+
+function bufferTurnsEqual(left: BufferTurn | undefined, right: BufferTurn): boolean {
+  if (!left) return false;
+  return (
+    left.role === right.role &&
+    left.content === right.content &&
+    left.timestamp === right.timestamp &&
+    left.sessionKey === right.sessionKey &&
+    left.logicalSessionKey === right.logicalSessionKey &&
+    left.providerThreadId === right.providerThreadId &&
+    left.turnFingerprint === right.turnFingerprint &&
+    left.persistProcessedFingerprint === right.persistProcessedFingerprint
+  );
+}
+
+function liveTurnsFromExtractionSnapshot(
+  entry: BufferEntryState,
+  extractedTurns: readonly BufferTurn[],
+): readonly BufferTurn[] {
+  const retainedTurns = entry.retainedTurns ?? [];
+  if (
+    retainedTurns.length > 0 &&
+    extractedTurns.length >= retainedTurns.length &&
+    retainedTurns.every((turn, index) =>
+      bufferTurnsEqual(extractedTurns[index], turn),
+    )
+  ) {
+    const withoutRetainedPrefix = extractedTurns.slice(retainedTurns.length);
+    if (
+      withoutRetainedPrefix.length > 0 &&
+      matchingPrefixLength(entry.turns, withoutRetainedPrefix) > 0
+    ) {
+      return withoutRetainedPrefix;
+    }
+  }
+  return extractedTurns;
+}
+
+function matchingPrefixLength(
+  liveTurns: readonly BufferTurn[],
+  extractedTurns: readonly BufferTurn[],
+): number {
+  let index = 0;
+  while (
+    index < liveTurns.length &&
+    index < extractedTurns.length &&
+    bufferTurnsEqual(liveTurns[index], extractedTurns[index])
+  ) {
+    index += 1;
+  }
+  return index;
+}
+
+function matchingQueuedExtractionPrefixLength(
+  liveTurns: readonly BufferTurn[],
+  extractedTurns: readonly BufferTurn[],
+): number {
+  let bestMatchedCount = 0;
+  for (let start = 0; start < extractedTurns.length; start += 1) {
+    const matchedCount = matchingPrefixLength(
+      liveTurns,
+      extractedTurns.slice(start),
+    );
+    if (matchedCount > bestMatchedCount) {
+      bestMatchedCount = matchedCount;
+      if (bestMatchedCount === liveTurns.length) break;
+    }
+  }
+  return bestMatchedCount;
 }
 
 /**

--- a/packages/remnic-core/src/orchestrator-flush.test.ts
+++ b/packages/remnic-core/src/orchestrator-flush.test.ts
@@ -183,6 +183,36 @@ test("processTurn honors an explicit logical buffer key and turn fingerprint", a
   assert.equal(capturedTurn?.turnFingerprint, "fp-thread-7");
 });
 
+test("processTurn queues a guarded extraction snapshot from promoted buffer outcomes", async () => {
+  const orchestrator = Object.create(Orchestrator.prototype) as any;
+  const guardedTurns = [makeTurn("thread-a", "guarded surprising turn")];
+  const laterTurns = [makeTurn("thread-a", "post-flush turn")];
+  let queuedTurns: BufferTurn[] | undefined;
+
+  orchestrator.config = parseConfig({});
+  orchestrator.buffer = {
+    async addTurnWithOutcome() {
+      return {
+        decision: "extract_now",
+        extractionTurns: guardedTurns,
+      };
+    },
+    getTurns() {
+      return laterTurns;
+    },
+  };
+  orchestrator.queueBufferedExtraction = async (turns: BufferTurn[]) => {
+    queuedTurns = turns;
+  };
+
+  await orchestrator.processTurn("user", "guarded surprising turn", "thread-a");
+
+  assert.deepEqual(
+    queuedTurns?.map((turn) => turn.content),
+    ["guarded surprising turn"],
+  );
+});
+
 test("buildExtractionFingerprint normalizes fallback content like turn fingerprints", () => {
   const orchestrator = Object.create(Orchestrator.prototype) as any;
   orchestrator.config = parseConfig({});

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -10285,11 +10285,14 @@ export class Orchestrator {
       persistProcessedFingerprint: options.persistProcessedFingerprint === true,
     };
 
-    const decision = await this.buffer.addTurn(bufferKey, turn);
+    const outcome =
+      typeof this.buffer.addTurnWithOutcome === "function"
+        ? await this.buffer.addTurnWithOutcome(bufferKey, turn)
+        : { decision: await this.buffer.addTurn(bufferKey, turn) };
 
-    if (decision === "keep_buffering") return;
+    if (outcome.decision === "keep_buffering") return;
     await this.queueBufferedExtraction(
-      this.buffer.getTurns(bufferKey),
+      outcome.extractionTurns ?? this.buffer.getTurns(bufferKey),
       "trigger_mode",
       { bufferKey },
     );
@@ -10853,7 +10856,7 @@ export class Orchestrator {
         throwIfAborted("before_clear_buffer");
       }
       if (clearBufferAfterExtraction) {
-        await this.buffer.clearAfterExtraction(bufferKey);
+        await this.buffer.clearAfterExtraction(bufferKey, turns);
       }
     };
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4524,9 +4524,15 @@ export class StorageManager {
       }
     }
 
+    events.sort(
+      (left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp),
+    );
+
     if (effectiveLimit === null) return events;
     // Slice over VALID rows, not raw lines, so malformed tails cannot
-    // mask good data above them.
+    // mask good data above them. Sort by event timestamp before slicing
+    // so concurrent probe completion order cannot make an older scored
+    // turn look newer than a later scored turn.
     return events.slice(-effectiveLimit);
   }
 


### PR DESCRIPTION
## Summary
- serialize SmartBuffer load/mutation/save paths to preserve concurrent first writes and clears
- serialize BoxBuilder open-box and trace state transitions
- serialize causal chain index updates per chain directory so concurrent stitches keep every edge

## Verification
- pnpm exec tsx --test packages/remnic-core/src/buffer-session.test.ts tests/memory-boxes.test.ts tests/causal-chain.test.ts
- npm_config_workspace_concurrency=1 npm run preflight:quick

Addresses clawpatch finding fnd_sig-feat-library-530363e974-7b1a_973a938ce8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core buffering/extraction paths (turn persistence, surprise-trigger promotion, and post-extraction clearing) and could affect when/what turns get flushed under concurrency. Added tests reduce risk but race-condition changes are still moderately risky.
> 
> **Overview**
> **SmartBuffer mutations are now concurrency-safe.** `loadUnlocked` is deduped via `loadPromise`, `addTurn` is split so persistence happens inside the mutation queue while the (potentially slow) surprise probe runs outside it, and an optional `addTurnWithOutcome` API can return a *guarded* extraction snapshot.
> 
> **Extraction clearing is now snapshot-aware.** `clearAfterExtraction(bufferKey, extractedTurns?)` clears only the matching live prefix from the queued extraction snapshot (handling overlaps and retained-turn prefixes) and skips stale clears without bumping extraction metadata.
> 
> **Surprise telemetry/reporting is made order-stable.** `StorageManager.readBufferSurpriseEvents` and `reportBufferSurpriseDistribution` now sort by parsed event timestamps before applying the recent-window limit, with normalized limit handling.
> 
> **Orchestrator integration.** `processTurn` prefers `addTurnWithOutcome` when available to queue the guarded snapshot, and `runExtraction` passes the extracted turns into `clearAfterExtraction` to avoid wiping turns appended after the extraction was queued.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe5377ddc13dd19e29234e74e2984eb77b6fb1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->