### PR TITLE
fix(core): refresh contradiction cooldowns for changed memories

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -46,6 +46,8 @@ export interface ContradictionPair {
   resolution?: ResolutionVerb;
   /** ISO timestamp until which a non-terminal deferral remains hidden from review. */
   deferredUntil?: string;
+  /** Content hashes captured for each referenced memory when this pair was judged. */
+  memoryContentHashes?: Record<string, string>;
   /** Namespace scope. */
   namespace?: string;
 }
@@ -216,6 +218,25 @@ function writePairFile(filePath: string, pair: ContradictionPair): void {
   }
 }
 
+export function computeMemoryContentHash(content: string, category?: string): string {
+  const normalized = JSON.stringify({
+    content: content.trim(),
+    category: (category ?? "").trim(),
+  });
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}
+
+function suppliedMemoryHashesChanged(
+  existing: ContradictionPair,
+  pair: Omit<ContradictionPair, "pairId"> & { memoryIds: [string, string] },
+): boolean {
+  if (!existing.memoryContentHashes || !pair.memoryContentHashes) return false;
+  return pair.memoryIds.some((memoryId) => {
+    const current = pair.memoryContentHashes?.[memoryId];
+    return typeof current === "string" && existing.memoryContentHashes?.[memoryId] !== current;
+  });
+}
+
 // ── Write ──────────────────────────────────────────────────────────────────────
 
 /**
@@ -257,6 +278,11 @@ export function writePair(
     && options.cooldownDays !== undefined
     && isCoolingDown(existing, options.cooldownDays),
   );
+  const dormantContentChanged = Boolean(
+    existing
+    && existingDormantCooldownActive
+    && suppliedMemoryHashesChanged(existing, pair),
+  );
   const existingDormantExpired = Boolean(
     existing
     && isDormantReviewedPair(existing)
@@ -266,7 +292,10 @@ export function writePair(
   if (
     existing
     && !existingDeferralExpired
-    && (existingDormantCooldownActive || (!existingDormantExpired && existing.confidence >= pair.confidence))
+    && (
+      (existingDormantCooldownActive && !dormantContentChanged)
+      || (!existingDormantExpired && !dormantContentChanged && existing.confidence >= pair.confidence)
+    )
   ) {
     return existing;
   }
@@ -274,11 +303,11 @@ export function writePair(
   const full: ContradictionPair = {
     ...pair,
     pairId,
-    lastReviewedAt: (existingDeferralExpired || existingDormantExpired)
+    lastReviewedAt: (existingDeferralExpired || existingDormantExpired || dormantContentChanged)
       ? pair.lastReviewedAt
       : (existing?.lastReviewedAt ?? pair.lastReviewedAt),
     resolution: undefined,
-    deferredUntil: (existingDeferralExpired || existingDormantExpired)
+    deferredUntil: (existingDeferralExpired || existingDormantExpired || dormantContentChanged)
       ? undefined
       : existing?.deferredUntil,
   };
@@ -520,10 +549,18 @@ export function deferPair(
  */
 export function memoryHashesChanged(
   _memoryDir: string,
-  _pair: ContradictionPair,
-  _getCurrentHash: (memoryId: string) => string | null,
+  pair: ContradictionPair,
+  getCurrentHash: (memoryId: string) => string | null,
 ): boolean {
-  // Intentionally a stub for now — the full implementation would compare
-  // content hashes stored at detection time with current hashes.
+  if (!pair.memoryContentHashes) return false;
+
+  for (const memoryId of pair.memoryIds) {
+    const previousHash = pair.memoryContentHashes[memoryId];
+    if (typeof previousHash !== "string") continue;
+
+    const currentHash = getCurrentHash(memoryId);
+    if (currentHash !== null && currentHash !== previousHash) return true;
+  }
+
   return false;
 }

--- a/packages/remnic-core/src/contradiction/contradiction-scan.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-scan.ts
@@ -23,6 +23,8 @@ import {
   writePairs,
   listPairs,
   isCoolingDown,
+  memoryHashesChanged,
+  computeMemoryContentHash,
   computePairId,
   migrateUnscopedPairsToNamespace,
   type ContradictionPair,
@@ -167,6 +169,7 @@ export async function runContradictionScan(deps: ScanDependencies): Promise<Scan
 
   // 7. Write to review queue
   const queueEntries: Array<Omit<ContradictionPair, "pairId"> & { memoryIds: [string, string] }> = [];
+  const currentMemoryHashes = memoryContentHashMap(memories);
   for (const [key, result] of judgeResult.results) {
     queueEntries.push({
       memoryIds: [result.memoryIdA, result.memoryIdB],
@@ -176,6 +179,7 @@ export async function runContradictionScan(deps: ScanDependencies): Promise<Scan
       detectedAt: new Date().toISOString(),
       // Set lastReviewedAt for non-actionable verdicts so cooldown prevents re-judging
       lastReviewedAt: result.verdict === "independent" ? new Date().toISOString() : undefined,
+      memoryContentHashes: pairMemoryContentHashes(result.memoryIdA, result.memoryIdB, currentMemoryHashes),
       namespace,
     });
   }
@@ -224,12 +228,17 @@ async function generatePairs(
   if (maxPairs === 0) return { pairs, skipped };
 
   const orderedMemories = [...memories].sort(compareMemoryId);
+  const currentMemoryHashes = memoryContentHashMap(orderedMemories);
 
   const pushCandidate = (pair: CandidatePair): void => {
     if (pairs.length < maxPairs) pairs.push(pair);
   };
 
   const hasCapacity = (): boolean => pairs.length < maxPairs;
+  const isSkippedByCooldown = (existing: ContradictionPair | undefined): boolean => {
+    if (!existing || !isCoolingDown(existing, scanConfig.cooldownDays)) return false;
+    return !memoryHashesChanged("", existing, (memoryId) => currentMemoryHashes.get(memoryId) ?? null);
+  };
 
   // Build index by entityRef for fast lookup
   const byEntity = new Map<string, MemoryFile[]>();
@@ -259,7 +268,7 @@ async function generatePairs(
 
         // Check cooldown
         const existing = existingPairs.get(pairId);
-        if (existing && isCoolingDown(existing, scanConfig.cooldownDays)) {
+        if (isSkippedByCooldown(existing)) {
           skipped++;
           continue;
         }
@@ -296,7 +305,7 @@ async function generatePairs(
       seen.add(pairId);
 
       const existing = existingPairs.get(pairId);
-      if (existing && isCoolingDown(existing, scanConfig.cooldownDays)) {
+      if (isSkippedByCooldown(existing)) {
         skipped++;
         continue;
       }
@@ -335,7 +344,7 @@ async function generatePairs(
           seen.add(pairId);
 
           const existing = existingPairs.get(pairId);
-          if (existing && isCoolingDown(existing, scanConfig.cooldownDays)) {
+          if (isSkippedByCooldown(existing)) {
             skipped++;
             continue;
           }
@@ -468,4 +477,28 @@ function jaccardOverlap(a: string[], b: string[]): number {
 
 function compareMemoryId(a: MemoryFile, b: MemoryFile): number {
   return (a.frontmatter.id ?? "").localeCompare(b.frontmatter.id ?? "");
+}
+
+function memoryContentHashMap(memories: MemoryFile[]): Map<string, string> {
+  const hashes = new Map<string, string>();
+  for (const memory of memories) {
+    const id = memory.frontmatter.id;
+    if (!id) continue;
+    hashes.set(id, computeMemoryContentHash(memory.content, memory.frontmatter.category as string | undefined));
+  }
+  return hashes;
+}
+
+function pairMemoryContentHashes(
+  memoryIdA: string,
+  memoryIdB: string,
+  currentMemoryHashes: Map<string, string>,
+): Record<string, string> | undefined {
+  const hashA = currentMemoryHashes.get(memoryIdA);
+  const hashB = currentMemoryHashes.get(memoryIdB);
+  if (!hashA || !hashB) return undefined;
+  return {
+    [memoryIdA]: hashA,
+    [memoryIdB]: hashB,
+  };
 }

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -12,6 +12,8 @@ import {
   readPair,
   listPairs,
   isCoolingDown,
+  memoryHashesChanged,
+  computeMemoryContentHash,
   resolvePair,
   deferPair,
   migrateUnscopedPairsToNamespace,
@@ -370,6 +372,76 @@ test("writePair preserves dormant independent verdicts during cooldown", async (
   } finally {
     await cleanup();
   }
+});
+
+test("writePair refreshes dormant independent verdicts during cooldown when memory content changed", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const now = new Date().toISOString();
+    const staleAHash = computeMemoryContentHash("old content for mem-a-001", "fact");
+    const currentAHash = computeMemoryContentHash("new content for mem-a-001", "fact");
+    const bHash = computeMemoryContentHash("content for mem-b-002", "fact");
+    const dormant = writePair(dir, makePair({
+      verdict: "independent",
+      confidence: 0.95,
+      lastReviewedAt: now,
+      memoryContentHashes: {
+        "mem-a-001": staleAHash,
+        "mem-b-002": bHash,
+      },
+    }));
+
+    const refreshed = writePair(dir, makePair({
+      verdict: "contradicts",
+      confidence: 0.5,
+      rationale: "Changed source memories now conflict",
+      memoryContentHashes: {
+        "mem-a-001": currentAHash,
+        "mem-b-002": bHash,
+      },
+    }), { cooldownDays: 14 });
+
+    assert.equal(refreshed.pairId, dormant.pairId);
+    assert.equal(refreshed.verdict, "contradicts");
+    assert.equal(refreshed.confidence, 0.5);
+    assert.equal(refreshed.resolution, undefined);
+    assert.equal(refreshed.lastReviewedAt, undefined);
+    assert.deepEqual(refreshed.memoryContentHashes, {
+      "mem-a-001": currentAHash,
+      "mem-b-002": bHash,
+    });
+  } finally {
+    await cleanup();
+  }
+});
+
+test("memoryHashesChanged compares stored pair hashes with current memory hashes", async () => {
+  const previousHash = computeMemoryContentHash("old content", "fact");
+  const unchangedHash = computeMemoryContentHash("same content", "fact");
+  const currentHash = computeMemoryContentHash("new content", "fact");
+  const pair = makePair({
+    memoryContentHashes: {
+      "mem-a-001": previousHash,
+      "mem-b-002": unchangedHash,
+    },
+  });
+
+  assert.equal(
+    memoryHashesChanged("", { ...pair, pairId: computePairId("mem-a-001", "mem-b-002") }, (memoryId) => {
+      if (memoryId === "mem-a-001") return currentHash;
+      if (memoryId === "mem-b-002") return unchangedHash;
+      return null;
+    }),
+    true,
+  );
+  assert.equal(
+    memoryHashesChanged("", { ...pair, pairId: computePairId("mem-a-001", "mem-b-002") }, (memoryId) => {
+      if (memoryId === "mem-a-001") return previousHash;
+      if (memoryId === "mem-b-002") return unchangedHash;
+      return null;
+    }),
+    false,
+  );
 });
 
 test("writePair refreshes expired independent verdicts with actionable lower-confidence results", async () => {
@@ -1047,6 +1119,75 @@ test("runContradictionScan migrates legacy unscoped cooldown pairs for explicit 
     const queued = listPairs(dir, { filter: "all", namespace: "configured-default" }).pairs;
     assert.equal(queued.length, 1);
     assert.equal(queued[0]!.namespace, "configured-default");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("runContradictionScan rejudges cooling pairs when referenced memory content changed", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const defaultA = makeMemory("default-a");
+    defaultA.frontmatter.entityRef = "entity:shared";
+    defaultA.content = "Joshua uses pnpm for Remnic";
+    const defaultB = makeMemory("default-b");
+    defaultB.frontmatter.entityRef = "entity:shared";
+    defaultB.content = "Joshua uses npm for Remnic";
+    const currentAHash = computeMemoryContentHash(defaultA.content, "fact");
+    const currentBHash = computeMemoryContentHash(defaultB.content, "fact");
+
+    writePair(dir, makePair({
+      memoryIds: ["default-a", "default-b"],
+      verdict: "independent",
+      lastReviewedAt: new Date().toISOString(),
+      memoryContentHashes: {
+        "default-a": computeMemoryContentHash("Joshua uses yarn for Remnic", "fact"),
+        "default-b": currentBHash,
+      },
+    }));
+
+    const storage = makeScanStorage([defaultA, defaultB]);
+    const config = parseConfig({
+      memoryDir: dir,
+      contradictionScan: {
+        enabled: true,
+        cooldownDays: 14,
+        maxPairsPerRun: 10,
+        topicOverlapFloor: 0,
+        similarityFloor: 0,
+      },
+    });
+
+    const result = await runContradictionScan({
+      storage,
+      config,
+      memoryDir: dir,
+      localLlm: null,
+      fallbackLlm: {
+        async complete() {
+          return {
+            content: JSON.stringify([{
+              pairKey: "default-a:default-b",
+              verdict: "independent",
+              rationale: "Still no contradiction after changed content",
+              confidence: 0.4,
+            }]),
+          };
+        },
+      } as any,
+    });
+
+    assert.equal(result.cooledDown, 0);
+    assert.equal(result.candidates, 1);
+    assert.equal(result.judged, 1);
+    assert.equal(result.queued, 1);
+
+    const queued = listPairs(dir, { filter: "all" }).pairs;
+    assert.equal(queued.length, 1);
+    assert.deepEqual(queued[0]!.memoryContentHashes, {
+      "default-a": currentAHash,
+      "default-b": currentBHash,
+    });
   } finally {
     await cleanup();
   }


### PR DESCRIPTION
## Summary
- store per-memory content hashes on contradiction review pairs when scan results are written
- bypass dormant cooldowns when a referenced memory hash differs from the stored snapshot
- refresh stored snapshots when changed memories are rejudged

## Verification
- pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick

Closes clawpatch finding fnd_sig-feat-library-058376cb2a-5e60_da28fe1ed4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes contradiction scan/write cooldown behavior by persisting and comparing per-memory content hashes, which can increase re-judging and alter what enters the review queue. Risk is moderate due to logic changes in core scan gating and review state refresh, but is covered by new targeted tests.
> 
> **Overview**
> **Contradiction review pairs now snapshot per-memory content hashes and use them to override cooldowns.** Scan writes (`runContradictionScan`) store a `memoryContentHashes` map for each queued pair, and candidate generation no longer skips cooling pairs if the current memory hash differs from the stored snapshot.
> 
> **Review queue write semantics are updated to refresh dormant/cooling pairs when content changed.** `writePair` detects hash changes during cooldown and, when detected, clears deferrals/last-reviewed state so updated judge results can replace the dormant entry; `memoryHashesChanged` is implemented (was a stub) and new tests cover both `writePair` refresh and scan re-judging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb7f21dc8b07d73f1711f0f0d97e76f54713a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->