### PR TITLE
fix(core): reject invalid contradiction resolution verbs

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -19,6 +19,14 @@ import type { ContradictionVerdict } from "./contradiction-judge.js";
 
 export type ResolutionVerb = "keep-a" | "keep-b" | "merge" | "both-valid" | "needs-more-context";
 
+const VALID_RESOLUTION_VERBS: readonly ResolutionVerb[] = [
+  "keep-a",
+  "keep-b",
+  "merge",
+  "both-valid",
+  "needs-more-context",
+];
+
 export interface ContradictionPair {
   /** Deterministic pair ID: sha256(sorted(memoryIdA, memoryIdB) plus namespace when scoped). */
   pairId: string;
@@ -456,6 +464,10 @@ export function resolvePair(
   pairId: string,
   verb: ResolutionVerb,
 ): ContradictionPair | null {
+  if (typeof verb !== "string" || !VALID_RESOLUTION_VERBS.includes(verb)) {
+    throw new Error(`Invalid contradiction resolution verb: ${String(verb)}`);
+  }
+
   if (verb === "needs-more-context") {
     return deferPair(memoryDir, pairId);
   }

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -1311,6 +1311,46 @@ test("isValidResolutionVerb rejects invalid verbs", () => {
   assert.equal(isValidResolutionVerb("unknown"), false);
 });
 
+test("executeResolution rejects invalid runtime verbs without poisoning the pair", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+    const storage = makeResolutionStorage();
+
+    await assert.rejects(
+      () => executeResolution(dir, storage, written.pairId, "delete" as never),
+      /Invalid contradiction resolution verb: delete/,
+    );
+
+    assert.deepEqual(storage.supersedeCalls, []);
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+
+    const valid = await executeResolution(dir, storage, written.pairId, "keep-a");
+
+    assert.deepEqual(valid.affectedIds, ["mem-b-002"]);
+    assert.equal(readPair(dir, written.pairId)?.resolution, "keep-a");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resolvePair rejects invalid runtime verbs without mutating the pair", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const written = writePair(dir, makePair());
+
+    assert.throws(
+      () => resolvePair(dir, written.pairId, "delete" as never),
+      /Invalid contradiction resolution verb: delete/,
+    );
+
+    assert.equal(readPair(dir, written.pairId)?.resolution, undefined);
+    assert.equal(resolvePair(dir, written.pairId, "both-valid")?.resolution, "both-valid");
+  } finally {
+    await cleanup();
+  }
+});
+
 test("executeResolution merge requires a real merged memory", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {

--- a/packages/remnic-core/src/contradiction/resolution.ts
+++ b/packages/remnic-core/src/contradiction/resolution.ts
@@ -53,6 +53,10 @@ export async function executeResolution(
   verb: ResolutionVerb,
   options: ExecuteResolutionOptions = {},
 ): Promise<ResolutionResult> {
+  if (typeof verb !== "string" || !isValidResolutionVerb(verb)) {
+    throw new Error(`Invalid contradiction resolution verb: ${String(verb)}`);
+  }
+
   const pair = readPair(memoryDir, pairId);
   if (!pair) {
     return { pairId, verb, affectedIds: [], message: `Pair ${pairId} not found` };


### PR DESCRIPTION
## Summary
- validate runtime resolution verbs before executeResolution reads or mutates contradiction pairs
- reject invalid direct resolvePair calls before writing review state
- add regressions proving invalid verbs cannot poison a pair and later valid resolution still works

## Verification
- pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- npm run preflight:quick

Closes clawpatch finding fnd_sig-feat-library-058376cb2a-08cf_5f653e1ee6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds upfront runtime validation and tests around contradiction resolution verbs, changing only error behavior for invalid inputs while leaving valid resolution flows intact.
> 
> **Overview**
> Prevents invalid `ResolutionVerb` values from reaching mutation paths by adding explicit runtime validation in `executeResolution` and `resolvePair`.
> 
> Adds regression tests ensuring an invalid verb throws, does **not** supersede memories or write a pair `resolution`, and that a subsequent valid resolution still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ffcc2ccff315e811bcf42ffd32eb88678da0ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->