### PR TITLE
Fix release package version bumps

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -258,6 +258,40 @@ jobs:
             git commit -m "chore(release): v${NEXT_VERSION} [skip ci]"
           fi
 
+      - name: Bump changed workspace package versions
+        if: steps.version.outputs.tag_exists != 'true'
+        env:
+          BASE_TAG: ${{ steps.version.outputs.base_tag }}
+          BUMP_TYPE: ${{ steps.version.outputs.bump_type }}
+          SOURCE_MAIN_SHA: ${{ steps.version.outputs.source_main_sha }}
+        run: |
+          if [ -z "${BASE_TAG}" ]; then
+            BASE_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*' "${SOURCE_MAIN_SHA}^" 2>/dev/null || true)"
+          fi
+          if [ -z "${BASE_TAG}" ]; then
+            echo "::notice title=Package version bump skipped::No prior release tag found for ${SOURCE_MAIN_SHA}."
+            exit 0
+          fi
+          PACKAGE_BUMP="${BUMP_TYPE:-patch}"
+          case "${PACKAGE_BUMP}" in
+            major|minor|patch) ;;
+            *) PACKAGE_BUMP="patch" ;;
+          esac
+
+          node scripts/bump-changed-packages.mjs \
+            --base "${BASE_TAG}" \
+            --head "${SOURCE_MAIN_SHA}" \
+            --bump "${PACKAGE_BUMP}"
+
+          if git diff --quiet -- packages/*/package.json packages/*/openclaw.plugin.json openclaw.plugin.json; then
+            echo "::notice title=Package version bump skipped::No public workspace package versions changed."
+            exit 0
+          fi
+
+          pnpm install --lockfile-only
+          git add packages/*/package.json packages/*/openclaw.plugin.json openclaw.plugin.json pnpm-lock.yaml
+          git commit -m "chore(release): bump changed workspace packages [skip ci]"
+
       - name: Promote CHANGELOG.md for release
         if: steps.version.outputs.tag_exists != 'true'
         env:

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "check:openclaw-plugin-sync": "node scripts/check-openclaw-plugin-sync.mjs",
     "check:openclaw-sdk-surface": "node scripts/check-openclaw-sdk-surface.mjs",
     "check:openclaw-sdk-surface:required": "node scripts/check-openclaw-sdk-surface.mjs --require",
+    "release:bump-changed-packages": "node scripts/bump-changed-packages.mjs",
     "build": "pnpm --filter @remnic/core build && pnpm run check:openclaw-plugin-sync && tsup && node scripts/copy-admin-console.mjs",
     "dev": "tsup --watch",
     "check-types": "pnpm --filter @remnic/core build && tsc --noEmit && pnpm --recursive --if-present --filter=\"./packages/*\" run check-types && node scripts/check-test-types.mjs",

--- a/scripts/bump-changed-packages.mjs
+++ b/scripts/bump-changed-packages.mjs
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const publicManifestAliases = new Map([
+  ["openclaw.plugin.json", ["packages/plugin-openclaw"]],
+]);
+const validBumpTypes = new Set(["major", "minor", "patch"]);
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (value === undefined || value === "" || value === "--" || value.startsWith("--")) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+function parseArgs(argv) {
+  const args = {
+    base: "",
+    head: "HEAD",
+    bump: "patch",
+    dryRun: false,
+    json: false,
+    repoRoot: process.cwd(),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--base") {
+      args.base = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--head") {
+      args.head = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--bump") {
+      args.bump = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--repo-root") {
+      args.repoRoot = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--dry-run") {
+      args.dryRun = true;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--") {
+      continue;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.help && !validBumpTypes.has(args.bump)) {
+    throw new Error(
+      `Invalid --bump value "${args.bump}". Valid values: major, minor, patch.`,
+    );
+  }
+
+  return args;
+}
+
+function usage() {
+  return [
+    "Usage: node scripts/bump-changed-packages.mjs --base <ref> [--head <ref>] [--bump patch|minor|major] [--dry-run] [--json]",
+    "",
+    "Diffs release source files between refs and bumps only public workspace packages whose own files changed.",
+    "If a package version was already changed in the release source, the script leaves that version alone.",
+  ].join("\n");
+}
+
+function runGit(repoRoot, args, options = {}) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: options.quiet ? ["ignore", "pipe", "ignore"] : ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function tryGit(repoRoot, args) {
+  try {
+    return runGit(repoRoot, args, { quiet: true });
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRelativePath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function sortByPath(left, right) {
+  return left.relativePath.localeCompare(right.relativePath);
+}
+
+async function readJson(jsonPath) {
+  return JSON.parse(await readFile(jsonPath, "utf8"));
+}
+
+async function writeJson(jsonPath, value, dryRun) {
+  const next = `${JSON.stringify(value, null, 2)}\n`;
+  const current = await readFile(jsonPath, "utf8").catch(() => "");
+  if (current === next) {
+    return false;
+  }
+  if (!dryRun) {
+    await writeFile(jsonPath, next);
+  }
+  return true;
+}
+
+function parseSemver(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (!match) {
+    throw new Error(`Cannot compare non-semver package version: ${version}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareVersions(left, right) {
+  const leftParts = parseSemver(left);
+  const rightParts = parseSemver(right);
+
+  for (const key of ["major", "minor", "patch"]) {
+    if (leftParts[key] > rightParts[key]) {
+      return 1;
+    }
+    if (leftParts[key] < rightParts[key]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function bumpVersion(version, bump) {
+  const { major, minor, patch } = parseSemver(version);
+
+  if (bump === "major") {
+    return `${major + 1}.0.0`;
+  }
+  if (bump === "minor") {
+    return `${major}.${minor + 1}.0`;
+  }
+  if (bump === "patch") {
+    return `${major}.${minor}.${patch + 1}`;
+  }
+  throw new Error(`Unsupported package bump type: ${bump}`);
+}
+
+async function pathExists(filePath) {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function discoverPublicPackages(repoRoot) {
+  const packagesRoot = path.join(repoRoot, "packages");
+  const entries = await readdir(packagesRoot, { withFileTypes: true });
+  const packages = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const packageDir = path.join(packagesRoot, entry.name);
+    const packageJsonPath = path.join(packageDir, "package.json");
+    if (!(await pathExists(packageJsonPath))) {
+      continue;
+    }
+
+    const manifest = await readJson(packageJsonPath);
+    if (manifest.private === true) {
+      continue;
+    }
+
+    packages.push({
+      dir: packageDir,
+      relativeDir: normalizeRelativePath(path.relative(repoRoot, packageDir)),
+      packageJsonPath,
+      relativePath: normalizeRelativePath(path.relative(repoRoot, packageJsonPath)),
+      manifest,
+      name: manifest.name,
+      version: manifest.version,
+    });
+  }
+
+  return packages.sort(sortByPath);
+}
+
+function changedPackageDirs(changedFiles, packages) {
+  const byDir = new Map(packages.map((pkg) => [pkg.relativeDir, pkg]));
+  const changed = new Map();
+
+  for (const file of changedFiles) {
+    for (const [alias, packageDirs] of publicManifestAliases) {
+      if (file === alias) {
+        for (const packageDir of packageDirs) {
+          const pkg = byDir.get(packageDir);
+          if (pkg) {
+            changed.set(pkg.relativeDir, pkg);
+          }
+        }
+      }
+    }
+
+    for (const pkg of packages) {
+      if (file === pkg.relativeDir || file.startsWith(`${pkg.relativeDir}/`)) {
+        changed.set(pkg.relativeDir, pkg);
+      }
+    }
+  }
+
+  return [...changed.values()].sort(sortByPath);
+}
+
+function packageVersionAtRef(repoRoot, ref, relativePath) {
+  const raw = tryGit(repoRoot, ["show", `${ref}:${relativePath}`]);
+  if (raw === null) {
+    return null;
+  }
+
+  return JSON.parse(raw).version ?? null;
+}
+
+function releaseSourceShaAtRef(repoRoot, ref) {
+  const raw = tryGit(repoRoot, ["cat-file", "-p", ref]);
+  const match = raw?.match(/^source-main-sha:\s*([0-9a-f]{7,40})$/im);
+  if (!match) {
+    return null;
+  }
+
+  const sha = match[1];
+  return tryGit(repoRoot, ["rev-parse", "--verify", `${sha}^{commit}`]) ?? null;
+}
+
+function changedFilesBaseRef(repoRoot, base, head) {
+  return (
+    releaseSourceShaAtRef(repoRoot, base) ??
+    tryGit(repoRoot, ["merge-base", base, head]) ??
+    base
+  );
+}
+
+async function syncOpenClawManifestVersion(repoRoot, relativeManifestPath, version, dryRun) {
+  const manifestPath = path.join(repoRoot, relativeManifestPath);
+  if (!(await pathExists(manifestPath))) {
+    return false;
+  }
+
+  const manifest = await readJson(manifestPath);
+  manifest.version = version;
+  return writeJson(manifestPath, manifest, dryRun);
+}
+
+async function syncCompanionVersions(repoRoot, pkg, version, dryRun) {
+  const changedFiles = [];
+
+  if (pkg.relativeDir === "packages/plugin-openclaw") {
+    const packageManifest = "packages/plugin-openclaw/openclaw.plugin.json";
+    const rootManifest = "openclaw.plugin.json";
+    if (await syncOpenClawManifestVersion(repoRoot, packageManifest, version, dryRun)) {
+      changedFiles.push(packageManifest);
+    }
+    if (await syncOpenClawManifestVersion(repoRoot, rootManifest, version, dryRun)) {
+      changedFiles.push(rootManifest);
+    }
+  }
+
+  if (pkg.relativeDir === "packages/shim-openclaw-engram") {
+    const shimManifest = "packages/shim-openclaw-engram/openclaw.plugin.json";
+    if (await syncOpenClawManifestVersion(repoRoot, shimManifest, version, dryRun)) {
+      changedFiles.push(shimManifest);
+    }
+  }
+
+  return changedFiles;
+}
+
+async function bumpChangedPackages(options) {
+  const repoRoot = path.resolve(options.repoRoot);
+  const base = options.base;
+  const head = options.head || "HEAD";
+
+  if (!base) {
+    throw new Error("--base is required");
+  }
+  if (!tryGit(repoRoot, ["rev-parse", "--verify", base])) {
+    throw new Error(`Base ref not found: ${base}`);
+  }
+  if (!tryGit(repoRoot, ["rev-parse", "--verify", head])) {
+    throw new Error(`Head ref not found: ${head}`);
+  }
+
+  const changedBase = changedFilesBaseRef(repoRoot, base, head);
+  const changedFiles = runGit(repoRoot, ["diff", "--name-only", `${changedBase}..${head}`])
+    .split("\n")
+    .map((file) => file.trim())
+    .filter(Boolean);
+
+  const packages = await discoverPublicPackages(repoRoot);
+  const changedPackages = changedPackageDirs(changedFiles, packages);
+  const updates = [];
+
+  for (const pkg of changedPackages) {
+    const baseVersion = packageVersionAtRef(repoRoot, base, pkg.relativePath);
+    let nextVersion = pkg.version;
+    let reason = "new-package";
+
+    if (baseVersion !== null) {
+      const versionComparison = compareVersions(pkg.version, baseVersion);
+      if (versionComparison === 0) {
+        nextVersion = bumpVersion(pkg.version, options.bump);
+        reason = "auto-bump";
+      } else if (versionComparison > 0) {
+        reason = "manual-version";
+      } else {
+        nextVersion = bumpVersion(baseVersion, options.bump);
+        reason = "catch-up-bump";
+      }
+    }
+
+    const changedFilesForPackage = [];
+    if (nextVersion !== pkg.version) {
+      const nextManifest = { ...pkg.manifest, version: nextVersion };
+      if (await writeJson(pkg.packageJsonPath, nextManifest, options.dryRun)) {
+        changedFilesForPackage.push(pkg.relativePath);
+      }
+    }
+
+    changedFilesForPackage.push(
+      ...(await syncCompanionVersions(repoRoot, pkg, nextVersion, options.dryRun)),
+    );
+
+    updates.push({
+      name: pkg.name,
+      path: pkg.relativeDir,
+      from: pkg.version,
+      to: nextVersion,
+      baseVersion,
+      reason,
+      changedFiles: changedFilesForPackage,
+    });
+  }
+
+  return { base, changedBase, head, bump: options.bump, changedFiles, updates };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  const result = await bumpChangedPackages(args);
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (result.updates.length === 0) {
+    console.log(
+      `No public workspace package versions need changes for ${result.base}..${result.head}.`,
+    );
+    return;
+  }
+
+  for (const update of result.updates) {
+    const suffix = update.changedFiles.length
+      ? `; wrote ${update.changedFiles.join(", ")}`
+      : "";
+    console.log(
+      `${update.name}: ${update.from} -> ${update.to} (${update.reason})${suffix}`,
+    );
+  }
+}
+
+const entrypoint = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (entrypoint === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}
+
+export {
+  bumpChangedPackages,
+  bumpVersion,
+  changedPackageDirs,
+  discoverPublicPackages,
+  parseArgs,
+};

--- a/scripts/bump-changed-packages.test.mjs
+++ b/scripts/bump-changed-packages.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { parseArgs } from "./bump-changed-packages.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.join(here, "bump-changed-packages.mjs");
+
+function run(cwd, command, args) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function git(cwd, args) {
+  return run(cwd, "git", args);
+}
+
+async function writeJson(filePath, value) {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+async function withRepo(fn) {
+  const repo = await mkdtemp(path.join(os.tmpdir(), "remnic-bump-packages-"));
+  try {
+    git(repo, ["init", "-q"]);
+    git(repo, ["config", "user.name", "Test User"]);
+    git(repo, ["config", "user.email", "test@example.com"]);
+
+    await mkdir(path.join(repo, "packages", "remnic-core", "src"), { recursive: true });
+    await mkdir(path.join(repo, "packages", "plugin-openclaw"), { recursive: true });
+    await mkdir(path.join(repo, "packages", "bench-ui"), { recursive: true });
+
+    await writeJson(path.join(repo, "package.json"), {
+      name: "fixture",
+      private: true,
+      version: "0.0.0",
+      workspaces: ["packages/*"],
+    });
+    await writeJson(path.join(repo, "packages", "remnic-core", "package.json"), {
+      name: "@remnic/core",
+      version: "1.0.0",
+    });
+    await writeFile(path.join(repo, "packages", "remnic-core", "src", "index.ts"), "export {};\n");
+    await writeJson(path.join(repo, "packages", "plugin-openclaw", "package.json"), {
+      name: "@remnic/plugin-openclaw",
+      version: "2.0.0",
+    });
+    await writeJson(path.join(repo, "packages", "plugin-openclaw", "openclaw.plugin.json"), {
+      id: "openclaw-remnic",
+      version: "2.0.0",
+    });
+    await writeJson(path.join(repo, "openclaw.plugin.json"), {
+      id: "openclaw-remnic",
+      version: "2.0.0",
+    });
+    await writeJson(path.join(repo, "packages", "bench-ui", "package.json"), {
+      name: "@remnic/bench-ui",
+      private: true,
+      version: "0.1.0",
+    });
+
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "initial"]);
+    git(repo, ["tag", "v1.0.0"]);
+
+    await fn(repo);
+  } finally {
+    await rm(repo, { recursive: true, force: true });
+  }
+}
+
+test("bumps only the public package whose files changed", async () => {
+  await withRepo(async (repo) => {
+    await writeFile(
+      path.join(repo, "packages", "remnic-core", "src", "index.ts"),
+      "export const changed = true;\n",
+    );
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "change core"]);
+
+    run(repo, "node", [scriptPath, "--base", "v1.0.0"]);
+
+    const core = await readJson(path.join(repo, "packages", "remnic-core", "package.json"));
+    const plugin = await readJson(path.join(repo, "packages", "plugin-openclaw", "package.json"));
+    const benchUi = await readJson(path.join(repo, "packages", "bench-ui", "package.json"));
+    assert.equal(core.version, "1.0.1");
+    assert.equal(plugin.version, "2.0.0");
+    assert.equal(benchUi.version, "0.1.0");
+  });
+});
+
+test("root OpenClaw manifest changes bump plugin package and synced manifests", async () => {
+  await withRepo(async (repo) => {
+    await writeJson(path.join(repo, "openclaw.plugin.json"), {
+      id: "openclaw-remnic",
+      version: "2.0.0",
+      description: "changed",
+    });
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "change root manifest"]);
+
+    run(repo, "node", [scriptPath, "--base", "v1.0.0"]);
+
+    const plugin = await readJson(path.join(repo, "packages", "plugin-openclaw", "package.json"));
+    const rootManifest = await readJson(path.join(repo, "openclaw.plugin.json"));
+    const packageManifest = await readJson(
+      path.join(repo, "packages", "plugin-openclaw", "openclaw.plugin.json"),
+    );
+    assert.equal(plugin.version, "2.0.1");
+    assert.equal(rootManifest.version, "2.0.1");
+    assert.equal(packageManifest.version, "2.0.1");
+  });
+});
+
+test("does not auto-bump when the package version already changed", async () => {
+  await withRepo(async (repo) => {
+    const packageJson = path.join(repo, "packages", "remnic-core", "package.json");
+    const manifest = await readJson(packageJson);
+    manifest.version = "1.2.0";
+    await writeJson(packageJson, manifest);
+    await writeFile(
+      path.join(repo, "packages", "remnic-core", "src", "index.ts"),
+      "export const manuallyBumped = true;\n",
+    );
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "manual package bump"]);
+
+    run(repo, "node", [scriptPath, "--base", "v1.0.0"]);
+
+    const core = await readJson(packageJson);
+    assert.equal(core.version, "1.2.0");
+  });
+});
+
+test("bumps from tagged version when current package version lags behind base tag", async () => {
+  await withRepo(async (repo) => {
+    const packageJson = path.join(repo, "packages", "remnic-core", "package.json");
+    const manifest = await readJson(packageJson);
+    manifest.version = "0.9.0";
+    await writeJson(packageJson, manifest);
+    await writeFile(
+      path.join(repo, "packages", "remnic-core", "src", "index.ts"),
+      "export const sourceChanged = true;\n",
+    );
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "lagging main package version"]);
+
+    run(repo, "node", [scriptPath, "--base", "v1.0.0"]);
+
+    const core = await readJson(packageJson);
+    assert.equal(core.version, "1.0.1");
+  });
+});
+
+test("uses release tag source sha for changed files while reading versions from tag", async () => {
+  await withRepo(async (repo) => {
+    const sourceSha = git(repo, ["rev-parse", "HEAD"]);
+
+    const corePackageJson = path.join(repo, "packages", "remnic-core", "package.json");
+    const coreManifest = await readJson(corePackageJson);
+    coreManifest.version = "1.0.1";
+    await writeJson(corePackageJson, coreManifest);
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "release-only package bump"]);
+    git(repo, [
+      "tag",
+      "-f",
+      "-a",
+      "v1.0.0",
+      "-m",
+      "Release v1.0.0",
+      "-m",
+      `source-main-sha: ${sourceSha}`,
+    ]);
+
+    git(repo, ["reset", "--hard", sourceSha]);
+    await writeJson(path.join(repo, "packages", "plugin-openclaw", "openclaw.plugin.json"), {
+      id: "openclaw-remnic",
+      version: "2.0.0",
+      description: "changed",
+    });
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "change plugin manifest"]);
+
+    run(repo, "node", [scriptPath, "--base", "v1.0.0"]);
+
+    const core = await readJson(corePackageJson);
+    const plugin = await readJson(path.join(repo, "packages", "plugin-openclaw", "package.json"));
+    assert.equal(core.version, "1.0.0");
+    assert.equal(plugin.version, "2.0.1");
+  });
+});
+
+test("rejects missing option values before parsing later flags", () => {
+  assert.throws(
+    () => parseArgs(["--base", "--head", "HEAD"]),
+    /Missing value for --base/,
+  );
+});
+
+test("rejects invalid bump values upfront", () => {
+  assert.throws(
+    () => parseArgs(["--base", "v1.0.0", "--bump", "banana"]),
+    /Invalid --bump value "banana". Valid values: major, minor, patch./,
+  );
+});


### PR DESCRIPTION
## Summary
- add a release helper that diffs source changes since the previous release tag and bumps only affected public workspace package versions
- sync OpenClaw plugin manifest versions when the OpenClaw package or legacy shim package is bumped
- run the helper in the release workflow before tagging so npm and ClawHub see unpublished package versions

## Verification
- node --test scripts/bump-changed-packages.test.mjs
- pnpm run release:bump-changed-packages -- --base v9.3.491 --head 1637e14c --dry-run
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-and-publish.yml"); puts "workflow yaml ok"'
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release workflow and introduces automated version bumping that can affect what gets published to npm/ClawHub if the diffing or tag-base selection is wrong.
> 
> **Overview**
> Adds a new release helper (`scripts/bump-changed-packages.mjs`) that diffs changes since the previous `v*` tag (or the tag’s embedded `source-main-sha`) and **bumps versions only for changed, non-private workspace packages**, leaving already-manually-bumped versions intact and handling “lagging” versions.
> 
> Integrates this into `release-and-publish.yml` so releases create an additional commit that updates the affected `packages/*/package.json` files (plus `pnpm-lock.yaml`) *before* tagging/publishing, and syncs OpenClaw plugin manifest version fields (`openclaw.plugin.json` in root and package, plus the shim manifest) alongside the package bump.
> 
> Adds a root script entry (`release:bump-changed-packages`) and a dedicated Node test suite covering the bumping and OpenClaw manifest-sync behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45735a682c0c009f22821d037bbc86c0fb842c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->