### PR TITLE
fix(bench): abort timed-out adapter phases

### DIFF
--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -146,6 +146,32 @@ test("timeout guard merges caller abort signal with phase timeout signal", async
   assert.equal(sawAbort, true);
 });
 
+test("timeout guard removes merged caller abort listeners after successful phases", async () => {
+  const adapter = makeAdapter();
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 100,
+  });
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const originalAdd = signal.addEventListener.bind(signal);
+  const originalRemove = signal.removeEventListener.bind(signal);
+  let activeAbortListeners = 0;
+  signal.addEventListener = ((type, listener, options) => {
+    if (type === "abort") activeAbortListeners += 1;
+    return originalAdd(type, listener, options);
+  }) as AbortSignal["addEventListener"];
+  signal.removeEventListener = ((type, listener, options) => {
+    if (type === "abort") activeAbortListeners -= 1;
+    return originalRemove(type, listener, options);
+  }) as AbortSignal["removeEventListener"];
+
+  await guarded.getStats("s", { signal });
+  await guarded.getStats("s", { signal });
+
+  assert.equal(activeAbortListeners, 0);
+});
+
 test("timeout guard forwards recall options", async () => {
   const adapter = makeAdapter();
   let forwardedAsOf = "";

--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -158,20 +158,18 @@ test("timeout guard removes merged caller abort listeners after successful phase
   const originalRemove = signal.removeEventListener.bind(signal);
   let activeAbortListeners = 0;
   const trackedAdd: AbortSignal["addEventListener"] = (
-    type: Parameters<AbortSignal["addEventListener"]>[0],
-    listener: Parameters<AbortSignal["addEventListener"]>[1],
-    options?: Parameters<AbortSignal["addEventListener"]>[2],
+    ...args: Parameters<AbortSignal["addEventListener"]>
   ) => {
+    const [type] = args;
     if (type === "abort") activeAbortListeners += 1;
-    return originalAdd(type, listener, options);
+    return originalAdd(...args);
   };
   const trackedRemove: AbortSignal["removeEventListener"] = (
-    type: Parameters<AbortSignal["removeEventListener"]>[0],
-    listener: Parameters<AbortSignal["removeEventListener"]>[1],
-    options?: Parameters<AbortSignal["removeEventListener"]>[2],
+    ...args: Parameters<AbortSignal["removeEventListener"]>
   ) => {
+    const [type] = args;
     if (type === "abort") activeAbortListeners -= 1;
-    return originalRemove(type, listener, options);
+    return originalRemove(...args);
   };
   signal.addEventListener = trackedAdd;
   signal.removeEventListener = trackedRemove;

--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -83,6 +83,69 @@ test("timeout guard aborts adapter phase work on timeout", async () => {
   assert.equal(delayedSideEffect, false);
 });
 
+test("timeout guard preserves caller abort signal without phase timeout", async () => {
+  const adapter = makeAdapter();
+  let sawAbort = false;
+  adapter.store = (_sessionId, _messages, control) =>
+    new Promise<never>((_, reject) => {
+      const signal = control?.signal;
+      const onAbort = () => {
+        sawAbort = true;
+        reject(signal?.reason);
+      };
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+  });
+  const controller = new AbortController();
+  const storePromise = guarded.store(
+    "s",
+    [{ role: "user", content: "hello" }],
+    { signal: controller.signal },
+  );
+
+  controller.abort(new Error("caller aborted"));
+
+  await assert.rejects(() => storePromise, /caller aborted/);
+  assert.equal(sawAbort, true);
+});
+
+test("timeout guard merges caller abort signal with phase timeout signal", async () => {
+  const adapter = makeAdapter();
+  let sawAbort = false;
+  adapter.search = (_query, _limit, _sessionId, control) =>
+    new Promise<never>((_, reject) => {
+      const signal = control?.signal;
+      const onAbort = () => {
+        sawAbort = true;
+        reject(signal?.reason);
+      };
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 1000,
+  });
+  const controller = new AbortController();
+  const searchPromise = guarded.search("q", 5, "s", {
+    signal: controller.signal,
+  });
+
+  controller.abort(new Error("caller aborted search"));
+
+  await assert.rejects(() => searchPromise, /caller aborted search/);
+  assert.equal(sawAbort, true);
+});
+
 test("timeout guard forwards recall options", async () => {
   const adapter = makeAdapter();
   let forwardedAsOf = "";
@@ -130,6 +193,74 @@ test("timeout guard wraps responder and judge calls", async () => {
     "answer",
   );
   assert.equal(await guarded.judge?.score("q", "p", "e"), 1);
+});
+
+test("timeout guard merges caller abort signal for responder calls", async () => {
+  const adapter = makeAdapter();
+  let sawAbort = false;
+  adapter.responder = {
+    respond(_question, _recalledText, control) {
+      return new Promise<never>((_, reject) => {
+        const signal = control?.signal;
+        const onAbort = () => {
+          sawAbort = true;
+          reject(signal?.reason);
+        };
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+  };
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 1000,
+  });
+  const controller = new AbortController();
+  const responsePromise = guarded.responder!.respond("q", "r", {
+    signal: controller.signal,
+  });
+
+  controller.abort(new Error("caller aborted responder"));
+
+  await assert.rejects(() => responsePromise, /caller aborted responder/);
+  assert.equal(sawAbort, true);
+});
+
+test("timeout guard merges caller abort signal for judge calls", async () => {
+  const adapter = makeAdapter();
+  let sawAbort = false;
+  adapter.judge = {
+    score(_question, _predicted, _expected, control) {
+      return new Promise<never>((_, reject) => {
+        const signal = control?.signal;
+        const onAbort = () => {
+          sawAbort = true;
+          reject(signal?.reason);
+        };
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+  };
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 1000,
+  });
+  const controller = new AbortController();
+  const scorePromise = guarded.judge!.score("q", "p", "e", {
+    signal: controller.signal,
+  });
+
+  controller.abort(new Error("caller aborted judge"));
+
+  await assert.rejects(() => scorePromise, /caller aborted judge/);
+  assert.equal(sawAbort, true);
 });
 
 test("timeout guard aborts responder phase work on timeout", async () => {

--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -157,14 +157,24 @@ test("timeout guard removes merged caller abort listeners after successful phase
   const originalAdd = signal.addEventListener.bind(signal);
   const originalRemove = signal.removeEventListener.bind(signal);
   let activeAbortListeners = 0;
-  signal.addEventListener = ((type, listener, options) => {
+  const trackedAdd: AbortSignal["addEventListener"] = (
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ) => {
     if (type === "abort") activeAbortListeners += 1;
     return originalAdd(type, listener, options);
-  }) as AbortSignal["addEventListener"];
-  signal.removeEventListener = ((type, listener, options) => {
+  };
+  const trackedRemove: AbortSignal["removeEventListener"] = (
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ) => {
     if (type === "abort") activeAbortListeners -= 1;
     return originalRemove(type, listener, options);
-  }) as AbortSignal["removeEventListener"];
+  };
+  signal.addEventListener = trackedAdd;
+  signal.removeEventListener = trackedRemove;
 
   await guarded.getStats("s", { signal });
   await guarded.getStats("s", { signal });

--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -158,17 +158,17 @@ test("timeout guard removes merged caller abort listeners after successful phase
   const originalRemove = signal.removeEventListener.bind(signal);
   let activeAbortListeners = 0;
   const trackedAdd: AbortSignal["addEventListener"] = (
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions,
+    type: Parameters<AbortSignal["addEventListener"]>[0],
+    listener: Parameters<AbortSignal["addEventListener"]>[1],
+    options?: Parameters<AbortSignal["addEventListener"]>[2],
   ) => {
     if (type === "abort") activeAbortListeners += 1;
     return originalAdd(type, listener, options);
   };
   const trackedRemove: AbortSignal["removeEventListener"] = (
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | EventListenerOptions,
+    type: Parameters<AbortSignal["removeEventListener"]>[0],
+    listener: Parameters<AbortSignal["removeEventListener"]>[1],
+    options?: Parameters<AbortSignal["removeEventListener"]>[2],
   ) => {
     if (type === "abort") activeAbortListeners -= 1;
     return originalRemove(type, listener, options);

--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -45,6 +45,44 @@ test("timeout guard rejects a stuck adapter phase", async () => {
   assert.equal(timedOutPhase, "timeout-test:recall session=s");
 });
 
+test("timeout guard aborts adapter phase work on timeout", async () => {
+  const adapter = makeAdapter();
+  let sawAbort = false;
+  let delayedSideEffect = false;
+  let sideEffectTimer: ReturnType<typeof setTimeout> | undefined;
+  adapter.store = (_sessionId, _messages, control) =>
+    new Promise<never>((_, reject) => {
+      sideEffectTimer = setTimeout(() => {
+        delayedSideEffect = true;
+      }, 25);
+      const signal = control?.signal;
+      const onAbort = () => {
+        sawAbort = true;
+        if (sideEffectTimer) {
+          clearTimeout(sideEffectTimer);
+        }
+        reject(signal?.reason);
+      };
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  const guarded = createTimeoutGuardedAdapter(adapter, {
+    benchmarkId: "timeout-test",
+    timeoutMs: 5,
+  });
+
+  await assert.rejects(
+    () => guarded.store("s", [{ role: "user", content: "hello" }]),
+    /benchmark phase timed out after 5ms: timeout-test:store session=s messages=1/,
+  );
+  assert.equal(sawAbort, true);
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  assert.equal(delayedSideEffect, false);
+});
+
 test("timeout guard forwards recall options", async () => {
   const adapter = makeAdapter();
   let forwardedAsOf = "";

--- a/packages/bench/src/adapters/timeout-guard.ts
+++ b/packages/bench/src/adapters/timeout-guard.ts
@@ -97,9 +97,14 @@ export function createTimeoutGuardedAdapter(
       if (phaseTimeoutMs === undefined) {
         return adapter.store(sessionId, messages, control);
       }
-      return run(`store session=${sessionId} messages=${messages.length}`, (signal) =>
-        adapter.store(sessionId, messages, mergeBenchPhaseControl(signal, control)),
-      );
+      return run(`store session=${sessionId} messages=${messages.length}`, async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await adapter.store(sessionId, messages, merged.control);
+        } finally {
+          merged.cleanup();
+        }
+      });
     },
     recall(
       sessionId: string,
@@ -111,15 +116,20 @@ export function createTimeoutGuardedAdapter(
       if (phaseTimeoutMs === undefined) {
         return adapter.recall(sessionId, query, budgetChars, recallOptions, control);
       }
-      return run(`recall session=${sessionId}`, (signal) =>
-        adapter.recall(
-          sessionId,
-          query,
-          budgetChars,
-          recallOptions,
-          mergeBenchPhaseControl(signal, control),
-        ),
-      );
+      return run(`recall session=${sessionId}`, async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await adapter.recall(
+            sessionId,
+            query,
+            budgetChars,
+            recallOptions,
+            merged.control,
+          );
+        } finally {
+          merged.cleanup();
+        }
+      });
     },
     search(
       query: string,
@@ -130,25 +140,40 @@ export function createTimeoutGuardedAdapter(
       if (phaseTimeoutMs === undefined) {
         return adapter.search(query, limit, sessionId, control);
       }
-      return run(`search session=${sessionId ?? "all"} limit=${limit}`, (signal) =>
-        adapter.search(query, limit, sessionId, mergeBenchPhaseControl(signal, control)),
-      );
+      return run(`search session=${sessionId ?? "all"} limit=${limit}`, async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await adapter.search(query, limit, sessionId, merged.control);
+        } finally {
+          merged.cleanup();
+        }
+      });
     },
     reset(sessionId?: string, control?: BenchPhaseControl): Promise<void> {
       if (phaseTimeoutMs === undefined) {
         return adapter.reset(sessionId, control);
       }
-      return run(`reset session=${sessionId ?? "all"}`, (signal) =>
-        adapter.reset(sessionId, mergeBenchPhaseControl(signal, control)),
-      );
+      return run(`reset session=${sessionId ?? "all"}`, async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await adapter.reset(sessionId, merged.control);
+        } finally {
+          merged.cleanup();
+        }
+      });
     },
     getStats(sessionId?: string, control?: BenchPhaseControl): Promise<MemoryStats> {
       if (phaseTimeoutMs === undefined) {
         return adapter.getStats(sessionId, control);
       }
-      return run(`stats session=${sessionId ?? "all"}`, (signal) =>
-        adapter.getStats(sessionId, mergeBenchPhaseControl(signal, control)),
-      );
+      return run(`stats session=${sessionId ?? "all"}`, async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await adapter.getStats(sessionId, merged.control);
+        } finally {
+          merged.cleanup();
+        }
+      });
     },
     destroy(): Promise<void> {
       return adapter.destroy();
@@ -161,7 +186,14 @@ export function createTimeoutGuardedAdapter(
         ? adapter.drain!(control)
         : run(
           "drain",
-          (signal) => adapter.drain!(mergeBenchPhaseControl(signal, control)),
+          async (signal) => {
+            const merged = mergeBenchPhaseControl(signal, control);
+            try {
+              return await adapter.drain!(merged.control);
+            } finally {
+              merged.cleanup();
+            }
+          },
           drainTimeoutMs,
         );
   }
@@ -182,35 +214,39 @@ export function createTimeoutGuardedAdapter(
 function mergeBenchPhaseControl(
   timeoutSignal: AbortSignal,
   callerControl: BenchPhaseControl | undefined,
-): BenchPhaseControl {
-  const signal = mergeAbortSignals(timeoutSignal, callerControl?.signal);
-  return signal === undefined ? {} : { signal };
+): { control: BenchPhaseControl; cleanup: () => void } {
+  const merged = mergeAbortSignals(timeoutSignal, callerControl?.signal);
+  return {
+    control: merged.signal === undefined ? {} : { signal: merged.signal },
+    cleanup: merged.cleanup,
+  };
 }
 
 function mergeAbortSignals(
   timeoutSignal: AbortSignal,
   callerSignal: AbortSignal | undefined,
-): AbortSignal | undefined {
-  if (!callerSignal) return timeoutSignal;
-  if (timeoutSignal.aborted) return timeoutSignal;
+): { signal: AbortSignal | undefined; cleanup: () => void } {
+  const noop = () => {};
+  if (!callerSignal) return { signal: timeoutSignal, cleanup: noop };
+  if (timeoutSignal.aborted) return { signal: timeoutSignal, cleanup: noop };
   if (callerSignal.aborted) {
-    return AbortSignal.abort(callerSignal.reason);
+    return { signal: AbortSignal.abort(callerSignal.reason), cleanup: noop };
   }
 
   const controller = new AbortController();
   const abortFromTimeout = () => controller.abort(timeoutSignal.reason);
   const abortFromCaller = () => controller.abort(callerSignal.reason);
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    timeoutSignal.removeEventListener("abort", abortFromTimeout);
+    callerSignal.removeEventListener("abort", abortFromCaller);
+  };
   timeoutSignal.addEventListener("abort", abortFromTimeout, { once: true });
   callerSignal.addEventListener("abort", abortFromCaller, { once: true });
-  controller.signal.addEventListener(
-    "abort",
-    () => {
-      timeoutSignal.removeEventListener("abort", abortFromTimeout);
-      callerSignal.removeEventListener("abort", abortFromCaller);
-    },
-    { once: true },
-  );
-  return controller.signal;
+  controller.signal.addEventListener("abort", cleanup, { once: true });
+  return { signal: controller.signal, cleanup };
 }
 
 export function createTimeoutGuardedIngestionAdapter(
@@ -285,9 +321,14 @@ function wrapResponder(
 ): BenchResponder {
   return {
     respond(question, recalledText, control) {
-      return run("respond", (signal) =>
-        responder.respond(question, recalledText, mergeBenchPhaseControl(signal, control)),
-      );
+      return run("respond", async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await responder.respond(question, recalledText, merged.control);
+        } finally {
+          merged.cleanup();
+        }
+      });
     },
   };
 }
@@ -298,29 +339,44 @@ function wrapJudge(
 ): BenchJudge {
   const wrapped: BenchJudge = {
     score(question, predicted, expected, control) {
-      return run("judge.score", (signal) =>
-        judge.score(question, predicted, expected, mergeBenchPhaseControl(signal, control)),
-      );
+      return run("judge.score", async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await judge.score(question, predicted, expected, merged.control);
+        } finally {
+          merged.cleanup();
+        }
+      });
     },
   };
 
   if (judge.scoreWithMetrics) {
     wrapped.scoreWithMetrics = (question, predicted, expected, control) =>
-      run("judge.scoreWithMetrics", (signal) =>
-        judge.scoreWithMetrics!(
-          question,
-          predicted,
-          expected,
-          mergeBenchPhaseControl(signal, control),
-        ),
-      );
+      run("judge.scoreWithMetrics", async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await judge.scoreWithMetrics!(
+            question,
+            predicted,
+            expected,
+            merged.control,
+          );
+        } finally {
+          merged.cleanup();
+        }
+      });
   }
 
   if (judge.scoreBinaryPrompt) {
     wrapped.scoreBinaryPrompt = (prompt, control) =>
-      run("judge.scoreBinaryPrompt", (signal) =>
-        judge.scoreBinaryPrompt!(prompt, mergeBenchPhaseControl(signal, control)),
-      );
+      run("judge.scoreBinaryPrompt", async (signal) => {
+        const merged = mergeBenchPhaseControl(signal, control);
+        try {
+          return await judge.scoreBinaryPrompt!(prompt, merged.control);
+        } finally {
+          merged.cleanup();
+        }
+      });
   }
 
   return wrapped;

--- a/packages/bench/src/adapters/timeout-guard.ts
+++ b/packages/bench/src/adapters/timeout-guard.ts
@@ -1,6 +1,7 @@
 import type {
   BenchJudge,
   BenchMemoryAdapter,
+  BenchPhaseControl,
   BenchRecallOptions,
   BenchResponder,
   MemoryStats,
@@ -88,12 +89,16 @@ export function createTimeoutGuardedAdapter(
   };
 
   const wrapped: BenchMemoryAdapter = {
-    store(sessionId: string, messages: Message[]): Promise<void> {
+    store(
+      sessionId: string,
+      messages: Message[],
+      control?: BenchPhaseControl,
+    ): Promise<void> {
       if (phaseTimeoutMs === undefined) {
-        return adapter.store(sessionId, messages);
+        return adapter.store(sessionId, messages, control);
       }
       return run(`store session=${sessionId} messages=${messages.length}`, (signal) =>
-        adapter.store(sessionId, messages, { signal }),
+        adapter.store(sessionId, messages, mergeBenchPhaseControl(signal, control)),
       );
     },
     recall(
@@ -101,40 +106,48 @@ export function createTimeoutGuardedAdapter(
       query: string,
       budgetChars?: number,
       recallOptions?: BenchRecallOptions,
+      control?: BenchPhaseControl,
     ): Promise<string> {
       if (phaseTimeoutMs === undefined) {
-        return adapter.recall(sessionId, query, budgetChars, recallOptions);
+        return adapter.recall(sessionId, query, budgetChars, recallOptions, control);
       }
       return run(`recall session=${sessionId}`, (signal) =>
-        adapter.recall(sessionId, query, budgetChars, recallOptions, { signal }),
+        adapter.recall(
+          sessionId,
+          query,
+          budgetChars,
+          recallOptions,
+          mergeBenchPhaseControl(signal, control),
+        ),
       );
     },
     search(
       query: string,
       limit: number,
       sessionId?: string,
+      control?: BenchPhaseControl,
     ): Promise<SearchResult[]> {
       if (phaseTimeoutMs === undefined) {
-        return adapter.search(query, limit, sessionId);
+        return adapter.search(query, limit, sessionId, control);
       }
       return run(`search session=${sessionId ?? "all"} limit=${limit}`, (signal) =>
-        adapter.search(query, limit, sessionId, { signal }),
+        adapter.search(query, limit, sessionId, mergeBenchPhaseControl(signal, control)),
       );
     },
-    reset(sessionId?: string): Promise<void> {
+    reset(sessionId?: string, control?: BenchPhaseControl): Promise<void> {
       if (phaseTimeoutMs === undefined) {
-        return adapter.reset(sessionId);
+        return adapter.reset(sessionId, control);
       }
       return run(`reset session=${sessionId ?? "all"}`, (signal) =>
-        adapter.reset(sessionId, { signal }),
+        adapter.reset(sessionId, mergeBenchPhaseControl(signal, control)),
       );
     },
-    getStats(sessionId?: string): Promise<MemoryStats> {
+    getStats(sessionId?: string, control?: BenchPhaseControl): Promise<MemoryStats> {
       if (phaseTimeoutMs === undefined) {
-        return adapter.getStats(sessionId);
+        return adapter.getStats(sessionId, control);
       }
       return run(`stats session=${sessionId ?? "all"}`, (signal) =>
-        adapter.getStats(sessionId, { signal }),
+        adapter.getStats(sessionId, mergeBenchPhaseControl(signal, control)),
       );
     },
     destroy(): Promise<void> {
@@ -143,10 +156,14 @@ export function createTimeoutGuardedAdapter(
   };
 
   if (adapter.drain) {
-    wrapped.drain = (): Promise<void> =>
+    wrapped.drain = (control?: BenchPhaseControl): Promise<void> =>
       drainTimeoutMs === undefined
-        ? adapter.drain!()
-        : run("drain", (signal) => adapter.drain!({ signal }), drainTimeoutMs);
+        ? adapter.drain!(control)
+        : run(
+          "drain",
+          (signal) => adapter.drain!(mergeBenchPhaseControl(signal, control)),
+          drainTimeoutMs,
+        );
   }
   if (adapter.responder) {
     wrapped.responder =
@@ -160,6 +177,40 @@ export function createTimeoutGuardedAdapter(
   }
 
   return wrapped;
+}
+
+function mergeBenchPhaseControl(
+  timeoutSignal: AbortSignal,
+  callerControl: BenchPhaseControl | undefined,
+): BenchPhaseControl {
+  const signal = mergeAbortSignals(timeoutSignal, callerControl?.signal);
+  return signal === undefined ? {} : { signal };
+}
+
+function mergeAbortSignals(
+  timeoutSignal: AbortSignal,
+  callerSignal: AbortSignal | undefined,
+): AbortSignal | undefined {
+  if (!callerSignal) return timeoutSignal;
+  if (timeoutSignal.aborted) return timeoutSignal;
+  if (callerSignal.aborted) {
+    return AbortSignal.abort(callerSignal.reason);
+  }
+
+  const controller = new AbortController();
+  const abortFromTimeout = () => controller.abort(timeoutSignal.reason);
+  const abortFromCaller = () => controller.abort(callerSignal.reason);
+  timeoutSignal.addEventListener("abort", abortFromTimeout, { once: true });
+  callerSignal.addEventListener("abort", abortFromCaller, { once: true });
+  controller.signal.addEventListener(
+    "abort",
+    () => {
+      timeoutSignal.removeEventListener("abort", abortFromTimeout);
+      callerSignal.removeEventListener("abort", abortFromCaller);
+    },
+    { once: true },
+  );
+  return controller.signal;
 }
 
 export function createTimeoutGuardedIngestionAdapter(
@@ -233,9 +284,9 @@ function wrapResponder(
   run: <T>(phase: string, fn: (signal: AbortSignal) => Promise<T>) => Promise<T>,
 ): BenchResponder {
   return {
-    respond(question, recalledText) {
+    respond(question, recalledText, control) {
       return run("respond", (signal) =>
-        responder.respond(question, recalledText, { signal }),
+        responder.respond(question, recalledText, mergeBenchPhaseControl(signal, control)),
       );
     },
   };
@@ -246,24 +297,29 @@ function wrapJudge(
   run: <T>(phase: string, fn: (signal: AbortSignal) => Promise<T>) => Promise<T>,
 ): BenchJudge {
   const wrapped: BenchJudge = {
-    score(question, predicted, expected) {
+    score(question, predicted, expected, control) {
       return run("judge.score", (signal) =>
-        judge.score(question, predicted, expected, { signal }),
+        judge.score(question, predicted, expected, mergeBenchPhaseControl(signal, control)),
       );
     },
   };
 
   if (judge.scoreWithMetrics) {
-    wrapped.scoreWithMetrics = (question, predicted, expected) =>
+    wrapped.scoreWithMetrics = (question, predicted, expected, control) =>
       run("judge.scoreWithMetrics", (signal) =>
-        judge.scoreWithMetrics!(question, predicted, expected, { signal }),
+        judge.scoreWithMetrics!(
+          question,
+          predicted,
+          expected,
+          mergeBenchPhaseControl(signal, control),
+        ),
       );
   }
 
   if (judge.scoreBinaryPrompt) {
-    wrapped.scoreBinaryPrompt = (prompt) =>
+    wrapped.scoreBinaryPrompt = (prompt, control) =>
       run("judge.scoreBinaryPrompt", (signal) =>
-        judge.scoreBinaryPrompt!(prompt, { signal }),
+        judge.scoreBinaryPrompt!(prompt, mergeBenchPhaseControl(signal, control)),
       );
   }
 

--- a/packages/bench/src/adapters/timeout-guard.ts
+++ b/packages/bench/src/adapters/timeout-guard.ts
@@ -92,8 +92,8 @@ export function createTimeoutGuardedAdapter(
       if (phaseTimeoutMs === undefined) {
         return adapter.store(sessionId, messages);
       }
-      return run(`store session=${sessionId} messages=${messages.length}`, () =>
-        adapter.store(sessionId, messages),
+      return run(`store session=${sessionId} messages=${messages.length}`, (signal) =>
+        adapter.store(sessionId, messages, { signal }),
       );
     },
     recall(
@@ -105,8 +105,8 @@ export function createTimeoutGuardedAdapter(
       if (phaseTimeoutMs === undefined) {
         return adapter.recall(sessionId, query, budgetChars, recallOptions);
       }
-      return run(`recall session=${sessionId}`, () =>
-        adapter.recall(sessionId, query, budgetChars, recallOptions),
+      return run(`recall session=${sessionId}`, (signal) =>
+        adapter.recall(sessionId, query, budgetChars, recallOptions, { signal }),
       );
     },
     search(
@@ -117,24 +117,24 @@ export function createTimeoutGuardedAdapter(
       if (phaseTimeoutMs === undefined) {
         return adapter.search(query, limit, sessionId);
       }
-      return run(`search session=${sessionId ?? "all"} limit=${limit}`, () =>
-        adapter.search(query, limit, sessionId),
+      return run(`search session=${sessionId ?? "all"} limit=${limit}`, (signal) =>
+        adapter.search(query, limit, sessionId, { signal }),
       );
     },
     reset(sessionId?: string): Promise<void> {
       if (phaseTimeoutMs === undefined) {
         return adapter.reset(sessionId);
       }
-      return run(`reset session=${sessionId ?? "all"}`, () =>
-        adapter.reset(sessionId),
+      return run(`reset session=${sessionId ?? "all"}`, (signal) =>
+        adapter.reset(sessionId, { signal }),
       );
     },
     getStats(sessionId?: string): Promise<MemoryStats> {
       if (phaseTimeoutMs === undefined) {
         return adapter.getStats(sessionId);
       }
-      return run(`stats session=${sessionId ?? "all"}`, () =>
-        adapter.getStats(sessionId),
+      return run(`stats session=${sessionId ?? "all"}`, (signal) =>
+        adapter.getStats(sessionId, { signal }),
       );
     },
     destroy(): Promise<void> {
@@ -146,7 +146,7 @@ export function createTimeoutGuardedAdapter(
     wrapped.drain = (): Promise<void> =>
       drainTimeoutMs === undefined
         ? adapter.drain!()
-        : run("drain", () => adapter.drain!(), drainTimeoutMs);
+        : run("drain", (signal) => adapter.drain!({ signal }), drainTimeoutMs);
   }
   if (adapter.responder) {
     wrapped.responder =

--- a/packages/bench/src/adapters/types.ts
+++ b/packages/bench/src/adapters/types.ts
@@ -82,18 +82,28 @@ export interface BenchJudge {
 }
 
 export interface BenchMemoryAdapter {
-  store(sessionId: string, messages: Message[]): Promise<void>;
+  store(
+    sessionId: string,
+    messages: Message[],
+    control?: BenchPhaseControl,
+  ): Promise<void>;
   recall(
     sessionId: string,
     query: string,
     budgetChars?: number,
     options?: BenchRecallOptions,
+    control?: BenchPhaseControl,
   ): Promise<string>;
-  search(query: string, limit: number, sessionId?: string): Promise<SearchResult[]>;
-  reset(sessionId?: string): Promise<void>;
-  getStats(sessionId?: string): Promise<MemoryStats>;
+  search(
+    query: string,
+    limit: number,
+    sessionId?: string,
+    control?: BenchPhaseControl,
+  ): Promise<SearchResult[]>;
+  reset(sessionId?: string, control?: BenchPhaseControl): Promise<void>;
+  getStats(sessionId?: string, control?: BenchPhaseControl): Promise<MemoryStats>;
   /** Wait for background summarization (e.g. LCM) to finish after store(). */
-  drain?(): Promise<void>;
+  drain?(control?: BenchPhaseControl): Promise<void>;
   destroy(): Promise<void>;
   responder?: BenchResponder;
   judge?: BenchJudge;

--- a/packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/diagnostics.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import type {
   BenchMemoryAdapter,
+  BenchPhaseControl,
   Message,
   SearchResult,
 } from "../../../adapters/types.ts";
@@ -28,6 +29,7 @@ class FakeAdapter implements BenchMemoryAdapter {
   recalledText = "";
   drainCalls = 0;
   storeCalls = 0;
+  controls: BenchPhaseControl[] = [];
   responder = {
     async respond() {
       return {
@@ -39,25 +41,62 @@ class FakeAdapter implements BenchMemoryAdapter {
     },
   };
 
-  async store(): Promise<void> {
+  async store(
+    _sessionId: string,
+    _messages: Message[],
+    control?: BenchPhaseControl,
+  ): Promise<void> {
     this.storeCalls += 1;
+    if (control) {
+      this.controls.push(control);
+    }
   }
 
-  async recall(): Promise<string> {
+  async recall(
+    _sessionId: string,
+    _query: string,
+    _budgetChars?: number,
+    _options?: unknown,
+    control?: BenchPhaseControl,
+  ): Promise<string> {
+    if (control) {
+      this.controls.push(control);
+    }
     return this.recalledText;
   }
 
-  async search(): Promise<SearchResult[]> {
+  async search(
+    _query: string,
+    _limit: number,
+    _sessionId?: string,
+    control?: BenchPhaseControl,
+  ): Promise<SearchResult[]> {
+    if (control) {
+      this.controls.push(control);
+    }
     return [];
   }
 
-  async reset(): Promise<void> {}
+  async reset(
+    _sessionId?: string,
+    control?: BenchPhaseControl,
+  ): Promise<void> {
+    if (control) {
+      this.controls.push(control);
+    }
+  }
 
-  async getStats(): Promise<{
+  async getStats(
+    _sessionId?: string,
+    control?: BenchPhaseControl,
+  ): Promise<{
     totalMessages: number;
     totalSummaryNodes: number;
     maxDepth: number;
   }> {
+    if (control) {
+      this.controls.push(control);
+    }
     return {
       totalMessages: 0,
       totalSummaryNodes: 0,
@@ -67,8 +106,11 @@ class FakeAdapter implements BenchMemoryAdapter {
 
   async destroy(): Promise<void> {}
 
-  async drain(): Promise<void> {
+  async drain(control?: BenchPhaseControl): Promise<void> {
     this.drainCalls += 1;
+    if (control) {
+      this.controls.push(control);
+    }
   }
 }
 
@@ -151,6 +193,23 @@ test("diagnostic adapter supports explicit-evidence-only recall and strong respo
   assert.match(recalled, /\[Action 1\]: Open settings/);
   assert.doesNotMatch(recalled, /Search evidence/);
   assert.doesNotMatch(recalled, /Unrelated search context/);
+});
+
+test("diagnostic adapter forwards phase control to delegated adapter calls", async () => {
+  const base = new FakeAdapter();
+  const adapter = createAmaBenchDiagnosticAdapter(base, explicitOnlyVariant);
+  const controller = new AbortController();
+  const control: BenchPhaseControl = { signal: controller.signal };
+
+  await adapter.store("ama-ep-1", [], control);
+  await adapter.recall("ama-ep-1", "What happened?", undefined, undefined, control);
+  await adapter.search("settings", 3, "ama-ep-1", control);
+  await adapter.reset("ama-ep-1", control);
+  await adapter.getStats("ama-ep-1", control);
+  await adapter.drain?.(control);
+
+  assert.equal(base.controls.length, 6);
+  assert.ok(base.controls.every((seenControl) => seenControl === control));
 });
 
 test("oracle trajectory recall uses stored visible messages and clears on reset", async () => {

--- a/packages/bench/src/benchmarks/published/ama-bench/diagnostics.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/diagnostics.ts
@@ -1,4 +1,5 @@
 import type {
+  BenchPhaseControl,
   BenchMemoryAdapter,
   BenchRecallOptions,
   BenchResponder,
@@ -131,11 +132,11 @@ export function createAmaBenchDiagnosticAdapter(
   };
 
   const diagnostic: BenchMemoryAdapter = {
-    async store(sessionId, messages) {
+    async store(sessionId, messages, control?: BenchPhaseControl) {
       const existing = sessions.get(sessionId) ?? [];
       sessions.set(sessionId, [...existing, ...messages]);
       if (variant.recallMode !== "oracle-trajectory") {
-        await base.store(sessionId, messages);
+        await base.store(sessionId, messages, control);
       }
     },
     async recall(
@@ -143,6 +144,7 @@ export function createAmaBenchDiagnosticAdapter(
       query,
       budgetChars,
       recallOptions?: BenchRecallOptions,
+      control?: BenchPhaseControl,
     ) {
       if (variant.recallMode === "oracle-trajectory") {
         return buildOracleTrajectoryRecall(
@@ -151,7 +153,13 @@ export function createAmaBenchDiagnosticAdapter(
         );
       }
 
-      const recalled = await base.recall(sessionId, query, budgetChars, recallOptions);
+      const recalled = await base.recall(
+        sessionId,
+        query,
+        budgetChars,
+        recallOptions,
+        control,
+      );
       if (variant.recallMode === "explicit-evidence-only") {
         return extractMarkdownSectionsByTitle(recalled, [
           "Explicit Cue Evidence",
@@ -160,19 +168,19 @@ export function createAmaBenchDiagnosticAdapter(
 
       return recalled;
     },
-    async search(query, limit, sessionId) {
-      return base.search(query, limit, sessionId);
+    async search(query, limit, sessionId, control?: BenchPhaseControl) {
+      return base.search(query, limit, sessionId, control);
     },
-    async reset(sessionId) {
+    async reset(sessionId, control?: BenchPhaseControl) {
       clearCapturedSession(sessionId);
-      await base.reset(sessionId);
+      await base.reset(sessionId, control);
     },
-    async getStats(sessionId) {
-      return base.getStats(sessionId);
+    async getStats(sessionId, control?: BenchPhaseControl) {
+      return base.getStats(sessionId, control);
     },
-    async drain() {
+    async drain(control?: BenchPhaseControl) {
       if (variant.recallMode !== "oracle-trajectory") {
-        await base.drain?.();
+        await base.drain?.(control);
       }
     },
     async destroy() {


### PR DESCRIPTION
## Summary
- add optional abort control to bench adapter store/recall/search/reset/stats/drain phases
- forward timeout guard AbortSignal into core adapter phases, matching existing responder/judge cancellation behavior
- add regression coverage that timed-out store work cancels a delayed side effect

Clawpatch finding: fnd_sig-feat-library-0c857094a2-7a57_81c2a30b2f

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/bench/src/adapters/timeout-guard.test.ts
- pnpm --filter @remnic/bench run check-types
- git diff --check
- node scripts/ensure-better-sqlite3.mjs
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bench adapter public interface to thread optional abort control through core phases and updates the timeout guard to merge/cancel signals, which could affect any custom adapter implementations and cancellation behavior.
> 
> **Overview**
> **Adds first-class cancellation to core bench adapter phases.** `BenchMemoryAdapter` methods (`store`/`recall`/`search`/`reset`/`getStats`/`drain`) now accept an optional `BenchPhaseControl` so callers and the timeout guard can abort in-flight work.
> 
> **Timeout guard now actively aborts phase work and merges signals.** `createTimeoutGuardedAdapter` forwards a timeout `AbortSignal` into adapter calls, merges it with any caller-provided signal (with listener cleanup), and extends the same behavior to responder/judge wrappers.
> 
> **Tests/diagnostics updated for the new control flow.** New regression tests cover aborting timed-out work (including cancelling delayed side effects), preserving caller abort reasons, and removing merged listeners; AMA-bench diagnostic adapter now forwards `BenchPhaseControl` to its delegated adapter calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb2d87cc9f03b31ad62f8200fa8295222336c8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->