### PR TITLE
fix(core): require contradiction judge pair keys

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction-judge.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-judge.test.ts
@@ -140,20 +140,19 @@ test("contradiction judge does not positional-fallback after unmatched pairKey v
   assert.equal(result.results.get("c:d")?.confidence, 0);
 });
 
-test("contradiction judge fallback ignores skipped response items without shifting verdicts", async () => {
+test("contradiction judge marks pairKey-less response items as needs-user", async () => {
   const localLlm = {
     async chatCompletion() {
       return {
         content: JSON.stringify([
-          null,
           {
             verdict: "duplicates",
-            rationale: "The first requested pair is equivalent.",
+            rationale: "The first requested pair is equivalent but lacks a key.",
             confidence: 0.8,
           },
           {
             verdict: "independent",
-            rationale: "The second requested pair is unrelated.",
+            rationale: "The second requested pair is unrelated but lacks a key.",
             confidence: 0.7,
           },
         ]),
@@ -183,6 +182,8 @@ test("contradiction judge fallback ignores skipped response items without shifti
   );
 
   assert.equal(result.judged, 2);
-  assert.equal(result.results.get("a:b")?.verdict, "duplicates");
-  assert.equal(result.results.get("c:d")?.verdict, "independent");
+  assert.equal(result.results.get("a:b")?.verdict, "needs-user");
+  assert.equal(result.results.get("a:b")?.confidence, 0);
+  assert.equal(result.results.get("c:d")?.verdict, "needs-user");
+  assert.equal(result.results.get("c:d")?.confidence, 0);
 });

--- a/packages/remnic-core/src/contradiction/contradiction-judge.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-judge.ts
@@ -268,10 +268,8 @@ function parseJudgeResponse(
       const items = Array.isArray(parsed) ? parsed : [parsed];
       const results: ContradictionJudgeResult[] = [];
       const matchedKeys = new Set<string>();
-      let sawUnmatchedKeyedItem = false;
 
-      for (let itemIndex = 0; itemIndex < items.length; itemIndex += 1) {
-        const item = items[itemIndex];
+      for (const item of items) {
         if (!item || typeof item !== "object") continue;
 
         const verdict = typeof item.verdict === "string" && VALID_VERDICTS.includes(item.verdict as ContradictionVerdict)
@@ -285,26 +283,17 @@ function parseJudgeResponse(
           ? inputs.find((p) => pairKey(p.memoryIdA, p.memoryIdB) === pairKeyVal)
           : null;
 
-        if (pairKeyVal && !input) {
-          sawUnmatchedKeyedItem = true;
-          continue;
-        }
+        if (!input) continue;
 
-        const fallbackInput = input ?? (sawUnmatchedKeyedItem
-          ? undefined
-          : inputs.find((inputCandidate) =>
-            !matchedKeys.has(pairKey(inputCandidate.memoryIdA, inputCandidate.memoryIdB))));
-        if (!fallbackInput) continue;
-
-        matchedKeys.add(pairKey(fallbackInput.memoryIdA, fallbackInput.memoryIdB));
+        matchedKeys.add(pairKey(input.memoryIdA, input.memoryIdB));
 
         const confidence = typeof item.confidence === "number"
           ? Math.min(1, Math.max(0, item.confidence))
           : 0.5;
 
         results.push({
-          memoryIdA: fallbackInput.memoryIdA,
-          memoryIdB: fallbackInput.memoryIdB,
+          memoryIdA: input.memoryIdA,
+          memoryIdB: input.memoryIdB,
           verdict,
           rationale: typeof item.rationale === "string" ? item.rationale : "No rationale provided",
           confidence,


### PR DESCRIPTION
## Summary
- require exact pairKey matches when parsing contradiction judge responses
- ignore unmatched or missing pair keys and let omitted pairs backfill as needs-user
- update regression coverage for pairKey-less malformed responses

## Verification
- pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction-judge.test.ts
- pnpm --filter @remnic/core exec tsc --noEmit --pretty false
- node /Users/joshuawarren/src/clawpatch/dist/cli.js revalidate --finding fnd_sig-feat-library-058376cb2a-e85d_a979efc3d8 --json
- npm_config_workspace_concurrency=1 npm run preflight:quick

Note: local @remnic/core dist was rebuilt for clawpatch runtime validation, but dist/ is gitignored and not committed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how LLM verdicts are mapped to requested contradiction pairs; malformed/missing `pairKey` items are now ignored, which can shift outcomes to `needs-user` but reduces risk of misattribution.
> 
> **Overview**
> **Contradiction judge response parsing now requires explicit `pairKey` matches.** `parseJudgeResponse` no longer falls back to positional/first-unmatched pairing; response items without a valid `pairKey` (or with unmatched keys) are ignored and the corresponding requested inputs are backfilled as `needs-user`.
> 
> Tests were updated to assert that pairKey-less response items no longer apply verdicts to requested pairs and instead result in `needs-user` with `0` confidence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a153c17180c4bf69717d66e684fc292a3c22a077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->