### PR TITLE
Report effective extraction judge config

### DIFF
--- a/packages/bench/src/benchmarks/remnic/extraction-judge-calibration/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/extraction-judge-calibration/runner.test.ts
@@ -31,3 +31,40 @@ test("Extraction judge calibration treats absent negative class as neutral", asy
   assert.equal(result.results.aggregates.specificity.mean, 1);
   assert.equal(result.results.aggregates.sensitivity.mean, 1);
 });
+
+test("Extraction judge calibration reports the effective forced judge config", async () => {
+  const result = await runExtractionJudgeCalibrationBenchmark({
+    benchmark: extractionJudgeCalibrationDefinition,
+    mode: "quick",
+    limit: 1,
+    system: {
+      async reset() {},
+      async store() {},
+      async recall() {
+        return "";
+      },
+      async search() {
+        return [];
+      },
+      async destroy() {},
+      async getStats() {
+        return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+    },
+    remnicConfig: {
+      extractionJudgeEnabled: false,
+      extractionJudgeBatchSize: 99,
+      extractionJudgeShadow: true,
+      extractionJudgeMaxDeferrals: 0,
+      modelSource: "gateway",
+    },
+  });
+
+  assert.deepEqual(result.config.remnicConfig, {
+    extractionJudgeEnabled: true,
+    extractionJudgeBatchSize: 4,
+    extractionJudgeShadow: false,
+    extractionJudgeMaxDeferrals: 2,
+    extractionJudgeModel: "",
+  });
+});

--- a/packages/bench/src/benchmarks/remnic/extraction-judge-calibration/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/extraction-judge-calibration/runner.ts
@@ -5,7 +5,14 @@
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import { clearVerdictCache, judgeFactDurability, parseConfig, type JudgeCandidate, type JudgeVerdict } from "@remnic/core";
+import {
+  clearVerdictCache,
+  judgeFactDurability,
+  parseConfig,
+  type JudgeCandidate,
+  type JudgeVerdict,
+  type PluginConfig,
+} from "@remnic/core";
 import type { BenchmarkDefinition, BenchmarkResult, MetricAggregate, ResolvedRunBenchmarkOptions, TaskResult } from "../../../types.js";
 import { aggregateTaskScores, exactMatch } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
@@ -42,6 +49,7 @@ export async function runExtractionJudgeCalibrationBenchmark(
       extractionJudgeBatchSize: 4,
       extractionJudgeShadow: false,
     });
+    const effectiveRemnicConfig = buildReportedRemnicConfig(config);
 
     clearVerdictCache();
 
@@ -131,10 +139,7 @@ export async function runExtractionJudgeCalibrationBenchmark(
         systemProvider: options.systemProvider ?? null,
         judgeProvider: options.judgeProvider ?? null,
         adapterMode: options.adapterMode ?? "direct",
-        remnicConfig: {
-          ...(options.remnicConfig ?? {}),
-          extractionJudgeBatchSize: config.extractionJudgeBatchSize,
-        },
+        remnicConfig: effectiveRemnicConfig,
       },
       cost: {
         totalTokens: 0,
@@ -154,6 +159,18 @@ export async function runExtractionJudgeCalibrationBenchmark(
         hardware: process.arch,
       },
     };
+}
+
+function buildReportedRemnicConfig(
+  config: PluginConfig,
+): Record<string, unknown> {
+  return {
+    extractionJudgeEnabled: config.extractionJudgeEnabled,
+    extractionJudgeBatchSize: config.extractionJudgeBatchSize,
+    extractionJudgeShadow: config.extractionJudgeShadow,
+    extractionJudgeMaxDeferrals: config.extractionJudgeMaxDeferrals,
+    extractionJudgeModel: config.extractionJudgeModel,
+  };
 }
 
 function loadCases(


### PR DESCRIPTION
## Summary
- stop echoing caller remnicConfig values that the extraction judge calibration runner does not use
- derive the result artifact config from the parsed effective judge config
- add a regression for conflicting caller settings

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/bench/src/benchmarks/remnic/extraction-judge-calibration/runner.test.ts
- pnpm --filter @remnic/bench exec tsc --noEmit --pretty false
- git diff --check
- node scripts/ensure-better-sqlite3.mjs && npm run preflight:quick
- npm run review:cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect the extraction-judge calibration benchmark’s reported config metadata and adds a regression test; no production judging logic is modified.
> 
> **Overview**
> Updates the extraction-judge calibration benchmark to **report the parsed/effective extraction-judge config** (from `parseConfig`) in the result artifact, instead of echoing caller-provided `remnicConfig` values the runner doesn’t actually use.
> 
> Adds a regression test ensuring conflicting caller `remnicConfig` settings are overridden by the benchmark’s forced judge settings, and includes additional judge fields (`extractionJudgeMaxDeferrals`, `extractionJudgeModel`) in the reported config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aeb5f8ceae46e2888abf99047ec48bc71b13ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->