### PR TITLE
fix(config): align package manager and native dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,19 @@ help:
 	@echo ""
 
 build:
-	npm run build
+	pnpm build
 
 test:
-	npm test
+	pnpm test
 
 lint:
-	npm run check-types
+	pnpm check-types
 
 preflight:
-	npm run preflight
+	pnpm preflight
 
 preflight-quick:
-	npm run preflight:quick
+	pnpm preflight:quick
 
 clean:
 	rm -rf dist/

--- a/package.json
+++ b/package.json
@@ -76,11 +76,12 @@
     "scripts/ensure-better-sqlite3.mjs"
   ],
   "dependencies": {
-    "@remnic/core": "workspace:^",
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
+    "@node-rs/argon2": "^2.0.2",
     "@orama/orama": "^3.0.0",
     "@orama/plugin-data-persistence": "^3.0.0",
+    "@remnic/core": "workspace:^",
     "@sinclair/typebox": "^0.34.0",
     "apache-arrow": "^18.1.0",
     "better-sqlite3": "^12.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@lancedb/lancedb':
         specifier: ^0.26.2
         version: 0.26.2(apache-arrow@18.1.0)
+      '@node-rs/argon2':
+        specifier: ^2.0.2
+        version: 2.0.2
       '@orama/orama':
         specifier: ^3.0.0
         version: 3.1.18

--- a/tests/makefile-lint-target.test.ts
+++ b/tests/makefile-lint-target.test.ts
@@ -14,8 +14,8 @@ test("make lint delegates to an existing type-check script", () => {
   });
 
   assert.equal(dryRun.status, 0, dryRun.stderr);
-  assert.match(dryRun.stdout, /\bnpm run check-types\b/);
-  assert.doesNotMatch(dryRun.stdout, /\bnpm run lint\b/);
+  assert.match(dryRun.stdout, /\bpnpm check-types\b/);
+  assert.doesNotMatch(dryRun.stdout, /\bpnpm lint\b/);
 
   const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
     scripts?: Record<string, string>;


### PR DESCRIPTION
## Summary
- switch Makefile quality/build recipes from npm to the repo canonical pnpm commands
- declare `@node-rs/argon2` in the root runtime dependencies with the same range used by `@remnic/core`
- refresh the pnpm lockfile for the root dependency contract

## Verification
- `pnpm install --frozen-lockfile --prefer-offline`
- `node scripts/ensure-better-sqlite3.mjs`
- `make lint`
- `npm run preflight:quick`
- `clawpatch review --feature feat_config_0902ad7be8`
- `clawpatch review --feature feat_config_7528cb5b98`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to build/CI command changes and adding a native `@node-rs/argon2` dependency, which can affect installs across platforms.
> 
> **Overview**
> Updates the `Makefile` to invoke the repo’s canonical `pnpm` commands for `build`, `test`, `lint`, and preflight targets (replacing `npm` invocations), and adjusts the corresponding `make lint` test expectations.
> 
> Adds `@node-rs/argon2` to root runtime dependencies (and refreshes `pnpm-lock.yaml`) to ensure the native hashing dependency is explicitly installed at the workspace root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4162e0d7cda405b6f8ee69a3eee7afe379a7d676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->