### PR TITLE
fix(bench): cover semantic surprise flushes

### DIFF
--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/fixture.ts
@@ -69,6 +69,21 @@ export const BUFFER_SURPRISE_TRIGGER_FIXTURE: BufferSurpriseTriggerCase[] = [
     topicShiftTurnIndices: [6],
   },
   {
+    id: "cue-free-cooking-to-astronomy",
+    turns: [
+      "I'm refining a mushroom risotto recipe with arborio rice and vegetable stock.",
+      "The pan absorbs liquid slowly when I add one ladle at a time.",
+      "Toasted rice grains help the final texture stay creamy without turning mushy.",
+      "Finishing with parmesan and butter gives the sauce a glossy texture.",
+      // Topic shift: cooking -> astronomy, intentionally without a lexical pivot cue.
+      "Jupiter's magnetosphere traps charged particles across a vast radiation belt.",
+      "Rapid planetary rotation and metallic hydrogen can power a strong dynamo.",
+      "The polar auroras brighten when solar wind particles interact with the field.",
+      "Spacecraft have measured intense radiation around the inner moons.",
+    ],
+    topicShiftTurnIndices: [4],
+  },
+  {
     id: "music-to-gardening-to-finance",
     turns: [
       "I've been learning the blues scale on guitar this week.",

--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.test.ts
@@ -147,6 +147,30 @@ test("candidate flushes exactly at annotated topic shifts on the full fixture", 
   }
 });
 
+test("candidate flushes on a cue-free semantic topic shift", async () => {
+  const options: ResolvedRunBenchmarkOptions = {
+    mode: "full",
+    benchmark: bufferSurpriseTriggerDefinition,
+    system: noopAdapter(),
+  };
+  const result = await runBufferSurpriseTriggerBenchmark(options);
+  const task = result.results.tasks.find(
+    (item) => item.taskId === "cue-free-cooking-to-astronomy",
+  );
+  assert.ok(task, "expected cue-free semantic shift task");
+
+  const details = task.details as {
+    candidateFlushTurnIndices?: number[];
+    controlFlushTurnIndices?: number[];
+    topicShiftTurnIndices?: number[];
+  };
+  assert.deepEqual(details.topicShiftTurnIndices, [4]);
+  assert.deepEqual(details.candidateFlushTurnIndices, [4]);
+  assert.deepEqual(details.controlFlushTurnIndices, []);
+  assert.equal(task.scores.candidate_topic_shift_f1, 1);
+  assert.equal(task.scores.control_topic_shift_f1, 0);
+});
+
 // ---------------------------------------------------------------------------
 // topicShiftF1 unit tests
 // ---------------------------------------------------------------------------

--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.ts
@@ -22,10 +22,11 @@
  * That means its results are stable across machines and seeds, but it
  * CANNOT stand in for a production semantic embedder. Sparse hash
  * embeddings over short English turns can over-fire on mundane follow-up
- * questions, so this benchmark only lets explicit topic-pivot turns cross
- * the calibrated flush threshold. The semantic score remains in the
- * probe as a deterministic regression signal, capped below the flush
- * threshold so it cannot swamp the discourse-boundary cue.
+ * questions, so this benchmark only lets explicit topic-pivot turns and
+ * very strong semantic novelty cross the calibrated flush threshold. The
+ * semantic score remains capped for ordinary turns so it cannot swamp the
+ * discourse-boundary cue, while one cue-free fixture verifies that the
+ * semantic path can independently trigger.
  *
  * Per #563's PR 4 scope, the production default stays `false` in this
  * PR. Flipping it requires a real-embedder benchmark run, which is
@@ -320,9 +321,10 @@ async function runSingleCase(
     bufferSurpriseTriggerEnabled: options.surpriseEnabled,
     // Benchmark threshold is tuned higher than the package default
     // (0.35). The deterministic probe reserves scores above this line
-    // for explicit topic-pivot turns; raw hash-semantic novelty is capped
-    // below it because sparse vocabulary overlap in short English turns
-    // otherwise over-fires on ordinary follow-ups.
+    // for explicit topic-pivot turns and very strong semantic novelty;
+    // weaker hash-semantic novelty is capped below it because sparse
+    // vocabulary overlap in short English turns otherwise over-fires on
+    // ordinary follow-ups.
     bufferSurpriseThreshold: 0.85,
     bufferSurpriseK: 3,
     bufferSurpriseRecentMemoryCount: 20,
@@ -351,6 +353,9 @@ async function runSingleCase(
         })),
         { embedFn: embed, k: 3 },
       );
+      if (recentTurns.length >= 4 && semanticSurprise >= 0.92) {
+        return semanticSurprise;
+      }
       return Math.min(semanticSurprise, 0.8);
     },
   };


### PR DESCRIPTION
## Summary
- add a cue-free buffer-surprise fixture where semantic novelty, not pivot wording, should trigger the flush
- allow only very strong deterministic semantic surprise with enough context to cross the benchmark threshold
- add regression coverage proving the candidate flushes at the cue-free semantic shift while control does not

Clawpatch finding: fnd_sig-feat-library-10e9655f37-8b50_3ac0340492

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx --test packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.test.ts
- pnpm --filter @remnic/bench run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts benchmark probe scoring and adds a new fixture/test case; risk is moderate because it changes benchmark behavior/expectations and could affect CI performance signals, but it is isolated to the bench harness (not production runtime).
> 
> **Overview**
> Adds a new cue-free conversation fixture (`cue-free-cooking-to-astronomy`) to ensure the buffer surprise benchmark can flush on **semantic novelty alone**, not just explicit pivot phrases.
> 
> Updates the benchmark probe in `runner.ts` to allow only *very strong* semantic surprise (with sufficient prior context) to exceed the flush threshold, while continuing to cap ordinary semantic scores so they don’t swamp pivot-cue detection.
> 
> Extends `runner.test.ts` with a regression test asserting the **candidate** flushes exactly at the cue-free shift while the **control** does not, and updates benchmark documentation/comments to reflect the new semantic-trigger path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96644214494e8aefb558eeae30846478795a86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->