### PR TITLE
fix(config): build core before root tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "dev": "tsup --watch",
     "check-types": "pnpm --filter @remnic/core build && tsc --noEmit && pnpm --recursive --if-present --filter=\"./packages/*\" run check-types && node scripts/check-test-types.mjs",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
-    "test": "tsx --test 'tests/**/*.test.ts' 'packages/*/src/**/*.test.ts' dashboard/lib/*.test.ts",
+    "test": "pnpm --filter @remnic/core build && tsx --test 'tests/**/*.test.ts' 'packages/*/src/**/*.test.ts' dashboard/lib/*.test.ts",
     "test:openclaw-scenarios": "pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",

--- a/tests/root-test-build-contract.test.ts
+++ b/tests/root-test-build-contract.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("root test script builds core before running package tests", () => {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+
+  const testScript = pkg.scripts?.test ?? "";
+  assert.match(testScript, /^pnpm --filter @remnic\/core build && /);
+  assert.match(testScript, /'packages\/\*\/src\/\*\*\/\*\.test\.ts'/);
+});


### PR DESCRIPTION
## Summary
- build `@remnic/core` before the root `test` script loads package tests
- add a contract test that keeps root test discovery tied to a prior core build

## Verification
- `pnpm exec tsx --test tests/root-test-build-contract.test.ts`
- `rm -rf packages/remnic-core/dist && pnpm --filter @remnic/core build && node -e "import('@remnic/core').then(() => console.log('core import ok'))"`\n- `npm run check-types`\n- `npm run preflight:quick`\n- `clawpatch review --feature feat_config_7528cb5b98`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the root `test` command ordering and adds a small contract test to prevent regressions; no runtime or production code paths are affected.
> 
> **Overview**
> **Root test execution now guarantees `@remnic/core` is built first.** The root `package.json` `test` script prepends `pnpm --filter @remnic/core build &&` before running `tsx` test discovery.
> 
> **Adds a guardrail test** (`tests/root-test-build-contract.test.ts`) that asserts the root `test` script includes the core build step and still targets package test globs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1d9d0cf36d9ec9d86852b766861a5cd4c44e5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->