### PR TITLE
chore(openclaw): publish plugin release versions

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-remnic",
   "name": "Remnic OpenClaw Plugin",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "OpenClaw adapter for Remnic memory with bundled @remnic/core runtime",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-engram",
   "name": "Remnic OpenClaw Plugin",
-  "version": "9.3.21",
+  "version": "9.3.22",
   "kind": "memory",
   "description": "Local semantic memory for OpenClaw with bundled Remnic core runtime. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
   "setup": {

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.21",
+  "version": "9.3.22",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump @remnic/plugin-openclaw to 1.0.36 so the merged gpt-5.5/default-model fix is publishable
- bump legacy @joshuaswarren/openclaw-engram shim to 9.3.22 so compatibility installs can receive the same manifest fix

## Checks
- pnpm run check:openclaw-plugin-sync
- pnpm run check-config-contract
- pnpm run verify:openclaw-clawpack

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps published version numbers in plugin manifests/package metadata, with no functional code changes.
> 
> **Overview**
> Publishes a new OpenClaw plugin release by bumping version metadata for `@remnic/plugin-openclaw` from `1.0.35` to `1.0.36` (including both root and package `openclaw.plugin.json`).
> 
> Also bumps the deprecated compatibility shim `@joshuaswarren/openclaw-engram` from `9.3.21` to `9.3.22` so legacy installs can pick up the same updated plugin manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c633b0a331efe48f6096ef40f3bb262f29854a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->