### PR TITLE
fix(core): contain shared-context output paths

### DIFF
--- a/packages/remnic-core/src/shared-context/manager.ts
+++ b/packages/remnic-core/src/shared-context/manager.ts
@@ -33,6 +33,55 @@ function safeSlug(s: string): string {
   return slug.slice(start, end).slice(0, 80) || "output";
 }
 
+function safePathSegment(s: string, label: string): string {
+  if (s.length === 0) throw new Error(`${label} must not be empty`);
+  if (/[\r\n]/.test(s)) throw new Error(`${label} must not contain line breaks`);
+  const encoded = encodeURIComponent(s);
+  if (encoded === "." || encoded === "..") {
+    return encoded.replace(/\./g, "%2E");
+  }
+  return encoded;
+}
+
+function safeDecodePathSegment(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
+function normalizeFrontmatterScalar(value: string): string {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      // Fall through to the legacy partial unescape below.
+    }
+    return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+  if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
+  return value;
+}
+
+function formatFrontmatterScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
+function readFrontmatterScalar(raw: string, key: string): string | null {
+  const frontmatter = raw.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1];
+  if (!frontmatter) return null;
+  for (const line of frontmatter.split(/\r?\n/)) {
+    if (!line.startsWith(`${key}:`)) continue;
+    const value = line.slice(key.length + 1).trim();
+    return value ? normalizeFrontmatterScalar(value) : null;
+  }
+  return null;
+}
+
 function ymd(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
@@ -457,23 +506,34 @@ export class SharedContextManager {
     const date = ymd(createdAt);
     const time = createdAt.toISOString().slice(11, 19).replace(/:/g, "");
     const slug = safeSlug(opts.title);
+    const agentPathSegment = safePathSegment(opts.agentId, "agentId");
 
-    const dir = path.join(this.outputsDir, opts.agentId, date);
+    const dir = path.join(this.outputsDir, agentPathSegment, date);
     await mkdir(dir, { recursive: true });
-    const fp = path.join(dir, `${time}-${slug}.md`);
 
     const body =
       `---\n` +
       `kind: agent_output\n` +
-      `agent: ${opts.agentId}\n` +
+      `agent: ${formatFrontmatterScalar(opts.agentId)}\n` +
       `createdAt: ${createdAt.toISOString()}\n` +
-      `title: ${opts.title.replace(/\n/g, " ").slice(0, 200)}\n` +
+      `title: ${formatFrontmatterScalar(opts.title.replace(/\n/g, " ").slice(0, 200))}\n` +
       `---\n\n` +
       opts.content.trimEnd() +
       "\n";
 
-    await writeFile(fp, body, "utf-8");
-    return fp;
+    for (let attempt = 0; attempt < 100; attempt++) {
+      const suffix = attempt === 0 ? "" : `-${attempt + 1}`;
+      const fp = path.join(dir, `${time}-${slug}${suffix}.md`);
+      try {
+        await writeFile(fp, body, { encoding: "utf-8", flag: "wx" });
+        return fp;
+      } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "EEXIST") continue;
+        throw error;
+      }
+    }
+
+    throw new Error(`Unable to allocate unique shared-context output path for ${opts.agentId}`);
   }
 
   async appendFeedback(entry: SharedFeedbackEntry): Promise<void> {
@@ -512,8 +572,9 @@ export class SharedContextManager {
           for (const f of files) {
             const p = path.join(dayDir, f);
             const raw = await readFile(p, "utf-8");
-            const title = (raw.match(/^title:\s*(.+)$/m)?.[1] ?? f).trim();
-            outputs.push({ agent: a.name, path: p, title, raw });
+            const title = readFrontmatterScalar(raw, "title") ?? f;
+            const agent = readFrontmatterScalar(raw, "agent") ?? safeDecodePathSegment(a.name);
+            outputs.push({ agent, path: p, title, raw });
           }
         } catch {
           // no outputs for this agent/date

--- a/tests/shared-context.test.ts
+++ b/tests/shared-context.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import type { PluginConfig } from "../src/types.js";
@@ -166,4 +166,190 @@ test("v4 shared context manager bootstraps structure and writes outputs", async 
   const raw = await readFile(fp, "utf-8");
   assert.match(raw, /kind: agent_output/);
   assert.match(raw, /Hello world/);
+});
+
+test("shared context output path encodes agent ids that contain traversal", async () => {
+  const memoryDir = tmpDir("engram-sc-mem");
+  const sharedDir = tmpDir("engram-shared");
+  await mkdir(memoryDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  const m = new SharedContextManager(cfg);
+  await m.ensureStructure();
+
+  const fp = await m.writeAgentOutput({
+    agentId: "../../escape",
+    title: "Traversal Attempt",
+    content: "Hello world",
+    createdAt: new Date("2026-05-19T10:11:12.000Z"),
+  });
+
+  const outputsRoot = path.join(sharedDir, "agent-outputs");
+  const relativePath = path.relative(outputsRoot, fp);
+  assert.equal(path.isAbsolute(relativePath), false);
+  assert.notEqual(relativePath.split(path.sep)[0], "..");
+  assert.match(relativePath, /^\.\.%2F\.\.%2Fescape\/2026-05-19\/101112-traversal-attempt\.md$/);
+
+  const raw = await readFile(fp, "utf-8");
+  assert.match(raw, /agent: "\.\.\/\.\.\/escape"/);
+});
+
+test("shared context output rejects agent ids with line breaks", async () => {
+  const memoryDir = tmpDir("engram-sc-mem");
+  const sharedDir = tmpDir("engram-shared");
+  await mkdir(memoryDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  const m = new SharedContextManager(cfg);
+  await m.ensureStructure();
+
+  await assert.rejects(
+    () => m.writeAgentOutput({
+      agentId: "team\nred",
+      title: "Invalid Agent",
+      content: "Hello world",
+    }),
+    /agentId must not contain line breaks/,
+  );
+});
+
+test("shared context output writes do not overwrite same-second same-title files", async () => {
+  const memoryDir = tmpDir("engram-sc-mem");
+  const sharedDir = tmpDir("engram-shared");
+  await mkdir(memoryDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  const m = new SharedContextManager(cfg);
+  await m.ensureStructure();
+  const createdAt = new Date("2026-05-19T10:11:12.000Z");
+
+  const first = await m.writeAgentOutput({
+    agentId: "generalist",
+    title: "Same Title",
+    content: "first",
+    createdAt,
+  });
+  const second = await m.writeAgentOutput({
+    agentId: "generalist",
+    title: "Same Title",
+    content: "second",
+    createdAt,
+  });
+
+  assert.notEqual(first, second);
+  assert.equal(await readFile(first, "utf-8"), [
+    "---",
+    "kind: agent_output",
+    'agent: "generalist"',
+    "createdAt: 2026-05-19T10:11:12.000Z",
+    'title: "Same Title"',
+    "---",
+    "",
+    "first",
+    "",
+  ].join("\n"));
+  assert.match(await readFile(second, "utf-8"), /\nsecond\n$/);
+
+  const files = await readdir(path.dirname(first));
+  assert.deepEqual(files.sort(), ["101112-same-title-2.md", "101112-same-title.md"]);
+});
+
+test("shared context frontmatter preserves literal quote-wrapped agent ids and titles", async () => {
+  const memoryDir = tmpDir("engram-sc-mem");
+  const sharedDir = tmpDir("engram-shared");
+  await mkdir(memoryDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  const m = new SharedContextManager(cfg);
+  await m.ensureStructure();
+
+  const fp = await m.writeAgentOutput({
+    agentId: '"research bot"',
+    title: '"Quoted Title"',
+    content: "quote boundary topic",
+    createdAt: new Date("2026-05-19T10:11:12.000Z"),
+  });
+
+  const raw = await readFile(fp, "utf-8");
+  assert.match(raw, /agent: "\\"research bot\\""/);
+  assert.match(raw, /title: "\\"Quoted Title\\""/);
+
+  const result = await m.synthesizeCrossSignals({ date: "2026-05-19" });
+  assert.deepEqual(result.report.sources.map((source) => source.agent), ['"research bot"']);
+  assert.deepEqual(result.report.sources.map((source) => source.title), ['"Quoted Title"']);
+});
+
+test("shared context frontmatter preserves JSON-escaped control characters", async () => {
+  const memoryDir = tmpDir("engram-sc-mem");
+  const sharedDir = tmpDir("engram-shared");
+  await mkdir(memoryDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  const m = new SharedContextManager(cfg);
+  await m.ensureStructure();
+
+  const fp = await m.writeAgentOutput({
+    agentId: "research\tbot",
+    title: "Tabbed\tTitle",
+    content: "control character topic",
+    createdAt: new Date("2026-05-19T10:11:12.000Z"),
+  });
+
+  const raw = await readFile(fp, "utf-8");
+  assert.match(raw, /agent: "research\\tbot"/);
+  assert.match(raw, /title: "Tabbed\\tTitle"/);
+
+  const result = await m.synthesizeCrossSignals({ date: "2026-05-19" });
+  assert.deepEqual(result.report.sources.map((source) => source.agent), ["research\tbot"]);
+  assert.deepEqual(result.report.sources.map((source) => source.title), ["Tabbed\tTitle"]);
+});
+
+test("cross signals preserve original agent ids from encoded output paths", async () => {
+  const memoryDir = tmpDir("engram-sc-mem");
+  const sharedDir = tmpDir("engram-shared");
+  await mkdir(memoryDir, { recursive: true });
+
+  const cfg = minimalConfig(memoryDir, sharedDir);
+  const m = new SharedContextManager(cfg);
+  await m.ensureStructure();
+  const createdAt = new Date("2026-05-19T10:11:12.000Z");
+
+  await m.writeAgentOutput({
+    agentId: "research bot",
+    title: "Encoded Path",
+    content: "alignment topic",
+    createdAt,
+  });
+
+  const legacyDir = path.join(sharedDir, "agent-outputs", "research bot", "2026-05-19");
+  await mkdir(legacyDir, { recursive: true });
+  await writeFile(
+    path.join(legacyDir, "101113-legacy-path.md"),
+    [
+      "---",
+      "kind: agent_output",
+      'agent: "research bot"',
+      "createdAt: 2026-05-19T10:11:13.000Z",
+      "title: Legacy Path",
+      "---",
+      "",
+      "alignment topic",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  const encodedDir = path.join(sharedDir, "agent-outputs", "research%20bot", "2026-05-19");
+  await writeFile(
+    path.join(encodedDir, "101114-no-frontmatter.md"),
+    "agent: spoofed body value\nalignment topic\n",
+    "utf-8",
+  );
+
+  const result = await m.synthesizeCrossSignals({ date: "2026-05-19" });
+
+  assert.deepEqual(
+    result.report.sources.map((source) => source.agent).sort(),
+    ["research bot", "research bot", "research bot"],
+  );
+  assert.equal(result.report.overlaps.length, 0);
 });


### PR DESCRIPTION
## Summary
- encode shared-context agent output path segments so caller-supplied agent ids cannot escape the output root
- create output files with exclusive writes and deterministic suffixes to avoid same-second title collisions overwriting earlier output
- add regression coverage for traversal-like agent ids and collision handling

## Verification
- pnpm exec tsx --test tests/shared-context.test.ts tests/shared-context-cross-signals.test.ts tests/shared-context-cross-signals-semantic.test.ts tests/shared-context-tools.test.ts
- pnpm --filter @remnic/core check-types
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem path construction and frontmatter parsing for shared-context outputs; mistakes could break output discovery or introduce incompatibilities with existing output files.
> 
> **Overview**
> **Hardens shared-context agent outputs.** Agent IDs are now percent-encoded when used as output path segments (and rejected if they contain line breaks) to prevent directory traversal outside `agent-outputs`.
> 
> Output frontmatter for `agent`/`title` is now JSON-string-quoted and parsed with a more robust scalar reader, and output writes use exclusive creation (`wx`) with deterministic `-2..-100` suffixes to avoid same-second/title overwrites. Tests add coverage for traversal-like IDs, collision handling, and quote/control-character preservation (including decoding agent IDs from encoded output directories).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e5bc6fa6cc5b0379198256f2762a3d4722411f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->