### PR TITLE
fix(export): register weclone adapter in caller registry

### DIFF
--- a/packages/export-weclone/package.json
+++ b/packages/export-weclone/package.json
@@ -23,10 +23,11 @@
     "access": "public",
     "provenance": true
   },
-  "dependencies": {
+  "peerDependencies": {
     "@remnic/core": "workspace:^"
   },
   "devDependencies": {
+    "@remnic/core": "workspace:*",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
     "tsx": "^4.0.0"

--- a/packages/export-weclone/src/index.ts
+++ b/packages/export-weclone/src/index.ts
@@ -9,6 +9,7 @@
 import {
   getTrainingExportAdapter,
   registerTrainingExportAdapter,
+  type TrainingExportAdapter,
 } from "@remnic/core";
 
 import { wecloneExportAdapter } from "./adapter.js";
@@ -17,6 +18,11 @@ export { wecloneExportAdapter } from "./adapter.js";
 export { synthesizeTrainingPairs, type SynthesizerOptions } from "./synthesizer.js";
 export { extractStyleMarkers, type StyleMarkers } from "./style-extractor.js";
 export { sweepPii, type PrivacySweepResult } from "./privacy.js";
+
+export interface TrainingExportRegistry {
+  getTrainingExportAdapter(name: string): TrainingExportAdapter | undefined;
+  registerTrainingExportAdapter(adapter: TrainingExportAdapter): void;
+}
 
 /**
  * Idempotently register the WeClone adapter with the core training-export
@@ -27,11 +33,16 @@ export { sweepPii, type PrivacySweepResult } from "./privacy.js";
  * Returns true when the adapter was newly registered, false when an adapter
  * with the same name already exists.
  */
-export function ensureWecloneExportAdapterRegistered(): boolean {
-  if (getTrainingExportAdapter(wecloneExportAdapter.name) !== undefined) {
+export function ensureWecloneExportAdapterRegistered(
+  registry: TrainingExportRegistry = {
+    getTrainingExportAdapter,
+    registerTrainingExportAdapter,
+  },
+): boolean {
+  if (registry.getTrainingExportAdapter(wecloneExportAdapter.name) !== undefined) {
     return false;
   }
-  registerTrainingExportAdapter(wecloneExportAdapter);
+  registry.registerTrainingExportAdapter(wecloneExportAdapter);
   return true;
 }
 

--- a/packages/export-weclone/src/integration.test.ts
+++ b/packages/export-weclone/src/integration.test.ts
@@ -128,6 +128,19 @@ describe("@remnic/export-weclone — end-to-end integration", () => {
     assert.equal(looked!.fileExtension, ".json");
   });
 
+  it("can register into a caller-supplied core registry", () => {
+    const registered = new Map<string, typeof wecloneExportAdapter>();
+    const didRegister = ensureWecloneExportAdapterRegistered({
+      getTrainingExportAdapter: (name) => registered.get(name),
+      registerTrainingExportAdapter: (adapter) => {
+        registered.set(adapter.name, adapter);
+      },
+    });
+
+    assert.equal(didRegister, true);
+    assert.equal(registered.get("weclone"), wecloneExportAdapter);
+  });
+
   it("converts memoryDir → Alpaca JSON end-to-end", async () => {
     const records = await convertMemoriesToRecords({
       memoryDir: tmpDir,

--- a/packages/remnic-cli/src/export-weclone-runtime.d.ts
+++ b/packages/remnic-cli/src/export-weclone-runtime.d.ts
@@ -1,5 +1,11 @@
+import type { TrainingExportAdapter } from "@remnic/core";
+
 declare module "@remnic/export-weclone" {
-  export function ensureWecloneExportAdapterRegistered(): boolean;
+  export const wecloneExportAdapter: TrainingExportAdapter;
+  export function ensureWecloneExportAdapterRegistered(registry?: {
+    getTrainingExportAdapter(name: string): unknown;
+    registerTrainingExportAdapter(adapter: TrainingExportAdapter): void;
+  }): boolean;
   export function synthesizeTrainingPairs(
     records: Array<Record<string, unknown>>,
     options?: { maxPairsPerRecord?: number; styleMarkers?: unknown },

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -664,7 +664,7 @@ interface CoreTrainingExportRuntime {
   convertMemoriesToRecords(
     options: TrainingExportOptions,
   ): Promise<TrainingExportRecord[]>;
-  getTrainingExportAdapter(name: string): TrainingExportAdapter | undefined;
+  getTrainingExportAdapter(name: string): TrainingExportAdapter | undefined; registerTrainingExportAdapter(adapter: TrainingExportAdapter): void;
   listTrainingExportAdapters(): string[];
   parseStrictCliDate(value: string, flag: string): Date;
 }
@@ -8097,7 +8097,7 @@ export async function runTrainingExport(
     convertMemoriesToRecords,
     getTrainingExportAdapter,
     listTrainingExportAdapters,
-    parseStrictCliDate,
+    parseStrictCliDate, registerTrainingExportAdapter,
   } = await loadTrainingExportCoreRuntime();
 
   // Resolve the adapter from the registry first. If the user picks a
@@ -8124,7 +8124,7 @@ export async function runTrainingExport(
     // surface the normal "unknown format" error below, not a weclone
     // install hint. (Codex feedback on PR #545.)
     const mod = await ensureWeclone();
-    mod.ensureWecloneExportAdapterRegistered();
+    mod.ensureWecloneExportAdapterRegistered({ getTrainingExportAdapter, registerTrainingExportAdapter });
     adapter = getTrainingExportAdapter(args.format);
   }
   if (!adapter) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,11 +149,10 @@ importers:
         version: 5.9.3
 
   packages/export-weclone:
-    dependencies:
-      '@remnic/core':
-        specifier: workspace:^
-        version: link:../remnic-core
     devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
- register the WeClone export adapter against a caller-provided core registry
- make @remnic/core a peer/dev dependency for @remnic/export-weclone so packed installs use the host core instance
- add regression coverage for caller-supplied registry registration

## Verification
- pnpm --filter @remnic/export-weclone exec tsc --noEmit --pretty false
- pnpm --filter @remnic/cli exec tsc --noEmit --pretty false
- pnpm exec tsx --test packages/export-weclone/src/*.test.ts
- pnpm exec tsx --test tests/remnic-cli-package.test.ts tests/workspace-runtime-deps.test.ts
- node /Users/joshuawarren/src/clawpatch/dist/cli.js revalidate --finding fnd_sig-feat-library-0216fcc53d-b15a_b2d1ad174d --json
- npm_config_workspace_concurrency=1 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches adapter registration wiring and dependency declaration, which can affect runtime resolution in packaged/optional installs, but the behavior change is small and covered by tests.
> 
> **Overview**
> Ensures `@remnic/export-weclone` can register its `weclone` training-export adapter into a *caller-supplied* core registry, instead of always using the module-global `@remnic/core` registry.
> 
> Updates `@remnic/cli` to pass the core runtime’s `getTrainingExportAdapter`/`registerTrainingExportAdapter` into `ensureWecloneExportAdapterRegistered()`, adds a regression test for custom-registry registration, and adjusts `@remnic/core` to be a `peerDependency` (and dev dep) of `@remnic/export-weclone` so consumers use the host core instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31bd5128272f5a8b115f685801d2e4da0b2718ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->