### PR TITLE
Honor fallback LLM model overrides

### DIFF
--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -73,6 +73,63 @@ test("fallback llm prefers the active gateway provider config over models.json",
   }
 });
 
+test("fallback llm tries an explicit model override before the configured chain", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+          fallbacks: ["openai/fallback-model"],
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  let capturedBody = "";
+  globalThis.fetch = (async (_url, init) => {
+    capturedBody = String(init?.body ?? "");
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "judge ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Judge this" }],
+      { temperature: 0, maxTokens: 16, model: "openai/judge-model" },
+    );
+
+    assert.equal(response?.content, "judge ok");
+    assert.equal(response?.modelUsed, "openai/judge-model");
+    const parsedBody = JSON.parse(capturedBody) as { model?: string };
+    assert.equal(parsedBody.model, "judge-model");
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 test("fallback llm passes the OpenClaw workspace to runtime auth", { concurrency: false }, async () => {
   clearModelsJsonCache();
   clearSecretCache();

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -18,6 +18,8 @@ export interface FallbackLlmOptions {
   maxTokens?: number;
   timeoutMs?: number;
   signal?: AbortSignal;
+  /** Explicit "provider/model" override to try before the configured chain. */
+  model?: string;
   /** Override which agent persona's model chain to use (by ID from agents.list[]). */
   agentId?: string;
 }
@@ -104,7 +106,7 @@ export class FallbackLlmClient {
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
     options: FallbackLlmOptions = {},
   ): Promise<FallbackLlmResponse | null> {
-    const models = this.getModelChain(options.agentId);
+    const models = this.getModelChain(options.agentId, options.model);
     if (models.length === 0) {
       log.warn("fallback LLM: no models configured in gateway");
       return null;
@@ -236,7 +238,7 @@ export class FallbackLlmClient {
    * and uses that persona's model chain. Falls back to agents.defaults.model
    * if agentId is not found or not provided.
    */
-  private getModelChain(agentId?: string): ModelRef[] {
+  private getModelChain(agentId?: string, modelOverride?: string): ModelRef[] {
     const chain: ModelRef[] = [];
     const providers = this.gatewayConfig?.models?.providers ?? {};
 
@@ -264,8 +266,14 @@ export class FallbackLlmClient {
     // Build list of model strings: primary + fallbacks
     const modelStrings: string[] = [];
 
+    if (typeof modelOverride === "string" && modelOverride.trim().length > 0) {
+      modelStrings.push(modelOverride.trim());
+    }
+
     if (modelConfig?.primary) {
-      modelStrings.push(modelConfig.primary);
+      if (!modelStrings.includes(modelConfig.primary)) {
+        modelStrings.push(modelConfig.primary);
+      }
     }
 
     if (Array.isArray(modelConfig?.fallbacks)) {


### PR DESCRIPTION
## Summary
- add a supported `model` option to `FallbackLlmOptions`
- try explicit model overrides before agent/default fallback chains
- add a regression test proving the gateway request and `modelUsed` honor the override

Fixes clawpatch finding `fnd_sig-feat-library-0dfe449a13-a52e_6aa0a7aa0b`.

## Verification
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/fallback-llm.test.ts`
- `pnpm --filter @remnic/core run check-types`
- `git diff --check`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged unless callers pass the new optional `model` field, and the change is limited to model-chain ordering plus a regression test.
> 
> **Overview**
> `FallbackLlmClient` now accepts an optional `model` in `FallbackLlmOptions` and prepends it to the resolved model chain (deduping against configured primary/fallbacks) so an explicit override is attempted first.
> 
> Adds a regression test ensuring the override is used for the outbound request model ID and reported via `modelUsed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 073b44077f51946a6d3783ffc7879661df004416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->