### PR TITLE
Tighten heartbeat hyphen title matching

### DIFF
--- a/packages/plugin-openclaw/src/runtime-surfaces.test.ts
+++ b/packages/plugin-openclaw/src/runtime-surfaces.test.ts
@@ -911,6 +911,38 @@ test("syncHeartbeatOutcomeLinks does not false-match heartbeat titles inside lar
   );
 });
 
+test("syncHeartbeatOutcomeLinks does not false-match heartbeat titles inside hyphenated tokens", async () => {
+  const storage = makeStorage([
+    makeMemory({
+      id: "fact-1",
+      content: "The pre-test-run note belongs to a different workflow.",
+      tags: ["ops"],
+    }),
+  ]);
+
+  const result = await syncHeartbeatOutcomeLinks({
+    storage,
+    entries: [
+      {
+        id: "heartbeat-a",
+        slug: "heartbeat-test",
+        title: "test",
+        body: "Run the focused test checklist.",
+        schedule: "hourly",
+        tags: ["ci"],
+        sourceOffset: 0,
+      },
+    ],
+  });
+
+  assert.deepEqual(result, { created: 0, updated: 0, linked: 0 });
+  assert.equal(
+    storage.memories[0]?.frontmatter.structuredAttributes?.relatedHeartbeatSlug,
+    undefined,
+  );
+  assert.deepEqual(storage.memories[0]?.frontmatter.tags, ["ops"]);
+});
+
 test("syncHeartbeatOutcomeLinks does not false-match hyphenated slugs inside larger hyphenated tokens", async () => {
   const storage = makeStorage([
     makeMemory({

--- a/packages/plugin-openclaw/src/runtime-surfaces.ts
+++ b/packages/plugin-openclaw/src/runtime-surfaces.ts
@@ -358,18 +358,14 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function buildDelimitedBoundaryClass(value: string): string {
-  const parts = ["a-z0-9"];
-  if (value.includes("-")) {
-    parts.push("-");
-  }
-  return parts.join("");
+function buildDelimitedBoundaryClass(): string {
+  return "a-z0-9-";
 }
 
 function compileDelimitedPhrasePattern(value: string): RegExp | null {
   const normalized = value.trim().toLowerCase();
   if (normalized.length === 0) return null;
-  const boundaryClass = buildDelimitedBoundaryClass(normalized);
+  const boundaryClass = buildDelimitedBoundaryClass();
   return new RegExp(
     `(^|[^${boundaryClass}])${escapeRegExp(normalized)}([^${boundaryClass}]|$)`,
   );


### PR DESCRIPTION
## Summary
- Treat hyphens as token characters for all heartbeat title and slug phrase matching
- Add regression coverage so a generic title like `test` does not match inside `pre-test-run`

## Verification
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/plugin-openclaw/src/runtime-surfaces.test.ts`
- `pnpm --filter @remnic/plugin-openclaw run check-types`
- `git diff --check`
- `node scripts/check-test-types.mjs`
- `npm run test:openclaw-scenarios` after `pnpm rebuild better-sqlite3` repaired the worktree native binding
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the regex token-boundary logic used to auto-link memories to heartbeats, which could change which notes get linked/tagged in real data. Covered by new regression tests, but matching behavior changes are user-visible.
> 
> **Overview**
> Tightens heartbeat outcome auto-linking by treating `-` as a token character when matching heartbeat titles/slugs, preventing matches inside larger hyphenated tokens (e.g., title `test` no longer matches `pre-test-run`).
> 
> Adds regression coverage in `runtime-surfaces.test.ts` for the new hyphenated-title case, alongside the existing hyphenated-slug false-positive test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63076d0df1c4c98d061c5aa996e1e36f6afc26dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->