### PR TITLE
fix(core): preserve mixed openclaw message parts

### DIFF
--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -250,8 +250,8 @@ export function parseOpenClawMessageParts(
 
   const content = obj.content;
   if (Array.isArray(content)) {
-    const hasOpenAiBlocks = content.some(isOpenAiContentBlock);
-    if (hasOpenAiBlocks) return parseOpenAiMessageParts(content, options);
+    const mixedParts = parseOpenClawContentArray(content, options);
+    if (mixedParts.length > 0) return mixedParts;
     const hasAnthropicBlocks = content.some(isAnthropicContentBlock);
     if (hasAnthropicBlocks) return parseAnthropicMessageParts({ content }, options);
     const piParts = parsePiMessageParts(input, { ...options, allowRenderedFallback: false });
@@ -398,6 +398,13 @@ function inferSourceFormat(input: unknown): MessagePartSourceFormat | undefined 
     }
     if (Array.isArray(obj.output)) return "openai";
     if (isOpenAiResponseItem(obj)) return "openai";
+    if (
+      Array.isArray(obj.content) &&
+      obj.content.some(isOpenAiContentBlock) &&
+      obj.content.some(isPiContentBlock)
+    ) {
+      return "openclaw";
+    }
     if (Array.isArray(obj.content) && obj.content.some(isOpenAiContentBlock)) return "openai";
     if (isAnthropicMessageObject(obj)) return "anthropic";
     if (isPiMessageObject(obj)) return "pi";
@@ -419,11 +426,32 @@ function isPiMessageObject(obj: Record<string, unknown>): boolean {
   const type = asNonEmptyString(obj.type ?? obj.kind);
   if (type === "toolCall" || type === "tool_call" || type === "toolResult" || type === "tool_result") return true;
   if (!Array.isArray(obj.content)) return false;
-  return obj.content.some((block) => {
-    if (!isRecord(block)) return false;
-    const blockType = asNonEmptyString(block.type ?? block.kind);
-    return blockType === "toolCall" || blockType === "tool_call" || blockType === "toolResult" || blockType === "tool_result";
-  });
+  return obj.content.some(isPiContentBlock);
+}
+
+function parseOpenClawContentArray(
+  content: unknown[],
+  options: ParseMessagePartsOptions,
+): LcmMessagePartInput[] {
+  const parts: LcmMessagePartInput[] = [];
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    const blockParts = isOpenAiContentBlock(block) || isOpenAiResponseItem(block)
+      ? parseOpenAiMessageParts([block], options)
+      : isAnthropicContentBlock(block)
+        ? parseAnthropicMessageParts({ content: [block] }, options)
+        : isPiContentBlock(block)
+          ? parsePiMessageParts(block, { ...options, allowRenderedFallback: false })
+          : [];
+    parts.push(...blockParts.map(({ ordinal: _ordinal, ...part }) => part));
+  }
+  return withRenderedFallback(withOrdinals(parts), { ...options, allowRenderedFallback: false });
+}
+
+function isPiContentBlock(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const blockType = asNonEmptyString(value.type ?? value.kind);
+  return blockType === "toolCall" || blockType === "tool_call" || blockType === "toolResult" || blockType === "tool_result";
 }
 
 function isAnthropicMessageObject(obj: Record<string, unknown>): boolean {

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -167,6 +167,37 @@ describe("message-parts parsers", () => {
     assert.equal(parts[0]!.filePath, "src/openclaw.ts");
   });
 
+  it("preserves mixed OpenClaw OpenAI text and tool-call content blocks", () => {
+    const parts = parseOpenClawMessageParts({
+      content: [
+        { type: "output_text", text: "Updated src/openclaw.ts." },
+        { type: "toolCall", name: "edit", arguments: { path: "src/openclaw.ts" } },
+      ],
+    });
+
+    assert.equal(parts.length, 2);
+    assert.equal(parts[0]!.kind, "text");
+    assert.equal(parts[0]!.filePath, "src/openclaw.ts");
+    assert.equal(parts[1]!.kind, "file_write");
+    assert.equal(parts[1]!.toolName, "edit");
+    assert.equal(parts[1]!.filePath, "src/openclaw.ts");
+  });
+
+  it("infers mixed OpenClaw content without dropping tool-call blocks", () => {
+    const parts = parseMessageParts({
+      content: [
+        { type: "output_text", text: "Updated src/openclaw.ts." },
+        { type: "toolCall", name: "edit", arguments: { path: "src/openclaw.ts" } },
+      ],
+    });
+
+    assert.equal(parts.length, 2);
+    assert.equal(parts[0]!.kind, "text");
+    assert.equal(parts[1]!.kind, "file_write");
+    assert.equal(parts[1]!.toolName, "edit");
+    assert.equal(parts[1]!.filePath, "src/openclaw.ts");
+  });
+
   it("extracts Pi tool-call content blocks as structured file writes", () => {
     const parts = parsePiMessageParts({
       role: "assistant",


### PR DESCRIPTION
## Summary
- parse mixed OpenClaw content arrays block-by-block so OpenAI text and structured tool calls are both retained
- infer mixed OpenAI/Pi content wrappers as OpenClaw instead of routing the whole array through the OpenAI parser
- add regression coverage for explicit and inferred mixed OpenClaw content

## Verification
- pnpm exec tsx --test packages/remnic-core/src/message-parts/message-parts.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- npm run preflight:quick

Closes clawpatch finding fnd_sig-feat-library-02343f97d8-68a2_9e867ba62b.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message-part parsing and source-format inference for `openclaw` wrappers, which could alter how mixed content is classified and ordered across providers. Risk is contained to parsing logic and is covered by new regression tests.
> 
> **Overview**
> Fixes `openclaw` parsing to **preserve mixed content arrays** by parsing each `content` block with the appropriate parser (OpenAI/Anthropic/Pi) instead of routing the whole array through a single parser.
> 
> Updates source-format inference to detect OpenAI+Pi mixed `content` as `openclaw`, and refactors Pi block detection via a shared `isPiContentBlock` helper. Adds tests ensuring mixed OpenAI text + Pi tool-call blocks are retained for both explicit `parseOpenClawMessageParts` and inferred `parseMessageParts` flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa7eb3a56c9141f12604c38419980b142c294807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->