### PR TITLE
fix(cli): harden clawpatch CLI findings

### DIFF
--- a/packages/remnic-cli/src/bench-build-freshness.test.ts
+++ b/packages/remnic-cli/src/bench-build-freshness.test.ts
@@ -46,6 +46,25 @@ test("checkBenchBuildFreshness ignores non-local bench package paths", async () 
   assert.equal(checkBenchBuildFreshness(benchDir).stale, false);
 });
 
+test("checkBenchBuildFreshness ignores published bench packages without source", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-freshness-"));
+  const benchDir = path.join(root, "bench");
+  const distDir = path.join(benchDir, "dist");
+  await mkdir(distDir, { recursive: true });
+  await writeFile(
+    path.join(benchDir, "package.json"),
+    JSON.stringify({ name: "@remnic/bench" }),
+  );
+  await writeFile(path.join(distDir, "index.js"), "export const value = 0;\n");
+
+  const oldTime = new Date("2026-01-01T00:00:00.000Z");
+  const newTime = new Date("2026-01-01T00:00:05.000Z");
+  await touch(path.join(distDir, "index.js"), oldTime);
+  await touch(path.join(benchDir, "package.json"), newTime);
+
+  assert.equal(checkBenchBuildFreshness(benchDir).stale, false);
+});
+
 async function touch(filePath: string, date: Date): Promise<void> {
   const { utimes } = await import("node:fs/promises");
   await utimes(filePath, date, date);

--- a/packages/remnic-cli/src/bench-build-freshness.ts
+++ b/packages/remnic-cli/src/bench-build-freshness.ts
@@ -68,8 +68,13 @@ export function checkBenchBuildFreshness(
     return { stale: false };
   }
 
+  const srcDir = path.join(benchPackageDir, "src");
+  if (!isDirectory(srcDir)) {
+    return { stale: false };
+  }
+
   const sourceRoots = [
-    path.join(benchPackageDir, "src"),
+    srcDir,
     packageJsonPath,
     path.join(benchPackageDir, "tsup.config.ts"),
     path.join(benchPackageDir, "tsconfig.json"),
@@ -136,6 +141,14 @@ function newestMtime(
     visit(root);
   }
   return newest;
+}
+
+function isDirectory(entryPath: string): boolean {
+  try {
+    return statSync(entryPath).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 function isTruthyEnv(value: string | undefined): boolean {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -7466,18 +7466,6 @@ async function cmdOpenclawUpgrade(opts: OpenclawUpgradeOptions): Promise<void> {
   const preservedMemoryDir = opts.memoryDir
     ? path.resolve(expandTilde(opts.memoryDir))
     : resolveCurrentOpenclawMemoryDir(entries, slots, fallbackMemoryDir);
-  const backupDir = path.join(
-    resolveHomeDir(),
-    ".openclaw",
-    "backups",
-    `remnic-openclaw-upgrade-${formatOpenclawUpgradeStamp()}`,
-  );
-  const configBackupPath = path.join(backupDir, "openclaw.json");
-  const pluginBackupDir = path.join(backupDir, "extensions", REMNIC_OPENCLAW_PLUGIN_ID);
-  const legacyPluginBackupDir = legacyPluginDirForBackup
-    ? path.join(backupDir, "extensions", REMNIC_OPENCLAW_LEGACY_PLUGIN_ID)
-    : undefined;
-
   assertDirectoryPathOrMissing(pluginDir, "OpenClaw plugin dir");
   if (legacyPluginDirForBackup) {
     assertDirectoryPathOrMissing(legacyPluginDirForBackup, "Legacy OpenClaw plugin dir");
@@ -7490,7 +7478,7 @@ async function cmdOpenclawUpgrade(opts: OpenclawUpgradeOptions): Promise<void> {
   }
   console.log(`Memory dir:      ${preservedMemoryDir}`);
   console.log(`Package spec:    ${packageSpec}`);
-  console.log(`Backup dir:      ${backupDir}`);
+  console.log(`Backup root:     ${path.join(resolveHomeDir(), ".openclaw", "backups")}`);
 
   const plannedActions = [
     `backup openclaw.json and the existing ${REMNIC_OPENCLAW_PLUGIN_ID} extension`,
@@ -7522,6 +7510,13 @@ async function cmdOpenclawUpgrade(opts: OpenclawUpgradeOptions): Promise<void> {
       return;
     }
   }
+
+  const backupDir = createOpenclawUpgradeBackupDir();
+  const configBackupPath = path.join(backupDir, "openclaw.json");
+  const pluginBackupDir = path.join(backupDir, "extensions", REMNIC_OPENCLAW_PLUGIN_ID);
+  const legacyPluginBackupDir = legacyPluginDirForBackup
+    ? path.join(backupDir, "extensions", REMNIC_OPENCLAW_LEGACY_PLUGIN_ID)
+    : undefined;
 
   const backupNotes: string[] = [];
   if (backupPathIfPresent(configPath, configBackupPath)) {
@@ -7637,6 +7632,11 @@ async function cmdOpenclawMigrateEngram(opts: OpenclawUpgradeOptions): Promise<v
   console.log(`  - plugins.entries["${REMNIC_OPENCLAW_PLUGIN_ID}"] is the canonical entry.`);
   console.log(`  - plugins.entries["${REMNIC_OPENCLAW_LEGACY_PLUGIN_ID}"] is retained temporarily for rollback.`);
   console.log("  - Re-apply any local source patches to the new package only after verifying the published build.");
+}
+
+function createOpenclawUpgradeBackupDir(): string {
+  const backupsRoot = path.join(resolveHomeDir(), ".openclaw", "backups"); fs.mkdirSync(backupsRoot, { recursive: true });
+  return fs.mkdtempSync(path.join(backupsRoot, `remnic-openclaw-upgrade-${formatOpenclawUpgradeStamp()}-`));
 }
 
 // ── Taxonomy commands (#366) ─────────────────────────────────────────────────

--- a/tests/engram-access-bin-errors.test.ts
+++ b/tests/engram-access-bin-errors.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import { tmpdir } from "node:os";
@@ -39,6 +39,48 @@ for (const [label, sourceBinPath] of [
       assert.equal(result.status, 1);
       assert.match(result.stderr, /engram-access failed: runtime failure after import/);
       assert.doesNotMatch(result.stderr, /failed to load dist\/access-cli\.js/);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test(`${label} engram-access forwards args with the legacy plugin id`, async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "engram-access-bin-"));
+    try {
+      const tempBinDir = join(tempRoot, "bin");
+      const tempDistDir = join(tempRoot, "dist");
+      const tempBinPath = join(tempBinDir, "engram-access.js");
+      const capturePath = join(tempRoot, "capture.json");
+      await mkdir(tempBinDir, { recursive: true });
+      await mkdir(tempDistDir, { recursive: true });
+      await copyFile(sourceBinPath, tempBinPath);
+      await writeFile(join(tempRoot, "package.json"), '{"type":"module"}\n');
+      await writeFile(
+        join(tempDistDir, "access-cli.js"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          "export async function runCli(args, options) {",
+          "  writeFileSync(process.env.ENGRAM_ACCESS_CAPTURE_PATH, JSON.stringify({ args, options }));",
+          "}",
+          "",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(process.execPath, [tempBinPath, "query", "hello"], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ENGRAM_ACCESS_CAPTURE_PATH: capturePath,
+        },
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const captured = JSON.parse(await readFile(capturePath, "utf8")) as {
+        args: string[];
+        options: { preferredId?: string };
+      };
+      assert.deepEqual(captured.args, ["query", "hello"]);
+      assert.deepEqual(captured.options, { preferredId: "openclaw-engram" });
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }

--- a/tests/openclaw-install-cli.test.ts
+++ b/tests/openclaw-install-cli.test.ts
@@ -261,6 +261,37 @@ test("CLI openclaw upgrade mentions backups and npm package refresh", async () =
   );
 });
 
+test("CLI openclaw upgrade uses collision-resistant backup directories", async () => {
+  const src = await readCli();
+  const upgradeStart = src.indexOf("async function cmdOpenclawUpgrade");
+  const migrateStart = src.indexOf("async function cmdOpenclawMigrateEngram");
+  assert.ok(upgradeStart >= 0 && migrateStart > upgradeStart, "CLI upgrade function must be present");
+  const upgradeSrc = src.slice(upgradeStart, migrateStart);
+  assert.ok(
+    src.includes("function createOpenclawUpgradeBackupDir"),
+    "CLI upgrade must isolate backup directory creation behind a helper",
+  );
+  assert.ok(
+    src.includes("fs.mkdtempSync(") &&
+      src.includes("remnic-openclaw-upgrade-${formatOpenclawUpgradeStamp()}-"),
+    "CLI upgrade backups must reserve a unique directory even for same-second retries",
+  );
+  assert.ok(
+    src.includes("const backupDir = createOpenclawUpgradeBackupDir();"),
+    "CLI upgrade must use the collision-resistant backup directory helper",
+  );
+  assert.ok(
+    upgradeSrc.indexOf("if (opts.dryRun)") <
+      upgradeSrc.indexOf("const backupDir = createOpenclawUpgradeBackupDir();"),
+    "CLI upgrade must not create backup directories during dry runs",
+  );
+  assert.ok(
+    upgradeSrc.indexOf("if (!opts.yes)") <
+      upgradeSrc.indexOf("const backupDir = createOpenclawUpgradeBackupDir();"),
+    "CLI upgrade must not create backup directories before confirmation",
+  );
+});
+
 test("CLI openclaw upgrade rolls back if the published plugin install fails after swap", async () => {
   const src = await readCli();
   assert.ok(


### PR DESCRIPTION
## Summary
- skip the bench stale-build guard for published @remnic/bench layouts that have dist but no src directory
- reserve OpenClaw upgrade backup roots with mkdtemp so same-second runs cannot collide
- add regression coverage for legacy engram-access forwarding the openclaw-engram plugin id

## Verification
- node scripts/check-test-types.mjs && node --import tsx --test packages/remnic-cli/src/bench-build-freshness.test.ts tests/openclaw-install-cli.test.ts tests/engram-access-bin-errors.test.ts
- npm run check-types
- npm_config_workspace_concurrency=1 npm run preflight:quick
- clawpatch revalidate fnd_sig-feat-cli-command-72fd8b2e72-_d196d935ab -> fixed
- clawpatch revalidate fnd_sig-feat-cli-command-7a2b4279cc-_6a4de04048 -> fixed
- clawpatch revalidate fnd_sig-feat-cli-command-362ce05acf-_d77bd6e1ab -> fixed

Note: the first preflight run exposed a missing local better-sqlite3 native binding in this fresh worktree. I rebuilt it with pnpm rebuild better-sqlite3 and reran preflight successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `remnic openclaw upgrade` filesystem backup flow and bench build-staleness guardrails; failures could affect upgrade/rollback behavior, but changes are small and covered by new tests.
> 
> **Overview**
> **Bench freshness guard:** `checkBenchBuildFreshness` now returns *not stale* when `@remnic/bench` is present but lacks a `src/` directory (e.g., published/dist-only layouts), with a new test to prevent regressions.
> 
> **OpenClaw upgrade backups:** `cmdOpenclawUpgrade` now creates backup directories via a `createOpenclawUpgradeBackupDir()` helper that uses `fs.mkdtempSync` under `~/.openclaw/backups` to avoid same-second collisions, and adjusts logging accordingly; a new CLI test asserts the ordering (no backup dir creation during `--dry-run` or before confirmation).
> 
> **engram-access regression coverage:** Adds a test ensuring the `engram-access` bin forwards args and sets `preferredId: "openclaw-engram"` when invoking `runCli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b76eb58864a76a16bd003b9ce94ca24940dc50c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->