### PR TITLE
fix(bench): export mitigated attack APIs

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -477,10 +477,15 @@ export type {
 // ADAM baseline runner + default scenarios (issue #565 PR 3/5).
 export {
   DEFAULT_BASELINE_SCENARIOS,
+  MITIGATED_BASELINE_SCENARIOS,
+  createMitigatedTarget,
   renderBaselineMarkdown,
   runBaseline,
+  runMitigatedBaseline,
 } from "./security/extraction-attack/index.js";
 export type {
   BaselineRow,
   BaselineScenario,
+  MitigatedBaselineConfig,
+  MitigatedTargetConfig,
 } from "./security/extraction-attack/index.js";

--- a/tests/bench-package-surface.test.ts
+++ b/tests/bench-package-surface.test.ts
@@ -105,3 +105,13 @@ test("@remnic/bench index exports provider factory and discovery helpers", async
   assert.match(source, /createProvider/);
   assert.match(source, /discoverAllProviders/);
 });
+
+test("@remnic/bench index exports mitigated ADAM security harness APIs", async () => {
+  const source = await readFile("packages/bench/src/index.ts", "utf8");
+
+  assert.match(source, /createMitigatedTarget/);
+  assert.match(source, /runMitigatedBaseline/);
+  assert.match(source, /MITIGATED_BASELINE_SCENARIOS/);
+  assert.match(source, /MitigatedBaselineConfig/);
+  assert.match(source, /MitigatedTargetConfig/);
+});


### PR DESCRIPTION
## Summary
- export mitigated ADAM attack harness APIs from the @remnic/bench root entrypoint
- add a package-surface regression test for the mitigated API names

Clawpatch finding: fnd_sig-feat-library-73477a0f7d-c2c4_55fa90635a

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx --test tests/bench-package-surface.test.ts
- pnpm --filter @remnic/bench run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds root entrypoint re-exports and a regression test; no runtime logic changes beyond making APIs publicly accessible.
> 
> **Overview**
> Exports the mitigated ADAM baseline harness APIs from `@remnic/bench`’s root `index.ts` (including `MITIGATED_BASELINE_SCENARIOS`, `createMitigatedTarget`, `runMitigatedBaseline`, and related config types).
> 
> Adds a package-surface regression test to ensure these mitigated security harness symbols remain exported from the entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678fab45ec1b369b6f4527875ec7dd00d62ed5c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->