### PR TITLE
Fix provider secret cache keying

### DIFF
--- a/packages/remnic-core/src/resolve-provider-secret.test.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.test.ts
@@ -16,24 +16,25 @@ test("resolveProviderApiKey scopes cached gateway secrets by agent directory", a
     calls.push(String(agentDir));
     return { apiKey: `key:${agentDir}` };
   });
+  const gatewayConfig = {};
 
   try {
     const first = await resolveProviderApiKey(
       "openai",
       "secretref-managed",
-      {},
+      gatewayConfig,
       "/tmp/openclaw-profile-a/agent",
     );
     const second = await resolveProviderApiKey(
       "openai",
       "secretref-managed",
-      {},
+      gatewayConfig,
       "/tmp/openclaw-profile-b/agent",
     );
     const repeatFirst = await resolveProviderApiKey(
       "openai",
       "secretref-managed",
-      {},
+      gatewayConfig,
       "/tmp/openclaw-profile-a/agent",
     );
 
@@ -82,24 +83,26 @@ test("resolveProviderApiKey scopes cached gateway secrets by auth input and conf
     calls.push(profile);
     return { apiKey: `key:${profile}` };
   });
+  const alphaConfig = { profile: "alpha" };
+  const betaConfig = { profile: "beta" };
 
   try {
     const first = await resolveProviderApiKey(
       "openai",
       "secretref-managed",
-      { profile: "alpha" },
+      alphaConfig,
       "/tmp/openclaw-profile-shared/agent",
     );
     const second = await resolveProviderApiKey(
       "openai",
       "secretref-managed",
-      { profile: "beta" },
+      betaConfig,
       "/tmp/openclaw-profile-shared/agent",
     );
     const repeatFirst = await resolveProviderApiKey(
       "openai",
       "secretref-managed",
-      { profile: "alpha" },
+      alphaConfig,
       "/tmp/openclaw-profile-shared/agent",
     );
 

--- a/packages/remnic-core/src/resolve-provider-secret.test.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.test.ts
@@ -49,6 +49,69 @@ test("resolveProviderApiKey scopes cached gateway secrets by agent directory", a
   }
 });
 
+test("resolveProviderApiKey does not reuse cached literal keys for different inputs", async () => {
+  clearSecretCache();
+
+  try {
+    const first = await resolveProviderApiKey(
+      "openai",
+      "sk-first",
+      {},
+      "/tmp/openclaw-profile-literals/agent",
+    );
+    const second = await resolveProviderApiKey(
+      "openai",
+      "sk-second",
+      {},
+      "/tmp/openclaw-profile-literals/agent",
+    );
+
+    assert.equal(first, "sk-first");
+    assert.equal(second, "sk-second");
+  } finally {
+    clearSecretCache();
+  }
+});
+
+test("resolveProviderApiKey scopes cached gateway secrets by auth input and config", async () => {
+  clearSecretCache();
+
+  const calls: string[] = [];
+  __setGatewayResolverForTest(async ({ cfg }) => {
+    const profile = (cfg as { profile?: string } | undefined)?.profile ?? "unknown";
+    calls.push(profile);
+    return { apiKey: `key:${profile}` };
+  });
+
+  try {
+    const first = await resolveProviderApiKey(
+      "openai",
+      "secretref-managed",
+      { profile: "alpha" },
+      "/tmp/openclaw-profile-shared/agent",
+    );
+    const second = await resolveProviderApiKey(
+      "openai",
+      "secretref-managed",
+      { profile: "beta" },
+      "/tmp/openclaw-profile-shared/agent",
+    );
+    const repeatFirst = await resolveProviderApiKey(
+      "openai",
+      "secretref-managed",
+      { profile: "alpha" },
+      "/tmp/openclaw-profile-shared/agent",
+    );
+
+    assert.equal(first, "key:alpha");
+    assert.equal(second, "key:beta");
+    assert.equal(repeatFirst, first);
+    assert.deepEqual(calls, ["alpha", "beta"]);
+  } finally {
+    clearSecretCache();
+  }
+});
+
 test("resolveProviderApiKey treats env-var-shaped config strings as markers", async () => {
   clearSecretCache();
   const previousOpenAI = process.env.OPENAI_API_KEY;

--- a/packages/remnic-core/src/resolve-provider-secret.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.ts
@@ -1,6 +1,5 @@
 import { log } from "./logger.js";
 import { readEnvVar } from "./runtime/env.js";
-import { createHash } from "node:crypto";
 import path from "node:path";
 import os from "node:os";
 
@@ -46,6 +45,8 @@ let _resolverLoaded = false;
 let _resolverNextRetryAt = 0;
 const RESOLVER_RETRY_BACKOFF_MS = 60_000; // 1 minute between retries after first failure
 const resolvedCache = new Map<string, string | undefined>();
+const cacheObjectIds = new WeakMap<object, number>();
+let nextCacheObjectId = 1;
 const NON_LITERAL_AUTH_MARKERS = new Set([
   "secretref-managed",
   "lm-studio",
@@ -243,32 +244,22 @@ function resolveFromNamedEnvVar(marker: string): string | undefined {
   return value && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-function stableSerializeForCache(value: unknown, seen = new WeakSet<object>()): string {
+function cacheIdentity(value: unknown): string {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
-  if (typeof value === "string") return `string:${JSON.stringify(value)}`;
+  if (typeof value === "string") return `string:${value}`;
   if (typeof value === "number") return `number:${String(value)}`;
   if (typeof value === "boolean") return `boolean:${String(value)}`;
   if (typeof value === "bigint") return `bigint:${String(value)}`;
   if (typeof value === "symbol" || typeof value === "function") return typeof value;
-  if (value instanceof Date) return `date:${Number.isNaN(value.getTime()) ? "invalid" : value.toISOString()}`;
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableSerializeForCache(item, seen)).join(",")}]`;
-  }
   if (typeof value === "object") {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    const entries = Object.keys(value as Record<string, unknown>)
-      .sort()
-      .map((key) => `${JSON.stringify(key)}:${stableSerializeForCache((value as Record<string, unknown>)[key], seen)}`);
-    seen.delete(value);
-    return `{${entries.join(",")}}`;
+    const existingId = cacheObjectIds.get(value);
+    if (existingId !== undefined) return `object:${existingId}`;
+    const newId = nextCacheObjectId++;
+    cacheObjectIds.set(value, newId);
+    return `object:${newId}`;
   }
   return String(value);
-}
-
-function cacheFingerprint(value: unknown): string {
-  return createHash("sha256").update(stableSerializeForCache(value)).digest("hex");
 }
 
 function providerSecretCacheKey(
@@ -280,8 +271,8 @@ function providerSecretCacheKey(
   return [
     `provider:${providerId}`,
     `agentDir:${resolvedAgentDir}`,
-    `apiKey:${cacheFingerprint(apiKeyValue)}`,
-    `cfg:${cacheFingerprint(gatewayConfig)}`,
+    `apiKey:${cacheIdentity(apiKeyValue)}`,
+    `cfg:${cacheIdentity(gatewayConfig)}`,
   ].join(":");
 }
 

--- a/packages/remnic-core/src/resolve-provider-secret.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.ts
@@ -1,5 +1,6 @@
 import { log } from "./logger.js";
 import { readEnvVar } from "./runtime/env.js";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import os from "node:os";
 
@@ -242,6 +243,48 @@ function resolveFromNamedEnvVar(marker: string): string | undefined {
   return value && value.trim().length > 0 ? value.trim() : undefined;
 }
 
+function stableSerializeForCache(value: unknown, seen = new WeakSet<object>()): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "string") return `string:${JSON.stringify(value)}`;
+  if (typeof value === "number") return `number:${String(value)}`;
+  if (typeof value === "boolean") return `boolean:${String(value)}`;
+  if (typeof value === "bigint") return `bigint:${String(value)}`;
+  if (typeof value === "symbol" || typeof value === "function") return typeof value;
+  if (value instanceof Date) return `date:${Number.isNaN(value.getTime()) ? "invalid" : value.toISOString()}`;
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerializeForCache(item, seen)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableSerializeForCache((value as Record<string, unknown>)[key], seen)}`);
+    seen.delete(value);
+    return `{${entries.join(",")}}`;
+  }
+  return String(value);
+}
+
+function cacheFingerprint(value: unknown): string {
+  return createHash("sha256").update(stableSerializeForCache(value)).digest("hex");
+}
+
+function providerSecretCacheKey(
+  providerId: string,
+  resolvedAgentDir: string,
+  apiKeyValue: unknown,
+  gatewayConfig: unknown,
+): string {
+  return [
+    `provider:${providerId}`,
+    `agentDir:${resolvedAgentDir}`,
+    `apiKey:${cacheFingerprint(apiKeyValue)}`,
+    `cfg:${cacheFingerprint(gatewayConfig)}`,
+  ].join(":");
+}
+
 /**
  * Resolve a provider API key from various OpenClaw formats.
  *
@@ -261,12 +304,6 @@ export async function resolveProviderApiKey(
     agentDir ?? path.join(os.homedir(), ".openclaw", "agents", "main", "agent"),
   );
 
-  // Check cache first
-  const cacheKey = `provider:${providerId}:agentDir:${resolvedAgentDir}`;
-  if (resolvedCache.has(cacheKey)) {
-    return resolvedCache.get(cacheKey);
-  }
-
   let resolved: string | undefined;
 
   // Fast path: plain-text string that looks like an actual API key
@@ -277,16 +314,17 @@ export async function resolveProviderApiKey(
     if (isNonLiteralAuthMarker(trimmedApiKeyValue)) {
       const markerEnvValue = resolveFromNamedEnvVar(trimmedApiKeyValue);
       if (markerEnvValue) {
-        resolved = markerEnvValue;
-        resolvedCache.set(cacheKey, resolved);
-        return resolved;
+        return markerEnvValue;
       }
       // Fall through to gateway resolver / env var fallback
     } else {
-      resolved = trimmedApiKeyValue;
-      resolvedCache.set(cacheKey, resolved);
-      return resolved;
+      return trimmedApiKeyValue;
     }
+  }
+
+  const cacheKey = providerSecretCacheKey(providerId, resolvedAgentDir, apiKeyValue, gatewayConfig);
+  if (resolvedCache.has(cacheKey)) {
+    return resolvedCache.get(cacheKey);
   }
 
   // The API key is either a SecretRef object, "secretref-managed", or empty.


### PR DESCRIPTION
## Summary
- avoid caching direct literal and named-env marker provider keys before auth input inspection
- key gateway secret cache entries by provider, agent dir, auth input fingerprint, and gateway config fingerprint
- add regressions for literal key changes and same-agent gateway configs resolving different credentials

## Verification
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/resolve-provider-secret.test.ts
- pnpm --filter @remnic/core run check-types
- git diff --check
- node scripts/ensure-better-sqlite3.mjs
- npm run preflight:quick
- npm run review:cursor (exited 0; wrapper skipped changed-file review against base)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the caching behavior for provider API key resolution; incorrect cache keys could cause the wrong credentials to be reused across different configs/inputs. Risk is limited to auth resolution/caching logic but impacts runtime provider authentication.
> 
> **Overview**
> Fixes provider API key caching so cached gateway-resolved secrets are scoped not just by `providerId` and `agentDir`, but also by the *auth input* (`apiKeyValue`) and *gateway config* identity.
> 
> The fast path for literal API keys and named-env-var markers now returns immediately without populating the shared cache, preventing stale literal values from being reused. Adds regression tests covering per-agent scoping, literal-key non-reuse, and different gateway configs producing distinct cached results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d8cf195a1eb1921d0a6ab165460431fe9581f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->