### PR TITLE
Require daemon health for PID bridge detection

### DIFF
--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -236,8 +236,14 @@ export function detectBridgeMode(): BridgeConfig {
   const daemonHost = readCompatEnv("REMNIC_HOST", "ENGRAM_HOST") ?? DEFAULT_HOST;
   const daemonPort = readDaemonPort();
 
-  // Auto-detect: if daemon is running or reachable locally, delegate; otherwise embedded.
-  if (isDaemonRunning() || (shouldProbeDaemonHealth(daemonHost) && checkDaemonHealthSync(daemonHost, daemonPort))) {
+  const hasDaemonPidHint = isDaemonRunning();
+
+  // Auto-detect: PID files are only hints, because PIDs can be stale or reused.
+  // Delegate only after the configured Remnic endpoint proves it is healthy.
+  if (
+    (hasDaemonPidHint || shouldProbeDaemonHealth(daemonHost)) &&
+    checkDaemonHealthSync(daemonHost, daemonPort)
+  ) {
     return {
       mode: "delegate",
       daemonHost,

--- a/tests/integration/bridge-mode.test.ts
+++ b/tests/integration/bridge-mode.test.ts
@@ -160,8 +160,8 @@ test("detectBridgeMode reads legacy config port when remnic config is malformed"
   }
 });
 
-test("detectBridgeMode delegates when a Remnic daemon pid file is live", async () => {
-  const previousHome = process.env.HOME;
+test("detectBridgeMode does not delegate solely because a Remnic daemon pid file is live", async () => {
+  const previousHome = process.env.HOME, previousPort = process.env.REMNIC_PORT;
   const previousMode = process.env.REMNIC_BRIDGE_MODE;
   const previousLegacyMode = process.env.ENGRAM_BRIDGE_MODE;
   const homeDir = await mkdtemp(path.join(os.tmpdir(), "bridge-live-pid-"));
@@ -171,16 +171,16 @@ test("detectBridgeMode delegates when a Remnic daemon pid file is live", async (
   await writeFile(path.join(remnicDir, "server.pid"), `${process.pid}\n`, "utf8");
 
   try {
-    process.env.HOME = homeDir;
+    process.env.HOME = homeDir; process.env.REMNIC_PORT = "49999";
     delete process.env.REMNIC_BRIDGE_MODE;
     delete process.env.ENGRAM_BRIDGE_MODE;
 
     const { detectBridgeMode } = await import(path.join(ROOT, "packages/plugin-openclaw/src/bridge.ts"));
     const config = detectBridgeMode();
-    assert.equal(config.mode, "delegate");
+    assert.equal(config.mode, "embedded");
   } finally {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
+    if (previousHome === undefined) delete process.env.HOME; else process.env.HOME = previousHome;
+    if (previousPort === undefined) delete process.env.REMNIC_PORT; else process.env.REMNIC_PORT = previousPort;
     if (previousMode === undefined) delete process.env.REMNIC_BRIDGE_MODE;
     else process.env.REMNIC_BRIDGE_MODE = previousMode;
     if (previousLegacyMode === undefined) delete process.env.ENGRAM_BRIDGE_MODE;


### PR DESCRIPTION
## Summary
- treat Remnic daemon PID files as hints during OpenClaw bridge auto-detection
- require the configured daemon health endpoint to pass before selecting delegate mode
- update the live-PID regression test so a reused/stale PID falls back to embedded mode when the endpoint is unhealthy

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/integration/bridge-mode.test.ts
- pnpm --filter @remnic/plugin-openclaw run check-types
- git diff --check
- node scripts/check-test-types.mjs
- pnpm rebuild better-sqlite3
- npm run preflight:quick
- npm run review:cursor (skipped: Cursor agent auth unavailable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bridge auto-detection behavior for choosing embedded vs delegate mode, which can affect runtime connectivity/boot behavior. Risk is moderate due to relying on synchronous health probing that may change startup timing or cause unexpected fallbacks if health checks fail.
> 
> **Overview**
> **Bridge auto-detection now requires a healthy daemon endpoint before selecting `delegate` mode.** `detectBridgeMode` no longer delegates just because a daemon PID file looks live; it treats PID presence as a hint and confirms the configured host/port via `checkDaemonHealthSync`.
> 
> Integration coverage is updated so the “live PID” regression test now expects fallback to `embedded` when the health endpoint is unreachable (and preserves/restores `REMNIC_PORT` during the test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3953efdf63971127f10a23c90394d449c6cfe6ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->