### PR TITLE
Avoid corpus fallback for unresolved citation refs

### DIFF
--- a/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.test.ts
@@ -76,3 +76,72 @@ test("citation accuracy accepts deterministic source support when the LLM judge 
   assert.ok((details.claimOutcomes[0]?.deterministicSupport ?? 0) >= 0.72);
   assert.equal(details.claimOutcomes[0]?.valid, true);
 });
+
+test("citation accuracy does not score unresolved page backlinks against the full corpus", async () => {
+  const result = await runIngestionCitationAccuracyBenchmark({
+    benchmark: ingestionCitationAccuracyDefinition,
+    mode: "quick",
+    system: {
+      async reset() {},
+      async store() {},
+      async recall() {
+        return "";
+      },
+      async search() {
+        return [];
+      },
+      async destroy() {},
+      async getStats() {
+        return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+      judge: {
+        async score() {
+          return 0;
+        },
+      },
+    },
+    ingestionAdapter: {
+      async reset() {},
+      async destroy() {},
+      async ingest() {
+        return {
+          commandsIssued: [],
+          promptsShown: [],
+          errors: [],
+          durationMs: 1,
+        };
+      },
+      async getMemoryGraph() {
+        return {
+          entities: [],
+          links: [],
+          pages: [
+            {
+              path: "Project Beacon.md",
+              title: "Project Beacon",
+              frontmatter: {},
+              hasExecSummary: true,
+              hasTimeline: false,
+              seeAlso: ["Project Horizon"],
+              content:
+                "Marcus should coordinate with Project Beacon on shared data-pipeline components.",
+            },
+          ],
+        };
+      },
+    },
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.valid_citations, 0);
+  assert.equal(task.scores.citation_accuracy, 0);
+
+  const details = task.details as {
+    claimOutcomes: Array<{
+      deterministicSupport: number;
+      valid: boolean;
+    }>;
+  };
+  assert.equal(details.claimOutcomes[0]?.deterministicSupport, 0);
+  assert.equal(details.claimOutcomes[0]?.valid, false);
+});

--- a/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
@@ -84,11 +84,11 @@ function extractClaims(
 
 /**
  * Build the cited source content for a claim by resolving its page's seeAlso
- * references against the fixture file map. Falls back to a basename match if
- * no seeAlso entry resolves directly, and falls back to all sources only if
- * no narrower match is available. This prevents a misattributed citation from
- * scoring as valid just because the claim is supported somewhere else in the
- * merged corpus.
+ * references against the fixture file map. Non-empty unresolved seeAlso values
+ * are treated as unresolved citation metadata rather than as permission to
+ * search the full fixture corpus. Empty citation metadata still falls back to a
+ * basename match and then to all sources for legacy adapters that do not expose
+ * source references yet.
  */
 function resolveCitedSources(
   seeAlso: string[],
@@ -113,6 +113,10 @@ function resolveCitedSources(
 
   if (resolved.length > 0) {
     return resolved.join("\n\n---\n\n");
+  }
+
+  if (seeAlso.length > 0) {
+    return "";
   }
 
   // Fall back to a source whose basename matches the page path


### PR DESCRIPTION
## Summary\n- treat non-empty unresolved seeAlso refs as unresolved citation metadata\n- avoid scoring those claims against the full fixture corpus\n- add a regression covering page-title backlinks like Project Horizon\n\n## Verification\n- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.test.ts\n- pnpm --filter @remnic/bench exec tsc --noEmit --pretty false\n- git diff --check\n\nNote: node scripts/check-test-types.mjs currently reproduces unrelated local bench/CLI baseline drift outside this PR scope; CI has passed that gate on the preceding PRs from the same mainline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes citation-scoring source resolution logic in the ingestion benchmark, which can materially alter benchmark scores and CI expectations. Risk is limited to benchmarking/evaluation behavior (no production runtime paths).
> 
> **Overview**
> Updates `resolveCitedSources` in `ingestion-citation-accuracy/runner.ts` so that **non-empty but unresolvable** `seeAlso` refs yield *no cited source content* (instead of falling back to basename/all-sources), avoiding false-positive citation validity from unrelated corpus matches.
> 
> Adds a regression test ensuring a page backlink like `seeAlso: ["Project Horizon"]` results in `valid_citations`/`citation_accuracy` of `0` with `deterministicSupport` `0` and `valid` `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ff28b085d3b7e2ebafd15d4fa2b8f6165b15c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->