### PR TITLE
fix(cli): harden clawpatch audit findings

### DIFF
--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -108,6 +108,9 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
   assert.equal(manifest.run.mode, "full");
   assert.match(manifest.run.id, /^20[0-9]{2}-/);
   assert.deepEqual(manifest.run.runtimeProfiles, ["real"]);
+  assert.deepEqual(manifest.run.selectedWorkItems, [
+    { benchmark: "longmemeval", runtimeProfile: "real" },
+  ]);
   assert.equal(manifest.run.seed, 42);
   assert.deepEqual(manifest.command.argv, [
     "bench",
@@ -260,4 +263,29 @@ test("buildBenchmarkReproManifest preserves explicitly empty result paths", asyn
 
   assert.deepEqual(manifest.results, []);
   assert.deepEqual(manifest.run.selectedBenchmarks, []);
+});
+
+test("buildBenchmarkReproManifest preserves uneven benchmark/profile work pairings", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-work-items-");
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval", "locomo"],
+    runtimeProfiles: ["real", "baseline"],
+    selectedWorkItems: [
+      { benchmark: "longmemeval", runtimeProfile: "real" },
+      { benchmark: "locomo", runtimeProfile: "baseline" },
+    ],
+  });
+
+  assert.deepEqual(manifest.run.selectedBenchmarks, ["longmemeval", "locomo"]);
+  assert.deepEqual(manifest.run.runtimeProfiles, ["real", "baseline"]);
+  assert.deepEqual(manifest.run.selectedWorkItems, [
+    { benchmark: "longmemeval", runtimeProfile: "real" },
+    { benchmark: "locomo", runtimeProfile: "baseline" },
+  ]);
 });

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -60,6 +60,10 @@ export interface BenchmarkReproManifest {
     mode?: BenchmarkMode;
     selectedBenchmarks: string[];
     runtimeProfiles: string[];
+    selectedWorkItems: Array<{
+      benchmark: string;
+      runtimeProfile: string;
+    }>;
     limit?: number;
     seed?: number;
   };
@@ -103,6 +107,10 @@ export interface BuildBenchmarkReproManifestOptions {
   runId?: string;
   selectedBenchmarks?: string[];
   runtimeProfiles?: string[];
+  selectedWorkItems?: Array<{
+    benchmark: string;
+    runtimeProfile: string;
+  }>;
   mode?: BenchmarkMode;
   limit?: number;
   seed?: number;
@@ -229,6 +237,7 @@ function buildArtifactHashIdentity(manifest: Omit<BenchmarkReproManifest, "artif
       ...(manifest.run.mode ? { mode: manifest.run.mode } : {}),
       selectedBenchmarks: manifest.run.selectedBenchmarks,
       runtimeProfiles: manifest.run.runtimeProfiles,
+      selectedWorkItems: manifest.run.selectedWorkItems,
       ...(manifest.run.limit !== undefined ? { limit: manifest.run.limit } : {}),
       ...(manifest.run.seed !== undefined ? { seed: manifest.run.seed } : {}),
     },
@@ -485,6 +494,11 @@ export async function buildBenchmarkReproManifest(
   );
   const selectedBenchmarks = options.selectedBenchmarks ??
     [...new Set(loadedResults.map((result) => result.meta.benchmark))].sort();
+  const selectedWorkItems = options.selectedWorkItems ??
+    loadedResults.map((result) => ({
+      benchmark: result.meta.benchmark,
+      runtimeProfile: result.config.runtimeProfile ?? "unknown",
+    }));
   const datasetDirs = options.datasetDirs ?? {};
   const datasets = await Promise.all(
     selectedBenchmarks.map((benchmark) => buildDatasetManifest(benchmark, datasetDirs[benchmark])),
@@ -499,6 +513,7 @@ export async function buildBenchmarkReproManifest(
       ...(options.mode ? { mode: options.mode } : {}),
       selectedBenchmarks,
       runtimeProfiles: options.runtimeProfiles ?? [],
+      selectedWorkItems,
       ...(options.limit !== undefined ? { limit: options.limit } : {}),
       ...(options.seed !== undefined ? { seed: options.seed } : {}),
     },

--- a/packages/connector-weclone/package.json
+++ b/packages/connector-weclone/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsup src/index.ts src/cli.ts --format esm --dts",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/*.test.ts",
+    "test": "npm run build && tsx --test src/*.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/connector-weclone/src/cli.test.ts
+++ b/packages/connector-weclone/src/cli.test.ts
@@ -12,6 +12,18 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
 const tsxCli = join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
 const cliPath = join(__dirname, "cli.ts");
+const builtCliPath = join(__dirname, "..", "dist", "cli.js");
+
+function buildConnectorCli(): void {
+  const result = spawnSync("pnpm", ["--filter", "@remnic/connector-weclone", "build"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+}
 
 function buildCliEnv(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env = { ...process.env };
@@ -40,6 +52,21 @@ function runCliWithConfig(config: unknown) {
   writeFileSync(configPath, JSON.stringify(config), { mode: 0o600 });
   try {
     return spawnSync(process.execPath, [tsxCli, cliPath, "--config", configPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function runBuiltCliWithConfig(config: unknown) {
+  const tempDir = mkdtempSync(join(tmpdir(), "remnic-weclone-built-cli-"));
+  const configPath = join(tempDir, "weclone.json");
+  writeFileSync(configPath, JSON.stringify(config), { mode: 0o600 });
+  try {
+    return spawnSync(process.execPath, [builtCliPath, "--config", configPath], {
       cwd: repoRoot,
       encoding: "utf8",
       timeout: 5_000,
@@ -95,6 +122,20 @@ function deferred<T = void>(): {
 }
 
 describe("remnic-weclone-proxy CLI", () => {
+  it("exercises the built package bin artifact", () => {
+    buildConnectorCli();
+
+    const result = runBuiltCliWithConfig({
+      proxyPort: 8100,
+      remnicDaemonUrl: "http://127.0.0.1:4318",
+    });
+
+    assert.ifError(result.error);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Invalid config at .*weclone\.json:/);
+    assert.match(result.stderr, /wecloneApiUrl/);
+  });
+
   it("prints a controlled error for semantically invalid config", () => {
     const result = runCliWithConfig({
       proxyPort: 8100,

--- a/packages/remnic-cli/bin/engram.cjs
+++ b/packages/remnic-cli/bin/engram.cjs
@@ -13,15 +13,17 @@ const cwd = __dirname;
 const distEntry = resolve(cwd, "../dist/index.js");
 const srcEntry = resolve(cwd, "../src/index.ts");
 
-// Respect user color preferences: only force color if not explicitly disabled
-const colorEnv = {};
-if (!process.env.NO_COLOR && process.env.FORCE_COLOR === undefined) {
-  colorEnv.FORCE_COLOR = "1";
-}
-
 function exitCodeForSignal(signal) {
   const signalNumber = osConstants.signals?.[signal];
   return typeof signalNumber === "number" ? 128 + signalNumber : 1;
+}
+
+function resolveLocalTsx() {
+  const tsxCandidates = [
+    resolve(cwd, "../node_modules/.bin/tsx"),
+    resolve(cwd, "../../../node_modules/.bin/tsx"),
+  ];
+  return tsxCandidates.find((c) => existsSync(c));
 }
 
 try {
@@ -32,22 +34,29 @@ try {
       [distEntry, ...process.argv.slice(2)],
       {
         stdio: "inherit",
-        env: { ...process.env, REMNIC_CLI_BIN: "1", ENGRAM_CLI_BIN: "1", ...colorEnv },
+        env: { ...process.env, REMNIC_CLI_BIN: "1", ENGRAM_CLI_BIN: "1" },
       },
     );
   } else {
     // Development: run TypeScript source via tsx
-    const tsxCandidates = [
-      resolve(cwd, "../node_modules/.bin/tsx"),
-      resolve(cwd, "../../../node_modules/.bin/tsx"),
-    ];
-    const tsxCmd = tsxCandidates.find((c) => existsSync(c)) || "tsx";
+    const hasSrcEntry = existsSync(srcEntry);
+    const tsxCmd = hasSrcEntry ? resolveLocalTsx() : undefined;
+    if (!tsxCmd) {
+      if (hasSrcEntry) {
+        throw new Error(
+          `tsx runtime is missing for source CLI entrypoint: ${srcEntry}. Install dependencies or rebuild @remnic/cli.`,
+        );
+      }
+      throw new Error(
+        `built CLI entrypoint is missing: ${distEntry}. Rebuild or reinstall @remnic/cli.`,
+      );
+    }
     execFileSync(
       tsxCmd,
       [srcEntry, ...process.argv.slice(2)],
       {
         stdio: "inherit",
-        env: { ...process.env, REMNIC_CLI_BIN: "1", ENGRAM_CLI_BIN: "1", ...colorEnv },
+        env: { ...process.env, REMNIC_CLI_BIN: "1", ENGRAM_CLI_BIN: "1" },
       },
     );
   }

--- a/packages/remnic-cli/bin/remnic.cjs
+++ b/packages/remnic-cli/bin/remnic.cjs
@@ -13,31 +13,41 @@ const cwd = __dirname;
 const distEntry = resolve(cwd, "../dist/index.js");
 const srcEntry = resolve(cwd, "../src/index.ts");
 
-const colorEnv = {};
-if (!process.env.NO_COLOR && process.env.FORCE_COLOR === undefined) {
-  colorEnv.FORCE_COLOR = "1";
-}
-
 function exitCodeForSignal(signal) {
   const signalNumber = osConstants.signals?.[signal];
   return typeof signalNumber === "number" ? 128 + signalNumber : 1;
+}
+
+function resolveLocalTsx() {
+  const tsxCandidates = [
+    resolve(cwd, "../node_modules/.bin/tsx"),
+    resolve(cwd, "../../../node_modules/.bin/tsx"),
+  ];
+  return tsxCandidates.find((c) => existsSync(c));
 }
 
 try {
   if (existsSync(distEntry)) {
     execFileSync(process.execPath, [distEntry, ...process.argv.slice(2)], {
       stdio: "inherit",
-      env: { ...process.env, REMNIC_CLI_BIN: "1", ...colorEnv },
+      env: { ...process.env, REMNIC_CLI_BIN: "1" },
     });
   } else {
-    const tsxCandidates = [
-      resolve(cwd, "../node_modules/.bin/tsx"),
-      resolve(cwd, "../../../node_modules/.bin/tsx"),
-    ];
-    const tsxCmd = tsxCandidates.find((c) => existsSync(c)) || "tsx";
+    const hasSrcEntry = existsSync(srcEntry);
+    const tsxCmd = hasSrcEntry ? resolveLocalTsx() : undefined;
+    if (!tsxCmd) {
+      if (hasSrcEntry) {
+        throw new Error(
+          `tsx runtime is missing for source CLI entrypoint: ${srcEntry}. Install dependencies or rebuild @remnic/cli.`,
+        );
+      }
+      throw new Error(
+        `built CLI entrypoint is missing: ${distEntry}. Rebuild or reinstall @remnic/cli.`,
+      );
+    }
     execFileSync(tsxCmd, [srcEntry, ...process.argv.slice(2)], {
       stdio: "inherit",
-      env: { ...process.env, REMNIC_CLI_BIN: "1", ...colorEnv },
+      env: { ...process.env, REMNIC_CLI_BIN: "1" },
     });
   }
 } catch (err) {

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -28,7 +28,7 @@
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "precheck-types": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/*.test.ts ../../tests/remnic-cli-bin-wrapper.test.ts ../../tests/evals-engram-adapter-buffering.test.ts ../../tests/shim-openclaw-engram-package.test.ts ../../tests/engram-access-bin-errors.test.ts",
+    "test": "cd ../.. && tsx --test packages/remnic-cli/src/*.test.ts tests/remnic-cli-bin-wrapper.test.ts tests/evals-engram-adapter-buffering.test.ts tests/shim-openclaw-engram-package.test.ts tests/engram-access-bin-errors.test.ts tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts tests/bench-remnic-deterministic-runners.test.ts tests/bench-remnic-stateful-runners.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parseBenchArgs } from "./bench-args.js";
+import {
+  createBenchWorkItems,
+  deriveRuntimeProfilesFromBenchWorkItems,
+  filterBenchWorkItemsForPreviousStatus,
+  parseBenchArgs,
+} from "./bench-args.js";
 
 test("parseBenchArgs keeps validated matrix profiles typed and ordered", () => {
   const parsed = parseBenchArgs([
@@ -34,6 +39,89 @@ test("parseBenchArgs rejects action-incompatible bench flags", () => {
     () => parseBenchArgs(["run", "locomo", "--format", "json"]),
     /--format is not supported for bench run/,
   );
+});
+
+test("parseBenchArgs treats action help flags as help requests", () => {
+  assert.equal(parseBenchArgs(["run", "--help"]).action, "help");
+  assert.equal(parseBenchArgs(["datasets", "--help"]).action, "help");
+});
+
+test("retry-failed filters matrix work at profile granularity", () => {
+  const workItems = createBenchWorkItems(["locomo"], ["baseline", "real"]);
+  const filtered = filterBenchWorkItemsForPreviousStatus(
+    workItems,
+    [
+      { id: "locomo [baseline]", status: "complete" },
+      { id: "locomo [real]", status: "failed" },
+    ],
+    "retry-failed",
+  );
+
+  assert.deepEqual(filtered, [{ benchmarkId: "locomo", runtimeProfile: "real" }]);
+});
+
+test("retry-failed preserves prior matrix status for single-profile reruns", () => {
+  const workItems = createBenchWorkItems(["locomo"], ["baseline"]);
+  const filtered = filterBenchWorkItemsForPreviousStatus(
+    workItems,
+    [
+      { id: "locomo [baseline]", status: "failed" },
+      { id: "locomo", status: "complete" },
+    ],
+    "retry-failed",
+  );
+
+  assert.deepEqual(filtered, [{ benchmarkId: "locomo", runtimeProfile: "baseline" }]);
+});
+
+test("resume skips only completed matrix profile work", () => {
+  const workItems = createBenchWorkItems(["locomo"], ["baseline", "real"]);
+  const filtered = filterBenchWorkItemsForPreviousStatus(
+    workItems,
+    [
+      { id: "locomo [baseline]", status: "complete" },
+      { id: "locomo [real]", status: "failed" },
+    ],
+    "resume",
+  );
+
+  assert.deepEqual(filtered, [{ benchmarkId: "locomo", runtimeProfile: "real" }]);
+});
+
+test("runtime profiles for repro manifests follow filtered matrix work", () => {
+  const workItems = createBenchWorkItems(["locomo"], ["baseline", "real"]);
+  const filtered = filterBenchWorkItemsForPreviousStatus(
+    workItems,
+    [
+      { id: "locomo [baseline]", status: "complete" },
+      { id: "locomo [real]", status: "failed" },
+    ],
+    "resume",
+  );
+
+  assert.deepEqual(deriveRuntimeProfilesFromBenchWorkItems(filtered), ["real"]);
+});
+
+test("resume treats new matrix profiles as unrun when only bare status exists", () => {
+  const workItems = createBenchWorkItems(["locomo"], ["baseline", "real"]);
+  const filtered = filterBenchWorkItemsForPreviousStatus(
+    workItems,
+    [{ id: "locomo", status: "complete" }],
+    "resume",
+  );
+
+  assert.deepEqual(filtered, workItems);
+});
+
+test("retry-failed expands bare failed status across matrix profiles", () => {
+  const workItems = createBenchWorkItems(["locomo"], ["baseline", "real"]);
+  const filtered = filterBenchWorkItemsForPreviousStatus(
+    workItems,
+    [{ id: "locomo", status: "failed" }],
+    "retry-failed",
+  );
+
+  assert.deepEqual(filtered, workItems);
 });
 
 // ---------- `bench published` (issue #566 PR 4/7) ----------

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -111,6 +111,57 @@ export interface ParsedBenchArgs {
   retryFailed?: boolean;
 }
 
+export interface BenchWorkItem {
+  benchmarkId: string;
+  runtimeProfile: BenchRuntimeProfile;
+}
+
+export interface PreviousBenchStatusEntry {
+  id: string;
+  status: string;
+}
+
+export function createBenchWorkItems(
+  benchmarks: readonly string[],
+  runtimeProfiles: readonly BenchRuntimeProfile[],
+): BenchWorkItem[] {
+  return benchmarks.flatMap((benchmarkId) =>
+    runtimeProfiles.map((runtimeProfile) => ({ benchmarkId, runtimeProfile })),
+  );
+}
+
+export function deriveRuntimeProfilesFromBenchWorkItems(
+  workItems: readonly BenchWorkItem[],
+): BenchRuntimeProfile[] {
+  return [...new Set(workItems.map((item) => item.runtimeProfile))];
+}
+
+export function filterBenchWorkItemsForPreviousStatus(
+  workItems: readonly BenchWorkItem[],
+  previousEntries: readonly PreviousBenchStatusEntry[],
+  mode: "resume" | "retry-failed",
+): BenchWorkItem[] {
+  const statusById = new Map(previousEntries.map((entry) => [entry.id, entry.status]));
+  const hasMatrixWork = new Set(workItems.map((item) => item.benchmarkId)).size !== workItems.length;
+
+  function statusFor(item: BenchWorkItem): string | undefined {
+    const profileStatus = statusById.get(`${item.benchmarkId} [${item.runtimeProfile}]`);
+    if (profileStatus !== undefined) return profileStatus;
+    if (hasMatrixWork) {
+      return mode === "retry-failed" ? statusById.get(item.benchmarkId) : undefined;
+    }
+    return statusById.get(item.benchmarkId);
+  }
+
+  return workItems.filter((item) => {
+    const status = statusFor(item);
+    if (mode === "retry-failed") {
+      return status === "failed";
+    }
+    return status !== "complete";
+  });
+}
+
 export const PUBLISHED_BENCHMARK_NAMES = Object.freeze([
   "ama-bench",
   "memory-arena",
@@ -547,6 +598,16 @@ export function parseBenchActionArgs(argv: string[]): {
 
 export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const { action, args } = parseBenchActionArgs(argv);
+  if (args.includes("--help") || args.includes("-h")) {
+    return {
+      action: "help",
+      benchmarks: [],
+      quick: false,
+      all: false,
+      json: false,
+      detail: false,
+    };
+  }
   const baselineAction =
     action === "baseline"
       ? args[0] === "save" || args[0] === "list"

--- a/packages/remnic-cli/src/cli-args.test.ts
+++ b/packages/remnic-cli/src/cli-args.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasFlag, parseTaxonomyResolveArgs, resolveFlag, stripResolveFlags } from "./cli-args.js";
+
+test("parseTaxonomyResolveArgs captures boolean and value flags", () => {
+  const parsed = parseTaxonomyResolveArgs([
+    "--json",
+    "--category",
+    "preference",
+    "likes",
+    "coffee",
+  ]);
+
+  assert.deepEqual(parsed.textParts, ["likes", "coffee"]);
+  assert.equal(parsed.values["--category"], "preference");
+  assert.equal(parsed.booleans.has("--json"), true);
+});
+
+test("parseTaxonomyResolveArgs rejects unknown flags and missing values", () => {
+  assert.throws(() => parseTaxonomyResolveArgs(["--bogus"]), /Unknown flag: --bogus/);
+  assert.throws(() => parseTaxonomyResolveArgs(["--category"]), /--category requires a value/);
+  assert.throws(() => parseTaxonomyResolveArgs(["--category", "--json"]), /--category requires a value/);
+});
+
+test("stripResolveFlags preserves literal text after --", () => {
+  assert.deepEqual(
+    stripResolveFlags(["--category", "fact", "--", "--literal", "text"]),
+    ["--literal", "text"],
+  );
+});
+
+test("resolveFlag treats a following option token as a missing value", () => {
+  const args = ["--memory-dir", "--format", "json"];
+  const shortOptionArgs = ["--memory-dir", "-h"];
+
+  assert.equal(hasFlag(args, "--memory-dir"), true);
+  assert.equal(resolveFlag(args, "--memory-dir"), undefined);
+  assert.equal(resolveFlag(args, "--format"), "json");
+  assert.equal(resolveFlag(shortOptionArgs, "--memory-dir"), undefined);
+});
+
+test("resolveFlag accepts negative numeric scalar values", () => {
+  const args = ["--priority", "-1", "--threshold", "-.5"];
+
+  assert.equal(resolveFlag(args, "--priority"), "-1");
+  assert.equal(resolveFlag(args, "--threshold"), "-.5");
+});

--- a/packages/remnic-cli/src/cli-args.ts
+++ b/packages/remnic-cli/src/cli-args.ts
@@ -14,7 +14,15 @@
  */
 export function resolveFlag(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
-  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : undefined;
+  if (idx === -1 || idx + 1 >= args.length) return undefined;
+  const value = args[idx + 1];
+  return isOptionToken(value) ? undefined : value;
+}
+
+function isOptionToken(value: string): boolean {
+  if (!value.startsWith("-")) return false;
+  if (/^-\d/.test(value) || /^-\.\d/.test(value)) return false;
+  return true;
 }
 
 /**

--- a/packages/remnic-cli/src/config-path.test.ts
+++ b/packages/remnic-cli/src/config-path.test.ts
@@ -1,16 +1,18 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { resolveConfigPath } from "./index.js";
+import { resolveConfigPath, resolveMemoryDir, resolveSyncSourceDir } from "./index.js";
 
 const ORIGINAL_ENV = {
   HOME: process.env.HOME,
   USERPROFILE: process.env.USERPROFILE,
   REMNIC_CONFIG_PATH: process.env.REMNIC_CONFIG_PATH,
   ENGRAM_CONFIG_PATH: process.env.ENGRAM_CONFIG_PATH,
+  REMNIC_MEMORY_DIR: process.env.REMNIC_MEMORY_DIR,
+  ENGRAM_MEMORY_DIR: process.env.ENGRAM_MEMORY_DIR,
 };
 
 function restoreEnv(): void {
@@ -46,6 +48,44 @@ test("resolveConfigPath expands home-relative CLI paths", async () => {
     restoreEnv();
     await rm(home, { recursive: true, force: true });
   }
+});
+
+test("resolveMemoryDir expands home-relative env and config paths", async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), "remnic-memory-home-"));
+  try {
+    process.env.HOME = home;
+    process.env.REMNIC_MEMORY_DIR = "~/memory";
+    delete process.env.ENGRAM_MEMORY_DIR;
+    delete process.env.ENGRAM_CONFIG_PATH;
+    delete process.env.REMNIC_CONFIG_PATH;
+
+    assert.equal(resolveMemoryDir(), path.join(home, "memory"));
+
+    delete process.env.REMNIC_MEMORY_DIR;
+    process.env.REMNIC_CONFIG_PATH = "~/remnic.json";
+    await writeFile(
+      path.join(home, "remnic.json"),
+      JSON.stringify({ remnic: { memoryDir: "${HOME}/configured-memory" } }),
+    );
+
+    assert.equal(resolveMemoryDir(), path.join(home, "configured-memory"));
+  } finally {
+    restoreEnv();
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("resolveSyncSourceDir rejects bare source flags", () => {
+  assert.equal(resolveSyncSourceDir([]), ".");
+  assert.equal(resolveSyncSourceDir(["--source", "/tmp/source", "--json"]), "/tmp/source");
+  assert.throws(
+    () => resolveSyncSourceDir(["--source"]),
+    /--source requires a value/,
+  );
+  assert.throws(
+    () => resolveSyncSourceDir(["--source", "--json"]),
+    /--source requires a value/,
+  );
 });
 
 test("resolveConfigPath expands home-relative env config paths", async () => {

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -180,7 +180,7 @@ describe("parseImportArgs", () => {
   it("rejects stray positional arguments rather than silently dropping them", () => {
     assert.throws(
       () => parseImportArgs(["--adapter", "chatgpt", "/tmp/export.json"]),
-      /Unknown argument.*\/tmp\/export\.json/,
+      /positional argument '\/tmp\/export\.json'/,
     );
   });
 
@@ -225,6 +225,15 @@ describe("parseImportArgs", () => {
           "--dry-run",
         ]),
       /--file/,
+    );
+  });
+});
+
+describe("parseImportBundleArgs", () => {
+  it("rejects stray positional arguments after the bundle directory", () => {
+    assert.throws(
+      () => parseImportBundleArgs(["--all-from-bundle", "/bundle", "/other"]),
+      /positional argument '\/other'/,
     );
   });
 });
@@ -486,7 +495,7 @@ describe("parseImportBundleArgs", () => {
           "/tmp/bundle",
           "/tmp/other",
         ]),
-      /Unknown argument.*\/tmp\/other/,
+      /positional argument '\/tmp\/other'/,
     );
   });
 });

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -193,15 +193,7 @@ export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
   const dryRun = consumeFlag(args, "--dry-run");
   const includeConversations = consumeFlag(args, "--include-conversations");
 
-  // Any remaining tokens should be rejected rather than silently ignored
-  // (CLAUDE.md rule 51). There is no structured passthrough field in the
-  // returned args, so accepting positional leftovers would discard them.
-  if (args.length > 0) {
-    throw new Error(
-      `Unknown argument(s) for 'remnic import': ${args.join(", ")}. ` +
-        `Run 'remnic import --help' for the full option list.`,
-    );
-  }
+  rejectLeftoverImportArgs(args, "remnic import");
 
   return {
     adapter,
@@ -211,6 +203,21 @@ export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
     rateLimit,
     includeConversations,
   };
+}
+
+function rejectLeftoverImportArgs(args: readonly string[], command: string): void {
+  const unknownFlags = args.filter((arg) => arg.startsWith("--"));
+  const positional = args.filter((arg) => !arg.startsWith("--"));
+  if (unknownFlags.length > 0 || positional.length > 0) {
+    const labels = [
+      ...unknownFlags.map((flag) => `flag ${flag}`),
+      ...positional.map((arg) => `positional argument '${arg}'`),
+    ];
+    throw new Error(
+      `Unknown argument(s) for '${command}': ${labels.join(", ")}. ` +
+        `Run '${command} --help' for the full option list.`,
+    );
+  }
 }
 
 /**
@@ -360,11 +367,7 @@ export function parseImportBundleArgs(
   const dryRun = consumeFlag(args, "--dry-run");
   const includeConversations = consumeFlag(args, "--include-conversations");
 
-  if (args.length > 0) {
-    throw new Error(
-      `Unknown argument(s) for 'remnic import --all-from-bundle': ${args.join(", ")}.`,
-    );
-  }
+  rejectLeftoverImportArgs(args, "remnic import --all-from-bundle");
 
   return {
     bundleDir,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -177,6 +177,9 @@ import {
   type BenchAction,
   type ParsedBenchArgs,
   PUBLISHED_BENCHMARK_NAMES,
+  createBenchWorkItems,
+  deriveRuntimeProfilesFromBenchWorkItems,
+  filterBenchWorkItemsForPreviousStatus,
   parseBenchActionArgs,
   parseBenchArgs,
 } from "./bench-args.js";
@@ -561,6 +564,10 @@ type PackageBenchModule = {
     resultPaths?: string[];
     selectedBenchmarks?: string[];
     runtimeProfiles?: string[];
+    selectedWorkItems?: Array<{
+      benchmark: string;
+      runtimeProfile: string;
+    }>;
     mode?: "full" | "quick";
     limit?: number;
     seed?: number;
@@ -2511,6 +2518,7 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
     parsed,
     benchmarkIds: [benchmarkId],
     runtimeProfiles,
+    workItems: runtimeProfiles.map((runtimeProfile) => ({ benchmarkId, runtimeProfile })),
     resultPaths: writtenPaths,
   });
 
@@ -3132,6 +3140,10 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
     parsed,
     benchmarkIds: [...new Set(customBenchmarkIds)],
     runtimeProfiles,
+    workItems: plans.map((plan, index) => ({
+      benchmarkId: customBenchmarkIds[index] ?? "custom",
+      runtimeProfile: plan.runtime.profile,
+    })),
     resultPaths: writtenPaths,
   });
 
@@ -3194,6 +3206,10 @@ async function writeBenchReproManifestForPackageRun(args: {
   parsed: ParsedBenchArgs;
   benchmarkIds: string[];
   runtimeProfiles: BenchRuntimeProfile[];
+  workItems?: Array<{
+    benchmarkId: string;
+    runtimeProfile: BenchRuntimeProfile;
+  }>;
   resultPaths: string[];
 }): Promise<void> {
   if (args.resultPaths.length === 0) {
@@ -3213,6 +3229,10 @@ async function writeBenchReproManifestForPackageRun(args: {
       resultPaths: args.resultPaths,
       selectedBenchmarks: args.benchmarkIds,
       runtimeProfiles: args.runtimeProfiles,
+      selectedWorkItems: args.workItems?.map((item) => ({
+        benchmark: item.benchmarkId,
+        runtimeProfile: item.runtimeProfile,
+      })),
       mode: args.parsed.quick ? "quick" : "full",
       ...(effectiveLimit !== undefined ? { limit: effectiveLimit } : {}),
       ...(args.parsed.publishedSeed !== undefined ? { seed: args.parsed.publishedSeed } : {}),
@@ -3356,19 +3376,25 @@ async function resolvePackageBenchRuntime(
   );
 }
 
-function resolveMemoryDir(): string {
+function normalizeMemoryDirPath(memoryDir: string): string {
+  return path.resolve(expandTilde(memoryDir));
+}
+
+export function resolveMemoryDir(): string {
   // Priority: env var > config file > auto-detect
   const configMemoryDir = (() => {
     // Env var takes top priority (deployment override)
     const envMemoryDir = readCompatEnv("REMNIC_MEMORY_DIR", "ENGRAM_MEMORY_DIR");
-    if (envMemoryDir) return envMemoryDir;
+    if (envMemoryDir) return normalizeMemoryDirPath(envMemoryDir);
     // Then config file
     const configPath = resolveConfigPath();
     const raw = fs.existsSync(configPath)
       ? JSON.parse(fs.readFileSync(configPath, "utf8"))
       : {};
     const remnicCfg = raw.remnic ?? raw.engram ?? raw;
-    if (remnicCfg.memoryDir) return remnicCfg.memoryDir;
+    if (typeof remnicCfg.memoryDir === "string" && remnicCfg.memoryDir.length > 0) {
+      return normalizeMemoryDirPath(remnicCfg.memoryDir);
+    }
     // Auto-detect: prefer standalone path if it exists, fall back to OpenClaw
     const home = resolveHomeDir();
     const standalonePath = path.join(home, ".remnic", "memory");
@@ -3385,11 +3411,12 @@ function resolveMemoryDir(): string {
     try {
       const active = getActiveSpace();
       if (active?.memoryDir) {
-        if (!fs.existsSync(active.memoryDir)) {
+        const activeMemoryDir = normalizeMemoryDirPath(active.memoryDir);
+        if (!fs.existsSync(activeMemoryDir)) {
           // Recreate missing directory instead of silently falling back
-          fs.mkdirSync(active.memoryDir, { recursive: true });
+          fs.mkdirSync(activeMemoryDir, { recursive: true });
         }
-        return active.memoryDir;
+        return activeMemoryDir;
       }
       // No active space with memoryDir — fall through to config
     } catch (err: unknown) {
@@ -5342,10 +5369,21 @@ function cmdReview(action: string, rest: string[]): void {
   }
 }
 
-async function cmdSync(action: string, rest: string[], json: boolean): Promise<void> {
+export function resolveSyncSourceDir(rest: string[]): string {
   // Extract --source before positional args so that rest args can override it
   const sourceIdx = rest.indexOf("--source");
-  const sourceDir = sourceIdx >= 0 && rest[sourceIdx + 1] ? rest[sourceIdx + 1] : ".";
+  if (sourceIdx < 0) return ".";
+  const value = rest[sourceIdx + 1];
+  if (!value || value.startsWith("-")) {
+    throw new Error(
+      "--source requires a value. Provide it as `--source <dir>`, not as a bare flag.",
+    );
+  }
+  return value;
+}
+
+async function cmdSync(action: string, rest: string[], json: boolean): Promise<void> {
+  const sourceDir = resolveSyncSourceDir(rest);
   const memoryDir = resolveMemoryDir();
 
   if (action === "run") {
@@ -6351,6 +6389,7 @@ async function cmdBench(rest: string[]): Promise<void> {
   }
 
   const runtimeProfiles = resolveBenchRunProfiles(parsed);
+  let selectedWorkItems = createBenchWorkItems(selectedBenchmarks, runtimeProfiles);
 
   // Validate benchmark IDs before resume/retry-failed filtering so unknown
   // names are caught early instead of being silently dropped by the filter.
@@ -6385,67 +6424,27 @@ async function cmdBench(rest: string[]): Promise<void> {
     console.log(`  Previous run: ${prevStatus.startedAt}`);
     console.log(`  Benchmarks: ${prevStatus.benchmarks.length} total, ${completeCount} complete, ${failedCount} failed`);
 
-    const statusEntryMap = new Map(prevStatus.benchmarks.map((b) => [b.id, b.status]));
-
-    // Helper: collect all status entries relevant to a benchmark ID across
-    // profile variations. Handles all four combinations of current/previous
-    // single vs matrix runs.
-    const relevantStatuses = (benchmarkId: string): string[] => {
-      const profileEntries = runtimeProfiles.length > 1
-        ? runtimeProfiles.map((p) => `${benchmarkId} [${p}]`)
-        : [benchmarkId];
-      const statuses: string[] = [];
-      // Direct match: current profile entries against previous status entries.
-      for (const id of profileEntries) {
-        const s = statusEntryMap.get(id);
-        if (s) statuses.push(s);
-      }
-      // Bare ID from a previous single-profile run (needed for
-      // single→matrix and matrix→single transitions).
-      const bareStatus = statusEntryMap.get(benchmarkId);
-      if (bareStatus && !statuses.includes(bareStatus)) {
-        statuses.push(bareStatus);
-      }
-      // Bracket-suffixed entries ONLY for profiles in the current run.
-      // This avoids contamination from profiles not being re-run.
-      for (const p of runtimeProfiles) {
-        const entryStatus = statusEntryMap.get(`${benchmarkId} [${p}]`);
-        if (entryStatus && !statuses.includes(entryStatus)) {
-          statuses.push(entryStatus);
-        }
-      }
-      return statuses;
-    };
-
     const before = selectedBenchmarks.length;
 
     if (parsed.resume) {
-      // Skip benchmarks where ALL expected profile entries completed; re-run
-      // if any entry is pending, running, failed, or absent (new profile).
-      selectedBenchmarks = selectedBenchmarks.filter((benchmarkId) => {
-        const statuses = relevantStatuses(benchmarkId);
-        if (statuses.length === 0) return true; // not in previous run
-        // When running multiple profiles, check that each expected profile
-        // entry exists in the previous status. Missing profiles mean the
-        // benchmark hasn't been run for that profile yet.
-        if (runtimeProfiles.length > 1) {
-          for (const p of runtimeProfiles) {
-            if (!statusEntryMap.has(`${benchmarkId} [${p}]`)) return true;
-          }
-        }
-        return !statuses.every((s) => s === "complete");
-      });
+      selectedWorkItems = filterBenchWorkItemsForPreviousStatus(
+        selectedWorkItems,
+        prevStatus.benchmarks,
+        "resume",
+      );
+      selectedBenchmarks = [...new Set(selectedWorkItems.map((item) => item.benchmarkId))];
       console.log(`  Resuming: ${selectedBenchmarks.length} of ${before} benchmarks to re-run`);
     } else {
-      // --retry-failed: only re-run benchmarks that had failures.
-      selectedBenchmarks = selectedBenchmarks.filter((benchmarkId) => {
-        const statuses = relevantStatuses(benchmarkId);
-        return statuses.some((s) => s === "failed");
-      });
+      selectedWorkItems = filterBenchWorkItemsForPreviousStatus(
+        selectedWorkItems,
+        prevStatus.benchmarks,
+        "retry-failed",
+      );
+      selectedBenchmarks = [...new Set(selectedWorkItems.map((item) => item.benchmarkId))];
       console.log(`  Retrying: ${selectedBenchmarks.length} of ${before} selected benchmarks had failures`);
     }
 
-    if (selectedBenchmarks.length === 0) {
+    if (selectedWorkItems.length === 0) {
       if (parsed.retryFailed) {
         console.log("Nothing to re-run — no selected benchmarks had failures.");
       } else {
@@ -6465,20 +6464,17 @@ async function cmdBench(rest: string[]): Promise<void> {
   // When running a matrix (multiple profiles), create profile-specific status
   // entries so that a failed profile doesn't get overwritten by a later success.
   const statusEntryIds = [...new Set(
-    runtimeProfiles.length > 1
-      ? selectedBenchmarks.flatMap((benchmarkId) =>
-          runtimeProfiles.map((profile) => `${benchmarkId} [${profile}]`),
-        )
-      : selectedBenchmarks,
+    selectedWorkItems.map(({ benchmarkId, runtimeProfile }) =>
+      runtimeProfiles.length > 1 ? `${benchmarkId} [${runtimeProfile}]` : benchmarkId,
+    ),
   )];
   try { await initBenchStatus(benchStatusPath, statusEntryIds, process.pid); } catch { /* non-fatal */ }
   const writtenPaths: string[] = [];
   try {
-    for (const benchmarkId of selectedBenchmarks) {
-      for (const runtimeProfile of runtimeProfiles) {
-        const statusId = runtimeProfiles.length > 1
-          ? `${benchmarkId} [${runtimeProfile}]`
-          : benchmarkId;
+    for (const { benchmarkId, runtimeProfile } of selectedWorkItems) {
+      const statusId = runtimeProfiles.length > 1
+        ? `${benchmarkId} [${runtimeProfile}]`
+        : benchmarkId;
         try { await updateBenchmarkStarted(benchStatusPath, statusId); } catch { /* non-fatal */ }
         try {
           const handledByPackage = await runBenchViaPackage(
@@ -6502,7 +6498,6 @@ async function cmdBench(rest: string[]): Promise<void> {
           failures.add(benchmarkId);
           try { await updateBenchmarkFailed(benchStatusPath, statusId, message); } catch { /* non-fatal */ }
         }
-      }
     }
   } finally {
     try { await finalizeBenchStatus(benchStatusPath); } catch { /* non-fatal */ }
@@ -6510,7 +6505,8 @@ async function cmdBench(rest: string[]): Promise<void> {
   await writeBenchReproManifestForPackageRun({
     parsed,
     benchmarkIds: selectedBenchmarks,
-    runtimeProfiles,
+    runtimeProfiles: deriveRuntimeProfilesFromBenchWorkItems(selectedWorkItems),
+    workItems: selectedWorkItems,
     resultPaths: writtenPaths,
   });
   if (failures.size > 0) {

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -18,6 +18,18 @@
       "import": "./dist/cli.js",
       "types": "./dist/cli.d.ts"
     },
+    "./memory-projection-format": {
+      "import": "./dist/memory-projection-format.js",
+      "types": "./dist/memory-projection-format.d.ts"
+    },
+    "./model-registry": {
+      "import": "./dist/model-registry.js",
+      "types": "./dist/model-registry.d.ts"
+    },
+    "./orchestrator": {
+      "import": "./dist/orchestrator.js",
+      "types": "./dist/orchestrator.d.ts"
+    },
     "./connectors": {
       "import": "./dist/connectors/index.js",
       "types": "./dist/connectors/index.d.ts"
@@ -37,6 +49,14 @@
     "./connectors/codex-materialize-runner.js": {
       "import": "./dist/connectors/codex-materialize-runner.js",
       "types": "./dist/connectors/codex-materialize-runner.d.ts"
+    },
+    "./contradiction": {
+      "import": "./dist/contradiction/index.js",
+      "types": "./dist/contradiction/index.d.ts"
+    },
+    "./contradiction/index.js": {
+      "import": "./dist/contradiction/index.js",
+      "types": "./dist/contradiction/index.d.ts"
     }
   },
   "files": [

--- a/packages/remnic-core/src/access-cli.test.ts
+++ b/packages/remnic-core/src/access-cli.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
-import { main, runCli } from "./access-cli.js";
+import { main, runCli, sanitizeAccessCliErrorMessage } from "./access-cli.js";
+import { PLUGIN_ID } from "./plugin-id.js";
 
 async function rejectsUsage(argv: string[]): Promise<void> {
   await assert.rejects(
@@ -18,12 +20,17 @@ async function rejectsUsage(argv: string[]): Promise<void> {
 async function captureRunCliFailure(argv: string[]): Promise<string> {
   let output = "";
   const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
   const originalExit = process.exit;
 
   process.stdout.write = ((chunk: string | Uint8Array) => {
     output += String(chunk);
     return true;
   }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
   process.exit = ((code?: string | number | null | undefined): never => {
     throw new Error(`process.exit:${code ?? 0}`);
   }) as typeof process.exit;
@@ -38,8 +45,49 @@ async function captureRunCliFailure(argv: string[]): Promise<string> {
     return output;
   } finally {
     process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
     process.exit = originalExit;
   }
+}
+
+async function withPatchedEnv<T>(
+  patch: Record<string, string | undefined>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const original: Record<string, string | undefined> = {};
+  for (const key of Object.keys(patch)) {
+    original[key] = process.env[key];
+    const value = patch[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function writeOpenClawConfig(configPath: string, config: Record<string, unknown>): void {
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: { config },
+        },
+      },
+    }),
+  );
 }
 
 test("access-cli rejects malformed dry-run values before store can run", async () => {
@@ -79,6 +127,7 @@ test("access-cli rejects value options with missing values", async () => {
   await rejectsUsage(["browse", "--limit"]);
   await rejectsUsage(["browse", "--principal"]);
   await rejectsUsage(["store", "--content", "hello", "--category"]);
+  await rejectsUsage(["store", "--content", "hello", "--category", ""]);
 });
 
 test("access-cli rejects partial numeric values", async () => {
@@ -134,10 +183,10 @@ test("access-cli rejects confidence outside the documented range", async () => {
 });
 
 test("access-cli prefers active OpenClaw config path over legacy config path", async () => {
-  const tempRoot = await mkdtemp(join(tmpdir(), "access-cli-config-"));
-  const activeConfigPath = join(tempRoot, "active-openclaw.json");
-  const legacyConfigPath = join(tempRoot, "legacy-openclaw.json");
-  const memoryDir = join(tempRoot, "memory");
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "access-cli-config-"));
+  const activeConfigPath = path.join(tempRoot, "active-openclaw.json");
+  const legacyConfigPath = path.join(tempRoot, "legacy-openclaw.json");
+  const memoryDir = path.join(tempRoot, "memory");
   const previousOpenClawConfigPath = process.env.OPENCLAW_CONFIG_PATH;
   const previousOpenClawEngramConfigPath = process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
   let output = "";
@@ -193,4 +242,125 @@ test("access-cli prefers active OpenClaw config path over legacy config path", a
     }
     await rm(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("access-cli browse uses OPENCLAW_CONFIG_PATH before legacy config path", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-access-cli-"));
+  try {
+    const primaryConfigPath = path.join(tempDir, "primary.json");
+    const legacyConfigPath = path.join(tempDir, "legacy.json");
+    writeOpenClawConfig(primaryConfigPath, {
+      memoryDir: path.join(tempDir, "primary-memory"),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      namespacePolicies: [
+        { name: "team", readPrincipals: ["reader"], writePrincipals: ["writer"] },
+      ],
+      agentAccessHttp: { principal: "reader" },
+    });
+    writeOpenClawConfig(legacyConfigPath, {
+      memoryDir: path.join(tempDir, "legacy-memory"),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      namespacePolicies: [
+        { name: "team", readPrincipals: ["legacy-reader"], writePrincipals: ["writer"] },
+      ],
+    });
+
+    await withPatchedEnv(
+      {
+        OPENCLAW_CONFIG_PATH: primaryConfigPath,
+        OPENCLAW_ENGRAM_CONFIG_PATH: legacyConfigPath,
+      },
+      async () => {
+        await main(["browse", "--namespace", "team", "--limit", "1"]);
+      },
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("access-cli browse accepts an explicit principal for namespace reads", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-access-cli-"));
+  try {
+    const configPath = path.join(tempDir, "openclaw.json");
+    writeOpenClawConfig(configPath, {
+      memoryDir: path.join(tempDir, "memory"),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      namespacePolicies: [
+        { name: "team", readPrincipals: ["reader"], writePrincipals: ["writer"] },
+      ],
+    });
+
+    await withPatchedEnv(
+      {
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_ENGRAM_CONFIG_PATH: undefined,
+      },
+      async () => {
+        await main(["browse", "--namespace", "team", "--principal", "reader", "--limit", "1"]);
+      },
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("access-cli runtime failures do not log sensitive message content", async () => {
+  const output = await captureRunCliFailure([
+    "store",
+    "--content-file",
+    "/path/that/does/not/exist",
+    "--category",
+    "fact",
+  ]);
+
+  assert.match(output, /access-cli failed/);
+  assert.doesNotMatch(output, /does\/not\/exist/);
+  assert.doesNotMatch(output, /ENOENT/);
+});
+
+test("access-cli redacts configured API keys from runtime failures", () => {
+  assert.equal(
+    sanitizeAccessCliErrorMessage("openaiApiKey: sk-test localLlmApiKey='local-secret' path=/tmp/file"),
+    "openaiApiKey: [redacted] localLlmApiKey=[redacted] path=/tmp/file",
+  );
+});
+
+test("access-cli accepts inline string values that begin with dashes", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-access-cli-"));
+  try {
+    const configPath = path.join(tempDir, "openclaw.json");
+    writeOpenClawConfig(configPath, {
+      memoryDir: path.join(tempDir, "memory"),
+      defaultNamespace: "default",
+    });
+
+    await withPatchedEnv(
+      {
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_ENGRAM_CONFIG_PATH: undefined,
+      },
+      async () => {
+        await main(["browse", "--query=--literal", "--limit", "1"]);
+        await main(["store", "--content=--note", "--category", "fact", "--dry-run"]);
+      },
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("access-cli rejects adjacent option-looking values", async () => {
+  const output = await captureRunCliFailure([
+    "store",
+    "--content",
+    "--dry-run",
+    "--category",
+    "fact",
+  ]);
+
+  assert.match(output, /missing required option: --content/);
 });

--- a/packages/remnic-core/src/access-cli.ts
+++ b/packages/remnic-core/src/access-cli.ts
@@ -211,7 +211,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
 
     const next = rest[i + 1];
-    if (!next || next.startsWith("--")) {
+    if (next === undefined || next.length === 0 || next.startsWith("--")) {
       throw new UsageError("missing-option", key);
     }
     if (!options[key]) {
@@ -324,8 +324,9 @@ function buildRuntime(preferredId?: string): Runtime {
 }
 
 async function runBrowse(args: ParsedArgs, preferredId?: string): Promise<void> {
-  const request = {
+  const browseArgs = {
     namespace: getLastOption(args, "namespace"),
+    principal: getLastOption(args, "principal"),
     query: getLastOption(args, "query"),
     category: getLastOption(args, "category"),
     status: getLastOption(args, "status"),
@@ -334,10 +335,17 @@ async function runBrowse(args: ParsedArgs, preferredId?: string): Promise<void> 
     offset: parseIntegerOption(args, "offset", { min: 0 }),
   };
   const { config, service } = buildRuntime(preferredId);
-  const result = await service.memoryBrowse({
-    ...request,
-    authenticatedPrincipal: getLastOption(args, "principal") ?? config.agentAccessHttp.principal,
-  });
+  const request = {
+    namespace: browseArgs.namespace,
+    authenticatedPrincipal: browseArgs.principal ?? config.agentAccessHttp.principal,
+    query: browseArgs.query,
+    category: browseArgs.category,
+    status: browseArgs.status,
+    sort: browseArgs.sort,
+    limit: browseArgs.limit,
+    offset: browseArgs.offset,
+  };
+  const result = await service.memoryBrowse(request);
   console.log(JSON.stringify(result, null, 2));
 }
 
@@ -392,6 +400,13 @@ export async function main(
   await runStore(args, options.preferredId);
 }
 
+export function sanitizeAccessCliErrorMessage(message: string): string {
+  return message.replace(
+    /\b(openaiApiKey|localLlmApiKey)\b(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,}\]]+)/gi,
+    (_match, name: string, separator: string) => `${name}${separator}[redacted]`,
+  );
+}
+
 export function printUsage(): void {
   writeCliOutput(usage());
 }
@@ -410,7 +425,7 @@ export async function runCli(
       process.exit(1);
     }
 
-    console.error("access-cli failed");
+    console.error("access-cli failed: runtime error");
     process.exit(1);
   }
 }

--- a/packages/remnic-core/src/contradiction/contradiction-judge.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-judge.test.ts
@@ -45,3 +45,144 @@ test("contradiction judge tags local LLM calls for thinking suppression", async 
   assert.equal(result.judged, 1);
   assert.equal(result.results.get("a:b")?.verdict, "independent");
 });
+
+test("contradiction judge ignores unmatched pairKey verdicts", async () => {
+  const localLlm = {
+    async chatCompletion() {
+      return {
+        content: JSON.stringify([
+          {
+            pairKey: "x:y",
+            verdict: "contradicts",
+            rationale: "This pair is not in the request.",
+            confidence: 0.9,
+          },
+        ]),
+      };
+    },
+  } as unknown as LocalLlmClient;
+
+  const result = await judgeContradictionPairs(
+    [
+      {
+        memoryIdA: "a",
+        memoryIdB: "b",
+        textA: "Joshua uses pnpm",
+        textB: "Joshua uses npm",
+      },
+      {
+        memoryIdA: "c",
+        memoryIdB: "d",
+        textA: "Remnic stores memories locally",
+        textB: "Remnic stores memories locally",
+      },
+    ],
+    {} as PluginConfig,
+    localLlm,
+    null,
+    new Map(),
+  );
+
+  assert.equal(result.judged, 2);
+  assert.equal(result.results.get("a:b")?.verdict, "needs-user");
+  assert.equal(result.results.get("a:b")?.confidence, 0);
+  assert.equal(result.results.get("c:d")?.verdict, "needs-user");
+  assert.equal(result.results.get("c:d")?.confidence, 0);
+  assert.equal(result.results.has("x:y"), false);
+});
+
+test("contradiction judge does not positional-fallback after unmatched pairKey verdicts", async () => {
+  const localLlm = {
+    async chatCompletion() {
+      return {
+        content: JSON.stringify([
+          {
+            pairKey: "x:y",
+            verdict: "contradicts",
+            rationale: "This pair is not in the request.",
+            confidence: 0.9,
+          },
+          {
+            verdict: "duplicates",
+            rationale: "This unkeyed verdict should not shift onto a requested pair.",
+            confidence: 0.8,
+          },
+        ]),
+      };
+    },
+  } as unknown as LocalLlmClient;
+
+  const result = await judgeContradictionPairs(
+    [
+      {
+        memoryIdA: "a",
+        memoryIdB: "b",
+        textA: "Joshua uses pnpm",
+        textB: "Joshua uses npm",
+      },
+      {
+        memoryIdA: "c",
+        memoryIdB: "d",
+        textA: "Remnic stores memories locally",
+        textB: "Remnic stores memories locally",
+      },
+    ],
+    {} as PluginConfig,
+    localLlm,
+    null,
+    new Map(),
+  );
+
+  assert.equal(result.judged, 2);
+  assert.equal(result.results.get("a:b")?.verdict, "needs-user");
+  assert.equal(result.results.get("a:b")?.confidence, 0);
+  assert.equal(result.results.get("c:d")?.verdict, "needs-user");
+  assert.equal(result.results.get("c:d")?.confidence, 0);
+});
+
+test("contradiction judge fallback ignores skipped response items without shifting verdicts", async () => {
+  const localLlm = {
+    async chatCompletion() {
+      return {
+        content: JSON.stringify([
+          null,
+          {
+            verdict: "duplicates",
+            rationale: "The first requested pair is equivalent.",
+            confidence: 0.8,
+          },
+          {
+            verdict: "independent",
+            rationale: "The second requested pair is unrelated.",
+            confidence: 0.7,
+          },
+        ]),
+      };
+    },
+  } as unknown as LocalLlmClient;
+
+  const result = await judgeContradictionPairs(
+    [
+      {
+        memoryIdA: "a",
+        memoryIdB: "b",
+        textA: "Remnic stores memories locally",
+        textB: "Remnic stores memories locally",
+      },
+      {
+        memoryIdA: "c",
+        memoryIdB: "d",
+        textA: "Joshua uses pnpm",
+        textB: "Joshua uses npm",
+      },
+    ],
+    {} as PluginConfig,
+    localLlm,
+    null,
+    new Map(),
+  );
+
+  assert.equal(result.judged, 2);
+  assert.equal(result.results.get("a:b")?.verdict, "duplicates");
+  assert.equal(result.results.get("c:d")?.verdict, "independent");
+});

--- a/packages/remnic-core/src/contradiction/contradiction-judge.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-judge.ts
@@ -268,21 +268,32 @@ function parseJudgeResponse(
       const items = Array.isArray(parsed) ? parsed : [parsed];
       const results: ContradictionJudgeResult[] = [];
       const matchedKeys = new Set<string>();
+      let sawUnmatchedKeyedItem = false;
 
-      for (const item of items) {
+      for (let itemIndex = 0; itemIndex < items.length; itemIndex += 1) {
+        const item = items[itemIndex];
         if (!item || typeof item !== "object") continue;
 
         const verdict = typeof item.verdict === "string" && VALID_VERDICTS.includes(item.verdict as ContradictionVerdict)
           ? (item.verdict as ContradictionVerdict)
           : "needs-user";
 
-        const pairKeyVal = typeof item.pairKey === "string" ? item.pairKey : null;
+        const pairKeyVal = typeof item.pairKey === "string" && item.pairKey.length > 0
+          ? item.pairKey
+          : null;
         const input = pairKeyVal
           ? inputs.find((p) => pairKey(p.memoryIdA, p.memoryIdB) === pairKeyVal)
           : null;
 
-        // If we can't match the pairKey, fall back to index-based matching
-        const fallbackInput = input ?? inputs[results.length] ?? inputs[0];
+        if (pairKeyVal && !input) {
+          sawUnmatchedKeyedItem = true;
+          continue;
+        }
+
+        const fallbackInput = input ?? (sawUnmatchedKeyedItem
+          ? undefined
+          : inputs.find((inputCandidate) =>
+            !matchedKeys.has(pairKey(inputCandidate.memoryIdA, inputCandidate.memoryIdB))));
         if (!fallbackInput) continue;
 
         matchedKeys.add(pairKey(fallbackInput.memoryIdA, fallbackInput.memoryIdB));

--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -462,6 +462,7 @@ export function resolvePair(
 
   const existing = readPair(memoryDir, pairId);
   if (!existing) return null;
+  if (preservesDirectResolution(existing.resolution)) return existing;
 
   const updated: ContradictionPair = {
     ...existing,

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -1888,6 +1888,30 @@ test("needs-more-context deferral does not clear terminal resolutions", async ()
   }
 });
 
+test("resolvePair does not overwrite terminal resolutions", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const first = resolvePair(dir, written.pairId, "keep-a");
+    assert.equal(first?.resolution, "keep-a");
+    assert.ok(first?.lastReviewedAt);
+
+    const second = resolvePair(dir, written.pairId, "keep-b");
+    assert.equal(second?.resolution, "keep-a");
+    assert.equal(second?.lastReviewedAt, first?.lastReviewedAt);
+
+    const third = resolvePair(dir, written.pairId, "merge");
+    assert.equal(third?.resolution, "keep-a");
+    assert.equal(third?.lastReviewedAt, first?.lastReviewedAt);
+
+    const stored = readPair(dir, written.pairId);
+    assert.equal(stored?.resolution, "keep-a");
+    assert.equal(stored?.lastReviewedAt, first?.lastReviewedAt);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("resolvePair returns null for nonexistent pair", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -49,6 +49,9 @@ export {
   sanitizeSessionKeyForFilename,
   defaultWorkspaceDir,
 } from "./orchestrator.js";
+export * from "./memory-projection-format.js";
+export * from "./model-registry.js";
+export * from "./contradiction/index.js";
 
 export {
   buildEvidencePack,

--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -252,13 +252,10 @@ export function parseOpenClawMessageParts(
   if (Array.isArray(content)) {
     const hasOpenAiBlocks = content.some(isOpenAiContentBlock);
     if (hasOpenAiBlocks) return parseOpenAiMessageParts(content, options);
-    const hasAnthropicBlocks = content.some(
-      (block) =>
-        block &&
-        typeof block === "object" &&
-        typeof (block as Record<string, unknown>).type === "string",
-    );
+    const hasAnthropicBlocks = content.some(isAnthropicContentBlock);
     if (hasAnthropicBlocks) return parseAnthropicMessageParts({ content }, options);
+    const piParts = parsePiMessageParts(input, { ...options, allowRenderedFallback: false });
+    if (piParts.length > 0) return piParts;
   }
 
   const toolName = asNonEmptyString(obj.toolName ?? obj.tool_name ?? obj.name);
@@ -715,6 +712,9 @@ function isLikelyFilePath(value: string): boolean {
 function hasValidFileExtension(value: string): boolean {
   const lastSlash = value.lastIndexOf("/");
   const basename = value.slice(lastSlash + 1);
+  if (isKnownExtensionlessRepositoryFile(basename)) return true;
+  if (isKnownBareDotfile(basename)) return true;
+  if (isBasenameDotfile(basename)) return isPathLikeFilePath(value);
   const dot = basename.lastIndexOf(".");
   if (dot <= 0 || dot === basename.length - 1) return false;
   const ext = basename.slice(dot + 1);
@@ -723,6 +723,22 @@ function hasValidFileExtension(value: string): boolean {
     if (!isFileExtensionChar(char)) return false;
   }
   return true;
+}
+
+function isKnownExtensionlessRepositoryFile(basename: string): boolean {
+  return /^(Dockerfile|Containerfile|Makefile|GNUmakefile|LICENSE|NOTICE|README|CHANGELOG|Procfile)$/.test(basename);
+}
+
+function isKnownBareDotfile(basename: string): boolean {
+  return /^(\.env|\.gitignore|\.gitattributes|\.npmrc|\.yarnrc|\.editorconfig|\.prettierrc|\.eslintrc)$/.test(basename);
+}
+
+function isPathLikeFilePath(value: string): boolean {
+  return value.startsWith("/") || value.startsWith("./") || value.startsWith("../") || value.startsWith("~/") || value.includes("/");
+}
+
+function isBasenameDotfile(basename: string): boolean {
+  return /^\.[A-Za-z0-9][A-Za-z0-9._+-]*$/.test(basename);
 }
 
 function isFileExtensionChar(char: string): boolean {

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -93,6 +93,47 @@ describe("message-parts parsers", () => {
     assert.equal(parts[2]!.filePath, ".github/workflows/ci.yml");
   });
 
+  it("extracts basename dotfiles and extensionless repository files", () => {
+    const parts = parseMessageParts([
+      { type: "output_text", text: "Updated .env." },
+      { type: "output_text", text: "Updated .gitignore." },
+      { type: "output_text", text: "Read Dockerfile." },
+      { type: "output_text", text: "Read Makefile." },
+    ]);
+
+    assert.equal(parts.length, 4);
+    assert.deepEqual(parts.map((part) => part.filePath), [
+      ".env",
+      ".gitignore",
+      "Dockerfile",
+      "Makefile",
+    ]);
+  });
+
+  it("does not treat lowercase prose as extensionless repository files", () => {
+    const parts = parseMessageParts([
+      { type: "output_text", text: "I notice this issue and will readme later." },
+      { type: "output_text", text: "Read README." },
+    ]);
+
+    assert.equal(parts.length, 2);
+    assert.equal(parts[0]!.filePath, null);
+    assert.equal(parts[1]!.filePath, "README");
+  });
+
+  it("does not treat prose dot-prefixed words as bare dotfiles", () => {
+    const parts = parseMessageParts([
+      { type: "output_text", text: "I built it in .NET." },
+      { type: "output_text", text: "Updated .env." },
+      { type: "output_text", text: "Updated ./.config." },
+    ]);
+
+    assert.equal(parts.length, 3);
+    assert.equal(parts[0]!.filePath, null);
+    assert.equal(parts[1]!.filePath, ".env");
+    assert.equal(parts[2]!.filePath, "./.config");
+  });
+
   it("routes OpenClaw OpenAI-style typed content blocks through the OpenAI parser", () => {
     const parts = parseOpenClawMessageParts({
       content: [{ type: "output_text", text: "Updated src/openclaw.ts." }],
@@ -100,6 +141,19 @@ describe("message-parts parsers", () => {
 
     assert.equal(parts.length, 1);
     assert.equal(parts[0]!.kind, "text");
+    assert.equal(parts[0]!.filePath, "src/openclaw.ts");
+  });
+
+  it("routes OpenClaw tool-call blocks through the structured tool parser", () => {
+    const parts = parseOpenClawMessageParts({
+      content: [
+        { type: "toolCall", name: "edit", arguments: { path: "src/openclaw.ts" } },
+      ],
+    });
+
+    assert.equal(parts.length, 1);
+    assert.equal(parts[0]!.kind, "file_write");
+    assert.equal(parts[0]!.toolName, "edit");
     assert.equal(parts[0]!.filePath, "src/openclaw.ts");
   });
 

--- a/packages/remnic-core/tsup.config.ts
+++ b/packages/remnic-core/tsup.config.ts
@@ -9,6 +9,7 @@ const srcFiles = readdirSync(join(__dirname, "src"))
   .map((f) => `src/${f}`);
 
 const connectorEntryFiles = [
+  "src/contradiction/index.ts",
   "src/connectors/index.ts",
   "src/connectors/codex-materialize.ts",
   "src/connectors/codex-materialize-runner.ts",

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -49,9 +49,9 @@ packages/import-mem0/src/client.test.ts(132,38): TS2304
 packages/import-mem0/src/client.test.ts(225,38): TS2304
 packages/import-mem0/src/client.test.ts(253,38): TS2304
 packages/import-mem0/src/client.test.ts(286,38): TS2304
-packages/remnic-cli/src/index.ts(3818,30): TS18046
-packages/remnic-cli/src/index.ts(8192,43): TS2345
-packages/remnic-cli/src/index.ts(8201,34): TS2345
+packages/remnic-cli/src/index.ts(3845,30): TS18046
+packages/remnic-cli/src/index.ts(8188,43): TS2345
+packages/remnic-cli/src/index.ts(8197,34): TS2345
 src/index.ts(2,40): TS2307
 src/index.ts(2871,38): TS2307
 src/index.ts(2922,23): TS2307
@@ -508,9 +508,6 @@ tests/recall-hardening.test.ts(796,3): TS2349
 tests/recall-hardening.test.ts(798,3): TS2349
 tests/recall-no-recall-short-circuit.test.ts(14,3): TS2740
 tests/register-multi-registry.test.ts(184,13): TS18048
-tests/remnic-cli-bench-surface.test.ts(914,44): TS7006
-tests/remnic-cli-bin-wrapper.test.ts(30,16): TS2345
-tests/remnic-cli-bin-wrapper.test.ts(31,16): TS2345
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006
 tests/remnic-plugin-register-migration.test.ts(66,12): TS2352
 tests/remnic-server-cli.test.ts(8,30): TS7016

--- a/src/memory-projection-format.ts
+++ b/src/memory-projection-format.ts
@@ -1,1 +1,1 @@
-export * from "../packages/remnic-core/src/memory-projection-format.js";
+export * from "@remnic/core/memory-projection-format";

--- a/src/model-registry.ts
+++ b/src/model-registry.ts
@@ -1,1 +1,1 @@
-export * from "../packages/remnic-core/src/model-registry.js";
+export * from "@remnic/core/model-registry";

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,1 +1,1 @@
-export * from "../packages/remnic-core/src/orchestrator.js";
+export * from "@remnic/core/orchestrator";

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -2002,6 +2002,48 @@ test("access HTTP server binds namespace write authorization to its configured p
   }
 });
 
+test("access HTTP server binds namespace browse authorization to its configured principal", async () => {
+  let capturedNamespace: unknown;
+  let capturedPrincipal: unknown;
+  const service = {
+    ...createFakeService(),
+    memoryBrowse: async (request: Record<string, unknown>) => {
+      capturedNamespace = request.namespace;
+      capturedPrincipal = request.authenticatedPrincipal;
+      return {
+        namespace: request.namespace ?? "global",
+        sort: "updated_desc",
+        total: 0,
+        count: 0,
+        limit: request.limit,
+        offset: request.offset,
+        memories: [],
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    principal: "secret-team",
+    maxBodyBytes: 1024,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+
+  try {
+    const response = await fetch(`${base}/engram/v1/memories?namespace=secret-team&limit=3`, {
+      headers: { Authorization: "Bearer secret-token" },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(capturedNamespace, "secret-team");
+    assert.equal(capturedPrincipal, "secret-team");
+  } finally {
+    await server.stop();
+  }
+});
+
 test("access HTTP server returns 400 for empty recall query", async () => {
   const server = new EngramAccessHttpServer({
     service: {

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -911,7 +911,7 @@ export function ensureWecloneImportAdapterRegistered() {}
 
     const plans = await buildPackageBenchExecutionPlans(
       {
-        resolveBenchRuntimeProfile: async (options) => ({
+        resolveBenchRuntimeProfile: async (options: { runtimeProfile?: string }) => ({
           profile: options.runtimeProfile ?? "baseline",
           remnicConfig: {},
           effectiveRemnicConfig: {},

--- a/tests/remnic-cli-bin-wrapper.test.ts
+++ b/tests/remnic-cli-bin-wrapper.test.ts
@@ -27,8 +27,14 @@ test("@remnic/cli package test script includes linked root tests", async () => {
 
   const testScript = (scripts as Record<string, unknown>).test;
   assert.equal(typeof testScript, "string");
-  assert.match(testScript, /\.\.\/\.\.\/tests\/evals-engram-adapter-buffering\.test\.ts/);
-  assert.match(testScript, /\.\.\/\.\.\/tests\/shim-openclaw-engram-package\.test\.ts.*\.\.\/\.\.\/tests\/engram-access-bin-errors\.test\.ts/);
+  const testScriptText = testScript as string;
+  assert.match(testScriptText, /tests\/evals-engram-adapter-buffering\.test\.ts/);
+  assert.match(testScriptText, /tests\/shim-openclaw-engram-package\.test\.ts/);
+  assert.match(testScriptText, /tests\/engram-access-bin-errors\.test\.ts/);
+  assert.match(testScriptText, /tests\/remnic-cli-bench-surface\.test\.ts/);
+  assert.match(testScriptText, /tests\/remnic-cli-bench-ui-surface\.test\.ts/);
+  assert.match(testScriptText, /tests\/bench-remnic-deterministic-runners\.test\.ts/);
+  assert.match(testScriptText, /tests\/bench-remnic-stateful-runners\.test\.ts/);
 });
 
 test("remnic package bins are executable on POSIX checkouts", async () => {
@@ -74,6 +80,99 @@ test("package bin wrappers preserve child signal termination", async () => {
   }
 });
 
+test("package bin wrappers report a clear missing build artifact error", async () => {
+  for (const sourceBin of [remnicBin, engramBin]) {
+    const tempRoot = await mkdtemp(join(tmpdir(), "remnic-cli-bin-wrapper-"));
+    try {
+      const tempBinDir = join(tempRoot, "bin");
+      await mkdir(tempBinDir, { recursive: true });
+
+      const tempBin = join(tempBinDir, "wrapper.cjs");
+      await copyFile(sourceBin, tempBin);
+      await chmod(tempBin, 0o755);
+
+      const result = spawnSync(process.execPath, [tempBin], { encoding: "utf8" });
+
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /built CLI entrypoint is missing:/);
+      assert.match(result.stderr, /Rebuild or reinstall @remnic\/cli/);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+test("package bin wrappers report a clear missing tsx runtime error", async () => {
+  for (const sourceBin of [remnicBin, engramBin]) {
+    const tempRoot = await mkdtemp(join(tmpdir(), "remnic-cli-bin-wrapper-"));
+    try {
+      const tempBinDir = join(tempRoot, "bin");
+      const tempSrcDir = join(tempRoot, "src");
+      await mkdir(tempBinDir, { recursive: true });
+      await mkdir(tempSrcDir, { recursive: true });
+
+      const tempBin = join(tempBinDir, "wrapper.cjs");
+      await copyFile(sourceBin, tempBin);
+      await chmod(tempBin, 0o755);
+      await writeFile(join(tempSrcDir, "index.ts"), "process.exit(0);\n");
+
+      const result = spawnSync(process.execPath, [tempBin], { encoding: "utf8" });
+
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /tsx runtime is missing for source CLI entrypoint:/);
+      assert.match(result.stderr, /Install dependencies or rebuild @remnic\/cli/);
+      assert.doesNotMatch(result.stderr, /built CLI entrypoint is missing:/);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+test("package bin wrappers do not inject FORCE_COLOR", async () => {
+  for (const sourceBin of [remnicBin, engramBin]) {
+    const tempRoot = await mkdtemp(join(tmpdir(), "remnic-cli-bin-wrapper-"));
+    try {
+      const tempBinDir = join(tempRoot, "bin");
+      const tempDistDir = join(tempRoot, "dist");
+      await mkdir(tempBinDir, { recursive: true });
+      await mkdir(tempDistDir, { recursive: true });
+
+      const tempBin = join(tempBinDir, "wrapper.cjs");
+      const preload = join(tempRoot, "capture-env.cjs");
+      await copyFile(sourceBin, tempBin);
+      await chmod(tempBin, 0o755);
+      await writeFile(join(tempDistDir, "index.js"), "process.exit(0);\n");
+      await writeFile(
+        preload,
+        [
+          'const childProcess = require("node:child_process");',
+          "childProcess.execFileSync = (_cmd, _args, options) => {",
+          '  if (Object.prototype.hasOwnProperty.call(options.env, "FORCE_COLOR")) {',
+          '    const err = new Error("FORCE_COLOR was injected");',
+          "    err.status = 42;",
+          "    throw err;",
+          "  }",
+          "};",
+          "",
+        ].join("\n"),
+      );
+
+      const env = { ...process.env };
+      delete env.FORCE_COLOR;
+      delete env.NO_COLOR;
+      const result = spawnSync(process.execPath, ["--require", preload, tempBin], {
+        encoding: "utf8",
+        env,
+      });
+
+      assert.equal(result.status, 0);
+      assert.doesNotMatch(result.stderr, /FORCE_COLOR was injected/);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  }
+});
+
 test("package bin wrappers keep a failing exit code when a self-signal is ignored", async () => {
   if (process.platform === "win32") {
     return;
@@ -85,12 +184,15 @@ test("package bin wrappers keep a failing exit code when a self-signal is ignore
     const tempRoot = await mkdtemp(join(tmpdir(), "remnic-cli-bin-wrapper-"));
     try {
       const tempBinDir = join(tempRoot, "bin");
+      const tempDistDir = join(tempRoot, "dist");
       await mkdir(tempBinDir, { recursive: true });
+      await mkdir(tempDistDir, { recursive: true });
 
       const tempBin = join(tempBinDir, "wrapper.cjs");
       const preload = join(tempRoot, "throw-sigpipe.cjs");
       await copyFile(sourceBin, tempBin);
       await chmod(tempBin, 0o755);
+      await writeFile(join(tempDistDir, "index.js"), "process.exit(0);\n");
       await writeFile(
         preload,
         [

--- a/tests/root-cli-package-boundary.test.ts
+++ b/tests/root-cli-package-boundary.test.ts
@@ -20,10 +20,19 @@ const ROOT_CONNECTOR_SHIMS = [
   ],
 ] as const;
 
+const ROOT_CORE_SOURCE_SHIMS = [
+  ["src/memory-projection-format.ts", "@remnic/core/memory-projection-format"],
+  ["src/model-registry.ts", "@remnic/core/model-registry"],
+  ["src/orchestrator.ts", "@remnic/core/orchestrator"],
+] as const;
+
 const ROOT_PACKAGE_ENTRIES = [...ROOT_CLI_SHIMS, ...ROOT_CONNECTOR_SHIMS] as const;
 
 describe("root CLI package boundaries", () => {
-  for (const [filePath, publicSpecifier] of ROOT_PACKAGE_ENTRIES) {
+  for (const [filePath, publicSpecifier] of [
+    ...ROOT_PACKAGE_ENTRIES,
+    ...ROOT_CORE_SOURCE_SHIMS,
+  ] as const) {
     it(`${filePath} uses the public @remnic/core package export`, () => {
       const source = readFileSync(resolve(filePath), "utf8");
 
@@ -114,6 +123,56 @@ describe("root CLI package boundaries", () => {
         tsupConfig.includes(`"${coreFilePath}"`) ||
           tsupConfig.includes(`'${coreFilePath}'`),
         `${coreFilePath} must be a core tsup entry so ${distPath} exists after build`,
+      );
+    }
+  });
+
+  it("core package exposes the contradiction module through public exports", () => {
+    const manifest = JSON.parse(
+      readFileSync(resolve("packages/remnic-core/package.json"), "utf8"),
+    ) as {
+      exports?: Record<string, { import?: string; types?: string }>;
+    };
+    const tsupConfig = readFileSync(resolve("packages/remnic-core/tsup.config.ts"), "utf8");
+
+    assert.equal(
+      manifest.exports?.["./contradiction"]?.import,
+      "./dist/contradiction/index.js",
+      "@remnic/core/contradiction must resolve to the built contradiction entrypoint",
+    );
+    assert.equal(
+      manifest.exports?.["./contradiction"]?.types,
+      "./dist/contradiction/index.d.ts",
+      "@remnic/core/contradiction must publish declaration files",
+    );
+    assert.ok(
+      tsupConfig.includes('"src/contradiction/index.ts"') ||
+        tsupConfig.includes("'src/contradiction/index.ts'"),
+      "src/contradiction/index.ts must be a core tsup entry so the exported subpath exists after build",
+    );
+  });
+
+  it("core package exposes root source shim dependencies through public exports", () => {
+    const manifest = JSON.parse(
+      readFileSync(resolve("packages/remnic-core/package.json"), "utf8"),
+    ) as {
+      exports?: Record<string, { import?: string; types?: string }>;
+    };
+
+    for (const [, publicSpecifier] of ROOT_CORE_SOURCE_SHIMS) {
+      const subpath = publicSpecifier.replace(/^@remnic\/core/, ".");
+      const distPath = `./dist/${subpath.replace(/^\.\//, "")}.js`;
+      const typesPath = distPath.replace(/\.js$/, ".d.ts");
+
+      assert.equal(
+        manifest.exports?.[subpath]?.import,
+        distPath,
+        `${publicSpecifier} must resolve through @remnic/core exports`,
+      );
+      assert.equal(
+        manifest.exports?.[subpath]?.types,
+        typesPath,
+        `${publicSpecifier} must publish declarations`,
       );
     }
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,15 @@
       "@remnic/core/cli": [
         "./packages/remnic-core/src/cli.ts"
       ],
+      "@remnic/core/memory-projection-format": [
+        "./packages/remnic-core/src/memory-projection-format.ts"
+      ],
+      "@remnic/core/model-registry": [
+        "./packages/remnic-core/src/model-registry.ts"
+      ],
+      "@remnic/core/orchestrator": [
+        "./packages/remnic-core/src/orchestrator.ts"
+      ],
       "@remnic/core/connectors": [
         "./packages/remnic-core/src/connectors/index.ts"
       ],


### PR DESCRIPTION
## Summary

This PR addresses the Remnic clawpatch audit findings from the CLI/core slices and adds regression coverage for the fixed behaviors:

- hardens CLI wrapper behavior for missing built artifacts and avoids forcing ANSI color
- rejects malformed import and sync arguments instead of silently treating flags or cwd as values
- makes bench help/retry/resume planning respect profile-scoped matrix work items
- adds access-cli principal/config precedence/value parsing fixes with clearer runtime errors
- expands memoryDir `~` handling for env/config/active-space paths
- exercises the WeClone built CLI bin in package tests
- fixes message-part extraction for basename dotfiles, extensionless repo files, and OpenClaw tool-call blocks
- preserves terminal contradiction review decisions and ignores unmatched judge `pairKey` verdicts
- routes root core shims through explicit `@remnic/core` public subpath exports

## Verification

- `pnpm exec tsx --test packages/remnic-cli/src/config-path.test.ts packages/remnic-core/src/message-parts/message-parts.test.ts packages/remnic-core/src/contradiction/contradiction.test.ts packages/remnic-core/src/contradiction/contradiction-judge.test.ts tests/root-cli-package-boundary.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm --filter @remnic/cli test`
- `pnpm --filter @remnic/core test`
- `node scripts/check-test-types.mjs`
- `npm_config_workspace_concurrency=1 npm run preflight:quick`
- `node /Users/joshuawarren/src/clawpatch/dist/cli.js map`
- `node /Users/joshuawarren/src/clawpatch/dist/cli.js review --limit 12 --jobs 4`

## Clawpatch notes

The local clawpatch rerun reviewed the next 12-feature slice and reported additional findings outside this PR's original CLI/core patch scope. The report also continues to list older findings that this branch now covers, so I kept this PR focused and left the new slice findings for follow-up PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple CLI/core entrypoints (bin wrappers, argument parsing, bench resume/retry planning, and access-cli behavior) where small logic mistakes can break workflows or leak/omit data. Changes are well-covered by new regression tests but span many surfaces.
> 
> **Overview**
> **CLI hardening and test reliability:** Bin wrappers (`remnic.cjs`/`engram.cjs`) now fail with explicit errors when build artifacts or `tsx` are missing, and stop injecting `FORCE_COLOR`. Package tests are updated to run from repo root and include new coverage for these wrapper behaviors, plus `connector-weclone` tests now build and exercise the published `dist/cli.js` bin artifact.
> 
> **Bench resume/retry + repro manifests:** `bench` run planning is refactored to operate on explicit benchmark/profile *work items* so `--resume`/`--retry-failed` can filter at profile granularity; repro manifests now record `run.selectedWorkItems` and include it in the artifact hash, preserving uneven benchmark/profile pairings.
> 
> **Argument parsing + path normalization:** Adds pure CLI flag helpers (`cli-args.ts`) with stricter “missing value” detection (while allowing negative numerics), improves import flag leftover reporting to distinguish unknown flags vs positional args, and rejects bare `sync --source` flags. `resolveMemoryDir` now consistently expands/normalizes `~` and config/env/active-space paths.
> 
> **Core behavior fixes:** `access-cli` tightens missing-value checks (including empty strings), supports explicit browse principals while honoring OpenClaw config precedence, and avoids leaking sensitive runtime error details (with API key redaction helper + tests). Contradiction judging ignores unmatched `pairKey` items without misapplying positional fallbacks, and contradiction review no longer overwrites terminal resolutions. Message-part extraction better detects dotfiles/extensionless repo files and correctly routes OpenClaw tool-call blocks; core exports/tsconfig/tsup are updated to expose new public subpaths (including `contradiction`) and keep root shims using public `@remnic/core/*` exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8331b6250be23bdcb70af772a519d0a1d81841a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->