### PR TITLE
Fix assistant benchmark latency accounting

### DIFF
--- a/packages/bench/src/benchmarks/remnic/_assistant-common/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/_assistant-common/runner.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BenchMemoryAdapter } from "../../../adapters/types.js";
+import type {
+  BenchmarkDefinition,
+  ResolvedRunBenchmarkOptions,
+} from "../../../types.js";
+import type { StructuredJudge } from "../../../judges/sealed-rubric.js";
+import { runAssistantBenchmark } from "./runner.js";
+import type { AssistantAgent, AssistantScenario } from "./types.js";
+
+test("assistant benchmark latency includes judge wall time", async () => {
+  const spotCheckDir = mkdtempSync(
+    path.join(tmpdir(), "remnic-assistant-latency-"),
+  );
+
+  try {
+    const judgeDelayMs = 40;
+    const result = await runAssistantBenchmark(
+      definition,
+      [scenario],
+      resolvedOptions(),
+      {
+        agent: immediateAgent,
+        judge: delayedJudge(judgeDelayMs),
+        seeds: [101],
+        spotCheckDir,
+        random: () => 0.5,
+      },
+    );
+
+    const [task] = result.results.tasks;
+    assert.ok(task);
+    assert.equal(task.taskId, "latency-scenario");
+    assert.ok(
+      task.latencyMs >= judgeDelayMs - 5,
+      `task latency ${task.latencyMs} should include judge delay`,
+    );
+    assert.ok(
+      result.cost.totalLatencyMs >= judgeDelayMs - 5,
+      `total latency ${result.cost.totalLatencyMs} should include judge delay`,
+    );
+    assert.equal(result.cost.totalLatencyMs, task.latencyMs);
+
+    const perSeedScores = task.details?.perSeedScores;
+    assert.ok(Array.isArray(perSeedScores));
+    const perSeed = perSeedScores[0] as
+      | {
+          agentLatencyMs?: number;
+          judgeLatencyMs?: number;
+          latencyMs?: number;
+        }
+      | undefined;
+    assert.ok(perSeed);
+    assert.ok(
+      typeof perSeed.judgeLatencyMs === "number" &&
+        perSeed.judgeLatencyMs >= judgeDelayMs - 5,
+      `judge latency ${perSeed.judgeLatencyMs} should include judge delay`,
+    );
+    assert.equal(
+      perSeed.latencyMs,
+      (perSeed.agentLatencyMs ?? 0) + perSeed.judgeLatencyMs,
+    );
+  } finally {
+    rmSync(spotCheckDir, { recursive: true, force: true });
+  }
+});
+
+const definition: BenchmarkDefinition = {
+  id: "assistant-latency-test",
+  title: "Assistant Latency Test",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "assistant-latency-test",
+    version: "1.0.0",
+    description: "Verifies assistant benchmark latency accounting.",
+    category: "agentic",
+  },
+};
+
+const scenario: AssistantScenario = {
+  id: "latency-scenario",
+  title: "Latency Scenario",
+  scenarioPrompt: "Answer using the user's project memory.",
+  focus: "latency",
+  memoryGraph: {
+    userHandle: "test-user",
+    userRole: "engineer",
+    facts: [
+      {
+        id: "fact-1",
+        summary: "The user prefers benchmark latency to include judge work.",
+      },
+    ],
+    stances: [],
+    openThreads: [],
+  },
+};
+
+const immediateAgent: AssistantAgent = {
+  async respond() {
+    return "The benchmark should count both assistant and judge latency.";
+  },
+};
+
+function delayedJudge(delayMs: number): StructuredJudge {
+  return {
+    async evaluate() {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      return JSON.stringify({
+        identity_accuracy: 1,
+        stance_coherence: 1,
+        novelty: 1,
+        calibration: 1,
+        notes: "ok",
+      });
+    },
+  };
+}
+
+function resolvedOptions(): ResolvedRunBenchmarkOptions {
+  return {
+    benchmark: definition,
+    mode: "quick",
+    system: noopAdapter,
+  };
+}
+
+const noopAdapter: BenchMemoryAdapter = {
+  async store() {},
+  async recall() {
+    return "";
+  },
+  async search() {
+    return [];
+  },
+  async reset() {},
+  async getStats() {
+    return {
+      totalMessages: 0,
+      totalSummaryNodes: 0,
+      maxDepth: 0,
+    };
+  },
+  async destroy() {},
+};

--- a/packages/bench/src/benchmarks/remnic/_assistant-common/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/_assistant-common/runner.ts
@@ -49,6 +49,8 @@ const DEFAULT_BOOTSTRAP_ITERATIONS = 1_000;
 interface PerScenarioRunResult {
   seed: number;
   decision: SealedJudgeDecision;
+  agentLatencyMs: number;
+  judgeLatencyMs: number;
   latencyMs: number;
   assistantOutput: string;
 }
@@ -86,30 +88,36 @@ export async function runAssistantBenchmark(
 
     for (const seed of seeds) {
       const memoryView = renderMemoryViewForAgent(scenario.memoryGraph);
-      const { result: assistantOutput, durationMs } = await timed(() =>
-        runnerOptions.agent.respond({
-          scenarioId: scenario.id,
-          prompt: scenario.scenarioPrompt,
-          memoryView,
-        }),
-      );
+      const { result: assistantOutput, durationMs: agentLatencyMs } =
+        await timed(() =>
+          runnerOptions.agent.respond({
+            scenarioId: scenario.id,
+            prompt: scenario.scenarioPrompt,
+            memoryView,
+          }),
+        );
 
-      const decision = await runSealedJudge(
-        runnerOptions.judge,
-        rubric,
-        {
-          taskId: `${scenario.id}#seed-${seed}`,
-          scenario: scenario.scenarioPrompt,
-          memorySummary: renderMemorySummaryForJudge(scenario.memoryGraph),
-          assistantOutput,
-        },
-        { spotCheckLogger },
+      const { result: decision, durationMs: judgeLatencyMs } = await timed(
+        () =>
+          runSealedJudge(
+            runnerOptions.judge,
+            rubric,
+            {
+              taskId: `${scenario.id}#seed-${seed}`,
+              scenario: scenario.scenarioPrompt,
+              memorySummary: renderMemorySummaryForJudge(scenario.memoryGraph),
+              assistantOutput,
+            },
+            { spotCheckLogger },
+          ),
       );
 
       perSeedResults.push({
         seed,
         decision,
-        latencyMs: durationMs,
+        agentLatencyMs,
+        judgeLatencyMs,
+        latencyMs: agentLatencyMs + judgeLatencyMs,
         assistantOutput,
       });
     }
@@ -185,6 +193,8 @@ function collapseScenario(
     scores: run.decision.scores,
     parseOk: run.decision.parseOk,
     latencyMs: run.latencyMs,
+    agentLatencyMs: run.agentLatencyMs,
+    judgeLatencyMs: run.judgeLatencyMs,
     notes: run.decision.notes,
   }));
 


### PR DESCRIPTION
## Summary
- include sealed judge wall time in assistant benchmark per-seed latency
- expose agent/judge latency breakdowns in per-seed details
- add a regression test with a delayed structured judge

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx --test packages/bench/src/benchmarks/remnic/_assistant-common/runner.test.ts
- pnpm --filter @remnic/bench run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick

Clawpatch finding: fnd_sig-feat-library-333570d585-131e_43ecf345e2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Assistant benchmark latency/cost metrics are computed and reported, which may affect dashboard numbers and performance regressions comparisons, though it is limited to benchmarking logic.
> 
> **Overview**
> **Assistant benchmark latency accounting is corrected** to include both agent response time and sealed-judge evaluation wall time.
> 
> Per-seed results now record `agentLatencyMs` and `judgeLatencyMs` and compute `latencyMs` as their sum, with these breakdowns exposed in task `perSeedScores`. A new regression test (`runner.test.ts`) uses a delayed judge to assert that task and total latency include judge time and that the per-seed breakdown is consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92549b71f34d83dc62e958a9ab9d46a635345156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->