### PR TITLE
fix(build): make clean skip symlinked packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ preflight-quick:
 	pnpm preflight:quick
 
 clean:
-	rm -rf dist/ packages/*/dist
+	node scripts/clean-dist.mjs

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+
+function removeDist(targetPath) {
+  fs.rmSync(targetPath, { recursive: true, force: true });
+}
+
+removeDist(path.join(root, "dist"));
+
+const packagesDir = path.join(root, "packages");
+let packageEntries = [];
+try {
+  packageEntries = fs.readdirSync(packagesDir);
+} catch (error) {
+  if (error?.code === "ENOENT") {
+    process.exit(0);
+  }
+  throw error;
+}
+
+for (const entry of packageEntries) {
+  const packageDir = path.join(packagesDir, entry);
+  const stat = fs.lstatSync(packageDir);
+  if (!stat.isDirectory()) continue;
+
+  removeDist(path.join(packageDir, "dist"));
+}

--- a/tests/make-clean-contract.test.ts
+++ b/tests/make-clean-contract.test.ts
@@ -1,13 +1,46 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import test from "node:test";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import os from "node:os";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
 test("make clean removes root and workspace package dist artifacts", () => {
   const makefile = readFileSync(join(repoRoot, "Makefile"), "utf8");
 
-  assert.match(makefile, /^clean:\n\trm -rf dist\/ packages\/\*\/dist$/m);
+  assert.match(makefile, /^clean:\n\tnode scripts\/clean-dist\.mjs$/m);
 });
+
+test("make clean skips symlinked package entries", () => {
+  const tempRoot = mkTempRoot();
+  const externalPackage = join(tempRoot, "external-package");
+  const fixture = join(tempRoot, "repo");
+
+  try {
+    mkdirSync(join(fixture, "scripts"), { recursive: true });
+    mkdirSync(join(fixture, "dist"), { recursive: true });
+    mkdirSync(join(fixture, "packages", "real", "dist"), { recursive: true });
+    mkdirSync(join(externalPackage, "dist"), { recursive: true });
+    writeFileSync(join(fixture, "dist", "root.txt"), "root");
+    writeFileSync(join(fixture, "packages", "real", "dist", "real.txt"), "real");
+    writeFileSync(join(externalPackage, "dist", "external.txt"), "external");
+    symlinkSync(externalPackage, join(fixture, "packages", "linked"), "dir");
+    cpSync(join(repoRoot, "Makefile"), join(fixture, "Makefile"));
+    cpSync(join(repoRoot, "scripts", "clean-dist.mjs"), join(fixture, "scripts", "clean-dist.mjs"));
+
+    execFileSync("make", ["clean"], { cwd: fixture, stdio: "pipe" });
+
+    assert.equal(existsSync(join(fixture, "dist")), false);
+    assert.equal(existsSync(join(fixture, "packages", "real", "dist")), false);
+    assert.equal(existsSync(join(externalPackage, "dist", "external.txt")), true);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+function mkTempRoot(): string {
+  return mkdtempSync(join(os.tmpdir(), "remnic-make-clean-"));
+}


### PR DESCRIPTION
## Summary
- replace the Makefile clean glob with a symlink-safe cleanup helper
- skip symlinked entries under packages/ while still removing root and real package dist directories
- add a regression test that preserves an external symlink target during make clean

## Finding
- Fixes clawpatch finding `fnd_sig-feat-config-0902ad7be8-18931_0c09c0271a`

## Verification
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" /Users/joshuawarren/src/remnic/node_modules/.bin/tsx --test tests/make-clean-contract.test.ts`
- `make clean`
- `clawpatch review --feature feat_config_0902ad7be8 --jobs 1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-tooling change that only affects cleanup behavior; main concern is accidentally deleting unexpected directories, but the new symlink-safe logic reduces that risk.
> 
> **Overview**
> Updates `make clean` to run a new `scripts/clean-dist.mjs` helper instead of `rm -rf dist/ packages/*/dist`, preventing cleanup from traversing symlinked entries under `packages/`.
> 
> Adds a contract/regression test that builds a temporary repo with a symlinked package and asserts `make clean` removes root/real package `dist` directories while leaving the external symlink target untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ab1d523380d40123ab19c8827642224df13a86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->