### PR TITLE
fix(core): skip symlinks during legacy migration

### DIFF
--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   chmod,
   copyFile,
+  lstat,
   mkdir,
   open,
   readFile,
@@ -152,9 +153,30 @@ function isRemnicTokenStorePath(filePath: string, homeDir: string): boolean {
   return path.resolve(filePath) === path.resolve(path.join(remnicRoot(homeDir), "tokens.json"));
 }
 
-async function copyTreeMissing(source: string, destination: string, copied: string[]): Promise<void> {
+async function pathExistsNoFollow(filePath: string): Promise<boolean> {
+  try {
+    await lstat(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function copyTreeMissing(
+  source: string,
+  destination: string,
+  copied: string[],
+  isRoot = true,
+): Promise<void> {
   if (!existsSync(source)) return;
-  const sourceStat = await stat(source);
+  const sourceStat = await lstat(source);
+  if (sourceStat.isSymbolicLink()) {
+    if (isRoot) {
+      throw new Error(`legacy migration root must not be a symlink: ${source}`);
+    }
+    return;
+  }
   if (sourceStat.isDirectory()) {
     await mkdir(destination, { recursive: true });
     const entries = await readdir(source, { withFileTypes: true });
@@ -166,12 +188,13 @@ async function copyTreeMissing(source: string, destination: string, copied: stri
         path.join(source, entry.name),
         path.join(destination, entry.name),
         copied,
+        false,
       );
     }
     return;
   }
 
-  if (existsSync(destination)) return;
+  if (await pathExistsNoFollow(destination)) return;
   await ensureParent(destination);
   await copyFile(source, destination);
   copied.push(destination);

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { chmod, mkdtemp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import {
   migrateFromEngram,
@@ -188,6 +188,80 @@ test("migrateFromEngram copies legacy state, rewrites tokens, updates connector 
       ["launchctl", "load", "-w", path.join(homeDir, "Library", "LaunchAgents", "ai.remnic.daemon.plist")],
     ],
   );
+});
+
+test("migrateFromEngram skips legacy file symlinks without copying external target content", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-file-symlink-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const externalSecret = path.join(homeDir, "outside-secret.txt");
+  const legacyLink = path.join(legacyRoot, "copied-key");
+  const remnicLinkDestination = path.join(homeDir, ".remnic", "copied-key");
+
+  await mkdir(legacyRoot, { recursive: true });
+  await writeFile(path.join(legacyRoot, "tokens.json"), JSON.stringify({ tokens: [] }), "utf8");
+  await writeFile(externalSecret, "synthetic external secret", "utf8");
+  await symlink(externalSecret, legacyLink);
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.equal(existsSync(remnicLinkDestination), false);
+  assert.equal(result.copied.includes(remnicLinkDestination), false);
+});
+
+test("migrateFromEngram skips legacy directory symlinks without traversing outside the legacy root", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-dir-symlink-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const externalDir = path.join(homeDir, "outside-dir");
+  const legacyLink = path.join(legacyRoot, "linked-dir");
+  const remnicLinkedFile = path.join(homeDir, ".remnic", "linked-dir", "secret.txt");
+
+  await mkdir(legacyRoot, { recursive: true });
+  await mkdir(externalDir, { recursive: true });
+  await writeFile(path.join(legacyRoot, "tokens.json"), JSON.stringify({ tokens: [] }), "utf8");
+  await writeFile(path.join(externalDir, "secret.txt"), "synthetic external directory secret", "utf8");
+  await symlink(externalDir, legacyLink, "dir");
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.equal(existsSync(remnicLinkedFile), false);
+  assert.equal(result.copied.includes(remnicLinkedFile), false);
+});
+
+test("migrateFromEngram rejects a symlinked legacy root before writing the marker", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-root-symlink-");
+  const externalLegacyRoot = path.join(homeDir, "external-engram");
+  const legacyRoot = path.join(homeDir, ".engram");
+
+  await mkdir(externalLegacyRoot, { recursive: true });
+  await writeFile(path.join(externalLegacyRoot, "tokens.json"), JSON.stringify({ tokens: [] }), "utf8");
+  await symlink(externalLegacyRoot, legacyRoot, "dir");
+
+  await assert.rejects(
+    migrateFromEngram({
+      homeDir,
+      cwd: homeDir,
+      quiet: true,
+    }),
+    /legacy migration root must not be a symlink/,
+  );
+
+  assert.equal(existsSync(path.join(homeDir, ".remnic", ".migrated-from-engram")), false);
 });
 
 test("migrateFromEngram is idempotent after the marker is written", async () => {


### PR DESCRIPTION
## Summary
- harden Engram-to-Remnic legacy tree migration to inspect entries with lstat and skip symlinks instead of following them
- avoid treating destination symlinks as missing by checking destination paths without following links
- add regression coverage for file and directory symlinks that point outside the legacy root

## Verification
- pnpm exec tsx --test tests/remnic-migration.test.ts
- pnpm --filter @remnic/core check-types
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem migration logic that runs on user machines; behavior changes for symlinked legacy paths and could skip expected data for users relying on symlinks.
> 
> **Overview**
> Hardens Engram→Remnic legacy migration to **not follow symlinks**: `copyTreeMissing` now uses `lstat`, skips non-root symlink entries, and **fails fast** if the legacy root itself is a symlink.
> 
> Also avoids copying into destinations that are symlinks by checking destination existence via `lstat` (`pathExistsNoFollow`). Adds regression tests covering file/dir symlinks pointing outside the legacy root and rejecting a symlinked legacy root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a23fb2e81bd3f9ea7621bc82df12b052579f17f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->