### PR TITLE
Retry Hermes recall requests

### DIFF
--- a/packages/hermes-provider/src/index.test.ts
+++ b/packages/hermes-provider/src/index.test.ts
@@ -42,13 +42,51 @@ test("recall retries transient server errors according to client policy", async 
       retryBaseDelayMs: 0,
     });
 
-    const result = await client.recall("what matters?");
+    const result = await client.recall("what matters?", {
+      idempotencyKey: "recall-retry-test",
+    });
 
     assert.equal(calls, 2);
     assert.equal(typeof idempotencyKeys[0], "string");
     assert.equal(idempotencyKeys[1], idempotencyKeys[0]);
     assert.equal(result.context, "remembered context");
     assert.equal(result.results?.[0]?.id, "mem-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("recall remains single-attempt without an idempotency key", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  let sawIdempotencyKey = false;
+
+  globalThis.fetch = (async (_input, init) => {
+    calls += 1;
+    const body = JSON.parse(String(init?.body ?? "{}")) as {
+      idempotencyKey?: unknown;
+    };
+    sawIdempotencyKey ||= body.idempotencyKey !== undefined;
+    return new Response(JSON.stringify({ error: "temporary failure" }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const client = new HermesClient({
+      baseUrl: "http://127.0.0.1:4318",
+      authToken: "test-token",
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+    });
+
+    await assert.rejects(
+      () => client.recall("what matters?"),
+      /HTTP 500/,
+    );
+    assert.equal(calls, 1);
+    assert.equal(sawIdempotencyKey, false);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/hermes-provider/src/index.test.ts
+++ b/packages/hermes-provider/src/index.test.ts
@@ -6,9 +6,14 @@ import { HermesClient } from "./index.js";
 test("recall retries transient server errors according to client policy", async () => {
   const originalFetch = globalThis.fetch;
   let calls = 0;
+  const idempotencyKeys: unknown[] = [];
 
-  globalThis.fetch = (async () => {
+  globalThis.fetch = (async (_input, init) => {
     calls += 1;
+    const body = JSON.parse(String(init?.body ?? "{}")) as {
+      idempotencyKey?: unknown;
+    };
+    idempotencyKeys.push(body.idempotencyKey);
     if (calls === 1) {
       return new Response(JSON.stringify({ error: "temporary failure" }), {
         status: 500,
@@ -40,6 +45,8 @@ test("recall retries transient server errors according to client policy", async 
     const result = await client.recall("what matters?");
 
     assert.equal(calls, 2);
+    assert.equal(typeof idempotencyKeys[0], "string");
+    assert.equal(idempotencyKeys[1], idempotencyKeys[0]);
     assert.equal(result.context, "remembered context");
     assert.equal(result.results?.[0]?.id, "mem-1");
   } finally {

--- a/packages/hermes-provider/src/index.test.ts
+++ b/packages/hermes-provider/src/index.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { HermesClient } from "./index.js";
+
+test("recall retries transient server errors according to client policy", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+
+  globalThis.fetch = (async () => {
+    calls += 1;
+    if (calls === 1) {
+      return new Response(JSON.stringify({ error: "temporary failure" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        context: "remembered context",
+        results: [{ id: "mem-1", content: "remembered context", score: 1 }],
+        count: 1,
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const client = new HermesClient({
+      baseUrl: "http://127.0.0.1:4318",
+      authToken: "test-token",
+      maxRetries: 1,
+      retryBaseDelayMs: 0,
+    });
+
+    const result = await client.recall("what matters?");
+
+    assert.equal(calls, 2);
+    assert.equal(result.context, "remembered context");
+    assert.equal(result.results?.[0]?.id, "mem-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/hermes-provider/src/index.ts
+++ b/packages/hermes-provider/src/index.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * @remnic/hermes-provider
  *
@@ -109,6 +111,7 @@ export interface RecallOptions {
   topK?: number;
   mode?: "auto" | "no_recall" | "minimal" | "full" | "graph_mode";
   includeDebug?: boolean;
+  idempotencyKey?: string;
 }
 
 export interface ObserveOptions {
@@ -225,6 +228,7 @@ export class HermesClient {
     if (options?.topK !== undefined) body.topK = options.topK;
     if (options?.mode) body.mode = options.mode;
     if (options?.includeDebug !== undefined) body.includeDebug = options.includeDebug;
+    body.idempotencyKey = options?.idempotencyKey ?? randomUUID();
     return this.request<EngramAccessRecallResponse>("POST", "/engram/v1/recall", body);
   }
 

--- a/packages/hermes-provider/src/index.ts
+++ b/packages/hermes-provider/src/index.ts
@@ -225,7 +225,7 @@ export class HermesClient {
     if (options?.topK !== undefined) body.topK = options.topK;
     if (options?.mode) body.mode = options.mode;
     if (options?.includeDebug !== undefined) body.includeDebug = options.includeDebug;
-    return this.request<EngramAccessRecallResponse>("POST", "/engram/v1/recall", body, { noRetry: true });
+    return this.request<EngramAccessRecallResponse>("POST", "/engram/v1/recall", body);
   }
 
   async observe(

--- a/packages/hermes-provider/src/index.ts
+++ b/packages/hermes-provider/src/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-
 /**
  * @remnic/hermes-provider
  *
@@ -228,8 +226,10 @@ export class HermesClient {
     if (options?.topK !== undefined) body.topK = options.topK;
     if (options?.mode) body.mode = options.mode;
     if (options?.includeDebug !== undefined) body.includeDebug = options.includeDebug;
-    body.idempotencyKey = options?.idempotencyKey ?? randomUUID();
-    return this.request<EngramAccessRecallResponse>("POST", "/engram/v1/recall", body);
+    if (options?.idempotencyKey) body.idempotencyKey = options.idempotencyKey;
+    return this.request<EngramAccessRecallResponse>("POST", "/engram/v1/recall", body, {
+      noRetry: !options?.idempotencyKey,
+    });
   }
 
   async observe(

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -514,6 +514,7 @@ export class EngramAccessHttpServer {
         query: body.query ?? "",
         sessionKey: body.sessionKey,
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
+        idempotencyKey: body.idempotencyKey,
         namespace: this.resolveNamespace(req, body.namespace),
         topK: body.topK,
         mode: body.mode as RecallPlanMode | "auto" | undefined,

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -86,6 +86,7 @@ export const recallRequestSchema = z.object({
   topK: z.number().int().min(0).max(200).optional(),
   mode: z.enum(["auto", "no_recall", "minimal", "full", "graph_mode"]).optional(),
   includeDebug: z.boolean().optional(),
+  idempotencyKey: idempotencyKeySchema,
   disclosure: recallDisclosureSchema.optional(),
   codingContext: codingContextSchema.optional(),
   /** Working directory for auto git-context resolution (issue #569). */

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -933,6 +933,7 @@ export function shapeMemorySummary(
 export class EngramAccessService {
   private readonly idempotency: AccessIdempotencyStore;
   private readonly idempotencyLocks = new Map<string, Promise<void>>();
+  private readonly budgetLocks = new Map<string, Promise<void>>();
   private readonly budget: CrossNamespaceBudget;
   private readonly auditAdapter: AccessAuditAdapter | null;
 
@@ -1329,10 +1330,13 @@ export class EngramAccessService {
     idempotencyKey?: string;
     requestFingerprint: unknown;
     execute: () => Promise<T>;
+    afterStore?: (response: T) => Promise<void> | void;
   }): Promise<T> {
     const key = options.idempotencyKey?.trim();
     if (!key) {
-      return options.execute();
+      const response = await options.execute();
+      await options.afterStore?.(response);
+      return response;
     }
     return this.withIdempotencyLock(key, async () => {
       return this.idempotency.withKeyLock(key, async () => {
@@ -1349,6 +1353,7 @@ export class EngramAccessService {
         }
         const response = await options.execute();
         await this.idempotency.put(key, requestHash, response);
+        await options.afterStore?.(response);
         return response;
       });
     });
@@ -1398,6 +1403,27 @@ export class EngramAccessService {
       release();
       if (this.idempotencyLocks.get(key) === queued) {
         this.idempotencyLocks.delete(key);
+      }
+    }
+  }
+
+  private async withBudgetLock<T>(principal: string, fn: () => Promise<T>): Promise<T> {
+    const key = principal || "__anonymous__";
+    const previous = this.budgetLocks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current, () => current);
+    this.budgetLocks.set(key, queued);
+
+    await previous.catch(() => {});
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.budgetLocks.get(key) === queued) {
+        this.budgetLocks.delete(key);
       }
     }
   }
@@ -1646,17 +1672,39 @@ export class EngramAccessService {
       throw new EngramAccessInputError("query is required");
     }
     const normalizedRequest = { ...request, query };
-    return this.handleIdempotentRead({
-      operation: "recall",
-      idempotencyKey: request.idempotencyKey,
-      requestFingerprint: normalizedRequest,
-      execute: () => this.executeRecall(normalizedRequest),
+    const authenticatedPrincipal = request.authenticatedPrincipal?.trim();
+    const principal = this.resolveRequestPrincipal(request.sessionKey, authenticatedPrincipal);
+    return this.withBudgetLock(principal, async () => {
+      let budgetRecordPrincipal: string | null = null;
+      const response = await this.handleIdempotentRead({
+        operation: "recall",
+        idempotencyKey: request.idempotencyKey,
+        requestFingerprint: normalizedRequest,
+        execute: async () => {
+          const result = await this.executeRecall(normalizedRequest);
+          budgetRecordPrincipal = result.budgetRecordPrincipal;
+          return result.response;
+        },
+        afterStore: () => {
+          if (!budgetRecordPrincipal) return;
+          const recordedBudgetDecision = this.budget.record(budgetRecordPrincipal);
+          if (!recordedBudgetDecision.allowed) {
+            throw new EngramAccessInputError(
+              `recall denied: cross-namespace budget exceeded (${recordedBudgetDecision.count}/${recordedBudgetDecision.limit.hardLimit} in ${recordedBudgetDecision.limit.windowMs}ms window)`,
+            );
+          }
+        },
+      });
+      return response;
     });
   }
 
   private async executeRecall(
     request: EngramAccessRecallRequest,
-  ): Promise<EngramAccessRecallResponse> {
+  ): Promise<{
+    response: EngramAccessRecallResponse;
+    budgetRecordPrincipal: string | null;
+  }> {
     const query = request.query;
     // Disclosure depth (issue #677).  Default to `"chunk"` when omitted so
     // pre-#677 callers see unchanged behavior.  Reject explicitly invalid
@@ -1827,12 +1875,6 @@ export class EngramAccessService {
     };
     const startedAt = Date.now();
     const context = await this.orchestrator.recall(query, request.sessionKey, recallOptions);
-    if (recordBudgetAfterSuccess) {
-      const recordedBudgetDecision = this.budget.record(principal);
-      if (recordedBudgetDecision.allowed) {
-        budgetDecision = recordedBudgetDecision;
-      }
-    }
     const snapshot = request.sessionKey
       ? this.orchestrator.lastRecall.get(request.sessionKey)
       : null;
@@ -1997,26 +2039,29 @@ export class EngramAccessService {
     }
 
     return {
-      query,
-      sessionKey: request.sessionKey,
-      namespace: effectiveNamespace,
-      context: effectiveContext,
-      count: filterTags && filterTags.length > 0
-        ? results.length
-        : (snapshot?.memoryIds.length ?? results.length),
-      memoryIds: filteredMemoryIds,
-      results,
-      recordedAt: snapshot?.recordedAt,
-      traceId: snapshot?.traceId,
-      plannerMode: snapshot?.plannerMode ?? mode,
-      fallbackUsed: snapshot?.fallbackUsed ?? false,
-      sourcesUsed: snapshot?.sourcesUsed ?? [],
-      disclosure,
-      budgetsApplied: snapshot?.budgetsApplied,
-      auditAnomalies,
-      budgetWarning: budgetDecision.reason === "warn-over-soft" ? budgetDecision : undefined,
-      latencyMs: snapshot?.latencyMs ?? (Date.now() - startedAt),
-      debug,
+      response: {
+        query,
+        sessionKey: request.sessionKey,
+        namespace: effectiveNamespace,
+        context: effectiveContext,
+        count: filterTags && filterTags.length > 0
+          ? results.length
+          : (snapshot?.memoryIds.length ?? results.length),
+        memoryIds: filteredMemoryIds,
+        results,
+        recordedAt: snapshot?.recordedAt,
+        traceId: snapshot?.traceId,
+        plannerMode: snapshot?.plannerMode ?? mode,
+        fallbackUsed: snapshot?.fallbackUsed ?? false,
+        sourcesUsed: snapshot?.sourcesUsed ?? [],
+        disclosure,
+        budgetsApplied: snapshot?.budgetsApplied,
+        auditAnomalies,
+        budgetWarning: budgetDecision.reason === "warn-over-soft" ? budgetDecision : undefined,
+        latencyMs: snapshot?.latencyMs ?? (Date.now() - startedAt),
+        debug,
+      },
+      budgetRecordPrincipal: recordBudgetAfterSuccess ? principal : null,
     };
   }
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -214,6 +214,7 @@ export interface EngramAccessRecallRequest {
   sessionKey?: string;
   namespace?: string;
   authenticatedPrincipal?: string;
+  idempotencyKey?: string;
   topK?: number;
   mode?: RecallPlanMode | "auto";
   includeDebug?: boolean;
@@ -1323,6 +1324,36 @@ export class EngramAccessService {
     });
   }
 
+  private async handleIdempotentRead<T>(options: {
+    operation: string;
+    idempotencyKey?: string;
+    requestFingerprint: unknown;
+    execute: () => Promise<T>;
+  }): Promise<T> {
+    const key = options.idempotencyKey?.trim();
+    if (!key) {
+      return options.execute();
+    }
+    return this.withIdempotencyLock(key, async () => {
+      return this.idempotency.withKeyLock(key, async () => {
+        const requestHash = hashAccessIdempotencyPayload({
+          operation: options.operation,
+          request: options.requestFingerprint,
+        });
+        const existing = await this.idempotency.get(key, requestHash);
+        if (existing.conflict) {
+          throw new EngramAccessInputError(`idempotencyKey reuse conflict: ${key}`);
+        }
+        if (existing.response) {
+          return existing.response as T;
+        }
+        const response = await options.execute();
+        await this.idempotency.put(key, requestHash, response);
+        return response;
+      });
+    });
+  }
+
   private async peekIdempotentWrite(options: {
     operation: EngramAccessWriteResponse["operation"];
     idempotencyKey?: string;
@@ -1614,6 +1645,19 @@ export class EngramAccessService {
     if (query.length === 0) {
       throw new EngramAccessInputError("query is required");
     }
+    const normalizedRequest = { ...request, query };
+    return this.handleIdempotentRead({
+      operation: "recall",
+      idempotencyKey: request.idempotencyKey,
+      requestFingerprint: normalizedRequest,
+      execute: () => this.executeRecall(normalizedRequest),
+    });
+  }
+
+  private async executeRecall(
+    request: EngramAccessRecallRequest,
+  ): Promise<EngramAccessRecallResponse> {
+    const query = request.query;
     // Disclosure depth (issue #677).  Default to `"chunk"` when omitted so
     // pre-#677 callers see unchanged behavior.  Reject explicitly invalid
     // string values per CLAUDE.md rule 51 (do not silently fall back).
@@ -1677,6 +1721,7 @@ export class EngramAccessService {
       ? [namespaceOverride]
       : recallNamespacesForPrincipal(principal, this.orchestrator.config);
     let budgetDecision: BudgetDecision;
+    let recordBudgetAfterSuccess = false;
     if (modeSkipsBudget) {
       budgetDecision = {
         allowed: true as const,
@@ -1692,9 +1737,13 @@ export class EngramAccessService {
       // Peek at every effective namespace to determine whether ANY would be
       // cross-namespace WITHOUT recording side effects (Cursor review:
       // multi-count bug).  Record a single budget event only when at least
-      // one effective namespace differs from the principal's self namespace.
+      // one effective namespace differs from the principal's self namespace,
+      // and only after recall succeeds so retried transient failures do not
+      // consume budget multiple times before a successful response can be
+      // cached behind the request idempotency key.
       let anyCrossNamespace = false;
       let denied: BudgetDecision | null = null;
+      let crossNamespaceDecision: BudgetDecision | null = null;
       for (const ns of effectiveNamespaces) {
         const peek = this.budget.peek({
           principal,
@@ -1703,6 +1752,7 @@ export class EngramAccessService {
         });
         if (peek.reason !== "allowed-same-namespace") {
           anyCrossNamespace = true;
+          crossNamespaceDecision ??= peek;
         }
         if (!peek.allowed) {
           denied = peek;
@@ -1714,7 +1764,17 @@ export class EngramAccessService {
         // bucket is not inflated by rejected attempts.
         budgetDecision = denied;
       } else if (anyCrossNamespace) {
-        budgetDecision = this.budget.record(principal);
+        budgetDecision = crossNamespaceDecision ?? {
+          allowed: true as const,
+          reason: "allowed-under-soft" as const,
+          count: 0,
+          limit: {
+            softLimit: this.orchestrator.config.recallCrossNamespaceBudgetSoftLimit ?? 10,
+            hardLimit: this.orchestrator.config.recallCrossNamespaceBudgetHardLimit ?? 30,
+            windowMs: this.orchestrator.config.recallCrossNamespaceBudgetWindowMs ?? 60_000,
+          },
+        };
+        recordBudgetAfterSuccess = true;
       } else {
         budgetDecision = {
           allowed: true as const,
@@ -1767,6 +1827,12 @@ export class EngramAccessService {
     };
     const startedAt = Date.now();
     const context = await this.orchestrator.recall(query, request.sessionKey, recallOptions);
+    if (recordBudgetAfterSuccess) {
+      const recordedBudgetDecision = this.budget.record(principal);
+      if (recordedBudgetDecision.allowed) {
+        budgetDecision = recordedBudgetDecision;
+      }
+    }
     const snapshot = request.sessionKey
       ? this.orchestrator.lastRecall.get(request.sessionKey)
       : null;

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -3942,3 +3942,91 @@ test("access service idempotent recall retries do not double count cross-namespa
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("access service serializes recall budget records under the hard limit", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-recall-budget-lock-"));
+  let recallCalls = 0;
+  let releaseFirstRecall: (() => void) | undefined;
+  let markFirstRecallEntered: (() => void) | undefined;
+  const firstRecallEntered = new Promise<void>((resolve) => {
+    markFirstRecallEntered = resolve;
+  });
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "shared",
+          readPrincipals: ["project-x"],
+          writePrincipals: [],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: true,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 0,
+      recallCrossNamespaceBudgetHardLimit: 1,
+      dreamsPhases: dreamsPhasesConfig(),
+    },
+    recall: async () => {
+      recallCalls += 1;
+      if (recallCalls === 1) {
+        markFirstRecallEntered?.();
+        await new Promise<void>((release) => {
+          releaseFirstRecall = release;
+        });
+      }
+      return "ctx";
+    },
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async () => ({
+      dir: memoryDir,
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  } as any);
+
+  try {
+    const first = service.recall({
+      query: "hello",
+      sessionKey: "agent:project-x:chat",
+      namespace: "shared",
+      idempotencyKey: "recall-budget-lock-1",
+    });
+    await firstRecallEntered;
+
+    const second = service.recall({
+      query: "hello again",
+      sessionKey: "agent:project-x:chat",
+      namespace: "shared",
+      idempotencyKey: "recall-budget-lock-2",
+    });
+
+    await new Promise((settle) => setTimeout(settle, 25));
+    assert.equal(recallCalls, 1);
+    releaseFirstRecall?.();
+
+    const firstResponse = await first;
+    assert.equal(firstResponse.context, "ctx");
+    assert.equal(firstResponse.budgetWarning?.reason, "warn-over-soft");
+    await assert.rejects(
+      () => second,
+      /cross-namespace budget exceeded/,
+    );
+    assert.equal(recallCalls, 1);
+  } finally {
+    releaseFirstRecall?.();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -3870,3 +3870,75 @@ test("access service liveConnectorsRun enforces write ACL before ingestion", asy
   await service.liveConnectorsRun({}, "writer");
   assert.equal(runCount, 1);
 });
+
+test("access service idempotent recall retries do not double count cross-namespace budget", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-recall-idempotent-"));
+  let recallCalls = 0;
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "shared",
+          readPrincipals: ["project-x"],
+          writePrincipals: [],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: true,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 0,
+      recallCrossNamespaceBudgetHardLimit: 1,
+      dreamsPhases: dreamsPhasesConfig(),
+    },
+    recall: async () => {
+      recallCalls += 1;
+      if (recallCalls === 1) {
+        throw new Error("transient recall failure");
+      }
+      return "ctx";
+    },
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async () => ({
+      dir: memoryDir,
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  } as any);
+
+  const request = {
+    query: "hello",
+    sessionKey: "agent:project-x:chat",
+    namespace: "shared",
+    idempotencyKey: "recall-retry-key",
+  };
+
+  try {
+    await assert.rejects(
+      () => service.recall(request),
+      /transient recall failure/,
+    );
+
+    const response = await service.recall(request);
+    assert.equal(response.context, "ctx");
+    assert.equal(recallCalls, 2);
+    assert.equal(response.budgetWarning?.reason, "warn-over-soft");
+
+    const replay = await service.recall(request);
+    assert.equal(replay.context, "ctx");
+    assert.equal(recallCalls, 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- let Hermes recall use the configured retry policy like other read-only requests
- keep mutating observe/store/suggestion requests single-attempt through noRetry
- add a focused recall retry regression with a transient 500 followed by success

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/hermes-provider/src/index.test.ts
- pnpm --filter @remnic/hermes-provider exec tsc --noEmit --pretty false
- git diff --check
- node scripts/ensure-better-sqlite3.mjs && npm run preflight:quick
- npm run review:cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall request semantics by introducing idempotency-keyed caching/retry behavior and new per-principal budget serialization, which could affect recall throughput and cross-namespace budget enforcement under concurrency.
> 
> **Overview**
> Enables Hermes `recall` to participate in the client retry policy **only when** callers provide an `idempotencyKey`; without a key, recall stays single-attempt to avoid duplicate side effects.
> 
> Plumbs `idempotencyKey` through the HTTP API and access service, adding idempotent caching for recall responses and deferring cross-namespace budget recording until after a successful recall so transient retries don’t consume budget multiple times; also serializes budget recording per principal to avoid racing past the hard limit.
> 
> Adds focused regression tests covering Hermes recall retry behavior, idempotent recall budget non-double-counting, and budget locking under concurrent recall calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278ec812515e467a416984b980587512449d394e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->