### PR TITLE
fix(core): reject invalid HTTP server ports

### DIFF
--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -10,6 +10,24 @@ import { parseConfig } from "./config.js";
 import { readPair, writePair } from "./contradiction/contradiction-review.js";
 import type { StorageManager } from "./storage.js";
 
+test("HTTP server rejects invalid constructor ports", () => {
+  const service = {} as EngramAccessService;
+
+  for (const port of [-1, 3.7, Number.NaN, Number.POSITIVE_INFINITY, 65536]) {
+    assert.throws(
+      () =>
+        new EngramAccessHttpServer({
+          service,
+          port,
+          authToken: "test-token",
+          adminConsoleEnabled: false,
+        }),
+      /access HTTP port must be an integer from 0 to 65535/,
+      `port ${port} should be rejected`,
+    );
+  }
+});
+
 test("HTTP contradiction scan uses writable namespace resolver", async () => {
   const resolverCalls: Array<{ namespace: string | undefined; principal: string | undefined }> = [];
   const storage = {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -89,6 +89,14 @@ function hostToUrlAuthority(host: string): string {
   return host;
 }
 
+function parseHttpServerPort(port: number | undefined): number {
+  if (port === undefined) return 0;
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error("access HTTP port must be an integer from 0 to 65535");
+  }
+  return port;
+}
+
 function parseTrustZoneKindFilter(raw: string | null): TrustZoneRecordKind | undefined {
   if (raw === null) return undefined;
   if ((TRUST_ZONE_RECORD_KINDS as readonly string[]).includes(raw)) {
@@ -159,7 +167,7 @@ export class EngramAccessHttpServer {
   constructor(options: EngramAccessHttpServerOptions) {
     this.service = options.service;
     this.host = options.host?.trim() || "127.0.0.1";
-    this.requestedPort = Number.isFinite(options.port) ? Math.max(0, Math.floor(options.port ?? 0)) : 0;
+    this.requestedPort = parseHttpServerPort(options.port);
     this.authToken = options.authToken?.trim() || undefined;
     this.authTokens = (options.authTokens ?? []).map((t) => t.trim()).filter(Boolean);
     this.authTokensGetter = options.authTokensGetter;


### PR DESCRIPTION
## Summary
- reject invalid `EngramAccessHttpServer` constructor ports instead of flooring/defaulting them
- preserve `0` as the existing programmatic ephemeral-port value
- add regression coverage for negative, fractional, non-finite, and out-of-range ports

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/access-http.test.ts`
- `pnpm exec tsx --test tests/remnic-server-cli.test.ts`
- `pnpm --filter @remnic/core exec tsc --noEmit --pretty false`
- `node /Users/joshuawarren/src/clawpatch/dist/cli.js revalidate --finding fnd_sig-feat-cli-command-7ec1517679-_aea31484e3 --json`
- `npm_config_workspace_concurrency=1 npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: tightens constructor input validation for the HTTP server and adds a regression test; main impact is that previously-accepted invalid port values will now throw early.
> 
> **Overview**
> **Tightens HTTP server constructor validation** by introducing `parseHttpServerPort()` and using it in `EngramAccessHttpServer` so `port` must be an integer in the `0..65535` range (still defaulting `undefined` to `0` for ephemeral port binding) rather than silently flooring/coercing invalid inputs.
> 
> Adds a regression test ensuring negative, fractional, non-finite, and out-of-range port values throw with the expected error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71c0f51fac33468f79563b7230cab6a1ee509d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->