### PR TITLE
fix(config): include dashboard tests in root test

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "dev": "tsup --watch",
     "check-types": "pnpm --filter @remnic/core build && tsc --noEmit && pnpm --recursive --if-present --filter=\"./packages/*\" run check-types",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
-    "test": "tsx --test 'tests/**/*.test.ts' 'packages/*/src/**/*.test.ts'",
+    "test": "tsx --test 'tests/**/*.test.ts' 'packages/*/src/**/*.test.ts' dashboard/lib/*.test.ts",
     "test:openclaw-scenarios": "pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",


### PR DESCRIPTION
## Summary
- include dashboard test files in the root `npm test` glob
- closes the remaining clawpatch finding that `dashboard/lib/graph-diff.test.ts` was omitted from root test coverage

## Verification
- `pnpm exec tsx --test dashboard/**/*.test.ts`
- `pnpm --filter @remnic/core check-types`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the root `test` script glob to include additional dashboard tests, with no runtime code changes.
> 
> **Overview**
> Root `npm test`/`pnpm test` now also runs dashboard unit tests by adding `dashboard/lib/*.test.ts` to the `tsx --test` glob, closing a gap where `dashboard/lib` tests were previously omitted from the main test run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ca4bc028ce9056beb7aa66adcc1d4cab044871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->