### PR TITLE
fix(core): restrict judge training file permissions

### DIFF
--- a/packages/remnic-core/src/extraction-judge-training.ts
+++ b/packages/remnic-core/src/extraction-judge-training.ts
@@ -22,7 +22,7 @@
 
 import path from "node:path";
 import { homedir } from "node:os";
-import { appendFile, mkdir, readFile, readdir } from "node:fs/promises";
+import { appendFile, chmod, mkdir, readFile, readdir } from "node:fs/promises";
 import { log } from "./logger.js";
 import type { JudgeVerdictKind } from "./extraction-judge.js";
 
@@ -121,8 +121,12 @@ export async function recordJudgeTrainingPair(
   const dir = resolveTrainingDir(options);
   const filePath = trainingFilePathFor(dir, row.ts);
   try {
-    await mkdir(dir, { recursive: true });
-    await appendFile(filePath, `${JSON.stringify(row)}\n`, "utf-8");
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+    await appendFile(filePath, `${JSON.stringify(row)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    await chmod(filePath, 0o600);
   } catch (err) {
     log.debug(
       `extraction-judge-training: append failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,

--- a/tests/extraction-judge-training.test.ts
+++ b/tests/extraction-judge-training.test.ts
@@ -1,6 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile, mkdir, readdir } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+  mkdir,
+  readdir,
+} from "node:fs/promises";
 import path from "node:path";
 import { homedir, tmpdir } from "node:os";
 import {
@@ -66,6 +75,50 @@ test("PR 4: recordJudgeTrainingPair appends one row per day file", async () => {
     const day2 = await readFile(path.join(dir, "2026-04-11.jsonl"), "utf-8");
     assert.equal(day1.trim().split("\n").length, 2);
     assert.equal(day2.trim().split("\n").length, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 4: recordJudgeTrainingPair creates private training files", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX mode bits are not portable on Windows");
+    return;
+  }
+
+  const dir = await mkdirTmp();
+  try {
+    await recordJudgeTrainingPair(basePair(), {
+      enabled: true,
+      directory: dir,
+    });
+
+    const fileStat = await stat(path.join(dir, "2026-04-10.jsonl"));
+    assert.equal(fileStat.mode & 0o077, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 4: recordJudgeTrainingPair tightens existing permissive training files", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX mode bits are not portable on Windows");
+    return;
+  }
+
+  const dir = await mkdirTmp();
+  try {
+    const filePath = path.join(dir, "2026-04-10.jsonl");
+    await writeFile(filePath, "", { encoding: "utf-8", mode: 0o666 });
+    await chmod(filePath, 0o666);
+
+    await recordJudgeTrainingPair(basePair(), {
+      enabled: true,
+      directory: dir,
+    });
+
+    const fileStat = await stat(filePath);
+    assert.equal(fileStat.mode & 0o077, 0);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- create judge training directories with restrictive permissions
- append judge training JSONL rows with 0600 mode and tighten existing files after writes
- add POSIX regression tests for new and existing training file permissions

Clawpatch finding: fnd_sig-feat-library-0dfe449a13-f51e_ba9de6f043

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/extraction-judge-training.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- node scripts/ensure-better-sqlite3.mjs
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to filesystem permission hardening for opt-in local training logs plus POSIX-only regression tests; main risk is platform/umask quirks affecting write behavior.
> 
> **Overview**
> Hardens `recordJudgeTrainingPair` to create the judge-training directory as `0700` and ensure per-day JSONL files are private (`0600`), including explicitly `chmod`ing after appends to tighten any pre-existing permissive files.
> 
> Adds POSIX-only tests asserting the created and pre-existing training files end up with no group/other permissions (skipped on Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40d601b6c63089db9d3d2c937b254ea980498866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->