### PR TITLE
test(release): smoke check package artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,6 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Release artifact smoke test
+        run: node scripts/check-release-artifacts.mjs

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -61,6 +61,7 @@ jobs:
           pnpm run check-types
           pnpm test
           pnpm run build
+          node scripts/check-release-artifacts.mjs
 
       - name: Configure git identity
         run: |
@@ -322,7 +323,12 @@ jobs:
         run: pnpm rebuild better-sqlite3
 
       - name: Build all packages
-        run: pnpm -r run build
+        run: |
+          pnpm -r run build
+          pnpm run build
+
+      - name: Verify root release artifacts
+        run: node scripts/check-release-artifacts.mjs
 
       - name: Verify OpenClaw ClawHub artifact packlist
         run: pnpm run verify:openclaw-clawpack

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test:openclaw-scenarios": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",
+    "test:release-smoke": "pnpm run build && node scripts/check-release-artifacts.mjs",
     "plugin:inspect": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect",
     "plugin:inspect:runtime": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect:runtime",
     "scan:openclaw-plugin": "node scripts/openclaw-plugin-security-scan.mjs packages/plugin-openclaw",
@@ -133,7 +134,7 @@
     "hooks:install": "bash scripts/install-git-hooks.sh",
     "migrate": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx scripts/migrate.ts",
     "postinstall": "node scripts/ensure-better-sqlite3.mjs",
-    "prepack": "npm run build"
+    "prepack": "pnpm run check-types && pnpm run build"
   },
   "devDependencies": {
     "@openclaw/plugin-inspector": "0.3.10",

--- a/scripts/check-release-artifacts.mjs
+++ b/scripts/check-release-artifacts.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function assertFile(relativePath) {
+  await access(path.join(repoRoot, relativePath));
+}
+
+function normalizeJson(raw) {
+  return `${JSON.stringify(JSON.parse(raw), null, 2)}\n`;
+}
+
+const requiredFiles = [
+  "dist/index.js",
+  "dist/access-cli.js",
+  "dist/cli.js",
+  "dist/connectors/index.js",
+  "dist/connectors/codex-materialize.js",
+  "dist/connectors/codex-materialize-runner.js",
+  "dist/admin-console/public/index.html",
+  "dist/admin-console/public/app.js",
+];
+
+await Promise.all(requiredFiles.map(assertFile));
+
+const [rootManifest, packageManifest] = await Promise.all([
+  readFile(path.join(repoRoot, "openclaw.plugin.json"), "utf8"),
+  readFile(
+    path.join(repoRoot, "packages", "plugin-openclaw", "openclaw.plugin.json"),
+    "utf8",
+  ),
+]);
+
+assert.equal(
+  normalizeJson(rootManifest),
+  normalizeJson(packageManifest),
+  "root openclaw.plugin.json must stay synced with packages/plugin-openclaw/openclaw.plugin.json",
+);

--- a/tests/package-release-script-contract.test.ts
+++ b/tests/package-release-script-contract.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("prepack runs the type gate before building package artifacts", () => {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+
+  const prepack = pkg.scripts?.prepack ?? "";
+  const typeGateIndex = prepack.indexOf("pnpm run check-types");
+  const buildIndex = prepack.indexOf("pnpm run build");
+
+  assert.notEqual(typeGateIndex, -1, "prepack must include the repository type gate");
+  assert.notEqual(buildIndex, -1, "prepack must build package artifacts");
+  assert.ok(typeGateIndex < buildIndex, "prepack must typecheck before building artifacts");
+  assert.doesNotMatch(prepack, /\bnpm run build\b/, "prepack should use pnpm consistently");
+});
+
+test("release smoke coverage verifies build artifacts after the build", () => {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  const releaseSmoke = pkg.scripts?.["test:release-smoke"] ?? "";
+
+  assert.match(releaseSmoke, /pnpm run build/);
+  assert.match(releaseSmoke, /node scripts\/check-release-artifacts\.mjs/);
+
+  const smokeScript = readFileSync(join(repoRoot, "scripts", "check-release-artifacts.mjs"), "utf8");
+  assert.match(smokeScript, /"dist\/index\.js"/);
+  assert.match(smokeScript, /"dist\/connectors\/codex-materialize-runner\.js"/);
+  assert.match(smokeScript, /"dist\/admin-console\/public\/index\.html"/);
+  assert.match(smokeScript, /"dist\/admin-console\/public\/app\.js"/);
+  assert.match(smokeScript, /"openclaw\.plugin\.json"/);
+
+  const ciWorkflow = readFileSync(join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+  assert.match(ciWorkflow, /pnpm run build\s*\n\s*\n\s*- name: Release artifact smoke test\s*\n\s*run: node scripts\/check-release-artifacts\.mjs/);
+
+  const releaseWorkflow = readFileSync(
+    join(repoRoot, ".github", "workflows", "release-and-publish.yml"),
+    "utf8",
+  );
+  assert.match(releaseWorkflow, /pnpm run build\s*\n\s*node scripts\/check-release-artifacts\.mjs/);
+  assert.match(releaseWorkflow, /pnpm -r run build\s*\n\s*pnpm run build\s*\n\s*\n\s*- name: Verify root release artifacts/);
+  assert.match(releaseWorkflow, /- name: Verify root release artifacts\s*\n\s*run: node scripts\/check-release-artifacts\.mjs/);
+});


### PR DESCRIPTION
## Summary
- run the root type gate before `prepack` builds package artifacts
- add `scripts/check-release-artifacts.mjs` to verify root dist entrypoints, copied admin-console assets, and synced OpenClaw manifests
- wire the release artifact smoke check into CI and release validation

## Clawpatch
- Fixes `fnd_sig-feat-release-51170e0f9c-62b0_57ac394cfc`
- Also closes follow-up release smoke-test gap `fnd_sig-feat-release-51170e0f9c-24f9_22d1df4852`

## Verification
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" /Users/joshuawarren/src/remnic/node_modules/.bin/tsx --test tests/package-release-script-contract.test.ts`
- `node --check scripts/check-release-artifacts.mjs && git diff --check`
- `PATH="/Users/joshuawarren/src/remnic/node_modules/.bin:$PATH" pnpm run test:release-smoke` then `node scripts/check-release-artifacts.mjs`
- `clawpatch review --feature feat_release_51170e0f9c --jobs 1` -> 0 findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to build/release automation and lightweight file/manifest assertions, with no runtime product logic changes. Main risk is CI/release failures if artifact expectations drift from the build output.
> 
> **Overview**
> Adds a new `scripts/check-release-artifacts.mjs` smoke check that asserts key root `dist/*` entrypoints/admin-console assets exist and that the root `openclaw.plugin.json` matches `packages/plugin-openclaw/openclaw.plugin.json`.
> 
> Wires this smoke check into `ci.yml` and `release-and-publish.yml` (including tagged-source publish builds), adds `test:release-smoke`, and strengthens `prepack` to run `check-types` before `build` (with a contract test to keep these guarantees in place).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8595ce5e2e94cabb9746cdd07858b82e0f2f1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->