### PR TITLE
fix(bench): score personalization via memory adapter

### DIFF
--- a/packages/bench/src/benchmarks/remnic/retrieval-page-ids.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-page-ids.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { SchemaTierPage } from "../../fixtures/schema-tiers/index.js";
+import { extractRankedPageIds } from "./retrieval-page-ids.js";
+
+function page(id: string): SchemaTierPage {
+  return {
+    id,
+    owner: "alice",
+    namespace: "personal",
+    title: id,
+    canonicalTitle: id,
+    type: "note",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    aliases: [],
+    frontmatter: {},
+    timeline: [],
+    seeAlso: [],
+    body: "fixture",
+    dirtySignals: [],
+  };
+}
+
+test("extractRankedPageIds preserves dotted and slash-delimited IDs", () => {
+  const pages = [
+    page("project.alpha/task-1"),
+    page("project.alpha/task-2"),
+  ];
+
+  assert.deepEqual(
+    extractRankedPageIds(
+      "recall hit\npage_id: project.alpha/task-2\npage_id: project.alpha/task-1",
+      pages,
+    ),
+    ["project.alpha/task-2", "project.alpha/task-1"],
+  );
+});
+
+test("extractRankedPageIds ignores trailing punctuation on known IDs", () => {
+  const pages = [
+    page("task-1"),
+    page("project.alpha/task-2"),
+  ];
+
+  assert.deepEqual(
+    extractRankedPageIds(
+      "recall hit\npage_id: task-1,\npage_id: project.alpha/task-2)",
+      pages,
+    ),
+    ["task-1", "project.alpha/task-2"],
+  );
+});
+
+test("extractRankedPageIds ignores leading wrappers on known IDs", () => {
+  const pages = [
+    page("task-1"),
+    page("project.alpha/task-2"),
+  ];
+
+  assert.deepEqual(
+    extractRankedPageIds(
+      'recall hit\npage_id: "task-1"\npage_id: (project.alpha/task-2)',
+      pages,
+    ),
+    ["task-1", "project.alpha/task-2"],
+  );
+});
+
+test("extractRankedPageIds ignores page_id substrings inside larger keys", () => {
+  const pages = [page("task-1"), page("task-2")];
+
+  assert.deepEqual(
+    extractRankedPageIds(
+      "homepage_id: task-1\nprevious_page_id: task-2\npage_id: task-2",
+      pages,
+    ),
+    ["task-2"],
+  );
+});
+
+test("extractRankedPageIds keeps unknown IDs in recall order", () => {
+  const pages = [page("known")];
+
+  assert.deepEqual(
+    extractRankedPageIds("page_id: unknown.value,\npage_id: known", pages),
+    ["unknown.value", "known"],
+  );
+});
+
+test("extractRankedPageIds keeps duplicate hits as occupied ranking slots", () => {
+  const pages = [page("expected")];
+
+  assert.deepEqual(
+    extractRankedPageIds(
+      "page_id: wrong\npage_id: wrong\npage_id: expected",
+      pages,
+    ),
+    ["wrong", "wrong", "expected"],
+  );
+});
+
+test("extractRankedPageIds does not rescan markers inside extracted values", () => {
+  const pages = [page("known")];
+
+  assert.deepEqual(
+    extractRankedPageIds("page_id: some-page_id:-thing\npage_id: known", pages),
+    ["some-page_id:-thing", "known"],
+  );
+});

--- a/packages/bench/src/benchmarks/remnic/retrieval-page-ids.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-page-ids.ts
@@ -1,0 +1,153 @@
+import type { SchemaTierPage } from "../../fixtures/schema-tiers/index.js";
+
+export function extractRankedPageIds(recallText: string, pages: SchemaTierPage[]): string[] {
+  const pageIdByLowercase = new Map(
+    pages.map((page) => [page.id.toLowerCase(), page.id]),
+  );
+
+  return collectPageIdMarkers(recallText).sort((left, right) => {
+    if (left.index !== right.index) {
+      return left.index - right.index;
+    }
+    return left.id.localeCompare(right.id);
+  }).map((match) => resolvePageId(match.id, pageIdByLowercase));
+}
+
+function resolvePageId(
+  markerId: string,
+  pageIdByLowercase: Map<string, string>,
+): string {
+  const normalizedMarkerId = stripLeadingFormattingDelimiters(markerId);
+  const exact = pageIdByLowercase.get(normalizedMarkerId);
+  if (exact !== undefined) {
+    return exact;
+  }
+
+  let candidate = normalizedMarkerId;
+  while (
+    candidate.length > 0 &&
+    isTrailingFormattingDelimiter(candidate.charCodeAt(candidate.length - 1), { includePeriod: true })
+  ) {
+    candidate = candidate.slice(0, -1);
+    const known = pageIdByLowercase.get(candidate);
+    if (known !== undefined) {
+      return known;
+    }
+  }
+
+  return stripTrailingFormattingDelimiters(normalizedMarkerId);
+}
+
+function collectPageIdMarkers(recallText: string): Array<{ id: string; index: number }> {
+  const out: Array<{ id: string; index: number }> = [];
+  const lowerRecallText = recallText.toLowerCase();
+  const marker = "page_id:";
+  let searchStart = 0;
+
+  while (searchStart < lowerRecallText.length) {
+    const markerIndex = lowerRecallText.indexOf(marker, searchStart);
+    if (markerIndex < 0) break;
+    if (!hasMarkerBoundaryBefore(lowerRecallText, markerIndex)) {
+      searchStart = markerIndex + marker.length;
+      continue;
+    }
+
+    let valueStart = markerIndex + marker.length;
+    while (
+      valueStart < lowerRecallText.length &&
+      isAsciiWhitespace(lowerRecallText.charCodeAt(valueStart))
+    ) {
+      valueStart += 1;
+    }
+
+    let valueEnd = valueStart;
+    while (
+      valueEnd < lowerRecallText.length &&
+      !isAsciiWhitespace(lowerRecallText.charCodeAt(valueEnd))
+    ) {
+      valueEnd += 1;
+    }
+
+    const pageId = lowerRecallText.slice(valueStart, valueEnd);
+    if (pageId.length > 0) {
+      out.push({ id: pageId, index: markerIndex });
+    }
+    searchStart = valueEnd;
+  }
+
+  return out;
+}
+
+function hasMarkerBoundaryBefore(value: string, markerIndex: number): boolean {
+  if (markerIndex === 0) {
+    return true;
+  }
+  return !isAsciiIdentifier(value.charCodeAt(markerIndex - 1));
+}
+
+function isAsciiWhitespace(code: number): boolean {
+  return code === 9 || code === 10 || code === 13 || code === 32;
+}
+
+function isAsciiIdentifier(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    code === 95 ||
+    (code >= 97 && code <= 122)
+  );
+}
+
+function stripTrailingFormattingDelimiters(value: string): string {
+  let end = value.length;
+  while (
+    end > 0 &&
+    isTrailingFormattingDelimiter(value.charCodeAt(end - 1), { includePeriod: false })
+  ) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+function stripLeadingFormattingDelimiters(value: string): string {
+  let start = 0;
+  while (
+    start < value.length &&
+    isLeadingFormattingDelimiter(value.charCodeAt(start))
+  ) {
+    start += 1;
+  }
+  return value.slice(start);
+}
+
+function isLeadingFormattingDelimiter(code: number): boolean {
+  return (
+    code === 34 ||
+    code === 39 ||
+    code === 40 ||
+    code === 91 ||
+    code === 123
+  );
+}
+
+function isTrailingFormattingDelimiter(
+  code: number,
+  options: { includePeriod: boolean },
+): boolean {
+  if (options.includePeriod && code === 46) {
+    return true;
+  }
+
+  return (
+    code === 33 ||
+    code === 34 ||
+    code === 39 ||
+    code === 41 ||
+    code === 44 ||
+    code === 58 ||
+    code === 59 ||
+    code === 63 ||
+    code === 93 ||
+    code === 125
+  );
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  BenchMemoryAdapter,
+  MemoryStats,
+  Message,
+  SearchResult,
+} from "../../../adapters/types.js";
+import type { ResolvedRunBenchmarkOptions } from "../../../types.js";
+import {
+  RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE,
+  type RetrievalPersonalizationCase,
+} from "./fixture.js";
+import {
+  retrievalPersonalizationDefinition,
+  runRetrievalPersonalizationBenchmark,
+} from "./runner.js";
+
+interface RecallCall {
+  sessionId: string;
+  query: string;
+  budgetChars?: number;
+}
+
+class SpyPersonalizationAdapter implements BenchMemoryAdapter {
+  readonly resetSessions: string[] = [];
+  readonly storeCalls: Array<{ sessionId: string; messages: Message[] }> = [];
+  readonly recallCalls: RecallCall[] = [];
+  drainCalls = 0;
+
+  constructor(
+    private readonly recallTextForCase: (sample: RetrievalPersonalizationCase) => string,
+  ) {}
+
+  async reset(sessionId?: string): Promise<void> {
+    assert.ok(sessionId, "retrieval-personalization should reset the case session");
+    this.resetSessions.push(sessionId);
+  }
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    this.storeCalls.push({ sessionId, messages });
+  }
+
+  async recall(sessionId: string, query: string, budgetChars?: number): Promise<string> {
+    const sample = sampleForSession(sessionId);
+    assert.equal(query, sample.query);
+    assert.equal(budgetChars, 12_000);
+    this.recallCalls.push({ sessionId, query, budgetChars });
+    return this.recallTextForCase(sample);
+  }
+
+  async search(): Promise<SearchResult[]> {
+    throw new Error("retrieval-personalization should use recall, not fixture search");
+  }
+
+  async getStats(): Promise<MemoryStats> {
+    return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+  }
+
+  async drain(): Promise<void> {
+    this.drainCalls += 1;
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+function buildOptions(system: BenchMemoryAdapter): ResolvedRunBenchmarkOptions {
+  return {
+    benchmark: {
+      ...retrievalPersonalizationDefinition,
+      run: runRetrievalPersonalizationBenchmark,
+    },
+    mode: "quick",
+    system,
+  } as ResolvedRunBenchmarkOptions;
+}
+
+function sampleForSession(sessionId: string): RetrievalPersonalizationCase {
+  const sampleId = sessionId.replace(/^retrieval-personalization:/, "");
+  const sample = RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.find(
+    (entry) => entry.id === sampleId,
+  );
+  assert.ok(sample, `unexpected session ${sessionId}`);
+  return sample;
+}
+
+test("retrieval-personalization seeds and queries the supplied system adapter", async () => {
+  const adapter = new SpyPersonalizationAdapter(
+    (sample) => `recall hit\npage_id: ${sample.expectedPageIds[0]}`,
+  );
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  assert.equal(result.results.tasks.length, RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.length);
+  assert.deepEqual(
+    adapter.resetSessions,
+    RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.map((sample) => `retrieval-personalization:${sample.id}`),
+  );
+  assert.equal(adapter.storeCalls.length, RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.length);
+  assert.equal(adapter.recallCalls.length, RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.length);
+  assert.equal(adapter.drainCalls, RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.length);
+
+  for (const [index, call] of adapter.storeCalls.entries()) {
+    const sample = RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE[index]!;
+    assert.equal(call.messages.length, sample.pages.length);
+    assert.match(call.messages[0]!.content, /^page_id: /);
+    assert.match(call.messages[0]!.content, /owner: /);
+    assert.match(call.messages[0]!.content, /namespace: /);
+  }
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.p_at_1, 1);
+    assert.ok(task.scores.p_at_3 > 0);
+    assert.ok(task.scores.p_at_5 > 0);
+  }
+});
+
+test("retrieval-personalization scores adapter-returned page ids instead of fixture ranking", async () => {
+  const adapter = new SpyPersonalizationAdapter((sample) => {
+    const wrongPage = sample.pages.find(
+      (page) => !sample.expectedPageIds.includes(page.id),
+    );
+    assert.ok(wrongPage);
+    return `recall hit\npage_id: ${wrongPage.id}`;
+  });
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.p_at_1, 0);
+    assert.equal(task.scores.p_at_3, 0);
+    assert.equal(task.scores.p_at_5, 0);
+  }
+});
+
+test("retrieval-personalization does not score prefixed page id matches", async () => {
+  const adapter = new SpyPersonalizationAdapter(
+    (sample) => `recall hit\npage_id: ${sample.expectedPageIds[0]}-shadow`,
+  );
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.p_at_1, 0);
+    assert.equal(task.scores.p_at_3, 0);
+    assert.equal(task.scores.p_at_5, 0);
+    assert.match(task.actual, /-shadow/);
+  }
+});
+
+test("retrieval-personalization keeps unknown recall hits as ranking negatives", async () => {
+  const adapter = new SpyPersonalizationAdapter(
+    (sample) => [
+      "recall hit",
+      "page_id: outside-fixture",
+      `page_id: ${sample.expectedPageIds[0]}`,
+    ].join("\n"),
+  );
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.p_at_1, 0);
+    assert.equal(task.scores.p_at_3, 1 / 3);
+    assert.equal(task.scores.p_at_5, 1 / 5);
+    assert.match(task.actual, /outside-fixture/);
+  }
+});
+
+test("retrieval-personalization fails when the system adapter cannot be reset", async () => {
+  const adapter = new SpyPersonalizationAdapter(() => "");
+  adapter.reset = async () => {
+    throw new Error("forced reset failure");
+  };
+
+  await assert.rejects(
+    () => runRetrievalPersonalizationBenchmark(buildOptions(adapter)),
+    /forced reset failure/,
+  );
+  assert.equal(adapter.storeCalls.length, 0);
+  assert.equal(adapter.recallCalls.length, 0);
+});

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -11,11 +11,11 @@ import type {
 } from "../../../types.js";
 import { precisionAtK } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
-import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {
   buildTieredAggregates,
-  overlapCount,
 } from "../retrieval-shared.js";
+import { extractRankedPageIds } from "../retrieval-page-ids.js";
+import { buildSchemaTierMessages } from "../retrieval-schema-messages.js";
 import {
   RETRIEVAL_PERSONALIZATION_FIXTURE,
   RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE,
@@ -46,10 +46,16 @@ export async function runRetrievalPersonalizationBenchmark(
 
   for (const sample of cases) {
     const startedAt = performance.now();
-    const rankedPageIds = rankPages(sample.query, sample.pages).map((page) => page.id);
+    const sessionId = `retrieval-personalization:${sample.id}`;
+    await options.system.reset(sessionId);
+    await options.system.store(sessionId, buildSchemaTierMessages(sample.pages));
+    await options.system.drain?.();
+    const recallText = await options.system.recall(sessionId, sample.query, 12_000);
     const latencyMs = Math.round(performance.now() - startedAt);
+    const rankedPageIds = extractRankedPageIds(recallText, sample.pages);
+    const topRetrievedPageIds = rankedPageIds.slice(0, 5);
     const expectedJson = JSON.stringify(sample.expectedPageIds);
-    const actualJson = JSON.stringify(rankedPageIds.slice(0, 5));
+    const actualJson = JSON.stringify(topRetrievedPageIds);
 
     tasks.push({
       taskId: sample.id,
@@ -67,7 +73,8 @@ export async function runRetrievalPersonalizationBenchmark(
         tier: sample.tier,
         expectedOwner: sample.expectedOwner,
         expectedNamespace: sample.expectedNamespace,
-        retrievedPageIds: rankedPageIds.slice(0, 5),
+        recallLengthChars: recallText.length,
+        retrievedPageIds: topRetrievedPageIds,
       },
     });
   }
@@ -135,64 +142,4 @@ function loadCases(
     throw new Error("retrieval-personalization fixture is empty after applying the requested limit.");
   }
   return limited;
-}
-
-function rankPages(query: string, pages: SchemaTierPage[]): SchemaTierPage[] {
-  return [...pages].sort((left, right) => {
-    const scoreDelta = scorePage(query, right) - scorePage(query, left);
-    if (scoreDelta !== 0) return scoreDelta;
-    return left.id.localeCompare(right.id);
-  });
-}
-
-function scorePage(query: string, page: SchemaTierPage): number {
-  const queryTokens = tokenize(query);
-  const ownerHit = queryTokens.has(page.owner.toLowerCase()) ? 3 : 0;
-  const titleScore = overlapCount(queryTokens, tokenize(page.title)) * 4;
-  const canonicalTitleScore = overlapCount(queryTokens, tokenize(page.canonicalTitle)) * 3;
-  const aliasScore = overlapCount(queryTokens, tokenize(page.aliases.join(" "))) * 2;
-  const bodyScore = overlapCount(queryTokens, tokenize(page.body)) * 2;
-  const timelineScore = overlapCount(queryTokens, tokenize(page.timeline.join(" "))) * 1.5;
-  const penalty = schemaPenalty(queryTokens, page);
-
-  return ownerHit + titleScore + canonicalTitleScore + aliasScore + bodyScore + timelineScore - penalty;
-}
-
-function tokenize(value: string): Set<string> {
-  return new Set(
-    value
-      .toLowerCase()
-      .split(/[^a-z0-9]+/g)
-      .map(normalizeRetrievalToken)
-      .filter((token): token is string => token !== undefined),
-  );
-}
-
-function normalizeRetrievalToken(token: string): string | undefined {
-  const trimmed = token.trim();
-  if (trimmed.length === 0) {
-    return undefined;
-  }
-  if (trimmed.length < 3 && !/[0-9]/.test(trimmed)) {
-    return undefined;
-  }
-  if (/^decid(?:e|es|ed|ing)$/.test(trimmed) || /^decisions?$/.test(trimmed)) {
-    return "decide";
-  }
-  return trimmed;
-}
-
-function schemaPenalty(queryTokens: Set<string>, page: SchemaTierPage): number {
-  let penalty = 0;
-
-  if (page.title !== page.canonicalTitle) penalty += 2;
-  if (!page.frontmatter.type) penalty += 2.5;
-  if (!page.frontmatter.created) penalty += 1;
-  if (page.timeline.length === 0) penalty += 1;
-  if (page.type === "project" && page.seeAlso.length < 2) penalty += 1.5;
-  if (queryTokens.has("decide") && !page.frontmatter.type) {
-    penalty += 3;
-  }
-
-  return penalty;
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-schema-messages.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-schema-messages.ts
@@ -1,0 +1,25 @@
+import type { Message } from "../../adapters/types.js";
+import type { SchemaTierPage } from "../../fixtures/schema-tiers/index.js";
+
+export function buildSchemaTierMessages(pages: SchemaTierPage[]): Message[] {
+  return pages.map((page) => ({
+    role: "user",
+    timestamp: page.createdAt,
+    content: [
+      `page_id: ${page.id}`,
+      `owner: ${page.owner}`,
+      `namespace: ${page.namespace}`,
+      `title: ${page.title}`,
+      `canonical_title: ${page.canonicalTitle}`,
+      `type: ${page.type}`,
+      `created_at: ${page.createdAt}`,
+      `aliases: ${page.aliases.join(", ")}`,
+      `timeline: ${page.timeline.join(" | ")}`,
+      `see_also: ${page.seeAlso.join(", ")}`,
+      `body: ${page.body}`,
+      page.dirtySignals.length > 0
+        ? `dirty_signals: ${page.dirtySignals.join(" | ")}`
+        : undefined,
+    ].filter((line): line is string => Boolean(line)).join("\n"),
+  }));
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts
@@ -141,6 +141,20 @@ test("retrieval-temporal scores adapter-returned page ids instead of fixture ran
   }
 });
 
+test("retrieval-temporal does not score prefixed page id matches", async () => {
+  const adapter = new SpyTemporalAdapter(
+    (sample) => `recall hit\npage_id: ${sample.expectedPageIds[0]}-shadow`,
+  );
+
+  const result = await runRetrievalTemporalBenchmark(buildOptions(adapter));
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.qrel_at_1, 0);
+    assert.equal(task.scores.qrel_at_3, 0);
+    assert.equal(task.scores.qrel_at_5, 0);
+  }
+});
+
 test("retrieval-temporal fails when the system adapter cannot be reset", async () => {
   const adapter = new SpyTemporalAdapter(() => "");
   adapter.reset = async () => {

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -9,12 +9,13 @@ import type {
   ResolvedRunBenchmarkOptions,
   TaskResult,
 } from "../../../types.js";
-import type { Message } from "../../../adapters/types.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {
   buildTieredAggregates,
 } from "../retrieval-shared.js";
+import { extractRankedPageIds } from "../retrieval-page-ids.js";
+import { buildSchemaTierMessages } from "../retrieval-schema-messages.js";
 import {
   RETRIEVAL_TEMPORAL_FIXTURE,
   RETRIEVAL_TEMPORAL_SMOKE_FIXTURE,
@@ -49,7 +50,7 @@ export async function runRetrievalTemporalBenchmark(
     const startedAt = performance.now();
     const sessionId = `retrieval-temporal:${sample.id}`;
     await options.system.reset(sessionId);
-    await options.system.store(sessionId, buildTemporalMessages(sample.pages));
+    await options.system.store(sessionId, buildSchemaTierMessages(sample.pages));
     await options.system.drain?.();
     const recallText = await options.system.recall(
       sessionId,
@@ -276,49 +277,4 @@ function matchingPageIds(
     const page = pageById.get(pageId);
     return page ? pageQualifies(page, sample) : false;
   });
-}
-
-function buildTemporalMessages(pages: SchemaTierPage[]): Message[] {
-  return pages.map((page) => ({
-    role: "user",
-    timestamp: page.createdAt,
-    content: [
-      `page_id: ${page.id}`,
-      `owner: ${page.owner}`,
-      `namespace: ${page.namespace}`,
-      `title: ${page.title}`,
-      `canonical_title: ${page.canonicalTitle}`,
-      `type: ${page.type}`,
-      `created_at: ${page.createdAt}`,
-      `aliases: ${page.aliases.join(", ")}`,
-      `timeline: ${page.timeline.join(" | ")}`,
-      `see_also: ${page.seeAlso.join(", ")}`,
-      `body: ${page.body}`,
-      page.dirtySignals.length > 0
-        ? `dirty_signals: ${page.dirtySignals.join(" | ")}`
-        : undefined,
-    ].filter((line): line is string => Boolean(line)).join("\n"),
-  }));
-}
-
-function extractRankedPageIds(recallText: string, pages: SchemaTierPage[]): string[] {
-  const matches: Array<{ id: string; index: number }> = [];
-  const lowerRecallText = recallText.toLowerCase();
-
-  for (const page of pages) {
-    const marker = `page_id: ${page.id.toLowerCase()}`;
-    const index = lowerRecallText.indexOf(marker);
-    if (index >= 0) {
-      matches.push({ id: page.id, index });
-    }
-  }
-
-  matches.sort((left, right) => {
-    if (left.index !== right.index) {
-      return left.index - right.index;
-    }
-    return left.id.localeCompare(right.id);
-  });
-
-  return matches.map((match) => match.id);
 }

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -148,8 +148,8 @@ test("runBenchmark executes retrieval-personalization in quick mode", async () =
   assert.equal(result.meta.benchmark, "retrieval-personalization");
   assert.equal(result.meta.benchmarkTier, "remnic");
   assert.equal(result.results.tasks.length, 6);
-  assert.equal(result.results.aggregates["clean.p_at_1"].mean, 1);
-  assert.equal(result.results.aggregates["dirty.p_at_1"].mean, 1);
+  assert.equal(result.results.aggregates["clean.p_at_1"].mean, 0);
+  assert.equal(result.results.aggregates["dirty.p_at_1"].mean, 0);
   assert.equal(result.results.aggregates["dirty_penalty.p_at_1"].mean, 0);
 });
 


### PR DESCRIPTION
## Summary
- seed retrieval-personalization cases into the supplied bench memory adapter
- score page IDs extracted from adapter recall output instead of the fixture heuristic
- add spy-adapter regression coverage for adapter calls and wrong-result scoring

## Verification
- pnpm exec tsx --test packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.test.ts packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts
- pnpm --filter @remnic/bench run check-types
- git diff --check
- npm run preflight:quick

Clawpatch finding: fnd_sig-feat-library-2772acce84-d046_79f66136b3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `retrieval-personalization` (and shared parsing for `retrieval-temporal`) derives ranked page IDs, so benchmark scores and recorded outputs will shift and could hide regressions if parsing is wrong. Limited to bench runners/tests (no runtime product impact).
> 
> **Overview**
> **Retrieval benchmarks now score based on the memory adapter’s `recall` output, not fixture-side heuristics.** `retrieval-personalization` was rewritten to `reset`/`store` schema-tier pages into the provided adapter, `recall` with a fixed budget, and compute precision from `page_id:` markers parsed out of the returned text.
> 
> Adds shared utilities: `buildSchemaTierMessages` for consistent seeding, and a more robust `extractRankedPageIds` parser that preserves recall order while handling wrappers/punctuation, avoiding substring false-positives, and keeping unknown/duplicate IDs as ranking negatives.
> 
> Updates `retrieval-temporal` to reuse the shared message builder and page-id extractor, and expands/adjusts tests (spy adapters + deterministic runner expectations) to validate adapter call sequencing, prefixed-ID non-matches, and the new scoring behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5601bc1ed215857f285952bb336e9a0a8e2781d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->