### PR TITLE
fix(cli): reject unsafe namespace paths

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -3236,6 +3236,28 @@ async function exists(p: string): Promise<boolean> {
   }
 }
 
+function assertSafeNamespaceSegment(namespace: string): void {
+  if (
+    namespace.length === 0 ||
+    namespace === "." ||
+    namespace === ".." ||
+    namespace.includes("/") ||
+    namespace.includes("\\") ||
+    path.isAbsolute(namespace) ||
+    path.win32.isAbsolute(namespace)
+  ) {
+    throw new Error(`invalid namespace: ${namespace}`);
+  }
+}
+
+function assertPathInsideRoot(root: string, candidate: string, namespace: string): void {
+  const relative = path.relative(root, candidate);
+  if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+    return;
+  }
+  throw new Error(`invalid namespace path: ${namespace}`);
+}
+
 export async function resolveMemoryDirForNamespace(
   orchestrator: Orchestrator,
   namespace?: string,
@@ -3243,6 +3265,7 @@ export async function resolveMemoryDirForNamespace(
 ): Promise<string> {
   const ns = (namespace ?? "").trim();
   if (!ns) return orchestrator.config.memoryDir;
+  assertSafeNamespaceSegment(ns);
   if (!orchestrator.config.namespacesEnabled) {
     if (options?.rejectUnsupportedOverride && ns !== orchestrator.config.defaultNamespace) {
       throw new Error(`namespaces are disabled; cannot target namespace: ${ns}`);
@@ -3250,7 +3273,9 @@ export async function resolveMemoryDirForNamespace(
     return orchestrator.config.memoryDir;
   }
 
-  const candidate = path.join(orchestrator.config.memoryDir, "namespaces", ns);
+  const namespaceRoot = path.resolve(orchestrator.config.memoryDir, "namespaces");
+  const candidate = path.resolve(namespaceRoot, ns);
+  assertPathInsideRoot(namespaceRoot, candidate, ns);
   if (ns === orchestrator.config.defaultNamespace) {
     return (await exists(candidate)) ? candidate : orchestrator.config.memoryDir;
   }

--- a/tests/cli-memory-governance.test.ts
+++ b/tests/cli-memory-governance.test.ts
@@ -233,3 +233,30 @@ test("resolveMemoryDirForNamespace rejects unsupported namespace overrides when 
     "/tmp/engram",
   );
 });
+
+test("resolveMemoryDirForNamespace rejects traversal namespace segments", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cli-namespace-"));
+  const orchestrator = {
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+    },
+  } as any;
+
+  try {
+    for (const namespace of ["../team", "../../outside", "team/../other", ".", "..", "/tmp/outside", "team\\other"]) {
+      await assert.rejects(
+        () => resolveMemoryDirForNamespace(orchestrator, namespace),
+        /invalid namespace/,
+      );
+    }
+
+    assert.equal(
+      await resolveMemoryDirForNamespace(orchestrator, "team-alpha"),
+      path.join(memoryDir, "namespaces", "team-alpha"),
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- reject unsafe namespace values before resolving CLI memory directories
- keep namespaced paths inside `<memoryDir>/namespaces` with a resolved boundary check
- add traversal regression coverage for namespace-aware CLI helpers

## Verification
- `pnpm exec tsx --test tests/cli-memory-governance.test.ts`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens filesystem path resolution for namespace-specific memory directories, which is security-adjacent; low implementation complexity but could affect existing callers relying on previously accepted namespace strings.
> 
> **Overview**
> **Hardened namespace-to-path resolution for CLI memory directories.** `resolveMemoryDirForNamespace` now validates namespace strings (rejecting empty/dot segments, separators, and absolute paths) and resolves the namespace directory with a boundary check to ensure it stays within `<memoryDir>/namespaces`.
> 
> Adds tests covering traversal and Windows/Unix path edge cases, while preserving expected behavior for valid namespaces and disabled-namespace overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ca3c26c1afa50d3f4018cb87d8b07852d330edb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->