### PR TITLE
fix(core): exclude sensitive transfer artifacts

### DIFF
--- a/packages/remnic-core/src/transfer/backup.ts
+++ b/packages/remnic-core/src/transfer/backup.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir, rm, unlink, writeFile } from "node:fs/promises";
 import { gzipSync } from "node:zlib";
 import { exportMarkdownBundle } from "./export-md.js";
 import { encryptCapsuleFile } from "./capsule-crypto.js";
+import { isTransferPathExcluded } from "./exclusions.js";
 
 export interface BackupOptions {
   memoryDir: string;
@@ -48,12 +49,7 @@ export async function backupMemoryDir(opts: BackupOptions): Promise<string> {
     const records: Array<{ path: string; content: string }> = [];
     for (const abs of filesAbs) {
       const relPosix = toPosixRelPath(abs, memoryDirAbs);
-      const parts = relPosix.split("/");
-      // Skip VCS dirs, the secure-store dir (contains KDF params + verifier —
-      // sensitive and machine-specific, must not leave the local machine), and
-      // the .capsules dir (self-recursive inclusion). (Cursor / #690 PR 4/4)
-      if (parts.some((p) => p === "node_modules" || p === ".git" || p === ".secure-store" || p === ".capsules")) continue;
-      if (!includeTranscripts && parts[0] === "transcripts") continue;
+      if (isTransferPathExcluded(relPosix, { includeTranscripts })) continue;
       const content = await readFile(abs, "utf-8");
       records.push({ path: relPosix, content });
     }

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -19,25 +19,15 @@ import {
   type ExportMemoryRecordV1,
 } from "./types.js";
 import { encryptCapsuleFile } from "./capsule-crypto.js";
+import { computeTransferOutputRel, DEFAULT_TRANSFER_EXCLUDE_DIRS } from "./exclusions.js";
 
 /**
  * Default subdirectory excludes applied to every capsule export. These match
- * the existing `export-json` / `export-md` exclusions plus the `transcripts`
+ * the shared plaintext transfer exclusions plus the `transcripts`
  * directory, which is excluded by default and only included when the caller
  * explicitly passes `transcripts` in {@link ExportCapsuleOptions.includeKinds}.
  */
-const DEFAULT_EXCLUDE_DIRS: ReadonlySet<string> = new Set([
-  "node_modules",
-  ".git",
-  // Never export the secure-store directory: it contains the encryption
-  // header (KDF params + verifier) which is security-sensitive and
-  // machine-specific. The passphrase is not stored here, but including
-  // the header in a capsule would let an attacker brute-force the
-  // passphrase offline if the capsule is intercepted.
-  ".secure-store",
-  // Exclude .capsules to avoid recursive self-inclusion.
-  ".capsules",
-]);
+const DEFAULT_EXCLUDE_DIRS = DEFAULT_TRANSFER_EXCLUDE_DIRS;
 
 const TRANSCRIPTS_DIR = "transcripts" as const;
 
@@ -191,7 +181,7 @@ export async function exportCapsule(
   // re-import previous capsule archives on subsequent runs. Compute the
   // posix-relative path of the outDir under rootAbs (or `null` when it sits
   // outside) so {@link shouldInclude} can skip the entire subtree.
-  const outDirRelPosix = computeOutDirRel(rootAbs, outDirAbs);
+  const outDirRelPosix = computeTransferOutputRel(rootAbs, outDirAbs);
 
   const filesAbs = await listFilesRecursive(rootAbs);
 
@@ -424,32 +414,6 @@ function normalizePeerIds(
     set.add(raw);
   }
   return set;
-}
-
-/**
- * Return the posix-relative path of {@link outDirAbs} under {@link rootAbs},
- * or `null` if the output directory sits outside the export root. Used to
- * exclude the output directory's subtree from the input scan so re-running
- * the export does not package prior archives back into the new bundle.
- *
- * Both inputs are expected to be absolute paths already (post-`path.resolve`).
- */
-function computeOutDirRel(rootAbs: string, outDirAbs: string): string | null {
-  const rel = path.relative(rootAbs, outDirAbs);
-  // outDir == root: degenerate. {@link exportCapsule} rejects this case
-  // before calling us; this branch is defensive only. Returning `"."` would
-  // make `shouldInclude` drop every file, masking the misuse — return `null`
-  // instead so any direct caller that bypasses the check still produces a
-  // populated manifest rather than a silent empty export.
-  if (rel === "") return null;
-  // outDir outside root: nothing to exclude. Match real parent-traversal
-  // segments only — `rel.startsWith("..")` would also match valid in-tree
-  // names like `..capsules` and would skip excluding that subtree. The
-  // boundary check (`rel === ".."` or `rel` starts with `".." + sep`) is
-  // platform-aware via `path.sep` so Windows backslashes are respected.
-  if (rel === ".." || rel.startsWith(`..${path.sep}`)) return null;
-  if (path.isAbsolute(rel)) return null;
-  return rel.split(path.sep).join("/");
 }
 
 async function assertIsDirectory(absPath: string): Promise<void> {

--- a/packages/remnic-core/src/transfer/exclusions.ts
+++ b/packages/remnic-core/src/transfer/exclusions.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+
+export const DEFAULT_TRANSFER_EXCLUDE_DIRS: ReadonlySet<string> = new Set([
+  "node_modules",
+  ".git",
+  ".secure-store",
+  ".capsules",
+]);
+
+export interface TransferPathExcludeOptions {
+  includeTranscripts?: boolean;
+  outputRelPosix?: string | null;
+}
+
+export function computeTransferOutputRel(rootAbs: string, outputAbs: string): string | null {
+  const rel = path.relative(rootAbs, outputAbs);
+  if (rel === "") {
+    throw new Error("transfer export output path must not equal the memory directory");
+  }
+  if (rel === ".." || rel.startsWith(`..${path.sep}`)) return null;
+  if (path.isAbsolute(rel)) return null;
+  return rel.split(path.sep).join("/");
+}
+
+export function isTransferPathExcluded(relPosix: string, options: TransferPathExcludeOptions = {}): boolean {
+  const parts = relPosix.split("/");
+  if (parts.some((part) => DEFAULT_TRANSFER_EXCLUDE_DIRS.has(part))) return true;
+  if (!options.includeTranscripts && parts[0] === "transcripts") return true;
+
+  const outputRelPosix = options.outputRelPosix ?? null;
+  if (outputRelPosix !== null) {
+    if (outputRelPosix === ".") return true;
+    if (relPosix === outputRelPosix || relPosix.startsWith(`${outputRelPosix}/`)) return true;
+  }
+
+  return false;
+}

--- a/packages/remnic-core/src/transfer/export-json.ts
+++ b/packages/remnic-core/src/transfer/export-json.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile } from "node:fs/promises";
 import { EXPORT_FORMAT, EXPORT_SCHEMA_VERSION } from "./constants.js";
 import { listFilesRecursive, sha256File, sha256String, toPosixRelPath, writeJsonFile } from "./fs-utils.js";
 import type { ExportBundleV1, ExportManifestV1, ExportMemoryRecordV1 } from "./types.js";
+import { computeTransferOutputRel, isTransferPathExcluded } from "./exclusions.js";
 
 export interface ExportCommonOptions {
   memoryDir: string;
@@ -13,24 +14,13 @@ export interface ExportCommonOptions {
   pluginVersion: string;
 }
 
-const DEFAULT_EXCLUDES = new Set([
-  "node_modules",
-  ".git",
-]);
-
-function shouldExclude(relPosix: string, includeTranscripts: boolean): boolean {
-  const parts = relPosix.split("/");
-  if (parts.some((p) => DEFAULT_EXCLUDES.has(p))) return true;
-  if (!includeTranscripts && parts[0] === "transcripts") return true;
-  return false;
-}
-
 export async function exportJsonBundle(opts: ExportCommonOptions): Promise<void> {
   const includeTranscripts = opts.includeTranscripts === true;
   const outDirAbs = path.resolve(opts.outDir);
   await mkdir(outDirAbs, { recursive: true });
 
   const memoryDirAbs = path.resolve(opts.memoryDir);
+  const outputRelPosix = computeTransferOutputRel(memoryDirAbs, outDirAbs);
   const filesAbs = await listFilesRecursive(memoryDirAbs);
 
   const records: ExportMemoryRecordV1[] = [];
@@ -38,7 +28,7 @@ export async function exportJsonBundle(opts: ExportCommonOptions): Promise<void>
 
   for (const abs of filesAbs) {
     const relPosix = toPosixRelPath(abs, memoryDirAbs);
-    if (shouldExclude(relPosix, includeTranscripts)) continue;
+    if (isTransferPathExcluded(relPosix, { includeTranscripts, outputRelPosix })) continue;
 
     const content = await readFile(abs, "utf-8");
     records.push({ path: relPosix, content });

--- a/packages/remnic-core/src/transfer/export-md.ts
+++ b/packages/remnic-core/src/transfer/export-md.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { EXPORT_FORMAT, EXPORT_SCHEMA_VERSION } from "./constants.js";
 import { listFilesRecursive, sha256File, toPosixRelPath, writeJsonFile } from "./fs-utils.js";
 import type { ExportManifestV1 } from "./types.js";
+import { computeTransferOutputRel, isTransferPathExcluded } from "./exclusions.js";
 
 export interface ExportMdOptions {
   memoryDir: string;
@@ -11,25 +12,20 @@ export interface ExportMdOptions {
   pluginVersion: string;
 }
 
-function shouldExclude(relPosix: string, includeTranscripts: boolean): boolean {
-  const parts = relPosix.split("/");
-  if (!includeTranscripts && parts[0] === "transcripts") return true;
-  return false;
-}
-
 export async function exportMarkdownBundle(opts: ExportMdOptions): Promise<void> {
   const includeTranscripts = opts.includeTranscripts === true;
   const outDirAbs = path.resolve(opts.outDir);
   await mkdir(outDirAbs, { recursive: true });
 
   const memDirAbs = path.resolve(opts.memoryDir);
+  const outputRelPosix = computeTransferOutputRel(memDirAbs, outDirAbs);
   const filesAbs = await listFilesRecursive(memDirAbs);
 
   const manifestFiles: ExportManifestV1["files"] = [];
 
   for (const abs of filesAbs) {
     const relPosix = toPosixRelPath(abs, memDirAbs);
-    if (shouldExclude(relPosix, includeTranscripts)) continue;
+    if (isTransferPathExcluded(relPosix, { includeTranscripts, outputRelPosix })) continue;
 
     const dstAbs = path.join(outDirAbs, ...relPosix.split("/"));
     await mkdir(path.dirname(dstAbs), { recursive: true });
@@ -61,4 +57,3 @@ export async function looksLikeEngramMdExport(fromDir: string): Promise<boolean>
     return false;
   }
 }
-

--- a/packages/remnic-core/src/transfer/export-sqlite.ts
+++ b/packages/remnic-core/src/transfer/export-sqlite.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { SQLITE_SCHEMA_VERSION, SQLITE_TABLES_SQL } from "./sqlite-schema.js";
 import { listFilesRecursive, sha256File, toPosixRelPath } from "./fs-utils.js";
 import { openBetterSqlite3 } from "../runtime/better-sqlite.js";
+import { computeTransferOutputRel, isTransferPathExcluded } from "./exclusions.js";
 
 export interface ExportSqliteOptions {
   memoryDir: string;
@@ -11,16 +12,11 @@ export interface ExportSqliteOptions {
   pluginVersion: string;
 }
 
-function shouldExclude(relPosix: string, includeTranscripts: boolean): boolean {
-  const parts = relPosix.split("/");
-  if (!includeTranscripts && parts[0] === "transcripts") return true;
-  return false;
-}
-
 export async function exportSqlite(opts: ExportSqliteOptions): Promise<void> {
   const includeTranscripts = opts.includeTranscripts === true;
   const memDirAbs = path.resolve(opts.memoryDir);
   const outAbs = path.resolve(opts.outFile);
+  const outputRelPosix = computeTransferOutputRel(memDirAbs, outAbs);
 
   const filesAbs = await listFilesRecursive(memDirAbs);
   const db = openBetterSqlite3(outAbs);
@@ -45,7 +41,7 @@ export async function exportSqlite(opts: ExportSqliteOptions): Promise<void> {
     const rows: Array<{ rel: string; bytes: number; sha256: string; content: string }> = [];
     for (const abs of filesAbs) {
       const relPosix = toPosixRelPath(abs, memDirAbs);
-      if (shouldExclude(relPosix, includeTranscripts)) continue;
+      if (isTransferPathExcluded(relPosix, { includeTranscripts, outputRelPosix })) continue;
       const content = await readFile(abs, "utf-8");
       const { sha256, bytes } = await sha256File(abs);
       rows.push({ rel: relPosix, bytes, sha256, content });

--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -1,10 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readdir } from "node:fs/promises";
+import { access, mkdtemp, readFile, readdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { writeFixtureMemoryDir } from "./transfer-fixtures.js";
+import { writeFixtureMemoryDir, writeSensitiveTransferFixtureEntries } from "./transfer-fixtures.js";
 import { backupMemoryDir } from "../src/transfer/backup.js";
+
+async function assertPathMissing(filePath: string): Promise<void> {
+  await assert.rejects(access(filePath), { code: "ENOENT" });
+}
 
 test("v2.3 backup creates a timestamped directory", async () => {
   const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
@@ -20,3 +24,26 @@ test("v2.3 backup creates a timestamped directory", async () => {
   assert.ok(entries.includes("manifest.json"));
 });
 
+test("plaintext backup excludes secure store, capsules, VCS, and dependencies", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await writeFixtureMemoryDir(memDir);
+  await writeSensitiveTransferFixtureEntries(memDir);
+
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-backup-"));
+  const backupDir = await backupMemoryDir({ memoryDir: memDir, outDir, pluginVersion: "2.2.3" });
+
+  const manifest = JSON.parse(await readFile(path.join(backupDir, "manifest.json"), "utf-8")) as {
+    files: Array<{ path: string }>;
+  };
+  const paths = manifest.files.map((file) => file.path);
+  assert.equal(paths.some((entry) => entry.startsWith(".secure-store/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith(".capsules/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith(".git/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith("node_modules/")), false);
+  assert.ok(paths.includes("facts/2026-02-11/fact-1.md"));
+
+  await assertPathMissing(path.join(backupDir, ".secure-store", "header.json"));
+  await assertPathMissing(path.join(backupDir, ".capsules", "old.capsule.json.gz"));
+  await assertPathMissing(path.join(backupDir, ".git", "config"));
+  await assertPathMissing(path.join(backupDir, "node_modules", "pkg", "index.js"));
+});

--- a/tests/export-import-json.test.ts
+++ b/tests/export-import-json.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { exportJsonBundle } from "../src/transfer/export-json.js";
 import { importJsonBundle } from "../src/transfer/import-json.js";
-import { writeFixtureMemoryDir } from "./transfer-fixtures.js";
+import { writeFixtureMemoryDir, writeSensitiveTransferFixtureEntries } from "./transfer-fixtures.js";
 
 async function assertPathMissing(filePath: string): Promise<void> {
   await assert.rejects(access(filePath), { code: "ENOENT" });
@@ -65,6 +65,37 @@ test("v2.3 json export/import round-trips (without transcripts by default)", asy
 
   const fact = await readFile(path.join(targetDir, "facts", "2026-02-11", "fact-1.md"), "utf-8");
   assert.match(fact, /The user likes pianos/);
+});
+
+test("json export excludes secure store, capsules, VCS, and dependencies", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await writeFixtureMemoryDir(memDir);
+  await writeSensitiveTransferFixtureEntries(memDir);
+
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  await exportJsonBundle({ memoryDir: memDir, outDir, pluginVersion: "2.2.3" });
+
+  const bundle = JSON.parse(await readFile(path.join(outDir, "bundle.json"), "utf-8")) as {
+    records: Array<{ path: string; content: string }>;
+    manifest: { files: Array<{ path: string }> };
+  };
+  const paths = bundle.records.map((record) => record.path);
+  assert.equal(paths.some((entry) => entry.startsWith(".secure-store/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith(".capsules/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith(".git/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith("node_modules/")), false);
+  assert.ok(paths.includes("facts/2026-02-11/fact-1.md"));
+  assert.deepEqual(bundle.manifest.files.map((file) => file.path), paths);
+});
+
+test("json export rejects output directory equal to memory directory", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await writeFixtureMemoryDir(memDir);
+
+  await assert.rejects(
+    exportJsonBundle({ memoryDir: memDir, outDir: memDir, pluginVersion: "2.2.3" }),
+    /output path must not equal the memory directory/,
+  );
 });
 
 test("json import rejects invalid conflict policy without overwriting existing files", async () => {

--- a/tests/export-import-sqlite.test.ts
+++ b/tests/export-import-sqlite.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { writeFixtureMemoryDir } from "./transfer-fixtures.js";
+import { writeFixtureMemoryDir, writeSensitiveTransferFixtureEntries } from "./transfer-fixtures.js";
 import { exportSqlite } from "../src/transfer/export-sqlite.js";
 import { importSqlite } from "../src/transfer/import-sqlite.js";
 import { openBetterSqlite3 } from "../src/runtime/better-sqlite.js";
@@ -55,6 +55,38 @@ test("v2.3 sqlite export/import round-trips basic files", async () => {
 
   const importedProfile = await readFile(path.join(targetDir, "profile.md"), "utf-8");
   assert.match(importedProfile, /Profile/);
+});
+
+test("sqlite export excludes secure store, capsules, VCS, and dependencies", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await writeFixtureMemoryDir(memDir);
+  await writeSensitiveTransferFixtureEntries(memDir);
+
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-sqlite-"));
+  const sqliteFile = path.join(outDir, "export.sqlite");
+  await exportSqlite({ memoryDir: memDir, outFile: sqliteFile, pluginVersion: "2.2.3" });
+
+  const db = openBetterSqlite3(sqliteFile);
+  try {
+    const paths = db.prepare("SELECT path_rel FROM files ORDER BY path_rel").all() as Array<{ path_rel: string }>;
+    assert.equal(paths.some((row) => row.path_rel.startsWith(".secure-store/")), false);
+    assert.equal(paths.some((row) => row.path_rel.startsWith(".capsules/")), false);
+    assert.equal(paths.some((row) => row.path_rel.startsWith(".git/")), false);
+    assert.equal(paths.some((row) => row.path_rel.startsWith("node_modules/")), false);
+    assert.ok(paths.some((row) => row.path_rel === "facts/2026-02-11/fact-1.md"));
+  } finally {
+    db.close();
+  }
+});
+
+test("sqlite export rejects output file equal to memory directory", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await writeFixtureMemoryDir(memDir);
+
+  await assert.rejects(
+    exportSqlite({ memoryDir: memDir, outFile: memDir, pluginVersion: "2.2.3" }),
+    /output path must not equal the memory directory/,
+  );
 });
 
 test("sqlite import rejects invalid conflict policy without overwriting existing files", async () => {

--- a/tests/export-md.test.ts
+++ b/tests/export-md.test.ts
@@ -1,10 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { access, mkdtemp, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { writeFixtureMemoryDir } from "./transfer-fixtures.js";
+import { writeFixtureMemoryDir, writeSensitiveTransferFixtureEntries } from "./transfer-fixtures.js";
 import { exportMarkdownBundle } from "../src/transfer/export-md.js";
+
+async function assertPathMissing(filePath: string): Promise<void> {
+  await assert.rejects(access(filePath), { code: "ENOENT" });
+}
 
 test("v2.3 md export copies files and writes a manifest", async () => {
   const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
@@ -21,3 +25,36 @@ test("v2.3 md export copies files and writes a manifest", async () => {
   assert.match(fact, /pianos/);
 });
 
+test("md export excludes secure store, capsules, VCS, and dependencies", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await writeFixtureMemoryDir(memDir);
+  await writeSensitiveTransferFixtureEntries(memDir);
+
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
+  await exportMarkdownBundle({ memoryDir: memDir, outDir, pluginVersion: "2.2.3" });
+
+  const manifest = JSON.parse(await readFile(path.join(outDir, "manifest.json"), "utf-8")) as {
+    files: Array<{ path: string }>;
+  };
+  const paths = manifest.files.map((file) => file.path);
+  assert.equal(paths.some((entry) => entry.startsWith(".secure-store/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith(".capsules/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith(".git/")), false);
+  assert.equal(paths.some((entry) => entry.startsWith("node_modules/")), false);
+  assert.ok(paths.includes("facts/2026-02-11/fact-1.md"));
+
+  await assertPathMissing(path.join(outDir, ".secure-store", "header.json"));
+  await assertPathMissing(path.join(outDir, ".capsules", "old.capsule.json.gz"));
+  await assertPathMissing(path.join(outDir, ".git", "config"));
+  await assertPathMissing(path.join(outDir, "node_modules", "pkg", "index.js"));
+});
+
+test("md export rejects output directory equal to memory directory", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await writeFixtureMemoryDir(memDir);
+
+  await assert.rejects(
+    exportMarkdownBundle({ memoryDir: memDir, outDir: memDir, pluginVersion: "2.2.3" }),
+    /output path must not equal the memory directory/,
+  );
+});

--- a/tests/transfer-fixtures.ts
+++ b/tests/transfer-fixtures.ts
@@ -34,3 +34,14 @@ export async function writeFixtureMemoryDir(memoryDir: string): Promise<void> {
   );
 }
 
+export async function writeSensitiveTransferFixtureEntries(memoryDir: string): Promise<void> {
+  await mkdir(path.join(memoryDir, ".secure-store"), { recursive: true });
+  await mkdir(path.join(memoryDir, ".capsules"), { recursive: true });
+  await mkdir(path.join(memoryDir, ".git"), { recursive: true });
+  await mkdir(path.join(memoryDir, "node_modules", "pkg"), { recursive: true });
+
+  await writeFile(path.join(memoryDir, ".secure-store", "header.json"), "{\"verifier\":\"secret\"}\n", "utf-8");
+  await writeFile(path.join(memoryDir, ".capsules", "old.capsule.json.gz"), "old capsule\n", "utf-8");
+  await writeFile(path.join(memoryDir, ".git", "config"), "repo config\n", "utf-8");
+  await writeFile(path.join(memoryDir, "node_modules", "pkg", "index.js"), "module\n", "utf-8");
+}


### PR DESCRIPTION
## Summary
- add one shared transfer exclusion policy for plaintext exports and backups
- exclude .secure-store, .capsules, .git, node_modules, transcripts by default, and in-tree output paths where applicable
- add regression coverage for markdown, JSON, SQLite, plaintext backup, and capsule export compatibility

## Verification
- pnpm exec tsx --test tests/export-md.test.ts tests/export-import-json.test.ts tests/export-import-sqlite.test.ts tests/backup.test.ts tests/capsule-export.test.ts
- pnpm --filter @remnic/core check-types
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core export/backup file selection logic; mistakes could silently omit user data or break exports, but changes are narrow and well-covered by new regression tests.
> 
> **Overview**
> **Unifies plaintext transfer filtering** by introducing `exclusions.ts` and switching backup/JSON/Markdown/SQLite exports to a shared `isTransferPathExcluded` policy that skips `node_modules`, `.git`, `.secure-store`, `.capsules`, and (by default) `transcripts`.
> 
> **Hardens export output handling** by computing and excluding in-tree output subtrees to prevent self-inclusion, and by rejecting cases where the export output resolves to the memory directory.
> 
> **Adds regression tests/fixtures** ensuring the excluded directories are neither present in manifests nor copied into plaintext outputs across backup, md, json, and sqlite exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b97eb56ead2389e3b63128e6a27d13929b2bebbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->