### PR TITLE
fix(config): clean workspace package dist artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ preflight-quick:
 	pnpm preflight:quick
 
 clean:
-	rm -rf dist/
+	rm -rf dist/ packages/*/dist

--- a/tests/make-clean-contract.test.ts
+++ b/tests/make-clean-contract.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("make clean removes root and workspace package dist artifacts", () => {
+  const makefile = readFileSync(join(repoRoot, "Makefile"), "utf8");
+
+  assert.match(makefile, /^clean:\n\trm -rf dist\/ packages\/\*\/dist$/m);
+});


### PR DESCRIPTION
## Summary
- extend `make clean` to remove workspace package `dist` directories as well as root `dist`
- add a Makefile contract test for root and package clean behavior

## Verification
- `pnpm exec tsx --test tests/make-clean-contract.test.ts`
- `mkdir -p dist packages/remnic-core/dist && make clean && test ! -e dist && test ! -e packages/remnic-core/dist`
- `npm run preflight:quick`
- `clawpatch review --feature feat_config_0902ad7be8 --jobs 1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build tooling change; primary risk is the broader `rm -rf` glob potentially deleting unintended `packages/*/dist` directories if the workspace layout changes.
> 
> **Overview**
> Updates `make clean` to remove both the root `dist/` and all workspace package build outputs under `packages/*/dist`.
> 
> Adds a Node-based contract test (`tests/make-clean-contract.test.ts`) that asserts the Makefile’s `clean` target matches the expected `rm -rf dist/ packages/*/dist` command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34be5b22360e8576ad6e8e36b6b5cb7e642a3340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->