### PR TITLE
fix(cli): write OpenClaw config atomically

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -201,7 +201,7 @@ import {
   resolveFallbackBenchResultPath,
 } from "./bench-fallback.js";
 import {
-  cleanupRollbackDirectoryBestEffort,
+  atomicWriteFileSync, cleanupRollbackDirectoryBestEffort,
   createOpenclawUpgradeRollbackFailure,
   runBestEffortGatewayRestart,
   rollbackOpenclawUpgrade,
@@ -7429,7 +7429,7 @@ async function cmdOpenclawInstall(opts: OpenclawInstallOptions): Promise<void> {
   if (!fs.existsSync(configDir)) {
     fs.mkdirSync(configDir, { recursive: true });
   }
-  fs.writeFileSync(configPath, JSON.stringify(updatedConfig, null, 2) + "\n");
+  atomicWriteFileSync(configPath, JSON.stringify(updatedConfig, null, 2) + "\n");
 
   console.log("\nDone! Summary of changes:");
   for (const c of changes) console.log("  " + c);

--- a/packages/remnic-cli/src/openclaw-upgrade-swap.test.ts
+++ b/packages/remnic-cli/src/openclaw-upgrade-swap.test.ts
@@ -67,6 +67,23 @@ test("atomicCopyFileSync preserves the target when temp copy fails", async () =>
   assert.deepEqual(await visibleEntries(path.dirname(configPath)), ["openclaw.json"]);
 });
 
+test("atomicCopyFileSync preserves backup file permissions on restore", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-openclaw-atomic-copy-mode-"));
+  const backupPath = path.join(root, "backup", "openclaw.json");
+  const configPath = path.join(root, "live", "openclaw.json");
+  await mkdir(path.dirname(backupPath), { recursive: true });
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(backupPath, '{"plugins":{"entries":{"backup":true}}}\n', "utf8");
+  await writeFile(configPath, '{"plugins":{"entries":{"live":true}}}\n', "utf8");
+  await chmod(backupPath, 0o600);
+  await chmod(configPath, 0o644);
+
+  atomicCopyFileSync(backupPath, configPath);
+
+  assert.equal(await readFile(configPath, "utf8"), '{"plugins":{"entries":{"backup":true}}}\n');
+  assert.equal((await stat(configPath)).mode & 0o777, 0o600);
+});
+
 async function visibleEntries(dir: string): Promise<string[]> {
   return (await readdir(dir)).filter((entry) => !entry.startsWith(".")).sort();
 }

--- a/packages/remnic-cli/src/openclaw-upgrade-swap.test.ts
+++ b/packages/remnic-cli/src/openclaw-upgrade-swap.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, readdir, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -42,6 +42,20 @@ test("atomicWriteFileSync preserves existing owner-only config permissions", asy
   assert.equal((await stat(configPath)).mode & 0o777, 0o600);
 });
 
+test("atomicWriteFileSync updates symlink targets without replacing the link", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-openclaw-atomic-symlink-write-"));
+  const targetPath = path.join(root, "managed", "openclaw.json");
+  const linkPath = path.join(root, "openclaw.json");
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, '{"plugins":{"entries":{"old":true}}}\n', "utf8");
+  await symlink(targetPath, linkPath);
+
+  atomicWriteFileSync(linkPath, '{"plugins":{"entries":{"new":true}}}\n');
+
+  assert.equal((await lstat(linkPath)).isSymbolicLink(), true);
+  assert.equal(await readFile(targetPath, "utf8"), '{"plugins":{"entries":{"new":true}}}\n');
+});
+
 test("atomicCopyFileSync preserves the target when temp copy fails", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-openclaw-atomic-copy-"));
   const backupPath = path.join(root, "backup", "openclaw.json");
@@ -82,6 +96,23 @@ test("atomicCopyFileSync preserves backup file permissions on restore", async ()
 
   assert.equal(await readFile(configPath, "utf8"), '{"plugins":{"entries":{"backup":true}}}\n');
   assert.equal((await stat(configPath)).mode & 0o777, 0o600);
+});
+
+test("atomicCopyFileSync restores through symlink targets without replacing the link", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-openclaw-atomic-symlink-copy-"));
+  const backupPath = path.join(root, "backup", "openclaw.json");
+  const targetPath = path.join(root, "managed", "openclaw.json");
+  const linkPath = path.join(root, "openclaw.json");
+  await mkdir(path.dirname(backupPath), { recursive: true });
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(backupPath, '{"plugins":{"entries":{"backup":true}}}\n', "utf8");
+  await writeFile(targetPath, '{"plugins":{"entries":{"live":true}}}\n', "utf8");
+  await symlink(targetPath, linkPath);
+
+  atomicCopyFileSync(backupPath, linkPath);
+
+  assert.equal((await lstat(linkPath)).isSymbolicLink(), true);
+  assert.equal(await readFile(targetPath, "utf8"), '{"plugins":{"entries":{"backup":true}}}\n');
 });
 
 async function visibleEntries(dir: string): Promise<string[]> {

--- a/packages/remnic-cli/src/openclaw-upgrade-swap.test.ts
+++ b/packages/remnic-cli/src/openclaw-upgrade-swap.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  atomicCopyFileSync,
+  atomicWriteFileSync,
+} from "./openclaw-upgrade-swap.js";
+
+test("atomicWriteFileSync preserves the target when temp write fails", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-openclaw-atomic-write-"));
+  const configPath = path.join(root, "openclaw.json");
+  await writeFile(configPath, '{"plugins":{"entries":{"old":true}}}\n', "utf8");
+
+  assert.throws(
+    () =>
+      atomicWriteFileSync(configPath, '{"plugins":{"entries":{"new":true}}}\n', {
+        hooks: {
+          writeTempFileSync(tempPath) {
+            throw new Error(`simulated write failure for ${tempPath}`);
+          },
+        },
+      }),
+    /simulated write failure/,
+  );
+
+  assert.equal(await readFile(configPath, "utf8"), '{"plugins":{"entries":{"old":true}}}\n');
+  assert.deepEqual(await visibleEntries(root), ["openclaw.json"]);
+});
+
+test("atomicCopyFileSync preserves the target when temp copy fails", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-openclaw-atomic-copy-"));
+  const backupPath = path.join(root, "backup", "openclaw.json");
+  const configPath = path.join(root, "live", "openclaw.json");
+  await mkdir(path.dirname(backupPath), { recursive: true });
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(backupPath, '{"plugins":{"entries":{"backup":true}}}\n', "utf8");
+  await writeFile(configPath, '{"plugins":{"entries":{"live":true}}}\n', "utf8");
+
+  assert.throws(
+    () =>
+      atomicCopyFileSync(backupPath, configPath, {
+        hooks: {
+          copyTempFileSync(sourcePath, tempPath) {
+            throw new Error(`simulated copy failure from ${sourcePath} to ${tempPath}`);
+          },
+        },
+      }),
+    /simulated copy failure/,
+  );
+
+  assert.equal(await readFile(configPath, "utf8"), '{"plugins":{"entries":{"live":true}}}\n');
+  assert.deepEqual(await visibleEntries(path.dirname(configPath)), ["openclaw.json"]);
+});
+
+async function visibleEntries(dir: string): Promise<string[]> {
+  return (await readdir(dir)).filter((entry) => !entry.startsWith(".")).sort();
+}

--- a/packages/remnic-cli/src/openclaw-upgrade-swap.test.ts
+++ b/packages/remnic-cli/src/openclaw-upgrade-swap.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -28,6 +28,18 @@ test("atomicWriteFileSync preserves the target when temp write fails", async () 
 
   assert.equal(await readFile(configPath, "utf8"), '{"plugins":{"entries":{"old":true}}}\n');
   assert.deepEqual(await visibleEntries(root), ["openclaw.json"]);
+});
+
+test("atomicWriteFileSync preserves existing owner-only config permissions", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-openclaw-atomic-mode-"));
+  const configPath = path.join(root, "openclaw.json");
+  await writeFile(configPath, '{"plugins":{"entries":{"old":true}}}\n', "utf8");
+  await chmod(configPath, 0o600);
+
+  atomicWriteFileSync(configPath, '{"plugins":{"entries":{"new":true}}}\n');
+
+  assert.equal(await readFile(configPath, "utf8"), '{"plugins":{"entries":{"new":true}}}\n');
+  assert.equal((await stat(configPath)).mode & 0o777, 0o600);
 });
 
 test("atomicCopyFileSync preserves the target when temp copy fails", async () => {

--- a/packages/remnic-cli/src/openclaw-upgrade-swap.ts
+++ b/packages/remnic-cli/src/openclaw-upgrade-swap.ts
@@ -45,6 +45,20 @@ function resolveAtomicWriteMode(targetPath: string, explicitMode: fs.Mode | unde
   }
 }
 
+function resolveAtomicReplacementPath(targetPath: string): string {
+  try {
+    if (fs.lstatSync(targetPath).isSymbolicLink()) {
+      return fs.realpathSync(targetPath);
+    }
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return targetPath;
+    }
+    throw error;
+  }
+  return targetPath;
+}
+
 function createSiblingSwapPath(targetDir: string, label: string): string {
   const nonce = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
   return path.join(path.dirname(targetDir), `.${path.basename(targetDir)}.${label}.${nonce}`);
@@ -72,9 +86,10 @@ export function atomicWriteFileSync(
   data: string | NodeJS.ArrayBufferView,
   options: { hooks?: AtomicFileOperationHooks; mode?: fs.Mode } = {},
 ): void {
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  const tempPath = createSiblingTempFilePath(targetPath, "write");
-  const mode = resolveAtomicWriteMode(targetPath, options.mode);
+  const resolvedTargetPath = resolveAtomicReplacementPath(targetPath);
+  fs.mkdirSync(path.dirname(resolvedTargetPath), { recursive: true });
+  const tempPath = createSiblingTempFilePath(resolvedTargetPath, "write");
+  const mode = resolveAtomicWriteMode(resolvedTargetPath, options.mode);
 
   try {
     if (options.hooks?.writeTempFileSync) {
@@ -84,7 +99,7 @@ export function atomicWriteFileSync(
     }
     fs.chmodSync(tempPath, mode);
     const renameTempFileSync = options.hooks?.renameTempFileSync ?? fs.renameSync;
-    renameTempFileSync(tempPath, targetPath);
+    renameTempFileSync(tempPath, resolvedTargetPath);
   } catch (error) {
     fs.rmSync(tempPath, { force: true });
     throw error;
@@ -97,8 +112,9 @@ export function atomicCopyFileSync(
   options: { hooks?: AtomicFileOperationHooks } = {},
 ): void {
   if (!fs.existsSync(sourcePath)) return;
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  const tempPath = createSiblingTempFilePath(targetPath, "copy");
+  const resolvedTargetPath = resolveAtomicReplacementPath(targetPath);
+  fs.mkdirSync(path.dirname(resolvedTargetPath), { recursive: true });
+  const tempPath = createSiblingTempFilePath(resolvedTargetPath, "copy");
   const mode = fs.statSync(sourcePath).mode & 0o7777;
 
   try {
@@ -106,7 +122,7 @@ export function atomicCopyFileSync(
     copyTempFileSync(sourcePath, tempPath);
     fs.chmodSync(tempPath, mode);
     const renameTempFileSync = options.hooks?.renameTempFileSync ?? fs.renameSync;
-    renameTempFileSync(tempPath, targetPath);
+    renameTempFileSync(tempPath, resolvedTargetPath);
   } catch (error) {
     fs.rmSync(tempPath, { force: true });
     throw error;

--- a/packages/remnic-cli/src/openclaw-upgrade-swap.ts
+++ b/packages/remnic-cli/src/openclaw-upgrade-swap.ts
@@ -99,10 +99,12 @@ export function atomicCopyFileSync(
   if (!fs.existsSync(sourcePath)) return;
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
   const tempPath = createSiblingTempFilePath(targetPath, "copy");
+  const mode = fs.statSync(sourcePath).mode & 0o7777;
 
   try {
     const copyTempFileSync = options.hooks?.copyTempFileSync ?? fs.copyFileSync;
     copyTempFileSync(sourcePath, tempPath);
+    fs.chmodSync(tempPath, mode);
     const renameTempFileSync = options.hooks?.renameTempFileSync ?? fs.renameSync;
     renameTempFileSync(tempPath, targetPath);
   } catch (error) {

--- a/packages/remnic-cli/src/openclaw-upgrade-swap.ts
+++ b/packages/remnic-cli/src/openclaw-upgrade-swap.ts
@@ -18,8 +18,19 @@ export interface BestEffortGatewayRestartResult {
   restarted: boolean;
 }
 
+interface AtomicFileOperationHooks {
+  copyTempFileSync?: (sourcePath: string, tempPath: string) => void;
+  renameTempFileSync?: (tempPath: string, targetPath: string) => void;
+  writeTempFileSync?: (tempPath: string) => void;
+}
+
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function createSiblingTempFilePath(targetPath: string, label: string): string {
+  const nonce = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+  return path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.${label}.${nonce}.tmp`);
 }
 
 function createSiblingSwapPath(targetDir: string, label: string): string {
@@ -41,6 +52,48 @@ function cleanupDisplacedDirectoryBestEffort(
       `Warning: ${context}, but failed to remove the displaced plugin copy at ` +
       `${displacedDir}: ${describeError(error)}`
     );
+  }
+}
+
+export function atomicWriteFileSync(
+  targetPath: string,
+  data: string | NodeJS.ArrayBufferView,
+  options: { hooks?: AtomicFileOperationHooks; mode?: fs.Mode } = {},
+): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const tempPath = createSiblingTempFilePath(targetPath, "write");
+
+  try {
+    if (options.hooks?.writeTempFileSync) {
+      options.hooks.writeTempFileSync(tempPath);
+    } else {
+      fs.writeFileSync(tempPath, data, options.mode === undefined ? undefined : { mode: options.mode });
+    }
+    const renameTempFileSync = options.hooks?.renameTempFileSync ?? fs.renameSync;
+    renameTempFileSync(tempPath, targetPath);
+  } catch (error) {
+    fs.rmSync(tempPath, { force: true });
+    throw error;
+  }
+}
+
+export function atomicCopyFileSync(
+  sourcePath: string,
+  targetPath: string,
+  options: { hooks?: AtomicFileOperationHooks } = {},
+): void {
+  if (!fs.existsSync(sourcePath)) return;
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const tempPath = createSiblingTempFilePath(targetPath, "copy");
+
+  try {
+    const copyTempFileSync = options.hooks?.copyTempFileSync ?? fs.copyFileSync;
+    copyTempFileSync(sourcePath, tempPath);
+    const renameTempFileSync = options.hooks?.renameTempFileSync ?? fs.renameSync;
+    renameTempFileSync(tempPath, targetPath);
+  } catch (error) {
+    fs.rmSync(tempPath, { force: true });
+    throw error;
   }
 }
 
@@ -196,9 +249,7 @@ function restoreDirectoryFromBackup(targetDir: string, backupDir: string): strin
 }
 
 function restoreFileFromBackup(targetPath: string, backupPath: string): void {
-  if (!fs.existsSync(backupPath)) return;
-  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.cpSync(backupPath, targetPath);
+  atomicCopyFileSync(backupPath, targetPath);
 }
 
 export function rollbackOpenclawUpgrade({

--- a/packages/remnic-cli/src/openclaw-upgrade-swap.ts
+++ b/packages/remnic-cli/src/openclaw-upgrade-swap.ts
@@ -33,6 +33,18 @@ function createSiblingTempFilePath(targetPath: string, label: string): string {
   return path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.${label}.${nonce}.tmp`);
 }
 
+function resolveAtomicWriteMode(targetPath: string, explicitMode: fs.Mode | undefined): fs.Mode {
+  if (explicitMode !== undefined) return explicitMode;
+  try {
+    return fs.statSync(targetPath).mode & 0o7777;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return 0o600;
+    }
+    throw error;
+  }
+}
+
 function createSiblingSwapPath(targetDir: string, label: string): string {
   const nonce = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
   return path.join(path.dirname(targetDir), `.${path.basename(targetDir)}.${label}.${nonce}`);
@@ -62,13 +74,15 @@ export function atomicWriteFileSync(
 ): void {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
   const tempPath = createSiblingTempFilePath(targetPath, "write");
+  const mode = resolveAtomicWriteMode(targetPath, options.mode);
 
   try {
     if (options.hooks?.writeTempFileSync) {
       options.hooks.writeTempFileSync(tempPath);
     } else {
-      fs.writeFileSync(tempPath, data, options.mode === undefined ? undefined : { mode: options.mode });
+      fs.writeFileSync(tempPath, data, { mode });
     }
+    fs.chmodSync(tempPath, mode);
     const renameTempFileSync = options.hooks?.renameTempFileSync ?? fs.renameSync;
     renameTempFileSync(tempPath, targetPath);
   } catch (error) {

--- a/tests/openclaw-install-cli.test.ts
+++ b/tests/openclaw-install-cli.test.ts
@@ -144,6 +144,24 @@ test("CLI openclaw install grants required conversation hook access", async () =
   );
 });
 
+test("CLI openclaw install writes config atomically", async () => {
+  const src = await readCli();
+  const installStart = src.indexOf("async function cmdOpenclawInstall");
+  const upgradeStart = src.indexOf("async function cmdOpenclawUpgrade");
+  assert.ok(installStart >= 0, "cmdOpenclawInstall must exist");
+  assert.ok(upgradeStart > installStart, "cmdOpenclawUpgrade should follow cmdOpenclawInstall");
+  const installBody = src.slice(installStart, upgradeStart);
+
+  assert.ok(
+    installBody.includes("atomicWriteFileSync(configPath"),
+    "OpenClaw install must write openclaw.json through the atomic config writer",
+  );
+  assert.ok(
+    !installBody.includes("writeFileSync(configPath"),
+    "OpenClaw install must not write directly to the live openclaw.json path",
+  );
+});
+
 test("CLI query does not wait for deferred QMD startup maintenance", async () => {
   const src = await readCli();
   const queryStart = src.indexOf("async function cmdQuery");


### PR DESCRIPTION
## Summary
- add atomic same-directory temp-file replace helpers for OpenClaw config writes/restores
- use the atomic writer for `remnic openclaw install` config persistence
- add regression coverage for failed temp writes/copies preserving the live config

## Verification
- pnpm exec tsx --test packages/remnic-cli/src/openclaw-upgrade-swap.test.ts tests/openclaw-install-cli.test.ts
- pnpm --filter @remnic/cli check-types
- node scripts/check-test-types.mjs
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem write/restore paths for OpenClaw config and rollback, so mistakes could corrupt or change permissions on user config files; changes are localized and covered by new regression tests.
> 
> **Overview**
> **OpenClaw CLI config persistence is now atomic.** `remnic openclaw install` writes `openclaw.json` via a new `atomicWriteFileSync` helper (same-directory temp file + rename) instead of writing directly to the live path.
> 
> Adds `atomicCopyFileSync` for rollback/restore file copies and switches config restore to use it, with behavior to preserve existing permissions and update symlink targets without replacing the symlink. Adds focused tests covering failure safety (live file unchanged on temp failure), permission preservation, and symlink handling, plus a CLI regression test ensuring the install path uses the atomic writer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9c9b27d371c593b26ee1750f96bf97dee8476b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->