### PR TITLE
fix(test): include AMB node tests in root suite

### DIFF
--- a/integrations/amb/install-remnic-provider.test.mjs
+++ b/integrations/amb/install-remnic-provider.test.mjs
@@ -68,6 +68,22 @@ function runAmbPreflight(ambDir, env) {
   );
 }
 
+function commandExists(command) {
+  return spawnSync("sh", ["-c", 'command -v "$1"', "sh", command], {
+    encoding: "utf8",
+  }).status === 0;
+}
+
+const codexCliAvailable = commandExists(
+  process.env.OMB_CODEX_EXECUTABLE ||
+    process.env.REMNIC_BENCH_CODEX_CLI_EXECUTABLE ||
+    "codex",
+);
+const uvAvailable = commandExists("uv");
+const requireCodexCli = {
+  skip: codexCliAvailable && uvAvailable ? false : "codex CLI and uv are required",
+};
+
 test("installRemnicProvider exposes provider files before registry patches", () => {
   const source = readFileSync(
     path.join(__dirname, "install-remnic-provider.mjs"),
@@ -393,7 +409,7 @@ def run(llm: str): _resolve_gemini_key(); ds = get_dataset(dataset)
   );
 });
 
-test("check-remnic-run accepts the Codex CLI iteration profile", async () => {
+test("check-remnic-run accepts the Codex CLI iteration profile", requireCodexCli, async () => {
   const ambDir = await createAmbFixture();
   const storeDir = await mkdtemp(path.join(tmpdir(), "remnic-amb-store-test-"));
 
@@ -477,7 +493,7 @@ test("check-remnic-run rejects Codex profile without AMB LLM registration", asyn
   }
 });
 
-test("check-remnic-run treats Codex internal LLM vars as optional unless configured", async () => {
+test("check-remnic-run treats Codex internal LLM vars as optional unless configured", requireCodexCli, async () => {
   const ambDir = await createAmbFixture();
   const storeDir = await mkdtemp(path.join(tmpdir(), "remnic-amb-store-test-"));
 
@@ -519,7 +535,7 @@ test("check-remnic-run treats Codex internal LLM vars as optional unless configu
   }
 });
 
-test("check-remnic-run does not reset the caller AMB store directory", async () => {
+test("check-remnic-run does not reset the caller AMB store directory", requireCodexCli, async () => {
   const ambDir = await createAmbFixture();
   const storeDir = await mkdtemp(path.join(tmpdir(), "remnic-amb-store-preserve-test-"));
   const sentinelPath = path.join(storeDir, "sentinel.txt");

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "dev": "tsup --watch",
     "check-types": "pnpm --filter @remnic/core build && tsc --noEmit && pnpm --recursive --if-present --filter=\"./packages/*\" run check-types && node scripts/check-test-types.mjs",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
-    "test": "pnpm --filter @remnic/core build && tsx --test \"tests/**/*.test.ts\" \"packages/*/src/**/*.test.ts\" dashboard/lib/*.test.ts",
+    "test": "pnpm --filter @remnic/core build && tsx --test \"tests/**/*.test.ts\" \"packages/*/src/**/*.test.ts\" dashboard/lib/*.test.ts integrations/amb/*.test.mjs",
     "test:openclaw-scenarios": "pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",

--- a/tests/root-test-build-contract.test.ts
+++ b/tests/root-test-build-contract.test.ts
@@ -14,6 +14,7 @@ test("root test script builds core before running package tests", () => {
   const testScript = pkg.scripts?.test ?? "";
   assert.match(testScript, /^pnpm --filter @remnic\/core build && /);
   assert.match(testScript, /"packages\/\*\/src\/\*\*\/\*\.test\.ts"/);
+  assert.match(testScript, /\bintegrations\/amb\/\*\.test\.mjs\b/);
   assert.doesNotMatch(
     testScript,
     /'[^']*\*[^']*'/,


### PR DESCRIPTION
## Summary
- include the AMB `.test.mjs` files in the root `pnpm test` command
- extend the root test-script contract so the AMB glob stays covered

## Verification
- `pnpm exec tsx --test tests/root-test-build-contract.test.ts`
- `pnpm exec tsx --test 'integrations/amb/*.test.mjs'`\n- `npm run preflight:quick`\n- `clawpatch review --feature feat_test-suite_84ae84a25a --jobs 1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the default `pnpm test` surface area to include AMB integration tests, which can affect CI runtime and introduce environment-dependent behavior (mitigated by skipping Codex/uv-dependent cases when unavailable).
> 
> **Overview**
> **Root test suite now runs AMB integration tests.** The `pnpm test` script is extended to include the `integrations/amb/*.test.mjs` glob, and the root test-script contract test is updated to enforce that coverage.
> 
> **AMB tests become more CI-friendly.** `install-remnic-provider.test.mjs` adds a `commandExists` check and conditionally skips Codex/uv-dependent `check-remnic-run` tests when required executables are not available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aafed993d08b10ad3a9b5827e84b543fd458e537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->