### PR TITLE
fix(core): preserve pi text in openclaw mixed parts

### DIFF
--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -401,7 +401,7 @@ function inferSourceFormat(input: unknown): MessagePartSourceFormat | undefined 
     if (
       Array.isArray(obj.content) &&
       obj.content.some(isOpenAiContentBlock) &&
-      obj.content.some(isPiContentBlock)
+      obj.content.some(isPiToolContentBlock)
     ) {
       return "openclaw";
     }
@@ -426,7 +426,7 @@ function isPiMessageObject(obj: Record<string, unknown>): boolean {
   const type = asNonEmptyString(obj.type ?? obj.kind);
   if (type === "toolCall" || type === "tool_call" || type === "toolResult" || type === "tool_result") return true;
   if (!Array.isArray(obj.content)) return false;
-  return obj.content.some(isPiContentBlock);
+  return obj.content.some(isPiToolContentBlock);
 }
 
 function parseOpenClawContentArray(
@@ -440,7 +440,7 @@ function parseOpenClawContentArray(
       ? parseOpenAiMessageParts([block], options)
       : isAnthropicContentBlock(block)
         ? parseAnthropicMessageParts({ content: [block] }, options)
-        : isPiContentBlock(block)
+        : isPiOpenClawContentBlock(block)
           ? parsePiMessageParts({ content: [block] }, { ...options, allowRenderedFallback: false })
           : [];
     parts.push(...blockParts.map(({ ordinal: _ordinal, ...part }) => part));
@@ -448,10 +448,20 @@ function parseOpenClawContentArray(
   return withRenderedFallback(withOrdinals(parts), { ...options, allowRenderedFallback: false });
 }
 
-function isPiContentBlock(value: unknown): boolean {
+function isPiOpenClawContentBlock(value: unknown): boolean {
   if (!isRecord(value)) return false;
   const blockType = asNonEmptyString(value.type ?? value.kind);
-  return blockType === "text" || blockType === "toolCall" || blockType === "tool_call" || blockType === "toolResult" || blockType === "tool_result";
+  return blockType === "text" || isPiToolBlockType(blockType);
+}
+
+function isPiToolContentBlock(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const blockType = asNonEmptyString(value.type ?? value.kind);
+  return isPiToolBlockType(blockType);
+}
+
+function isPiToolBlockType(blockType: string | null): boolean {
+  return blockType === "toolCall" || blockType === "tool_call" || blockType === "toolResult" || blockType === "tool_result";
 }
 
 function isAnthropicMessageObject(obj: Record<string, unknown>): boolean {

--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -441,7 +441,7 @@ function parseOpenClawContentArray(
       : isAnthropicContentBlock(block)
         ? parseAnthropicMessageParts({ content: [block] }, options)
         : isPiContentBlock(block)
-          ? parsePiMessageParts(block, { ...options, allowRenderedFallback: false })
+          ? parsePiMessageParts({ content: [block] }, { ...options, allowRenderedFallback: false })
           : [];
     parts.push(...blockParts.map(({ ordinal: _ordinal, ...part }) => part));
   }
@@ -451,7 +451,7 @@ function parseOpenClawContentArray(
 function isPiContentBlock(value: unknown): boolean {
   if (!isRecord(value)) return false;
   const blockType = asNonEmptyString(value.type ?? value.kind);
-  return blockType === "toolCall" || blockType === "tool_call" || blockType === "toolResult" || blockType === "tool_result";
+  return blockType === "text" || blockType === "toolCall" || blockType === "tool_call" || blockType === "toolResult" || blockType === "tool_result";
 }
 
 function isAnthropicMessageObject(obj: Record<string, unknown>): boolean {

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -199,6 +199,19 @@ describe("message-parts parsers", () => {
     assert.equal(parts[1]!.filePath, "packages/plugin-pi/src/index.ts");
   });
 
+  it("does not infer text-only content arrays as Pi", () => {
+    const parts = parseMessageParts({
+      role: "assistant",
+      content: [
+        { type: "text", text: "Updated packages/plugin-anthropic/src/index.ts" },
+      ],
+    });
+
+    assert.equal(parts.length, 1);
+    assert.equal(parts[0]!.kind, "text");
+    assert.equal(parts[0]!.filePath, "packages/plugin-anthropic/src/index.ts");
+  });
+
   it("infers mixed OpenClaw content without dropping tool-call blocks", () => {
     const parts = parseMessageParts({
       content: [

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -183,6 +183,22 @@ describe("message-parts parsers", () => {
     assert.equal(parts[1]!.filePath, "src/openclaw.ts");
   });
 
+  it("preserves mixed OpenClaw Pi text and tool-call content blocks", () => {
+    const parts = parseOpenClawMessageParts({
+      content: [
+        { type: "text", text: "Updated packages/plugin-pi/src/index.ts" },
+        { type: "toolCall", name: "edit", arguments: { path: "packages/plugin-pi/src/index.ts" } },
+      ],
+    });
+
+    assert.equal(parts.length, 2);
+    assert.equal(parts[0]!.kind, "text");
+    assert.equal(parts[0]!.filePath, "packages/plugin-pi/src/index.ts");
+    assert.equal(parts[1]!.kind, "file_write");
+    assert.equal(parts[1]!.toolName, "edit");
+    assert.equal(parts[1]!.filePath, "packages/plugin-pi/src/index.ts");
+  });
+
   it("infers mixed OpenClaw content without dropping tool-call blocks", () => {
     const parts = parseMessageParts({
       content: [


### PR DESCRIPTION
## Summary
- recognize Pi text blocks when parsing OpenClaw mixed content arrays
- parse Pi blocks through the content-array path so text and tool-call blocks are both retained
- add regression coverage for Pi text plus tool-call content arrays

## Verification
- pnpm exec tsx --test packages/remnic-core/src/message-parts/message-parts.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- npm run preflight:quick

Follow-up to #1155 for Cursor Bugbot review thread on Pi text blocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes message source-format inference and OpenClaw/Pi parsing heuristics, which could affect how mixed provider payloads are classified and rendered.
> 
> **Overview**
> **Fixes OpenClaw parsing for mixed Pi content.** OpenClaw content arrays now recognize Pi `text` blocks *and* Pi tool blocks together, routing them through the content-array path so both text and tool-call parts are preserved.
> 
> **Tightens Pi inference.** Pi message detection and OpenClaw-format inference now key off Pi *tool* block types (not generic `text`), avoiding misclassifying text-only content arrays as Pi.
> 
> Adds regression tests covering mixed Pi text+tool blocks in OpenClaw and ensuring text-only arrays aren’t inferred as Pi.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d354c0f241c0d238ad09428e3d156ecf2a86a29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->