### PR TITLE
fix(cli): reject stray import arguments

### DIFF
--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -173,7 +173,14 @@ describe("parseImportArgs", () => {
   it("rejects unknown flags rather than silently ignoring", () => {
     assert.throws(
       () => parseImportArgs(["--adapter", "chatgpt", "--unknown-opt", "x"]),
-      /Unknown flag/,
+      /Unknown argument/,
+    );
+  });
+
+  it("rejects stray positional arguments rather than silently dropping them", () => {
+    assert.throws(
+      () => parseImportArgs(["--adapter", "chatgpt", "/tmp/export.json"]),
+      /Unknown argument.*\/tmp\/export\.json/,
     );
   });
 
@@ -467,7 +474,19 @@ describe("parseImportBundleArgs", () => {
           "/tmp/bundle",
           "--bogus",
         ]),
-      /Unknown flag/,
+      /Unknown argument/,
+    );
+  });
+
+  it("rejects extra positional arguments in bundle mode", () => {
+    assert.throws(
+      () =>
+        parseImportBundleArgs([
+          "--all-from-bundle",
+          "/tmp/bundle",
+          "/tmp/other",
+        ]),
+      /Unknown argument.*\/tmp\/other/,
     );
   });
 });

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -193,14 +193,12 @@ export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
   const dryRun = consumeFlag(args, "--dry-run");
   const includeConversations = consumeFlag(args, "--include-conversations");
 
-  // Any remaining unknown --flag tokens should be rejected rather than
-  // silently ignored (CLAUDE.md rule 51). We allow positional leftovers to
-  // pass through untouched because adapters may define their own hints in
-  // future slices.
-  const unknownFlags = args.filter((a) => a.startsWith("--"));
-  if (unknownFlags.length > 0) {
+  // Any remaining tokens should be rejected rather than silently ignored
+  // (CLAUDE.md rule 51). There is no structured passthrough field in the
+  // returned args, so accepting positional leftovers would discard them.
+  if (args.length > 0) {
     throw new Error(
-      `Unknown flag(s) for 'remnic import': ${unknownFlags.join(", ")}. ` +
+      `Unknown argument(s) for 'remnic import': ${args.join(", ")}. ` +
         `Run 'remnic import --help' for the full option list.`,
     );
   }
@@ -362,10 +360,9 @@ export function parseImportBundleArgs(
   const dryRun = consumeFlag(args, "--dry-run");
   const includeConversations = consumeFlag(args, "--include-conversations");
 
-  const unknownFlags = args.filter((a) => a.startsWith("--"));
-  if (unknownFlags.length > 0) {
+  if (args.length > 0) {
     throw new Error(
-      `Unknown flag(s) for 'remnic import --all-from-bundle': ${unknownFlags.join(", ")}.`,
+      `Unknown argument(s) for 'remnic import --all-from-bundle': ${args.join(", ")}.`,
     );
   }
 


### PR DESCRIPTION
## Summary
- reject leftover positional tokens in single-adapter import parsing instead of silently dropping them
- reject extra positional tokens in --all-from-bundle parsing as well
- add parser regression coverage for both paths

## Verification
- pnpm exec tsx --test packages/remnic-cli/src/import-dispatch.test.ts
- npm run preflight:quick

Clawpatch source finding: fnd_sig-feat-cli-command-7a2b4279cc-_87a6874d61 (medium, confirmed bug).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI argument parsing to error on any leftover tokens, which may break existing scripts that relied on ignored extra args, but is limited to `remnic import` parsing and covered by new tests.
> 
> **Overview**
> `remnic import` parsing now **rejects any leftover arguments** (including stray positional tokens), instead of only erroring on unknown `--flags` and silently dropping extra values.
> 
> This tightens validation for both single-adapter mode (`parseImportArgs`) and bundle mode (`parseImportBundleArgs`), updates error wording from "Unknown flag" to "Unknown argument", and adds regression tests for unknown flags and extra positional args in both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479b43cc0dd1d370d083ae169b0adbe2bf76adc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->