### PR TITLE
Record OpenClaw 2026.5.19 compatibility

### DIFF
--- a/.changeset/openclaw-2026-5-19-compat.md
+++ b/.changeset/openclaw-2026-5-19-compat.md
@@ -3,6 +3,5 @@
 "@joshuaswarren/openclaw-engram": patch
 ---
 
-Record OpenClaw 2026.5.16-beta.6 through 2026.5.19-beta.1 compatibility and
-publish the adapter packages with the current OpenClaw Node.js 22.19 runtime
-floor.
+Record OpenClaw 2026.5.16-beta.6 through 2026.5.19-beta.1 compatibility while
+keeping Remnic's broad OpenClaw host range aligned with its package metadata.

--- a/.changeset/openclaw-2026-5-19-compat.md
+++ b/.changeset/openclaw-2026-5-19-compat.md
@@ -1,0 +1,8 @@
+---
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Record OpenClaw 2026.5.16-beta.6 through 2026.5.19-beta.1 compatibility and
+publish the adapter packages with the current OpenClaw Node.js 22.19 runtime
+floor.

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -168,8 +168,9 @@ The plugin manifest advertises compatibility on two surfaces:
   surfaces compatible. Remnic stays on the full `definePluginEntry` SDK path
   instead of the simple `defineToolPlugin` helper because the adapter combines
   memory-slot hooks, lifecycle handlers, command metadata, public artifacts,
-  and runtime tools. Published OpenClaw adapter packages declare Node.js
-  `>=22.19.0` to match the current OpenClaw runtime floor.
+  and runtime tools. Newer OpenClaw hosts enforce their Node.js `>=22.19.0`
+  runtime floor at the host level while Remnic keeps the package-level host
+  range broad for older advertised 2026.5.16 runtimes.
 
 Keep the supported blocks. `contracts.tools` is additive for older OpenClaw runtimes, but
 OpenClaw 2026.5 rejects plugin tool registration when a runtime tool is missing

--- a/docs/plugins/openclaw.md
+++ b/docs/plugins/openclaw.md
@@ -164,6 +164,12 @@ The plugin manifest advertises compatibility on two surfaces:
 - `setup.providers` is intentionally omitted because OpenClaw treats setup
   provider ids as globally unique provider ownership metadata, and Remnic does
   not own the `openai` provider.
+- OpenClaw 2026.5.16-beta.6 through 2026.5.19-beta.1 keep these runtime
+  surfaces compatible. Remnic stays on the full `definePluginEntry` SDK path
+  instead of the simple `defineToolPlugin` helper because the adapter combines
+  memory-slot hooks, lifecycle handlers, command metadata, public artifacts,
+  and runtime tools. Published OpenClaw adapter packages declare Node.js
+  `>=22.19.0` to match the current OpenClaw runtime floor.
 
 Keep the supported blocks. `contracts.tools` is additive for older OpenClaw runtimes, but
 OpenClaw 2026.5 rejects plugin tool registration when a runtime tool is missing

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -211,12 +211,13 @@ tools.
 
 OpenClaw 2026.5.16-beta.7 through 2026.5.19-beta.1 keep the Remnic-required
 plugin install, ClawHub fallback, manifest contract, hook, memory-slot, gateway
-LLM, and plugin security-scan surfaces compatible. The only package-level
-compatibility change Remnic needs for this range is publishing the OpenClaw
-runtime floor of Node.js `>=22.19.0` on the OpenClaw adapter packages. The
-manifest continues to avoid `setup.providers.openai`; OpenClaw still treats
-provider ids there as ownership metadata, while Remnic only advertises an
-optional plugin-mode OpenAI key through `providerAuthChoices` and the deprecated
+LLM, and plugin security-scan surfaces compatible. Those newer OpenClaw hosts
+raise their runtime floor to Node.js `>=22.19.0`, but the Remnic adapter package
+keeps its broad host peer range so older advertised 2026.5.16 hosts do not
+select a package with an incompatible package-level engine gate. The manifest
+continues to avoid `setup.providers.openai`; OpenClaw still treats provider ids
+there as ownership metadata, while Remnic only advertises an optional
+plugin-mode OpenAI key through `providerAuthChoices` and the deprecated
 `providerAuthEnvVars.openai` compatibility probe.
 
 Native memory registrars are tracked separately in

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -164,12 +164,15 @@ CI jobs that provision OpenClaw should use
 `npm run check:openclaw-sdk-surface:required` or pass
 `-- --require --package-root <path>` so a missing SDK fails instead of skipping.
 
-Last compatibility sweep: May 16, 2026. The SDK surface check passed against
+Last compatibility sweep: May 19, 2026. The SDK surface check passed against
 `openclaw@2026.5.3`, `openclaw@2026.5.3-1`, `openclaw@2026.5.4-beta.1`,
 `openclaw@2026.5.4-beta.2`, `openclaw@2026.5.4-beta.3`,
 `openclaw@2026.5.4`, `openclaw@2026.5.5`, `openclaw@2026.5.6`,
 `openclaw@2026.5.16-beta.2`, `openclaw@2026.5.16-beta.3`, and
-`openclaw@2026.5.16-beta.4`.
+`openclaw@2026.5.16-beta.4`. The May 19 sweep also checked the source SDK
+surface for `openclaw@2026.5.19-beta.1`, which covers the intervening
+`2026.5.16-beta.6`, `2026.5.16-beta.7`, and `2026.5.18-beta.1` release line
+for the Remnic adapter surfaces.
 Keep the peer range broad unless an upstream release removes a runtime surface
 Remnic actively uses.
 
@@ -199,6 +202,22 @@ metadata with globally unique ids. Remnic does not own the `openai` provider,
 so the canonical manifest keeps OpenAI API-key metadata on `providerAuthChoices`
 and the compatibility `providerAuthEnvVars.openai` surface instead of declaring
 `setup.providers`.
+
+OpenClaw 2026.5.16-beta.6 added `defineToolPlugin` and the authoring CLI for
+simple typed tool-only plugins. Remnic intentionally stays on `definePluginEntry`
+because the adapter owns mixed memory-slot hooks, lifecycle handlers, slash
+command metadata, public artifacts, and runtime tools rather than only static
+tools.
+
+OpenClaw 2026.5.16-beta.7 through 2026.5.19-beta.1 keep the Remnic-required
+plugin install, ClawHub fallback, manifest contract, hook, memory-slot, gateway
+LLM, and plugin security-scan surfaces compatible. The only package-level
+compatibility change Remnic needs for this range is publishing the OpenClaw
+runtime floor of Node.js `>=22.19.0` on the OpenClaw adapter packages. The
+manifest continues to avoid `setup.providers.openai`; OpenClaw still treats
+provider ids there as ownership metadata, while Remnic only advertises an
+optional plugin-mode OpenAI key through `providerAuthChoices` and the deprecated
+`providerAuthEnvVars.openai` compatibility probe.
 
 Native memory registrars are tracked separately in
 [`docs/plugins/openclaw-native-memory-registrars.md`](../../docs/plugins/openclaw-native-memory-registrars.md).

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -4,9 +4,6 @@
   "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",
-  "engines": {
-    "node": ">=22.19.0"
-  },
   "exports": {
     ".": {
       "import": "./dist/index.js"

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -4,6 +4,9 @@
   "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js"
@@ -31,8 +34,8 @@
       "pluginApi": ">=2026.5.16-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.5.16-beta.4",
-      "pluginSdkVersion": "2026.5.16-beta.4"
+      "openclawVersion": "2026.5.19-beta.1",
+      "pluginSdkVersion": "2026.5.19-beta.1"
     },
     "install": {
       "clawhubSpec": "clawhub:@remnic/plugin-openclaw",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -4,9 +4,6 @@
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",
-  "engines": {
-    "node": ">=22.19.0"
-  },
   "exports": {
     ".": {
       "import": "./dist/index.js"

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -4,6 +4,9 @@
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js"
@@ -37,8 +40,8 @@
       "pluginApi": ">=2026.5.16-beta.1"
     },
     "build": {
-      "openclawVersion": "2026.5.16-beta.3",
-      "pluginSdkVersion": "2026.5.16-beta.3"
+      "openclawVersion": "2026.5.19-beta.1",
+      "pluginSdkVersion": "2026.5.19-beta.1"
     },
     "install": {
       "clawhubSpec": "clawhub:@remnic/plugin-openclaw",

--- a/tests/monorepo-structure.test.ts
+++ b/tests/monorepo-structure.test.ts
@@ -159,11 +159,6 @@ test("published OpenClaw packages require an OpenClaw release with registerComma
       ">=2026.5.16-beta.1",
       `${packageDir} must require openclaw >=2026.5.16-beta.1`,
     );
-    assert.equal(
-      pkg.engines?.node,
-      ">=22.19.0",
-      `${packageDir} must publish the OpenClaw 2026.5.19 Node.js runtime floor`,
-    );
   }
 });
 

--- a/tests/monorepo-structure.test.ts
+++ b/tests/monorepo-structure.test.ts
@@ -159,6 +159,11 @@ test("published OpenClaw packages require an OpenClaw release with registerComma
       ">=2026.5.16-beta.1",
       `${packageDir} must require openclaw >=2026.5.16-beta.1`,
     );
+    assert.equal(
+      pkg.engines?.node,
+      ">=22.19.0",
+      `${packageDir} must publish the OpenClaw 2026.5.19 Node.js runtime floor`,
+    );
   }
 });
 

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -50,7 +50,7 @@ const OPENCLAW_PACKAGE_EXPECTATIONS = [
   {
     packageJsonPath: "packages/plugin-openclaw/package.json",
     name: "@remnic/plugin-openclaw",
-    buildVersion: "2026.5.16-beta.4",
+    buildVersion: "2026.5.19-beta.1",
     install: {
       clawhubSpec: "clawhub:@remnic/plugin-openclaw",
       npmSpec: "@remnic/plugin-openclaw",
@@ -59,7 +59,7 @@ const OPENCLAW_PACKAGE_EXPECTATIONS = [
   {
     packageJsonPath: "packages/shim-openclaw-engram/package.json",
     name: "@joshuaswarren/openclaw-engram",
-    buildVersion: "2026.5.16-beta.3",
+    buildVersion: "2026.5.19-beta.1",
     install: {
       clawhubSpec: "clawhub:@remnic/plugin-openclaw",
       npmSpec: "@joshuaswarren/openclaw-engram",
@@ -385,6 +385,9 @@ for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
     const openclaw = packageJson.openclaw ?? {};
 
     assert.equal(packageJson.name, expectation.name);
+    assert.deepEqual(packageJson.engines, {
+      node: ">=22.19.0",
+    });
     assert.deepEqual(openclaw.extensions, ["./dist/index.js"]);
     assert.deepEqual(
       openclaw.runtimeExtensions,

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -385,9 +385,6 @@ for (const expectation of OPENCLAW_PACKAGE_EXPECTATIONS) {
     const openclaw = packageJson.openclaw ?? {};
 
     assert.equal(packageJson.name, expectation.name);
-    assert.deepEqual(packageJson.engines, {
-      node: ">=22.19.0",
-    });
     assert.deepEqual(openclaw.extensions, ["./dist/index.js"]);
     assert.deepEqual(
       openclaw.runtimeExtensions,


### PR DESCRIPTION
## Summary
- Record OpenClaw 2026.5.16-beta.6, 2026.5.16-beta.7, 2026.5.18-beta.1, and 2026.5.19-beta.1 compatibility for the Remnic OpenClaw adapter.
- Bump the advertised OpenClaw build / SDK metadata to 2026.5.19-beta.1 for `@remnic/plugin-openclaw` and the legacy `@joshuaswarren/openclaw-engram` shim.
- Keep the package-level OpenClaw host range broad and document that newer OpenClaw hosts enforce the Node.js >=22.19.0 runtime floor at the host level.

## Verification
- `npm run check:openclaw-plugin-sync`
- `pnpm exec tsx --test tests/openclaw-plugin-runtime-surfaces.test.ts tests/monorepo-structure.test.ts`
- `node scripts/check-openclaw-sdk-surface.mjs --package-root /tmp/openclaw-2026.5.19`
- `git diff --check`
- `npm run preflight:quick`
- Cursor local review skipped: `agent/cursor-agent` is not installed in this environment.

Closes #1063
Closes #1078
Closes #1079
Closes #1096