### PR TITLE
fix(weclone): await proxy shutdown signals

### DIFF
--- a/packages/connector-weclone/src/cli.test.ts
+++ b/packages/connector-weclone/src/cli.test.ts
@@ -6,6 +6,7 @@ import * as net from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createGracefulShutdownHandler } from "./shutdown.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
@@ -77,6 +78,20 @@ function closeServer(server: net.Server): Promise<void> {
       else resolveClose();
     });
   });
+}
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
 }
 
 describe("remnic-weclone-proxy CLI", () => {
@@ -205,5 +220,63 @@ describe("remnic-weclone-proxy CLI", () => {
     } finally {
       await closeServer(server);
     }
+  });
+
+  it("awaits proxy stop before exiting and ignores duplicate shutdown signals", async () => {
+    const stopGate = deferred();
+    const exitGate = deferred<number>();
+    const exitCodes: number[] = [];
+    let stopCalls = 0;
+
+    const handler = createGracefulShutdownHandler(
+      {
+        async stop() {
+          stopCalls += 1;
+          await stopGate.promise;
+        },
+      },
+      {
+        exit(code) {
+          exitCodes.push(code);
+          exitGate.resolve(code);
+        },
+        logError() {},
+      },
+    );
+
+    handler();
+    handler();
+
+    assert.equal(stopCalls, 1);
+    assert.deepEqual(exitCodes, []);
+
+    stopGate.resolve();
+    assert.equal(await exitGate.promise, 0);
+    assert.deepEqual(exitCodes, [0]);
+  });
+
+  it("reports a failed proxy stop and exits nonzero", async () => {
+    const exitGate = deferred<number>();
+    const logged: string[] = [];
+    const handler = createGracefulShutdownHandler(
+      {
+        async stop() {
+          throw new Error("flush failed");
+        },
+      },
+      {
+        exit(code) {
+          exitGate.resolve(code);
+        },
+        logError(message) {
+          logged.push(message);
+        },
+      },
+    );
+
+    handler();
+
+    assert.equal(await exitGate.promise, 1);
+    assert.match(logged.join("\n"), /Failed to stop WeClone proxy: flush failed/);
   });
 });

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -10,6 +10,7 @@
 
 import { createWeCloneProxy } from "./proxy.js";
 import { parseConfig, type WeCloneConnectorConfig } from "./config.js";
+import { createGracefulShutdownHandler, errorMessage } from "./shutdown.js";
 import { readFileSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -54,10 +55,6 @@ function defaultConfigPath(): string {
     return resolve(expandTildePath(override), "connectors", "weclone.json");
   }
   return resolve(homeDir(), ".remnic", "connectors", "weclone.json");
-}
-
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 async function main(): Promise<void> {
@@ -124,10 +121,7 @@ async function main(): Promise<void> {
   console.log(`  WeClone API: ${config.wecloneApiUrl}`);
   console.log(`  Remnic daemon: ${config.remnicDaemonUrl}`);
 
-  const stopAndExit = () => {
-    void proxy.stop();
-    process.exit(0);
-  };
+  const stopAndExit = createGracefulShutdownHandler(proxy);
   process.on("SIGINT", stopAndExit);
   process.on("SIGTERM", stopAndExit);
 }

--- a/packages/connector-weclone/src/shutdown.ts
+++ b/packages/connector-weclone/src/shutdown.ts
@@ -1,0 +1,32 @@
+import type { WeCloneProxy } from "./proxy.js";
+
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function createGracefulShutdownHandler(
+  proxy: Pick<WeCloneProxy, "stop">,
+  options: {
+    exit?: (code: number) => void;
+    logError?: (message: string) => void;
+  } = {},
+): () => void {
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const logError = options.logError ?? ((message: string) => console.error(message));
+  let stopping = false;
+
+  return () => {
+    if (stopping) return;
+    stopping = true;
+
+    void (async () => {
+      try {
+        await proxy.stop();
+        exit(0);
+      } catch (err) {
+        logError(`Failed to stop WeClone proxy: ${errorMessage(err)}`);
+        exit(1);
+      }
+    })();
+  };
+}


### PR DESCRIPTION
## Summary
- await `proxy.stop()` before exiting on SIGINT/SIGTERM
- guard graceful shutdown against duplicate signal handling
- add focused shutdown handler regression tests for successful and failed stops

## Verification
- `pnpm --filter @remnic/connector-weclone test`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI shutdown behavior (awaiting `proxy.stop()`, de-duping signals) plus new unit tests; main risk is potential hang if `stop()` never resolves.
> 
> **Overview**
> Ensures the WeClone proxy CLI shuts down *gracefully* by replacing the fire-and-forget signal handler with `createGracefulShutdownHandler()`, which **awaits** `proxy.stop()` before exiting and **ignores duplicate** SIGINT/SIGTERM handling.
> 
> Adds a new `shutdown.ts` helper (including shared `errorMessage`) and regression tests covering successful shutdown ordering, duplicate-signal suppression, and nonzero exit/logging when `stop()` throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc52870c5271aa46a39e3dd65521c1f544ee28dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->