### PR TITLE
Fail MemoryArena on prerequisite drain errors

### DIFF
--- a/packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
@@ -167,6 +167,93 @@ test("MemoryArena quick fixture seeds prerequisite subtasks before scoring follo
   assert.match(storedMessages.join("\n"), /Environment result: trail mix/);
 });
 
+test("MemoryArena reports prerequisite drain failures before scoring follow-ups", async () => {
+  const storedMessages: string[] = [];
+  const completedCounts: number[] = [];
+  let drainCalls = 0;
+  let recallCalls = 0;
+  let responderCalls = 0;
+  let judgeCalls = 0;
+
+  const result = await runMemoryArenaBenchmark({
+    benchmark: memoryArenaDefinition,
+    mode: "quick",
+    system: {
+      async store(_sessionId, messages) {
+        storedMessages.push(...messages.map((message) => message.content));
+      },
+      async recall() {
+        recallCalls += 1;
+        return storedMessages.join("\n\n");
+      },
+      async search() {
+        return [];
+      },
+      async reset() {
+        storedMessages.length = 0;
+      },
+      async drain() {
+        drainCalls += 1;
+        if (drainCalls === 2) {
+          throw new Error("drain timed out");
+        }
+      },
+      async destroy() {},
+      async getStats() {
+        return { totalMessages: storedMessages.length, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+      responder: {
+        async respond() {
+          responderCalls += 1;
+          return {
+            text: "trail mix",
+            tokens: { input: 1, output: 1 },
+            latencyMs: 1,
+            model: "memory-arena-test-responder",
+          };
+        },
+      },
+      judge: {
+        async score() {
+          judgeCalls += 1;
+          return 1;
+        },
+        async scoreWithMetrics() {
+          judgeCalls += 1;
+          return {
+            score: 1,
+            tokens: { input: 0, output: 0 },
+            latencyMs: 0,
+            model: "judge-smoke",
+          };
+        },
+      },
+    },
+    onTaskComplete(_task, completed) {
+      completedCounts.push(completed);
+    },
+  });
+
+  assert.equal(recallCalls, 0);
+  assert.equal(responderCalls, 0);
+  assert.equal(judgeCalls, 0);
+  assert.deepEqual(completedCounts, [1]);
+  assert.equal(result.results.tasks.length, 1);
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.taskId, "bundled_shopping-t1-q1");
+  assert.match(
+    task.actual,
+    /MemoryArena prerequisite failed before bundled_shopping-t1-q1/,
+  );
+  assert.match(task.actual, /MemoryArena drain failed after completed subtask 1/);
+  assert.equal(task.scores.f1, -1);
+  assert.equal(task.scores.contains_answer, -1);
+  assert.equal(task.scores.llm_judge, -1);
+  assert.equal(task.scores.process_score, 0);
+  assert.equal(task.details?.error, "MemoryArena prerequisite failed before bundled_shopping-t1-q1: MemoryArena drain failed after completed subtask 1: drain timed out");
+});
+
 test("MemoryArena accepts optional string-array backgrounds from dataset files", async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-memory-arena-"));
   const datasetPath = path.join(tempDir, "shopping.jsonl");

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -79,6 +79,7 @@ export async function runMemoryArenaBenchmark(
 
       const sessionId = `arena-${domain}-${task.id}`;
       let initialSeedError: string | undefined;
+      let pendingPrerequisiteError: string | undefined;
       if (isGroupTravelPlannerCategory(task.category)) {
         try {
           await storeInitialTaskState(options, sessionId, task);
@@ -109,6 +110,12 @@ export async function runMemoryArenaBenchmark(
         const isScored = shouldScoreSubtask(task, questionIndex);
 
         try {
+          if (isScored && pendingPrerequisiteError !== undefined) {
+            throw new Error(
+              `MemoryArena prerequisite failed before ${taskResultId}: ${pendingPrerequisiteError}`,
+            );
+          }
+
           const background = backgroundForSubtask(task, questionIndex);
           if (background) {
             await options.system.store(sessionId, [
@@ -119,11 +126,7 @@ export async function runMemoryArenaBenchmark(
             ]);
           }
 
-          try {
-            await options.system.drain?.();
-          } catch (drainErr) {
-            console.error(`  [WARN] memory-arena drain failed for ${taskResultId}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
-          }
+          await drainMemoryArena(options, taskResultId);
 
           if (!isScored) {
             await storeCompletedSubtask(
@@ -135,6 +138,7 @@ export async function runMemoryArenaBenchmark(
               expectedAnswer,
               webshopCatalog,
             );
+            pendingPrerequisiteError = undefined;
             continue;
           }
 
@@ -236,18 +240,21 @@ export async function runMemoryArenaBenchmark(
               webshopCatalog,
             );
           } catch (storeErr) {
-            console.error(`  [WARN] memory-arena store failed for ${taskResultId}: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`);
+            pendingPrerequisiteError = formatUnknownError(storeErr);
+            console.error(`  [WARN] memory-arena store failed for ${taskResultId}: ${pendingPrerequisiteError}`);
           }
 
           try {
-            await options.system.drain?.();
+            await drainMemoryArena(options, taskResultId);
           } catch (drainErr) {
-            console.error(`  [WARN] memory-arena drain failed for ${taskResultId}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+            pendingPrerequisiteError = formatUnknownError(drainErr);
+            console.error(`  [WARN] memory-arena drain failed for ${taskResultId}: ${pendingPrerequisiteError}`);
           }
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
+          const message = formatUnknownError(err);
           console.error(`  [WARN] memory-arena task ${taskResultId} failed: ${message}`);
           if (!isScored) {
+            pendingPrerequisiteError = message;
             continue;
           }
           tasks.push({
@@ -2628,6 +2635,19 @@ function tokenizePlanText(value: string): string[] {
     .filter((token) => token.length > 0);
 }
 
+async function drainMemoryArena(
+  options: ResolvedRunBenchmarkOptions,
+  taskResultId: string,
+): Promise<void> {
+  try {
+    await options.system.drain?.();
+  } catch (drainErr) {
+    throw new Error(
+      `MemoryArena drain failed for ${taskResultId}: ${formatUnknownError(drainErr)}`,
+    );
+  }
+}
+
 async function storeCompletedSubtask(
   options: ResolvedRunBenchmarkOptions,
   sessionId: string,
@@ -2667,8 +2687,14 @@ async function storeCompletedSubtask(
   try {
     await options.system.drain?.();
   } catch (drainErr) {
-    console.error(`  [WARN] memory-arena drain failed after completed subtask ${questionIndex + 1}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+    throw new Error(
+      `MemoryArena drain failed after completed subtask ${questionIndex + 1}: ${formatUnknownError(drainErr)}`,
+    );
   }
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function summarizeMemoryArenaSubtaskQuestion(question: string): string {


### PR DESCRIPTION
## Summary\n- propagate MemoryArena drain failures that happen before recall instead of scoring dependent follow-ups\n- carry failed prerequisite state to the next scored subtask as an infrastructure failure\n- add a regression test that asserts recall/responder/judge are skipped after a prerequisite drain timeout\n\n## Verification\n- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/bench/src/benchmarks/published/memory-arena/runner.test.ts\n- pnpm --filter @remnic/bench exec tsc --noEmit --pretty false\n- git diff --check\n- node scripts/ensure-better-sqlite3.mjs\n- npm run preflight:quick\n- npm run review:cursor (exited 0; skipped: no changed files against 8feca43d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark execution/error propagation and can alter reported scores by short-circuiting recall/LLM scoring when prerequisite persistence fails. Risk is limited to benchmark correctness (no production auth/data paths), but impacts result comparability.
> 
> **Overview**
> **MemoryArena prerequisite failures are now propagated into the next scored subtask instead of being logged and ignored.** The runner tracks a `pendingPrerequisiteError` and, for scored subtasks, aborts before `recall`/responder/judge scoring if a prior `store` or `drain` failed.
> 
> Drain handling is centralized via `drainMemoryArena()` (throws on failure) and error formatting is normalized with `formatUnknownError()`. A new regression test asserts that a prerequisite drain timeout produces an infrastructure-style task failure (`-1` metric scores) and skips `recall`/responder/judge calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db074946abb916af49af28444f0ed4b7922e9f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->