### PR TITLE
fix(bench): reject symlinked Remnic state dirs

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -274,6 +283,221 @@ test("direct adapter rejects unsafe caller-owned memory directories before initi
     assert.equal(await readFile(sentinelPath, "utf8"), "preserve temp root data");
   } finally {
     await rm(sentinelPath, { force: true });
+  }
+});
+
+test("direct adapter rejects symlinked caller-owned memory directories before initialization", async () => {
+  const parentDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-parent-"));
+  const protectedDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-target-"));
+  const protectedStateDir = path.join(protectedDir, "state");
+  const sentinelPath = path.join(protectedStateDir, "sentinel.txt");
+  const memoryDir = path.join(parentDir, "memory-link");
+  await mkdir(protectedStateDir);
+  await writeFile(sentinelPath, "preserve symlink target data");
+  await symlink(protectedDir, memoryDir, "dir");
+
+  try {
+    await assert.rejects(
+      () => createRemnicAdapter({ memoryDir }),
+      /must not be a symlink path/,
+    );
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve symlink target data");
+  } finally {
+    await rm(parentDir, { recursive: true, force: true });
+    await rm(protectedDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter rejects symlinked parent directories before creating state", async () => {
+  const parentDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-parent-"));
+  const protectedDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-target-"));
+  const protectedStateDir = path.join(protectedDir, "state");
+  const sentinelPath = path.join(protectedStateDir, "sentinel.txt");
+  const linkedParent = path.join(parentDir, "linked-parent");
+  const memoryDir = path.join(linkedParent, "bench-memory");
+  await mkdir(protectedStateDir);
+  await writeFile(sentinelPath, "preserve symlink parent data");
+  await symlink(protectedDir, linkedParent, "dir");
+
+  try {
+    await assert.rejects(
+      () => createRemnicAdapter({ memoryDir }),
+      /must not be a symlink path/,
+    );
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve symlink parent data");
+  } finally {
+    await rm(parentDir, { recursive: true, force: true });
+    await rm(protectedDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter allows caller-owned memory directories under macOS /tmp alias", async (t) => {
+  if (process.platform !== "darwin") {
+    t.skip("macOS-only system alias check");
+    return;
+  }
+  const memoryDir = path.join("/tmp", `remnic-bench-system-alias-${process.pid}-${Date.now()}`);
+  const adapter = await createRemnicAdapter({ memoryDir });
+
+  try {
+    await adapter.store("tmp-alias-session", [
+      {
+        role: "user",
+        content: "Remember the macOS tmp alias code is silver-94.",
+      },
+    ]);
+    await adapter.drain?.();
+    const recalled = await adapter.recall(
+      "tmp-alias-session",
+      "What is the macOS tmp alias code?",
+    );
+    assert.match(recalled, /silver-94/);
+  } finally {
+    await adapter.destroy();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter rejects dangling symlink directories before creating state", async () => {
+  const parentDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-dangling-symlink-"));
+  const missingTarget = path.join(parentDir, "missing-target");
+  const memoryDir = path.join(parentDir, "memory-link");
+  await symlink(missingTarget, memoryDir, "dir");
+
+  try {
+    await assert.rejects(
+      () => createRemnicAdapter({ memoryDir }),
+      /must not be a symlink path/,
+    );
+  } finally {
+    await rm(parentDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter rejects symlinked caller-owned Remnic state children", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-child-"));
+  const protectedDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-target-"));
+  const sentinelPath = path.join(protectedDir, "sentinel.txt");
+  await writeFile(sentinelPath, "preserve symlink child data");
+  await symlink(protectedDir, path.join(memoryDir, "state"), "dir");
+
+  try {
+    await assert.rejects(
+      () => createRemnicAdapter({ memoryDir }),
+      /must not be a symlink path/,
+    );
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve symlink child data");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(protectedDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter rejects symlinked caller-owned search index children", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-search-"));
+  const protectedDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-target-"));
+  const sentinelPath = path.join(protectedDir, "sentinel.txt");
+  await writeFile(sentinelPath, "preserve search index symlink data");
+  await symlink(protectedDir, path.join(memoryDir, "orama"), "dir");
+
+  try {
+    await assert.rejects(
+      () => createRemnicAdapter({ memoryDir, configOverrides: { searchBackend: "orama" } }),
+      /must not be a symlink path/,
+    );
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve search index symlink data");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(protectedDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter rejects symlinked custom caller-owned search index children", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-search-"));
+  const protectedDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-target-"));
+  const indexPath = path.join(memoryDir, "custom-index");
+  const sentinelPath = path.join(protectedDir, "sentinel.txt");
+  await writeFile(sentinelPath, "preserve custom search index symlink data");
+  await symlink(protectedDir, indexPath, "dir");
+
+  try {
+    await assert.rejects(
+      () =>
+        createRemnicAdapter({
+          memoryDir,
+          configOverrides: { searchBackend: "orama", oramaDbPath: indexPath },
+        }),
+      /must not be a symlink path/,
+    );
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve custom search index symlink data");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(protectedDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter rejects custom caller-owned search index paths outside memory dir", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-search-outside-"));
+  const outsideDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-search-outside-target-"));
+
+  try {
+    await assert.rejects(
+      () =>
+        createRemnicAdapter({
+          memoryDir,
+          configOverrides: { searchBackend: "orama", oramaDbPath: outsideDir },
+        }),
+      /search index paths must stay inside memoryDir\/sandboxDir/,
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter rejects custom search index paths under symlinked parents", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-search-"));
+  const protectedDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-target-"));
+  const linkedParent = path.join(memoryDir, "idx-link");
+  const indexPath = path.join(linkedParent, "orama");
+  const sentinelPath = path.join(protectedDir, "sentinel.txt");
+  await writeFile(sentinelPath, "preserve custom search parent symlink data");
+  await symlink(protectedDir, linkedParent, "dir");
+
+  try {
+    await assert.rejects(
+      () =>
+        createRemnicAdapter({
+          memoryDir,
+          configOverrides: { searchBackend: "orama", oramaDbPath: indexPath },
+        }),
+      /must not be a symlink path/,
+    );
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve custom search parent symlink data");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(protectedDir, { recursive: true, force: true });
+  }
+});
+
+test("direct adapter rejects nested symlinks in caller-owned Remnic state children", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-child-"));
+  const protectedDir = await mkdtemp(path.join(tmpdir(), "remnic-bench-symlink-target-"));
+  const factsDir = path.join(memoryDir, "facts");
+  const sentinelPath = path.join(protectedDir, "sentinel.txt");
+  await mkdir(factsDir);
+  await writeFile(sentinelPath, "preserve nested symlink data");
+  await symlink(protectedDir, path.join(factsDir, "2026-05-19"), "dir");
+
+  try {
+    await assert.rejects(
+      () => createRemnicAdapter({ memoryDir }),
+      /must not contain symlinked Remnic state children/,
+    );
+    assert.equal(await readFile(sentinelPath, "utf8"), "preserve nested symlink data");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(protectedDir, { recursive: true, force: true });
   }
 });
 

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -6,10 +6,12 @@ import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import {
   chmod,
+  lstat,
   mkdir,
   mkdtemp,
   readdir,
   readFile,
+  realpath,
   rename,
   rm,
   unlink,
@@ -190,6 +192,8 @@ const BENCH_REMNIC_STATE_CHILDREN = [
   "entities",
   "facts",
   "identity",
+  "lancedb",
+  "orama",
   "profiling",
   "procedures",
   "qmd-bench",
@@ -332,10 +336,14 @@ async function createBenchOrchestrator(
   configuredMemoryDir?: string,
 ): Promise<BenchOrchestratorState> {
   const tempDir = configuredMemoryDir
-    ? assertSafeConfiguredBenchDir(configuredMemoryDir)
+    ? await assertSafeConfiguredBenchDir(configuredMemoryDir)
     : await mkdtemp(path.join(tmpdir(), `remnic-bench-${mode}-`));
   const ownsTempDir = !configuredMemoryDir;
   await mkdir(tempDir, { recursive: true });
+  await assertNoUnsafeBenchStateChildren(
+    tempDir,
+    resolveConfiguredBenchIndexDirs(tempDir, overrides),
+  );
   await mkdir(path.join(tempDir, "state"), { recursive: true });
   const qmdSandbox = await createBenchQmdSandbox(tempDir, overrides);
 
@@ -515,8 +523,16 @@ function resolveConfiguredBenchDir(options: RemnicAdapterOptions): string | unde
   return sandboxDir ?? memoryDir;
 }
 
-function assertSafeConfiguredBenchDir(configuredDir: string): string {
+async function assertSafeConfiguredBenchDir(configuredDir: string): Promise<string> {
   const resolved = path.resolve(expandTildePath(configuredDir));
+  assertSafeBenchDirPath(resolved);
+  await assertNoUnsafeSymlinkComponents(resolved);
+  await mkdir(resolved, { recursive: true });
+  assertSafeBenchDirPath(await realpath(resolved));
+  return resolved;
+}
+
+function assertSafeBenchDirPath(resolved: string): void {
   const root = path.parse(resolved).root;
   const dangerousDirs = [
     root,
@@ -532,12 +548,129 @@ function assertSafeConfiguredBenchDir(configuredDir: string): string {
       `Remnic benchmark memoryDir/sandboxDir must not be a root, home, temp, cwd, or repository ancestor path: ${resolved}`,
     );
   }
-  return resolved;
 }
 
 function isPathAncestorOf(candidate: string, child: string): boolean {
   const relative = path.relative(candidate, child);
   return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+async function assertNoUnsafeSymlinkComponents(candidate: string): Promise<void> {
+  let current = candidate;
+  while (true) {
+    try {
+      const stats = await lstat(current);
+      if (stats.isSymbolicLink()) {
+        const target = await realpath(current).catch(() => undefined);
+        if (!isAllowedSystemPathAlias(current, target)) {
+          throw new Error(
+            `Remnic benchmark memoryDir/sandboxDir must not be a symlink path or contain symlink path components: ${current}`,
+          );
+        }
+      }
+    } catch (error) {
+      if (!isErrnoCode(error, "ENOENT")) {
+        throw error;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return;
+    }
+    current = parent;
+  }
+}
+
+function isAllowedSystemPathAlias(linkPath: string, targetPath: string | undefined): boolean {
+  if (targetPath === undefined) {
+    return false;
+  }
+  return (
+    process.platform === "darwin" &&
+    (
+      (path.resolve(linkPath) === "/var" && path.resolve(targetPath) === "/private/var") ||
+      (path.resolve(linkPath) === "/tmp" && path.resolve(targetPath) === "/private/tmp")
+    )
+  );
+}
+
+async function assertNoUnsafeBenchStateChildren(
+  memoryDir: string,
+  extraStateDirs: string[] = [],
+): Promise<void> {
+  const stateDirs = new Set([
+    ...BENCH_REMNIC_STATE_CHILDREN.map((entry) => path.join(memoryDir, entry)),
+    ...extraStateDirs,
+  ]);
+  await Promise.all(
+    [...stateDirs].map(async (childPath) => {
+      try {
+        await assertNoUnsafeSymlinkComponents(childPath);
+        const stats = await lstat(childPath);
+        if (stats.isSymbolicLink()) {
+          throw new Error(
+            `Remnic benchmark memoryDir/sandboxDir must not contain symlinked Remnic state children: ${childPath}`,
+          );
+        }
+        if (stats.isDirectory()) {
+          await assertNoUnsafeSymlinksInTree(childPath);
+        }
+      } catch (error) {
+        if (!isErrnoCode(error, "ENOENT")) {
+          throw error;
+        }
+      }
+    }),
+  );
+}
+
+function resolveConfiguredBenchIndexDirs(
+  memoryDir: string,
+  overrides?: Record<string, unknown>,
+): string[] {
+  const dirs = [
+    normalizeConfiguredBenchDir(overrides?.oramaDbPath),
+    normalizeConfiguredBenchDir(overrides?.lanceDbPath),
+  ].filter((value): value is string => value !== undefined)
+    .map((value) => resolveConfiguredBenchIndexDir(memoryDir, value));
+  for (const dir of dirs) {
+    if (!isPathInsideOrEqual(memoryDir, dir)) {
+      throw new Error(
+        `Remnic benchmark search index paths must stay inside memoryDir/sandboxDir: ${dir}`,
+      );
+    }
+  }
+  return dirs;
+}
+
+function resolveConfiguredBenchIndexDir(memoryDir: string, value: string): string {
+  const expanded = expandTildePath(value);
+  return path.isAbsolute(expanded)
+    ? path.resolve(expanded)
+    : path.resolve(memoryDir, expanded);
+}
+
+function isPathInsideOrEqual(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative.length === 0 || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function assertNoUnsafeSymlinksInTree(dirPath: string): Promise<void> {
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dirPath, entry.name);
+      const stats = await lstat(entryPath);
+      if (stats.isSymbolicLink()) {
+        throw new Error(
+          `Remnic benchmark memoryDir/sandboxDir must not contain symlinked Remnic state children: ${entryPath}`,
+        );
+      }
+      if (stats.isDirectory()) {
+        await assertNoUnsafeSymlinksInTree(entryPath);
+      }
+    }),
+  );
 }
 
 function normalizeBenchSessionId(sessionId: string): string {


### PR DESCRIPTION
## Summary
- reject caller-provided benchmark memory/sandbox roots that are symlinks before Remnic adapter initialization
- validate the real configured directory path after creation so destructive benchmark cleanup stays inside accepted state dirs
- add a regression test proving a symlink target sentinel survives rejection

## Verification
- `pnpm exec tsx --test packages/bench/src/adapters/remnic-adapter.test.ts`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens filesystem safety checks around caller-provided benchmark directories (including symlink and path-boundary validation) which can affect initialization/cleanup behavior across platforms. Risk is moderate due to new path-resolution logic and additional error cases.
> 
> **Overview**
> **Hardens benchmark adapter directory safety checks** by rejecting caller-provided `memoryDir`/`sandboxDir` paths that are symlinks *or contain symlink components*, and by re-validating the post-`mkdir` realpath so cleanup cannot target an unexpected resolved location.
> 
> **Adds pre-initialization validation of existing state/index directories** (including `orama`/`lancedb` and custom `oramaDbPath`/`lanceDbPath`) to ensure they’re not symlinks, contain no nested symlinks, and that custom index paths stay within `memoryDir`/`sandboxDir`.
> 
> **Expands tests** with multiple symlink regression cases (root dir, parent dir, dangling symlink, state/search child symlinks, nested symlinks) plus a macOS-only allowance for `/tmp` and `/var` system alias symlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3337bf2c2c5092597ccf7087c9ba91e0df7984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->