### PR TITLE
fix(core): reconcile live connector cron cadence

### DIFF
--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -72,23 +72,73 @@ export async function ensureCronJob(
   jobsPath: string,
   jobId: string,
   buildJob: () => Record<string, unknown>,
-): Promise<{ created: boolean; jobId: string }> {
+  options: { updateExisting?: boolean; updateFields?: string[] } = {},
+): Promise<{ created: boolean; updated: boolean; jobId: string }> {
   const releaseLock = await acquireCronJobsLock(jobsPath);
   try {
     const raw = await readFile(jobsPath, "utf-8");
     const { parsed, jobs } = parseCronJobsShape(raw);
 
-    if (jobs.some((job) => job.id === jobId)) {
-      return { created: false, jobId };
+    const existingIndex = jobs.findIndex((job) => job.id === jobId);
+    if (existingIndex >= 0) {
+      if (!options.updateExisting) {
+        return { created: false, updated: false, jobId };
+      }
+
+      const desired = buildJob();
+      const existing = jobs[existingIndex];
+      const next = mergeCronJobUpdate(existing, desired, options.updateFields);
+      if (stableJson(existing) === stableJson(next)) {
+        return { created: false, updated: false, jobId };
+      }
+
+      jobs[existingIndex] = next;
+      const output = Array.isArray(parsed) ? jobs : { ...parsed, jobs };
+      await writeCronJobsAtomic(jobsPath, output);
+      return { created: false, updated: true, jobId };
     }
 
     jobs.push(buildJob());
     const output = Array.isArray(parsed) ? jobs : { ...parsed, jobs };
     await writeCronJobsAtomic(jobsPath, output);
-    return { created: true, jobId };
+    return { created: true, updated: false, jobId };
   } finally {
     await releaseLock();
   }
+}
+
+function mergeCronJobUpdate(
+  existing: Record<string, unknown>,
+  desired: Record<string, unknown>,
+  updateFields?: string[],
+): Record<string, unknown> {
+  if (!updateFields) {
+    return desired;
+  }
+
+  const next = { ...existing };
+  for (const field of updateFields) {
+    if (Object.prototype.hasOwnProperty.call(desired, field)) {
+      next[field] = desired[field];
+    } else {
+      delete next[field];
+    }
+  }
+  return next;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJson(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
 }
 
 export async function ensureDaySummaryCron(

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,12 +363,12 @@ async function maybeRegisterLiveConnectorCron(orchestrator: Orchestrator): Promi
       log.debug("live connectors cron: jobs.json not found, skipping auto-register");
       return;
     }
-    const created = await ensureLiveConnectorCron(jobsPath, {
+    const result = await ensureLiveConnectorCron(jobsPath, {
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       connectors: orchestrator.config.connectors,
     });
-    if (created.created) {
-      log.info(`live connectors cron auto-registered (${created.jobId})`);
+    if (result.created || result.updated) {
+      log.info(`live connectors cron ${result.created ? "auto-registered" : "reconciled"} (${result.jobId})`);
     } else {
       log.debug("live connectors cron already exists, skipping auto-register");
     }

--- a/src/openclaw-live-connector-cron.ts
+++ b/src/openclaw-live-connector-cron.ts
@@ -13,7 +13,7 @@ export async function ensureLiveConnectorCron(
     connectors?: LiveConnectorsConfig;
     scheduleExpr?: string;
   },
-): Promise<{ created: boolean; jobId: string }> {
+): Promise<{ created: boolean; updated: boolean; jobId: string }> {
   const scheduleExpr =
     typeof options.scheduleExpr === "string" && options.scheduleExpr.trim().length > 0
       ? options.scheduleExpr.trim()
@@ -23,28 +23,33 @@ export async function ensureLiveConnectorCron(
       ? options.agentId.trim()
       : "main";
 
-  return ensureCronJob(jobsPath, LIVE_CONNECTOR_CRON_ID, () => ({
-    id: LIVE_CONNECTOR_CRON_ID,
-    agentId,
-    name: "Remnic Live Connectors (poll due sources)",
-    enabled: true,
-    schedule: {
-      kind: "cron",
-      expr: scheduleExpr,
-      tz: options.timezone,
-    },
-    sessionTarget: "isolated",
-    wakeMode: "now",
-    payload: {
-      kind: "agentTurn",
-      timeoutSeconds: 900,
-      thinking: "off",
-      message:
-        "You are OpenClaw automation. Call tool `engram.live_connectors_run` with empty params. " +
-        "If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
-    },
-    delivery: { mode: "none" },
-  }));
+  return ensureCronJob(
+    jobsPath,
+    LIVE_CONNECTOR_CRON_ID,
+    () => ({
+      id: LIVE_CONNECTOR_CRON_ID,
+      agentId,
+      name: "Remnic Live Connectors (poll due sources)",
+      enabled: true,
+      schedule: {
+        kind: "cron",
+        expr: scheduleExpr,
+        tz: options.timezone,
+      },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        timeoutSeconds: 900,
+        thinking: "off",
+        message:
+          "You are OpenClaw automation. Call tool `engram.live_connectors_run` with empty params. " +
+          "If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
+      },
+      delivery: { mode: "none" },
+    }),
+    { updateExisting: true, updateFields: ["agentId", "schedule", "payload"] },
+  );
 }
 
 export function liveConnectorCronExprForConfig(

--- a/tests/openclaw-live-connector-cron.test.ts
+++ b/tests/openclaw-live-connector-cron.test.ts
@@ -51,6 +51,98 @@ test("OpenClaw live connector cron uses one-minute base cadence when connectors 
   assert.equal(liveConnectorCronExprForConfig(connectors), "* * * * *");
 });
 
+test("OpenClaw live connector cron updates an existing default cadence when connectors become enabled", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "engram-live-connectors-cron-"));
+  const jobsPath = path.join(tempDir, "jobs.json");
+  try {
+    await writeFile(jobsPath, JSON.stringify({ version: 1, jobs: [] }, null, 2) + "\n", "utf-8");
+    await ensureLiveConnectorCron(jobsPath, { timezone: "UTC" });
+
+    const result = await ensureLiveConnectorCron(jobsPath, {
+      timezone: "UTC",
+      connectors: {
+        googleDrive: { enabled: true, pollIntervalMs: 60_000 },
+        notion: { enabled: false, pollIntervalMs: 60_000 },
+        gmail: { enabled: false, pollIntervalMs: 60_000 },
+        github: { enabled: false, pollIntervalMs: 60_000 },
+      } as any,
+    });
+
+    assert.equal(result.created, false);
+    assert.equal(result.updated, true);
+    const parsed = JSON.parse(await readFile(jobsPath, "utf-8")) as {
+      jobs: Array<{ id: string; schedule: { kind: string; expr: string; tz: string } }>;
+    };
+    const matchingJobs = parsed.jobs.filter((j) => j.id === "engram-live-connectors-sync");
+    assert.equal(matchingJobs.length, 1);
+    assert.deepEqual(matchingJobs[0].schedule, {
+      kind: "cron",
+      expr: "* * * * *",
+      tz: "UTC",
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("OpenClaw live connector cron preserves operator-owned fields when reconciling cadence", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "engram-live-connectors-cron-"));
+  const jobsPath = path.join(tempDir, "jobs.json");
+  try {
+    await writeFile(
+      jobsPath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "engram-live-connectors-sync",
+              agentId: "main",
+              name: "Operator edited live connector job",
+              enabled: true,
+              schedule: { kind: "cron", expr: "*/5 * * * *", tz: "UTC" },
+              sessionTarget: "current",
+              wakeMode: "deferred",
+              payload: { kind: "agentTurn", message: "old" },
+              delivery: { mode: "message", channelId: "ops" },
+              failureDelivery: { mode: "message", channelId: "alerts" },
+            },
+          ],
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf-8",
+    );
+
+    const result = await ensureLiveConnectorCron(jobsPath, {
+      timezone: "UTC",
+      connectors: {
+        googleDrive: { enabled: true, pollIntervalMs: 60_000 },
+        notion: { enabled: false, pollIntervalMs: 60_000 },
+        gmail: { enabled: false, pollIntervalMs: 60_000 },
+        github: { enabled: false, pollIntervalMs: 60_000 },
+      } as any,
+    });
+
+    assert.equal(result.created, false);
+    assert.equal(result.updated, true);
+    const parsed = JSON.parse(await readFile(jobsPath, "utf-8")) as {
+      jobs: Array<Record<string, unknown> & { id: string; schedule: { expr: string } }>;
+    };
+    const job = parsed.jobs.find((j) => j.id === "engram-live-connectors-sync");
+    assert.ok(job);
+    assert.equal(job.schedule.expr, "* * * * *");
+    assert.equal(job.name, "Operator edited live connector job");
+    assert.equal(job.sessionTarget, "current");
+    assert.equal(job.wakeMode, "deferred");
+    assert.deepEqual(job.delivery, { mode: "message", channelId: "ops" });
+    assert.deepEqual(job.failureDelivery, { mode: "message", channelId: "alerts" });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("OpenClaw live connector cron keeps five-minute default when no connector config is supplied", () => {
   assert.equal(liveConnectorCronExprForConfig(undefined), "*/5 * * * *");
 });


### PR DESCRIPTION
## Summary
- add opt-in cron upsert support for existing jobs whose desired definition changes
- update the live connector cron to reconcile schedule/agent/payload drift instead of returning the stale job unchanged
- cover enabling connectors after the default five-minute cron exists, ensuring the job updates to one-minute cadence without duplication

Clawpatch finding: fnd_sig-feat-library-08970f7337-e8b1_1375e765dc

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/openclaw-live-connector-cron.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- npm run check-types
- node scripts/ensure-better-sqlite3.mjs
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds opt-in cron job upsert/reconciliation that can rewrite existing `jobs.json` entries; while scoped and field-limited, mistakes could unintentionally alter operator-managed cron configuration.
> 
> **Overview**
> Ensures cron registration can now *reconcile* an existing job when the desired definition changes, instead of only creating-once. `ensureCronJob` gains an opt-in `updateExisting` mode with `updateFields`-scoped merging plus change detection, and returns an `updated` flag.
> 
> Updates the live connector cron auto-registration to upsert specific fields (`agentId`, `schedule`, `payload`) so cadence/definition drift is corrected without duplicating jobs, and adjusts logging to report "reconciled" vs "auto-registered". Adds tests covering cadence updates when connectors become enabled and preserving operator-owned fields during reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466a25be6d3d84c1c254f3f9f8e787c049a38c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->