### PR TITLE
fix(config): keep root tsconfig typecheck-only

### DIFF
--- a/tests/root-tsconfig-contract.test.ts
+++ b/tests/root-tsconfig-contract.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("root tsconfig is typecheck-only when package path aliases point at source files", () => {
+  const tsconfig = JSON.parse(readFileSync(join(repoRoot, "tsconfig.json"), "utf8")) as {
+    compilerOptions?: {
+      noEmit?: boolean;
+      paths?: Record<string, string[]>;
+    };
+  };
+
+  const paths = tsconfig.compilerOptions?.paths ?? {};
+  const sourceAliases = Object.entries(paths).filter(([, targets]) =>
+    targets.some((target) => target.includes("/src/") || target.endsWith("/src/index.ts")),
+  );
+
+  assert.notEqual(sourceAliases.length, 0, "expected root tsconfig to define source-backed package aliases");
+  assert.equal(
+    tsconfig.compilerOptions?.noEmit,
+    true,
+    "root tsconfig must stay typecheck-only so source-backed aliases are not emitted into release output",
+  );
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "noEmit": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary
- mark the root `tsconfig.json` as `noEmit` so source-backed path aliases stay typecheck-only
- add a root tsconfig contract test that prevents source-backed aliases from becoming release emit output

Closes clawpatch finding `fnd_sig-feat-config-0c1c23856a-9053a_546b77c6f6`.

## Verification
- `pnpm exec tsx --test tests/root-tsconfig-contract.test.ts`
- `npm_config_workspace_concurrency=1 npm run check-types`
- `node packages/remnic-core/scripts/ensure-better-sqlite3.mjs`
- `npm_config_workspace_concurrency=1 npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration-only change plus a small test; main impact is build/typecheck behavior by ensuring the root `tsconfig.json` never emits output.
> 
> **Overview**
> Ensures the root `tsconfig.json` is *typecheck-only* by setting `compilerOptions.noEmit: true`, preventing source-backed `paths` aliases (pointing into `packages/*/src`) from being emitted into release artifacts.
> 
> Adds `tests/root-tsconfig-contract.test.ts` to enforce this contract by asserting at least one source-backed alias exists and `noEmit` remains enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5828f37a4531e5ee436550aec78608a7bcea198a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->