### PR TITLE
fix(evals): reject invalid legacy limits

### DIFF
--- a/evals/run.ts
+++ b/evals/run.ts
@@ -41,6 +41,20 @@ function hasFlag(flag: string): boolean {
   return process.argv.includes(flag);
 }
 
+function parseLimitArg(value: string | undefined, isPresent: boolean): number | undefined {
+  if (!isPresent) {
+    return undefined;
+  }
+  if (value === undefined || !/^(0|[1-9]\d*)$/.test(value)) {
+    throw new Error("--limit must be a non-negative integer (use 0 to load zero items).");
+  }
+  const limit = Number(value);
+  if (!Number.isSafeInteger(limit)) {
+    throw new Error("--limit must be a safe non-negative integer.");
+  }
+  return limit;
+}
+
 async function main(): Promise<void> {
   if (hasFlag("--help") || hasFlag("-h")) {
     console.log(`
@@ -92,7 +106,14 @@ Options:
   const mcpUrl = readArg("--mcp-url") ?? "http://localhost:18789";
   const mcpToken = readArg("--mcp-token");
   const limitStr = readArg("--limit");
-  const limit = limitStr ? parseInt(limitStr, 10) : undefined;
+  let limit: number | undefined;
+  try {
+    limit = parseLimitArg(limitStr, hasFlag("--limit"));
+  } catch (err) {
+    console.error(`ERROR: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+    return;
+  }
   const datasetDirOverride = readArg("--dataset-dir");
   const outputDir =
     readArg("--output-dir") ??

--- a/tests/evals-run-surface.test.ts
+++ b/tests/evals-run-surface.test.ts
@@ -32,3 +32,24 @@ test("eval runner rejects dataset overrides when benchmark=all", async () => {
     /--dataset-dir cannot be used with --benchmark all/i,
   );
 });
+
+test("eval runner rejects invalid legacy limit values before running benchmarks", () => {
+  const tsxPath = path.resolve("node_modules/.bin/tsx");
+
+  for (const limit of ["abc", "-1", "1.5", "--dataset-dir"]) {
+    const result = spawnSync(
+      tsxPath,
+      ["evals/run.ts", "--benchmark", "longmemeval", "--limit", limit],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      },
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(
+      `${result.stdout}\n${result.stderr}`,
+      /--limit must be a non-negative integer/i,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- validate the legacy eval runner `--limit` flag before benchmark execution
- reject missing, negative, decimal, and non-numeric limit values while preserving `--limit 0`
- cover invalid direct legacy invocations in `tests/evals-run-surface.test.ts`

## Verification
- `pnpm exec tsx --test tests/evals-run-surface.test.ts`
- `node packages/remnic-core/scripts/ensure-better-sqlite3.mjs && npm_config_workspace_concurrency=1 npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI argument validation and an added surface test, with no impact on benchmark logic beyond rejecting bad inputs earlier.
> 
> **Overview**
> **Tightens validation for the legacy eval runner `--limit` flag.** `evals/run.ts` now explicitly distinguishes between an omitted `--limit` and a provided value, rejecting missing/negative/decimal/non-numeric inputs while still allowing `--limit 0`, and exits early with a clear error message.
> 
> Adds a regression test in `tests/evals-run-surface.test.ts` to ensure invalid `--limit` values fail fast (before benchmarks run).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd1204b84c06993794ac507568d483f05113747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->