### PR TITLE
fix(cli): prefer active OpenClaw config path

### DIFF
--- a/packages/plugin-codex/bin/materialize.cjs
+++ b/packages/plugin-codex/bin/materialize.cjs
@@ -100,18 +100,18 @@ function safeErrorDetail(error) {
 function configCandidates(env = process.env) {
   const home = envValue(env, "HOME") || "";
   const openclawConfigPath =
-    envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") ||
     envValue(env, "OPENCLAW_CONFIG_PATH") ||
+    envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") ||
     path.join(home, ".openclaw", "openclaw.json");
   return [
     { path: envValue(env, "REMNIC_CONFIG"), label: "REMNIC_CONFIG" },
     {
       path: openclawConfigPath,
       label:
-        envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
-          ? "OPENCLAW_ENGRAM_CONFIG_PATH"
-          : envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
-            ? "OPENCLAW_CONFIG_PATH"
+        envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
+          ? "OPENCLAW_CONFIG_PATH"
+          : envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
+            ? "OPENCLAW_ENGRAM_CONFIG_PATH"
             : "default OpenClaw config",
     },
     path.join(home, ".config", "remnic", "config.json"),

--- a/packages/remnic-core/src/access-cli.test.ts
+++ b/packages/remnic-core/src/access-cli.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import test from "node:test";
 
 import { main, runCli } from "./access-cli.js";
@@ -125,4 +128,66 @@ test("access-cli rejects confidence outside the documented range", async () => {
     "--confidence",
     "1.1",
   ]);
+});
+
+test("access-cli prefers active OpenClaw config path over legacy config path", async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), "access-cli-config-"));
+  const activeConfigPath = join(tempRoot, "active-openclaw.json");
+  const legacyConfigPath = join(tempRoot, "legacy-openclaw.json");
+  const memoryDir = join(tempRoot, "memory");
+  const previousOpenClawConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const previousOpenClawEngramConfigPath = process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+  let output = "";
+  const originalStdoutWrite = process.stdout.write;
+
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    await writeFile(
+      activeConfigPath,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "openclaw-remnic": {
+              config: {
+                memoryDir,
+              },
+            },
+          },
+        },
+      }),
+    );
+    await writeFile(legacyConfigPath, "{not valid json");
+
+    process.env.OPENCLAW_CONFIG_PATH = activeConfigPath;
+    process.env.OPENCLAW_ENGRAM_CONFIG_PATH = legacyConfigPath;
+
+    await main([
+      "store",
+      "--content",
+      "hello",
+      "--category",
+      "fact",
+      "--dry-run",
+    ]);
+
+    assert.match(output, /"operation": "memory_store"/);
+    assert.match(output, /"dryRun": true/);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    if (previousOpenClawConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = previousOpenClawConfigPath;
+    }
+    if (previousOpenClawEngramConfigPath === undefined) {
+      delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_ENGRAM_CONFIG_PATH = previousOpenClawEngramConfigPath;
+    }
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/access-cli.ts
+++ b/packages/remnic-core/src/access-cli.ts
@@ -300,8 +300,8 @@ function parseFloatOption(
 
 function loadPluginConfig(preferredId?: string): Record<string, unknown> {
   const configPath =
-    readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH") ||
     readEnvVar("OPENCLAW_CONFIG_PATH") ||
+    readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH") ||
     path.join(resolveHomeDir(), ".openclaw", "openclaw.json");
   const raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
   // Delegate slot → preferredId → PLUGIN_ID → LEGACY_PLUGIN_ID resolution to

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -384,8 +384,8 @@ export interface OperatorRepairOptions {
 function resolveConfigPath(explicitPath?: string): string {
   if (explicitPath && explicitPath.trim().length > 0) return explicitPath.trim();
   const configured =
-    readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH") ||
-    readEnvVar("OPENCLAW_CONFIG_PATH");
+    readEnvVar("OPENCLAW_CONFIG_PATH") ||
+    readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH");
   if (configured && configured.trim().length > 0) return configured.trim();
   return path.join(resolveHomeDir(), ".openclaw", "openclaw.json");
 }

--- a/packages/remnic-core/src/opik-exporter.test.ts
+++ b/packages/remnic-core/src/opik-exporter.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createOpikExporter } from "./opik-exporter.js";
+import type { LoggerBackend } from "./logger.js";
+
+const silentLogger: LoggerBackend = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+test("createOpikExporter prefers active OpenClaw config path over legacy config path", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-opik-config-path-"));
+  const activeConfigPath = path.join(root, "active-openclaw.json");
+  const legacyConfigPath = path.join(root, "legacy-openclaw.json");
+  const previousOpenClawConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const previousOpenClawEngramConfigPath = process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+
+  try {
+    await writeFile(
+      activeConfigPath,
+      JSON.stringify({
+        plugins: {
+          entries: {
+            "opik-openclaw": {
+              enabled: true,
+              config: {
+                apiUrl: "https://opik-active.example/api",
+                projectName: "active-project",
+                workspaceName: "active-workspace",
+                apiKey: "active-key",
+              },
+            },
+          },
+        },
+      }),
+      "utf8",
+    );
+    await writeFile(legacyConfigPath, "{not valid json", "utf8");
+
+    process.env.OPENCLAW_CONFIG_PATH = activeConfigPath;
+    process.env.OPENCLAW_ENGRAM_CONFIG_PATH = legacyConfigPath;
+
+    const exporter = createOpikExporter({}, silentLogger);
+    assert.ok(exporter, "expected Opik exporter to auto-detect active config");
+    assert.deepEqual((exporter as any).cfg, {
+      enabled: true,
+      apiUrl: "https://opik-active.example/api",
+      projectName: "active-project",
+      workspaceName: "active-workspace",
+      apiKey: "active-key",
+      traceRecallContent: false,
+    });
+  } finally {
+    if (previousOpenClawConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = previousOpenClawConfigPath;
+    }
+    if (previousOpenClawEngramConfigPath === undefined) {
+      delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_ENGRAM_CONFIG_PATH = previousOpenClawEngramConfigPath;
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/opik-exporter.ts
+++ b/packages/remnic-core/src/opik-exporter.ts
@@ -85,8 +85,8 @@ export interface OpikExporterConfig {
 function readOpikOpenclawConfig(log?: LoggerBackend): Partial<OpikExporterConfig> {
   try {
     const configPath =
-      readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH") ||
       readEnvVar("OPENCLAW_CONFIG_PATH") ||
+      readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH") ||
       path.join(resolveHomeDir(), ".openclaw", "openclaw.json");
     const raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
     const entry = raw?.plugins?.entries?.["opik-openclaw"];

--- a/scripts/codex-materialize.ts
+++ b/scripts/codex-materialize.ts
@@ -103,18 +103,18 @@ export function configCandidates(
 ): ConfigCandidate[] {
   const home = envValue(env, "HOME") ?? "";
   const openclawConfigPath =
-    envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") ??
     envValue(env, "OPENCLAW_CONFIG_PATH") ??
+    envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") ??
     path.join(home, ".openclaw", "openclaw.json");
   return [
     { path: envValue(env, "REMNIC_CONFIG"), label: "REMNIC_CONFIG" },
     {
       path: openclawConfigPath,
       label:
-        envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
-          ? "OPENCLAW_ENGRAM_CONFIG_PATH"
-          : envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
-            ? "OPENCLAW_CONFIG_PATH"
+        envValue(env, "OPENCLAW_CONFIG_PATH") !== undefined
+          ? "OPENCLAW_CONFIG_PATH"
+          : envValue(env, "OPENCLAW_ENGRAM_CONFIG_PATH") !== undefined
+            ? "OPENCLAW_ENGRAM_CONFIG_PATH"
             : "default OpenClaw config",
     },
     {
@@ -159,7 +159,7 @@ export function loadRawConfig(
   //
   // Order of precedence:
   //   1. `REMNIC_CONFIG` env var (developer escape hatch)
-  //   2. `OPENCLAW_ENGRAM_CONFIG_PATH` / `OPENCLAW_CONFIG_PATH` — the same
+  //   2. `OPENCLAW_CONFIG_PATH` / `OPENCLAW_ENGRAM_CONFIG_PATH` — the same
   //      env vars the Remnic plugin reads at runtime
   //   3. `~/.openclaw/openclaw.json` — standard OpenClaw install location
   //   4. Legacy `~/.config/remnic/config.json`, `~/.config/engram/config.json`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,8 +288,8 @@ function buildServiceKeys(serviceId: string): ServiceKeys {
 function loadPluginEntryFromFile(pluginId?: string): Record<string, unknown> | undefined {
   try {
     const explicitConfigPath =
-      readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH") ||
-      readEnvVar("OPENCLAW_CONFIG_PATH");
+      readEnvVar("OPENCLAW_CONFIG_PATH") ||
+      readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH");
     const homeDir = resolveHomeDir();
     const configPath =
       explicitConfigPath && explicitConfigPath.length > 0
@@ -317,8 +317,8 @@ function loadPluginConfigFromFile(pluginId?: string): Record<string, unknown> | 
 function loadRawConfigFromFile(): Record<string, unknown> | undefined {
   try {
     const explicitConfigPath =
-      readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH") ||
-      readEnvVar("OPENCLAW_CONFIG_PATH");
+      readEnvVar("OPENCLAW_CONFIG_PATH") ||
+      readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH");
     const homeDir = resolveHomeDir();
     const configPath =
       explicitConfigPath && explicitConfigPath.length > 0

--- a/tests/codex-materialize-config-resolution.test.ts
+++ b/tests/codex-materialize-config-resolution.test.ts
@@ -77,7 +77,7 @@ for (const [name, loadRawConfig] of loaders) {
     });
   });
 
-  test(`${name} keeps OPENCLAW_ENGRAM_CONFIG_PATH ahead of OPENCLAW_CONFIG_PATH`, () => {
+  test(`${name} keeps OPENCLAW_CONFIG_PATH ahead of OPENCLAW_ENGRAM_CONFIG_PATH`, () => {
     withTempDir((dir) => {
       const primaryPath = path.join(dir, "primary.json");
       const legacyPath = path.join(dir, "legacy.json");
@@ -89,8 +89,8 @@ for (const [name, loadRawConfig] of loaders) {
         OPENCLAW_CONFIG_PATH: primaryPath,
         OPENCLAW_ENGRAM_CONFIG_PATH: legacyPath,
       });
-      assert.equal(raw.marker, "legacy");
-      assert.equal(raw.memoryDir, "/tmp/legacy");
+      assert.equal(raw.marker, "primary");
+      assert.equal(raw.memoryDir, "/tmp/primary");
     });
   });
 

--- a/tests/sdk-compat-hook-handlers.test.ts
+++ b/tests/sdk-compat-hook-handlers.test.ts
@@ -513,9 +513,10 @@ test("before_prompt_build still prepends Remnic active recall when chaining is d
   assert.match(String(result?.prependSystemContext ?? ""), /remembered context from Remnic/);
 });
 
-test("before_prompt_build falls back to file-backed active-memory config when api.config is partial", async () => {
+test("before_prompt_build prefers active OpenClaw config path for file-backed active-memory config", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-active-recall-file-collision-"));
   const configPath = path.join(root, "openclaw.json");
+  const legacyConfigPath = path.join(root, "legacy-openclaw.json");
   await writeFile(
     configPath,
     JSON.stringify(
@@ -539,9 +540,11 @@ test("before_prompt_build falls back to file-backed active-memory config when ap
     ),
     "utf8",
   );
+  await writeFile(legacyConfigPath, "{not valid json", "utf8");
 
-  const previousConfigPath = process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
-  process.env.OPENCLAW_ENGRAM_CONFIG_PATH = configPath;
+  const previousConfigPaths = [process.env.OPENCLAW_CONFIG_PATH, process.env.OPENCLAW_ENGRAM_CONFIG_PATH] as const;
+  process.env.OPENCLAW_CONFIG_PATH = configPath;
+  process.env.OPENCLAW_ENGRAM_CONFIG_PATH = legacyConfigPath;
 
   try {
     const { default: plugin } = await import("../src/index.js");
@@ -590,11 +593,8 @@ test("before_prompt_build falls back to file-backed active-memory config when ap
       "expected the file-backed active-memory config to suppress Remnic active recall",
     );
   } finally {
-    if (previousConfigPath === undefined) {
-      delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
-    } else {
-      process.env.OPENCLAW_ENGRAM_CONFIG_PATH = previousConfigPath;
-    }
+    if (previousConfigPaths[0] === undefined) delete process.env.OPENCLAW_CONFIG_PATH; else process.env.OPENCLAW_CONFIG_PATH = previousConfigPaths[0];
+    if (previousConfigPaths[1] === undefined) delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH; else process.env.OPENCLAW_ENGRAM_CONFIG_PATH = previousConfigPaths[1];
   }
 });
 


### PR DESCRIPTION
## Summary
- read OPENCLAW_CONFIG_PATH before legacy OPENCLAW_ENGRAM_CONFIG_PATH in access-cli
- add a regression test that sets both env vars and proves dry-run store uses the active config

## Verification
- pnpm exec tsx --test packages/remnic-core/src/access-cli.test.ts
- node -e "require('better-sqlite3'); console.log('better-sqlite3 ok')"
- npm run preflight:quick

Clawpatch source finding: fnd_sig-feat-cli-command-97f5c550dc-_ec3126f9ec (medium, confirmed bug).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes environment-variable precedence for loading config, which can alter which config file is used (and fail differently if the legacy path is invalid). Scope is limited to config-path resolution and covered by new tests.
> 
> **Overview**
> **Config-path precedence is flipped to prefer the active OpenClaw env var.** All OpenClaw-config readers in this PR now check `OPENCLAW_CONFIG_PATH` before the legacy `OPENCLAW_ENGRAM_CONFIG_PATH` (including `access-cli`, `operator-toolkit`, Opik exporter auto-detection, the Codex materialize script and packaged binary, and file-backed config loading in `src/index.ts`).
> 
> **Regression coverage added/updated.** New tests assert the active path wins even when the legacy path points to invalid JSON (`access-cli.test.ts`, new `opik-exporter.test.ts`, and updates to existing config-resolution and SDK compat tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498483618584263523ac8646ec7b465d8b332881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->