### PR TITLE
fix(core): validate materialize namespaces

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -60,6 +60,7 @@ import {
   runNamespaceMigration,
   verifyNamespaces,
 } from "./namespaces/migrate.js";
+import { resolveNamespaceChildRoot } from "./namespaces/path.js";
 import {
   runBenchmarkRecall,
   runOperatorConfigReview,
@@ -3250,14 +3251,6 @@ function assertSafeNamespaceSegment(namespace: string): void {
   }
 }
 
-function assertPathInsideRoot(root: string, candidate: string, namespace: string): void {
-  const relative = path.relative(root, candidate);
-  if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
-    return;
-  }
-  throw new Error(`invalid namespace path: ${namespace}`);
-}
-
 export async function resolveMemoryDirForNamespace(
   orchestrator: Orchestrator,
   namespace?: string,
@@ -3273,9 +3266,7 @@ export async function resolveMemoryDirForNamespace(
     return orchestrator.config.memoryDir;
   }
 
-  const namespaceRoot = path.resolve(orchestrator.config.memoryDir, "namespaces");
-  const candidate = path.resolve(namespaceRoot, ns);
-  assertPathInsideRoot(namespaceRoot, candidate, ns);
+  const candidate = resolveNamespaceChildRoot(orchestrator.config.memoryDir, ns);
   if (ns === orchestrator.config.defaultNamespace) {
     return (await exists(candidate)) ? candidate : orchestrator.config.memoryDir;
   }

--- a/packages/remnic-core/src/connectors/codex-materialize-runner.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize-runner.ts
@@ -9,10 +9,11 @@
  * importance.ts — the two files Wave 1 agents are editing concurrently.
  */
 
-import path from "node:path";
 import { existsSync } from "node:fs";
 
 import { log } from "../logger.js";
+import { resolveNamespaceChildRoot } from "../namespaces/path.js";
+import { isSafeRouteNamespace } from "../routing/engine.js";
 import { StorageManager } from "../storage.js";
 import type { PluginConfig, MemoryFile } from "../types.js";
 import {
@@ -166,15 +167,15 @@ export async function runPostConsolidationMaterialize(
 
 function resolveNamespace(override: string | undefined, cfg: PluginConfig): string {
   const requested = (override ?? cfg.codexMaterializeNamespace ?? "auto").trim();
-  if (requested.length === 0 || requested === "auto") {
-    // When the caller asks for "auto", fall back to the configured default
-    // namespace (if any) so storage-root resolution lines up with what
-    // NamespaceStorageRouter would do for the same install.
-    return cfg.defaultNamespace && cfg.defaultNamespace.length > 0
-      ? cfg.defaultNamespace
-      : "default";
+  const defaultNamespace = (cfg.defaultNamespace ?? "").trim();
+  const namespace =
+    requested.length === 0 || requested === "auto"
+      ? (defaultNamespace.length > 0 ? defaultNamespace : "default")
+      : requested;
+  if (!isSafeRouteNamespace(namespace)) {
+    throw new Error(`invalid materialize namespace: ${namespace}`);
   }
-  return requested;
+  return namespace;
 }
 
 /**
@@ -197,10 +198,14 @@ function resolveNamespaceDir(
 ): string {
   if (!cfg.namespacesEnabled) return memoryDir;
 
-  const ns = namespace || cfg.defaultNamespace || "default";
-  const namespacedRoot = path.join(memoryDir, "namespaces", ns);
+  const defaultNamespace = (cfg.defaultNamespace ?? "").trim();
+  const ns = (namespace || defaultNamespace || "default").trim();
+  if (!isSafeRouteNamespace(ns)) {
+    throw new Error(`invalid materialize namespace: ${ns}`);
+  }
+  const namespacedRoot = resolveNamespaceChildRoot(memoryDir, ns, "materialize namespace path");
 
-  if (ns === cfg.defaultNamespace) {
+  if (ns === defaultNamespace) {
     return existsSync(namespacedRoot) ? namespacedRoot : memoryDir;
   }
   return namespacedRoot;

--- a/packages/remnic-core/src/namespaces/path.ts
+++ b/packages/remnic-core/src/namespaces/path.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+
+export function assertNamespacePathInsideRoot(
+  root: string,
+  candidate: string,
+  namespace: string,
+  label = "namespace path",
+): void {
+  const relative = path.relative(root, candidate);
+  if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+    return;
+  }
+  throw new Error(`invalid ${label}: ${namespace}`);
+}
+
+export function resolveNamespaceChildRoot(
+  memoryDir: string,
+  namespace: string,
+  label = "namespace path",
+): string {
+  const namespaceRoot = path.resolve(memoryDir, "namespaces");
+  const candidate = path.resolve(namespaceRoot, namespace);
+  assertNamespacePathInsideRoot(namespaceRoot, candidate, namespace, label);
+  return candidate;
+}

--- a/tests/codex-materialize-runner.test.ts
+++ b/tests/codex-materialize-runner.test.ts
@@ -144,6 +144,175 @@ test("runner reads namespaced memories from memoryDir/namespaces/<ns> (P1 fix)",
   }
 });
 
+test("runner rejects unsafe materialize namespaces before resolving storage paths", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-unsafe-ns-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-unsafe-ns-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    ensureSentinel(memoriesDir, "../../outside", new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      codexMaterializeMemories: true,
+    });
+
+    await assert.rejects(
+      runCodexMaterialize({
+        config,
+        namespace: "../../outside",
+        codexHome,
+        reason: "manual",
+        now: new Date("2026-04-02T00:00:00Z"),
+      }),
+      /invalid materialize namespace: \.\.\/\.\.\/outside/,
+    );
+
+    assert.equal(
+      existsSync(path.resolve(memoryDir, "..", "..", "outside")),
+      false,
+      "unsafe namespace must not materialize or inspect storage outside memoryDir/namespaces",
+    );
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("runner rejects unsafe default materialize namespace from auto resolution", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-unsafe-default-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-unsafe-default-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    ensureSentinel(memoriesDir, "default", new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      namespacesEnabled: true,
+      defaultNamespace: "../default",
+      codexMaterializeMemories: true,
+    });
+
+    await assert.rejects(
+      runCodexMaterialize({
+        config,
+        codexHome,
+        reason: "manual",
+        now: new Date("2026-04-02T00:00:00Z"),
+      }),
+      /invalid materialize namespace: \.\.\/default/,
+    );
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("runner trims configured default namespace before validation and storage resolution", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-trim-default-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-trim-default-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    const nsName = "trimmed-ns";
+    const nsRoot = path.join(memoryDir, "namespaces", nsName);
+    mkdirSync(nsRoot, { recursive: true });
+    const nsStorage = new StorageManager(nsRoot);
+    await nsStorage.writeMemory(
+      "fact",
+      "synthetic trimmed default namespace memory.",
+      { source: "runner-test" },
+    );
+    ensureSentinel(memoriesDir, nsName, new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      namespacesEnabled: true,
+      defaultNamespace: ` ${nsName} `,
+      codexMaterializeMemories: true,
+    });
+
+    const result = await runCodexMaterialize({
+      config,
+      codexHome,
+      reason: "manual",
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.ok(result, "runner should materialize using the trimmed default namespace");
+    assert.equal(result.namespace, nsName);
+    const rawContents = (await import("node:fs")).readFileSync(
+      path.join(memoriesDir, "raw_memories.md"),
+      "utf-8",
+    );
+    assert.match(rawContents, /synthetic trimmed default namespace memory/);
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("runner falls back to legacy root for trimmed default namespace without migrated directory", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-trim-legacy-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-trim-legacy-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    const nsName = "trimmed-legacy";
+    const storage = new StorageManager(memoryDir);
+    await storage.writeMemory(
+      "fact",
+      "synthetic trimmed default legacy-root memory.",
+      { source: "runner-test" },
+    );
+    ensureSentinel(memoriesDir, nsName, new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      namespacesEnabled: true,
+      defaultNamespace: ` ${nsName} `,
+      codexMaterializeMemories: true,
+    });
+
+    const result = await runCodexMaterialize({
+      config,
+      codexHome,
+      reason: "manual",
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.ok(result, "runner should materialize from the legacy root");
+    assert.equal(result.namespace, nsName);
+    const rawContents = (await import("node:fs")).readFileSync(
+      path.join(memoriesDir, "raw_memories.md"),
+      "utf-8",
+    );
+    assert.match(rawContents, /synthetic trimmed default legacy-root memory/);
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
 test("runner skips when reason=session_end and codexMaterializeOnSessionEnd=false (P2 fix)", async () => {
   const memoryDir = makeTempDir("codex-materialize-runner-sessend-memdir-");
   const workspaceDir = makeTempDir("codex-materialize-runner-sessend-workspace-");


### PR DESCRIPTION
## Summary
- validate Codex materialize namespaces with the existing safe namespace rule before resolving storage
- resolve namespaced storage roots with a containment check under memoryDir/namespaces
- add regression coverage for traversal namespace overrides and unsafe auto/default namespace resolution

## Verification
- pnpm exec tsx --test tests/codex-materialize-runner.test.ts
- pnpm --filter @remnic/core check-types
- git diff --check
- npm run preflight:quick

Clawpatch high finding addressed: Unvalidated materialize namespace can escape the namespace storage root.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace resolution and filesystem path construction, so mistakes could break materialization or block valid namespaces; changes are localized and covered by new regression tests.
> 
> **Overview**
> **Hardens Codex materialization namespace/path handling.** The runner now validates the resolved namespace (including `auto`/default resolution) via `isSafeRouteNamespace`, trims configured defaults, and rejects unsafe values before any storage path resolution.
> 
> **Prevents path traversal in namespaced storage resolution.** A new `namespaces/path.ts` centralizes a containment check (`resolveNamespaceChildRoot`), which is reused by both the CLI namespace memory-dir resolver and the Codex materialize runner; tests add coverage for traversal overrides, unsafe default namespaces, and trimmed-default behavior (including legacy-root fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b187483f3e294484e268a877f523edcb9ea5be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->