### PR TITLE
fix(bench): fail fast on amemgym drain errors

### DIFF
--- a/packages/bench/src/benchmarks/published/amemgym/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.test.ts
@@ -126,3 +126,64 @@ test("AMemGym batches tiny session messages before storing profile context", asy
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("AMemGym fails fast when profile drain fails before scoring", async () => {
+  let completedTasks = 0;
+  let recallCalls = 0;
+
+  await assert.rejects(
+    () =>
+      runAMemGymBenchmark({
+        benchmark: amemGymDefinition,
+        mode: "quick",
+        onTaskComplete() {
+          completedTasks += 1;
+        },
+        system: {
+          async store() {},
+          async recall() {
+            recallCalls += 1;
+            return "Chicago";
+          },
+          async search() {
+            return [];
+          },
+          async reset() {},
+          async drain() {
+            throw new Error("drain timed out");
+          },
+          async destroy() {},
+          async getStats() {
+            return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+          },
+          responder: {
+            async respond() {
+              return {
+                text: "1",
+                tokens: { input: 1, output: 1 },
+                latencyMs: 1,
+                model: "amemgym-test-responder",
+              };
+            },
+          },
+          judge: {
+            async score() {
+              return 1;
+            },
+            async scoreWithMetrics() {
+              return {
+                score: 1,
+                tokens: { input: 0, output: 0 },
+                latencyMs: 0,
+                model: "amemgym-test-judge",
+              };
+            },
+          },
+        },
+      }),
+    /AMemGym drain failed for profile smoke-profile-1: drain timed out/,
+  );
+
+  assert.equal(recallCalls, 0);
+  assert.equal(completedTasks, 0);
+});

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -107,7 +107,9 @@ export async function runAMemGymBenchmark(
     try {
       await options.system.drain?.();
     } catch (drainErr) {
-      console.error(`  [WARN] amemgym drain failed for profile ${profile.id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+      throw new Error(
+        `AMemGym drain failed for profile ${profile.id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`,
+      );
     }
 
     for (


### PR DESCRIPTION
## Summary
- treat AMemGym profile drain failures as fatal before the QA scoring loop
- add a regression test that verifies recall and task callbacks are skipped after a failed drain

## Verification
- pnpm exec tsx --test packages/bench/src/benchmarks/published/amemgym/runner.test.ts
- pnpm --filter @remnic/bench run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick

Closes clawpatch finding fnd_sig-feat-library-25da20613f-53a4_b1efe11551.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AMemGym runner behavior to throw (and abort scoring) when `system.drain()` fails, which may cause previously warning-only runs to hard-fail. Limited scope to benchmark execution/error handling.
> 
> **Overview**
> AMemGym benchmark runs now *fail fast* if `options.system.drain()` throws after storing profile context: the runner rethrows as a hard error instead of logging a warning and continuing into the QA loop.
> 
> Adds a regression test asserting that a drain failure aborts the run before any `recall()` calls or `onTaskComplete` callbacks occur, and that the thrown error includes the profile id and drain message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119715c4652b6522827cadf7be1c11ec016f111b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->