### PR TITLE
fix(test): use cross-shell glob quoting

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "dev": "tsup --watch",
     "check-types": "pnpm --filter @remnic/core build && tsc --noEmit && pnpm --recursive --if-present --filter=\"./packages/*\" run check-types && node scripts/check-test-types.mjs",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
-    "test": "pnpm --filter @remnic/core build && tsx --test 'tests/**/*.test.ts' 'packages/*/src/**/*.test.ts' dashboard/lib/*.test.ts",
+    "test": "pnpm --filter @remnic/core build && tsx --test \"tests/**/*.test.ts\" \"packages/*/src/**/*.test.ts\" dashboard/lib/*.test.ts",
     "test:openclaw-scenarios": "pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",

--- a/tests/root-test-build-contract.test.ts
+++ b/tests/root-test-build-contract.test.ts
@@ -13,5 +13,10 @@ test("root test script builds core before running package tests", () => {
 
   const testScript = pkg.scripts?.test ?? "";
   assert.match(testScript, /^pnpm --filter @remnic\/core build && /);
-  assert.match(testScript, /'packages\/\*\/src\/\*\*\/\*\.test\.ts'/);
+  assert.match(testScript, /"packages\/\*\/src\/\*\*\/\*\.test\.ts"/);
+  assert.doesNotMatch(
+    testScript,
+    /'[^']*\*[^']*'/,
+    "npm scripts should not use POSIX-only single quotes around glob arguments",
+  );
 });


### PR DESCRIPTION
## Summary
- switch the root test script glob arguments from POSIX single quotes to cross-shell double quotes
- update the root test-script contract test so single-quoted glob arguments are rejected

Closes clawpatch finding `fnd_sig-feat-test-suite-84ae84a25a-f_cddfbaa1ca`.

## Verification
- `pnpm exec tsx --test tests/root-test-build-contract.test.ts`
- `node packages/remnic-core/scripts/ensure-better-sqlite3.mjs`
- `npm_config_workspace_concurrency=1 npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the root `test` npm script quoting and tightens a contract test to prevent POSIX-only glob quoting; no runtime/business logic changes.
> 
> **Overview**
> **Improves cross-shell compatibility of the root test runner.** The root `package.json` `test` script now uses double quotes for glob arguments (instead of POSIX single quotes) so it works consistently across shells.
> 
> **Strengthens the contract test** (`tests/root-test-build-contract.test.ts`) to require the double-quoted glob and to explicitly reject single-quoted glob arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b22e292e6a562b9b625bfacd65ef426ba9e15a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->