### PR TITLE
fix(core): filter review items before limiting

### DIFF
--- a/packages/remnic-core/src/review/index.test.ts
+++ b/packages/remnic-core/src/review/index.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import type { TestContext } from "node:test";
-import { performReview } from "./index.js";
+import { listReviewItems, performReview, type ReviewItem } from "./index.js";
 
 async function makeMemoryDir(t: TestContext): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-review-"));
@@ -12,7 +12,10 @@ async function makeMemoryDir(t: TestContext): Promise<string> {
   return dir;
 }
 
-function reviewMarkdown(id: string): string {
+function reviewMarkdown(
+  id: string,
+  reviewReason: ReviewItem["reviewReason"] = "low_confidence",
+): string {
   return `---
 id: ${id}
 category: fact
@@ -20,10 +23,30 @@ confidence: 0.4
 confidenceTier: low
 source: test
 created: 2026-05-17T00:00:00.000Z
-reviewReason: low_confidence
+reviewReason: ${reviewReason}
 ---
 Candidate memory.`;
 }
+
+test("listReviewItems applies reason filtering before enforcing the limit", async (t) => {
+  const memoryDir = await makeMemoryDir(t);
+  const suggestionsDir = path.join(memoryDir, "suggestions");
+  const reviewDir = path.join(memoryDir, "review");
+  await mkdir(suggestionsDir, { recursive: true });
+  await mkdir(reviewDir, { recursive: true });
+  await writeFile(path.join(suggestionsDir, "first.md"), reviewMarkdown("suggestion-1", "suggestion"), "utf8");
+  await writeFile(path.join(suggestionsDir, "second.md"), reviewMarkdown("suggestion-2", "suggestion"), "utf8");
+  await writeFile(path.join(reviewDir, "contradiction.md"), reviewMarkdown("matching-review", "contradiction"), "utf8");
+
+  const result = listReviewItems({
+    memoryDir,
+    reason: "contradiction",
+    limit: 1,
+  });
+
+  assert.deepEqual(result.items.map((item) => item.id), ["matching-review"]);
+  assert.equal(result.total, 1);
+});
 
 test("approve promotes to the source basename when no target exists", async (t) => {
   const memoryDir = await makeMemoryDir(t);

--- a/packages/remnic-core/src/review/index.ts
+++ b/packages/remnic-core/src/review/index.ts
@@ -82,6 +82,11 @@ export function listReviewItems(options: ReviewOptions): ReviewListResult {
   } = options;
 
   const items: ReviewItem[] = [];
+  const addItem = (item: ReviewItem): void => {
+    if (items.length >= limit) return;
+    if (filterReason && item.reviewReason !== filterReason) return;
+    items.push(item);
+  };
 
   // Check suggestions directory
   const suggestionsDir = path.join(memoryDir, "suggestions");
@@ -93,7 +98,7 @@ export function listReviewItems(options: ReviewOptions): ReviewListResult {
       const body = extractBody(content);
       if (!fm?.id) return;
 
-      items.push({
+      addItem({
         id: fm.id as string,
         content: body,
         category: (fm.category as string) ?? "suggestion",
@@ -117,7 +122,7 @@ export function listReviewItems(options: ReviewOptions): ReviewListResult {
       const body = extractBody(content);
       if (!fm?.id) return;
 
-      items.push({
+      addItem({
         id: fm.id as string,
         content: body,
         category: (fm.category as string) ?? "review",
@@ -153,7 +158,7 @@ export function listReviewItems(options: ReviewOptions): ReviewListResult {
       // Skip if already in items
       if (items.some((i) => i.id === fm.id)) return;
 
-      items.push({
+      addItem({
         id: fm.id as string,
         content: body,
         category: (fm.category as string) ?? category.slice(0, -1),
@@ -167,14 +172,9 @@ export function listReviewItems(options: ReviewOptions): ReviewListResult {
     });
   }
 
-  // Filter by reason
-  const filtered = filterReason
-    ? items.filter((i) => i.reviewReason === filterReason)
-    : items;
-
   return {
-    items: filtered.slice(0, limit),
-    total: filtered.length,
+    items,
+    total: items.length,
     durationMs: Date.now() - startTime,
   };
 }


### PR DESCRIPTION
## Summary
- apply review reason filtering before a candidate consumes the list limit
- keep the existing limited-result behavior while scanning past non-matching earlier items
- add regression coverage for a matching review item after non-matching suggestions with limit 1

Clawpatch finding: fnd_sig-feat-library-0cbdccb48f-588b_557309a666

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx --test packages/remnic-core/src/review/index.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- pnpm rebuild better-sqlite3
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small behavioral fix to `listReviewItems` ordering that only affects which review items are returned under a reason filter + limit combination.
> 
> **Overview**
> Fixes `listReviewItems` so the `reason` filter is applied *before* consuming the `limit`, ensuring matching items aren’t dropped when earlier scanned items have a different `reviewReason`.
> 
> Adds a regression test covering the case where non-matching suggestions appear before a matching review item with `limit: 1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb1c02b7d49325c7cf6e9ada47f1e14825a380a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->