### PR TITLE
Validate Gemini activity timestamps

### DIFF
--- a/packages/import-gemini/src/parser.test.ts
+++ b/packages/import-gemini/src/parser.test.ts
@@ -107,6 +107,62 @@ describe("parseGeminiExport", () => {
       /must be a JSON array or object/,
     );
   });
+
+  it("rejects invalid Gemini activity timestamps", () => {
+    const invalidTimes = [
+      "",
+      "not-a-date",
+      "2026-02-30T00:00:00Z",
+      "2026-13-01T00:00:00Z",
+      "2026-01-01T24:00:00Z",
+      "2026-01-01",
+      "2026-01-01T00:00:00+01:00",
+    ];
+
+    for (const time of invalidTimes) {
+      assert.throws(
+        () =>
+          parseGeminiExport([
+            {
+              header: "Gemini Apps",
+              text: "Tell me about runtime timestamp validation.",
+              time,
+            },
+          ]),
+        /Gemini activity time must be/,
+        `time should be rejected: ${time}`,
+      );
+    }
+  });
+
+  it("accepts UTC ISO activity timestamps with or without milliseconds", () => {
+    const parsed = parseGeminiExport([
+      {
+        header: "Gemini Apps",
+        text: "Tell me about validated timestamp imports.",
+        time: "2026-01-01T00:00:00Z",
+      },
+      {
+        header: "Gemini Apps",
+        text: "Tell me about millisecond timestamp imports.",
+        time: "2026-01-02T00:00:00.123Z",
+      },
+      {
+        header: "Gemini Apps",
+        text: "Tell me about zero-offset timestamp imports.",
+        time: "2026-01-03T00:00:00+00:00",
+      },
+    ]);
+
+    assert.deepEqual(
+      parsed.activities.map((activity) => activity.time),
+      [
+        "2026-01-01T00:00:00Z",
+        "2026-01-02T00:00:00.123Z",
+        "2026-01-03T00:00:00+00:00",
+      ],
+    );
+  });
 });
 
 describe("extractUserPrompt", () => {

--- a/packages/import-gemini/src/parser.ts
+++ b/packages/import-gemini/src/parser.ts
@@ -48,6 +48,9 @@ export interface GeminiActivityRecord {
   details?: Array<{ name?: string }>;
 }
 
+const UTC_ISO_INSTANT_RE =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?(Z|[+-]00:00)$/;
+
 export interface ParsedGeminiExport {
   /** Prompts filtered to `header === "Gemini Apps"`. */
   activities: GeminiActivityRecord[];
@@ -157,7 +160,25 @@ function appendActivities(
     }
     const record = entry as GeminiActivityRecord;
     if (!options.keepNonGemini && !isGeminiRecord(record)) continue;
+    validateGeminiTimestamp(record.time);
     dest.push(record);
+  }
+}
+
+function validateGeminiTimestamp(value: unknown): void {
+  if (value === undefined) return;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("Gemini activity time must be an ISO-8601 UTC timestamp");
+  }
+  const match = UTC_ISO_INSTANT_RE.exec(value);
+  if (!match) {
+    throw new Error("Gemini activity time must be an ISO-8601 UTC timestamp");
+  }
+  const milliseconds = (match[2] ?? "").padEnd(3, "0");
+  const canonical = `${match[1]}.${milliseconds}Z`;
+  const parsedMs = Date.parse(canonical);
+  if (!Number.isFinite(parsedMs) || new Date(parsedMs).toISOString() !== canonical) {
+    throw new Error("Gemini activity time must be a valid ISO-8601 UTC timestamp");
   }
 }
 


### PR DESCRIPTION
## Summary
- validate Gemini activity `time` values at parse time before transform/import
- reject malformed, non-UTC, and overflow-normalized timestamps such as impossible dates
- add parser regression coverage for invalid and accepted UTC ISO timestamp forms

Finding: fnd_sig-feat-library-327ab4bd75-6274_379d26d18d

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/import-gemini/src/parser.test.ts packages/import-gemini/src/transform.test.ts
- git diff --check
- pnpm --filter @remnic/import-gemini run check-types
- node scripts/ensure-bench-build-deps.mjs
- node scripts/ensure-cli-bench-build-deps.mjs
- node scripts/check-test-types.mjs
- pnpm rebuild better-sqlite3
- npm run preflight:quick
- npm run review:cursor (skipped: no changed files against f36f3148bfc1a2c03b520ffd3ca6181c5caaa53b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Parsing now rejects records with malformed or non-UTC `time` values, which can cause previously-importable Takeout exports to fail until fixed/cleaned. Logic is localized to the Gemini importer and covered by new regression tests, limiting blast radius.
> 
> **Overview**
> Adds runtime validation for Gemini activity `time` fields during `parseGeminiExport`, rejecting missing/blank, malformed, non-UTC, and overflow-normalized timestamps (e.g., impossible dates/times). Validation allows only UTC ISO-8601 instants (`Z` or `+00:00`) with optional milliseconds.
> 
> Extends `parser.test.ts` with coverage that asserts invalid timestamps throw and that accepted UTC forms (with/without milliseconds and `+00:00`) round-trip unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1b7a3eee83dc40e602c1ea3d5139cc5e413a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->