### PR TITLE
fix(access): authorize memory browse namespaces

### DIFF
--- a/packages/remnic-core/src/access-cli.test.ts
+++ b/packages/remnic-core/src/access-cli.test.ts
@@ -77,6 +77,7 @@ test("access-cli rejects unknown options before runtime initialization", async (
 
 test("access-cli rejects value options with missing values", async () => {
   await rejectsUsage(["browse", "--limit"]);
+  await rejectsUsage(["browse", "--principal"]);
   await rejectsUsage(["store", "--content", "hello", "--category"]);
 });
 
@@ -111,11 +112,13 @@ test("access-cli browse sort error lists accepted values", async () => {
 test("access-cli browse pagination bound errors list accepted ranges", async () => {
   const limitOutput = await captureRunCliFailure(["browse", "--limit", "0"]);
   const offsetOutput = await captureRunCliFailure(["browse", "--offset", "-1"]);
+  const principalOutput = await captureRunCliFailure(["browse", "--principal"]);
 
   assert.match(limitOutput, /invalid value for --limit/);
   assert.match(limitOutput, /Accepted: integer >= 1\./);
   assert.match(offsetOutput, /invalid value for --offset/);
   assert.match(offsetOutput, /Accepted: integer >= 0\./);
+  assert.match(principalOutput, /missing required option: --principal/);
 });
 
 test("access-cli rejects confidence outside the documented range", async () => {

--- a/packages/remnic-core/src/access-cli.ts
+++ b/packages/remnic-core/src/access-cli.ts
@@ -94,6 +94,7 @@ function usage(): string {
     "",
     "Browse options:",
     "  --namespace <name>",
+    "  --principal <principal>",
     "  --query <text>",
     "  --category <name>",
     "  --status <name>",
@@ -121,6 +122,7 @@ const COMMAND_SPECS: Record<CommandName, CommandSpec> = {
   browse: {
     valueOptions: new Set([
       "namespace",
+      "principal",
       "query",
       "category",
       "status",
@@ -331,8 +333,11 @@ async function runBrowse(args: ParsedArgs, preferredId?: string): Promise<void> 
     limit: parseIntegerOption(args, "limit", { min: 1 }),
     offset: parseIntegerOption(args, "offset", { min: 0 }),
   };
-  const { service } = buildRuntime(preferredId);
-  const result = await service.memoryBrowse(request);
+  const { config, service } = buildRuntime(preferredId);
+  const result = await service.memoryBrowse({
+    ...request,
+    authenticatedPrincipal: getLastOption(args, "principal") ?? config.agentAccessHttp.principal,
+  });
   console.log(JSON.stringify(result, null, 2));
 }
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -869,6 +869,7 @@ export class EngramAccessHttpServer {
         status: parsed.searchParams.get("status") ?? undefined,
         category: parsed.searchParams.get("category") ?? undefined,
         namespace: parsed.searchParams.get("namespace") ?? undefined,
+        authenticatedPrincipal: this.resolveRequestPrincipal(req),
         sort,
         limit: Number.isFinite(limitRaw) ? limitRaw : 50,
         offset: Number.isFinite(offsetRaw) ? offsetRaw : 0,

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -35,7 +35,12 @@ function makeService(): {
   getStorageCalls: string[];
 } {
   const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
-  const storage = { marker: "team-storage" } as unknown as StorageManager;
+  const storage = {
+    marker: "team-storage",
+    async browseProjectedMemories() {
+      return { total: 0, memories: [] };
+    },
+  } as unknown as StorageManager;
   const getStorageCalls: string[] = [];
 
   (service as unknown as {
@@ -81,5 +86,38 @@ test("getWritableStorageForNamespace resolves namespace storage for write princi
 
   assert.equal(resolved.namespace, "team");
   assert.equal(resolved.storage, storage);
+  assert.deepEqual(getStorageCalls, ["team"]);
+});
+
+test("memoryBrowse denies missing principals before namespace storage lookup", async () => {
+  const { service, getStorageCalls } = makeService();
+
+  await assert.rejects(
+    () => service.memoryBrowse({ namespace: "team" }),
+    /authentication required/,
+  );
+  assert.deepEqual(getStorageCalls, []);
+});
+
+test("memoryBrowse denies principals without read access before namespace storage lookup", async () => {
+  const { service, getStorageCalls } = makeService();
+
+  await assert.rejects(
+    () => service.memoryBrowse({ namespace: "team", authenticatedPrincipal: "stranger" }),
+    /namespace is not readable: team/,
+  );
+  assert.deepEqual(getStorageCalls, []);
+});
+
+test("memoryBrowse resolves namespace storage for read principals", async () => {
+  const { service, getStorageCalls } = makeService();
+
+  const result = await service.memoryBrowse({
+    namespace: "team",
+    authenticatedPrincipal: "reader",
+  });
+
+  assert.equal(result.namespace, "team");
+  assert.equal(result.count, 0);
   assert.deepEqual(getStorageCalls, ["team"]);
 });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -428,6 +428,7 @@ export interface EngramAccessMemoryBrowseRequest {
   status?: string;
   category?: string;
   namespace?: string;
+  authenticatedPrincipal?: string;
   sort?: "updated_desc" | "updated_asc" | "created_desc" | "created_asc";
   limit?: number;
   offset?: number;
@@ -2643,8 +2644,11 @@ export class EngramAccessService {
   async memoryBrowse(
     request: EngramAccessMemoryBrowseRequest = {},
   ): Promise<EngramAccessMemoryBrowseResponse> {
-    const storage = await this.orchestrator.getStorage(request.namespace);
-    const resolvedNamespace = request.namespace?.trim() || this.orchestrator.config.defaultNamespace;
+    const resolvedNamespace = this.resolveReadableNamespace(
+      request.namespace,
+      request.authenticatedPrincipal,
+    );
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
     const { limit, offset } = normalizePagination(request.limit, request.offset);
     const sort = normalizeBrowseSort(request.sort);
     const query = request.query?.trim().toLowerCase() ?? "";


### PR DESCRIPTION
## Summary
- add principal support to `engram-access browse`
- route CLI and HTTP browse requests through `memoryBrowse` with an authenticated principal
- enforce readable namespace ACLs before browse storage lookup

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/access-service-namespace.test.ts`
- `pnpm exec tsx --test packages/remnic-core/src/access-cli.test.ts`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the authorization surface for `memoryBrowse` by requiring an authenticated principal when namespaces are enabled, which may break existing callers or cause unexpected 4xx responses if principals are missing/misresolved.
> 
> **Overview**
> **Memory browsing is now principal-aware and ACL-enforced.** `EngramAccessService.memoryBrowse` accepts `authenticatedPrincipal` and resolves/authorizes the namespace via `resolveReadableNamespace` *before* doing any storage lookup.
> 
> The CLI `browse` command adds `--principal` and defaults to the configured agent principal when omitted; the HTTP `GET /engram/v1/memories` handler now passes the resolved request principal into `memoryBrowse`. Tests are updated to validate missing/unauthorized principals fail early and that CLI usage errors include `--principal` handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c541e8e1a5ada4826bcf34625401d655faadaef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->