### PR TITLE
test(cli): unblock release quality gate

### DIFF
--- a/packages/remnic-cli/src/marketplace-cli.test.ts
+++ b/packages/remnic-cli/src/marketplace-cli.test.ts
@@ -9,12 +9,7 @@ import { fileURLToPath } from "node:url";
 const srcDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(srcDir, "../../..");
 const cliPath = path.join(srcDir, "index.ts");
-const tsxCli = path.join(
-  repoRoot,
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "tsx.cmd" : "tsx",
-);
+const tsxCli = path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
 
 interface SpawnTextResult {
   status: number | null;


### PR DESCRIPTION
## Summary
- make marketplace CLI tests invoke `node_modules/tsx/dist/cli.mjs` when using `process.execPath`
- fixes the release workflow failure where GitHub Actions tried to parse the `.bin/tsx` shell shim as JavaScript

## Checks
- pnpm exec tsx --test packages/remnic-cli/src/marketplace-cli.test.ts
- pnpm run check-types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adjusts how the CLI test runner invokes `tsx`, with minimal blast radius beyond CI/test execution.
> 
> **Overview**
> Updates `marketplace-cli.test.ts` to invoke `tsx` via `node_modules/tsx/dist/cli.mjs` instead of the `.bin/tsx` shim when spawning with `process.execPath`, preventing environments (e.g. GitHub Actions) from trying to parse the shell shim as JavaScript and unblocking the release quality gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a09ab1f5d7501deb9093bd9e6601c30f6b88cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->