### PR TITLE
fix(core): expand access cli tilde paths

### DIFF
--- a/packages/remnic-core/src/access-cli.test.ts
+++ b/packages/remnic-core/src/access-cli.test.ts
@@ -281,6 +281,35 @@ test("access-cli browse uses OPENCLAW_CONFIG_PATH before legacy config path", as
   }
 });
 
+test("access-cli expands tilde in OPENCLAW_CONFIG_PATH", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-access-cli-"));
+  try {
+    const configPath = path.join(tempDir, "openclaw.json");
+    writeOpenClawConfig(configPath, {
+      memoryDir: path.join(tempDir, "memory"),
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      namespacePolicies: [
+        { name: "team", readPrincipals: ["reader"], writePrincipals: ["writer"] },
+      ],
+      agentAccessHttp: { principal: "reader" },
+    });
+
+    await withPatchedEnv(
+      {
+        HOME: tempDir,
+        OPENCLAW_CONFIG_PATH: "~/openclaw.json",
+        OPENCLAW_ENGRAM_CONFIG_PATH: undefined,
+      },
+      async () => {
+        await main(["browse", "--namespace", "team", "--limit", "1"]);
+      },
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("access-cli browse accepts an explicit principal for namespace reads", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-access-cli-"));
   try {
@@ -304,6 +333,50 @@ test("access-cli browse accepts an explicit principal for namespace reads", asyn
       },
     );
   } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("access-cli store expands tilde in content-file path", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-access-cli-"));
+  let output = "";
+  const originalStdoutWrite = process.stdout.write;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    const configPath = path.join(tempDir, "openclaw.json");
+    const notePath = path.join(tempDir, "note.md");
+    writeOpenClawConfig(configPath, {
+      memoryDir: path.join(tempDir, "memory"),
+      defaultNamespace: "default",
+    });
+    fs.writeFileSync(notePath, "tilde content");
+
+    await withPatchedEnv(
+      {
+        HOME: tempDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_ENGRAM_CONFIG_PATH: undefined,
+      },
+      async () => {
+        await main([
+          "store",
+          "--content-file",
+          "~/note.md",
+          "--category",
+          "fact",
+          "--dry-run",
+        ]);
+      },
+    );
+
+    assert.match(output, /"operation": "memory_store"/);
+    assert.match(output, /"dryRun": true/);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });

--- a/packages/remnic-core/src/access-cli.ts
+++ b/packages/remnic-core/src/access-cli.ts
@@ -6,6 +6,7 @@ import { Orchestrator } from "./orchestrator.js";
 import { EngramAccessService } from "./access-service.js";
 import { readEnvVar, resolveHomeDir } from "./runtime/env.js";
 import { resolveRemnicPluginEntry } from "./plugin-id.js";
+import { expandTildePath } from "./utils/path.js";
 
 type CommandName = "browse" | "store";
 
@@ -302,8 +303,8 @@ function parseFloatOption(
 
 function loadPluginConfig(preferredId?: string): Record<string, unknown> {
   const configPath =
-    readEnvVar("OPENCLAW_CONFIG_PATH") ||
-    readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH") ||
+    expandOptionalPath(readEnvVar("OPENCLAW_CONFIG_PATH")) ||
+    expandOptionalPath(readEnvVar("OPENCLAW_ENGRAM_CONFIG_PATH")) ||
     path.join(resolveHomeDir(), ".openclaw", "openclaw.json");
   const raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
   // Delegate slot → preferredId → PLUGIN_ID → LEGACY_PLUGIN_ID resolution to
@@ -352,7 +353,9 @@ async function runBrowse(args: ParsedArgs, preferredId?: string): Promise<void> 
 async function runStore(args: ParsedArgs, preferredId?: string): Promise<void> {
   const contentFile = getLastOption(args, "content-file");
   const inlineContent = getLastOption(args, "content");
-  const content = contentFile ? fs.readFileSync(contentFile, "utf8") : inlineContent;
+  const content = contentFile
+    ? fs.readFileSync(expandTildePath(contentFile), "utf8")
+    : inlineContent;
   if (!content || content.trim().length === 0) {
     throw new UsageError("missing-content");
   }
@@ -386,6 +389,10 @@ async function runStore(args: ParsedArgs, preferredId?: string): Promise<void> {
     dryRun: storeArgs.dryRun,
   });
   console.log(JSON.stringify(result, null, 2));
+}
+
+function expandOptionalPath(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : expandTildePath(value);
 }
 
 export async function main(


### PR DESCRIPTION
## Summary
- expand tilde-prefixed access CLI config env paths before reading OpenClaw config
- expand tilde-prefixed --content-file paths before reading store content
- add regression coverage for both user-facing tilde inputs

## Verification
- pnpm exec tsx --test packages/remnic-core/src/access-cli.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- npm run preflight:quick

Closes clawpatch finding fnd_sig-feat-cli-command-97f5c550dc-_871051bfc9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI path-resolution tweak plus regression tests; main risk is unexpected behavior if a path intentionally begins with `~` and should not be expanded.
> 
> **Overview**
> **Fixes tilde-prefixed path handling in `access-cli`.** `OPENCLAW_CONFIG_PATH`/`OPENCLAW_ENGRAM_CONFIG_PATH` are now `~`-expanded before loading config, and `store --content-file` is `~`-expanded before reading content.
> 
> Adds regression tests to ensure both env-config loading and `--content-file` work when paths use `~`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1bcca69e7b67adcc42dc9f7ecbe87ec4f201459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->