### PR TITLE
Harden AMemGym dataset loading

### DIFF
--- a/packages/bench/src/benchmarks/published/amemgym/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.test.ts
@@ -127,6 +127,106 @@ test("AMemGym batches tiny session messages before storing profile context", asy
   }
 });
 
+test("AMemGym rejects malformed primary dataset files instead of falling back", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-amemgym-malformed-"));
+  let storeCalls = 0;
+
+  try {
+    await writeFile(path.join(tempDir, "amemgym-v1-base.json"), "{", "utf8");
+    await writeFile(
+      path.join(tempDir, "data.json"),
+      JSON.stringify([
+        {
+          id: "fallback-profile",
+          start_time: "2025-01-01T00:00:00Z",
+          user_profile: {
+            uuid: "user-1",
+            name: "Maya",
+            age: 29,
+            gender: "female",
+          },
+          state_schema: { city: { type: "string" } },
+          periods: [
+            {
+              period_start: "2025-01-01T00:00:00Z",
+              period_end: "2025-01-31T23:59:59Z",
+              period_summary: "Maya updated her city.",
+              sessions: [],
+              state: { city: "Chicago" },
+              updates: { city: "Chicago" },
+              update_cnts: { city: 1 },
+            },
+          ],
+          qas: [
+            {
+              query: "What city does Maya live in now?",
+              required_info: ["city"],
+              answer_choices: [
+                { state: ["Chicago"], answer: "Chicago" },
+                { state: ["Austin"], answer: "Austin" },
+              ],
+            },
+          ],
+        },
+      ]),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () =>
+        runAMemGymBenchmark({
+          benchmark: amemGymDefinition,
+          mode: "full",
+          datasetDir: tempDir,
+          system: {
+            async store() {
+              storeCalls += 1;
+            },
+            async recall() {
+              return "Chicago";
+            },
+            async search() {
+              return [];
+            },
+            async reset() {},
+            async drain() {},
+            async destroy() {},
+            async getStats() {
+              return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+            },
+            responder: {
+              async respond() {
+                return {
+                  text: "1",
+                  tokens: { input: 1, output: 1 },
+                  latencyMs: 1,
+                  model: "amemgym-test-responder",
+                };
+              },
+            },
+            judge: {
+              async score() {
+                return 1;
+              },
+              async scoreWithMetrics() {
+                return {
+                  score: 1,
+                  tokens: { input: 0, output: 0 },
+                  latencyMs: 0,
+                  model: "amemgym-test-judge",
+                };
+              },
+            },
+          },
+        }),
+      /AMemGym dataset file amemgym-v1-base\.json is invalid:/,
+    );
+    assert.equal(storeCalls, 0);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("AMemGym fails fast when profile drain fails before scoring", async () => {
   let completedTasks = 0;
   let recallCalls = 0;

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -645,6 +645,11 @@ async function loadDataset(
         const parsed = parseDataset(raw, filename);
         return ensureDatasetProfiles(applyLimit(parsed, normalizedLimit));
       } catch (error) {
+        if (!isFileNotFoundError(error)) {
+          throw new Error(
+            `AMemGym dataset file ${filename} is invalid: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
         datasetErrors.push(
           `${filename}: ${error instanceof Error ? error.message : String(error)}`,
         );
@@ -673,6 +678,13 @@ function parseDataset(raw: string, filename: string): AMemGymProfile[] {
     );
   }
   return parsed as AMemGymProfile[];
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { code?: unknown }).code === "ENOENT";
 }
 
 function normalizeLimit(limit: number | undefined): number | undefined {

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -1586,7 +1586,7 @@ test("runBenchmark fails fast when amemgym full mode is given an explicit unread
         datasetDir,
         system: adapter,
       }),
-    /AMemGym dataset not found under/,
+    /AMemGym dataset file data\.json is invalid:/,
   );
 });
 


### PR DESCRIPTION
## Summary
- Fail AMemGym dataset loading on malformed primary dataset files instead of falling through to lower-priority filenames.
- Add regression coverage for malformed `amemgym-v1-base.json` with valid `data.json` fallback present.
- Confirm AMemGym drain-failure behavior is already fail-fast on current main.

## Tests
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/bench/src/benchmarks/published/amemgym/runner.test.ts`
- `pnpm --filter @remnic/bench exec tsc --noEmit --pretty false`
- `node scripts/ensure-better-sqlite3.mjs && npm run preflight:quick`
- `npm run review:cursor` (skipped: Cursor agent authentication required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dataset-loading error handling to throw on malformed files rather than trying lower-priority filenames, which can alter behavior for misconfigured dataset directories. Scope is limited to AMemGym benchmark loading and its tests.
> 
> **Overview**
> **Hardens AMemGym dataset loading** so that if a candidate dataset file exists but is malformed, the runner immediately errors instead of falling through to try the next filename.
> 
> Adds `isFileNotFoundError` handling in `loadDataset` to distinguish missing files from invalid contents, and updates/adds tests to assert the new fail-fast behavior (including a regression case where `amemgym-v1-base.json` is broken but `data.json` is present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d281f16d9f873ce56dfa65f8c743f6303d704e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->