### PR TITLE
fix(cli): fail fallback bench without result artifact

### DIFF
--- a/packages/remnic-cli/src/bench-fallback.test.ts
+++ b/packages/remnic-cli/src/bench-fallback.test.ts
@@ -153,3 +153,17 @@ test("resolveFallbackBenchResultPath only reads the dedicated run directory", as
   const resultPath = resolveFallbackBenchResultPath(runDir);
   assert.equal(resultPath, path.join(runDir, "ama-bench-v1.json"));
 });
+
+test("resolveFallbackBenchResultPath rejects fallback runs without JSON artifacts", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-fallback-run-"));
+  const runDir = path.join(root, "fallback-runs", "locomo-1710000000456-789");
+  await mkdir(runDir, { recursive: true });
+  await writeFile(path.join(runDir, "locomo.log"), "completed without result\n");
+
+  assert.throws(
+    () => resolveFallbackBenchResultPath(runDir),
+    {
+      message: `Fallback benchmark runner did not write a JSON result artifact in ${runDir}`,
+    },
+  );
+});

--- a/packages/remnic-cli/src/bench-fallback.ts
+++ b/packages/remnic-cli/src/bench-fallback.ts
@@ -93,7 +93,7 @@ export function resolveFallbackBenchResultPath(outputDir: string): string {
     .map((entry) => entry.name)
     .sort();
   if (entries.length === 0) {
-    return "";
+    throw new Error(`Fallback benchmark runner did not write a JSON result artifact in ${outputDir}`);
   }
   return path.join(outputDir, entries[0]);
 }


### PR DESCRIPTION
## Summary
- reject fallback benchmark runs that do not produce a JSON result artifact
- keep the existing benchmark failure path responsible for failed status updates
- add regression coverage for empty fallback output directories

## Verification
- pnpm exec tsx --test packages/remnic-cli/src/bench-fallback.test.ts
- pnpm --filter @remnic/cli run check-types
- pnpm --filter @remnic/cli exec tsc --noEmit --pretty false
- git diff --check
- npm run preflight:quick

Closes clawpatch finding fnd_sig-feat-cli-command-fdb2abc43c-_4b3808ad73.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavior change in CLI fallback benchmarking to throw instead of returning an empty path, with a targeted regression test to prevent silent success when no result file is written.
> 
> **Overview**
> **Fallback bench runs now fail fast when no result artifact is produced.** `resolveFallbackBenchResultPath` no longer returns an empty string for empty output directories; it throws a clear error instead.
> 
> Adds a regression test ensuring fallback run directories that contain no `.json` files are rejected, preventing downstream code from treating a missing result as a valid path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ee00b135a88578361efdcbfb2108ac3f7d04cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->