### PR TITLE
Avoid ambiguous hidden-ASIN item credit

### DIFF
--- a/packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
@@ -2343,7 +2343,7 @@ test("MemoryArena scores hidden-ASIN selections by unique visible option text", 
   }
 });
 
-test("MemoryArena scores exact visible selections when expected option ranking ties", async () => {
+test("MemoryArena rejects ambiguous hidden-ASIN selections when option attributes tie", async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-memory-arena-"));
   const datasetPath = path.join(tempDir, "shopping.jsonl");
 
@@ -2391,7 +2391,7 @@ test("MemoryArena scores exact visible selections when expected option ranking t
         responder: {
           async respond() {
             return {
-              text: "item: A Premium Rose Sprinkle Mix.",
+              text: "item: A Budget Rose Sprinkle Mix.",
               tokens: { input: 1, output: 1 },
               latencyMs: 1,
               model: "memory-arena-test-responder",
@@ -2415,8 +2415,8 @@ test("MemoryArena scores exact visible selections when expected option ranking t
     });
 
     const task = result.results.tasks[0]!;
-    assert.equal(task.scores.item_selection_match, 1);
-    assert.equal(task.scores.process_score, 1);
+    assert.equal(task.scores.item_selection_match, 0);
+    assert.equal(task.scores.process_score, 0);
     assert.equal(task.scores.llm_judge, 0);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -1875,6 +1875,21 @@ function scoreItemSelectionAnswer(
     ? []
     : extractMemoryArenaVisibleOptions(question);
   const hits = expectations.filter((expectation) => {
+    if (
+      shouldUseVisibleOptionDisambiguation(
+        expectation,
+        asinContext,
+        visibleOptions,
+      )
+    ) {
+      if (predictionIncludesExpectedTargetAsin(predictedNormalized, expectation)) {
+        return true;
+      }
+      return expectationAttributesSelectUniqueVisibleOption(
+        expectation,
+        visibleOptions,
+      ) && visibleOptionSelectionMatches(predicted, expectation, visibleOptions);
+    }
     if (itemSelectionExpectationMatches(
       predictedNormalized,
       expectation,
@@ -1890,6 +1905,36 @@ function scoreItemSelectionAnswer(
   return {
     item_selection_match: hits / expectations.length,
   };
+}
+
+function shouldUseVisibleOptionDisambiguation(
+  expectation: ItemSelectionExpectation,
+  asinContext: ItemSelectionAsinContext,
+  visibleOptions: VisibleItemOption[],
+): boolean {
+  return expectation.targetAsin !== undefined
+    && asinContext.predictedExplicitAsins.length === 0
+    && visibleOptions.length > 0;
+}
+
+function predictionIncludesExpectedTargetAsin(
+  predictedNormalized: string,
+  expectation: ItemSelectionExpectation,
+): boolean {
+  if (expectation.targetAsin === undefined) {
+    return false;
+  }
+  return predictedNormalized.includes(
+    normalizeItemSelectionText(expectation.targetAsin),
+  );
+}
+
+function expectationAttributesSelectUniqueVisibleOption(
+  expectation: ItemSelectionExpectation,
+  visibleOptions: VisibleItemOption[],
+): boolean {
+  return selectVisibleOptionsForExpectation(visibleOptions, expectation)
+    .length === 1;
 }
 
 interface ItemSelectionExpectation {


### PR DESCRIPTION
## Summary
- require hidden-ASIN item expectations to disambiguate through visible options when a prediction omits an explicit ASIN
- keep explicit target-ASIN matches accepted while rejecting ambiguous attribute-only visible selections
- add a MemoryArena regression test for tied option attributes selecting the wrong item

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
- pnpm --filter @remnic/bench exec tsc --noEmit --pretty false
- git diff --check
- node scripts/ensure-better-sqlite3.mjs && npm run preflight:quick
- npm run review:cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts core `MemoryArena` scoring behavior for item-selection tasks, which can change benchmark scores and potentially break expectations for existing datasets. Logic is localized to scoring and backed by a regression test, but subtle matching edge cases may remain.
> 
> **Overview**
> Tightens `MemoryArena` item-selection scoring so **hidden `target_asin` expectations are only credited via visible-option matching when the expectation’s attributes uniquely identify a single visible option** (unless the prediction explicitly includes the expected ASIN).
> 
> Adds a regression test covering the tied-attribute case to ensure ambiguous attribute-only visible selections are rejected (driving `item_selection_match` and `process_score` to `0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2065399cd4fe97755f8c21222856ba12c1121920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->