### PR TITLE
Propagate bulk import option context

### DIFF
--- a/packages/remnic-core/src/bulk-import/index.ts
+++ b/packages/remnic-core/src/bulk-import/index.ts
@@ -27,6 +27,8 @@ export {
   runBulkImportPipeline,
   formatBatchTranscript,
   validateBatchSize,
+  resolveBulkImportContext,
   type ProcessBatchFn,
+  type ProcessBatchContext,
   type ProcessBatchResult,
 } from "./pipeline.js";

--- a/packages/remnic-core/src/bulk-import/pipeline.test.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.test.ts
@@ -4,7 +4,9 @@ import { describe, it } from "node:test";
 import {
   runBulkImportPipeline,
   formatBatchTranscript,
+  resolveBulkImportContext,
   validateBatchSize,
+  type ProcessBatchContext,
   type ProcessBatchFn,
 } from "./pipeline.js";
 import type {
@@ -49,13 +51,16 @@ function makeSource(
 function trackingProcessBatch(): {
   fn: ProcessBatchFn;
   calls: ImportTurn[][];
+  contexts: ProcessBatchContext[];
 } {
   const calls: ImportTurn[][] = [];
-  const fn: ProcessBatchFn = async (turns) => {
+  const contexts: ProcessBatchContext[] = [];
+  const fn: ProcessBatchFn = async (turns, context) => {
     calls.push([...turns]);
+    contexts.push(context);
     return { memoriesCreated: turns.length, duplicatesSkipped: 0 };
   };
-  return { fn, calls };
+  return { fn, calls, contexts };
 }
 
 describe("runBulkImportPipeline", () => {
@@ -117,6 +122,50 @@ describe("runBulkImportPipeline", () => {
     assert.equal(calls.length, 2); // 20 + 5
     assert.equal(calls[0].length, 20);
     assert.equal(calls[1].length, 5);
+  });
+
+  it("passes effective import options to every processBatch call", async () => {
+    const source = makeSource(5);
+    const { fn, contexts } = trackingProcessBatch();
+    await runBulkImportPipeline(
+      source,
+      {
+        batchSize: 2,
+        dedup: false,
+        trustLevel: "import",
+        namespace: "tenant-a",
+      },
+      fn,
+    );
+
+    assert.deepEqual(contexts, [
+      { dedup: false, trustLevel: "import", namespace: "tenant-a" },
+      { dedup: false, trustLevel: "import", namespace: "tenant-a" },
+      { dedup: false, trustLevel: "import", namespace: "tenant-a" },
+    ]);
+  });
+
+  it("uses explicit defaults for omitted import options", async () => {
+    const source = makeSource(1);
+    const { fn, contexts } = trackingProcessBatch();
+    await runBulkImportPipeline(source, {}, fn);
+
+    assert.deepEqual(contexts, [{ dedup: true, trustLevel: "import" }]);
+  });
+
+  it("validates no-op import option values before processing", () => {
+    assert.throws(
+      () => resolveBulkImportContext({ dedup: "false" as unknown as boolean }),
+      /dedup must be a boolean/,
+    );
+    assert.throws(
+      () => resolveBulkImportContext({ namespace: "" }),
+      /namespace must be a non-empty string/,
+    );
+    assert.throws(
+      () => resolveBulkImportContext({ trustLevel: "local" as "import" }),
+      /trustLevel must be 'import'/,
+    );
   });
 
   it("collects errors from processBatch in result.errors", async () => {

--- a/packages/remnic-core/src/bulk-import/pipeline.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.ts
@@ -25,8 +25,15 @@ export interface ProcessBatchResult {
   entitiesCreated?: number;
 }
 
+export interface ProcessBatchContext {
+  dedup: boolean;
+  trustLevel: "import";
+  namespace?: string;
+}
+
 export type ProcessBatchFn = (
   turns: ImportTurn[],
+  context: ProcessBatchContext,
 ) => Promise<ProcessBatchResult>;
 
 export function validateBatchSize(value: number | undefined): number {
@@ -47,6 +54,36 @@ export function validateBatchSize(value: number | undefined): number {
     );
   }
   return value;
+}
+
+export function resolveBulkImportContext(
+  options: BulkImportOptions,
+): ProcessBatchContext {
+  if (options.dedup !== undefined && typeof options.dedup !== "boolean") {
+    throw new Error(
+      `dedup must be a boolean when provided, received ${String(options.dedup)}`,
+    );
+  }
+  if (options.trustLevel !== undefined && options.trustLevel !== "import") {
+    throw new Error(
+      `trustLevel must be 'import' when provided, received ${String(options.trustLevel)}`,
+    );
+  }
+  if (options.namespace !== undefined) {
+    if (typeof options.namespace !== "string" || options.namespace.trim().length === 0) {
+      throw new Error(
+        `namespace must be a non-empty string when provided, received ${String(options.namespace)}`,
+      );
+    }
+  }
+
+  return {
+    dedup: options.dedup !== false,
+    trustLevel: options.trustLevel ?? "import",
+    ...(options.namespace !== undefined
+      ? { namespace: options.namespace }
+      : {}),
+  };
 }
 
 /**
@@ -75,6 +112,7 @@ export async function runBulkImportPipeline(
 ): Promise<BulkImportResult> {
   const batchSize = validateBatchSize(options.batchSize);
   const dryRun = options.dryRun === true;
+  const batchContext = resolveBulkImportContext(options);
 
   const result: BulkImportResult = {
     memoriesCreated: 0,
@@ -120,7 +158,7 @@ export async function runBulkImportPipeline(
   for (let i = 0; i < validTurns.length; i += batchSize) {
     const batch = validTurns.slice(i, i + batchSize);
     try {
-      const batchResult = await processBatch(batch);
+      const batchResult = await processBatch(batch, batchContext);
       result.memoriesCreated += batchResult.memoriesCreated;
       result.duplicatesSkipped += batchResult.duplicatesSkipped;
       if (typeof batchResult.entitiesCreated === "number") {


### PR DESCRIPTION
## Summary\n- add a validated ProcessBatchContext for bulk-import options\n- pass effective dedup/trustLevel/namespace values into every processBatch call\n- cover explicit context propagation, defaults, and invalid no-op option values\n\n## Verification\n- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/bulk-import/pipeline.test.ts\n- pnpm --filter @remnic/core exec tsc --noEmit --pretty false\n- git diff --check\n\nNote: node scripts/check-test-types.mjs currently reproduces unrelated local bench/CLI baseline drift outside this PR scope; CI passed that gate on the previous PR from the same mainline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `ProcessBatchFn` callback signature and runtime behavior by passing a new validated context object into every batch, which may require updates to downstream bulk-import implementations.
> 
> **Overview**
> `runBulkImportPipeline` now derives a validated `ProcessBatchContext` (dedup/trustLevel/namespace) via new `resolveBulkImportContext()` and passes it into every `processBatch` invocation.
> 
> This PR updates the public exports and tests to cover context propagation, explicit defaults for omitted options, and early validation of invalid no-op option values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec879e6014f9d1339007b9e1a3aa7b89ace2c09f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->