### PR TITLE
Validate capsule parent fork roots

### DIFF
--- a/packages/remnic-core/src/transfer/types.ts
+++ b/packages/remnic-core/src/transfer/types.ts
@@ -76,6 +76,12 @@ const SemverLikeSchema = z
     "capsule.version must be a semver-like string (e.g. 1.0.0)",
   );
 
+function isSafePosixRelativePathPrefix(value: string): boolean {
+  if (value.startsWith("/") || value.includes("\\")) return false;
+  const segments = value.split("/");
+  return segments.every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
 export const CapsuleRetrievalPolicySchema = z.object({
   /**
    * Per-tier weight overrides applied during recall when the capsule is the
@@ -128,8 +134,9 @@ export const CapsuleParentSchema = z.object({
   forkRoot: z
     .string()
     .min(1, "capsule.parent.forkRoot must not be empty")
-    .refine((v) => !v.startsWith("/"), {
-      message: "capsule.parent.forkRoot must be a relative path (no leading slash)",
+    .refine(isSafePosixRelativePathPrefix, {
+      message:
+        "capsule.parent.forkRoot must be a normalized posix-relative path with no traversal segments",
     }),
 });
 

--- a/tests/capsule-fork.test.ts
+++ b/tests/capsule-fork.test.ts
@@ -19,6 +19,7 @@ import {
   readForkLineage,
   type ForkLineage,
 } from "../packages/remnic-core/src/transfer/capsule-fork.js";
+import { CapsuleParentSchema } from "../packages/remnic-core/src/transfer/types.js";
 import { parseCapsuleForkArgs } from "../packages/remnic-cli/src/index.js";
 
 // ---------------------------------------------------------------------------
@@ -615,4 +616,26 @@ test("forkCapsule: rejects symlinked forks/ directory that escapes targetRoot be
       return true;
     },
   );
+});
+
+test("CapsuleParentSchema: rejects traversal-style forkRoot values", () => {
+  const invalidForkRoots = [
+    "../parent",
+    "forks/../parent",
+    "forks/./parent",
+    "./forks/parent",
+    "forks//parent",
+    "forks/parent/",
+    "forks\\parent",
+    "/forks/parent",
+  ];
+
+  for (const forkRoot of invalidForkRoots) {
+    const parsed = CapsuleParentSchema.safeParse({
+      capsuleId: "parent",
+      version: "1.0.0",
+      forkRoot,
+    });
+    assert.equal(parsed.success, false, `forkRoot should be rejected: ${forkRoot}`);
+  }
 });


### PR DESCRIPTION
## Summary
- tighten capsule parent forkRoot validation to normalized POSIX-relative path prefixes
- reject traversal, current-directory, empty-segment, trailing-slash, backslash, and absolute forkRoot values
- add regression coverage for traversal-style forkRoot values

Finding: fnd_sig-feat-library-326e848962-d033_ad4d4763fa

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/capsule-fork.test.ts
- git diff --check
- pnpm --filter @remnic/core run check-types
- node scripts/ensure-bench-build-deps.mjs
- node scripts/ensure-cli-bench-build-deps.mjs
- node scripts/check-test-types.mjs
- pnpm rebuild better-sqlite3
- npm run preflight:quick
- npm run review:cursor (skipped: no changed files against c22c3e7d932071a73e89152b1aeaa4b3ecffbe59)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens schema validation for `capsule.parent.forkRoot`, which could reject previously-accepted manifests and affect import/fork flows. Change is localized but touches path-safety constraints (traversal/absolute path handling).
> 
> **Overview**
> Strengthens `CapsuleParentSchema` validation for `forkRoot` to require a *normalized POSIX-relative* path prefix, rejecting absolute paths, backslashes, empty segments, and `.`/`..` traversal components.
> 
> Adds a regression test ensuring traversal-style `forkRoot` values are rejected by the schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f468903dfb700bd89572c452f76b8927521b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->