### PR TITLE
test(cli): include engram access regression

### DIFF
--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -28,7 +28,7 @@
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "precheck-types": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/*.test.ts ../../tests/remnic-cli-bin-wrapper.test.ts ../../tests/evals-engram-adapter-buffering.test.ts ../../tests/shim-openclaw-engram-package.test.ts",
+    "test": "tsx --test src/*.test.ts ../../tests/remnic-cli-bin-wrapper.test.ts ../../tests/evals-engram-adapter-buffering.test.ts ../../tests/shim-openclaw-engram-package.test.ts ../../tests/engram-access-bin-errors.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/tests/remnic-cli-bin-wrapper.test.ts
+++ b/tests/remnic-cli-bin-wrapper.test.ts
@@ -28,7 +28,7 @@ test("@remnic/cli package test script includes linked root tests", async () => {
   const testScript = (scripts as Record<string, unknown>).test;
   assert.equal(typeof testScript, "string");
   assert.match(testScript, /\.\.\/\.\.\/tests\/evals-engram-adapter-buffering\.test\.ts/);
-  assert.match(testScript, /\.\.\/\.\.\/tests\/shim-openclaw-engram-package\.test\.ts/);
+  assert.match(testScript, /\.\.\/\.\.\/tests\/shim-openclaw-engram-package\.test\.ts.*\.\.\/\.\.\/tests\/engram-access-bin-errors\.test\.ts/);
 });
 
 test("remnic package bins are executable on POSIX checkouts", async () => {


### PR DESCRIPTION
## Summary
- include the linked `engram-access` bin error regression in the `@remnic/cli` package test script
- extend the package-script guard so future edits keep that root regression wired into the package test command

## Verification
- `node scripts/check-test-types.mjs`
- `git diff --check`
- `npm run preflight:quick`

Note: `pnpm --filter @remnic/cli test` currently trips an unrelated local Node 26 harness issue in `marketplace-cli.test.ts`, where the test invokes the POSIX `node_modules/.bin/tsx` shell shim via `node`. The mandatory quick preflight passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test wiring and assertions, with no runtime CLI or production code changes.
> 
> **Overview**
> **Expands `@remnic/cli` test coverage** by adding the root-level `engram-access-bin-errors` regression test to the package `test` script.
> 
> **Hardens the guard test** in `remnic-cli-bin-wrapper.test.ts` to assert that the package `test` script continues to include the new regression test (in addition to the existing linked root tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df02be29dba8e117ff98b9ca37d603524ab3cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->