### PR TITLE
fix(config): cover package tests and core barrels

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "dev": "tsup --watch",
     "check-types": "pnpm --filter @remnic/core build && tsc --noEmit && pnpm --recursive --if-present --filter=\"./packages/*\" run check-types",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
-    "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts' 'packages/export-weclone/src/**/*.test.ts' 'packages/import-weclone/src/**/*.test.ts'",
+    "test": "tsx --test 'tests/**/*.test.ts' 'packages/*/src/**/*.test.ts'",
     "test:openclaw-scenarios": "pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,12 @@
       "@remnic/core": [
         "./packages/remnic-core/src/index.ts"
       ],
+      "@remnic/core/connectors": [
+        "./packages/remnic-core/src/connectors/index.ts"
+      ],
       "@remnic/core/*": [
-        "./packages/remnic-core/src/*.ts"
+        "./packages/remnic-core/src/*.ts",
+        "./packages/remnic-core/src/*/index.ts"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- add root tsconfig resolution for @remnic/core/connectors directory barrel imports
- add a directory-index fallback for @remnic/core/* path aliases
- broaden the root test script to include every workspace package source test under packages/*/src/**/*.test.ts

## Verification
- pnpm --filter @remnic/core check-types
- git diff --check
- pnpm exec tsx --test packages/connector-weclone/src/*.test.ts packages/import-chatgpt/src/*.test.ts packages/import-claude/src/*.test.ts packages/import-gemini/src/*.test.ts packages/import-lossless-claw/src/*.test.ts packages/import-mem0/src/*.test.ts packages/import-supermemory/src/*.test.ts packages/plugin-openclaw/src/**/*.test.ts packages/plugin-pi/src/**/*.test.ts packages/remnic-cli/src/*.test.ts
- npm run preflight:quick

Note: I also started the expanded root npm test command. It reached existing long-running root tests and was interrupted after several minutes; the package tests newly covered by the changed glob were then run directly and passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only changes: expands test discovery globs and adjusts TypeScript path aliases, which may affect local/CI type resolution but not runtime behavior.
> 
> **Overview**
> Broadens the root `test` script to run all workspace package tests under `packages/*/src/**/*.test.ts` instead of enumerating specific packages.
> 
> Updates `tsconfig.json` path aliases to support `@remnic/core/connectors` barrel imports and to allow `@remnic/core/*` to resolve directory `index.ts` barrels in addition to top-level `*.ts` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e5bfa385bdebe0cf220fbd77f968c84bbcac88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->