### PR TITLE
fix(core): reject duplicate work record ids

### DIFF
--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3,6 +3,7 @@ import { appendFileSync, mkdirSync, statSync } from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
 import { log } from "./logger.js";
+import { isErrnoCode } from "./utils/errno.js";
 import { getCachedEntities, invalidateCachedEntities, setCachedEntities } from "./memory-cache.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
@@ -189,15 +190,6 @@ function normalizeMemoryWriteTimestamp(
     throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(value)}`);
   }
   return new Date(parsed).toISOString();
-}
-
-function isErrnoCode(error: unknown, code: string): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: unknown }).code === code
-  );
 }
 
 function trimTrailingSpacesAndTabs(value: string): string {

--- a/packages/remnic-core/src/utils/errno.ts
+++ b/packages/remnic-core/src/utils/errno.ts
@@ -1,0 +1,6 @@
+export function isErrnoCode(error: unknown, code: string): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { code?: unknown }).code === code;
+}

--- a/packages/remnic-core/src/work/storage.ts
+++ b/packages/remnic-core/src/work/storage.ts
@@ -12,6 +12,7 @@ import type {
   WorkTaskListFilter,
   WorkTaskStatus,
 } from "./types.js";
+import { isErrnoCode } from "../utils/errno.js";
 
 const TASK_TRANSITIONS: Record<WorkTaskStatus, Set<WorkTaskStatus>> = {
   todo: new Set(["in_progress", "blocked", "cancelled"]),
@@ -133,6 +134,28 @@ export class WorkStorage {
     return `${serializeFrontmatter(project)}\n\n${project.description}\n`;
   }
 
+  private async writeNewTask(task: WorkTask): Promise<void> {
+    try {
+      await writeFile(this.taskPath(task.id), this.serializeTask(task), { encoding: "utf-8", flag: "wx" });
+    } catch (error) {
+      if (isErrnoCode(error, "EEXIST")) {
+        throw new Error(`task already exists: ${task.id}`);
+      }
+      throw error;
+    }
+  }
+
+  private async writeNewProject(project: WorkProject): Promise<void> {
+    try {
+      await writeFile(this.projectPath(project.id), this.serializeProject(project), { encoding: "utf-8", flag: "wx" });
+    } catch (error) {
+      if (isErrnoCode(error, "EEXIST")) {
+        throw new Error(`project already exists: ${project.id}`);
+      }
+      throw error;
+    }
+  }
+
   private parseTask(raw: string): WorkTask | null {
     const parsed = parseFrontmatter(raw);
     if (!parsed) return null;
@@ -195,7 +218,7 @@ export class WorkStorage {
       }
     }
 
-    await writeFile(this.taskPath(task.id), this.serializeTask(task), "utf-8");
+    await this.writeNewTask(task);
 
     if (task.projectId) {
       await this.addTaskIdToProject(task.projectId, task.id, now);
@@ -321,7 +344,7 @@ export class WorkStorage {
       createdAt: timestamp,
       updatedAt: timestamp,
     };
-    await writeFile(this.projectPath(project.id), this.serializeProject(project), "utf-8");
+    await this.writeNewProject(project);
     return project;
   }
 

--- a/tests/work-storage.test.ts
+++ b/tests/work-storage.test.ts
@@ -157,6 +157,60 @@ test("work storage generates collision-resistant ids for same timestamp/title", 
   assert.equal(tasks.length, 2);
 });
 
+test("work storage rejects duplicate task IDs without overwriting records or project links", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-work-storage-duplicate-task-"));
+  const storage = new WorkStorage(memoryDir);
+
+  const projectA = await storage.createProject({ id: "project-a", name: "Project A" });
+  const projectB = await storage.createProject({ id: "project-b", name: "Project B" });
+  const original = await storage.createTask(
+    { id: "task-duplicate", title: "Original task", projectId: projectA.id },
+    new Date("2026-02-26T00:00:00.000Z"),
+  );
+
+  await assert.rejects(
+    () => storage.createTask(
+      { id: original.id, title: "Replacement task", projectId: projectB.id },
+      new Date("2026-02-26T00:01:00.000Z"),
+    ),
+    /task already exists: task-duplicate/,
+  );
+
+  const fetched = await storage.getTask(original.id);
+  assert.ok(fetched);
+  assert.equal(fetched?.title, "Original task");
+  assert.equal(fetched?.projectId, projectA.id);
+
+  const fetchedProjectA = await storage.getProject(projectA.id);
+  const fetchedProjectB = await storage.getProject(projectB.id);
+  assert.deepEqual(fetchedProjectA?.taskIds, [original.id]);
+  assert.deepEqual(fetchedProjectB?.taskIds, []);
+});
+
+test("work storage rejects duplicate project IDs without overwriting records", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-work-storage-duplicate-project-"));
+  const storage = new WorkStorage(memoryDir);
+
+  const original = await storage.createProject(
+    { id: "project-duplicate", name: "Original project", owner: "platform" },
+    new Date("2026-02-26T00:00:00.000Z"),
+  );
+
+  await assert.rejects(
+    () => storage.createProject(
+      { id: original.id, name: "Replacement project", owner: "ops" },
+      new Date("2026-02-26T00:01:00.000Z"),
+    ),
+    /project already exists: project-duplicate/,
+  );
+
+  const fetched = await storage.getProject(original.id);
+  assert.ok(fetched);
+  assert.equal(fetched?.name, "Original project");
+  assert.equal(fetched?.owner, "platform");
+  assert.equal(fetched?.createdAt, "2026-02-26T00:00:00.000Z");
+});
+
 test("work storage rejects unsafe task and project IDs", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-work-storage-safe-id-"));
   const storage = new WorkStorage(memoryDir);


### PR DESCRIPTION
## Summary
- write new work tasks/projects with exclusive creation so reused IDs cannot overwrite existing records
- surface duplicate task/project IDs as explicit errors
- add regression tests that duplicate task/project creation preserves existing records and project membership

## Verification
- pnpm exec tsx --test tests/work-storage.test.ts
- pnpm --filter @remnic/core check-types
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes file-write semantics for work task/project creation to use exclusive writes and surface `EEXIST` as explicit errors; risk is limited but could affect any callers relying on overwrite behavior or error handling.
> 
> **Overview**
> Prevents `WorkStorage` from overwriting existing task/project records when a caller reuses an ID by switching creates to exclusive `writeFile(..., { flag: "wx" })` and mapping `EEXIST` to clear `task/project already exists` errors.
> 
> Refactors the shared `isErrnoCode` helper into `utils/errno.ts` and adds regression tests asserting duplicate creates do not overwrite task/project data or corrupt project task links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c33bbb32a3a8600d2a5f53e370b788b7832f556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->