### PR TITLE
fix(core): review category items in place

### DIFF
--- a/packages/remnic-core/src/review/index.test.ts
+++ b/packages/remnic-core/src/review/index.test.ts
@@ -48,6 +48,117 @@ test("listReviewItems applies reason filtering before enforcing the limit", asyn
   assert.equal(result.total, 1);
 });
 
+test("flag updates low-confidence category items returned by listReviewItems", async (t) => {
+  const memoryDir = await makeMemoryDir(t);
+  const factsDir = path.join(memoryDir, "facts", "2026-05-17");
+  await mkdir(factsDir, { recursive: true });
+  const memoryPath = path.join(factsDir, "low.md");
+  await writeFile(memoryPath, reviewMarkdown("low-category-flag"), "utf8");
+
+  assert.deepEqual(
+    listReviewItems({ memoryDir }).items.map((item) => item.id),
+    ["low-category-flag"],
+  );
+
+  const result = performReview(memoryDir, "low-category-flag", "flag");
+
+  assert.equal(result.updatedPath, memoryPath);
+  const updated = await readFile(memoryPath, "utf8");
+  assert.match(updated, /flagged: true/);
+  assert.match(updated, /flaggedAt: /);
+});
+
+test("approve raises low-confidence category item confidence in place", async (t) => {
+  const memoryDir = await makeMemoryDir(t);
+  const factsDir = path.join(memoryDir, "facts", "2026-05-17");
+  await mkdir(factsDir, { recursive: true });
+  const memoryPath = path.join(factsDir, "low.md");
+  await writeFile(memoryPath, reviewMarkdown("low-category-approve"), "utf8");
+
+  const result = performReview(memoryDir, "low-category-approve", "approve");
+
+  assert.equal(result.updatedPath, memoryPath);
+  const updated = await readFile(memoryPath, "utf8");
+  assert.match(updated, /confidence: 0\.9/);
+  assert.match(updated, /confidenceTier: high/);
+  assert.equal(listReviewItems({ memoryDir }).items.some((item) => item.id === "low-category-approve"), false);
+});
+
+test("dismiss marks low-confidence category items without deleting memory files", async (t) => {
+  const memoryDir = await makeMemoryDir(t);
+  const factsDir = path.join(memoryDir, "facts", "2026-05-17");
+  await mkdir(factsDir, { recursive: true });
+  const memoryPath = path.join(factsDir, "low.md");
+  await writeFile(memoryPath, reviewMarkdown("low-category-dismiss"), "utf8");
+
+  const result = performReview(memoryDir, "low-category-dismiss", "dismiss");
+
+  assert.equal(result.updatedPath, memoryPath);
+  await stat(memoryPath);
+  const updated = await readFile(memoryPath, "utf8");
+  assert.match(updated, /reviewDismissed: true/);
+  assert.equal(listReviewItems({ memoryDir }).items.some((item) => item.id === "low-category-dismiss"), false);
+});
+
+test("review actions do not mutate category memories that are not pending review", async (t) => {
+  const memoryDir = await makeMemoryDir(t);
+  const factsDir = path.join(memoryDir, "facts", "2026-05-17");
+  await mkdir(factsDir, { recursive: true });
+  const memoryPath = path.join(factsDir, "high.md");
+  const original = `---
+id: high-category
+category: fact
+confidence: 0.98
+confidenceTier: high
+source: test
+created: 2026-05-17T00:00:00.000Z
+---
+Reviewed memory.`;
+  await writeFile(memoryPath, original, "utf8");
+
+  assert.deepEqual(listReviewItems({ memoryDir }).items, []);
+
+  const result = performReview(memoryDir, "high-category", "approve");
+
+  assert.equal(result.message, "Item not found");
+  assert.equal(await readFile(memoryPath, "utf8"), original);
+});
+
+test("review actions can use the same custom confidence threshold as listReviewItems", async (t) => {
+  const memoryDir = await makeMemoryDir(t);
+  const factsDir = path.join(memoryDir, "facts", "2026-05-17");
+  await mkdir(factsDir, { recursive: true });
+  const memoryPath = path.join(factsDir, "medium.md");
+  await writeFile(
+    memoryPath,
+    `---
+id: medium-category
+category: fact
+confidence: 0.82
+confidenceTier: medium
+source: test
+created: 2026-05-17T00:00:00.000Z
+---
+Medium confidence memory.`,
+    "utf8",
+  );
+
+  assert.deepEqual(
+    listReviewItems({ memoryDir, confidenceThreshold: 0.9 }).items.map((item) => item.id),
+    ["medium-category"],
+  );
+  assert.equal(performReview(memoryDir, "medium-category", "approve").message, "Item not found");
+
+  const result = performReview(memoryDir, "medium-category", "approve", {
+    confidenceThreshold: 0.9,
+  });
+
+  assert.equal(result.updatedPath, memoryPath);
+  const updated = await readFile(memoryPath, "utf8");
+  assert.match(updated, /confidence: 0\.9/);
+  assert.match(updated, /confidenceTier: high/);
+});
+
 test("approve promotes to the source basename when no target exists", async (t) => {
   const memoryDir = await makeMemoryDir(t);
   const reviewDir = path.join(memoryDir, "review");

--- a/packages/remnic-core/src/review/index.ts
+++ b/packages/remnic-core/src/review/index.ts
@@ -67,6 +67,18 @@ export interface ReviewOptions {
   confidenceThreshold?: number;
 }
 
+export interface ReviewActionOptions {
+  /** Match the threshold used when listing review items (default: 0.7) */
+  confidenceThreshold?: number;
+}
+
+interface ReviewFileMatch {
+  filePath: string;
+  location: "queue" | "category";
+}
+
+const DEFAULT_CONFIDENCE_THRESHOLD = 0.7;
+
 // ── Main functions ───────────────────────────────────────────────────────────
 
 /**
@@ -78,7 +90,7 @@ export function listReviewItems(options: ReviewOptions): ReviewListResult {
     memoryDir,
     reason: filterReason,
     limit = 50,
-    confidenceThreshold = 0.7,
+    confidenceThreshold = DEFAULT_CONFIDENCE_THRESHOLD,
   } = options;
 
   const items: ReviewItem[] = [];
@@ -154,6 +166,7 @@ export function listReviewItems(options: ReviewOptions): ReviewListResult {
 
       const confidence = parseConfidence(fm.confidence, 1);
       if (confidence >= confidenceThreshold) return;
+      if (parseBoolean(fm.reviewDismissed)) return;
 
       // Skip if already in items
       if (items.some((i) => i.id === fm.id)) return;
@@ -186,110 +199,183 @@ export function performReview(
   memoryDir: string,
   itemId: string,
   action: ReviewAction,
+  options: ReviewActionOptions = {},
 ): ReviewResult {
   switch (action) {
     case "approve":
-      return approveItem(memoryDir, itemId);
+      return approveItem(memoryDir, itemId, options);
     case "dismiss":
-      return dismissItem(memoryDir, itemId);
+      return dismissItem(memoryDir, itemId, options);
     case "flag":
-      return flagItem(memoryDir, itemId);
+      return flagItem(memoryDir, itemId, options);
   }
 }
 
 // ── Actions ──────────────────────────────────────────────────────────────────
 
-function approveItem(memoryDir: string, itemId: string): ReviewResult {
-  // Find the item in suggestions/ or review/
-  const locations = ["suggestions", "review"];
-  for (const loc of locations) {
-    const dir = path.join(memoryDir, loc);
-    if (!fs.existsSync(dir)) continue;
+function approveItem(
+  memoryDir: string,
+  itemId: string,
+  options: ReviewActionOptions,
+): ReviewResult {
+  const found = findReviewFileById(memoryDir, itemId, options);
+  if (!found) {
+    return { itemId, action: "approve", message: "Item not found" };
+  }
 
-    const found = findFileById(dir, itemId);
-    if (!found) continue;
+  const content = fs.readFileSync(found.filePath, "utf8");
+  const fm = parseFrontmatter(content);
+  if (!fm) return { itemId, action: "approve", message: "Could not parse frontmatter" };
 
-    const content = fs.readFileSync(found, "utf8");
-    const fm = parseFrontmatter(content);
-    if (!fm) return { itemId, action: "approve", message: "Could not parse frontmatter" };
+  const updatedContent = updateFrontmatterFields(content, {
+    confidence: "0.9",
+    confidenceTier: "high",
+    reviewDismissed: null,
+  });
 
-    // Promote to facts/ with boosted confidence
-    const category = (fm.category as string) ?? "fact";
-    const targetDir = getCategoryDir(memoryDir, category);
-    const dateDir = new Date().toISOString().split("T")[0];
-    const outputPath = path.join(targetDir, dateDir, path.basename(found));
-
-    // Update confidence in content
-    const updatedContent = content
-      .replace(/confidence: [\d.]+/, "confidence: 0.9")
-      .replace(/confidenceTier: \w+/, "confidenceTier: high");
-
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-    const promotedPath = writeFileWithoutClobber(outputPath, updatedContent, itemId);
-
-    // Remove from review
-    fs.unlinkSync(found);
-
+  if (found.location === "category") {
+    fs.writeFileSync(found.filePath, updatedContent, "utf8");
     return {
       itemId,
       action: "approve",
-      updatedPath: promotedPath,
-      message: `Promoted to ${category} with confidence 0.9`,
+      updatedPath: found.filePath,
+      message: "Approved low-confidence memory in place with confidence 0.9",
     };
   }
 
-  return { itemId, action: "approve", message: "Item not found" };
+  // Promote queued suggestions/review items to their category directory.
+  const category = (fm.category as string) ?? "fact";
+  const targetDir = getCategoryDir(memoryDir, category);
+  const dateDir = new Date().toISOString().split("T")[0];
+  const outputPath = path.join(targetDir, dateDir, path.basename(found.filePath));
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  const promotedPath = writeFileWithoutClobber(outputPath, updatedContent, itemId);
+
+  // Remove from review
+  fs.unlinkSync(found.filePath);
+
+  return {
+    itemId,
+    action: "approve",
+    updatedPath: promotedPath,
+    message: `Promoted to ${category} with confidence 0.9`,
+  };
 }
 
-function dismissItem(memoryDir: string, itemId: string): ReviewResult {
-  const locations = ["suggestions", "review"];
-  for (const loc of locations) {
-    const dir = path.join(memoryDir, loc);
-    if (!fs.existsSync(dir)) continue;
-
-    const found = findFileById(dir, itemId);
-    if (found) {
-      fs.unlinkSync(found);
-      return { itemId, action: "dismiss", message: "Dismissed and removed" };
-    }
+function dismissItem(
+  memoryDir: string,
+  itemId: string,
+  options: ReviewActionOptions,
+): ReviewResult {
+  const found = findReviewFileById(memoryDir, itemId, options);
+  if (!found) {
+    return { itemId, action: "dismiss", message: "Item not found" };
   }
 
-  return { itemId, action: "dismiss", message: "Item not found" };
+  if (found.location === "queue") {
+    fs.unlinkSync(found.filePath);
+    return { itemId, action: "dismiss", message: "Dismissed and removed" };
+  }
+
+  const content = fs.readFileSync(found.filePath, "utf8");
+  fs.writeFileSync(
+    found.filePath,
+    updateFrontmatterFields(content, {
+      reviewDismissed: "true",
+      reviewDismissedAt: new Date().toISOString(),
+    }),
+    "utf8",
+  );
+  return {
+    itemId,
+    action: "dismiss",
+    updatedPath: found.filePath,
+    message: "Dismissed low-confidence memory in place",
+  };
 }
 
-function flagItem(memoryDir: string, itemId: string): ReviewResult {
-  const locations = ["suggestions", "review"];
-  for (const loc of locations) {
-    const dir = path.join(memoryDir, loc);
-    if (!fs.existsSync(dir)) continue;
-
-    const found = findFileById(dir, itemId);
-    if (found) {
-      // Add flagged marker to frontmatter
-      const content = fs.readFileSync(found, "utf8");
-      const fixed = content.replace(
-        /^(---\n)/,
-        `---\nflagged: true\nflaggedAt: ${new Date().toISOString()}\n`,
-      );
-      fs.writeFileSync(found, fixed);
-      return { itemId, action: "flag", message: "Flagged for further review" };
-    }
+function flagItem(
+  memoryDir: string,
+  itemId: string,
+  options: ReviewActionOptions,
+): ReviewResult {
+  const found = findReviewFileById(memoryDir, itemId, options);
+  if (!found) {
+    return { itemId, action: "flag", message: "Item not found" };
   }
 
-  return { itemId, action: "flag", message: "Item not found" };
+  const content = fs.readFileSync(found.filePath, "utf8");
+  const fixed = updateFrontmatterFields(content, {
+    flagged: "true",
+    flaggedAt: new Date().toISOString(),
+  });
+  fs.writeFileSync(found.filePath, fixed);
+  return {
+    itemId,
+    action: "flag",
+    updatedPath: found.filePath,
+    message: "Flagged for further review",
+  };
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function findFileById(dir: string, id: string): string | null {
+function findReviewFileById(
+  memoryDir: string,
+  id: string,
+  options: ReviewActionOptions = {},
+): ReviewFileMatch | null {
+  for (const loc of ["suggestions", "review"]) {
+    const dir = path.join(memoryDir, loc);
+    if (!fs.existsSync(dir)) continue;
+
+    const found = findFileById(dir, id);
+    if (found) return { filePath: found, location: "queue" };
+  }
+
+  for (const category of ALL_CATEGORY_DIRS) {
+    const dir = path.join(memoryDir, category);
+    if (!fs.existsSync(dir)) continue;
+
+    const found = findFileById(dir, id, (fm) => isLowConfidenceReviewCandidate(fm, options));
+    if (found) return { filePath: found, location: "category" };
+  }
+
+  return null;
+}
+
+function findFileById(
+  dir: string,
+  id: string,
+  include?: (frontmatter: Record<string, unknown>) => boolean,
+): string | null {
   const files = walkMdPaths(dir);
   for (const filePath of files) {
     const content = readFileSafe(filePath);
     if (!content) continue;
     const fm = parseFrontmatter(content);
-    if (fm?.id === id) return filePath;
+    if (fm?.id === id && (!include || include(fm))) return filePath;
   }
   return null;
+}
+
+function isLowConfidenceReviewCandidate(
+  fm: Record<string, unknown>,
+  options: ReviewActionOptions,
+): boolean {
+  const threshold = options.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD;
+  return (
+    parseConfidence(fm.confidence, 1) < threshold &&
+    !parseBoolean(fm.reviewDismissed)
+  );
+}
+
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "true" || normalized === "1" || normalized === "yes";
 }
 
 function parseConfidence(value: unknown, fallback: number): number {
@@ -299,6 +385,43 @@ function parseConfidence(value: unknown, fallback: number): number {
     return Number.isFinite(n) ? n : fallback;
   }
   return fallback;
+}
+
+function updateFrontmatterFields(
+  content: string,
+  fields: Record<string, string | null>,
+): string {
+  const match = content.match(/^(---\n)([\s\S]*?)(\n---(?:\n|$))/);
+  if (!match) return content;
+
+  const seen = new Set<string>();
+  const lines = match[2].split("\n");
+  const nextLines: string[] = [];
+  for (const line of lines) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) {
+      nextLines.push(line);
+      continue;
+    }
+    const key = line.slice(0, colonIdx).trim();
+    if (!Object.prototype.hasOwnProperty.call(fields, key)) {
+      nextLines.push(line);
+      continue;
+    }
+    seen.add(key);
+    const value = fields[key];
+    if (value !== null) {
+      nextLines.push(`${key}: ${value}`);
+    }
+  }
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== null && !seen.has(key)) {
+      nextLines.push(`${key}: ${value}`);
+    }
+  }
+
+  return `${match[1]}${nextLines.join("\n")}${match[3]}${content.slice(match[0].length)}`;
 }
 
 function readFileSafe(filePath: string): string | null {


### PR DESCRIPTION
## Summary
- resolve review actions through the same queue/category sources returned by listReviewItems
- update low-confidence category items in place for approve/flag/dismiss instead of returning "Item not found"
- add regression coverage for flag, approve, and dismiss on category-backed review items

Clawpatch finding: fnd_sig-feat-library-0cbdccb48f-fedc_72c650f7f5

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx --test packages/remnic-core/src/review/index.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- node scripts/ensure-better-sqlite3.mjs
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes review actions to mutate existing category memory files (approve/dismiss/flag) instead of only operating on queued items, which could affect user data on disk if IDs or thresholds are misapplied. Adds new frontmatter editing logic and dismissal filtering that should be validated across real-world frontmatter formats.
> 
> **Overview**
> `performReview` now resolves items from both the review queues (`suggestions/`, `review/`) **and** low-confidence category memories returned by `listReviewItems`, using a shared confidence-threshold option.
> 
> For category-backed items, review actions are applied **in place**: `approve` bumps confidence to `0.9`/`high`, `dismiss` marks `reviewDismissed` (+ timestamp) without deleting the file, and `flag` writes `flagged` (+ timestamp). `listReviewItems` also skips previously dismissed category items.
> 
> Adds regression tests covering flag/approve/dismiss behavior on category files, non-mutation of already-reviewed (high-confidence) items, and matching custom confidence thresholds between listing and actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3198377ddc60155039aec1c4220a63573c677ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->