### PR TITLE
Emit custom benchmark progress callbacks

### DIFF
--- a/packages/bench/src/benchmarks/custom/runner.ts
+++ b/packages/bench/src/benchmarks/custom/runner.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import type { RunBenchmarkOptions, BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../types.js";
 import { answerBenchmarkQuestion } from "../../answering.js";
 import { aggregateTaskScores, exactMatch, f1Score, llmJudgeScoreDetailed, rougeL, timed } from "../../scorer.js";
-import { orchestrateBenchmarkRuns } from "../../benchmark.js";
+import { orchestrateBenchmarkRuns, resolveBenchmarkRunCount } from "../../benchmark.js";
 import { finalizeBenchmarkResultConfig } from "../../result-config.js";
 import { getGitSha, getRemnicVersion } from "../../reporter.js";
 import { loadCustomBenchmarkFile } from "./loader.js";
@@ -36,10 +36,24 @@ async function runCustomBenchmark(
     );
   }
 
-  const { runCount, seeds, runs } = await orchestrateBenchmarkRuns(
+  const runCount = resolveBenchmarkRunCount(options.mode);
+  const tasksPerRun = selectTasks(spec, options.limit);
+  const totalTaskCount = runCount * tasksPerRun.length;
+  let completedTaskCount = 0;
+  const { seeds, runs } = await orchestrateBenchmarkRuns(
     options.mode,
     async (seed, runIndex) =>
-      runCustomBenchmarkRun(spec, options, seed, runIndex),
+      runCustomBenchmarkRun(
+        spec,
+        options,
+        seed,
+        runIndex,
+        tasksPerRun,
+        (taskResult) => {
+          completedTaskCount += 1;
+          options.onTaskComplete?.(taskResult, completedTaskCount, totalTaskCount);
+        },
+      ),
     undefined,
     options.seed,
   );
@@ -92,14 +106,9 @@ async function runCustomBenchmarkRun(
   options: ResolvedRunBenchmarkOptions,
   seed: number,
   runIndex: number,
+  tasks: readonly CustomBenchmarkSpec["tasks"][number][],
+  onTaskComplete?: (task: TaskResult) => void,
 ): Promise<TaskResult[]> {
-  const tasks = benchmark.tasks.slice(0, normalizeLimit(options.limit) ?? benchmark.tasks.length);
-  if (tasks.length === 0) {
-    throw new Error(
-      `Custom benchmark "${benchmark.name}" is empty after applying the requested limit.`,
-    );
-  }
-
   const results: TaskResult[] = [];
   for (const [taskIndex, task] of tasks.entries()) {
     const { result: searchResults, durationMs } = await timed(async () =>
@@ -119,7 +128,7 @@ async function runCustomBenchmarkRun(
       task.expected,
     );
 
-    results.push({
+    const taskResult: TaskResult = {
       taskId: `${slugify(benchmark.name)}-${runIndex + 1}-${taskIndex + 1}`,
       question: task.question,
       expected: task.expected,
@@ -143,10 +152,26 @@ async function runCustomBenchmarkRun(
         responderModel: answered.model,
         judgeModel: scored.judgeMetrics.model,
       },
-    });
+    };
+    results.push(taskResult);
+    onTaskComplete?.(taskResult);
   }
 
   return results;
+}
+
+function selectTasks(
+  benchmark: CustomBenchmarkSpec,
+  limit: number | undefined,
+): readonly CustomBenchmarkSpec["tasks"][number][] {
+  const tasks = benchmark.tasks.slice(0, normalizeLimit(limit) ?? benchmark.tasks.length);
+  if (tasks.length === 0) {
+    throw new Error(
+      `Custom benchmark "${benchmark.name}" is empty after applying the requested limit.`,
+    );
+  }
+
+  return tasks;
 }
 
 async function scoreTask(

--- a/tests/bench-custom-benchmark.test.ts
+++ b/tests/bench-custom-benchmark.test.ts
@@ -239,3 +239,86 @@ tasks:
   assert.equal(result.cost.totalLatencyMs >= 20, true);
   assert.equal(result.cost.meanQueryLatencyMs >= 20, true);
 });
+
+test("runCustomBenchmarkFile emits progress callbacks after each completed task", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-custom-bench-progress-"));
+  const filePath = path.join(tmpDir, "progress-check.yaml");
+  await writeFile(
+    filePath,
+    `
+name: Progress Check
+scoring: exact_match
+tasks:
+  - question: What is alphakey?
+    expected: alphakey
+  - question: What is betakey?
+    expected: betakey
+`,
+  );
+
+  const adapter = new FakeMemoryAdapter();
+  await adapter.store("memory", [
+    { role: "assistant", content: "alphakey" },
+    { role: "assistant", content: "betakey" },
+  ]);
+
+  const progressEvents: Array<{
+    completed: number;
+    total: number | undefined;
+    taskId: string;
+    actual: string;
+  }> = [];
+  const result = await runCustomBenchmarkFile(filePath, {
+    mode: "quick",
+    system: adapter,
+    onTaskComplete(task, completed, total) {
+      progressEvents.push({
+        completed,
+        total,
+        taskId: task.taskId,
+        actual: task.actual,
+      });
+    },
+  });
+
+  assert.equal(result.results.tasks.length, 2);
+  assert.deepEqual(
+    progressEvents.map((event) => event.completed),
+    [1, 2],
+  );
+  assert.deepEqual(
+    progressEvents.map((event) => event.total),
+    [2, 2],
+  );
+  assert.deepEqual(
+    progressEvents.map((event) => event.actual),
+    ["alphakey", "betakey"],
+  );
+  assert.deepEqual(
+    progressEvents.map((event) => event.taskId),
+    ["progress-check-1-1", "progress-check-1-2"],
+  );
+
+  const fullProgressEvents: Array<{
+    completed: number;
+    total: number | undefined;
+  }> = [];
+  const fullResult = await runCustomBenchmarkFile(filePath, {
+    mode: "full",
+    system: adapter,
+    onTaskComplete(_task, completed, total) {
+      fullProgressEvents.push({ completed, total });
+    },
+  });
+  const fullTotal = fullResult.meta.runCount * 2;
+
+  assert.equal(fullProgressEvents.length, fullTotal);
+  assert.deepEqual(
+    fullProgressEvents.map((event) => event.completed),
+    Array.from({ length: fullTotal }, (_value, index) => index + 1),
+  );
+  assert.deepEqual(
+    fullProgressEvents.map((event) => event.total),
+    Array.from({ length: fullTotal }, () => fullTotal),
+  );
+});


### PR DESCRIPTION
## Summary
- Emit `onTaskComplete` from custom benchmark runs after each task result is produced.
- Report cumulative completed counts across runs and the known total task count.
- Add regression coverage for two custom benchmark tasks receiving progress callbacks `[1, 2]`.

## Tests
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/bench-custom-benchmark.test.ts`
- `pnpm --filter @remnic/bench exec tsc --noEmit --pretty false`
- `node scripts/check-test-types.mjs`
- `node scripts/ensure-better-sqlite3.mjs && npm run preflight:quick`
- `npm run review:cursor` (skipped: Cursor agent authentication required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds progress callback wiring and small refactor around task selection; behavior change is limited to emitting `onTaskComplete` with cumulative counts.
> 
> **Overview**
> Custom benchmarks now emit `onTaskComplete` after each task finishes, reporting a cumulative completed count across all runs and a precomputed total task count (`runCount * tasksPerRun`).
> 
> This refactors custom task selection into `selectTasks()` and updates `runCustomBenchmarkRun()` to accept the selected tasks plus an internal per-task callback; tests add coverage for both `quick` and `full` modes to verify callback sequencing and totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91bff55e913cc274e366a10daa63116559efb6e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->