### PR TITLE
Handle raw-count metrics in benchmark detail

### DIFF
--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -209,8 +209,19 @@ const rawCountMetrics = new Set([
   "errors_count",
 ]);
 
-function isRawCountMetric(metricName?: string): boolean {
+const lowerIsBetterRawCountMetrics = new Set([
+  "setup_friction",
+  "commands_count",
+  "prompts_count",
+  "errors_count",
+]);
+
+export function isRawCountMetric(metricName?: string): boolean {
   return typeof metricName === "string" && rawCountMetrics.has(metricName);
+}
+
+export function isLowerIsBetterMetric(metricName?: string): boolean {
+  return typeof metricName === "string" && lowerIsBetterRawCountMetrics.has(metricName);
 }
 
 export function formatMetricValue(value: number | null, metricName?: string): string {

--- a/packages/bench-ui/src/components/TaskBreakdown.tsx
+++ b/packages/bench-ui/src/components/TaskBreakdown.tsx
@@ -4,9 +4,11 @@ import { formatDuration, formatMetricValue } from "../bench-data";
 export function TaskBreakdown({
   rows,
   title,
+  metricName,
 }: {
   rows: TaskDeltaRow[];
   title: string;
+  metricName?: string;
 }) {
   if (rows.length === 0) {
     return (
@@ -31,9 +33,9 @@ export function TaskBreakdown({
             </div>
             <p>{row.question}</p>
             <div className="task-card__scores">
-              <span>Baseline {formatMetricValue(row.baseline)}</span>
-              <span>Candidate {formatMetricValue(row.candidate)}</span>
-              <span>Delta {formatMetricValue(row.delta)}</span>
+              <span>Baseline {formatMetricValue(row.baseline, metricName)}</span>
+              <span>Candidate {formatMetricValue(row.candidate, metricName)}</span>
+              <span>Delta {formatMetricValue(row.delta, metricName)}</span>
             </div>
           </article>
         ))}

--- a/packages/bench-ui/src/pages/BenchmarkDetail.tsx
+++ b/packages/bench-ui/src/pages/BenchmarkDetail.tsx
@@ -7,6 +7,8 @@ import {
   formatMetricValue,
   formatTimestamp,
   humanizeIdentifier,
+  isLowerIsBetterMetric,
+  isRawCountMetric,
 } from "../bench-data";
 import { CostSummary } from "../components/CostSummary";
 import { TaskBreakdown } from "../components/TaskBreakdown";
@@ -22,7 +24,19 @@ export function buildBenchmarkDetailTaskRows(selected: BenchResultSummary): Task
   }));
 }
 
-export function selectLowestScoringTasks(taskRows: TaskDeltaRow[], limit = 5): TaskDeltaRow[] {
+export function selectLowestScoringTasks(
+  taskRows: TaskDeltaRow[],
+  metricName?: string,
+  limit = 5,
+): TaskDeltaRow[] {
+  if (isLowerIsBetterMetric(metricName)) {
+    return taskRows
+      .filter((task) => (task.candidate ?? 0) > 0)
+      .slice()
+      .sort((left, right) => (right.candidate ?? 0) - (left.candidate ?? 0))
+      .slice(0, limit);
+  }
+
   return taskRows
     .filter((task) => (task.candidate ?? 1) < 0.6)
     .slice()
@@ -69,9 +83,14 @@ export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayloa
     );
   }
 
-  const histogram = buildHistogram(selected);
+  const primaryMetric = selected.primaryMetric ?? undefined;
+  const showNormalizedHistogram = !isRawCountMetric(primaryMetric);
+  const histogram = showNormalizedHistogram ? buildHistogram(selected) : [];
   const taskRows = buildBenchmarkDetailTaskRows(selected);
-  const lowScoring = selectLowestScoringTasks(taskRows);
+  const lowScoring = selectLowestScoringTasks(taskRows, primaryMetric);
+  const failureTitle = isLowerIsBetterMetric(primaryMetric)
+    ? "Highest-friction tasks"
+    : "Lowest-scoring tasks";
 
   return (
     <section className="page">
@@ -101,7 +120,7 @@ export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayloa
       <div className="detail-hero">
         <article className="stat-card">
           <span>Primary score</span>
-          <strong>{formatMetricValue(selected.primaryScore)}</strong>
+          <strong>{formatMetricValue(selected.primaryScore, primaryMetric)}</strong>
           <p>{selected.primaryMetric ?? "No primary metric"}</p>
         </article>
         <article className="stat-card">
@@ -113,37 +132,39 @@ export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayloa
 
       <CostSummary summary={selected} />
 
-      <section className="panel">
-        <div className="section-title">
-          <span className="section-kicker">Distribution</span>
-          <h4>Task score histogram</h4>
-        </div>
-        <div className="histogram">
-          {histogram.map((bucket) => (
-            <div className="histogram__bucket" key={bucket.label}>
-              <div className="histogram__bar-wrap">
-                <div className="histogram__bar" style={{ height: `${Math.max(bucket.count * 18, 12)}px` }} />
+      {showNormalizedHistogram ? (
+        <section className="panel">
+          <div className="section-title">
+            <span className="section-kicker">Distribution</span>
+            <h4>Task score histogram</h4>
+          </div>
+          <div className="histogram">
+            {histogram.map((bucket) => (
+              <div className="histogram__bucket" key={bucket.label}>
+                <div className="histogram__bar-wrap">
+                  <div className="histogram__bar" style={{ height: `${Math.max(bucket.count * 18, 12)}px` }} />
+                </div>
+                <strong>{bucket.count}</strong>
+                <span>{bucket.label}</span>
               </div>
-              <strong>{bucket.count}</strong>
-              <span>{bucket.label}</span>
-            </div>
-          ))}
-        </div>
-      </section>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
-      <TaskBreakdown rows={taskRows} title="Task-level score breakdown" />
+      <TaskBreakdown rows={taskRows} title="Task-level score breakdown" metricName={primaryMetric} />
 
       <section className="panel">
         <div className="section-title">
           <span className="section-kicker">Failure analysis</span>
-          <h4>Lowest-scoring tasks</h4>
+          <h4>{failureTitle}</h4>
         </div>
         {lowScoring.length > 0 ? (
           <ul className="failure-list">
             {lowScoring.map((task) => (
               <li key={task.taskId}>
                 <strong>{task.taskId}</strong>
-                <span>{formatMetricValue(task.candidate)}</span>
+                <span>{formatMetricValue(task.candidate, primaryMetric)}</span>
                 <p>{task.question}</p>
               </li>
             ))}

--- a/tests/bench-ui-results.test.ts
+++ b/tests/bench-ui-results.test.ts
@@ -742,3 +742,19 @@ test("buildProviderRows keeps the newest benchmark score for each provider", () 
   assert.equal(rows[0]?.averageScore, (0.91 + 0.42) / 2);
   assert.equal(rows[0]?.averageCostUsd, (0.14 + 0.18) / 2);
 });
+
+test("benchmark detail helpers rank lower-is-better raw counts by highest friction", () => {
+  const taskRows: import("../packages/bench-ui/src/bench-data.js").TaskDeltaRow[] = [
+    { taskId: "setup-1", baseline: null, candidate: 1, delta: null, question: "Q1", latencyMs: 10 },
+    { taskId: "setup-4", baseline: null, candidate: 4, delta: null, question: "Q4", latencyMs: 10 },
+    { taskId: "setup-8", baseline: null, candidate: 8, delta: null, question: "Q8", latencyMs: 10 },
+    { taskId: "setup-0", baseline: null, candidate: 0, delta: null, question: "Q0", latencyMs: 10 },
+  ];
+
+  const frictionTasks = selectLowestScoringTasks(taskRows, "setup_friction");
+  assert.equal(frictionTasks.length, 3);
+  assert.equal(frictionTasks[0]?.taskId, "setup-8");
+  assert.equal(frictionTasks[1]?.taskId, "setup-4");
+  assert.equal(frictionTasks[2]?.taskId, "setup-1");
+  assert.equal(formatMetricValue(taskRows[0]?.candidate ?? null, "setup_friction"), "1");
+});


### PR DESCRIPTION
## Summary
- add bench UI helpers for raw-count and lower-is-better metrics
- rank setup-friction failures by highest raw count instead of treating counts as normalized low scores
- format task-level raw counts with the selected primary metric and suppress the normalized histogram for raw-count runs
- add a regression test for setup_friction task selection

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/bench-ui-results.test.ts
- pnpm --filter @remnic/bench-ui run check-types
- git diff --check
- node scripts/ensure-bench-build-deps.mjs && node scripts/ensure-cli-bench-build-deps.mjs && node scripts/check-test-types.mjs
- pnpm rebuild better-sqlite3
- npm run preflight:quick
- npm run review:cursor (skipped: Cursor agent auth unavailable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/data-presentation changes that adjust how raw-count primary metrics are formatted and how “failures” are ranked; no persistence, auth, or backend logic touched.
> 
> **Overview**
> Benchmark detail now treats certain *raw-count* primary metrics differently: values are formatted as counts (not percentages), the task histogram is hidden for raw-count runs, and task-level breakdowns receive the selected metric name for consistent formatting.
> 
> Failure analysis ranking is updated so *lower-is-better* raw-count metrics (e.g. `setup_friction`) surface the **highest** counts as the most problematic tasks, with a corresponding title change. A regression test was added to lock in the new ranking/formatting behavior for `setup_friction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ff32b3037001104685746e7df79b9c6f07b2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->