### PR TITLE
fix(core): reject routing state symlinks

### DIFF
--- a/packages/remnic-core/src/routing/store.ts
+++ b/packages/remnic-core/src/routing/store.ts
@@ -127,9 +127,7 @@ export class RoutingRulesStore {
 
   async reset(): Promise<void> {
     await this.withWriteLock(async () => {
-      const payload = defaultState();
-      await this.assertStatePathScoped();
-      await writeFile(this.statePath, JSON.stringify(payload, null, 2), "utf-8");
+      await this.writeState(defaultState());
     });
   }
 
@@ -188,6 +186,12 @@ export class RoutingRulesStore {
       rules: normalized,
     };
 
+    await this.writeState(payload);
+
+    return normalized;
+  }
+
+  private async writeState(payload: RoutingRulesState): Promise<void> {
     const tmpPath = `${this.statePath}.tmp-${process.pid}-${Date.now()}`;
     try {
       await this.assertStatePathScoped();
@@ -199,8 +203,6 @@ export class RoutingRulesStore {
     } finally {
       await rm(tmpPath, { force: true }).catch(() => {});
     }
-
-    return normalized;
   }
 
   private async withWriteLock<T>(op: () => Promise<T>): Promise<T> {
@@ -275,10 +277,7 @@ export class RoutingRulesStore {
     try {
       const stateStats = await lstat(this.statePath);
       if (stateStats.isSymbolicLink()) {
-        const canonicalFile = await realpath(this.statePath);
-        if (!this.isPathInside(canonicalRoot, canonicalFile)) {
-          throw new Error(`routing rules state symlink escaped memoryDir: ${canonicalFile}`);
-        }
+        throw new Error(`routing rules state path must not be a symlink: ${this.statePath}`);
       }
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;

--- a/tests/routing-store.test.ts
+++ b/tests/routing-store.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { RoutingRulesStore } from "../src/routing/store.ts";
 import type { RouteRule } from "../src/routing/engine.ts";
 
@@ -327,6 +327,54 @@ test("routing store blocks final state-file symlink escapes", async () => {
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
     await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("routing store reset rejects in-scope state-file symlinks without touching the target", async () => {
+  if (process.platform === "win32") return;
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-routing-store-file-symlink-inside-"));
+  try {
+    const targetFile = path.join(memoryDir, "state", "linked-target.json");
+    const statePath = path.join(memoryDir, "state", "routing-rules.json");
+    await mkdir(path.dirname(statePath), { recursive: true });
+    await writeFile(targetFile, "keep me", "utf-8");
+    await symlink(targetFile, statePath);
+
+    const store = new RoutingRulesStore(memoryDir);
+    await assert.rejects(
+      async () => store.reset(),
+      /routing rules state path must not be a symlink/,
+    );
+
+    assert.equal(await readFile(targetFile, "utf-8"), "keep me");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("routing store write rejects in-scope state-file symlinks without replacing the symlink", async () => {
+  if (process.platform === "win32") return;
+
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-routing-store-write-symlink-inside-"));
+  try {
+    const targetFile = path.join(memoryDir, "state", "linked-target.json");
+    const statePath = path.join(memoryDir, "state", "routing-rules.json");
+    await mkdir(path.dirname(statePath), { recursive: true });
+    await writeFile(targetFile, "keep me", "utf-8");
+    await symlink(targetFile, statePath);
+
+    const store = new RoutingRulesStore(memoryDir);
+    await assert.rejects(
+      async () => store.write([sampleRule()]),
+      /routing rules state path must not be a symlink/,
+    );
+
+    assert.equal(await readFile(targetFile, "utf-8"), "keep me");
+    const linkStat = await lstat(statePath);
+    assert.equal(linkStat.isSymbolicLink(), true);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- reject routing state files that are symlinks, even when the target is inside memoryDir
- route reset() through the same temp-file-and-rename write path used by normal writes
- add regression coverage proving reset/write do not modify symlink targets

## Verification
- pnpm exec tsx --test tests/routing-store.test.ts
- pnpm --filter @remnic/core check-types
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens filesystem write safeguards for routing rule persistence, which could impact environments relying on symlinked state files. Changes are localized but affect all `write`/`reset` paths.
> 
> **Overview**
> **Hardens routing rules persistence against symlink attacks.** `RoutingRulesStore.assertStatePathScoped()` now rejects state files that are symlinks (even if they point inside `memoryDir`) rather than resolving and allowing them.
> 
> **Unifies write behavior.** `reset()` now writes via the same atomic temp-file-then-rename logic as normal writes by reusing a new `writeState()` helper.
> 
> **Adds regression tests.** New test cases ensure `reset()`/`write()` reject in-scope state-file symlinks and do not modify the symlink target or replace the symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3d4e3b474af4759b4541c95449dc20eb968520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->