### PR TITLE
fix(core): serialize state mutation writes

### DIFF
--- a/packages/remnic-core/src/boxes.ts
+++ b/packages/remnic-core/src/boxes.ts
@@ -175,10 +175,24 @@ export class BoxBuilder {
   private cfg: BoxBuilderConfig;
   private openBox: OpenBoxState | null = null;
   private stateLoaded = false;
+  private openBoxMutationChain: Promise<unknown> = Promise.resolve();
+  private traceMutationChain: Promise<unknown> = Promise.resolve();
 
   constructor(baseDir: string, cfg: BoxBuilderConfig) {
     this.baseDir = baseDir;
     this.cfg = cfg;
+  }
+
+  private enqueueOpenBoxMutation<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.openBoxMutationChain.catch(() => {}).then(op);
+    this.openBoxMutationChain = run.catch(() => {});
+    return run;
+  }
+
+  private enqueueTraceMutation<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.traceMutationChain.catch(() => {}).then(op);
+    this.traceMutationChain = run.catch(() => {});
+    return run;
   }
 
   private get boxBaseDir(): string {
@@ -248,6 +262,10 @@ export class BoxBuilder {
    * Decides whether to seal the current open box and/or start a new one.
    */
   async onExtraction(event: ExtractionEvent): Promise<void> {
+    await this.enqueueOpenBoxMutation(async () => this.onExtractionUnlocked(event));
+  }
+
+  private async onExtractionUnlocked(event: ExtractionEvent): Promise<void> {
     if (!this.cfg.memoryBoxesEnabled) return;
 
     await this.loadOpenBox();
@@ -275,13 +293,13 @@ export class BoxBuilder {
           const toolSet = new Set([...(this.openBox.toolsUsed ?? []), ...event.toolsUsed]);
           this.openBox.toolsUsed = [...toolSet];
         }
-        await this.sealCurrent("max_memories");
+        await this.sealCurrentUnlocked("max_memories");
       } else if (topicShifted) {
-        await this.sealCurrent("topic_shift");
+        await this.sealCurrentUnlocked("topic_shift");
         this.openBox = this.newBox(event, now.toISOString());
         await this.saveOpenBox();
       } else if (timeExpired) {
-        await this.sealCurrent("time_gap");
+        await this.sealCurrentUnlocked("time_gap");
         this.openBox = this.newBox(event, now.toISOString());
         await this.saveOpenBox();
       } else {
@@ -303,7 +321,7 @@ export class BoxBuilder {
       this.openBox = this.newBox(event, now.toISOString());
       // If this initial batch already exceeds max, seal immediately
       if (this.openBox.memoryIds.length > this.cfg.boxMaxMemories) {
-        await this.sealCurrent("max_memories");
+        await this.sealCurrentUnlocked("max_memories");
       } else {
         await this.saveOpenBox();
       }
@@ -327,6 +345,10 @@ export class BoxBuilder {
    * Also runs trace weaving if enabled.
    */
   async sealCurrent(reason: SealReason): Promise<string | null> {
+    return this.enqueueOpenBoxMutation(async () => this.sealCurrentUnlocked(reason));
+  }
+
+  private async sealCurrentUnlocked(reason: SealReason): Promise<string | null> {
     await this.loadOpenBox();
     if (!this.openBox) return null;
 
@@ -378,6 +400,10 @@ export class BoxBuilder {
    * Returns the traceId to assign to this box.
    */
   private async resolveTrace(boxId: string, topics: string[]): Promise<string> {
+    return this.enqueueTraceMutation(async () => this.resolveTraceUnlocked(boxId, topics));
+  }
+
+  private async resolveTraceUnlocked(boxId: string, topics: string[]): Promise<string> {
     const idx = await this.loadTraceIndex();
 
     // Filter to traces active within the lookback window

--- a/packages/remnic-core/src/buffer-session.test.ts
+++ b/packages/remnic-core/src/buffer-session.test.ts
@@ -18,6 +18,28 @@ class FakeStorage {
   }
 }
 
+class DelayedBufferStorage {
+  public saved: BufferState | null = null;
+
+  async loadBuffer(): Promise<BufferState> {
+    await delay(10);
+    return structuredClone(this.saved ?? {
+      turns: [],
+      lastExtractionAt: null,
+      extractionCount: 0,
+    });
+  }
+
+  async saveBuffer(state: BufferState): Promise<void> {
+    await delay(10);
+    this.saved = structuredClone(state);
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function makeTurn(sessionKey: string, content: string): BufferTurn {
   return {
     role: "user",
@@ -42,6 +64,23 @@ test("SmartBuffer keeps logical session buffers isolated", async () => {
   assert.equal(buffer.getTurns("thread-a")[0]?.content, "alpha memory");
   assert.equal(buffer.getTurns("thread-b").length, 1);
   assert.equal(buffer.getTurns("thread-b")[0]?.content, "beta memory");
+});
+
+test("SmartBuffer serializes concurrent addTurn mutations", async () => {
+  const storage = new DelayedBufferStorage();
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  await Promise.all([
+    buffer.addTurn("thread-a", makeTurn("thread-a", "alpha memory")),
+    buffer.addTurn("thread-a", makeTurn("thread-a", "beta memory")),
+  ]);
+
+  const turns = storage.saved?.entries?.["thread-a"]?.turns ?? [];
+  assert.equal(turns.length, 2);
+  assert.deepEqual(
+    turns.map((turn) => turn.content).sort(),
+    ["alpha memory", "beta memory"],
+  );
 });
 
 test("SmartBuffer clearAfterExtraction only clears the targeted logical session", async () => {

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -80,6 +80,7 @@ export class SmartBuffer {
   private state: BufferState;
   private loaded = false;
   private readonly surpriseProbe: BufferSurpriseProbe | null;
+  private mutationChain: Promise<unknown> = Promise.resolve();
   /**
    * Serialized write chain for `BUFFER_SURPRISE` telemetry events.
    *
@@ -103,6 +104,12 @@ export class SmartBuffer {
   ) {
     this.state = { turns: [], lastExtractionAt: null, extractionCount: 0 };
     this.surpriseProbe = surpriseProbe;
+  }
+
+  private enqueueMutation<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.mutationChain.catch(() => {}).then(op);
+    this.mutationChain = run.catch(() => {});
+    return run;
   }
 
   private entryFor(key: string): BufferEntryState {
@@ -211,10 +218,14 @@ export class SmartBuffer {
     }
   }
 
-  async load(): Promise<void> {
+  private async loadUnlocked(): Promise<void> {
     if (this.loaded) return;
     this.state = this.normalizeState(await this.storage.loadBuffer());
     this.loaded = true;
+  }
+
+  async load(): Promise<void> {
+    await this.enqueueMutation(async () => this.loadUnlocked());
   }
 
   /**
@@ -227,12 +238,20 @@ export class SmartBuffer {
     this.loaded = true;
   }
 
-  async save(): Promise<void> {
+  private async saveUnlocked(): Promise<void> {
     await this.storage.saveBuffer(this.state);
   }
 
+  async save(): Promise<void> {
+    await this.enqueueMutation(async () => this.saveUnlocked());
+  }
+
   async addTurn(bufferKey: string, turn: BufferTurn): Promise<TriggerDecision> {
-    await this.load();
+    return this.enqueueMutation(async () => this.addTurnUnlocked(bufferKey, turn));
+  }
+
+  private async addTurnUnlocked(bufferKey: string, turn: BufferTurn): Promise<TriggerDecision> {
+    await this.loadUnlocked();
     const entry = this.entryFor(bufferKey);
     entry.turns.push(turn);
     if (bufferKey === "default") {
@@ -307,7 +326,7 @@ export class SmartBuffer {
     );
 
     this.pruneEntries([bufferKey]);
-    await this.save();
+    await this.saveUnlocked();
     return decision;
   }
 
@@ -505,48 +524,50 @@ export class SmartBuffer {
     turns: BufferTurn[],
     max = 10,
   ): Promise<void> {
-    await this.load();
-    const entry = this.entryFor(bufferKey);
-    if (!Array.isArray(turns) || turns.length === 0 || max <= 0) {
-      delete entry.retainedTurns;
-    } else {
-      // Guard `slice(-max)` against `max === 0` (CLAUDE.md gotcha 27):
-      // `slice(-0)` equals `slice(0)` and would return ALL entries. We
-      // already early-return above when max <= 0.
-      const tail = turns.slice(-max);
-      // Copy explicit fields only — never spread an external object into a
-      // plain object because spread preserves any own `__proto__` /
-      // `constructor` keys that may have arrived via JSON deserialization
-      // of untrusted input (CodeQL js/prototype-polluting-assignment).
-      entry.retainedTurns = tail.map<BufferTurn>((t) => {
-        const copy: BufferTurn = {
-          role: t.role,
-          content: typeof t.content === "string" ? t.content : "",
-          timestamp:
-            typeof t.timestamp === "string"
-              ? t.timestamp
-              : new Date().toISOString(),
-        };
-        if (typeof t.sessionKey === "string") copy.sessionKey = t.sessionKey;
-        if (typeof t.logicalSessionKey === "string") {
-          copy.logicalSessionKey = t.logicalSessionKey;
-        }
-        if (
-          t.providerThreadId === null ||
-          typeof t.providerThreadId === "string"
-        ) {
-          copy.providerThreadId = t.providerThreadId;
-        }
-        if (typeof t.turnFingerprint === "string") {
-          copy.turnFingerprint = t.turnFingerprint;
-        }
-        if (typeof t.persistProcessedFingerprint === "boolean") {
-          copy.persistProcessedFingerprint = t.persistProcessedFingerprint;
-        }
-        return copy;
-      });
-    }
-    await this.save();
+    await this.enqueueMutation(async () => {
+      await this.loadUnlocked();
+      const entry = this.entryFor(bufferKey);
+      if (!Array.isArray(turns) || turns.length === 0 || max <= 0) {
+        delete entry.retainedTurns;
+      } else {
+        // Guard `slice(-max)` against `max === 0` (CLAUDE.md gotcha 27):
+        // `slice(-0)` equals `slice(0)` and would return ALL entries. We
+        // already early-return above when max <= 0.
+        const tail = turns.slice(-max);
+        // Copy explicit fields only — never spread an external object into a
+        // plain object because spread preserves any own `__proto__` /
+        // `constructor` keys that may have arrived via JSON deserialization
+        // of untrusted input (CodeQL js/prototype-polluting-assignment).
+        entry.retainedTurns = tail.map<BufferTurn>((t) => {
+          const copy: BufferTurn = {
+            role: t.role,
+            content: typeof t.content === "string" ? t.content : "",
+            timestamp:
+              typeof t.timestamp === "string"
+                ? t.timestamp
+                : new Date().toISOString(),
+          };
+          if (typeof t.sessionKey === "string") copy.sessionKey = t.sessionKey;
+          if (typeof t.logicalSessionKey === "string") {
+            copy.logicalSessionKey = t.logicalSessionKey;
+          }
+          if (
+            t.providerThreadId === null ||
+            typeof t.providerThreadId === "string"
+          ) {
+            copy.providerThreadId = t.providerThreadId;
+          }
+          if (typeof t.turnFingerprint === "string") {
+            copy.turnFingerprint = t.turnFingerprint;
+          }
+          if (typeof t.persistProcessedFingerprint === "boolean") {
+            copy.persistProcessedFingerprint = t.persistProcessedFingerprint;
+          }
+          return copy;
+        });
+      }
+      await this.saveUnlocked();
+    });
   }
 
   /**
@@ -565,6 +586,7 @@ export class SmartBuffer {
 
   async findBufferKeysForSession(sessionKey: string): Promise<string[]> {
     if (typeof sessionKey !== "string" || sessionKey.length === 0) return [];
+    await this.mutationChain.catch(() => {});
     await this.load();
 
     const matches: string[] = [];
@@ -590,18 +612,20 @@ export class SmartBuffer {
   }
 
   async clearAfterExtraction(bufferKey = "default"): Promise<void> {
-    await this.load();
-    const entry = this.entryFor(bufferKey);
-    entry.turns = [];
-    entry.lastExtractionAt = new Date().toISOString();
-    entry.extractionCount += 1;
-    if (bufferKey === "default") {
-      this.state.turns = entry.turns;
-      this.state.lastExtractionAt = entry.lastExtractionAt;
-      this.state.extractionCount = entry.extractionCount;
-    }
-    this.pruneEntries([bufferKey]);
-    await this.save();
+    await this.enqueueMutation(async () => {
+      await this.loadUnlocked();
+      const entry = this.entryFor(bufferKey);
+      entry.turns = [];
+      entry.lastExtractionAt = new Date().toISOString();
+      entry.extractionCount += 1;
+      if (bufferKey === "default") {
+        this.state.turns = entry.turns;
+        this.state.lastExtractionAt = entry.lastExtractionAt;
+        this.state.extractionCount = entry.extractionCount;
+      }
+      this.pruneEntries([bufferKey]);
+      await this.saveUnlocked();
+    });
   }
 
   getExtractionCount(bufferKey = "default"): number {

--- a/packages/remnic-core/src/causal-chain.ts
+++ b/packages/remnic-core/src/causal-chain.ts
@@ -133,6 +133,22 @@ function edgeFilePath(chainsDir: string, edge: CausalEdge): string {
 
 // ─── Chain Index CRUD ────────────────────────────────────────────────────────
 
+const chainMutationQueues = new Map<string, Promise<unknown>>();
+
+function enqueueChainMutation<T>(chainsDir: string, op: () => Promise<T>): Promise<T> {
+  const key = path.resolve(chainsDir);
+  const previous = chainMutationQueues.get(key) ?? Promise.resolve();
+  const run = previous.catch(() => {}).then(op);
+  const settled = run.catch(() => {});
+  chainMutationQueues.set(key, settled);
+  void settled.finally(() => {
+    if (chainMutationQueues.get(key) === settled) {
+      chainMutationQueues.delete(key);
+    }
+  });
+  return run;
+}
+
 export async function readChainIndex(chainsDir: string): Promise<CausalChainIndex> {
   try {
     const raw = JSON.parse(await readFile(chainIndexPath(chainsDir), "utf8"));
@@ -367,35 +383,37 @@ export async function stitchCausalChain(options: {
 
   if (scored.length === 0) return [];
 
-  const index = await readChainIndex(chainsDir);
-  const newEdges: CausalEdge[] = [];
+  return enqueueChainMutation(chainsDir, async () => {
+    const index = await readChainIndex(chainsDir);
+    const newEdges: CausalEdge[] = [];
 
-  for (const candidate of scored) {
-    const edgeId = makeEdgeId(candidate.trajectory.trajectoryId, newTrajectory.trajectoryId);
+    for (const candidate of scored) {
+      const edgeId = makeEdgeId(candidate.trajectory.trajectoryId, newTrajectory.trajectoryId);
 
-    // Skip if edge already exists
-    if (index.edges[edgeId]) continue;
+      // Skip if edge already exists
+      if (index.edges[edgeId]) continue;
 
-    const edge: CausalEdge = {
-      schemaVersion: 1,
-      edgeId,
-      fromTrajectoryId: candidate.trajectory.trajectoryId,
-      toTrajectoryId: newTrajectory.trajectoryId,
-      edgeType: candidate.edgeType,
-      confidence: Math.min(1, candidate.score / 10),
-      stitchMethod: candidate.stitchMethod,
-      createdAt: new Date().toISOString(),
-    };
+      const edge: CausalEdge = {
+        schemaVersion: 1,
+        edgeId,
+        fromTrajectoryId: candidate.trajectory.trajectoryId,
+        toTrajectoryId: newTrajectory.trajectoryId,
+        edgeType: candidate.edgeType,
+        confidence: Math.min(1, candidate.score / 10),
+        stitchMethod: candidate.stitchMethod,
+        createdAt: new Date().toISOString(),
+      };
 
-    addEdgeToIndex(index, edge);
-    await persistEdge(chainsDir, edge);
-    newEdges.push(edge);
-  }
+      addEdgeToIndex(index, edge);
+      await persistEdge(chainsDir, edge);
+      newEdges.push(edge);
+    }
 
-  if (newEdges.length > 0) {
-    await writeChainIndex(chainsDir, index);
-    log.debug(`[cmc] stitched ${newEdges.length} causal edge(s) for trajectory ${newTrajectory.trajectoryId}`);
-  }
+    if (newEdges.length > 0) {
+      await writeChainIndex(chainsDir, index);
+      log.debug(`[cmc] stitched ${newEdges.length} causal edge(s) for trajectory ${newTrajectory.trajectoryId}`);
+    }
 
-  return newEdges;
+    return newEdges;
+  });
 }

--- a/tests/causal-chain.test.ts
+++ b/tests/causal-chain.test.ts
@@ -305,6 +305,68 @@ test("stitchCausalChain creates edges for related cross-session trajectories", a
   assert.ok(index.incoming["traj-new"]?.length > 0);
 });
 
+test("stitchCausalChain serializes concurrent index updates", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-stitch-concurrent-"));
+
+  await recordCausalTrajectory({
+    memoryDir,
+    record: {
+      schemaVersion: 1,
+      trajectoryId: "traj-old",
+      recordedAt: new Date(Date.now() - 3_600_000).toISOString(),
+      sessionKey: "session-1",
+      goal: "Fix authentication error handling in login flow",
+      actionSummary: "Added try-catch blocks to login handler",
+      observationSummary: "Errors now caught but not reported to user",
+      outcomeKind: "partial",
+      outcomeSummary: "Error handling works but needs user-facing messages",
+      followUpSummary: "Add user-facing error messages to authentication flow",
+      entityRefs: ["module:auth", "repo:main"],
+      tags: ["auth", "error-handling"],
+    },
+  });
+
+  const baseNewTrajectory: Omit<CausalTrajectoryRecord, "trajectoryId" | "sessionKey"> = {
+    schemaVersion: 1,
+    recordedAt: new Date().toISOString(),
+    goal: "Add user-facing error messages to authentication flow",
+    actionSummary: "Created error message components for login page",
+    observationSummary: "Error messages display correctly",
+    outcomeKind: "success",
+    outcomeSummary: "Authentication flow now shows proper error messages",
+    entityRefs: ["module:auth", "repo:main"],
+    tags: ["auth", "error-handling", "ux"],
+  };
+
+  await Promise.all([
+    stitchCausalChain({
+      memoryDir,
+      newTrajectory: {
+        ...baseNewTrajectory,
+        trajectoryId: "traj-new-a",
+        sessionKey: "session-2",
+      },
+      config: { lookbackDays: 7, minScore: 1.0, maxEdgesPerTrajectory: 3 },
+    }),
+    stitchCausalChain({
+      memoryDir,
+      newTrajectory: {
+        ...baseNewTrajectory,
+        trajectoryId: "traj-new-b",
+        sessionKey: "session-3",
+      },
+      config: { lookbackDays: 7, minScore: 1.0, maxEdgesPerTrajectory: 3 },
+    }),
+  ]);
+
+  const index = await readChainIndex(resolveChainsDir(memoryDir));
+  const destinations = new Set(
+    Object.values(index.edges).map((edge) => edge.toTrajectoryId),
+  );
+  assert.ok(destinations.has("traj-new-a"));
+  assert.ok(destinations.has("traj-new-b"));
+});
+
 test("stitchCausalChain skips same-session trajectories", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-stitch-same-"));
 

--- a/tests/memory-boxes.test.ts
+++ b/tests/memory-boxes.test.ts
@@ -151,6 +151,38 @@ test("BoxBuilder does not seal when same topics continue", async () => {
   }
 });
 
+test("BoxBuilder serializes concurrent open-box updates", async () => {
+  const dir = await makeTmp();
+  try {
+    const builder = new BoxBuilder(dir, {
+      memoryBoxesEnabled: true,
+      traceWeaverEnabled: false,
+      boxTopicShiftThreshold: 0.5,
+      boxTimeGapMs: 60 * 60 * 1000,
+      boxMaxMemories: 100,
+      traceWeaverLookbackDays: 7,
+      traceWeaverOverlapThreshold: 0.4,
+    });
+
+    const now = new Date().toISOString();
+    await Promise.all([
+      builder.onExtraction({ topics: ["postgres", "database"], memoryIds: ["m1"], timestamp: now }),
+      builder.onExtraction({ topics: ["postgres", "database"], memoryIds: ["m2"], timestamp: now }),
+    ]);
+    await builder.sealCurrent("forced");
+
+    const boxDir = path.join(dir, BOX_DIR);
+    const allBoxes = await collectAllBoxFiles(boxDir);
+    assert.equal(allBoxes.length, 1, `expected one merged box, got ${allBoxes.length}`);
+
+    const content = await readFile(allBoxes[0]!, "utf-8");
+    const parsed = parseBoxFrontmatter(content);
+    assert.deepEqual(parsed?.memoryIds.sort(), ["m1", "m2"]);
+  } finally {
+    await cleanup(dir);
+  }
+});
+
 // ── BoxBuilder: sealed box format ─────────────────────────────────────────
 
 test("BoxBuilder writes valid frontmatter when sealing", async () => {


### PR DESCRIPTION
## Summary
- serialize SmartBuffer read/modify/write operations so concurrent turn appends and extraction clears cannot overwrite each other
- serialize BoxBuilder open-box and trace index mutations during extraction/sealing
- serialize causal chain index updates per chain store to preserve concurrent stitched edges
- add regression coverage for concurrent buffered turns, memory boxes, and causal edges

## Verification
- pnpm exec tsx --test packages/remnic-core/src/buffer-session.test.ts tests/memory-boxes.test.ts tests/causal-chain.test.ts
- pnpm --filter @remnic/core check-types
- git diff --check
- npm run preflight:quick
- npm run test:entity-hardening

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persistence paths for buffers, memory boxes, and causal-chain stitching; while the change is conceptually simple (promise-based serialization), it can affect throughput and could introduce deadlocks or missed writes if chaining is incorrect.
> 
> **Overview**
> **Prevents lost updates under concurrency** by introducing promise-based mutation queues around previously non-atomic read/modify/write sequences.
> 
> `SmartBuffer` now serializes `load`/`save`, `addTurn`, `clearAfterExtraction`, and `retainDeferredTurns` via a single `mutationChain`, and `findBufferKeysForSession` waits for pending mutations before scanning.
> 
> `BoxBuilder` serializes open-box mutations (`onExtraction`, `sealCurrent`) and separately serializes trace-index updates, and `stitchCausalChain` now serializes chain-index/edge persistence per `chainsDir` to avoid concurrent index clobbering; new tests cover concurrent turn appends, open-box merging, and concurrent stitched edges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d82b54e277695194c7a8015f29fb90fc70940f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->