### PR TITLE
fix(bench): score personalization via adapter

### DIFF
--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  BenchMemoryAdapter,
+  BenchRecallOptions,
+  MemoryStats,
+  Message,
+  SearchResult,
+} from "../../../adapters/types.js";
+import type { ResolvedRunBenchmarkOptions } from "../../../types.js";
+import {
+  RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE,
+  type RetrievalPersonalizationCase,
+} from "./fixture.js";
+import {
+  retrievalPersonalizationDefinition,
+  runRetrievalPersonalizationBenchmark,
+} from "./runner.js";
+
+interface RecallCall {
+  sessionId: string;
+  query: string;
+  budgetChars?: number;
+  options?: BenchRecallOptions;
+}
+
+class SpyPersonalizationAdapter implements BenchMemoryAdapter {
+  readonly resetSessions: string[] = [];
+  readonly storeCalls: Array<{ sessionId: string; messages: Message[] }> = [];
+  readonly recallCalls: RecallCall[] = [];
+  drainCalls = 0;
+
+  constructor(
+    private readonly recallTextForCase: (sample: RetrievalPersonalizationCase) => string,
+  ) {}
+
+  async reset(sessionId?: string): Promise<void> {
+    assert.ok(sessionId, "retrieval-personalization should reset the case session");
+    this.resetSessions.push(sessionId);
+  }
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    this.storeCalls.push({ sessionId, messages });
+  }
+
+  async recall(
+    sessionId: string,
+    query: string,
+    budgetChars?: number,
+    options?: BenchRecallOptions,
+  ): Promise<string> {
+    const sample = sampleForSession(sessionId);
+    assert.equal(query, sample.query);
+    assert.equal(budgetChars, 12_000);
+    assert.equal(options, undefined);
+    this.recallCalls.push({ sessionId, query, budgetChars, options });
+    return this.recallTextForCase(sample);
+  }
+
+  async search(): Promise<SearchResult[]> {
+    throw new Error("retrieval-personalization should use recall, not fixture search");
+  }
+
+  async getStats(): Promise<MemoryStats> {
+    return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+  }
+
+  async drain(): Promise<void> {
+    this.drainCalls += 1;
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+function buildOptions(system: BenchMemoryAdapter): ResolvedRunBenchmarkOptions {
+  return {
+    benchmark: {
+      ...retrievalPersonalizationDefinition,
+      run: runRetrievalPersonalizationBenchmark,
+    },
+    mode: "quick",
+    system,
+  } as ResolvedRunBenchmarkOptions;
+}
+
+function sampleForSession(sessionId: string): RetrievalPersonalizationCase {
+  const sampleId = sessionId.replace(/^retrieval-personalization:/, "");
+  const sample = RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.find(
+    (entry) => entry.id === sampleId,
+  );
+  assert.ok(sample, `unexpected session ${sessionId}`);
+  return sample;
+}
+
+test("retrieval-personalization seeds and queries the supplied system adapter", async () => {
+  const adapter = new SpyPersonalizationAdapter(
+    (sample) => `recall hit\npage_id: ${sample.expectedPageIds[0]}`,
+  );
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  assert.equal(
+    result.results.tasks.length,
+    RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.length,
+  );
+  assert.deepEqual(
+    adapter.resetSessions,
+    RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.map(
+      (sample) => `retrieval-personalization:${sample.id}`,
+    ),
+  );
+  assert.equal(adapter.storeCalls.length, RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.length);
+  assert.equal(adapter.recallCalls.length, RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.length);
+  assert.equal(adapter.drainCalls, RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE.length);
+
+  for (const [index, call] of adapter.storeCalls.entries()) {
+    const sample = RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE[index]!;
+    assert.equal(call.messages.length, sample.pages.length);
+    assert.match(call.messages[0]!.content, /^page_id: /);
+    assert.match(call.messages[0]!.content, /^owner: /m);
+    assert.match(call.messages[0]!.content, /^namespace: /m);
+    assert.equal(call.messages[0]!.timestamp, sample.pages[0]!.createdAt);
+  }
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.p_at_1, 1);
+    assert.equal(task.scores.p_at_3, 1 / 3);
+    assert.equal(task.scores.p_at_5, 1 / 5);
+  }
+});
+
+test("retrieval-personalization scores adapter-returned page ids instead of fixture ranking", async () => {
+  const adapter = new SpyPersonalizationAdapter((sample) => {
+    const wrongPage = sample.pages.find(
+      (page) => !sample.expectedPageIds.includes(page.id),
+    );
+    assert.ok(wrongPage);
+    return `recall hit\npage_id: ${wrongPage.id}`;
+  });
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.p_at_1, 0);
+    assert.equal(task.scores.p_at_3, 0);
+    assert.equal(task.scores.p_at_5, 0);
+  }
+});
+
+test("retrieval-personalization does not match page ids by prefix", async () => {
+  const adapter = new SpyPersonalizationAdapter((sample) => {
+    const expectedPageId = sample.expectedPageIds[0]!;
+    return `recall hit\npage_id: ${expectedPageId}-suffix`;
+  });
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const task of result.results.tasks) {
+    assert.equal(task.scores.p_at_1, 0);
+    assert.equal(task.scores.p_at_3, 0);
+    assert.equal(task.scores.p_at_5, 0);
+    assert.deepEqual(task.details?.retrievedPageIds, []);
+  }
+});
+
+test("retrieval-personalization extracts page ids from labeled evidence lines", async () => {
+  const adapter = new SpyPersonalizationAdapter(
+    (sample) => `[retrieval-personalization, turn 1, user]: page_id: ${sample.expectedPageIds[0]}`,
+  );
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const [index, task] of result.results.tasks.entries()) {
+    const sample = RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE[index]!;
+    assert.equal(task.scores.p_at_1, 1);
+    assert.deepEqual(task.details?.retrievedPageIds, [sample.expectedPageIds[0]]);
+  }
+});
+
+test("retrieval-personalization strips surrounding punctuation from page ids", async () => {
+  const adapter = new SpyPersonalizationAdapter(
+    (sample) => `recall hit: page_id: \`${sample.expectedPageIds[0]}.\``,
+  );
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const [index, task] of result.results.tasks.entries()) {
+    const sample = RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE[index]!;
+    assert.equal(task.scores.p_at_1, 1);
+    assert.deepEqual(task.details?.retrievedPageIds, [sample.expectedPageIds[0]]);
+  }
+});
+
+test("retrieval-personalization strips bracket wrappers from page ids", async () => {
+  const adapter = new SpyPersonalizationAdapter(
+    (sample) => `recall hit: page_id: [${sample.expectedPageIds[0]}]`,
+  );
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const [index, task] of result.results.tasks.entries()) {
+    const sample = RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE[index]!;
+    assert.equal(task.scores.p_at_1, 1);
+    assert.deepEqual(task.details?.retrievedPageIds, [sample.expectedPageIds[0]]);
+  }
+});
+
+test("retrieval-personalization scores uppercased page ids case-insensitively", async () => {
+  const adapter = new SpyPersonalizationAdapter(
+    (sample) => `recall hit: page_id: ${sample.expectedPageIds[0]!.toUpperCase()}`,
+  );
+
+  const result = await runRetrievalPersonalizationBenchmark(buildOptions(adapter));
+
+  for (const [index, task] of result.results.tasks.entries()) {
+    const sample = RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE[index]!;
+    assert.equal(task.scores.p_at_1, 1);
+    assert.deepEqual(task.details?.retrievedPageIds, [sample.expectedPageIds[0]]);
+  }
+});
+
+test("retrieval-personalization fails when the system adapter cannot be reset", async () => {
+  const adapter = new SpyPersonalizationAdapter(() => "");
+  adapter.reset = async () => {
+    throw new Error("forced reset failure");
+  };
+
+  await assert.rejects(
+    () => runRetrievalPersonalizationBenchmark(buildOptions(adapter)),
+    /forced reset failure/,
+  );
+  assert.equal(adapter.storeCalls.length, 0);
+  assert.equal(adapter.recallCalls.length, 0);
+});

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -9,6 +9,7 @@ import type {
   ResolvedRunBenchmarkOptions,
   TaskResult,
 } from "../../../types.js";
+import type { Message } from "../../../adapters/types.js";
 import { precisionAtK } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
@@ -46,8 +47,18 @@ export async function runRetrievalPersonalizationBenchmark(
 
   for (const sample of cases) {
     const startedAt = performance.now();
-    const rankedPageIds = rankPages(sample.query, sample.pages).map((page) => page.id);
+    const sessionId = `retrieval-personalization:${sample.id}`;
+    await options.system.reset(sessionId);
+    await options.system.store(sessionId, buildPersonalizationMessages(sample.pages));
+    await options.system.drain?.();
+    const recallText = await options.system.recall(
+      sessionId,
+      sample.query,
+      12_000,
+    );
     const latencyMs = Math.round(performance.now() - startedAt);
+    const rankedPageIds = extractRankedPageIds(recallText, sample.pages);
+    const baselinePageIds = rankPages(sample.query, sample.pages).map((page) => page.id);
     const expectedJson = JSON.stringify(sample.expectedPageIds);
     const actualJson = JSON.stringify(rankedPageIds.slice(0, 5));
 
@@ -67,7 +78,9 @@ export async function runRetrievalPersonalizationBenchmark(
         tier: sample.tier,
         expectedOwner: sample.expectedOwner,
         expectedNamespace: sample.expectedNamespace,
+        recallLengthChars: recallText.length,
         retrievedPageIds: rankedPageIds.slice(0, 5),
+        baselinePageIds: baselinePageIds.slice(0, 5),
       },
     });
   }
@@ -195,4 +208,61 @@ function schemaPenalty(queryTokens: Set<string>, page: SchemaTierPage): number {
   }
 
   return penalty;
+}
+
+function buildPersonalizationMessages(pages: SchemaTierPage[]): Message[] {
+  return pages.map((page) => ({
+    role: "user",
+    timestamp: page.createdAt,
+    content: [
+      `page_id: ${page.id}`,
+      `owner: ${page.owner}`,
+      `namespace: ${page.namespace}`,
+      `title: ${page.title}`,
+      `canonical_title: ${page.canonicalTitle}`,
+      `type: ${page.type}`,
+      `created_at: ${page.createdAt}`,
+      `aliases: ${page.aliases.join(", ")}`,
+      `timeline: ${page.timeline.join(" | ")}`,
+      `see_also: ${page.seeAlso.join(", ")}`,
+      `body: ${page.body}`,
+      page.dirtySignals.length > 0
+        ? `dirty_signals: ${page.dirtySignals.join(" | ")}`
+        : undefined,
+    ].filter((line): line is string => Boolean(line)).join("\n"),
+  }));
+}
+
+function extractRankedPageIds(recallText: string, pages: SchemaTierPage[]): string[] {
+  const knownPageIds = new Map(pages.map((page) => [page.id.toLowerCase(), page.id]));
+  const matches: Array<{ id: string; index: number }> = [];
+  const seenPageIds = new Set<string>();
+  const pageIdPattern = /(?:^|[^\w-])page_id:\s*([^\s,;]+)/gi;
+
+  for (const match of recallText.matchAll(pageIdPattern)) {
+    const pageId = normalizeExtractedPageId(match[1]);
+    const canonicalPageId = pageId ? knownPageIds.get(pageId.toLowerCase()) : undefined;
+    if (!canonicalPageId || seenPageIds.has(canonicalPageId)) {
+      continue;
+    }
+    seenPageIds.add(canonicalPageId);
+    matches.push({
+      id: canonicalPageId,
+      index: match.index ?? 0,
+    });
+  }
+
+  matches.sort((left, right) => {
+    if (left.index !== right.index) {
+      return left.index - right.index;
+    }
+    return left.id.localeCompare(right.id);
+  });
+
+  return matches.map((match) => match.id);
+}
+
+function normalizeExtractedPageId(value: string | undefined): string | undefined {
+  const normalized = value?.replace(/^[`'"([{\s]+|[`'".:!?)[\]}\s]+$/g, "");
+  return normalized && normalized.length > 0 ? normalized : undefined;
 }

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -142,7 +142,7 @@ test("runBenchmark executes enrichment-fidelity in quick mode", async () => {
 test("runBenchmark executes retrieval-personalization in quick mode", async () => {
   const result = await runBenchmark("retrieval-personalization", {
     mode: "quick",
-    system: adapter,
+    system: expectedPersonalizationHits(),
   });
 
   assert.equal(result.meta.benchmark, "retrieval-personalization");
@@ -221,6 +221,33 @@ test("runBenchmark records adapter-returned page order for full retrieval-tempor
     ["morgan-q3-training-plan", "morgan-coffee-preferences"],
   );
 });
+
+class RetrievalPersonalizationFixtureAdapter extends NoopMemoryAdapter {
+  override async recall(
+    sessionId: string,
+    query: string,
+    budgetChars?: number,
+    options?: BenchRecallOptions,
+  ): Promise<string> {
+    const { RETRIEVAL_PERSONALIZATION_FIXTURE } = await import(
+      "../packages/bench/src/benchmarks/remnic/retrieval-personalization/fixture.js"
+    );
+    const sampleId = sessionId.replace(/^retrieval-personalization:/, "");
+    const sample = RETRIEVAL_PERSONALIZATION_FIXTURE.find(
+      (entry) => entry.id === sampleId,
+    );
+    assert.ok(sample, `unexpected retrieval-personalization session ${sessionId}`);
+    assert.equal(query, sample.query);
+    assert.equal(budgetChars, 12_000);
+    assert.equal(options, undefined);
+
+    return sample.expectedPageIds.map((pageId) => `page_id: ${pageId}`).join("\n");
+  }
+}
+
+function expectedPersonalizationHits(): RetrievalPersonalizationFixtureAdapter {
+  return new RetrievalPersonalizationFixtureAdapter();
+}
 
 test("runBenchmark rejects overflowed timeline dates in retrieval-temporal evidence", async () => {
   const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:morgan-q3-commitments");


### PR DESCRIPTION
## Summary
- seed retrieval-personalization cases into the supplied benchmark adapter
- score page ids returned by adapter recall instead of the fixture ranker
- add spy-adapter regression coverage for adapter calls and wrong-result scoring

## Verification
- node --import tsx --test packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.test.ts
- npm run check-types
- pnpm rebuild better-sqlite3
- pnpm exec tsx --test tests/openclaw-registration-capture.test.ts
- npm_config_workspace_concurrency=1 npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retrieval benchmarking/scoring expectations by normalizing recalled `page_id`s to lowercase and updating deterministic tests to score personalization based on adapter `recall` output. Moderate risk of changing benchmark results/CI baselines, but scope is limited to bench utilities and tests.
> 
> **Overview**
> **Retrieval `page_id` parsing now resolves known page IDs case-insensitively** by lowercasing the normalized marker before lookup, with new regression coverage in `retrieval-page-ids.test.ts`.
> 
> **Deterministic runner coverage for `retrieval-personalization` is updated to score against adapter `recall` output**, introducing a small fixture-backed `BenchMemoryAdapter` that asserts expected `recall` inputs and returns `page_id:` lines; the quick-mode test expectations for `clean.p_at_1`/`dirty.p_at_1` are updated from `0` to `1` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05c547a5dcb0f869104f0427a5492171978f67b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->