### PR TITLE
fix(core): retry partial contradiction migrations

### DIFF
--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -423,6 +423,7 @@ export function migrateUnscopedPairsToNamespace(memoryDir: string, namespace: st
   if (fs.existsSync(markerPath)) return 0;
 
   let migrated = 0;
+  let hadMigrationFailure = false;
   for (const entry of fs.readdirSync(dir)) {
     if (!entry.endsWith(".json")) continue;
     const filePath = path.join(dir, entry);
@@ -437,26 +438,33 @@ export function migrateUnscopedPairsToNamespace(memoryDir: string, namespace: st
       const pairId = computePairId(pair.memoryIds[0], pair.memoryIds[1], resolvedNamespace);
       const migratedPair = { ...pair, namespace: resolvedNamespace, pairId };
       const targetPath = pairPath(memoryDir, pairId);
-      if (targetPath === filePath) {
-        writePairFile(filePath, migratedPair);
-      } else if (!fs.existsSync(targetPath)) {
-        writePairFile(targetPath, migratedPair);
-        fs.rmSync(filePath, { force: true });
-      } else {
-        const existing = readPair(memoryDir, pairId);
-        writePairFile(targetPath, existing ? mergeMigratedPair(existing, migratedPair, options) : migratedPair);
-        fs.rmSync(filePath, { force: true });
+      try {
+        if (targetPath === filePath) {
+          writePairFile(filePath, migratedPair);
+        } else if (!fs.existsSync(targetPath)) {
+          writePairFile(targetPath, migratedPair);
+          fs.rmSync(filePath, { force: true });
+        } else {
+          const existing = readPair(memoryDir, pairId);
+          writePairFile(targetPath, existing ? mergeMigratedPair(existing, migratedPair, options) : migratedPair);
+          fs.rmSync(filePath, { force: true });
+        }
+        migrated += 1;
+      } catch {
+        hadMigrationFailure = true;
+        continue;
       }
-      migrated += 1;
     } catch {
       continue;
     }
   }
 
-  try {
-    fs.writeFileSync(markerPath, `${new Date().toISOString()}\n`, { encoding: "utf-8", flag: "wx" });
-  } catch {
-    // Another caller may have completed the same one-shot migration first.
+  if (!hadMigrationFailure) {
+    try {
+      fs.writeFileSync(markerPath, `${new Date().toISOString()}\n`, { encoding: "utf-8", flag: "wx" });
+    } catch {
+      // Another caller may have completed the same one-shot migration first.
+    }
   }
 
   return migrated;

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -637,6 +637,75 @@ test("migrateUnscopedPairsToNamespace skips review directory scan after completi
   }
 });
 
+test("migrateUnscopedPairsToNamespace retries after partial migration failure", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const failingLegacy = writePair(dir, makePair({ memoryIds: ["fail-a", "fail-b"] }));
+    writePair(dir, makePair({ memoryIds: ["ok-a", "ok-b"] }));
+
+    const reviewPath = path.join(dir, ".review", "contradictions");
+    const failingPath = path.join(reviewPath, `${failingLegacy.pairId}.json`);
+    const originalRmSync = fs.rmSync;
+    const fsMutable = fs as unknown as { rmSync: typeof fs.rmSync };
+    let failedOnce = false;
+
+    try {
+      fsMutable.rmSync = ((target: fs.PathLike, options?: fs.RmOptions) => {
+        if (!failedOnce && String(target) === failingPath) {
+          failedOnce = true;
+          throw new Error("simulated legacy cleanup failure");
+        }
+        return originalRmSync(target, options);
+      }) as typeof fs.rmSync;
+
+      assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+    } finally {
+      fsMutable.rmSync = originalRmSync;
+    }
+
+    const markerEntriesAfterFailure = fs
+      .readdirSync(reviewPath)
+      .filter((entry) => entry.startsWith(".unscoped-migrated-"));
+    assert.deepEqual(
+      markerEntriesAfterFailure,
+      [],
+      "partial migration failure must not write the completion marker",
+    );
+    assert.ok(readPair(dir, failingLegacy.pairId), "failed legacy pair remains retryable");
+
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+    assert.equal(readPair(dir, failingLegacy.pairId), null);
+    assert.equal(readPair(dir, computePairId("fail-a", "fail-b", "default"))?.namespace, "default");
+
+    const markerEntriesAfterRetry = fs
+      .readdirSync(reviewPath)
+      .filter((entry) => entry.startsWith(".unscoped-migrated-"));
+    assert.equal(markerEntriesAfterRetry.length, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("migrateUnscopedPairsToNamespace still completes when malformed files are skipped", async () => {
+  const { dir, cleanup } = await makeTempDir();
+  try {
+    const legacy = writePair(dir, makePair({ memoryIds: ["legacy-a", "legacy-b"] }));
+    const reviewPath = path.join(dir, ".review", "contradictions");
+    await writeFile(path.join(reviewPath, "malformed.json"), "{not-json", "utf-8");
+
+    assert.equal(migrateUnscopedPairsToNamespace(dir, "default"), 1);
+    assert.equal(readPair(dir, legacy.pairId), null);
+    assert.equal(readPair(dir, computePairId("legacy-a", "legacy-b", "default"))?.namespace, "default");
+
+    const markerEntries = fs
+      .readdirSync(reviewPath)
+      .filter((entry) => entry.startsWith(".unscoped-migrated-"));
+    assert.equal(markerEntries.length, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
 test("migrateUnscopedPairsToNamespace preserves legacy both-valid state on scoped collisions", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {


### PR DESCRIPTION
## Summary
- leave the unscoped contradiction migration marker absent when a per-file migration operation fails
- keep failed legacy pair files retryable on the next migration pass
- add a regression test that simulates a cleanup failure and verifies retry behavior

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick

Clawpatch finding: fnd_sig-feat-library-058376cb2a-87b9_b0aaf89a1b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk contradiction migration flow and its completion marker semantics; failures could cause repeated migrations or missed marker writes, though behavior is now covered by targeted regression tests.
> 
> **Overview**
> Ensures `migrateUnscopedPairsToNamespace` only writes the unscoped-migration completion marker when **all** per-file migrations succeed, leaving partially migrated runs retryable.
> 
> Adds tests that simulate a per-file cleanup failure (e.g., `rmSync` throwing) to verify the marker is not written and the legacy file remains for the next pass, and a separate test confirming malformed JSON files are skipped without blocking marker creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73f9668874ecfd0610e890327525824877012a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->