### PR TITLE
fix(server): reject missing explicit config paths

### DIFF
--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -48,11 +48,25 @@ function parseServerPort(value: unknown, source: string): number {
   return port;
 }
 
-function resolveConfigPath(cliPath?: string): string {
-  if (cliPath) return path.resolve(cliPath);
+interface ResolvedConfigPath {
+  path: string;
+  explicit: boolean;
+  source: string;
+}
+
+function resolveUserPath(value: string): string {
+  return path.resolve(expandTildePath(value));
+}
+
+function resolveConfigPath(cliPath?: string): ResolvedConfigPath {
+  if (cliPath) {
+    return { path: resolveUserPath(cliPath), explicit: true, source: "--config" };
+  }
 
   const envPath = readCompatEnv("REMNIC_CONFIG_PATH", "ENGRAM_CONFIG_PATH");
-  if (envPath) return path.resolve(envPath);
+  if (envPath) {
+    return { path: resolveUserPath(envPath), explicit: true, source: "REMNIC_CONFIG_PATH/ENGRAM_CONFIG_PATH" };
+  }
 
   const homeDir = process.env.HOME ?? "~";
   const candidates = [
@@ -62,10 +76,12 @@ function resolveConfigPath(cliPath?: string): string {
     path.join(homeDir, ".config", "engram", "config.json"),
   ];
   for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) return candidate;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return { path: candidate, explicit: false, source: "auto-discovery" };
+    }
   }
 
-  return path.join(homeDir, ".config", "remnic", "config.json");
+  return { path: path.join(homeDir, ".config", "remnic", "config.json"), explicit: false, source: "auto-discovery" };
 }
 
 function loadConfigFile(configPath: string): ServerConfig {
@@ -74,6 +90,25 @@ function loadConfigFile(configPath: string): ServerConfig {
     remnic: raw.remnic ?? raw.engram ?? raw ?? {},
     server: raw.server ?? {},
   };
+}
+
+function loadResolvedConfig(resolved: ResolvedConfigPath): ServerConfig {
+  if (!fs.existsSync(resolved.path)) {
+    if (resolved.explicit) {
+      throw new Error(`Config file from ${resolved.source} not found: ${resolved.path}`);
+    }
+    return { remnic: {}, server: {} };
+  }
+
+  const stat = fs.statSync(resolved.path);
+  if (!stat.isFile()) {
+    if (!resolved.explicit) {
+      return { remnic: {}, server: {} };
+    }
+    throw new Error(`Config file from ${resolved.source} is not a regular file: ${resolved.path}`);
+  }
+
+  return loadConfigFile(resolved.path);
 }
 
 function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Record<string, unknown> } {
@@ -135,10 +170,8 @@ export async function startServer(options?: {
 }): Promise<ServerResult> {
   initLogger();
 
-  const configPath = resolveConfigPath(options?.configPath);
-  const fileConfig = fs.existsSync(configPath)
-    ? loadConfigFile(configPath)
-    : { remnic: {}, server: {} };
+  const resolvedConfigPath = resolveConfigPath(options?.configPath);
+  const fileConfig = loadResolvedConfig(resolvedConfigPath);
 
   const env = envOverrides();
   const { remnic: envRemnic, ...envServer } = env;

--- a/tests/remnic-server-cli.test.ts
+++ b/tests/remnic-server-cli.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
 import net from "node:net";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { cliMain, startServer } from "../packages/remnic-server/src/index.js";
 import { runServerBin } from "../packages/remnic-server/bin/server-bin.js";
 
@@ -128,7 +128,6 @@ test("startServer rejects invalid direct option ports before initializing", asyn
   await assert.rejects(
     () =>
       startServer({
-        configPath: path.join(os.tmpdir(), "remnic-missing-config.json"),
         port: 0,
       }),
     /Invalid options\.port: expected an integer port from 1 to 65535/,
@@ -152,9 +151,17 @@ test("startServer lets direct option port override invalid environment ports", a
 
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-env-port-"));
   process.env.REMNIC_MEMORY_DIR = tempDir;
+  const configPath = path.join(tempDir, "remnic.config.json");
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      remnic: { memoryDir: tempDir, qmdEnabled: false, qmdDaemonEnabled: false, searchBackend: "noop" },
+    }),
+    "utf8",
+  );
   const port = await getFreePort();
   const result = await startServer({
-    configPath: path.join(tempDir, "missing-config.json"),
+    configPath,
     port,
   });
 
@@ -173,12 +180,134 @@ test("startServer rejects invalid environment ports before initializing", async 
   delete process.env.ENGRAM_PORT;
 
   await assert.rejects(
-    () =>
-      startServer({
-        configPath: path.join(os.tmpdir(), "remnic-missing-config.json"),
-      }),
+    () => startServer(),
     /Invalid REMNIC_PORT\/ENGRAM_PORT: expected an integer port from 1 to 65535/,
   );
+});
+
+test("startServer expands tilde in explicit config paths", async (t) => {
+  restoreEnv(t, [
+    "HOME",
+    "REMNIC_CONFIG_PATH",
+    "ENGRAM_CONFIG_PATH",
+    "REMNIC_PORT",
+    "ENGRAM_PORT",
+    "REMNIC_MEMORY_DIR",
+    "ENGRAM_MEMORY_DIR",
+    "REMNIC_AUTH_TOKEN",
+    "ENGRAM_AUTH_TOKEN",
+  ]);
+
+  const tempHome = await mkdtemp(path.join(os.tmpdir(), "remnic-server-home-"));
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-memory-"));
+  const configDir = path.join(tempHome, ".config", "remnic");
+  const configPath = path.join(configDir, "config.json");
+  const port = await getFreePort();
+
+  process.env.HOME = tempHome;
+  delete process.env.REMNIC_CONFIG_PATH;
+  delete process.env.ENGRAM_CONFIG_PATH;
+  delete process.env.REMNIC_PORT;
+  delete process.env.ENGRAM_PORT;
+  delete process.env.REMNIC_MEMORY_DIR;
+  delete process.env.ENGRAM_MEMORY_DIR;
+  delete process.env.REMNIC_AUTH_TOKEN;
+  delete process.env.ENGRAM_AUTH_TOKEN;
+
+  await mkdir(configDir, { recursive: true });
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      remnic: { memoryDir, qmdEnabled: false, qmdDaemonEnabled: false, searchBackend: "noop" },
+      server: { port, authToken: "test-token" },
+    }),
+    "utf8",
+  );
+
+  const result = await startServer({ configPath: "~/.config/remnic/config.json" });
+
+  try {
+    assert.equal(result.port, port);
+    assert.equal(result.config.memoryDir, memoryDir);
+  } finally {
+    result.cancelStartupSync();
+    result.abortDeferredInit();
+    await result.httpServer.stop();
+  }
+});
+
+test("startServer rejects missing explicit config paths", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-missing-config-"));
+
+  await assert.rejects(
+    () => startServer({ configPath: path.join(tempDir, "missing-config.json") }),
+    /Config file from --config not found:/,
+  );
+});
+
+test("startServer rejects missing explicit env config paths", async (t) => {
+  restoreEnv(t, ["REMNIC_CONFIG_PATH", "ENGRAM_CONFIG_PATH"]);
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-missing-env-config-"));
+  process.env.REMNIC_CONFIG_PATH = path.join(tempDir, "missing-config.json");
+  delete process.env.ENGRAM_CONFIG_PATH;
+
+  await assert.rejects(
+    () => startServer(),
+    /Config file from REMNIC_CONFIG_PATH\/ENGRAM_CONFIG_PATH not found:/,
+  );
+});
+
+test("startServer skips non-file auto-discovered config candidates", async (t) => {
+  restoreEnv(t, [
+    "REMNIC_CONFIG_PATH",
+    "ENGRAM_CONFIG_PATH",
+    "REMNIC_PORT",
+    "ENGRAM_PORT",
+    "REMNIC_MEMORY_DIR",
+    "ENGRAM_MEMORY_DIR",
+    "REMNIC_AUTH_TOKEN",
+    "ENGRAM_AUTH_TOKEN",
+  ]);
+
+  const previousCwd = process.cwd();
+  t.after(() => {
+    process.chdir(previousCwd);
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-server-autodiscovery-"));
+  const memoryDir = path.join(tempDir, "memory");
+  const port = await getFreePort();
+
+  delete process.env.REMNIC_CONFIG_PATH;
+  delete process.env.ENGRAM_CONFIG_PATH;
+  delete process.env.REMNIC_PORT;
+  delete process.env.ENGRAM_PORT;
+  delete process.env.REMNIC_MEMORY_DIR;
+  delete process.env.ENGRAM_MEMORY_DIR;
+  delete process.env.REMNIC_AUTH_TOKEN;
+  delete process.env.ENGRAM_AUTH_TOKEN;
+
+  await mkdir(path.join(tempDir, "remnic.config.json"), { recursive: true });
+  await writeFile(
+    path.join(tempDir, "engram.config.json"),
+    JSON.stringify({
+      remnic: { memoryDir, qmdEnabled: false, qmdDaemonEnabled: false, searchBackend: "noop" },
+      server: { port, authToken: "test-token" },
+    }),
+    "utf8",
+  );
+
+  process.chdir(tempDir);
+  const result = await startServer();
+
+  try {
+    assert.equal(result.port, port);
+    assert.equal(result.config.memoryDir, memoryDir);
+  } finally {
+    result.cancelStartupSync();
+    result.abortDeferredInit();
+    await result.httpServer.stop();
+  }
 });
 
 test("startServer rejects invalid config file ports before initializing", async (t) => {


### PR DESCRIPTION
## Summary
- expand `~` for explicit remnic-server config paths
- fail fast when `--config` or `REMNIC_CONFIG_PATH` points at a missing or non-file path
- preserve permissive auto-discovery fallback when no explicit config path is provided
- add regression coverage for tilde expansion and missing explicit CLI/env config paths

## Finding
- Fixes clawpatch finding `fnd_sig-feat-cli-command-7ec1517679-_5e0f4541aa`: Explicit config paths can be silently ignored

## Verification
- `pnpm exec tsx --test tests/remnic-server-cli.test.ts`
- `pnpm --filter @remnic/server exec tsc --noEmit --pretty false`
- `node /Users/joshuawarren/src/clawpatch/dist/cli.js revalidate --finding fnd_sig-feat-cli-command-7ec1517679-_5e0f4541aa --json`
- `pnpm rebuild better-sqlite3 && npm_config_workspace_concurrency=1 npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server startup config resolution/validation; explicit `--config`/env paths now error instead of silently falling back, which could break deployments relying on the old permissive behavior.
> 
> **Overview**
> **Server startup now distinguishes explicit vs auto-discovered config paths.** Explicit paths from `--config` or `REMNIC_CONFIG_PATH/ENGRAM_CONFIG_PATH` are `~`-expanded and must exist and be regular files; otherwise `startServer` throws a clear error.
> 
> **Auto-discovery remains permissive.** Missing or non-file candidates are skipped and startup proceeds with empty config when no explicit path is provided. Tests were updated/added to cover tilde expansion, missing explicit paths (CLI/env), and skipping directory candidates during auto-discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 990ffe18ace8cf109b6b961063729fbd1a18305a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->