### PR TITLE
fix(cli): honor fallback bench run scoping

### DIFF
--- a/evals/benchmarks/ama-bench/runner.ts
+++ b/evals/benchmarks/ama-bench/runner.ts
@@ -66,7 +66,7 @@ async function loadDataset(datasetDir: string, limit?: number): Promise<AMABench
       .filter((l) => l.trim())
       .map((l) => JSON.parse(l) as AMABenchEpisode);
     console.log(`  Loaded ${episodes.length} episodes (${episodes.reduce((s, e) => s + e.qa_pairs.length, 0)} QA pairs)`);
-    return limit ? episodes.slice(0, limit) : episodes;
+    return limit !== undefined ? episodes.slice(0, limit) : episodes;
   } catch {
     throw new Error(
       `AMA-Bench dataset not found at ${filePath}. Download with:\n` +

--- a/evals/benchmarks/amemgym/runner.ts
+++ b/evals/benchmarks/amemgym/runner.ts
@@ -81,7 +81,7 @@ async function loadDataset(datasetDir: string, limit?: number): Promise<AMemGymP
       const raw = await readFile(path.join(datasetDir, filename), "utf-8");
       const data: AMemGymProfile[] = JSON.parse(raw);
       console.log(`  Loaded ${data.length} user profiles (${data.reduce((s, p) => s + p.qas.length, 0)} QA pairs)`);
-      return limit ? data.slice(0, limit) : data;
+      return limit !== undefined ? data.slice(0, limit) : data;
     } catch {
       continue;
     }

--- a/evals/benchmarks/locomo/runner.ts
+++ b/evals/benchmarks/locomo/runner.ts
@@ -117,7 +117,7 @@ async function run(
   const overallStart = performance.now();
 
   // Limit applies to conversations (each has ~200 QA pairs)
-  const convsToRun = options.limit ? conversations.slice(0, options.limit) : conversations;
+  const convsToRun = options.limit !== undefined ? conversations.slice(0, options.limit) : conversations;
 
   for (let ci = 0; ci < convsToRun.length; ci++) {
     const conv = convsToRun[ci];

--- a/evals/benchmarks/longmemeval/runner.ts
+++ b/evals/benchmarks/longmemeval/runner.ts
@@ -57,7 +57,7 @@ async function loadDataset(datasetDir: string, limit?: number): Promise<LongMemE
       const raw = await readFile(path.join(datasetDir, filename), "utf-8");
       const data: LongMemEvalItem[] = JSON.parse(raw);
       console.log(`  Loaded ${data.length} questions from ${filename}`);
-      return limit ? data.slice(0, limit) : data;
+      return limit !== undefined ? data.slice(0, limit) : data;
     } catch {
       continue;
     }

--- a/evals/benchmarks/memory-arena/runner.ts
+++ b/evals/benchmarks/memory-arena/runner.ts
@@ -65,7 +65,7 @@ async function loadDataset(datasetDir: string, limit?: number): Promise<DomainDa
       .split("\n")
       .filter((l) => l.trim())
       .map((l) => JSON.parse(l) as ArenaTask);
-    if (limit) tasks = tasks.slice(0, limit);
+    if (limit !== undefined) tasks = tasks.slice(0, limit);
     domains.push({ domain, tasks });
     console.log(`  [memory-arena] ${domain}: ${tasks.length} tasks`);
   }

--- a/packages/remnic-cli/src/bench-fallback.test.ts
+++ b/packages/remnic-cli/src/bench-fallback.test.ts
@@ -10,7 +10,7 @@ import {
   findUnsupportedFallbackBenchOptions,
   resolveFallbackBenchResultPath,
 } from "./bench-fallback.js";
-import type { ParsedBenchArgs } from "./bench-args.js";
+import { parseBenchArgs, type ParsedBenchArgs } from "./bench-args.js";
 
 function createParsedBenchArgs(overrides: Partial<ParsedBenchArgs> = {}): ParsedBenchArgs {
   return {
@@ -49,6 +49,52 @@ test("buildBenchRunnerArgs forwards a run-scoped output directory", () => {
   ]);
 });
 
+test("buildBenchRunnerArgs forwards an explicit fallback run limit", () => {
+  const parsed = parseBenchArgs(["run", "locomo", "--limit", "5"]);
+
+  const args = buildBenchRunnerArgs(parsed, "locomo", "/tmp/remnic-bench/fallback-runs/locomo");
+
+  assert.deepEqual(args, [
+    "--benchmark",
+    "locomo",
+    "--limit",
+    "5",
+    "--output-dir",
+    "/tmp/remnic-bench/fallback-runs/locomo",
+  ]);
+});
+
+test("buildBenchRunnerArgs preserves an explicit zero fallback run limit", () => {
+  const parsed = parseBenchArgs(["run", "locomo", "--limit", "0"]);
+
+  const args = buildBenchRunnerArgs(parsed, "locomo", "/tmp/remnic-bench/fallback-runs/locomo");
+
+  assert.deepEqual(args, [
+    "--benchmark",
+    "locomo",
+    "--limit",
+    "0",
+    "--output-dir",
+    "/tmp/remnic-bench/fallback-runs/locomo",
+  ]);
+});
+
+test("buildBenchRunnerArgs lets explicit limits override quick-mode fallback limit", () => {
+  const parsed = parseBenchArgs(["run", "locomo", "--quick", "--limit", "5"]);
+
+  const args = buildBenchRunnerArgs(parsed, "locomo", "/tmp/remnic-bench/fallback-runs/locomo");
+
+  assert.deepEqual(args, [
+    "--benchmark",
+    "locomo",
+    "--lightweight",
+    "--limit",
+    "5",
+    "--output-dir",
+    "/tmp/remnic-bench/fallback-runs/locomo",
+  ]);
+});
+
 test("findUnsupportedFallbackBenchOptions rejects package-only timeout options", () => {
   const parsed = createParsedBenchArgs({
     drainTimeout: 1,
@@ -58,6 +104,24 @@ test("findUnsupportedFallbackBenchOptions rejects package-only timeout options",
   assert.deepEqual(findUnsupportedFallbackBenchOptions(parsed), [
     "--drain-timeout",
     "--max-429-wait",
+  ]);
+});
+
+test("findUnsupportedFallbackBenchOptions rejects package-only run scoping options", () => {
+  const parsed = createParsedBenchArgs({
+    publishedTrialLimit: 2,
+    publishedTrialConcurrency: 3,
+    publishedIngestConcurrency: 4,
+    publishedTaskFilter: "task-1",
+    publishedSeed: 5,
+  });
+
+  assert.deepEqual(findUnsupportedFallbackBenchOptions(parsed), [
+    "--trial-limit",
+    "--trial-concurrency",
+    "--ingest-concurrency",
+    "--task-filter",
+    "--seed",
   ]);
 });
 

--- a/packages/remnic-cli/src/bench-fallback.ts
+++ b/packages/remnic-cli/src/bench-fallback.ts
@@ -12,7 +12,12 @@ export function buildBenchRunnerArgs(
 ): string[] {
   const args = ["--benchmark", benchmarkId];
   if (parsed.quick) {
-    args.push("--lightweight", "--limit", "1");
+    args.push("--lightweight");
+  }
+  if (parsed.publishedLimit !== undefined) {
+    args.push("--limit", String(parsed.publishedLimit));
+  } else if (parsed.quick) {
+    args.push("--limit", "1");
   }
   if (parsed.datasetDir) {
     args.push("--dataset-dir", parsed.datasetDir);
@@ -60,6 +65,11 @@ export function findUnsupportedFallbackBenchOptions(parsed: ParsedBenchArgs): st
   add(parsed.requestTimeout !== undefined, "--request-timeout");
   add(parsed.drainTimeout !== undefined, "--drain-timeout");
   add(parsed.max429WaitMs !== undefined, "--max-429-wait");
+  add(parsed.publishedTrialLimit !== undefined, "--trial-limit");
+  add(parsed.publishedTrialConcurrency !== undefined, "--trial-concurrency");
+  add(parsed.publishedIngestConcurrency !== undefined, "--ingest-concurrency");
+  add(parsed.publishedTaskFilter !== undefined, "--task-filter");
+  add(parsed.publishedSeed !== undefined, "--seed");
 
   return unsupported;
 }

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -37,7 +37,7 @@ test("bench surface publishes the phase-1 benchmark catalog and quick-run fallba
   ]) {
     assert.match(source, new RegExp(`"${datasetBenchmarkId}"`));
   }
-  assert.match(fallbackSource, /args\.push\("--lightweight", "--limit", "1"\)/);
+  assert.match(fallbackSource, /if \(parsed\.quick\) \{\s*args\.push\("--lightweight"\);\s*\}[\s\S]*else if \(parsed\.quick\) \{\s*args\.push\("--limit", "1"\);\s*\}/);
   assert.match(fallbackSource, /args\.push\("--dataset-dir", parsed\.datasetDir\)/);
   assert.match(source, /Use 'remnic bench list' to see available\./);
 });


### PR DESCRIPTION
## Summary
- forward explicit `bench run --limit` values into the fallback eval runner
- keep quick mode lightweight while allowing explicit limits to override the quick default
- reject package-only fallback run controls that the eval runner cannot honor

Closes clawpatch finding `fnd_sig-feat-cli-command-7a2b4279cc-_9054e50ee0`.

## Verification
- `pnpm exec tsx --test packages/remnic-cli/src/bench-fallback.test.ts packages/remnic-cli/src/bench-args.test.ts`
- `node packages/remnic-core/scripts/ensure-better-sqlite3.mjs`
- `npm_config_workspace_concurrency=1 npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI fallback argument construction and dataset slicing guards, mainly affecting how `--limit` and quick-mode defaults are interpreted.
> 
> **Overview**
> Fixes fallback benchmark runs so an explicitly provided `bench run --limit` (including `0`) is forwarded to the eval runner, while quick mode still enables `--lightweight` and only defaults to `--limit 1` when no explicit limit is set.
> 
> Updates multiple benchmark runners to treat `limit=0` as a real value by switching from truthy checks to `limit !== undefined` when slicing datasets. Also expands fallback validation to reject package-only run-scoping flags (`--trial-limit`, `--trial-concurrency`, `--ingest-concurrency`, `--task-filter`, `--seed`) that the fallback runner can’t honor, and adds/adjusts tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919ee18a2d49f1655ddab937ed6e875bfc52f4f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->