### PR TITLE
Fix MemBench drain failure scoring

### DIFF
--- a/packages/bench/src/benchmarks/published/membench/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.test.ts
@@ -232,3 +232,78 @@ test("MemBench normalizes upstream JSONL trajectory QA records", async () => {
     await rm(datasetDir, { recursive: true, force: true });
   }
 });
+
+test("MemBench records a task failure when ingestion drain fails before scoring", async () => {
+  let completedTasks = 0;
+  let recallCalls = 0;
+  let responderCalls = 0;
+  let judgeCalls = 0;
+
+  const result = await runMemBenchBenchmark({
+    benchmark: memBenchDefinition,
+    mode: "quick",
+    limit: 1,
+    onTaskComplete() {
+      completedTasks += 1;
+    },
+    system: {
+      async reset() {},
+      async store() {},
+      async drain() {
+        throw new Error("drain timed out");
+      },
+      async recall() {
+        recallCalls += 1;
+        return "Lisbon";
+      },
+      async search() {
+        return [];
+      },
+      async destroy() {},
+      async getStats() {
+        return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+      responder: {
+        async respond() {
+          responderCalls += 1;
+          return {
+            text: "Lisbon",
+            tokens: { input: 1, output: 1 },
+            latencyMs: 1,
+            model: "membench-test-responder",
+          };
+        },
+      },
+      judge: {
+        async score() {
+          judgeCalls += 1;
+          return 1;
+        },
+        async scoreWithMetrics() {
+          judgeCalls += 1;
+          return {
+            score: 1,
+            tokens: { input: 0, output: 0 },
+            latencyMs: 0,
+            model: "membench-test-judge",
+          };
+        },
+      },
+    },
+  });
+
+  assert.equal(completedTasks, 1);
+  assert.equal(recallCalls, 0);
+  assert.equal(responderCalls, 0);
+  assert.equal(judgeCalls, 0);
+
+  const task = result.results.tasks[0]!;
+  assert.match(task.actual, /MemBench drain failed for factual-participant-1/);
+  assert.deepEqual(task.scores, {
+    f1: -1,
+    contains_answer: -1,
+    llm_judge: -1,
+    membench_accuracy: -1,
+  });
+  assert.equal(task.details?.error, "MemBench drain failed for factual-participant-1: drain timed out");
+});

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -100,7 +100,9 @@ export async function runMemBenchBenchmark(
       try {
         await options.system.drain?.();
       } catch (drainErr) {
-        console.error(`  [WARN] membench drain failed for ${testCase.id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+        throw new Error(
+          `MemBench drain failed for ${testCase.id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`,
+        );
       }
 
       const recallQuery = buildRecallQuery(testCase);


### PR DESCRIPTION
## Summary
- make MemBench drain failures fail the task instead of continuing into recall/scoring
- preserve sentinel failure scores through the existing task-level error path
- add regression coverage that recall, response, and judge calls are skipped after drain failure

## Verification
- pnpm exec tsx --test packages/bench/src/benchmarks/published/membench/runner.test.ts
- pnpm --filter @remnic/bench run check-types
- git diff --check
- node scripts/check-test-types.mjs
- node scripts/ensure-better-sqlite3.mjs
- npm run preflight:quick
- npm run review:cursor (exited 0; wrapper skipped changed-file review against base)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to MemBench benchmark error handling, ensuring drain failures abort recall/scoring and are surfaced as task errors with sentinel scores.
> 
> **Overview**
> MemBench now treats `system.drain()` failures as **hard task failures** by throwing an error instead of logging and continuing into recall/answering/judging, so the task is recorded via the existing error path with `-1` sentinel scores.
> 
> Adds a regression test covering that a drain error still triggers `onTaskComplete`, skips recall/responder/judge calls, and stores the drain error message in `task.actual`/`task.details.error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 551a0675913923bf9882053dfccfb0d3b267ffd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->