### PR TITLE
Allow Remnic to disable direct OpenAI env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ After installation, add the Remnic bridge plugin to your `openclaw.json`:
           "fastGatewayAgentId": "remnic-llm-fast",
 
           // Optional: Use Remnic's local LLM path (plugin mode only; no API key needed):
+          // "openaiApiKey": false,
           // "localLlmEnabled": true,
           // "localLlmUrl": "http://localhost:1234/v1",
           // "localLlmModel": "qwen2.5-32b-instruct"
@@ -1009,7 +1010,7 @@ OpenClaw plugin settings live in `openclaw.json` under `plugins.entries.openclaw
 | `localLlmEnabled` | `false` | Enable Remnic's local LLM path when `modelSource` is `plugin` |
 | `localLlmUrl` | unset | Local LLM endpoint (e.g., `http://localhost:1234/v1`) |
 | `localLlmModel` | unset | Local model name (e.g., `qwen2.5-32b-instruct`) |
-| `model` | `gpt-5.2` | OpenAI model for extraction when `modelSource` is `plugin` and local LLM is disabled |
+| `model` | `gpt-5.5` | OpenAI model for extraction when `modelSource` is `plugin` and local LLM is disabled |
 | `searchBackend` | `"qmd"` | Search engine: `qmd`, `orama`, `lancedb`, `meilisearch`, `remote`, `noop` |
 | `captureMode` | `implicit` | Memory write policy: `implicit`, `explicit`, `hybrid` |
 | `recallBudgetChars` | `maxMemoryTokens * 4` | Recall budget (default ~8K chars; set 64K+ for large-context models) |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -8,9 +8,9 @@ Use `openclaw engram config-review` for opinionated tuning recommendations and `
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `openaiApiKey` | `(env fallback in plugin mode)` | Optional OpenAI API key or `${ENV_VAR}` reference. When `modelSource` is `gateway`, Remnic does not inherit `OPENAI_API_KEY`; gateway provider auth is used instead. |
+| `openaiApiKey` | `(env fallback in plugin mode)` | Optional OpenAI API key, `${ENV_VAR}` reference, or `false` to disable direct OpenAI entirely. When `modelSource` is `gateway`, Remnic does not inherit `OPENAI_API_KEY`; gateway provider auth is used instead. |
 | `openaiBaseUrl` | `(env fallback)` | Override OpenAI API base URL (e.g. for proxies or compatible endpoints); falls back to `OPENAI_BASE_URL` env var |
-| `model` | `gpt-5.2` | OpenAI model for extraction and consolidation |
+| `model` | `gpt-5.5` | OpenAI model for extraction and consolidation |
 | `reasoningEffort` | `low` | `none`, `low`, `medium`, `high` |
 | `memoryDir` | `~/.openclaw/workspace/memory/local` | Memory storage root |
 | `workspaceDir` | `~/.openclaw/workspace` | Workspace root (IDENTITY.md location) |
@@ -1080,9 +1080,9 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 
 | Setting | Default | Recommended |
 |---------|---------|-------------|
-| `openaiApiKey` | `(env fallback in plugin mode)` | unset when `modelSource` is `gateway`; otherwise explicit key or `OPENAI_API_KEY` env fallback |
+| `openaiApiKey` | `(env fallback in plugin mode)` | unset when `modelSource` is `gateway`; set `false` for local-only plugin mode; otherwise explicit key or `OPENAI_API_KEY` env fallback |
 | `openaiBaseUrl` | (unset) | (unset) |
-| `model` | `gpt-5.2` | `gpt-5.2` |
+| `model` | `gpt-5.5` | `gpt-5.5` |
 | `reasoningEffort` | `low` | `low` |
 | `triggerMode` | `smart` | `smart` |
 | `bufferMaxTurns` | `5` | `5` |
@@ -1181,7 +1181,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `boostAccessCount` | `true` | `true` |
 | `recordEmptyRecallImpressions` | `false` | `false` |
 | `recallPlannerEnabled` | `true` | `true` |
-| `recallPlannerModel` | `gpt-5.2-mini` | `gpt-5.2-mini` |
+| `recallPlannerModel` | `gpt-5.5` | `gpt-5.5` |
 | `recallPlannerTimeoutMs` | `1500` | `1500` |
 | `recallPlannerUseResponsesApi` | `true` | `true` |
 | `recallPlannerMaxPromptChars` | `4000` | `4000` |
@@ -1320,7 +1320,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `hourlySummariesEnabled` | `true` | `true` |
 | `summaryRecallHours` | `24` | `24` |
 | `maxSummaryCount` | `6` | `6` |
-| `summaryModel` | `gpt-5.2` | `gpt-5.2` |
+| `summaryModel` | `gpt-5.5` | `gpt-5.5` |
 | `localLlmEnabled` | `false` | `false` unless you have a healthy compatible endpoint |
 | `localLlmUrl` | `http://localhost:1234/v1` | `http://localhost:1234/v1` |
 | `localLlmModel` | `local-model` | `local-model` |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -115,7 +115,10 @@
     "additionalProperties": false,
     "properties": {
       "openaiApiKey": {
-        "type": "string",
+        "anyOf": [
+          { "type": "string" },
+          { "const": false }
+        ],
         "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
       },
       "openaiBaseUrl": {
@@ -124,7 +127,7 @@
       },
       "model": {
         "type": "string",
-        "default": "gpt-5.2",
+        "default": "gpt-5.5",
         "description": "OpenAI model for extraction/consolidation"
       },
       "reasoningEffort": {
@@ -1768,7 +1771,7 @@
       },
       "recallPlannerModel": {
         "type": "string",
-        "default": "gpt-5.2-mini",
+        "default": "gpt-5.5",
         "description": "Model to use for the recall planner."
       },
       "recallPlannerTimeoutMs": {
@@ -4765,7 +4768,7 @@
     "model": {
       "label": "Extraction Model",
       "advanced": true,
-      "placeholder": "gpt-5.2"
+      "placeholder": "gpt-5.5"
     },
     "reasoningEffort": {
       "label": "Reasoning Effort",

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -378,7 +378,7 @@ replays stay idempotent:
             "maxEntries": 500,
             "injectRecentCount": 3,
             "minIntervalMinutes": 120,
-            "narrativeModel": "gpt-5.2",
+            "narrativeModel": "gpt-5.5",
             "narrativePromptStyle": "reflective",
             "watchFile": true
           }

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -115,7 +115,10 @@
     "additionalProperties": false,
     "properties": {
       "openaiApiKey": {
-        "type": "string",
+        "anyOf": [
+          { "type": "string" },
+          { "const": false }
+        ],
         "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
       },
       "openaiBaseUrl": {
@@ -124,7 +127,7 @@
       },
       "model": {
         "type": "string",
-        "default": "gpt-5.2",
+        "default": "gpt-5.5",
         "description": "OpenAI model for extraction/consolidation"
       },
       "reasoningEffort": {
@@ -1768,7 +1771,7 @@
       },
       "recallPlannerModel": {
         "type": "string",
-        "default": "gpt-5.2-mini",
+        "default": "gpt-5.5",
         "description": "Model to use for the recall planner."
       },
       "recallPlannerTimeoutMs": {
@@ -4765,7 +4768,7 @@
     "model": {
       "label": "Extraction Model",
       "advanced": true,
-      "placeholder": "gpt-5.2"
+      "placeholder": "gpt-5.5"
     },
     "reasoningEffort": {
       "label": "Reasoning Effort",

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -356,7 +356,9 @@ const CLI_MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const CLI_REPO_ROOT = path.resolve(CLI_MODULE_DIR, "../../..");
 const EVAL_RUNNER_PATH = path.join(CLI_REPO_ROOT, "evals", "run.ts");
 const OPENCLAW_GATEWAY_LABEL = "ai.openclaw.gateway";
-const CLI_SUCCESS_EXIT_GRACE_MS = 2_000;
+// QMD teardown and cache reads can leave short-lived filesystem requests after
+// successful one-shot commands; give them enough time to drain before forcing.
+const CLI_SUCCESS_EXIT_GRACE_MS = 5_000;
 const CLI_OUTPUT_FLUSH_GRACE_MS = 250;
 
 export const BENCHMARK_CATALOG: BenchCatalogEntry[] = [
@@ -3841,8 +3843,9 @@ async function cmdStatus(json: boolean): Promise<void> {
     if (!response.ok) {
       console.log(`Health: server responded with ${response.status} ${response.statusText}`);
     } else {
-      const health = await response.json();
-      console.log(`Health: ${health.status ?? "ok"}`);
+      const health = (await response.json()) as { status?: unknown };
+      const status = typeof health.status === "string" ? health.status : "ok";
+      console.log(`Health: ${status}`);
     }
   } catch {
     console.log("Health: unable to reach server");
@@ -3898,7 +3901,11 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
   const remnicCfg = raw.remnic ?? raw.engram ?? raw;
-  const config = parseConfig(remnicCfg);
+  const remnicQueryCfg =
+    remnicCfg && typeof remnicCfg === "object" && !Array.isArray(remnicCfg)
+      ? { ...remnicCfg, qmdMaintenanceEnabled: false }
+      : { qmdMaintenanceEnabled: false };
+  const config = parseConfig(remnicQueryCfg);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
   const service = new EngramAccessService(orchestrator);
@@ -3970,7 +3977,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
   } finally {
     // One-shot CLI calls should not wait for or orphan deferred QMD
     // maintenance; the daemon/gateway process performs full warmup instead.
-    orchestrator.abortDeferredInit();
+    await orchestrator.destroy();
   }
 }
 
@@ -4901,6 +4908,23 @@ async function cmdDoctor(): Promise<void> {
   const configPath = resolveConfigPath();
   const configExists = fs.existsSync(configPath);
   checks.push({ name: "Config file", ok: configExists, detail: configPath });
+  let standaloneConfig: ReturnType<typeof parseConfig> | undefined;
+  let standaloneConfigError: string | undefined;
+  let standaloneOpenaiApiKeyExplicitlyFalse = false;
+  if (configExists) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
+      const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+      standaloneOpenaiApiKeyExplicitlyFalse =
+        typeof remnicCfg === "object" &&
+        remnicCfg !== null &&
+        !Array.isArray(remnicCfg) &&
+        (remnicCfg as Record<string, unknown>).openaiApiKey === false;
+      standaloneConfig = parseConfig(remnicCfg);
+    } catch (err) {
+      standaloneConfigError = err instanceof Error ? err.message : String(err);
+    }
+  }
 
   const memoryDir = resolveMemoryDir();
   try {
@@ -5099,17 +5123,30 @@ async function cmdDoctor(): Promise<void> {
     }
   }
 
-  const hasApiKey = !!process.env.OPENAI_API_KEY;
+  const hasApiKey = standaloneConfig
+    ? !!standaloneConfig.openaiApiKey
+    : !!process.env.OPENAI_API_KEY;
+  const localLlmConfigured = standaloneConfig?.localLlmEnabled === true;
   const openaiKeyOptionalForGateway =
     openclawPluginModeConfigured && activeOpenclawModelSource === "gateway";
+  const openaiKeyOptionalForStandalone =
+    standaloneConfig?.modelSource === "gateway" || localLlmConfigured;
   checks.push({
     name: "OPENAI_API_KEY",
-    ok: hasApiKey || openaiKeyOptionalForGateway,
-    warn: !hasApiKey,
-    detail: hasApiKey
-      ? "set"
+    ok: hasApiKey || openaiKeyOptionalForGateway || openaiKeyOptionalForStandalone,
+    warn: !hasApiKey && !openaiKeyOptionalForGateway && !openaiKeyOptionalForStandalone,
+    detail: standaloneConfigError
+      ? `config parse failed (${standaloneConfigError})`
+      : hasApiKey
+      ? "configured"
+      : standaloneOpenaiApiKeyExplicitlyFalse && localLlmConfigured
+      ? "disabled by config (local LLM enabled)"
+      : standaloneOpenaiApiKeyExplicitlyFalse && standaloneConfig?.modelSource === "gateway"
+      ? "disabled by config (gateway modelSource)"
       : openaiKeyOptionalForGateway
       ? "not set (not required for OpenClaw gateway modelSource)"
+      : openaiKeyOptionalForStandalone
+      ? "not set (standalone local/gateway model path configured)"
       : "not set (required for direct OpenAI-backed extraction)",
   });
 
@@ -8108,6 +8145,8 @@ export async function runTrainingExport(
   // still supporting `--format weclone` out of the box.
   // (Codex feedback on PR #545.)
   type WecloneExportModule = Awaited<ReturnType<typeof loadWecloneExportModule>>;
+  type WecloneTrainingRecords = Parameters<WecloneExportModule["synthesizeTrainingPairs"]>[0];
+  type WeclonePrivacyRecords = Parameters<WecloneExportModule["sweepPii"]>[0];
   let wecloneExport: WecloneExportModule | undefined;
   const ensureWeclone = async (): Promise<WecloneExportModule> => {
     if (!wecloneExport) {
@@ -8185,7 +8224,7 @@ export async function runTrainingExport(
       );
     }
     const mod = await ensureWeclone();
-    records = mod.synthesizeTrainingPairs(records as unknown as Record<string, unknown>[], {
+    records = mod.synthesizeTrainingPairs(records as unknown as WecloneTrainingRecords, {
       maxPairsPerRecord: args.maxPairsPerRecord,
     }) as unknown as TrainingExportRecord[];
   }
@@ -8194,7 +8233,7 @@ export async function runTrainingExport(
   if (args.privacySweep) {
     if (adapterIsWeclone) {
       const mod = await ensureWeclone();
-      const swept = mod.sweepPii(records as unknown as Record<string, unknown>[]);
+      const swept = mod.sweepPii(records as unknown as WeclonePrivacyRecords);
       records = swept.cleanRecords as unknown as TrainingExportRecord[];
       redactedCount = swept.redactedCount;
     } else {
@@ -8956,6 +8995,17 @@ function waitForStreamDrain(stream: NodeJS.WriteStream): Promise<void> {
   });
 }
 
+function activeNonStdioHandleCount(): number {
+  const getActiveHandles = (process as unknown as {
+    _getActiveHandles?: () => unknown[];
+  })._getActiveHandles;
+  const handles = getActiveHandles?.call(process) ?? [];
+  return handles.filter((handle) => {
+    const fd = (handle as { fd?: unknown })?.fd;
+    return fd !== 0 && fd !== 1 && fd !== 2;
+  }).length;
+}
+
 async function armCliSuccessExitWatchdog(): Promise<void> {
   const exitCode = process.exitCode ?? 0;
   process.exitCode = exitCode;
@@ -8969,12 +9019,14 @@ async function armCliSuccessExitWatchdog(): Promise<void> {
   ]);
 
   const watchdog = setTimeout(() => {
-    try {
-      process.stderr.write(
-        `Warning: remnic CLI forced a clean exit after ${CLI_SUCCESS_EXIT_GRACE_MS}ms because a handle remained open.\n`,
-      );
-    } catch {
-      // Ignore write failures during forced shutdown.
+    if (activeNonStdioHandleCount() > 0) {
+      try {
+        process.stderr.write(
+          `Warning: remnic CLI forced a clean exit after ${CLI_SUCCESS_EXIT_GRACE_MS}ms because a handle remained open.\n`,
+        );
+      } catch {
+        // Ignore write failures during forced shutdown.
+      }
     }
     process.exit(exitCode);
   }, CLI_SUCCESS_EXIT_GRACE_MS);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -39,6 +39,8 @@ import * as childProcess from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   parseConfig,
+  isOpenaiApiKeyDisabled,
+  resolveEnvVars,
   Orchestrator,
   EngramAccessService,
   initLogger,
@@ -3901,11 +3903,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
   const remnicCfg = raw.remnic ?? raw.engram ?? raw;
-  const remnicQueryCfg =
-    remnicCfg && typeof remnicCfg === "object" && !Array.isArray(remnicCfg)
-      ? { ...remnicCfg, qmdMaintenanceEnabled: false }
-      : { qmdMaintenanceEnabled: false };
-  const config = parseConfig(remnicQueryCfg);
+  const config = parseConfig(remnicCfg);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
   const service = new EngramAccessService(orchestrator);
@@ -3977,6 +3975,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
   } finally {
     // One-shot CLI calls should not wait for or orphan deferred QMD
     // maintenance; the daemon/gateway process performs full warmup instead.
+    orchestrator.abortDeferredInit();
     await orchestrator.destroy();
   }
 }
@@ -4919,7 +4918,7 @@ async function cmdDoctor(): Promise<void> {
         typeof remnicCfg === "object" &&
         remnicCfg !== null &&
         !Array.isArray(remnicCfg) &&
-        (remnicCfg as Record<string, unknown>).openaiApiKey === false;
+        isOpenaiApiKeyDisabled((remnicCfg as Record<string, unknown>).openaiApiKey);
       standaloneConfig = parseConfig(remnicCfg);
     } catch (err) {
       standaloneConfigError = err instanceof Error ? err.message : String(err);
@@ -4941,6 +4940,7 @@ async function cmdDoctor(): Promise<void> {
   let openclawConfigValid = false;
   let openclawPluginModeConfigured = false;
   let activeOpenclawModelSource: string | undefined;
+  let activeOpenclawEntryConfig: Record<string, unknown> | null = null;
 
   if (openclawConfigExists) {
     try {
@@ -5087,6 +5087,7 @@ async function cmdDoctor(): Promise<void> {
         (slotValue === REMNIC_OPENCLAW_PLUGIN_ID || slotValue === REMNIC_OPENCLAW_LEGACY_PLUGIN_ID)
       ) {
         openclawPluginModeConfigured = true;
+        activeOpenclawEntryConfig = entryConfig;
         activeOpenclawModelSource =
           typeof entryConfig?.modelSource === "string" ? entryConfig.modelSource : undefined;
       }
@@ -5123,28 +5124,67 @@ async function cmdDoctor(): Promise<void> {
     }
   }
 
-  const hasApiKey = standaloneConfig
+  const standaloneHasApiKey = standaloneConfig
     ? !!standaloneConfig.openaiApiKey
     : !!process.env.OPENAI_API_KEY;
+  const activeOpenclawOpenaiApiKey = activeOpenclawEntryConfig?.openaiApiKey;
+  const activeOpenclawOpenaiApiKeyExplicitlyFalse =
+    isOpenaiApiKeyDisabled(activeOpenclawOpenaiApiKey);
+  const hasExplicitOpenclawOpenaiApiKey =
+    typeof activeOpenclawOpenaiApiKey === "string" && activeOpenclawOpenaiApiKey.trim().length > 0;
+  let activeOpenclawConfigHasApiKey = false;
+  let activeOpenclawOpenaiApiKeyError: string | undefined;
+  if (hasExplicitOpenclawOpenaiApiKey) {
+    try {
+      activeOpenclawConfigHasApiKey = resolveEnvVars(activeOpenclawOpenaiApiKey).trim().length > 0;
+    } catch (err) {
+      activeOpenclawOpenaiApiKeyError = err instanceof Error ? err.message : String(err);
+    }
+  }
+  const openclawHasApiKey = activeOpenclawOpenaiApiKeyExplicitlyFalse
+    ? false
+    : hasExplicitOpenclawOpenaiApiKey
+      ? activeOpenclawConfigHasApiKey
+      : !!process.env.OPENAI_API_KEY;
+  const diagnosingOpenclawPluginMode = openclawPluginModeConfigured;
+  const hasApiKey = diagnosingOpenclawPluginMode ? openclawHasApiKey : standaloneHasApiKey;
+  const openclawKeyErrorBlocksOk = diagnosingOpenclawPluginMode && !!activeOpenclawOpenaiApiKeyError;
+  const standaloneConfigErrorBlocksOk = !diagnosingOpenclawPluginMode && !!standaloneConfigError;
   const localLlmConfigured = standaloneConfig?.localLlmEnabled === true;
-  const openaiKeyOptionalForGateway =
-    openclawPluginModeConfigured && activeOpenclawModelSource === "gateway";
+  const activeOpenclawLocalLlmConfigured =
+    activeOpenclawEntryConfig?.localLlmEnabled === true || activeOpenclawEntryConfig?.localLlmEnabled === "true";
+  const openaiKeyOptionalForOpenclaw =
+    openclawPluginModeConfigured &&
+    (activeOpenclawModelSource === "gateway" || activeOpenclawLocalLlmConfigured);
   const openaiKeyOptionalForStandalone =
-    standaloneConfig?.modelSource === "gateway" || localLlmConfigured;
+    !diagnosingOpenclawPluginMode &&
+    (standaloneConfig?.modelSource === "gateway" || localLlmConfigured);
   checks.push({
     name: "OPENAI_API_KEY",
-    ok: hasApiKey || openaiKeyOptionalForGateway || openaiKeyOptionalForStandalone,
-    warn: !hasApiKey && !openaiKeyOptionalForGateway && !openaiKeyOptionalForStandalone,
-    detail: standaloneConfigError
-      ? `config parse failed (${standaloneConfigError})`
+    ok:
+      !openclawKeyErrorBlocksOk &&
+      !standaloneConfigErrorBlocksOk &&
+      (hasApiKey || openaiKeyOptionalForOpenclaw || openaiKeyOptionalForStandalone),
+    warn:
+      openclawKeyErrorBlocksOk ||
+      standaloneConfigErrorBlocksOk ||
+      (!hasApiKey && !openaiKeyOptionalForOpenclaw && !openaiKeyOptionalForStandalone),
+    detail: standaloneConfigErrorBlocksOk
+      ? "config parse failed"
+      : openclawKeyErrorBlocksOk
+      ? "OpenClaw openaiApiKey placeholder failed"
       : hasApiKey
       ? "configured"
-      : standaloneOpenaiApiKeyExplicitlyFalse && localLlmConfigured
+      : !diagnosingOpenclawPluginMode && standaloneOpenaiApiKeyExplicitlyFalse && localLlmConfigured
       ? "disabled by config (local LLM enabled)"
-      : standaloneOpenaiApiKeyExplicitlyFalse && standaloneConfig?.modelSource === "gateway"
+      : !diagnosingOpenclawPluginMode && standaloneOpenaiApiKeyExplicitlyFalse && standaloneConfig?.modelSource === "gateway"
       ? "disabled by config (gateway modelSource)"
-      : openaiKeyOptionalForGateway
-      ? "not set (not required for OpenClaw gateway modelSource)"
+      : activeOpenclawOpenaiApiKeyExplicitlyFalse
+      ? "disabled by OpenClaw config"
+      : openaiKeyOptionalForOpenclaw
+      ? activeOpenclawModelSource === "gateway"
+        ? "not set (not required for OpenClaw gateway modelSource)"
+        : "not set (not required for OpenClaw local LLM)"
       : openaiKeyOptionalForStandalone
       ? "not set (standalone local/gateway model path configured)"
       : "not set (required for direct OpenAI-backed extraction)",

--- a/packages/remnic-core/src/active-recall.test.ts
+++ b/packages/remnic-core/src/active-recall.test.ts
@@ -400,7 +400,7 @@ test("active recall engine normalizes timeout to NONE and persists transcripts w
         return "Primary recall";
       },
       async generateSummary() {
-        return { text: "timeout", modelUsed: "gpt-5.2-mini" };
+        return { text: "timeout", modelUsed: "gpt-5.5" };
       },
     },
     baseConfig({
@@ -425,7 +425,7 @@ test("active recall transcript persistence sanitizes agent and session path segm
         return "Primary recall";
       },
       async generateSummary() {
-        return { text: "useful summary", modelUsed: "gpt-5.2-mini" };
+        return { text: "useful summary", modelUsed: "gpt-5.5" };
       },
     },
     baseConfig({
@@ -460,7 +460,7 @@ test("active recall transcript persistence encodes bare dot path segments", asyn
         return "Primary recall";
       },
       async generateSummary() {
-        return { text: "useful summary", modelUsed: "gpt-5.2-mini" };
+        return { text: "useful summary", modelUsed: "gpt-5.5" };
       },
     },
     baseConfig({

--- a/packages/remnic-core/src/active-recall.ts
+++ b/packages/remnic-core/src/active-recall.ts
@@ -407,14 +407,14 @@ export function createActiveRecallEngine(
             prompt,
             sessionKey: input.sessionKey,
             agentId: input.agentId,
-            model: config.modelOverride ?? "gpt-5.2",
+            model: config.modelOverride ?? "gpt-5.5",
             timeoutMs: config.timeoutMs,
             thinking: config.thinking,
             fallbackPolicy: config.modelFallbackPolicy,
           })
         : {
             text: recallContext,
-            modelUsed: config.modelOverride ?? "gpt-5.2",
+            modelUsed: config.modelOverride ?? "gpt-5.5",
             cacheHit: false,
           };
       const summary = normalizeActiveRecallSummary(
@@ -431,7 +431,7 @@ export function createActiveRecallEngine(
         citations,
         latencyMs: Math.max(0, now() - start),
         cacheHit: generated.cacheHit === true,
-        modelUsed: generated.modelUsed ?? config.modelOverride ?? "gpt-5.2",
+        modelUsed: generated.modelUsed ?? config.modelOverride ?? "gpt-5.5",
         transcriptPath: null,
       };
       if (config.persistTranscripts) {

--- a/packages/remnic-core/src/active-recall.ts
+++ b/packages/remnic-core/src/active-recall.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
+import { DEFAULT_REASONING_MODEL } from "./config.js";
 import { collapseWhitespace, truncateCodePointSafe } from "./whitespace.js";
 import type {
   ActiveRecallChatType,
@@ -407,14 +408,14 @@ export function createActiveRecallEngine(
             prompt,
             sessionKey: input.sessionKey,
             agentId: input.agentId,
-            model: config.modelOverride ?? "gpt-5.5",
+            model: config.modelOverride ?? DEFAULT_REASONING_MODEL,
             timeoutMs: config.timeoutMs,
             thinking: config.thinking,
             fallbackPolicy: config.modelFallbackPolicy,
           })
         : {
             text: recallContext,
-            modelUsed: config.modelOverride ?? "gpt-5.5",
+            modelUsed: config.modelOverride ?? DEFAULT_REASONING_MODEL,
             cacheHit: false,
           };
       const summary = normalizeActiveRecallSummary(
@@ -431,7 +432,7 @@ export function createActiveRecallEngine(
         citations,
         latencyMs: Math.max(0, now() - start),
         cacheHit: generated.cacheHit === true,
-        modelUsed: generated.modelUsed ?? config.modelOverride ?? "gpt-5.5",
+        modelUsed: generated.modelUsed ?? config.modelOverride ?? DEFAULT_REASONING_MODEL,
         transcriptPath: null,
       };
       if (config.persistTranscripts) {

--- a/packages/remnic-core/src/briefing.test.ts
+++ b/packages/remnic-core/src/briefing.test.ts
@@ -745,10 +745,10 @@ test("BRIEFING_FOLLOWUP_DEFAULT_MODEL is exported and matches canonical extracti
     typeof BRIEFING_FOLLOWUP_DEFAULT_MODEL === "string" && BRIEFING_FOLLOWUP_DEFAULT_MODEL.length > 0,
     "BRIEFING_FOLLOWUP_DEFAULT_MODEL must be a non-empty string",
   );
-  // Must match the same model family the extraction engine defaults to ("gpt-5.2").
+  // Must match the same model family the extraction engine defaults to ("gpt-5.5").
   assert.equal(
     BRIEFING_FOLLOWUP_DEFAULT_MODEL,
-    "gpt-5.2",
+    "gpt-5.5",
     "default model must align with the extraction engine default in config.ts",
   );
 });
@@ -921,7 +921,7 @@ test("buildBriefing: model-not-found 400 error produces user-friendly followupsU
     allowLlm: true,
     openaiApiKey: "sk-synthetic-key",
     followupGenerator: async () => {
-      throw new Error("The model 'gpt-5.2' does not exist");
+      throw new Error("The model 'gpt-5.5' does not exist");
     },
     now: new Date("2026-04-11T10:00:00.000Z"),
   });
@@ -946,7 +946,7 @@ test("buildBriefing: model 'not found' phrasing also produces user-friendly mess
     allowLlm: true,
     openaiApiKey: "sk-synthetic-key",
     followupGenerator: async () => {
-      throw new Error("model not found: gpt-5.2");
+      throw new Error("model not found: gpt-5.5");
     },
     now: new Date("2026-04-11T10:00:00.000Z"),
   });

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -47,7 +47,7 @@ export const BRIEFING_FORMAT_ALLOWED = ["markdown", "json"] as const;
  * Default model used for the Responses API follow-up generation call.
  * Mirrors the extraction engine default in config.ts — keep in sync.
  */
-export const BRIEFING_FOLLOWUP_DEFAULT_MODEL = "gpt-5.2";
+export const BRIEFING_FOLLOWUP_DEFAULT_MODEL = "gpt-5.5";
 export type BriefingFormatValue = typeof BRIEFING_FORMAT_ALLOWED[number];
 
 /**

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -138,6 +138,23 @@ test("parseConfig modelSource=gateway still honors an explicit openaiApiKey over
   }
 });
 
+test("parseConfig openaiApiKey=false disables implicit OPENAI_API_KEY inheritance", () => {
+  const original = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";
+  try {
+    const cfg = parseConfig({
+      openaiApiKey: false,
+      localLlmEnabled: true,
+    });
+    assert.equal(cfg.modelSource, "plugin");
+    assert.equal(cfg.localLlmEnabled, true);
+    assert.equal(cfg.openaiApiKey, undefined);
+  } finally {
+    if (original === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = original;
+  }
+});
+
 test("parseConfig localLlmTimeoutMs accepts CLI-style numeric strings for gateway fallback", () => {
   const cfg = parseConfig({ localLlmTimeoutMs: "600000" });
   assert.equal(cfg.localLlmTimeoutMs, 600_000);

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -155,6 +155,38 @@ test("parseConfig openaiApiKey=false disables implicit OPENAI_API_KEY inheritanc
   }
 });
 
+test("parseConfig openaiApiKey string false disables implicit OPENAI_API_KEY inheritance", () => {
+  const original = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";
+  try {
+    const cfg = parseConfig({
+      openaiApiKey: "false",
+      localLlmEnabled: "true",
+    });
+    assert.equal(cfg.localLlmEnabled, true);
+    assert.equal(cfg.openaiApiKey, undefined);
+  } finally {
+    if (original === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = original;
+  }
+});
+
+test("parseConfig openaiApiKey string 0 is not treated as a direct OpenAI opt-out", () => {
+  const original = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";
+  try {
+    const cfg = parseConfig({
+      openaiApiKey: "0",
+      localLlmEnabled: "true",
+    });
+    assert.equal(cfg.localLlmEnabled, true);
+    assert.equal(cfg.openaiApiKey, "0");
+  } finally {
+    if (original === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = original;
+  }
+});
+
 test("parseConfig localLlmTimeoutMs accepts CLI-style numeric strings for gateway fallback", () => {
   const cfg = parseConfig({ localLlmTimeoutMs: "600000" });
   assert.equal(cfg.localLlmTimeoutMs, 600_000);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -262,13 +262,13 @@ function parseSemanticChunkingConfig(
 
 // Cursor review on PR #736: the default reasoning model used by the
 // extraction pipeline (`config.model`) and the new peer profile
-// reasoner (`peerProfileReasonerModel`) was hardcoded as `"gpt-5.2"`
+// reasoner (`peerProfileReasonerModel`) was hardcoded as `"gpt-5.5"`
 // in two places. Centralize the default so both surfaces — and any
 // future LLM-backed surface — always agree on the same model id.
 // Sibling packages (briefing, active-recall) keep their own constants
 // because they're scoped to those subsystems; this one lives in the
 // config module because it spans extraction + peer-profile.
-export const DEFAULT_REASONING_MODEL = "gpt-5.2";
+export const DEFAULT_REASONING_MODEL = "gpt-5.5";
 
 const VALID_EFFORTS: ReasoningEffort[] = ["none", "low", "medium", "high"];
 const VALID_TRIGGERS: TriggerMode[] = ["smart", "every_n", "time_based"];
@@ -465,8 +465,15 @@ export function parseConfig(raw: unknown): PluginConfig {
   const modelSource =
     cfg.modelSource === "gateway" ? "gateway" : "plugin";
 
+  const openaiApiKeyDisabled = cfg.openaiApiKey === false;
+
   let apiKey: string | undefined;
-  if (typeof cfg.openaiApiKey === "string" && cfg.openaiApiKey.length > 0) {
+  if (openaiApiKeyDisabled) {
+    // Explicit opt-out for local/gateway-only deployments. Without this,
+    // a stale process-level OPENAI_API_KEY can be captured even when the
+    // operator wants Remnic to use local LLMs and never try direct OpenAI.
+    apiKey = undefined;
+  } else if (typeof cfg.openaiApiKey === "string" && cfg.openaiApiKey.length > 0) {
     apiKey = resolveEnvVars(cfg.openaiApiKey);
   } else if (modelSource === "gateway") {
     // Gateway mode deliberately delegates LLM calls to OpenClaw's model chain.
@@ -2544,7 +2551,7 @@ export function parseConfig(raw: unknown): PluginConfig {
     recallPlannerModel:
       typeof cfg.recallPlannerModel === "string" && cfg.recallPlannerModel.trim().length > 0
         ? cfg.recallPlannerModel.trim()
-        : "gpt-5.2-mini",
+        : "gpt-5.5",
     recallPlannerTimeoutMs:
       typeof cfg.recallPlannerTimeoutMs === "number" ? cfg.recallPlannerTimeoutMs : 1500,
     recallPlannerUseResponsesApi: cfg.recallPlannerUseResponsesApi !== false,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -113,6 +113,10 @@ function coerceBooleanLike(value: unknown): boolean | undefined {
   return undefined;
 }
 
+export function isOpenaiApiKeyDisabled(value: unknown): boolean {
+  return value === false || (typeof value === "string" && value.trim().toLowerCase() === "false");
+}
+
 /**
  * Detect a SecretRef-shaped object (issue #757) without resolving it.
  * SecretRefs are preserved verbatim through `parseConfig` and resolved at
@@ -154,7 +158,7 @@ function parseAgentAccessAuthToken(raw: unknown): import("./types.js").AgentAcce
   );
 }
 
-function resolveEnvVars(value: string): string {
+export function resolveEnvVars(value: string): string {
   const resolved = value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, envVar: string) => {
     const envValue = readEnvVar(envVar);
     if (!envValue) {
@@ -265,9 +269,9 @@ function parseSemanticChunkingConfig(
 // reasoner (`peerProfileReasonerModel`) was hardcoded as `"gpt-5.5"`
 // in two places. Centralize the default so both surfaces — and any
 // future LLM-backed surface — always agree on the same model id.
-// Sibling packages (briefing, active-recall) keep their own constants
-// because they're scoped to those subsystems; this one lives in the
-// config module because it spans extraction + peer-profile.
+// Sibling packages may keep their own constants only when they are scoped to
+// their own subsystem and intentionally diverge. Shared reasoning-model
+// defaults should use this constant.
 export const DEFAULT_REASONING_MODEL = "gpt-5.5";
 
 const VALID_EFFORTS: ReasoningEffort[] = ["none", "low", "medium", "high"];
@@ -465,7 +469,7 @@ export function parseConfig(raw: unknown): PluginConfig {
   const modelSource =
     cfg.modelSource === "gateway" ? "gateway" : "plugin";
 
-  const openaiApiKeyDisabled = cfg.openaiApiKey === false;
+  const openaiApiKeyDisabled = isOpenaiApiKeyDisabled(cfg.openaiApiKey);
 
   let apiKey: string | undefined;
   if (openaiApiKeyDisabled) {
@@ -2551,7 +2555,7 @@ export function parseConfig(raw: unknown): PluginConfig {
     recallPlannerModel:
       typeof cfg.recallPlannerModel === "string" && cfg.recallPlannerModel.trim().length > 0
         ? cfg.recallPlannerModel.trim()
-        : "gpt-5.5",
+        : DEFAULT_REASONING_MODEL,
     recallPlannerTimeoutMs:
       typeof cfg.recallPlannerTimeoutMs === "number" ? cfg.recallPlannerTimeoutMs : 1500,
     recallPlannerUseResponsesApi: cfg.recallPlannerUseResponsesApi !== false,

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -294,7 +294,7 @@ export class FallbackLlmClient {
     modelString: string,
     providers: Record<string, ModelProviderConfig>,
   ): ModelRef | null {
-    // Parse "provider/model" format (e.g., "openai/gpt-5.2", "anthropic/claude-opus-4-6")
+    // Parse "provider/model" format (e.g., "openai/gpt-5.5", "anthropic/claude-opus-4-6")
     const parts = modelString.split("/");
     if (parts.length < 2) {
       log.warn(`fallback LLM: invalid model format: ${modelString}`);
@@ -302,7 +302,7 @@ export class FallbackLlmClient {
     }
 
     const requestedProviderId = parts[0];
-    const modelId = parts.slice(1).join("/"); // Handle cases like "openai/gpt-5.2-turbo"
+    const modelId = parts.slice(1).join("/"); // Handle cases like "openai/gpt-5.5"
 
     // Respect the active gateway config first so profile-local overrides and
     // credentials win. Fall back to the materialized models.json only when

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -26,7 +26,7 @@ export { PLUGIN_ID, LEGACY_PLUGIN_ID, resolveRemnicPluginEntry } from "./plugin-
 // Configuration
 // ---------------------------------------------------------------------------
 
-export { parseConfig } from "./config.js";
+export { parseConfig, isOpenaiApiKeyDisabled, resolveEnvVars } from "./config.js";
 export {
   parseFlexibleIsoTimestamp,
   parseIsoOffsetTimestamp,

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -153,6 +153,20 @@ export class NamespaceSearchRouter {
     this.cache.clear();
   }
 
+  /** Release any per-namespace backend handles held by cached records. */
+  async dispose(): Promise<void> {
+    const pendingRecords = Array.from(this.cache.values());
+    this.cache.clear();
+    const settled = await Promise.allSettled(pendingRecords);
+    await Promise.allSettled(
+      settled.flatMap((entry) => {
+        if (entry.status !== "fulfilled") return [];
+        const dispose = (entry.value.backend as { dispose?: () => void | Promise<void> }).dispose;
+        return dispose ? [dispose.call(entry.value.backend)] : [];
+      }),
+    );
+  }
+
   private async backendRecordFor(namespace: string): Promise<NamespaceBackendRecord> {
     const key = namespace.trim() || this.config.defaultNamespace;
     const existing = this.cache.get(key);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1603,6 +1603,25 @@ export class Orchestrator {
     await (this.qmd as { dispose?: () => void | Promise<void> }).dispose?.();
   }
 
+  /**
+   * Stop background initialization and release runtime-owned handles.
+   * Long-lived hosts should call this from their shutdown path; one-shot
+   * commands should call it before returning to let Node exit naturally.
+   */
+  async destroy(): Promise<void> {
+    this.abortDeferredInit();
+    if (this.qmdMaintenanceTimer) {
+      clearTimeout(this.qmdMaintenanceTimer);
+      this.qmdMaintenanceTimer = null;
+    }
+    this.qmdMaintenancePending = false;
+    await this.namespaceSearchRouter.dispose();
+    await this.disposeSearchBackendIfNeeded();
+    if (this.conversationQmd && this.conversationQmd !== this.qmd) {
+      await (this.conversationQmd as { dispose?: () => void | Promise<void> }).dispose?.();
+    }
+  }
+
   /** Set per-session workspace for the next recall() call (compaction reset). @internal */
   setRecallWorkspaceOverride(sessionKey: string, dir: string): void {
     this._recallWorkspaceOverrides.set(sessionKey, dir);

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -524,6 +524,34 @@ class QmdDaemonSession {
     this.cleanup({ killChild: true });
   }
 
+  /** Kill stdio process and wait briefly for the child handle to close. */
+  async close(timeoutMs = 1_000): Promise<void> {
+    const target = this.child;
+    if (!target) {
+      this.cleanup({ killChild: true });
+      return;
+    }
+
+    let closed = false;
+    const closedPromise = new Promise<void>((resolve) => {
+      target.once("close", () => {
+        closed = true;
+        resolve();
+      });
+    });
+
+    this.cleanup({ killChild: true });
+    await Promise.race([closedPromise, sleep(timeoutMs)]);
+    if (!closed) {
+      try {
+        target.kill("SIGKILL");
+      } catch {
+        // Ignore process-kill races during shutdown.
+      }
+      await Promise.race([closedPromise, sleep(250)]);
+    }
+  }
+
   isActive(): boolean {
     return this.child !== null && !this.child.killed && this.initialized;
   }
@@ -782,15 +810,15 @@ function retainSharedDaemonSession(qmdPath: string): QmdDaemonSession {
   return session;
 }
 
-function releaseSharedDaemonSession(session: QmdDaemonSession | null): void {
+async function releaseSharedDaemonSession(session: QmdDaemonSession | null): Promise<void> {
   if (!session) return;
 
   for (const [qmdPath, entry] of SHARED_DAEMON_SESSIONS.entries()) {
     if (entry.session !== session) continue;
     entry.refs = Math.max(0, entry.refs - 1);
     if (entry.refs === 0) {
-      entry.session.invalidate();
       SHARED_DAEMON_SESSIONS.delete(qmdPath);
+      await entry.session.close();
     }
     return;
   }
@@ -872,7 +900,7 @@ export class QmdClient implements SearchBackend {
     this.lastDaemonCheckAtMs = Date.now();
     const normalizedPath = this.qmdPath.trim() || "qmd";
     if (!this.daemonSession || this.daemonSessionPath !== normalizedPath) {
-      releaseSharedDaemonSession(this.daemonSession);
+      await releaseSharedDaemonSession(this.daemonSession);
       this.daemonSession = retainSharedDaemonSession(normalizedPath);
       this.daemonSessionPath = normalizedPath;
     }
@@ -1019,8 +1047,8 @@ export class QmdClient implements SearchBackend {
     return this.daemonAvailable;
   }
 
-  dispose(): void {
-    releaseSharedDaemonSession(this.daemonSession);
+  async dispose(): Promise<void> {
+    await releaseSharedDaemonSession(this.daemonSession);
     this.daemonSession = null;
     this.daemonSessionPath = null;
     this.daemonAvailable = false;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1029,7 +1029,7 @@ export interface PluginConfig {
   /**
    * Model identifier used by the peer profile reasoner. Logged for
    * telemetry only — actual dispatch is via the same FallbackLlmClient
-   * the orchestrator uses for semantic consolidation. Default `gpt-5.2`.
+   * the orchestrator uses for semantic consolidation. Default `gpt-5.5`.
    */
   peerProfileReasonerModel: string;
   /**

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mergeRemnicConfigForServer } from "./index.js";
+
+test("server config merge preserves openaiApiKey=false over OPENAI_API_KEY env override", () => {
+  const merged = mergeRemnicConfigForServer(
+    {
+      openaiApiKey: false,
+      localLlmEnabled: true,
+    },
+    {
+      openaiApiKey: "sk-env-should-not-be-used",
+      memoryDir: "/tmp/remnic-memory",
+    },
+  );
+
+  assert.equal(merged.openaiApiKey, false);
+  assert.equal(merged.localLlmEnabled, true);
+  assert.equal(merged.memoryDir, "/tmp/remnic-memory");
+});
+
+test("server config merge keeps env OPENAI_API_KEY when direct client is not disabled", () => {
+  const merged = mergeRemnicConfigForServer(
+    {
+      localLlmEnabled: true,
+    },
+    {
+      openaiApiKey: "sk-env",
+    },
+  );
+
+  assert.equal(merged.openaiApiKey, "sk-env");
+});

--- a/packages/remnic-server/src/config.test.ts
+++ b/packages/remnic-server/src/config.test.ts
@@ -20,6 +20,23 @@ test("server config merge preserves openaiApiKey=false over OPENAI_API_KEY env o
   assert.equal(merged.memoryDir, "/tmp/remnic-memory");
 });
 
+test("server config merge preserves string openaiApiKey=false over OPENAI_API_KEY env override", () => {
+  const merged = mergeRemnicConfigForServer(
+    {
+      openaiApiKey: "false",
+      localLlmEnabled: "true",
+    },
+    {
+      openaiApiKey: "sk-env-should-not-be-used",
+      memoryDir: "/tmp/remnic-memory",
+    },
+  );
+
+  assert.equal(merged.openaiApiKey, "false");
+  assert.equal(merged.localLlmEnabled, "true");
+  assert.equal(merged.memoryDir, "/tmp/remnic-memory");
+});
+
 test("server config merge keeps env OPENAI_API_KEY when direct client is not disabled", () => {
   const merged = mergeRemnicConfigForServer(
     {
@@ -31,4 +48,21 @@ test("server config merge keeps env OPENAI_API_KEY when direct client is not dis
   );
 
   assert.equal(merged.openaiApiKey, "sk-env");
+});
+
+test("server config merge does not treat openaiApiKey=0 string as a direct client opt-out", () => {
+  const merged = mergeRemnicConfigForServer(
+    {
+      openaiApiKey: "0",
+      localLlmEnabled: "true",
+    },
+    {
+      openaiApiKey: "sk-env",
+      memoryDir: "/tmp/remnic-memory",
+    },
+  );
+
+  assert.equal(merged.openaiApiKey, "sk-env");
+  assert.equal(merged.localLlmEnabled, "true");
+  assert.equal(merged.memoryDir, "/tmp/remnic-memory");
 });

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -129,6 +129,20 @@ function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Record<str
   return { ...overrides, ...(Object.keys(remnic).length > 0 ? { remnic } : {}) };
 }
 
+export function mergeRemnicConfigForServer(
+  fileRemnic: Record<string, unknown>,
+  envRemnic: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const effectiveEnvRemnic = { ...(envRemnic ?? {}) };
+  if (fileRemnic.openaiApiKey === false) {
+    // A local/gateway-only deployment can explicitly disable the direct
+    // OpenAI client. Preserve that opt-out even when the process has a
+    // global OPENAI_API_KEY for unrelated tools.
+    delete effectiveEnvRemnic.openaiApiKey;
+  }
+  return { ...fileRemnic, ...effectiveEnvRemnic };
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
@@ -177,7 +191,7 @@ export async function startServer(options?: {
   const { remnic: envRemnic, ...envServer } = env;
 
   // Merge: file < env < cli flags
-  const remnicConfig = { ...fileConfig.remnic, ...(envRemnic ?? {}) };
+  const remnicConfig = mergeRemnicConfigForServer(fileConfig.remnic, envRemnic);
   const cliServerConfig: Partial<ServerConfig["server"]> = {};
   if (options?.host !== undefined) cliServerConfig.host = options.host;
   if (options?.port !== undefined) cliServerConfig.port = parseServerPort(options.port, "options.port");
@@ -374,7 +388,7 @@ Environment:
   REMNIC_HOST          Bind address (ENGRAM_HOST also supported)
   REMNIC_AUTH_TOKEN    Auth bearer token (ENGRAM_AUTH_TOKEN also supported)
   REMNIC_MEMORY_DIR    Override memory directory (ENGRAM_MEMORY_DIR also supported)
-  OPENAI_API_KEY       OpenAI API key for extraction
+  OPENAI_API_KEY       OpenAI API key for extraction; ignored when config sets openaiApiKey=false
 `);
     process.exit(0);
   }

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -14,7 +14,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { parseConfig, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, expandTildePath, type PluginConfig } from "@remnic/core";
+import { parseConfig, isOpenaiApiKeyDisabled, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, expandTildePath, type PluginConfig } from "@remnic/core";
 
 // ── Config loading ──────────────────────────────────────────────────────────
 
@@ -134,7 +134,7 @@ export function mergeRemnicConfigForServer(
   envRemnic: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
   const effectiveEnvRemnic = { ...(envRemnic ?? {}) };
-  if (fileRemnic.openaiApiKey === false) {
+  if (isOpenaiApiKeyDisabled(fileRemnic.openaiApiKey)) {
     // A local/gateway-only deployment can explicitly disable the direct
     // OpenAI client. Preserve that opt-out even when the process has a
     // global OPENAI_API_KEY for unrelated tools.

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -115,7 +115,10 @@
     "additionalProperties": false,
     "properties": {
       "openaiApiKey": {
-        "type": "string",
+        "anyOf": [
+          { "type": "string" },
+          { "const": false }
+        ],
         "description": "Optional OpenAI API key for plugin mode (or set OPENAI_API_KEY env var). Ignored by default gateway-mode installs; in plugin mode, Remnic may send conversation and memory content to OpenAI or the configured OpenAI-compatible endpoint for extraction, consolidation, summarization, and embeddings."
       },
       "openaiBaseUrl": {
@@ -124,7 +127,7 @@
       },
       "model": {
         "type": "string",
-        "default": "gpt-5.2",
+        "default": "gpt-5.5",
         "description": "OpenAI model for extraction/consolidation"
       },
       "reasoningEffort": {
@@ -1768,7 +1771,7 @@
       },
       "recallPlannerModel": {
         "type": "string",
-        "default": "gpt-5.2-mini",
+        "default": "gpt-5.5",
         "description": "Model to use for the recall planner."
       },
       "recallPlannerTimeoutMs": {
@@ -4765,7 +4768,7 @@
     "model": {
       "label": "Extraction Model",
       "advanced": true,
-      "placeholder": "gpt-5.2"
+      "placeholder": "gpt-5.5"
     },
     "reasoningEffort": {
       "label": "Reasoning Effort",

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -49,9 +49,6 @@ packages/import-mem0/src/client.test.ts(132,38): TS2304
 packages/import-mem0/src/client.test.ts(225,38): TS2304
 packages/import-mem0/src/client.test.ts(253,38): TS2304
 packages/import-mem0/src/client.test.ts(286,38): TS2304
-packages/remnic-cli/src/index.ts(3845,30): TS18046
-packages/remnic-cli/src/index.ts(8188,43): TS2345
-packages/remnic-cli/src/index.ts(8197,34): TS2345
 src/index.ts(2,40): TS2307
 src/index.ts(2871,38): TS2307
 src/index.ts(2922,23): TS2307

--- a/tests/openclaw-doctor-checks.test.ts
+++ b/tests/openclaw-doctor-checks.test.ts
@@ -148,6 +148,84 @@ test("doctor: OPENAI_API_KEY failure message is unambiguous", async () => {
   );
 });
 
+test("doctor: OPENAI_API_KEY optionality is scoped to the active runtime mode", async () => {
+  const src = await readCli();
+  assert.ok(
+    src.includes("const diagnosingOpenclawPluginMode = openclawPluginModeConfigured"),
+    "CLI doctor must first determine whether OpenClaw plugin mode is the active runtime",
+  );
+  assert.ok(
+    src.includes("const hasApiKey = diagnosingOpenclawPluginMode ? openclawHasApiKey : standaloneHasApiKey"),
+    "CLI doctor must check the OpenClaw key source in OpenClaw mode and the standalone key source otherwise",
+  );
+  assert.ok(
+    src.includes("activeOpenclawOpenaiApiKeyError") &&
+      src.includes("OpenClaw openaiApiKey placeholder failed"),
+    "CLI doctor must fail unresolved OpenClaw openaiApiKey placeholders instead of treating them as configured",
+  );
+  assert.ok(
+    src.includes("const openclawKeyErrorBlocksOk = diagnosingOpenclawPluginMode && !!activeOpenclawOpenaiApiKeyError") &&
+      src.includes("!openclawKeyErrorBlocksOk") &&
+      src.includes("openclawKeyErrorBlocksOk ||"),
+    "unresolved OpenClaw openaiApiKey placeholders must block a healthy result even when ambient OPENAI_API_KEY is set",
+  );
+  assert.ok(
+    src.includes("const standaloneConfigErrorBlocksOk = !diagnosingOpenclawPluginMode && !!standaloneConfigError") &&
+      src.includes("!standaloneConfigErrorBlocksOk") &&
+      src.includes("standaloneConfigErrorBlocksOk ||"),
+    "standalone config parse failures must block a healthy OPENAI_API_KEY result",
+  );
+  assert.ok(
+    src.includes("detail: standaloneConfigErrorBlocksOk") &&
+      src.includes(": openclawKeyErrorBlocksOk"),
+    "OPENAI_API_KEY detail must report errors only from the active runtime mode",
+  );
+  assert.ok(
+    src.includes("isOpenaiApiKeyDisabled,") &&
+    src.includes("isOpenaiApiKeyDisabled((remnicCfg as Record<string, unknown>).openaiApiKey)"),
+    "doctor must use the shared core helper to treat CLI-style string false as an explicit standalone OpenAI key opt-out",
+  );
+  assert.ok(
+    src.includes("resolveEnvVars,") &&
+      src.includes("activeOpenclawConfigHasApiKey = resolveEnvVars(activeOpenclawOpenaiApiKey).trim().length > 0"),
+    "doctor must use the shared core env resolver so Remnic/Engram placeholder fallbacks match runtime config parsing",
+  );
+  assert.ok(
+    src.includes("const activeOpenclawOpenaiApiKeyExplicitlyFalse") &&
+      src.includes("activeOpenclawOpenaiApiKeyExplicitlyFalse") &&
+      src.includes("? false"),
+    "doctor must not fall back to ambient OPENAI_API_KEY when OpenClaw config explicitly disables direct OpenAI",
+  );
+  assert.ok(
+    src.includes("!diagnosingOpenclawPluginMode") &&
+      src.includes("standaloneConfig?.modelSource === \"gateway\" || localLlmConfigured"),
+    "standalone local/gateway optionality must not make OpenClaw direct/plugin mode look healthy",
+  );
+  assert.ok(
+    src.includes("!diagnosingOpenclawPluginMode && standaloneOpenaiApiKeyExplicitlyFalse && localLlmConfigured") &&
+      src.includes("!diagnosingOpenclawPluginMode && standaloneOpenaiApiKeyExplicitlyFalse && standaloneConfig?.modelSource === \"gateway\""),
+    "standalone OpenAI key opt-out details must not override OpenClaw-mode diagnostics",
+  );
+  assert.ok(
+    src.includes("const openaiKeyOptionalForOpenclaw") &&
+      src.includes("activeOpenclawModelSource === \"gateway\" || activeOpenclawLocalLlmConfigured"),
+    "OpenClaw gateway modelSource and local LLM mode must both make OPENAI_API_KEY optional in plugin mode",
+  );
+});
+
+test("query command preserves QMD maintenance for startup index sync", async () => {
+  const src = await readCli();
+  assert.equal(
+    src.includes("qmdMaintenanceEnabled: false"),
+    false,
+    "remnic query must not disable startup QMD index maintenance",
+  );
+  assert.ok(
+    src.includes("const config = parseConfig(remnicCfg);"),
+    "remnic query must parse the configured Remnic settings without overriding qmdMaintenanceEnabled",
+  );
+});
+
 // ── Logic unit tests (pure config parsing) ───────────────────────────────────
 
 interface OpenclawConfig {

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -109,6 +109,14 @@ function readSourceToolNames(): string[] {
 }
 
 for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
+  test(`${manifestPath} keeps model defaults aligned with runtime config defaults`, () => {
+    const manifest = readManifest(manifestPath);
+    const configSchema = manifest.configSchema?.properties ?? {};
+
+    assert.equal(configSchema.model?.default, "gpt-5.5");
+    assert.equal(configSchema.recallPlannerModel?.default, "gpt-5.5");
+  });
+
   test(`${manifestPath} advertises the v2026.4.10 runtime capability surfaces`, () => {
     const manifest = readManifest(manifestPath);
 
@@ -225,6 +233,11 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
       manifest.configSchema?.properties?.openaiApiKey?.description ?? "",
       /conversation and memory content/,
       "openaiApiKey schema should disclose that configured model providers may process memory content",
+    );
+    assert.deepEqual(
+      manifest.configSchema?.properties?.openaiApiKey?.anyOf,
+      [{ type: "string" }, { const: false }],
+      "openaiApiKey schema must accept strings or false, but reject boolean true",
     );
   });
 


### PR DESCRIPTION
## Summary
- add explicit `openaiApiKey: false` support so local/gateway-only Remnic installs do not inherit global `OPENAI_API_KEY`
- preserve that opt-out in the standalone server env merge before `parseConfig`
- update doctor output and docs for local/gateway-only deployments

## Tests
- `pnpm exec tsx --test packages/remnic-core/src/config.test.ts packages/remnic-server/src/config.test.ts`
- `pnpm --filter @remnic/core check-types`
- `pnpm --filter @remnic/cli check-types`
- `pnpm --filter @remnic/server check-types`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config parsing and server env-merging around `openaiApiKey`, which can affect whether direct OpenAI calls are attempted and how diagnostics report key state. Also adds new shutdown/disposal paths for QMD and the orchestrator that could impact CLI/daemon lifecycle if regressions occur.
> 
> **Overview**
> Adds explicit support for `openaiApiKey: false` (and string `"false"`) to **opt out of inheriting `OPENAI_API_KEY`**, enabling local/gateway-only installs to guarantee no direct OpenAI usage; this is enforced in core `parseConfig`, preserved in `@remnic/server`’s env/file merge, and reflected in OpenClaw plugin schemas/docs.
> 
> Updates `remnic doctor` to determine the active runtime mode (standalone vs OpenClaw), validate/resolve `openaiApiKey` placeholders, and report scoped optionality/errors. Separately, improves one-shot CLI teardown by adding `Orchestrator.destroy()`, disposing namespace search backends, and making QMD daemon session cleanup async (with a `close()` wait) to reduce lingering handles; also centralizes/bumbs default model strings to `gpt-5.5` across configs/manifests/tests and tightens a few CLI typings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb4065c571790c3e0e10a2ca75c8d16e6750865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->