### PR TITLE
Fix migration rollback for created files

### DIFF
--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -167,6 +167,7 @@ async function copyTreeMissing(
   source: string,
   destination: string,
   copied: string[],
+  manifest: RollbackManifest,
   isRoot = true,
 ): Promise<void> {
   if (!existsSync(source)) return;
@@ -188,6 +189,7 @@ async function copyTreeMissing(
         path.join(source, entry.name),
         path.join(destination, entry.name),
         copied,
+        manifest,
         false,
       );
     }
@@ -197,6 +199,7 @@ async function copyTreeMissing(
   if (await pathExistsNoFollow(destination)) return;
   await ensureParent(destination);
   await copyFile(source, destination);
+  await recordCreatedPath(destination, manifest);
   copied.push(destination);
 }
 
@@ -462,7 +465,11 @@ async function updateConnectorConfigs(
   return updated;
 }
 
-async function copyLegacyConfig(homeDir: string, copied: string[]): Promise<void> {
+async function copyLegacyConfig(
+  homeDir: string,
+  copied: string[],
+  manifest: RollbackManifest,
+): Promise<void> {
   const source = legacyConfigPath(homeDir);
   const destination = remnicConfigPath(homeDir);
   if (!existsSync(source) || existsSync(destination)) return;
@@ -480,6 +487,7 @@ async function copyLegacyConfig(homeDir: string, copied: string[]): Promise<void
     // Keep rewritten text when config is not JSON.
   }
   await writeFile(destination, `${next.trimEnd()}\n`, "utf8");
+  await recordCreatedPath(destination, manifest);
   copied.push(destination);
 }
 
@@ -738,8 +746,8 @@ export async function migrateFromEngram(options?: MigrationOptions): Promise<Mig
 
     logger("First run after Engram -> Remnic rename. Migrating...");
     await mkdir(remnicRoot(homeDir), { recursive: true });
-    await copyTreeMissing(legacyRoot(homeDir), remnicRoot(homeDir), copied);
-    await copyLegacyConfig(homeDir, copied);
+    await copyTreeMissing(legacyRoot(homeDir), remnicRoot(homeDir), copied, manifest);
+    await copyLegacyConfig(homeDir, copied, manifest);
 
     const legacyTokens = path.join(legacyRoot(homeDir), "tokens.json");
     const remnicTokens = path.join(remnicRoot(homeDir), "tokens.json");

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -734,6 +734,74 @@ test("rollbackFromEngramMigration restores backed up connector configs and remov
   await assertFileMode(claudeConfig, 0o644);
 });
 
+test("rollbackFromEngramMigration removes files created from first-run legacy copies", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-created-rollback-");
+  const legacyRoot = path.join(homeDir, ".engram");
+  const legacyConfig = path.join(homeDir, ".config", "engram", "config.json");
+  const remnicTokensPath = path.join(homeDir, ".remnic", "tokens.json");
+  const remnicLogPath = path.join(homeDir, ".remnic", "logs", "daemon.log");
+  const remnicConfig = path.join(homeDir, ".config", "remnic", "config.json");
+
+  await mkdir(path.join(legacyRoot, "logs"), { recursive: true });
+  await mkdir(path.dirname(legacyConfig), { recursive: true });
+  await writeFile(
+    path.join(legacyRoot, "tokens.json"),
+    JSON.stringify({
+      tokens: [
+        { connector: "claude-code", token: "engram_cc_created", createdAt: "2026-04-08T00:00:00.000Z" },
+      ],
+    }),
+    "utf8",
+  );
+  await writeFile(path.join(legacyRoot, "logs", "daemon.log"), "legacy log\n", "utf8");
+  await writeFile(
+    legacyConfig,
+    JSON.stringify({
+      engram: {
+        memoryDir: path.join(homeDir, ".engram", "memory"),
+      },
+    }),
+    "utf8",
+  );
+
+  const result = await migrateFromEngram({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.equal(result.status, "migrated");
+  assert.ok(result.copied.includes(remnicTokensPath));
+  assert.ok(result.copied.includes(remnicLogPath));
+  assert.ok(result.copied.includes(remnicConfig));
+
+  const manifest = JSON.parse(await readFile(path.join(homeDir, ".remnic", ".rollback.json"), "utf8")) as {
+    entries: Array<{ targetPath: string; createdByMigration?: boolean }>;
+  };
+  const createdTargets = new Set(
+    manifest.entries
+      .filter((entry) => entry.createdByMigration)
+      .map((entry) => entry.targetPath),
+  );
+  assert.ok(createdTargets.has(remnicTokensPath), "expected copied token store in rollback manifest");
+  assert.ok(createdTargets.has(remnicLogPath), "expected copied log file in rollback manifest");
+  assert.ok(createdTargets.has(remnicConfig), "expected copied config in rollback manifest");
+
+  const rollback = await rollbackFromEngramMigration({
+    homeDir,
+    cwd: homeDir,
+    quiet: true,
+  });
+
+  assert.ok(rollback.removed.includes(remnicTokensPath));
+  assert.ok(rollback.removed.includes(remnicLogPath));
+  assert.ok(rollback.removed.includes(remnicConfig));
+  assert.equal(existsSync(remnicTokensPath), false);
+  assert.equal(existsSync(remnicLogPath), false);
+  assert.equal(existsSync(remnicConfig), false);
+  assert.equal(existsSync(path.join(homeDir, ".remnic", ".migrated-from-engram")), false);
+});
+
 test("rollbackFromEngramMigration reloads systemd after removing migrated unit files", async () => {
   const homeDir = await makeTempHome("remnic-migrate-linux-rollback-");
   const cwd = path.join(homeDir, "repo");


### PR DESCRIPTION
## Summary
- record first-run copied Remnic files in the rollback manifest as migration-created paths
- record copied Remnic config files the same way
- add regression coverage that rollback removes copied token, log, and config files

## Verification
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/remnic-migration.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- npm run review:cursor (exited 0; script reported no changed files against base and skipped)
- npm run preflight:quick (first run hit missing better-sqlite3 native binding in fresh worktree; rebuilt with node scripts/ensure-better-sqlite3.mjs; rerun passed)

Fixes clawpatch finding fnd_sig-feat-library-10121b507d-83ad_96f0b85a5f.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches migration/rollback bookkeeping and file deletion logic; incorrect manifest entries could cause rollback to miss cleanup or remove unintended paths.
> 
> **Overview**
> Improves Engram→Remnic migration rollback by recording *first-run copied* files (from legacy tree copy and legacy config copy) in the rollback manifest as `createdByMigration`, so `rollbackFromEngramMigration` removes them.
> 
> Adds a regression test that migrates a legacy token store, log file, and config, verifies those targets are marked as migration-created in `.rollback.json`, and asserts rollback deletes them along with the migration marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23abc820adba44509c245a5717fb81694fba9514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->