### PR TITLE
Harden FAISS sidecar lock ownership

### DIFF
--- a/packages/plugin-openclaw/scripts/faiss_index.py
+++ b/packages/plugin-openclaw/scripts/faiss_index.py
@@ -13,10 +13,12 @@ import os
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
 MODEL_CACHE: dict[str, Any] = {}
+LOCK_OWNERS: dict[str, str] = {}
 HASH_EMBED_DIM = 128
 LOCK_TIMEOUT_SECONDS = 10.0
 LOCK_STALE_SECONDS = 120.0
@@ -372,18 +374,65 @@ def merge_rows(existing: list[dict[str, Any]], updates: list[dict[str, Any]]) ->
     return [by_key[row_key] for row_key in order]
 
 
-def read_lock_owner_pid(lock_path: Path) -> int | None:
+def lock_owner_key(lock_path: Path) -> str:
+    return str(lock_path.resolve())
+
+
+def make_lock_owner_token() -> str:
+    return f"{os.getpid()}:{uuid.uuid4().hex}"
+
+
+def read_lock_contents(lock_path: Path) -> str | None:
     try:
         raw = lock_path.read_text(encoding="utf-8").strip()
     except Exception:
         return None
     if not raw:
         return None
+    return raw
+
+
+def read_lock_owner_pid(lock_path: Path) -> int | None:
+    raw = read_lock_contents(lock_path)
+    if raw is None:
+        return None
+    pid_raw = raw.split(":", 1)[0].strip()
     try:
-        pid = int(raw)
+        pid = int(pid_raw)
     except ValueError:
         return None
     return pid if pid > 0 else None
+
+
+def lock_stat_matches(current_stat: os.stat_result, observed_stat: os.stat_result) -> bool:
+    if current_stat.st_size != observed_stat.st_size:
+        return False
+    if current_stat.st_mtime_ns != observed_stat.st_mtime_ns:
+        return False
+    if getattr(current_stat, "st_ino", 0) and getattr(observed_stat, "st_ino", 0):
+        return current_stat.st_ino == observed_stat.st_ino
+    return True
+
+
+def unlink_lock_if_unchanged(
+    lock_path: Path,
+    observed_owner_token: str | None,
+    observed_stat: os.stat_result,
+) -> bool:
+    try:
+        current_stat = lock_path.stat()
+    except FileNotFoundError:
+        return False
+    current_owner_token = read_lock_contents(lock_path)
+    if current_owner_token != observed_owner_token:
+        return False
+    if not lock_stat_matches(current_stat, observed_stat):
+        return False
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        return False
+    return True
 
 
 def is_process_alive(pid: int) -> bool:
@@ -420,6 +469,7 @@ def is_process_alive(pid: int) -> bool:
 
 def acquire_lock(index_dir: Path, lock_name: str) -> Path:
     lock_path = index_dir / lock_name
+    lock_owner_token = make_lock_owner_token()
     lock_label = lock_name.strip(".")
     if lock_label.endswith(".lock"):
         lock_label = lock_label[: -len(".lock")]
@@ -430,19 +480,22 @@ def acquire_lock(index_dir: Path, lock_name: str) -> Path:
         try:
             fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(str(os.getpid()))
+                handle.write(lock_owner_token)
+            LOCK_OWNERS[lock_owner_key(lock_path)] = lock_owner_token
             return lock_path
         except FileExistsError:
             try:
-                age = time.time() - lock_path.stat().st_mtime
+                observed_stat = lock_path.stat()
             except FileNotFoundError:
                 continue
 
+            age = time.time() - observed_stat.st_mtime
+            observed_owner_token = read_lock_contents(lock_path)
             owner_pid = read_lock_owner_pid(lock_path)
             owner_alive = is_process_alive(owner_pid) if owner_pid is not None else False
 
             if age > LOCK_STALE_SECONDS and not owner_alive:
-                lock_path.unlink(missing_ok=True)
+                unlink_lock_if_unchanged(lock_path, observed_owner_token, observed_stat)
                 continue
 
             if time.monotonic() >= deadline:
@@ -459,7 +512,14 @@ def acquire_writer_lock(index_dir: Path) -> Path:
 
 
 def release_lock(lock_path: Path) -> None:
-    lock_path.unlink(missing_ok=True)
+    lock_owner_token = LOCK_OWNERS.pop(lock_owner_key(lock_path), None)
+    if lock_owner_token is None:
+        return
+    try:
+        observed_stat = lock_path.stat()
+    except FileNotFoundError:
+        return
+    unlink_lock_if_unchanged(lock_path, lock_owner_token, observed_stat)
 
 
 def release_index_lock(lock_path: Path) -> None:

--- a/packages/remnic-core/scripts/faiss_index.py
+++ b/packages/remnic-core/scripts/faiss_index.py
@@ -13,10 +13,12 @@ import os
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
 MODEL_CACHE: dict[str, Any] = {}
+LOCK_OWNERS: dict[str, str] = {}
 HASH_EMBED_DIM = 128
 LOCK_TIMEOUT_SECONDS = 10.0
 LOCK_STALE_SECONDS = 120.0
@@ -372,18 +374,65 @@ def merge_rows(existing: list[dict[str, Any]], updates: list[dict[str, Any]]) ->
     return [by_key[row_key] for row_key in order]
 
 
-def read_lock_owner_pid(lock_path: Path) -> int | None:
+def lock_owner_key(lock_path: Path) -> str:
+    return str(lock_path.resolve())
+
+
+def make_lock_owner_token() -> str:
+    return f"{os.getpid()}:{uuid.uuid4().hex}"
+
+
+def read_lock_contents(lock_path: Path) -> str | None:
     try:
         raw = lock_path.read_text(encoding="utf-8").strip()
     except Exception:
         return None
     if not raw:
         return None
+    return raw
+
+
+def read_lock_owner_pid(lock_path: Path) -> int | None:
+    raw = read_lock_contents(lock_path)
+    if raw is None:
+        return None
+    pid_raw = raw.split(":", 1)[0].strip()
     try:
-        pid = int(raw)
+        pid = int(pid_raw)
     except ValueError:
         return None
     return pid if pid > 0 else None
+
+
+def lock_stat_matches(current_stat: os.stat_result, observed_stat: os.stat_result) -> bool:
+    if current_stat.st_size != observed_stat.st_size:
+        return False
+    if current_stat.st_mtime_ns != observed_stat.st_mtime_ns:
+        return False
+    if getattr(current_stat, "st_ino", 0) and getattr(observed_stat, "st_ino", 0):
+        return current_stat.st_ino == observed_stat.st_ino
+    return True
+
+
+def unlink_lock_if_unchanged(
+    lock_path: Path,
+    observed_owner_token: str | None,
+    observed_stat: os.stat_result,
+) -> bool:
+    try:
+        current_stat = lock_path.stat()
+    except FileNotFoundError:
+        return False
+    current_owner_token = read_lock_contents(lock_path)
+    if current_owner_token != observed_owner_token:
+        return False
+    if not lock_stat_matches(current_stat, observed_stat):
+        return False
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        return False
+    return True
 
 
 def is_process_alive(pid: int) -> bool:
@@ -420,6 +469,7 @@ def is_process_alive(pid: int) -> bool:
 
 def acquire_lock(index_dir: Path, lock_name: str) -> Path:
     lock_path = index_dir / lock_name
+    lock_owner_token = make_lock_owner_token()
     lock_label = lock_name.strip(".")
     if lock_label.endswith(".lock"):
         lock_label = lock_label[: -len(".lock")]
@@ -430,19 +480,22 @@ def acquire_lock(index_dir: Path, lock_name: str) -> Path:
         try:
             fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(str(os.getpid()))
+                handle.write(lock_owner_token)
+            LOCK_OWNERS[lock_owner_key(lock_path)] = lock_owner_token
             return lock_path
         except FileExistsError:
             try:
-                age = time.time() - lock_path.stat().st_mtime
+                observed_stat = lock_path.stat()
             except FileNotFoundError:
                 continue
 
+            age = time.time() - observed_stat.st_mtime
+            observed_owner_token = read_lock_contents(lock_path)
             owner_pid = read_lock_owner_pid(lock_path)
             owner_alive = is_process_alive(owner_pid) if owner_pid is not None else False
 
             if age > LOCK_STALE_SECONDS and not owner_alive:
-                lock_path.unlink(missing_ok=True)
+                unlink_lock_if_unchanged(lock_path, observed_owner_token, observed_stat)
                 continue
 
             if time.monotonic() >= deadline:
@@ -459,7 +512,14 @@ def acquire_writer_lock(index_dir: Path) -> Path:
 
 
 def release_lock(lock_path: Path) -> None:
-    lock_path.unlink(missing_ok=True)
+    lock_owner_token = LOCK_OWNERS.pop(lock_owner_key(lock_path), None)
+    if lock_owner_token is None:
+        return
+    try:
+        observed_stat = lock_path.stat()
+    except FileNotFoundError:
+        return
+    unlink_lock_if_unchanged(lock_path, lock_owner_token, observed_stat)
 
 
 def release_index_lock(lock_path: Path) -> None:

--- a/scripts/faiss_index.py
+++ b/scripts/faiss_index.py
@@ -13,10 +13,12 @@ import os
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
 MODEL_CACHE: dict[str, Any] = {}
+LOCK_OWNERS: dict[str, str] = {}
 HASH_EMBED_DIM = 128
 LOCK_TIMEOUT_SECONDS = 10.0
 LOCK_STALE_SECONDS = 120.0
@@ -372,18 +374,65 @@ def merge_rows(existing: list[dict[str, Any]], updates: list[dict[str, Any]]) ->
     return [by_key[row_key] for row_key in order]
 
 
-def read_lock_owner_pid(lock_path: Path) -> int | None:
+def lock_owner_key(lock_path: Path) -> str:
+    return str(lock_path.resolve())
+
+
+def make_lock_owner_token() -> str:
+    return f"{os.getpid()}:{uuid.uuid4().hex}"
+
+
+def read_lock_contents(lock_path: Path) -> str | None:
     try:
         raw = lock_path.read_text(encoding="utf-8").strip()
     except Exception:
         return None
     if not raw:
         return None
+    return raw
+
+
+def read_lock_owner_pid(lock_path: Path) -> int | None:
+    raw = read_lock_contents(lock_path)
+    if raw is None:
+        return None
+    pid_raw = raw.split(":", 1)[0].strip()
     try:
-        pid = int(raw)
+        pid = int(pid_raw)
     except ValueError:
         return None
     return pid if pid > 0 else None
+
+
+def lock_stat_matches(current_stat: os.stat_result, observed_stat: os.stat_result) -> bool:
+    if current_stat.st_size != observed_stat.st_size:
+        return False
+    if current_stat.st_mtime_ns != observed_stat.st_mtime_ns:
+        return False
+    if getattr(current_stat, "st_ino", 0) and getattr(observed_stat, "st_ino", 0):
+        return current_stat.st_ino == observed_stat.st_ino
+    return True
+
+
+def unlink_lock_if_unchanged(
+    lock_path: Path,
+    observed_owner_token: str | None,
+    observed_stat: os.stat_result,
+) -> bool:
+    try:
+        current_stat = lock_path.stat()
+    except FileNotFoundError:
+        return False
+    current_owner_token = read_lock_contents(lock_path)
+    if current_owner_token != observed_owner_token:
+        return False
+    if not lock_stat_matches(current_stat, observed_stat):
+        return False
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        return False
+    return True
 
 
 def is_process_alive(pid: int) -> bool:
@@ -420,6 +469,7 @@ def is_process_alive(pid: int) -> bool:
 
 def acquire_lock(index_dir: Path, lock_name: str) -> Path:
     lock_path = index_dir / lock_name
+    lock_owner_token = make_lock_owner_token()
     lock_label = lock_name.strip(".")
     if lock_label.endswith(".lock"):
         lock_label = lock_label[: -len(".lock")]
@@ -430,19 +480,22 @@ def acquire_lock(index_dir: Path, lock_name: str) -> Path:
         try:
             fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(str(os.getpid()))
+                handle.write(lock_owner_token)
+            LOCK_OWNERS[lock_owner_key(lock_path)] = lock_owner_token
             return lock_path
         except FileExistsError:
             try:
-                age = time.time() - lock_path.stat().st_mtime
+                observed_stat = lock_path.stat()
             except FileNotFoundError:
                 continue
 
+            age = time.time() - observed_stat.st_mtime
+            observed_owner_token = read_lock_contents(lock_path)
             owner_pid = read_lock_owner_pid(lock_path)
             owner_alive = is_process_alive(owner_pid) if owner_pid is not None else False
 
             if age > LOCK_STALE_SECONDS and not owner_alive:
-                lock_path.unlink(missing_ok=True)
+                unlink_lock_if_unchanged(lock_path, observed_owner_token, observed_stat)
                 continue
 
             if time.monotonic() >= deadline:
@@ -459,7 +512,14 @@ def acquire_writer_lock(index_dir: Path) -> Path:
 
 
 def release_lock(lock_path: Path) -> None:
-    lock_path.unlink(missing_ok=True)
+    lock_owner_token = LOCK_OWNERS.pop(lock_owner_key(lock_path), None)
+    if lock_owner_token is None:
+        return
+    try:
+        observed_stat = lock_path.stat()
+    except FileNotFoundError:
+        return
+    unlink_lock_if_unchanged(lock_path, lock_owner_token, observed_stat)
 
 
 def release_index_lock(lock_path: Path) -> None:

--- a/tests/conversation-index-faiss-adapter.test.ts
+++ b/tests/conversation-index-faiss-adapter.test.ts
@@ -591,3 +591,59 @@ test("fail-open wrappers return safe defaults on adapter errors", async () => {
   const unavailable = await upsertConversationChunksFailOpen(undefined, sampleChunks());
   assert.equal(unavailable.reason, "adapter-unavailable");
 });
+
+test("FAISS sidecar lock cleanup and release only unlink matching owner tokens", {
+  skip: resolvePythonBin() === undefined,
+}, () => {
+  const pythonBin = resolvePythonBin();
+  assert.ok(pythonBin);
+  const modulePath = path.resolve("scripts/faiss_index.py");
+  const script = [
+    "import importlib.util, json, os, shutil, tempfile, time",
+    "from pathlib import Path",
+    `spec = importlib.util.spec_from_file_location("faiss_index", ${JSON.stringify(modulePath)})`,
+    "module = importlib.util.module_from_spec(spec)",
+    "spec.loader.exec_module(module)",
+    "tmp = Path(tempfile.mkdtemp())",
+    "try:",
+    "    stale = tmp / '.writer.lock'",
+    "    stale_token = '999999:stale-token'",
+    "    fresh_token = f'{os.getpid()}:fresh-token'",
+    "    stale.write_text(stale_token, encoding='utf-8')",
+    "    old_time = time.time() - module.LOCK_STALE_SECONDS - 5",
+    "    os.utime(stale, (old_time, old_time))",
+    "    observed_stat = stale.stat()",
+    "    stale.write_text(fresh_token, encoding='utf-8')",
+    "    stale_cleanup_preserved = (",
+    "        not module.unlink_lock_if_unchanged(stale, stale_token, observed_stat)",
+    "        and stale.read_text(encoding='utf-8') == fresh_token",
+    "    )",
+    "    owned = module.acquire_lock(tmp, '.owned.lock')",
+    "    owned.write_text(f'{os.getpid()}:other-owner', encoding='utf-8')",
+    "    module.release_lock(owned)",
+    "    release_preserved_changed_owner = owned.exists()",
+    "    owned.unlink()",
+    "    live = module.acquire_lock(tmp, '.live.lock')",
+    "    live_pid = module.read_lock_owner_pid(live)",
+    "    module.release_lock(live)",
+    "    released_owned_lock = not live.exists()",
+    "    print(json.dumps({",
+    "        'stale_cleanup_preserved': stale_cleanup_preserved,",
+    "        'release_preserved_changed_owner': release_preserved_changed_owner,",
+    "        'live_pid': live_pid,",
+    "        'released_owned_lock': released_owned_lock,",
+    "    }, separators=(',', ':')))",
+    "finally:",
+    "    shutil.rmtree(tmp, ignore_errors=True)",
+  ].join("\n");
+
+  const result = spawnSync(pythonBin, ["-c", script], { encoding: "utf-8" });
+  assert.equal(result.status, 0, result.stderr);
+
+  assert.deepEqual(JSON.parse(result.stdout), {
+    stale_cleanup_preserved: true,
+    release_preserved_changed_owner: true,
+    live_pid: result.pid,
+    released_owned_lock: true,
+  });
+});


### PR DESCRIPTION
## Summary\n- write unique owner tokens into FAISS sidecar lock files\n- only remove stale locks or release owned locks when the observed owner token still matches\n- keep packaged sidecar copies byte-for-byte synchronized and add a regression test for changed-owner preservation\n\n## Verification\n- python3 -m py_compile scripts/faiss_index.py packages/remnic-core/scripts/faiss_index.py packages/plugin-openclaw/scripts/faiss_index.py\n- git diff --check\n- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/conversation-index-faiss-adapter.test.ts\n\nNote: node scripts/check-test-types.mjs currently fails on latest origin/main with unrelated bench/CLI baseline drift outside this PR scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the FAISS sidecar locking/unlocking semantics to use per-acquisition owner tokens and conditional unlinking, which could affect concurrency behavior and leave stale locks if bugs exist. Impact is limited to local index file coordination but can block indexing/search if incorrect.
> 
> **Overview**
> FAISS sidecar lock files now store a unique *owner token* (`pid:uuid`) rather than just a PID, and lock release/cleanup will only unlink a lock if the file’s contents and stat metadata still match what was observed/owned.
> 
> This hardens stale-lock cleanup and `release_lock` against races where a lock file is replaced or its ownership changes between observation and unlink, and keeps the three packaged copies of `faiss_index.py` in sync. Adds a regression test that validates stale-lock preservation and that releasing a lock will not delete a lock whose contents were modified by another owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91fdd2980e1705b3d368052396a8c38623442892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->