### PR TITLE
Guard migration JSON config shape

### DIFF
--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -242,6 +242,10 @@ function parseTokenEntries(raw: unknown): TokenEntry[] {
     }));
 }
 
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 async function rewriteTokensIfPresent(filePath: string): Promise<number> {
   if (!existsSync(filePath)) return 0;
   await secureTokenFilePermissions(filePath);
@@ -375,12 +379,13 @@ async function rewriteJsonFile(
   if (!existsSync(targetPath)) return false;
 
   const original = await readFile(targetPath, "utf8");
-  let parsed: Record<string, unknown>;
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(original) as Record<string, unknown>;
+    parsed = JSON.parse(original) as unknown;
   } catch {
     return false;
   }
+  if (!isPlainJsonObject(parsed)) return false;
 
   let changed = false;
   if (
@@ -465,8 +470,8 @@ async function copyLegacyConfig(homeDir: string, copied: string[]): Promise<void
   const original = await readFile(source, "utf8");
   let next = rewriteRemnicText(original);
   try {
-    const parsed = JSON.parse(next) as Record<string, unknown>;
-    if (parsed.engram && !parsed.remnic) {
+    const parsed = JSON.parse(next) as unknown;
+    if (isPlainJsonObject(parsed) && parsed.engram && !parsed.remnic) {
       parsed.remnic = parsed.engram;
       delete parsed.engram;
       next = JSON.stringify(parsed, null, 2);

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -190,6 +190,47 @@ test("migrateFromEngram copies legacy state, rewrites tokens, updates connector 
   );
 });
 
+test("migrateFromEngram skips connector configs with valid non-object JSON", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-non-object-config-");
+  const cwd = path.join(homeDir, "repo");
+  const legacyConfig = path.join(homeDir, ".config", "engram", "config.json");
+  const nullConfig = path.join(cwd, "null.mcp.json");
+  const arrayConfig = path.join(cwd, "array.mcp.json");
+  const stringConfig = path.join(cwd, "string.mcp.json");
+  const invalidConfig = path.join(cwd, "invalid.mcp.json");
+
+  await mkdir(path.dirname(legacyConfig), { recursive: true });
+  await mkdir(cwd, { recursive: true });
+  await writeFile(legacyConfig, "null\n", "utf8");
+  await writeFile(nullConfig, "null\n", "utf8");
+  await writeFile(arrayConfig, "[]\n", "utf8");
+  await writeFile(stringConfig, '"engram"\n', "utf8");
+  await writeFile(invalidConfig, '{"mcpServers":{"engram":', "utf8");
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd,
+    quiet: true,
+    connectorConfigPaths: [nullConfig, arrayConfig, stringConfig, invalidConfig],
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.equal(await readFile(nullConfig, "utf8"), "null\n");
+  assert.equal(await readFile(arrayConfig, "utf8"), "[]\n");
+  assert.equal(await readFile(stringConfig, "utf8"), '"engram"\n');
+  assert.equal(await readFile(invalidConfig, "utf8"), '{"mcpServers":{"engram":');
+  assert.equal(await readFile(path.join(homeDir, ".config", "remnic", "config.json"), "utf8"), "null\n");
+
+  const manifest = JSON.parse(await readFile(path.join(homeDir, ".remnic", ".rollback.json"), "utf8")) as {
+    entries: Array<{ targetPath: string }>;
+  };
+  const backedUpTargets = manifest.entries.map((entry) => entry.targetPath);
+  assert.equal(backedUpTargets.includes(nullConfig), false);
+  assert.equal(backedUpTargets.includes(arrayConfig), false);
+  assert.equal(backedUpTargets.includes(stringConfig), false);
+  assert.equal(backedUpTargets.includes(invalidConfig), false);
+});
+
 test("migrateFromEngram skips legacy file symlinks without copying external target content", {
   skip: process.platform === "win32",
 }, async () => {


### PR DESCRIPTION
## Summary
- validate parsed migration config JSON is object-shaped before property access
- leave connector configs with valid non-object JSON untouched instead of throwing
- add migration coverage for null, array, string, and invalid connector config files

Fixes clawpatch finding `fnd_sig-feat-library-10121b507d-5ebe_85c3351287`.

## Verification
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/remnic-migration.test.ts`
- `pnpm --filter @remnic/core run check-types`
- `git diff --check`
- `node scripts/ensure-better-sqlite3.mjs`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds defensive JSON shape checks in migration rewriting to avoid crashes and unintended backups when configs parse to non-objects, plus targeted test coverage.
> 
> **Overview**
> Hardens Engram→Remnic migration config rewriting by **validating parsed JSON is a plain object** before accessing properties in `rewriteJsonFile` and legacy config copying.
> 
> Connector config files that contain *valid non-object JSON* (e.g. `null`, arrays, strings) or invalid JSON are now left untouched and are not added to the rollback backup manifest, with new tests covering these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf79f0d0ad2dabf29813e21ea3ec3713109571f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->