### PR TITLE
fix(cli): dispose failed import targets

### DIFF
--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -417,6 +417,44 @@ describe("cmdImport dispose contract", () => {
       process.exitCode = savedExitCode;
     }
   });
+
+  it("disposes when target construction starts and then rejects", async () => {
+    const savedExitCode = process.exitCode;
+    process.exitCode = 0;
+    try {
+      let factoryCalls = 0;
+      let disposeCalls = 0;
+      let constructed = false;
+      const adapter = makeFakeAdapter([]);
+
+      const factory = async () => {
+        factoryCalls += 1;
+        constructed = true;
+        throw new Error("target initialization failed");
+      };
+      const dispose = async () => {
+        assert.equal(constructed, true);
+        disposeCalls += 1;
+      };
+
+      const result = await cmdImport(
+        ["--adapter", "chatgpt", "--file", "/tmp/export.json"],
+        factory,
+        dispose,
+        {
+          loadAdapter: async () => adapter,
+          readFile: async () => "{}",
+        },
+      );
+
+      assert.equal(result, undefined);
+      assert.equal(process.exitCode, 1);
+      assert.equal(factoryCalls, 1);
+      assert.equal(disposeCalls, 1);
+    } finally {
+      process.exitCode = savedExitCode;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -478,6 +478,7 @@ export async function cmdImport(
   rest: string[],
   targetFactory: () => Promise<ImporterWriteTarget>,
   disposeTarget?: () => Promise<void>,
+  ioOverrides: Partial<Pick<ImportDispatchIO, "loadAdapter" | "readFile" | "runImporter">> = {},
 ): Promise<RunImporterResult | RunImporterResult[] | undefined> {
   if (rest.includes("--help") || rest.includes("-h")) {
     process.stdout.write(IMPORT_USAGE);
@@ -511,10 +512,11 @@ export async function cmdImport(
     }
   }
 
-  // Track whether `getWriteTarget` was actually called so dispose only runs
-  // when a target was materialized. An install-hint miss (loadAdapter throws)
-  // must NOT trigger dispose — there's nothing to dispose and disposing may
-  // itself throw, masking the original error.
+  // Track whether `getWriteTarget` was actually called so dispose runs after
+  // target construction starts, even if the factory rejects before resolving.
+  // An install-hint miss (loadAdapter throws) must NOT trigger dispose —
+  // there's nothing to dispose and disposing may itself throw, masking the
+  // original error.
   //
   // Cursor review on PR #610 — memoize the materialized target across all
   // calls to `getWriteTarget`. `runBundleImportCommand` invokes
@@ -527,9 +529,9 @@ export async function cmdImport(
   let materializedTarget: ImporterWriteTarget | undefined;
   let materializePromise: Promise<ImporterWriteTarget> | undefined;
   const io: ImportDispatchIO = {
-    readFile: async (p) => fs.promises.readFile(p, "utf-8"),
-    loadAdapter: async (name) => (await loadImporterModule(name)).adapter,
-    runImporter,
+    readFile: ioOverrides.readFile ?? (async (p) => fs.promises.readFile(p, "utf-8")),
+    loadAdapter: ioOverrides.loadAdapter ?? (async (name) => (await loadImporterModule(name)).adapter),
+    runImporter: ioOverrides.runImporter ?? runImporter,
     getWriteTarget: async () => {
       if (materializedTarget !== undefined) return materializedTarget;
       if (materializePromise === undefined) {
@@ -568,10 +570,10 @@ export async function cmdImport(
     process.exitCode = 1;
     return undefined;
   } finally {
-    // Only dispose when the write target was actually constructed. Checking
+    // Only dispose when write target construction actually started. Checking
     // `parsed.dryRun` alone would incorrectly dispose after install-hint
     // misses or parse errors that happen BEFORE `getWriteTarget` is called.
-    if (materializedTarget !== undefined && disposeTarget !== undefined) {
+    if (materializePromise !== undefined && disposeTarget !== undefined) {
       try {
         await disposeTarget();
       } catch {


### PR DESCRIPTION
## Summary
- dispose the import write target when target construction starts but rejects before resolving
- add a focused cmdImport regression using injected adapter/read IO to cover partial target construction failure

## Verification
- pnpm exec tsx --test packages/remnic-cli/src/import-dispatch.test.ts
- pnpm --filter @remnic/cli run check-types
- git diff --check
- npm run preflight:quick

Closes clawpatch finding fnd_sig-feat-cli-command-7a2b4279cc-_4432c1bf9f.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI control-flow change limited to cleanup timing plus a new test; main behavioral impact is improved resource disposal on target factory rejection.
> 
> **Overview**
> **Improves cleanup semantics for `remnic import`.** `cmdImport` now triggers `disposeTarget` once write-target construction *starts* (tracks `materializePromise`), ensuring resources are cleaned up even when `targetFactory` rejects before returning a target.
> 
> **Adds a regression test** that injects adapter/file IO into `cmdImport` and asserts disposal occurs on partial target construction failure, while preserving the existing guarantee that install-hint adapter-load failures do not call dispose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7b76335f2ff17afc4cd2274bd73735550d90ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->