### PR TITLE
fix(test): run root tests through portable node wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "dev": "tsup --watch",
     "check-types": "pnpm --filter @remnic/core build && tsc --noEmit && pnpm --recursive --if-present --filter=\"./packages/*\" run check-types && node scripts/check-test-types.mjs",
     "check-config-contract": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx scripts/validate-config-contract.ts",
-    "test": "pnpm --filter @remnic/core build && NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test \"tests/**/*.test.ts\" \"packages/*/src/**/*.test.ts\" dashboard/lib/*.test.ts integrations/amb/*.test.mjs",
+    "test": "pnpm --filter @remnic/core build && node scripts/run-root-tests.mjs",
     "test:openclaw-scenarios": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",

--- a/scripts/root-test-runner-env.mjs
+++ b/scripts/root-test-runner-env.mjs
@@ -1,0 +1,4 @@
+export function appendNodeOption(existing, option) {
+  const trimmed = typeof existing === "string" ? existing.trim() : "";
+  return trimmed.length > 0 ? `${trimmed} ${option}` : option;
+}

--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -1,0 +1,33 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { appendNodeOption } from "./root-test-runner-env.mjs";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
+const testArgs = [
+  "--test",
+  "tests/**/*.test.ts",
+  "packages/*/src/**/*.test.ts",
+  "dashboard/lib/*.test.ts",
+  "integrations/amb/*.test.mjs",
+];
+
+process.env.NODE_OPTIONS = appendNodeOption(
+  process.env.NODE_OPTIONS,
+  "--conditions=remnic-source",
+);
+
+const result = spawnSync(tsxBin, testArgs, {
+  cwd: repoRoot,
+  env: process.env,
+  stdio: "inherit",
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/tests/root-test-build-contract.test.ts
+++ b/tests/root-test-build-contract.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,11 +14,42 @@ test("root test script builds core before running package tests", () => {
 
   const testScript = pkg.scripts?.test ?? "";
   assert.match(testScript, /^pnpm --filter @remnic\/core build && /);
-  assert.match(testScript, /"packages\/\*\/src\/\*\*\/\*\.test\.ts"/);
-  assert.match(testScript, /\bintegrations\/amb\/\*\.test\.mjs\b/);
+  assert.match(testScript, /node scripts\/run-root-tests\.mjs/);
   assert.doesNotMatch(
     testScript,
     /'[^']*\*[^']*'/,
     "npm scripts should not use POSIX-only single quotes around glob arguments",
   );
+  assert.doesNotMatch(
+    testScript,
+    /(?:^|&&|\|\||;)\s*[A-Za-z_][A-Za-z0-9_]*=/,
+    "root package scripts should not use POSIX-only inline environment assignment",
+  );
+});
+
+test("root test runner applies remnic source conditions and test globs portably", () => {
+  const helperCheck = spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      [
+        "import assert from 'node:assert/strict';",
+        "import { appendNodeOption } from './scripts/root-test-runner-env.mjs';",
+        "assert.equal(appendNodeOption(undefined, '--conditions=remnic-source'), '--conditions=remnic-source');",
+        "assert.equal(appendNodeOption('--trace-warnings', '--conditions=remnic-source'), '--trace-warnings --conditions=remnic-source');",
+      ].join("\n"),
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  assert.equal(helperCheck.status, 0, helperCheck.stderr);
+
+  const script = readFileSync(join(repoRoot, "scripts", "run-root-tests.mjs"), "utf8");
+  assert.match(script, /"tests\/\*\*\/\*\.test\.ts"/);
+  assert.match(script, /"packages\/\*\/src\/\*\*\/\*\.test\.ts"/);
+  assert.match(script, /"dashboard\/lib\/\*\.test\.ts"/);
+  assert.match(script, /"integrations\/amb\/\*\.test\.mjs"/);
+  assert.match(script, /cwd: repoRoot/);
+  assert.match(script, /process\.platform === "win32" \? "tsx\.cmd" : "tsx"/);
+  assert.doesNotMatch(script, /shell:/);
 });


### PR DESCRIPTION
## Summary
- move the root `test` script NODE_OPTIONS setup into a Node wrapper
- keep the existing core build step before running the root test globs
- extend the root test-script contract to reject POSIX-only inline env assignment

## Finding
- Fixes clawpatch finding `fnd_sig-feat-test-suite-84ae84a25a-f_f52a51c9ec`

## Verification
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" /Users/joshuawarren/src/remnic/node_modules/.bin/tsx --test tests/root-test-build-contract.test.ts`
- `node --check scripts/run-root-tests.mjs`
- `node --check scripts/root-test-runner-env.mjs`
- `git diff --check`
- `clawpatch review --feature feat_test-suite_84ae84a25a --jobs 1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how the root test command is invoked (globs and `NODE_OPTIONS`) to be cross-platform, without altering product/runtime code.
> 
> **Overview**
> Moves the root `test` script’s `NODE_OPTIONS` setup and test globs out of `package.json` and into a Node-based wrapper (`scripts/run-root-tests.mjs`) that spawns `tsx` with a Windows-safe binary name and explicit args.
> 
> Adds a small helper (`appendNodeOption`) to safely extend existing `NODE_OPTIONS`, and updates/extends the contract test to enforce that root scripts avoid POSIX-only quoting/inline env assignment while verifying the wrapper applies the expected conditions and globs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393f155437189d97c218adf0c42a481d73d20ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->