### PR TITLE
Guard maintenance shims against private imports

### DIFF
--- a/tests/maintenance-shim-boundary.test.ts
+++ b/tests/maintenance-shim-boundary.test.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readdir, readFile } from "node:fs/promises";
+
+const maintenanceDir = path.resolve(import.meta.dirname, "../src/maintenance");
+const publicCoreMaintenanceExport = /from\s+["']@remnic\/core\/maintenance\/[^"']+["'];?/;
+const privatePackageSourceReference = /["'][^"']*(?:packages\/[^"']*\/src\/|@remnic\/[^"']*\/src\/)[^"']*["']/;
+
+test("root maintenance shims only re-export public core maintenance entrypoints", async () => {
+  const entries = await readdir(maintenanceDir, { withFileTypes: true });
+  const shimFiles = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => entry.name)
+    .sort();
+
+  assert.notEqual(shimFiles.length, 0, "expected maintenance shims to be present");
+
+  for (const fileName of shimFiles) {
+    const source = await readFile(path.join(maintenanceDir, fileName), "utf-8");
+
+    assert.match(
+      source,
+      publicCoreMaintenanceExport,
+      `${fileName} must use the public @remnic/core maintenance package export`,
+    );
+    assert.doesNotMatch(
+      source,
+      privatePackageSourceReference,
+      `${fileName} must not import or export private package source files`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a static regression test for root maintenance shims
- require each shim to use the public `@remnic/core/maintenance/*` package export
- reject private `packages/*/src/*` import/export specifiers in those shims

Finding: `fnd_sig-feat-library-2f616744f3-9e4e_f428ce1980`

## Verification
- `pnpm install --frozen-lockfile`
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/maintenance-shim-boundary.test.ts`
- `git diff --check`
- `node scripts/ensure-bench-build-deps.mjs`
- `node scripts/ensure-cli-bench-build-deps.mjs`
- `node scripts/check-test-types.mjs`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`
- `npm run review:cursor` (skipped: script reported no changed files against base)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single static test that enforces import/export boundaries without changing runtime code paths. Main risk is potential false positives/negatives in the regex checks that could block valid shim changes.
> 
> **Overview**
> Adds a new boundary regression test (`tests/maintenance-shim-boundary.test.ts`) that scans `src/maintenance/*.ts` shims and **enforces they only re-export from public `@remnic/core/maintenance/*` entrypoints**.
> 
> The test also **rejects any import/export specifiers** that reference private package source paths like `packages/*/src/*` or `@remnic/*/src/*`, preventing accidental coupling to internal source files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be823ac9d95e4c1afa542e63063e616898b7edb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->