### PR TITLE
fix(import-supermemory): reject malformed memory entries

### DIFF
--- a/packages/import-supermemory/src/parser.test.ts
+++ b/packages/import-supermemory/src/parser.test.ts
@@ -51,6 +51,27 @@ describe("parseSupermemoryExport", () => {
     );
   });
 
+  it("throws when a memory array entry is malformed", () => {
+    assert.throws(
+      () => parseSupermemoryExport({ memories: [null, { id: "m1", content: "hello" }] }),
+      /Supermemory export entry memories\[0\] must be an object record; received null\./,
+    );
+  });
+
+  it("throws with the top-level array index for malformed top-level entries", () => {
+    assert.throws(
+      () => parseSupermemoryExport([{ id: "m1", content: "hello" }, "lost"]),
+      /Supermemory export entry \[1\] must be an object record; received string\./,
+    );
+  });
+
+  it("throws when a memory array entry is an array instead of a record", () => {
+    assert.throws(
+      () => parseSupermemoryExport({ data: [[{ id: "nested" }]] }),
+      /Supermemory export entry data\[0\] must be an object record; received array\./,
+    );
+  });
+
   it("consumes only first matching key to avoid duplicates", () => {
     const parsed = parseSupermemoryExport({
       memories: [{ id: "m1", content: "hello" }],

--- a/packages/import-supermemory/src/parser.ts
+++ b/packages/import-supermemory/src/parser.ts
@@ -25,7 +25,7 @@ export function parseSupermemoryExport(input: unknown, filePath?: string): Parse
   const memories: SupermemoryRecord[] = [];
 
   if (Array.isArray(raw)) {
-    append(memories, raw);
+    append(memories, raw, "");
     return { memories, ...(filePath ? { importedFromPath: filePath } : {}) };
   } else if (raw && typeof raw === "object") {
     const obj = raw as Record<string, unknown>;
@@ -36,7 +36,7 @@ export function parseSupermemoryExport(input: unknown, filePath?: string): Parse
         if (!Array.isArray(obj[key])) {
           throw new Error(`Supermemory export key '${key}' must be an array.`);
         }
-        append(memories, obj[key] as unknown[]);
+        append(memories, obj[key] as unknown[], key);
         return { memories, ...(filePath ? { importedFromPath: filePath } : {}) };
       }
     }
@@ -50,9 +50,15 @@ export function parseSupermemoryExport(input: unknown, filePath?: string): Parse
   throw new Error(`Supermemory export must be a JSON array or object; received ${describeType(raw)}.`);
 }
 
-function append(dest: SupermemoryRecord[], src: unknown[]): void {
-  for (const item of src) {
-    if (item && typeof item === "object") dest.push(item as SupermemoryRecord);
+function append(dest: SupermemoryRecord[], src: unknown[], key: string): void {
+  for (const [index, item] of src.entries()) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      const location = key ? `${key}[${index}]` : `[${index}]`;
+      throw new Error(
+        `Supermemory export entry ${location} must be an object record; received ${describeType(item)}.`,
+      );
+    }
+    dest.push(item as SupermemoryRecord);
   }
 }
 
@@ -70,5 +76,6 @@ function coerceJson(input: unknown): unknown {
 
 function describeType(value: unknown): string {
   if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
   return typeof value;
 }


### PR DESCRIPTION
## Summary
- reject malformed Supermemory array entries instead of silently dropping them
- include source key/index context in parser errors
- add parser regression tests for null, primitive, and nested-array entries

Clawpatch finding: fnd_sig-feat-library-4f2bee553d-0415_3fc94648b1

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx --test packages/import-supermemory/src/parser.test.ts
- pnpm --filter @remnic/import-supermemory run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to stricter input validation and improved error messages in the Supermemory import parser, plus added tests. Main behavior change is that previously ignored malformed entries will now fail the import.
> 
> **Overview**
> **Supermemory import parsing is now strict about entry shape.** `parseSupermemoryExport` now throws when any memory entry is `null`, a primitive, or an array (instead of silently skipping), and error messages include the source key and array index (e.g., `memories[0]` or `[1]`).
> 
> Adds regression tests covering malformed entries for both top-level array exports and object exports under recognized keys (`memories`, `data`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16168b99eda197c36f4f541a1f808e91500b0224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->