### PR TITLE
fix(core): parse OpenAI content block wrappers

### DIFF
--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -467,6 +467,9 @@ function gatherOpenAiItems(input: unknown): Record<string, unknown>[] {
   if (!isRecord(input)) return [];
   if (Array.isArray(input.output)) return input.output.filter(isRecord);
   if (Array.isArray(input.items)) return input.items.filter(isRecord);
+  if (!isOpenAiResponseItem(input) && Array.isArray(input.content) && input.content.some(isOpenAiContentBlock)) {
+    return input.content.filter(isRecord);
+  }
   return [input];
 }
 

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -80,6 +80,16 @@ describe("message-parts parsers", () => {
     assert.equal(parts[1]!.filePath, "src/session.ts");
   });
 
+  it("infers untyped OpenAI content-block wrappers", () => {
+    const parts = parseMessageParts({
+      content: [{ type: "output_text", text: "Updated src/auth.ts" }],
+    });
+
+    assert.equal(parts.length, 1);
+    assert.equal(parts[0]!.kind, "text");
+    assert.equal(parts[0]!.filePath, "src/auth.ts");
+  });
+
   it("preserves leading dots in extracted file paths", () => {
     const parts = parseMessageParts([
       { type: "output_text", text: "Touched ./src/auth.ts." },


### PR DESCRIPTION
## Summary
- parse untyped OpenAI content-block wrapper objects by descending into their content array
- keep typed OpenAI response items on the existing response-item path
- add regression coverage for parseMessageParts({ content: [...] }) inference

## Verification
- pnpm exec tsx --test packages/remnic-core/src/message-parts/message-parts.test.ts
- node --experimental-strip-types --input-type=module -e "import { parseMessageParts } from './packages/remnic-core/src/message-parts/index.ts'; const parts=parseMessageParts({content:[{type:'output_text', text:'Updated src/auth.ts'}]}); if (parts.length !== 1 || parts[0]?.kind !== 'text' || parts[0]?.filePath !== 'src/auth.ts') process.exit(1);"
- pnpm --filter @remnic/core exec tsc --noEmit --pretty false
- node /Users/joshuawarren/src/clawpatch/dist/cli.js revalidate --finding fnd_sig-feat-library-02343f97d8-295f_24b4a02c6a --json
- npm_config_workspace_concurrency=1 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small parsing change limited to OpenAI message-part normalization with a targeted regression test.
> 
> **Overview**
> Updates the OpenAI item gathering logic to *descend into untyped wrapper objects* shaped like `{ content: [...] }` when the `content` array contains OpenAI content blocks, while keeping typed OpenAI response items on the existing path.
> 
> Adds a regression test ensuring `parseMessageParts({ content: [...] })` correctly yields a single `text` part with extracted `filePath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0cf973b168c96982172d9c14aa0998ba47b3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->