### PR TITLE
fix(core): ship builtin skill sources

### DIFF
--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2775,6 +2775,7 @@
   "files": [
     "src",
     "dist",
+    "skills",
     "scripts/ensure-better-sqlite3.mjs",
     "scripts/faiss_index.py",
     "scripts/faiss_requirements.txt"

--- a/packages/remnic-core/skills/remnic-entities/SKILL.md
+++ b/packages/remnic-core/skills/remnic-entities/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: remnic-entities
+description: Browse entities in the Remnic knowledge graph and surface their facts and relationships. Trigger phrases include "tell me about the entity", "look up", "what do we know about".
+allowed-tools:
+  - remnic_entity_get
+---
+
+## When to use
+
+Use when the user names a specific project, person, service, or concept and asks what is known about it. Entities are the graph-shaped view of memory — structured facts and relationships rather than free text.
+
+Triggers:
+
+- "Tell me about the entity …"
+- "Look up …"
+- "What do we know about project/service/tool X?"
+- Any reference to a named thing that could have linked facts.
+
+## Inputs
+
+- `name` (required) — canonical entity name, ideally as the user wrote it.
+- Optional: entity type hint (project, person, service, tool).
+
+## Procedure
+
+1. Extract the entity name from the user's message. Preserve original capitalization unless ambiguous.
+2. Call `remnic_entity_get` with that name.
+3. If the entity is found, present its facts and relationships in a short structured view (facts, relations, last updated).
+4. If the entity is missing, say so and offer to create one via `remnic-remember` with the user's permission.
+5. When multiple candidates match, list them briefly and ask which the user meant.
+
+## Efficiency plan
+
+- Do not call `remnic_entity_get` speculatively for every proper noun — only when the user asked or the task depends on it.
+- Cache the entity payload within the current turn; do not re-fetch for the same name.
+- Pair with `remnic-recall` when unstructured context would round out the entity view.
+
+## Pitfalls and fixes
+
+- **Pitfall:** Guessing entity names. **Fix:** Use the user's wording; disambiguate rather than inventing.
+- **Pitfall:** Dumping the full entity payload. **Fix:** Summarize into a compact facts/relations/last-updated block.
+- **Pitfall:** Treating a missing entity as a bug. **Fix:** Missing just means the graph has not captured it yet — offer to create it.
+
+## Verification checklist
+
+- [ ] `remnic_entity_get` was called with a user-supplied or user-confirmed name.
+- [ ] Output shows facts, relationships, and timestamps in a compact view.
+- [ ] Missing entities are acknowledged plainly with an offer to create.
+- [ ] Legacy `engram_entity_get` alias was not preferred over `remnic_entity_get`.
+
+> Tool names: canonical name is `remnic_entity_get`. The legacy `engram_entity_get` alias remains accepted during v1.x.

--- a/packages/remnic-core/skills/remnic-memory-workflow/SKILL.md
+++ b/packages/remnic-core/skills/remnic-memory-workflow/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: remnic-memory-workflow
+description: Shared memory workflow for Remnic-connected agents — recall before acting, observe during work, remember at the end. Trigger phrases include "what do you remember about", "save this for later", "any context from last time".
+disable-model-invocation: true
+allowed-tools:
+  - remnic_recall
+  - remnic_memory_store
+  - remnic_lcm_search
+  - remnic_entity_get
+  - remnic_observe
+---
+
+## When to use
+
+Use this skill as the default playbook whenever an agent picks up a task that could benefit from prior context, or when the user explicitly asks the agent to remember or recall something. It is the umbrella workflow — individual skills (`remnic-recall`, `remnic-remember`, `remnic-search`, `remnic-entities`, `remnic-status`) implement the detailed steps.
+
+Triggers:
+
+- The user opens a new task, ticket, or branch.
+- The user says "what do you know about X", "have we talked about Y before", "remind me of Z".
+- The user asks the agent to save a preference, decision, or fact.
+- A long-running turn produces a durable outcome worth capturing.
+
+## Inputs
+
+- Current user request (natural language).
+- Optional: active project path, ticket number, branch name.
+- Optional: topic keywords surfaced earlier in the session.
+
+## Procedure
+
+1. **Recall first.** Call `remnic_recall` with a concise natural-language query derived from the user's request. Pull 3–8 results. Skim them for anything relevant.
+2. **Mention relevant memories briefly** to the user if they materially change the plan, otherwise quietly use them as context.
+3. **Observe during work.** For significant tool outputs (file edits, command exits, test results) call `remnic_observe` so Remnic can keep its ambient context fresh.
+4. **Deep search when needed.** If `remnic_recall` misses something the user insists exists, call `remnic_lcm_search` with a more literal phrase.
+5. **Browse entities.** When the user references a specific project, person, or concept by name, call `remnic_entity_get` to pull its facts and relationships.
+6. **Remember at the end.** Before ending the turn, store any durable decision, preference, or finding with `remnic_memory_store`. Keep each entry under ~300 tokens.
+
+## Efficiency plan
+
+- Batch recalls. One broad query is usually cheaper than several narrow ones.
+- Skip recall for trivially local requests (e.g., "format this JSON").
+- Reuse the current turn's recall results instead of re-querying within the same turn.
+- Store each memory once. If you are about to store something you just recalled, update instead of duplicating.
+
+## Pitfalls and fixes
+
+- **Pitfall:** Storing transient task state ("user is running tests now"). **Fix:** Only store facts with durable value — decisions, preferences, conclusions, long-lived context.
+- **Pitfall:** Leaking secrets into memories. **Fix:** Redact API keys, tokens, and credentials before calling `remnic_memory_store`.
+- **Pitfall:** Drowning the user in recalled context. **Fix:** Summarize in 1–3 bullet points; offer to expand on request.
+- **Pitfall:** Forgetting the write. **Fix:** Make "remember the decision" the last step of any non-trivial turn.
+
+## Verification checklist
+
+- [ ] Recall was attempted before the agent committed to a plan.
+- [ ] Any user-facing mention of recalled context was concise and attributed.
+- [ ] Durable decisions, preferences, and findings were stored via `remnic_memory_store`.
+- [ ] No secrets, credentials, or transient state were written.
+- [ ] Legacy `engram_*` aliases were NOT preferred over canonical `remnic_*` tool names.
+
+> Tool names: this skill uses the canonical `remnic_*` MCP tools. Legacy `engram_*` aliases (`engram_recall`, `engram_memory_store`, `engram_lcm_search`, `engram_entity_get`, `engram_observe`) remain accepted during v1.x for backward compatibility.

--- a/packages/remnic-core/skills/remnic-recall/SKILL.md
+++ b/packages/remnic-core/skills/remnic-recall/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: remnic-recall
+description: Search Remnic memories by natural-language query. Trigger phrases include "what do you remember about", "recall anything on", "have we discussed".
+allowed-tools:
+  - remnic_recall
+---
+
+## When to use
+
+Use when the user or the current task needs prior context from Remnic. This is the default first step for any non-trivial turn that could benefit from memory.
+
+Triggers:
+
+- "What do you remember about …"
+- "Have we talked about …"
+- "Recall anything on …"
+- A new task begins and the agent wants background.
+
+## Inputs
+
+- `query` (required) — natural-language question or topic string.
+- Optional budget hint from the caller (e.g., "brief", "deep").
+
+## Procedure
+
+1. Build a concise natural-language query from the user's request. Prefer the user's own wording over paraphrase.
+2. Call `remnic_recall` with that query. Ask for 3–8 results unless the caller hinted otherwise.
+3. Skim the returned memories. Discard anything clearly off-topic.
+4. Present 1–5 relevant bullet points to the user, each attributed to its source memory when useful.
+5. If nothing relevant came back, say so plainly and suggest `remnic-remember` if there is something worth storing now.
+
+## Efficiency plan
+
+- One broad recall beats several narrow ones.
+- Reuse results within the same turn — do not re-query for the same topic.
+- Skip recall entirely for trivially local requests (formatting, arithmetic, mechanical refactors).
+
+## Pitfalls and fixes
+
+- **Pitfall:** Quoting irrelevant recalls just because they came back. **Fix:** Filter by topical relevance before surfacing.
+- **Pitfall:** Over-narrowing the query and missing useful context. **Fix:** Start broad; refine only if the first pass was noisy.
+- **Pitfall:** Presenting raw memory blobs. **Fix:** Summarize in the user's own terms.
+
+## Verification checklist
+
+- [ ] `remnic_recall` was called with a natural-language query.
+- [ ] Results were filtered for relevance before surfacing.
+- [ ] User-facing summary is concise (≤ 5 bullets unless requested).
+- [ ] Legacy `engram_recall` alias was not preferred over `remnic_recall`.
+
+> Tool names: canonical name is `remnic_recall`. The legacy `engram_recall` alias remains accepted during v1.x.

--- a/packages/remnic-core/skills/remnic-remember/SKILL.md
+++ b/packages/remnic-core/skills/remnic-remember/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: remnic-remember
+description: Store a durable memory in Remnic so every connected agent can recall it. Trigger phrases include "remember this", "save this for later", "add a note that".
+disable-model-invocation: true
+allowed-tools:
+  - remnic_memory_store
+---
+
+## When to use
+
+Use when the user explicitly asks the agent to remember something, or when a turn produces a durable decision, preference, or finding worth storing for later sessions.
+
+Triggers:
+
+- "Remember that …"
+- "Save this for later."
+- "Add a note that …"
+- End-of-turn consolidation after a non-trivial conclusion.
+
+## Inputs
+
+- `content` (required) — the statement to store, in the user's own words where possible.
+- Optional: category hint (preference, decision, fact, procedure).
+- Optional: related entity or project name.
+
+## Procedure
+
+1. Confirm the content is durable — it should still be useful days or weeks from now.
+2. Strip any secrets, credentials, or transient context (current PID, test run timestamps).
+3. Rephrase only if needed for clarity. Keep the user's voice.
+4. Call `remnic_memory_store` with the text as `content`. Include category/entity hints if the tool schema supports them.
+5. Confirm to the user what was stored, in one line.
+6. Mention that the memory is now available across connected agents (Claude Code, Codex, Hermes, OpenClaw).
+
+## Efficiency plan
+
+- Batch closely related facts into a single memory rather than writing many tiny ones.
+- If a prior memory on the same topic already exists, prefer an update-in-place phrasing over a fresh write.
+- Do not store anything that can be re-derived trivially from source code or docs.
+
+## Pitfalls and fixes
+
+- **Pitfall:** Storing transient state like "user is running tests now". **Fix:** Only commit facts that will still matter tomorrow.
+- **Pitfall:** Accidentally including a secret or token. **Fix:** Redact before calling the tool; reject any content that matches known secret patterns.
+- **Pitfall:** Duplicate memories on the same topic. **Fix:** Recall first; prefer update over re-store.
+- **Pitfall:** Vague entries ("user likes clean code"). **Fix:** Be specific — who, what, when, why.
+
+## Verification checklist
+
+- [ ] Content is durable and specific.
+- [ ] No secrets, credentials, or PII were included.
+- [ ] `remnic_memory_store` was called with the final content.
+- [ ] User received a one-line confirmation.
+- [ ] Legacy `engram_memory_store` alias was not preferred over `remnic_memory_store`.
+
+> Tool names: canonical name is `remnic_memory_store`. The legacy `engram_memory_store` alias remains accepted during v1.x.

--- a/packages/remnic-core/skills/remnic-search/SKILL.md
+++ b/packages/remnic-core/skills/remnic-search/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: remnic-search
+description: Run a deep full-text search across every Remnic memory. Trigger phrases include "search memories for", "find anything about", "deep search".
+allowed-tools:
+  - remnic_lcm_search
+---
+
+## When to use
+
+Use when a natural-language `remnic-recall` did not surface something the user insists exists, or when the task genuinely needs exhaustive coverage rather than a ranked summary.
+
+Triggers:
+
+- "Search memories for …"
+- "Deep search on …"
+- "I know I told you about X, find it."
+- Follow-up after `remnic-recall` returned nothing useful.
+
+## Inputs
+
+- `query` (required) — literal phrase or keyword string; this is full-text, not semantic.
+- Optional: date range, category filter, or entity constraint if the tool supports it.
+
+## Procedure
+
+1. Ask the user (or the calling skill) for the most literal phrase they expect to match.
+2. Call `remnic_lcm_search` with that phrase.
+3. Group results by date or category when the tool returns enough metadata.
+4. Present the top 5–10 matches with dates and short excerpts.
+5. If still nothing, say so plainly and suggest `remnic-remember` if the content should be captured going forward.
+
+## Efficiency plan
+
+- Use the most specific phrase available; literal matches are cheaper than wildcarding.
+- Prefer one targeted search over several broad ones.
+- When recall already worked, do not re-run a deep search for the same topic in the same turn.
+
+## Pitfalls and fixes
+
+- **Pitfall:** Using `remnic_lcm_search` as the default. **Fix:** Start with `remnic_recall`; escalate to search only when recall fails.
+- **Pitfall:** Pasting huge result dumps. **Fix:** Show the top matches with excerpts, not the raw payloads.
+- **Pitfall:** Over-broad queries like "notes". **Fix:** Require at least one distinctive keyword.
+
+## Verification checklist
+
+- [ ] `remnic_lcm_search` was called only after recall fell short or the task required exhaustive matching.
+- [ ] Results were grouped by relevance/date when possible.
+- [ ] User-facing output shows excerpts, not raw blobs.
+- [ ] Legacy `engram_lcm_search` alias was not preferred over `remnic_lcm_search`.
+
+> Tool names: canonical name is `remnic_lcm_search`. The legacy `engram_lcm_search` alias remains accepted during v1.x.

--- a/packages/remnic-core/skills/remnic-status/SKILL.md
+++ b/packages/remnic-core/skills/remnic-status/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: remnic-status
+description: Check the health of the Remnic daemon, stores, and connected clients. Trigger phrases include "is remnic running", "check memory status", "daemon health".
+---
+
+## When to use
+
+Use when the user asks whether Remnic is running, when recall or store calls start failing, or when diagnosing cross-agent memory issues.
+
+Triggers:
+
+- "Is Remnic running?"
+- "Check memory status."
+- "Is the daemon up?"
+- Recall/store tools returned connection errors in this turn.
+
+## Inputs
+
+- Optional: specific component to check (daemon, HTTP server, MCP server, store backend).
+
+## Procedure
+
+1. Check the Remnic health endpoint via the MCP bridge or by running `remnic daemon status` in a shell.
+2. Report, in a compact block:
+   - Daemon running state (PID if known).
+   - Listening port(s).
+   - Memory store path.
+   - Connected clients or plugins, if the health payload exposes them.
+3. If the daemon is not running, suggest `remnic daemon start`. Mention the log path for deeper debugging.
+4. If recall/store tools were erroring earlier in the turn, correlate the health state with those errors in one sentence.
+
+## Efficiency plan
+
+- One health call per turn is enough; do not poll.
+- Skip the check for trivially local tasks.
+- Reuse the health payload for downstream troubleshooting within the same turn.
+
+## Pitfalls and fixes
+
+- **Pitfall:** Running `remnic daemon status` on a host where the daemon lives in a container. **Fix:** Prefer the MCP health endpoint, or run the CLI inside the container.
+- **Pitfall:** Reporting "down" based on a single failed tool call. **Fix:** Confirm with the health endpoint before claiming an outage.
+- **Pitfall:** Forgetting the log path. **Fix:** Always include a pointer to logs when reporting a failure.
+
+## Verification checklist
+
+- [ ] Health was checked via the endpoint or CLI, not guessed.
+- [ ] Daemon state, port, store path, and clients were reported concisely.
+- [ ] If unhealthy, the user was given a concrete next step.
+- [ ] No legacy `engram daemon` wording was preferred over `remnic daemon` where the CLI has been renamed.
+
+> CLI names: canonical CLI is `remnic daemon`. The legacy `engram daemon` invocation remains accepted during v1.x.

--- a/packages/remnic-core/src/skills-registry.test.ts
+++ b/packages/remnic-core/src/skills-registry.test.ts
@@ -7,10 +7,12 @@ import { fileURLToPath } from "node:url";
 import { BUILTIN_SKILLS, isValidSkillSlug } from "./skills-registry.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const CORE_PACKAGE_DIR = resolve(HERE, "..");
 
 // The two on-disk directories that hold authored SKILL.md folders.
 const CODEX_SKILLS_DIR = resolve(HERE, "..", "..", "plugin-codex", "skills");
 const CLAUDE_CODE_SKILLS_DIR = resolve(HERE, "..", "..", "plugin-claude-code", "skills");
+const CORE_PACKAGED_SKILLS_DIR = resolve(CORE_PACKAGE_DIR, "skills");
 
 const REQUIRED_SECTIONS = [
   "When to use",
@@ -108,6 +110,36 @@ test("each BUILTIN_SKILLS staticPath points at a real SKILL.md on disk", () => {
       basename(skill.staticPath),
       "SKILL.md",
       `${skill.slug} staticPath filename should be SKILL.md`,
+    );
+  }
+});
+
+test("@remnic/core package ships the built-in skill sources referenced by BUILTIN_SKILLS", () => {
+  const packageJson = JSON.parse(readFileSync(resolve(CORE_PACKAGE_DIR, "package.json"), "utf8")) as {
+    files?: unknown;
+  };
+  assert.ok(
+    Array.isArray(packageJson.files) && packageJson.files.includes("skills"),
+    "packages/remnic-core/package.json files must include packaged skills",
+  );
+  assert.ok(
+    statSync(CORE_PACKAGED_SKILLS_DIR).isDirectory(),
+    "packaged skills path must be a directory",
+  );
+
+  for (const skill of BUILTIN_SKILLS) {
+    const packagedPath = resolve(CORE_PACKAGED_SKILLS_DIR, skill.slug, "SKILL.md");
+    const canonicalPath = resolve(CODEX_SKILLS_DIR, skill.slug, "SKILL.md");
+    assert.ok(existsSync(packagedPath), `${skill.slug} packaged SKILL.md must exist`);
+    assert.equal(
+      readFileSync(packagedPath, "utf8"),
+      readFileSync(canonicalPath, "utf8"),
+      `${skill.slug} packaged SKILL.md must match the canonical Codex skill source`,
+    );
+    assert.equal(
+      skill.staticPath,
+      packagedPath,
+      `${skill.slug} staticPath should resolve to the packaged core skill source`,
     );
   }
 });

--- a/packages/remnic-core/src/skills-registry.ts
+++ b/packages/remnic-core/src/skills-registry.ts
@@ -11,6 +11,7 @@
  */
 
 import { fileURLToPath } from "node:url";
+import { statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 /**
@@ -48,22 +49,36 @@ export function isValidSkillSlug(slug: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Built-in skill paths — resolved relative to this source file.
+// Built-in skill paths — resolved relative to this module.
 // ---------------------------------------------------------------------------
 //
 // This file lives at `packages/remnic-core/src/skills-registry.ts`.
 // After tsup build it lives at `packages/remnic-core/dist/skills-registry.js`.
-// In both cases, the shipped skill sources live four levels up at
-// `packages/plugin-codex/skills/<slug>/SKILL.md`.
+// Packaged @remnic/core artifacts ship skill sources under
+// `packages/remnic-core/skills/<slug>/SKILL.md`; source checkouts can fall back
+// to the canonical monorepo copies in `packages/plugin-codex/skills`.
 //
 // We compute the absolute path from the current module so that callers in any
 // cwd can resolve the files.
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGED_SKILLS_DIR = resolve(HERE, "..", "skills");
 const PLUGIN_CODEX_SKILLS_DIR = resolve(HERE, "..", "..", "plugin-codex", "skills");
 
+function isDirectory(pathname: string): boolean {
+  try {
+    return statSync(pathname).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function builtinSkillsDir(): string {
+  return isDirectory(PACKAGED_SKILLS_DIR) ? PACKAGED_SKILLS_DIR : PLUGIN_CODEX_SKILLS_DIR;
+}
+
 function codexSkillPath(slug: string): string {
-  return resolve(PLUGIN_CODEX_SKILLS_DIR, slug, "SKILL.md");
+  return resolve(builtinSkillsDir(), slug, "SKILL.md");
 }
 
 /**


### PR DESCRIPTION
## Summary
- package the built-in Remnic SKILL.md sources inside @remnic/core
- resolve skills-registry static paths to packaged core skill files when present, with monorepo plugin-codex fallback
- add regression coverage that package files include skills and packaged copies match canonical Codex skill sources

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx --test packages/remnic-core/src/skills-registry.test.ts
- git diff --check
- pnpm --filter @remnic/core run build
- pnpm --filter @remnic/core run check-types
- pnpm --dir packages/remnic-core pack --pack-destination <tmp> + unpack/import dist/skills-registry.js and existsSync every staticPath
- pnpm rebuild better-sqlite3
- npm run preflight:quick

Clawpatch finding: fnd_sig-feat-library-5ff64b0103-27d1_f8c4bbca67

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `BUILTIN_SKILLS` resolves on-disk `SKILL.md` paths, which could break skill materialization for consumers if packaging/layout assumptions are wrong. Added packaging and content-equality tests reduce the risk but it still impacts release artifacts.
> 
> **Overview**
> `@remnic/core` now **ships the built-in skill sources** by adding `skills/` to `package.json` published files and introducing packaged copies of the six built-in `SKILL.md` documents.
> 
> `skills-registry` is updated to resolve `BUILTIN_SKILLS[*].staticPath` to the packaged `packages/remnic-core/skills/<slug>/SKILL.md` when present, with a fallback to the canonical `plugin-codex/skills` directory for source checkouts. New regression tests verify `skills/` is included in the package, packaged skill files match the canonical Codex sources, and `staticPath` points at the packaged location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b42a0bb830600584fd2a0aa07d7d481f92e072f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->