### PR TITLE
fix(config): keep root tsconfig typecheck only

### DIFF
--- a/tests/root-tsconfig.test.ts
+++ b/tests/root-tsconfig.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+test("root tsconfig is typecheck-only and does not request emit artifacts", () => {
+  const tsconfigPath = path.resolve(import.meta.dirname, "..", "tsconfig.json");
+  const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, "utf8")) as {
+    compilerOptions?: Record<string, unknown>;
+  };
+  const compilerOptions = tsconfig.compilerOptions ?? {};
+
+  assert.equal(compilerOptions.noEmit, true);
+  for (const option of ["outDir", "declaration", "declarationMap", "sourceMap"]) {
+    assert.equal(
+      Object.hasOwn(compilerOptions, option),
+      false,
+      `${option} must live in an emitting build config, not the root noEmit tsconfig`,
+    );
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "lib": [
       "ES2022"
     ],
-    "outDir": "dist",
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
@@ -14,9 +13,6 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "noEmit": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
     "baseUrl": ".",
     "paths": {
       "@remnic/core": [


### PR DESCRIPTION
## Summary
- remove emit-only artifact options from the root noEmit TypeScript config
- keep build artifact ownership with emitting build tooling/package configs
- add regression coverage that prevents root tsconfig from mixing noEmit with output/declaration/source map options

## Verification
- pnpm exec tsx --test tests/root-tsconfig.test.ts
- pnpm run check-types
- git diff --check
- npm run preflight:quick

Closes clawpatch finding fnd_sig-feat-config-0c1c23856a-3bfec_9feb78094f.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that affects TypeScript build/typecheck behavior, with a small regression test to prevent reintroducing emit options under `noEmit`.
> 
> **Overview**
> Keeps the root `tsconfig.json` strictly *typecheck-only* by removing emit-oriented compiler options (`outDir`, `declaration`, `declarationMap`, `sourceMap`) while retaining `noEmit: true`.
> 
> Adds `tests/root-tsconfig.test.ts` to regression-test that the root tsconfig sets `noEmit` and does not define emit/artifact options, ensuring emitting settings live in dedicated build configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aa2f835a5f2f4e031ff4a521e03e31588338acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->