### PR TITLE
fix(cli): label engram-access runtime failures

### DIFF
--- a/bin/engram-access.js
+++ b/bin/engram-access.js
@@ -4,12 +4,19 @@
 // users. Identify it as the legacy OpenClaw plugin id so access-cli targets
 // plugins.entries["openclaw-engram"] before falling through to the canonical
 // Remnic entry when both config blocks exist.
-import("../dist/access-cli.js")
-  .then(({ runCli }) =>
-    runCli(process.argv.slice(2), { preferredId: "openclaw-engram" }),
-  )
-  .catch((error) => {
-    const message = error instanceof Error ? error.message : "unknown load error";
-    console.error(`access-cli failed to load dist/access-cli.js: ${message}`);
-    process.exit(1);
-  });
+let accessCli;
+try {
+  accessCli = await import("../dist/access-cli.js");
+} catch (error) {
+  const message = error instanceof Error ? error.message : "unknown load error";
+  console.error(`access-cli failed to load dist/access-cli.js: ${message}`);
+  process.exit(1);
+}
+
+try {
+  await accessCli.runCli(process.argv.slice(2), { preferredId: "openclaw-engram" });
+} catch (error) {
+  const message = error instanceof Error ? error.message : "unknown error";
+  console.error(`engram-access failed: ${message}`);
+  process.exit(1);
+}

--- a/packages/shim-openclaw-engram/bin/engram-access.js
+++ b/packages/shim-openclaw-engram/bin/engram-access.js
@@ -7,12 +7,19 @@
 // store during migration when both blocks exist with no plugins.slots.memory
 // override (#403).  The id is hardcoded (not imported from @remnic/core)
 // because the shim *is* the legacy alias — the string is its identity.
-import("../dist/access-cli.js")
-  .then(({ runCli }) =>
-    runCli(process.argv.slice(2), { preferredId: "openclaw-engram" }),
-  )
-  .catch((error) => {
-    const message = error instanceof Error ? error.message : "unknown load error";
-    console.error(`access-cli failed to load dist/access-cli.js: ${message}`);
-    process.exit(1);
-  });
+let accessCli;
+try {
+  accessCli = await import("../dist/access-cli.js");
+} catch (error) {
+  const message = error instanceof Error ? error.message : "unknown load error";
+  console.error(`access-cli failed to load dist/access-cli.js: ${message}`);
+  process.exit(1);
+}
+
+try {
+  await accessCli.runCli(process.argv.slice(2), { preferredId: "openclaw-engram" });
+} catch (error) {
+  const message = error instanceof Error ? error.message : "unknown error";
+  console.error(`engram-access failed: ${message}`);
+  process.exit(1);
+}

--- a/tests/engram-access-bin-errors.test.ts
+++ b/tests/engram-access-bin-errors.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+import { tmpdir } from "node:os";
+
+const rootBinPath = new URL("../bin/engram-access.js", import.meta.url);
+const shimBinPath = new URL("../packages/shim-openclaw-engram/bin/engram-access.js", import.meta.url);
+
+for (const [label, sourceBinPath] of [
+  ["root", rootBinPath],
+  ["shim", shimBinPath],
+] as const) {
+  test(`${label} engram-access reports runCli failures separately from load failures`, async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "engram-access-bin-"));
+    try {
+      const tempBinDir = join(tempRoot, "bin");
+      const tempDistDir = join(tempRoot, "dist");
+      const tempBinPath = join(tempBinDir, "engram-access.js");
+      await mkdir(tempBinDir, { recursive: true });
+      await mkdir(tempDistDir, { recursive: true });
+      await copyFile(sourceBinPath, tempBinPath);
+      await writeFile(join(tempRoot, "package.json"), '{"type":"module"}\n');
+      await writeFile(
+        join(tempDistDir, "access-cli.js"),
+        [
+          "export async function runCli() {",
+          '  throw new Error("runtime failure after import");',
+          "}",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, [tempBinPath], {
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /engram-access failed: runtime failure after import/);
+      assert.doesNotMatch(result.stderr, /failed to load dist\/access-cli\.js/);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- split legacy engram-access wrapper import failures from runCli runtime failures
- apply the same behavior to the root wrapper and the openclaw-engram shim wrapper
- add a regression test that stubs a successfully imported access-cli module whose runCli rejects

## Verification
- pnpm exec tsx --test tests/engram-access-bin-errors.test.ts
- npm run preflight:quick
- clawpatch review --feature feat_cli-command_362ce05acf --jobs 1

Clawpatch report: .clawpatch/reports/20260519T075528-2a4c75.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to legacy CLI wrapper error handling and add a regression test; no core business logic is modified.
> 
> **Overview**
> **Improves error reporting for the legacy `engram-access` wrappers.** Both the root `bin/engram-access.js` and the `shim-openclaw-engram` wrapper now handle `import("../dist/access-cli.js")` failures separately from `runCli` execution failures, emitting distinct messages (`access-cli failed to load...` vs `engram-access failed...`) and exiting with code 1.
> 
> Adds `tests/engram-access-bin-errors.test.ts`, which stubs a successfully imported `dist/access-cli.js` whose `runCli` throws, and asserts the wrappers report the runtime failure without incorrectly claiming an import/load failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a82f8acdbacd9b2d831a7060860c6b3dbecee2ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->