### PR TITLE
Split Remnic embedding fallback model from local chat model

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -303,6 +303,10 @@
         "default": "auto",
         "description": "Embedding provider selection for semantic fallback"
       },
+      "embeddingFallbackModel": {
+        "type": "string",
+        "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
+      },
       "qmdPath": {
         "type": "string",
         "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
@@ -4877,6 +4881,12 @@
       "label": "Embedding Provider",
       "advanced": true,
       "placeholder": "auto"
+    },
+    "embeddingFallbackModel": {
+      "label": "Embedding Model",
+      "advanced": true,
+      "placeholder": "(defaults to local LLM model)",
+      "help": "Optional embedding model for semantic fallback. Use this when the local chat model and embedding model are different."
     },
     "qmdPath": {
       "label": "QMD Path",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -303,6 +303,10 @@
         "default": "auto",
         "description": "Embedding provider selection for semantic fallback"
       },
+      "embeddingFallbackModel": {
+        "type": "string",
+        "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
+      },
       "qmdPath": {
         "type": "string",
         "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
@@ -4877,6 +4881,12 @@
       "label": "Embedding Provider",
       "advanced": true,
       "placeholder": "auto"
+    },
+    "embeddingFallbackModel": {
+      "label": "Embedding Model",
+      "advanced": true,
+      "placeholder": "(defaults to local LLM model)",
+      "help": "Optional embedding model for semantic fallback. Use this when the local chat model and embedding model are different."
     },
     "qmdPath": {
       "label": "QMD Path",

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -138,6 +138,21 @@ test("parseConfig modelSource=gateway still honors an explicit openaiApiKey over
   }
 });
 
+test("parseConfig separates local chat and embedding fallback models", () => {
+  const cfg = parseConfig({
+    localLlmEnabled: true,
+    localLlmModel: "google/gemma-4-26b-a4b",
+    embeddingFallbackProvider: "local",
+    embeddingFallbackModel: "text-embedding-nomic-embed-text-v1.5@q4_k_m",
+  });
+
+  assert.equal(cfg.localLlmModel, "google/gemma-4-26b-a4b");
+  assert.equal(
+    cfg.embeddingFallbackModel,
+    "text-embedding-nomic-embed-text-v1.5@q4_k_m",
+  );
+});
+
 test("parseConfig openaiApiKey=false disables implicit OPENAI_API_KEY inheritance", () => {
   const original = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1253,6 +1253,10 @@ export function parseConfig(raw: unknown): PluginConfig {
         : cfg.embeddingFallbackProvider === "local"
           ? "local"
           : "auto",
+    embeddingFallbackModel:
+      typeof cfg.embeddingFallbackModel === "string" && cfg.embeddingFallbackModel.length > 0
+        ? cfg.embeddingFallbackModel
+        : "",
     qmdPath:
       typeof cfg.qmdPath === "string" && cfg.qmdPath.length > 0
         ? cfg.qmdPath

--- a/packages/remnic-core/src/embedding-fallback.ts
+++ b/packages/remnic-core/src/embedding-fallback.ts
@@ -342,7 +342,10 @@ export class EmbeddingFallback {
         }
         return {
           type: "local",
-          model: this.config.localLlmModel || DEFAULT_OPENAI_MODEL,
+          model:
+            this.config.embeddingFallbackModel ||
+            this.config.localLlmModel ||
+            DEFAULT_OPENAI_MODEL,
           endpoint,
           headers,
         };

--- a/packages/remnic-core/src/search/embed-helper.ts
+++ b/packages/remnic-core/src/search/embed-helper.ts
@@ -101,7 +101,10 @@ export class EmbedHelper {
         }
         return {
           type: "local",
-          model: this.config.localLlmModel || DEFAULT_OPENAI_MODEL,
+          model:
+            this.config.embeddingFallbackModel ||
+            this.config.localLlmModel ||
+            DEFAULT_OPENAI_MODEL,
           endpoint,
           headers,
         };

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -572,6 +572,14 @@ export interface PluginConfig {
   qmdTierAutoBackfillEnabled: boolean;
   embeddingFallbackEnabled: boolean;
   embeddingFallbackProvider: "auto" | "openai" | "local";
+  /**
+   * Optional model identifier for local embedding fallback requests.
+   *
+   * Local chat/completion models and local embedding models are often
+   * different LM Studio/Ollama model IDs. When unset, Remnic preserves the
+   * legacy behavior and falls back to `localLlmModel`.
+   */
+  embeddingFallbackModel: string;
   /** Optional absolute path to qmd binary. If unset, PATH/fallback discovery is used. */
   qmdPath?: string;
   memoryDir: string;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -303,6 +303,10 @@
         "default": "auto",
         "description": "Embedding provider selection for semantic fallback"
       },
+      "embeddingFallbackModel": {
+        "type": "string",
+        "description": "Optional model identifier for embedding fallback requests. Defaults to localLlmModel for legacy installs."
+      },
       "qmdPath": {
         "type": "string",
         "description": "Optional absolute path to qmd binary (bypasses PATH/fallback discovery)"
@@ -4877,6 +4881,12 @@
       "label": "Embedding Provider",
       "advanced": true,
       "placeholder": "auto"
+    },
+    "embeddingFallbackModel": {
+      "label": "Embedding Model",
+      "advanced": true,
+      "placeholder": "(defaults to local LLM model)",
+      "help": "Optional embedding model for semantic fallback. Use this when the local chat model and embedding model are different."
     },
     "qmdPath": {
       "label": "QMD Path",


### PR DESCRIPTION
## Summary
- add `embeddingFallbackModel` to Remnic core config so local embedding fallback can use an embedding model without hijacking local chat/extraction
- update embedding fallback providers to prefer the dedicated embedding model and preserve `localLlmModel` as the legacy fallback
- expose the new setting in OpenClaw plugin manifests, including the compatibility shim

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/config.test.ts`
- `pnpm --filter @remnic/core check-types`
- `pnpm --filter @remnic/plugin-openclaw check-types`
- `pnpm --filter @remnic/plugin-openclaw plugin:inspect`
- `pnpm --filter @remnic/core build`
- `pnpm --filter @remnic/plugin-openclaw build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which model ID is sent to local embedding endpoints during fallback/search, which could break setups relying on the chat model ID or expecting a non-empty model value.
> 
> **Overview**
> Adds a new `embeddingFallbackModel` configuration option so local embedding-based fallback can use a dedicated embedding model instead of reusing `localLlmModel`.
> 
> Config parsing, types, and both embedding call sites (`embedding-fallback` and `search/embed-helper`) now prefer `embeddingFallbackModel`, falling back to the legacy `localLlmModel` behavior when unset. The OpenClaw plugin manifests (including the shim) expose this as an advanced setting, and a new test covers the model separation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb9ee60823d827a78cad6664145638f7bf51ac66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->