### PR TITLE
fix(core): validate transfer import checksums

### DIFF
--- a/packages/remnic-core/src/transfer/export-json.ts
+++ b/packages/remnic-core/src/transfer/export-json.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { mkdir, readFile } from "node:fs/promises";
 import { EXPORT_FORMAT, EXPORT_SCHEMA_VERSION } from "./constants.js";
-import { listFilesRecursive, sha256File, sha256String, toPosixRelPath, writeJsonFile } from "./fs-utils.js";
+import { listFilesRecursive, readUtf8FileStrict, sha256String, toPosixRelPath, writeJsonFile } from "./fs-utils.js";
 import type { ExportBundleV1, ExportManifestV1, ExportMemoryRecordV1 } from "./types.js";
 import { computeTransferOutputRel, isTransferPathExcluded } from "./exclusions.js";
 
@@ -30,9 +30,8 @@ export async function exportJsonBundle(opts: ExportCommonOptions): Promise<void>
     const relPosix = toPosixRelPath(abs, memoryDirAbs);
     if (isTransferPathExcluded(relPosix, { includeTranscripts, outputRelPosix })) continue;
 
-    const content = await readFile(abs, "utf-8");
+    const { content, sha256, bytes } = await readUtf8FileStrict(abs);
     records.push({ path: relPosix, content });
-    const { sha256, bytes } = await sha256File(abs);
     manifestFiles.push({ path: relPosix, sha256, bytes });
   }
 

--- a/packages/remnic-core/src/transfer/export-sqlite.ts
+++ b/packages/remnic-core/src/transfer/export-sqlite.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
-import { readFile } from "node:fs/promises";
 import { SQLITE_SCHEMA_VERSION, SQLITE_TABLES_SQL } from "./sqlite-schema.js";
-import { listFilesRecursive, sha256File, toPosixRelPath } from "./fs-utils.js";
+import { listFilesRecursive, readUtf8FileStrict, toPosixRelPath } from "./fs-utils.js";
 import { openBetterSqlite3 } from "../runtime/better-sqlite.js";
 import { computeTransferOutputRel, isTransferPathExcluded } from "./exclusions.js";
 
@@ -42,8 +41,7 @@ export async function exportSqlite(opts: ExportSqliteOptions): Promise<void> {
     for (const abs of filesAbs) {
       const relPosix = toPosixRelPath(abs, memDirAbs);
       if (isTransferPathExcluded(relPosix, { includeTranscripts, outputRelPosix })) continue;
-      const content = await readFile(abs, "utf-8");
-      const { sha256, bytes } = await sha256File(abs);
+      const { content, sha256, bytes } = await readUtf8FileStrict(abs);
       rows.push({ rel: relPosix, bytes, sha256, content });
     }
 

--- a/packages/remnic-core/src/transfer/fs-utils.ts
+++ b/packages/remnic-core/src/transfer/fs-utils.ts
@@ -10,16 +10,33 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 
+const fatalUtf8Decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+
 export async function sha256File(filePath: string): Promise<{ sha256: string; bytes: number }> {
   const buf = await readFile(filePath);
   const sha256 = createHash("sha256").update(buf).digest("hex");
   return { sha256, bytes: buf.byteLength };
 }
 
-export function sha256String(content: string): { sha256: string; bytes: number } {
-  const buf = Buffer.from(content, "utf-8");
+export function sha256Bytes(content: Uint8Array): { sha256: string; bytes: number } {
+  const buf = Buffer.from(content);
   const sha256 = createHash("sha256").update(buf).digest("hex");
   return { sha256, bytes: buf.byteLength };
+}
+
+export function sha256String(content: string): { sha256: string; bytes: number } {
+  return sha256Bytes(Buffer.from(content, "utf-8"));
+}
+
+export async function readUtf8FileStrict(filePath: string): Promise<{ content: string; sha256: string; bytes: number }> {
+  const buf = await readFile(filePath);
+  let content: string;
+  try {
+    content = fatalUtf8Decoder.decode(buf);
+  } catch {
+    throw new Error(`transfer export requires UTF-8 text files: ${filePath}`);
+  }
+  return { content, ...sha256Bytes(buf) };
 }
 
 export async function writeJsonFile(filePath: string, value: unknown): Promise<void> {

--- a/packages/remnic-core/src/transfer/import-json.ts
+++ b/packages/remnic-core/src/transfer/import-json.ts
@@ -9,6 +9,7 @@ import {
   type SafeArchiveRoot,
 } from "./fs-utils.js";
 import { parseConflictPolicy, type ConflictPolicy } from "./conflict-policy.js";
+import { validateExportBundleRecords } from "./integrity.js";
 
 export type { ConflictPolicy };
 
@@ -29,6 +30,7 @@ export async function importJsonBundle(opts: ImportJsonOptions): Promise<{ writt
   const fromDirAbs = path.resolve(opts.fromDir);
   const bundlePath = path.join(fromDirAbs, "bundle.json");
   const bundle = ExportBundleV1Schema.parse(await readJsonFile(bundlePath));
+  validateExportBundleRecords(bundle.manifest, bundle.records, "importJsonBundle");
 
   const memDirAbs = path.resolve(opts.targetMemoryDir);
   const memoryRoot = await prepareSafeArchiveRoot(

--- a/packages/remnic-core/src/transfer/import-md.ts
+++ b/packages/remnic-core/src/transfer/import-md.ts
@@ -4,10 +4,13 @@ import {
   fileExists,
   listFilesRecursive,
   prepareSafeArchiveRoot,
+  readJsonFile,
   resolveSafeArchiveTarget,
   toPosixRelPath,
 } from "./fs-utils.js";
 import { parseConflictPolicy, type ConflictPolicy } from "./conflict-policy.js";
+import { validateManifestRecords } from "./integrity.js";
+import { ExportManifestV1Schema } from "./types.js";
 
 export type { ConflictPolicy };
 
@@ -16,10 +19,6 @@ export interface ImportMdOptions {
   fromDir: string;
   conflict?: ConflictPolicy;
   dryRun?: boolean;
-}
-
-function normalizeForDedupe(s: string): string {
-  return s.replace(/\s+/g, " ").trim();
 }
 
 export async function importMarkdownBundle(opts: ImportMdOptions): Promise<{ written: number; skipped: number }> {
@@ -31,16 +30,26 @@ export async function importMarkdownBundle(opts: ImportMdOptions): Promise<{ wri
     "importMarkdownBundle",
     "targetMemoryDir",
   );
+  const manifest = ExportManifestV1Schema.parse(
+    await readJsonFile(path.join(fromAbs, "manifest.json")),
+  );
 
   const filesAbs = await listFilesRecursive(fromAbs);
-  const writes: Array<{ abs: string; content: string }> = [];
-  let skipped = 0;
-
+  const records: Array<{ path: string; content: Uint8Array }> = [];
   for (const abs of filesAbs) {
     const relPosix = toPosixRelPath(abs, fromAbs);
     if (relPosix === "manifest.json") continue;
+    records.push({ path: relPosix, content: await readFile(abs) });
+  }
+  validateManifestRecords(manifest, records, "importMarkdownBundle");
+
+  const writes: Array<{ abs: string; content: Uint8Array }> = [];
+  let skipped = 0;
+
+  for (const record of records) {
+    const relPosix = record.path;
     const dstAbs = await resolveSafeArchiveTarget(targetRoot, relPosix);
-    const content = await readFile(abs, "utf-8");
+    const content = record.content;
 
     const exists = await fileExists(dstAbs);
     if (exists) {
@@ -50,8 +59,8 @@ export async function importMarkdownBundle(opts: ImportMdOptions): Promise<{ wri
       }
       if (conflict === "dedupe") {
         try {
-          const existing = await (await import("node:fs/promises")).readFile(dstAbs, "utf-8");
-          if (normalizeForDedupe(existing) === normalizeForDedupe(content)) {
+          const existing = await readFile(dstAbs);
+          if (Buffer.compare(existing, Buffer.from(content)) === 0) {
             skipped += 1;
             continue;
           }
@@ -68,7 +77,7 @@ export async function importMarkdownBundle(opts: ImportMdOptions): Promise<{ wri
 
   for (const w of writes) {
     await mkdir(path.dirname(w.abs), { recursive: true });
-    await writeFile(w.abs, w.content, "utf-8");
+    await writeFile(w.abs, w.content);
   }
 
   return { written: writes.length, skipped };

--- a/packages/remnic-core/src/transfer/import-sqlite.ts
+++ b/packages/remnic-core/src/transfer/import-sqlite.ts
@@ -8,6 +8,7 @@ import {
 } from "./fs-utils.js";
 import { parseConflictPolicy, type ConflictPolicy } from "./conflict-policy.js";
 import { openBetterSqlite3 } from "../runtime/better-sqlite.js";
+import { validateManifestRecords } from "./integrity.js";
 
 export type { ConflictPolicy };
 
@@ -43,7 +44,24 @@ export async function importSqlite(opts: ImportSqliteOptions): Promise<{ written
       throw new Error(`unsupported sqlite schemaVersion: ${meta.schemaVersion}`);
     }
 
-    const rows = db.prepare("SELECT path_rel, content FROM files").all() as Array<{ path_rel: string; content: string }>;
+    const rows = db.prepare("SELECT path_rel, bytes, sha256, content FROM files").all() as Array<{
+      path_rel: string;
+      bytes: number;
+      sha256: string;
+      content: string;
+    }>;
+    validateManifestRecords(
+      {
+        files: rows.map((row) => ({
+          path: row.path_rel,
+          bytes: row.bytes,
+          sha256: row.sha256,
+        })),
+      },
+      rows.map((row) => ({ path: row.path_rel, content: row.content })),
+      "importSqlite",
+    );
+
     for (const r of rows) {
       const absTarget = await resolveSafeArchiveTarget(memoryRoot, r.path_rel);
 

--- a/packages/remnic-core/src/transfer/integrity.ts
+++ b/packages/remnic-core/src/transfer/integrity.ts
@@ -1,0 +1,71 @@
+import type { ExportManifestV1, ExportMemoryRecordV1 } from "./types.js";
+import { sha256Bytes, sha256String } from "./fs-utils.js";
+
+export interface TransferIntegrityRecord {
+  path: string;
+  content: string | Uint8Array;
+}
+
+export function validateManifestRecords(
+  manifest: Pick<ExportManifestV1, "files">,
+  records: readonly TransferIntegrityRecord[],
+  errorPrefix: string,
+): void {
+  const manifestByPath = new Map<string, ExportManifestV1["files"][number]>();
+  for (const file of manifest.files) {
+    if (manifestByPath.has(file.path)) {
+      throw new Error(`${errorPrefix}: duplicate manifest path: ${file.path}`);
+    }
+    manifestByPath.set(file.path, file);
+  }
+
+  const recordByPath = new Map<string, TransferIntegrityRecord>();
+  for (const record of records) {
+    if (recordByPath.has(record.path)) {
+      throw new Error(`${errorPrefix}: duplicate record path: ${record.path}`);
+    }
+    recordByPath.set(record.path, record);
+  }
+
+  for (const record of records) {
+    const expected = manifestByPath.get(record.path);
+    if (!expected) {
+      throw new Error(`${errorPrefix}: record missing from manifest: ${record.path}`);
+    }
+    assertContentIntegrity(record, expected, errorPrefix);
+  }
+
+  for (const file of manifest.files) {
+    if (!recordByPath.has(file.path)) {
+      throw new Error(`${errorPrefix}: manifest file missing from records: ${file.path}`);
+    }
+  }
+}
+
+export function validateExportBundleRecords(
+  manifest: Pick<ExportManifestV1, "files">,
+  records: readonly ExportMemoryRecordV1[],
+  errorPrefix: string,
+): void {
+  validateManifestRecords(manifest, records, errorPrefix);
+}
+
+function assertContentIntegrity(
+  record: TransferIntegrityRecord,
+  expected: ExportManifestV1["files"][number],
+  errorPrefix: string,
+): void {
+  const actual = typeof record.content === "string"
+    ? sha256String(record.content)
+    : sha256Bytes(record.content);
+  if (actual.bytes !== expected.bytes) {
+    throw new Error(
+      `${errorPrefix}: byte count mismatch for ${record.path}`,
+    );
+  }
+  if (actual.sha256 !== expected.sha256) {
+    throw new Error(
+      `${errorPrefix}: checksum mismatch for ${record.path}`,
+    );
+  }
+}

--- a/tests/export-import-json.test.ts
+++ b/tests/export-import-json.test.ts
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { access, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { exportJsonBundle } from "../src/transfer/export-json.js";
 import { importJsonBundle } from "../src/transfer/import-json.js";
+import { sha256String } from "../src/transfer/fs-utils.js";
 import { writeFixtureMemoryDir, writeSensitiveTransferFixtureEntries } from "./transfer-fixtures.js";
 
 async function assertPathMissing(filePath: string): Promise<void> {
@@ -23,8 +24,7 @@ async function writeJsonBundle(
     includesTranscripts: false,
     files: records.map((record) => ({
       path: record.path,
-      sha256: "test",
-      bytes: Buffer.byteLength(record.content),
+      ...sha256String(record.content),
     })),
   };
 
@@ -65,6 +65,85 @@ test("v2.3 json export/import round-trips (without transcripts by default)", asy
 
   const fact = await readFile(path.join(targetDir, "facts", "2026-02-11", "fact-1.md"), "utf-8");
   assert.match(fact, /The user likes pianos/);
+});
+
+test("json export rejects non-UTF8 files instead of emitting unverifiable v1 checksums", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await mkdir(path.join(memDir, "binary-lifecycle"), { recursive: true });
+  await writeFile(path.join(memDir, "binary-lifecycle", "payload.bin"), Buffer.from([0xff, 0xfe, 0xfd]));
+
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  await assert.rejects(
+    exportJsonBundle({ memoryDir: memDir, outDir, pluginVersion: "2.2.3" }),
+    /requires UTF-8 text files/,
+  );
+});
+
+test("json export preserves UTF-8 BOM bytes in manifest-validated records", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  const profileBytes = Buffer.from([0xef, 0xbb, 0xbf, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x0a]);
+  await writeFile(path.join(memDir, "profile.md"), profileBytes);
+
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  await exportJsonBundle({ memoryDir: memDir, outDir, pluginVersion: "2.2.3" });
+
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const res = await importJsonBundle({ targetMemoryDir: targetDir, fromDir: outDir });
+
+  assert.equal(res.written, 1);
+  assert.deepEqual(await readFile(path.join(targetDir, "profile.md")), profileBytes);
+});
+
+test("json import rejects tampered records before writing files", async () => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const targetPath = path.join(targetDir, "profile.md");
+
+  await writeJsonBundle(outDir, [
+    {
+      path: "profile.md",
+      content: "trusted profile\n",
+    },
+  ]);
+
+  const bundlePath = path.join(outDir, "bundle.json");
+  const bundle = JSON.parse(await readFile(bundlePath, "utf-8")) as {
+    records: Array<{ path: string; content: string }>;
+  };
+  bundle.records[0].content = "tampered profile\n";
+  await writeFile(bundlePath, JSON.stringify(bundle), "utf-8");
+
+  await assert.rejects(
+    importJsonBundle({ targetMemoryDir: targetDir, fromDir: outDir }),
+    /checksum mismatch|byte count mismatch/,
+  );
+  await assertPathMissing(targetPath);
+});
+
+test("json import rejects duplicate record paths before writing files", async () => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-export-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const targetPath = path.join(targetDir, "profile.md");
+
+  await writeJsonBundle(outDir, [
+    {
+      path: "profile.md",
+      content: "profile\n",
+    },
+  ]);
+
+  const bundlePath = path.join(outDir, "bundle.json");
+  const bundle = JSON.parse(await readFile(bundlePath, "utf-8")) as {
+    records: Array<{ path: string; content: string }>;
+  };
+  bundle.records.push({ path: "profile.md", content: "profile\n" });
+  await writeFile(bundlePath, JSON.stringify(bundle), "utf-8");
+
+  await assert.rejects(
+    importJsonBundle({ targetMemoryDir: targetDir, fromDir: outDir }),
+    /duplicate record path/,
+  );
+  await assertPathMissing(targetPath);
 });
 
 test("json export excludes secure store, capsules, VCS, and dependencies", async () => {

--- a/tests/export-import-md.test.ts
+++ b/tests/export-import-md.test.ts
@@ -4,6 +4,26 @@ import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promis
 import os from "node:os";
 import path from "node:path";
 import { importMarkdownBundle } from "../src/transfer/import-md.js";
+import { sha256Bytes, sha256String, writeJsonFile } from "../src/transfer/fs-utils.js";
+
+async function writeManifest(
+  fromDir: string,
+  records: Array<{ path: string; content: string | Uint8Array }>,
+): Promise<void> {
+  await writeJsonFile(path.join(fromDir, "manifest.json"), {
+    format: "openclaw-engram-export",
+    schemaVersion: 1,
+    createdAt: "1970-01-01T00:00:00.000Z",
+    pluginVersion: "test",
+    includesTranscripts: false,
+    files: records.map((record) => ({
+      path: record.path,
+      ...(typeof record.content === "string"
+        ? sha256String(record.content)
+        : sha256Bytes(record.content)),
+    })),
+  });
+}
 
 test("markdown import rejects invalid conflict policy without overwriting existing files", async () => {
   const fromDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
@@ -11,6 +31,7 @@ test("markdown import rejects invalid conflict policy without overwriting existi
   const targetPath = path.join(targetDir, "profile.md");
 
   await writeFile(path.join(fromDir, "profile.md"), "incoming profile\n", "utf-8");
+  await writeManifest(fromDir, [{ path: "profile.md", content: "incoming profile\n" }]);
   await writeFile(targetPath, "original profile\n", "utf-8");
 
   await assert.rejects(
@@ -32,6 +53,7 @@ test("markdown import rejects target subdirectory symlinks outside the memory ro
   try {
     await mkdir(path.join(fromDir, "facts"), { recursive: true });
     await writeFile(path.join(fromDir, "facts", "a.md"), "incoming fact\n", "utf-8");
+    await writeManifest(fromDir, [{ path: "facts/a.md", content: "incoming fact\n" }]);
     await symlink(outsideDir, path.join(targetDir, "facts"), "dir");
 
     await assert.rejects(
@@ -62,6 +84,7 @@ test("markdown import rejects symlinked target memory roots", async () => {
 
   try {
     await writeFile(path.join(fromDir, "profile.md"), "incoming profile\n", "utf-8");
+    await writeManifest(fromDir, [{ path: "profile.md", content: "incoming profile\n" }]);
     await symlink(targetDir, targetLink, "dir");
 
     await assert.rejects(
@@ -80,6 +103,95 @@ test("markdown import rejects symlinked target memory roots", async () => {
   } finally {
     await rm(fromDir, { recursive: true, force: true });
     await rm(parentDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+  }
+});
+
+test("markdown import rejects tampered files before writing", async () => {
+  const fromDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const targetPath = path.join(targetDir, "profile.md");
+
+  try {
+    await writeFile(path.join(fromDir, "profile.md"), "tampered profile\n", "utf-8");
+    await writeManifest(fromDir, [{ path: "profile.md", content: "trusted profile\n" }]);
+
+    await assert.rejects(
+      importMarkdownBundle({ targetMemoryDir: targetDir, fromDir }),
+      /checksum mismatch|byte count mismatch/,
+    );
+    await assert.rejects(readFile(targetPath, "utf-8"), /ENOENT/);
+  } finally {
+    await rm(fromDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+  }
+});
+
+test("markdown import rejects files missing from the manifest before writing", async () => {
+  const fromDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const targetPath = path.join(targetDir, "profile.md");
+
+  try {
+    await writeFile(path.join(fromDir, "profile.md"), "incoming profile\n", "utf-8");
+    await writeManifest(fromDir, []);
+
+    await assert.rejects(
+      importMarkdownBundle({ targetMemoryDir: targetDir, fromDir }),
+      /record missing from manifest/,
+    );
+    await assert.rejects(readFile(targetPath, "utf-8"), /ENOENT/);
+  } finally {
+    await rm(fromDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+  }
+});
+
+test("markdown import validates and writes raw file bytes", async () => {
+  const fromDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const sourceBytes = Buffer.from([0xff, 0xfe, 0xfd]);
+
+  try {
+    await mkdir(path.join(fromDir, "binary-lifecycle"), { recursive: true });
+    await writeFile(path.join(fromDir, "binary-lifecycle", "payload.bin"), sourceBytes);
+    await writeManifest(fromDir, [{ path: "binary-lifecycle/payload.bin", content: sourceBytes }]);
+
+    const result = await importMarkdownBundle({ targetMemoryDir: targetDir, fromDir });
+    assert.equal(result.written, 1);
+    assert.deepEqual(
+      await readFile(path.join(targetDir, "binary-lifecycle", "payload.bin")),
+      sourceBytes,
+    );
+  } finally {
+    await rm(fromDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+  }
+});
+
+test("markdown dedupe compares raw bytes for non-text content", async () => {
+  const fromDir = await mkdtemp(path.join(os.tmpdir(), "engram-md-"));
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const incomingBytes = Buffer.from([0xfe]);
+  const existingBytes = Buffer.from([0xff]);
+  const targetPath = path.join(targetDir, "binary-lifecycle", "payload.bin");
+
+  try {
+    await mkdir(path.join(fromDir, "binary-lifecycle"), { recursive: true });
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await writeFile(path.join(fromDir, "binary-lifecycle", "payload.bin"), incomingBytes);
+    await writeFile(targetPath, existingBytes);
+    await writeManifest(fromDir, [{ path: "binary-lifecycle/payload.bin", content: incomingBytes }]);
+
+    const result = await importMarkdownBundle({
+      targetMemoryDir: targetDir,
+      fromDir,
+      conflict: "dedupe",
+    });
+    assert.equal(result.written, 1);
+    assert.deepEqual(await readFile(targetPath), incomingBytes);
+  } finally {
+    await rm(fromDir, { recursive: true, force: true });
     await rm(targetDir, { recursive: true, force: true });
   }
 });

--- a/tests/export-import-sqlite.test.ts
+++ b/tests/export-import-sqlite.test.ts
@@ -1,12 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { writeFixtureMemoryDir, writeSensitiveTransferFixtureEntries } from "./transfer-fixtures.js";
 import { exportSqlite } from "../src/transfer/export-sqlite.js";
 import { importSqlite } from "../src/transfer/import-sqlite.js";
 import { openBetterSqlite3 } from "../src/runtime/better-sqlite.js";
+import { sha256String } from "../src/transfer/fs-utils.js";
 import { SQLITE_SCHEMA_VERSION, SQLITE_TABLES_SQL } from "../src/transfer/sqlite-schema.js";
 
 async function assertPathMissing(filePath: string): Promise<void> {
@@ -28,10 +29,11 @@ function writeSqliteExport(
       "INSERT INTO files(path_rel,bytes,sha256,content) VALUES (?,?,?,?)",
     );
     for (const row of rows) {
+      const hash = sha256String(row.content);
       insert.run(
         row.path,
-        Buffer.byteLength(row.content),
-        "test",
+        hash.bytes,
+        hash.sha256,
         row.content,
       );
     }
@@ -55,6 +57,48 @@ test("v2.3 sqlite export/import round-trips basic files", async () => {
 
   const importedProfile = await readFile(path.join(targetDir, "profile.md"), "utf-8");
   assert.match(importedProfile, /Profile/);
+});
+
+test("sqlite export rejects non-UTF8 files instead of emitting unverifiable v1 checksums", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await mkdir(path.join(memDir, "binary-lifecycle"), { recursive: true });
+  await writeFile(path.join(memDir, "binary-lifecycle", "payload.bin"), Buffer.from([0xff, 0xfe, 0xfd]));
+
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-sqlite-"));
+  const sqliteFile = path.join(outDir, "export.sqlite");
+  await assert.rejects(
+    exportSqlite({ memoryDir: memDir, outFile: sqliteFile, pluginVersion: "2.2.3" }),
+    /requires UTF-8 text files/,
+  );
+});
+
+test("sqlite import rejects tampered content before writing files", async () => {
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "engram-sqlite-"));
+  const sqliteFile = path.join(outDir, "export.sqlite");
+  const targetDir = await mkdtemp(path.join(os.tmpdir(), "engram-import-"));
+  const targetPath = path.join(targetDir, "profile.md");
+
+  writeSqliteExport(sqliteFile, [
+    {
+      path: "profile.md",
+      content: "trusted profile\n",
+    },
+  ]);
+  const db = openBetterSqlite3(sqliteFile);
+  try {
+    db.prepare("UPDATE files SET content = ? WHERE path_rel = ?").run(
+      "tampered profile\n",
+      "profile.md",
+    );
+  } finally {
+    db.close();
+  }
+
+  await assert.rejects(
+    importSqlite({ targetMemoryDir: targetDir, fromFile: sqliteFile }),
+    /checksum mismatch|byte count mismatch/,
+  );
+  await assertPathMissing(targetPath);
 });
 
 test("sqlite export excludes secure store, capsules, VCS, and dependencies", async () => {


### PR DESCRIPTION
## Summary
- validate transfer import records against manifest path, byte, and sha256 metadata before writing
- apply the same integrity checks to JSON, Markdown, and SQLite transfer imports
- add tamper/duplicate/missing-manifest regression coverage for transfer importers

## Verification
- pnpm exec tsx --test tests/export-import-json.test.ts tests/export-import-md.test.ts tests/export-import-sqlite.test.ts
- pnpm --filter @remnic/core check-types
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds strict integrity validation (bytes + SHA-256 + path uniqueness) to transfer imports and tightens export UTF-8 handling; failures now abort imports/exports earlier, which could break previously-tolerated malformed bundles. Risk is moderate due to behavior changes in import/export flows and broader test coverage indicating new rejection cases.
> 
> **Overview**
> **Transfer importers now enforce end-to-end integrity checks before writing any files.** A new `integrity.ts` validates that manifest entries and records match 1:1 (no missing/extra/duplicate paths) and that each record’s byte count and SHA-256 match the manifest; this is applied to JSON (`importJsonBundle`), Markdown (`importMarkdownBundle`), and SQLite (`importSqlite`) imports.
> 
> **Exports tighten checksum generation and UTF-8 handling.** JSON/SQLite exporters now use `readUtf8FileStrict` to compute hashes/bytes from the original file bytes (preserving BOM for hashing) and explicitly reject non-UTF8 files rather than emitting unverifiable checksums. Tests add regression coverage for tampering, duplicates, missing-manifest entries, BOM preservation, and binary-content handling (including raw-byte writes and dedupe-by-bytes for Markdown imports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8af36526cde594b8acee6aacfe89f00ab88d18d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->