### PR TITLE
Fail test typecheck on wrapper failures

### DIFF
--- a/scripts/check-test-types.mjs
+++ b/scripts/check-test-types.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -9,30 +9,26 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
 const baselinePath = resolve(scriptDir, "test-typecheck-baseline.txt");
 
-const result = spawnSync(
-  "pnpm",
-  ["exec", "tsc", "--noEmit", "--project", "tsconfig.tests.json", "--pretty", "false"],
-  {
-    cwd: repoRoot,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  },
-);
-
-if (result.error) {
-  console.error(`[test-typecheck] failed to start tsc: ${result.error.message}`);
-  process.exit(1);
-}
-
 const diagnosticHeaderPattern =
-  /^(?<path>.+?\.ts)\((?<line>\d+),(?<column>\d+)\): (?:error )?(?<code>TS\d+)(?::|$)/;
+  /^(?<path>.+?\.(?:cts|mts|ts|tsx))\((?<line>\d+),(?<column>\d+)\): (?:error )?(?<code>TS\d+)(?::|$)/;
 
-const normalize = (value) =>
+const normalizeOutputLines = (value, root = repoRoot) =>
   value
-    .replaceAll(repoRoot, "<repo>")
+    .replaceAll(root, "<repo>")
     .replace(/\r\n/g, "\n")
-    .split("\n")
-    .map((line) => line.trim())
+    .split("\n");
+
+const normalizeLines = (value, root = repoRoot) =>
+  normalizeOutputLines(value, root).map((line) => line.trim());
+
+const diagnosticContinuationPattern =
+  /^(?:A spread|An argument|Argument|Call signature|Cannot assign|Cannot find|Cannot invoke|Construct signature|Conversion of type|Did you mean|Element implicitly|Index signature|No overload|Object literal|Overload \d+|Property|Source has|Target signature|The |This condition|Type |Types |Value of type)/;
+
+const isTypeScriptContinuationLine = (line) =>
+  /^[ \t]/.test(line) && diagnosticContinuationPattern.test(line.trim());
+
+export const normalizeDiagnostics = (value, root = repoRoot) =>
+  normalizeLines(value, root)
     .map((line) => line.match(diagnosticHeaderPattern))
     .filter((match) => match?.groups)
     .map((match) => {
@@ -42,29 +38,129 @@ const normalize = (value) =>
     .join("\n")
     .trim();
 
-const actual = normalize(`${result.stdout ?? ""}${result.stderr ?? ""}`);
-const expected = existsSync(baselinePath)
-  ? normalize(readFileSync(baselinePath, "utf8"))
-  : "";
+export function nonDiagnosticFailureLines(value, root = repoRoot) {
+  const lines = [];
+  let sawDiagnostic = false;
+  for (const rawLine of normalizeOutputLines(value, root)) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    if (diagnosticHeaderPattern.test(line)) {
+      sawDiagnostic = true;
+      continue;
+    }
+    if (sawDiagnostic && isTypeScriptContinuationLine(rawLine)) continue;
+    lines.push(line);
+  }
+  return lines;
+}
 
-if (result.status === 0) {
-  if (expected.length > 0) {
-    console.error(
-      "[test-typecheck] tests now typecheck cleanly; clear scripts/test-typecheck-baseline.txt.",
-    );
+export function evaluateTestTypecheckResult({
+  status,
+  stdout = "",
+  stderr = "",
+  expectedText = "",
+  root = repoRoot,
+}) {
+  const rawOutput = `${stdout}${stderr}`;
+  const actual = normalizeDiagnostics(rawOutput, root);
+  const expected = normalizeDiagnostics(expectedText, root);
+  const actualNonDiagnosticText = nonDiagnosticFailureLines(rawOutput, root)
+    .join("\n")
+    .trim();
+  const expectedNonDiagnosticText = nonDiagnosticFailureLines(expectedText, root)
+    .join("\n")
+    .trim();
+
+  if (status === 0) {
+    if (expected.length > 0) {
+      return {
+        ok: false,
+        message:
+          "[test-typecheck] tests now typecheck cleanly; clear scripts/test-typecheck-baseline.txt.",
+      };
+    }
+    return { ok: true, message: "[test-typecheck] OK" };
+  }
+
+  if (actualNonDiagnosticText !== expectedNonDiagnosticText) {
+    return {
+      ok: false,
+      message:
+        "[test-typecheck] tsc failed with non-diagnostic output; investigate the wrapper/tooling failure before accepting the baseline.",
+      details: actualNonDiagnosticText,
+    };
+  }
+
+  if (actual.length === 0) {
+    return {
+      ok: false,
+      message:
+        "[test-typecheck] tsc failed without TypeScript diagnostics; investigate the wrapper/tooling failure before accepting the baseline.",
+    };
+  }
+
+  if (actual === expected) {
+    return {
+      ok: true,
+      message: "[test-typecheck] OK (matches existing baseline)",
+    };
+  }
+
+  return {
+    ok: false,
+    message:
+      "[test-typecheck] test type errors changed. Update the tests or refresh scripts/test-typecheck-baseline.txt intentionally.",
+    details: actual,
+  };
+}
+
+export function isDirectRunPath(argvPath, moduleUrl = import.meta.url) {
+  if (!argvPath) return false;
+  try {
+    return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  const result = spawnSync(
+    "pnpm",
+    ["exec", "tsc", "--noEmit", "--project", "tsconfig.tests.json", "--pretty", "false"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  if (result.error) {
+    console.error(`[test-typecheck] failed to start tsc: ${result.error.message}`);
     process.exit(1);
   }
-  console.log("[test-typecheck] OK");
-  process.exit(0);
+
+  const expectedText = existsSync(baselinePath)
+    ? readFileSync(baselinePath, "utf8")
+    : "";
+  const evaluation = evaluateTestTypecheckResult({
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    expectedText,
+  });
+
+  if (evaluation.ok) {
+    console.log(evaluation.message);
+    process.exit(0);
+  }
+
+  console.error(evaluation.message);
+  if (evaluation.details) {
+    console.error(evaluation.details);
+  }
+  process.exit(1);
 }
 
-if (actual === expected) {
-  console.log("[test-typecheck] OK (matches existing baseline)");
-  process.exit(0);
+if (isDirectRunPath(process.argv[1])) {
+  main();
 }
-
-console.error(
-  "[test-typecheck] test type errors changed. Update the tests or refresh scripts/test-typecheck-baseline.txt intentionally.",
-);
-console.error(actual);
-process.exit(1);

--- a/tests/check-test-types-script.test.ts
+++ b/tests/check-test-types-script.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptUrl = new URL("../scripts/check-test-types.mjs", import.meta.url);
+const { evaluateTestTypecheckResult, isDirectRunPath } = await import(scriptUrl.href);
+
+const ROOT = "/repo";
+const BASELINE_DIAGNOSTIC = "/repo/tests/example.test.ts(12,7): error TS2322: bad";
+
+describe("check-test-types wrapper", () => {
+  it("accepts nonzero tsc exits when diagnostics match the baseline", () => {
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout: `${BASELINE_DIAGNOSTIC}\n`,
+      expectedText: `${BASELINE_DIAGNOSTIC}\n`,
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.message, "[test-typecheck] OK (matches existing baseline)");
+  });
+
+  it("accepts baseline diagnostics for TypeScript file variants", () => {
+    for (const extension of ["cts", "mts", "tsx"]) {
+      const diagnostic = `/repo/tests/component.test.${extension}(4,2): error TS2322: bad`;
+      const result = evaluateTestTypecheckResult({
+        status: 2,
+        stdout: `${diagnostic}\n`,
+        expectedText: `${diagnostic}\n`,
+        root: ROOT,
+      });
+
+      assert.equal(result.ok, true, extension);
+    }
+  });
+
+  it("accepts baseline-owned TypeScript diagnostic continuation lines", () => {
+    const continuation = "  Type 'string' is not assignable to type 'number'.";
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout: `${BASELINE_DIAGNOSTIC}\n${continuation}\n`,
+      expectedText: `${BASELINE_DIAGNOSTIC}\n${continuation}\n`,
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, true);
+  });
+
+  it("rejects non-diagnostic tsc failure output even when diagnostics match", () => {
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout: `${BASELINE_DIAGNOSTIC}\n`,
+      stderr: "fatal: tsc wrapper crashed before finishing\n",
+      expectedText: `${BASELINE_DIAGNOSTIC}\n`,
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.message, /non-diagnostic output/);
+    assert.match(result.details ?? "", /wrapper crashed/);
+  });
+
+  it("rejects non-diagnostic tsc failure output after diagnostics", () => {
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout: `${BASELINE_DIAGNOSTIC}\nCommand failed with exit code 2\n`,
+      expectedText: `${BASELINE_DIAGNOSTIC}\n`,
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.message, /non-diagnostic output/);
+    assert.match(result.details ?? "", /Command failed/);
+  });
+
+  it("rejects pnpm failure output prefixed with Unicode spacing", () => {
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout: `${BASELINE_DIAGNOSTIC}\n\u2009ELIFECYCLE\u2009 Command failed with exit code 2\n`,
+      expectedText: `${BASELINE_DIAGNOSTIC}\n`,
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.message, /non-diagnostic output/);
+    assert.match(result.details ?? "", /ELIFECYCLE/);
+  });
+
+  it("rejects indented wrapper failure output after diagnostics", () => {
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout: `${BASELINE_DIAGNOSTIC}\n  at wrapper.js:12:3\n`,
+      expectedText: `${BASELINE_DIAGNOSTIC}\n`,
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.message, /non-diagnostic output/);
+    assert.match(result.details ?? "", /wrapper\.js/);
+  });
+
+  it("rejects tsc failures with no TypeScript diagnostics", () => {
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      expectedText: "",
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.message, /without TypeScript diagnostics/);
+  });
+
+  it("rejects global TypeScript errors that do not identify a test file", () => {
+    const result = evaluateTestTypecheckResult({
+      status: 2,
+      stdout: "error TS18003: No inputs were found in config file.\n",
+      expectedText: "",
+      root: ROOT,
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(result.details ?? "", /TS18003/);
+  });
+
+  it("can be imported when argv[1] is absent", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `process.argv[1] = undefined; await import(${JSON.stringify(scriptUrl.href)});`,
+      ],
+      {
+        encoding: "utf8",
+      },
+    );
+
+    assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+  });
+
+  it("recognizes direct execution through a symlinked path", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "remnic-check-test-types-"));
+    try {
+      const symlinkPath = join(tempDir, "check-test-types-link.mjs");
+      symlinkSync(fileURLToPath(scriptUrl), symlinkPath);
+
+      assert.equal(isDirectRunPath(symlinkPath), true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fail the test typecheck wrapper when tsc exits nonzero without file diagnostics
- surface global TypeScript/tooling failures instead of accepting a matching diagnostic baseline
- add focused coverage for baseline matches, continuation lines, non-diagnostic failures, and global errors

Finding: fnd_sig-feat-library-32b0f83226-243f_c8b225677d

## Verification
- pnpm install --frozen-lockfile
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/check-test-types-script.test.ts
- git diff --check
- node scripts/ensure-bench-build-deps.mjs
- node scripts/ensure-cli-bench-build-deps.mjs
- node scripts/check-test-types.mjs
- pnpm rebuild better-sqlite3
- npm run preflight:quick
- npm run review:cursor (skipped: no changed files against 6c48e96247a7c04ba19b639c0a4b49007a5bf6bd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `check-test-types` gate logic used in CI; while not production code, it can change pass/fail behavior and may surface previously masked tooling errors.
> 
> **Overview**
> **Tightens `scripts/check-test-types.mjs` failure handling** so a matching TypeScript diagnostic baseline is no longer accepted when `tsc` fails with additional *non-diagnostic* output or with no file-based diagnostics at all.
> 
> Refactors the script into importable helpers (`evaluateTestTypecheckResult`, `normalizeDiagnostics`, `nonDiagnosticFailureLines`) with improved diagnostic parsing (supports `cts`/`mts`/`tsx` and ignores typical continuation lines), and adds a focused test suite validating the new acceptance/rejection cases plus safe import and symlinked direct execution detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045c7c4b60a777146019e73f885ca5271431d422. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->