### PR TITLE
feat(qmd): support 2.5 capabilities

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -119,6 +119,19 @@ See [Search Backends](search-backends.md) for detailed configuration and compari
 | `qmdColdCollection` | `openclaw-engram-cold` | QMD collection name used for cold-tier recall |
 | `qmdColdMaxResults` | `8` | Final result cap for cold-tier recall before merging into the normal ranking pipeline |
 | `qmdPath` | `(auto)` | Absolute path to `qmd` binary (bypasses PATH) |
+| `qmdSupportedVersion` | `2.5.1` | Highest QMD version this Remnic build will auto-install |
+| `qmdAutoUpgradeEnabled` | `false` | Opt-in auto-upgrade for PATH/fallback QMD installs; explicit `qmdPath` is never overwritten |
+| `qmdAutoUpgradeCheckIntervalMs` | `86400000` | Minimum interval between auto-upgrade attempts |
+| `qmdChunkStrategy` | `auto` | QMD chunk strategy to forward when the installed QMD supports it (`auto` or `regex`) |
+| `qmdCandidateLimit` | `(none)` | Optional QMD candidate limit forwarded to supported QMD query paths |
+| `qmdQueryRerankEnabled` | `true` | Set `false` to ask QMD to skip its built-in rerank step when supported |
+| `qmdIndexName` | `(none)` | Optional QMD named index forwarded as `qmd --index <name> ...` when QMD 2.5+ supports named index selection |
+| `qmdForceCpu` | `false` | Set `QMD_FORCE_CPU=1` for QMD child processes to bypass GPU probing |
+| `qmdGpuBackend` | `(none)` | Optional `QMD_LLAMA_GPU` override (`auto`, `metal`, `cuda`, `vulkan`, or `false`) |
+| `qmdEmbedParallelism` | `(none)` | Optional `QMD_EMBED_PARALLELISM` override, clamped to 1-8 |
+| `qmdEmbedModel` | `(none)` | Optional `QMD_EMBED_MODEL` override used by QMD indexing and vector search |
+| `qmdRerankModel` | `(none)` | Optional `QMD_RERANK_MODEL` override used by QMD reranking |
+| `qmdGenerateModel` | `(none)` | Optional `QMD_GENERATE_MODEL` override used by QMD query expansion |
 | `qmdDaemonEnabled` | `true` | Prefer QMD MCP daemon for recall/search when available (lower contention); fail-open to subprocess search/hybrid paths |
 | `qmdDaemonUrl` | `http://localhost:8181/mcp` | Legacy compatibility setting; current runtime uses shared stdio `qmd mcp` rather than the HTTP endpoint directly |
 | `qmdDaemonRecheckIntervalMs` | `60000` | Interval to re-probe daemon availability after failure |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,14 +79,18 @@ grep '\[engram\]' ~/.openclaw/logs/gateway.log | tail -5
 
 [QMD](https://github.com/tobi/qmd) provides hybrid BM25 + vector + reranking search. Without it, Remnic falls back to semantic embedding search (using your OpenAI key when available) and then recency-ordered file reads.
 
-**QMD 2.0+ is recommended.** QMD 1.x still works but 2.0 resolves several known issues natively (session ID crash, model override env vars, join performance). Install via bun or npm:
+**QMD 2.5.1 is the current supported target.** QMD 1.x still works, but 2.0+
+resolves several known issues natively (session ID crash, model override env
+vars, join performance), and 2.5.1 adds runtime diagnostics, structured MCP
+searches, safer indexing, model/GPU env controls, and absolute snippet line
+numbers that Remnic can detect and use. Install via npm or bun:
 
 ```bash
-bun install -g @tobilu/qmd
-# or: npm install -g @tobilu/qmd
+npm install -g @tobilu/qmd@2.5.1
+# or: bun install -g @tobilu/qmd@2.5.1
 
 # Verify
-qmd --version  # should show 2.0.0+
+qmd --version  # should show 2.5.1
 ```
 
 Add to `~/.config/qmd/index.yml`:
@@ -112,9 +116,12 @@ Enable in your plugin config:
 }
 ```
 
-### Upgrading from QMD 1.x to 2.0
+### Upgrading QMD
 
-QMD 2.0 is a drop-in upgrade — existing collections, indexes, and config files work without changes. The MCP tool interface (`query`, `get`, `multi_get`, `status`) is backward compatible.
+QMD 2.5.1 is a drop-in upgrade from older 2.x installs. Existing collections,
+indexes, and config files work without changes. Remnic detects the installed
+version at startup and enables newer features only when the installed binary
+supports them.
 
 **What changed:**
 - Unified `search()` replaces the old query/search/structuredSearch split internally
@@ -131,24 +138,32 @@ QMD 2.0 is a drop-in upgrade — existing collections, indexes, and config files
 **Upgrade steps:**
 
 ```bash
-# 1. Install QMD 2.0
-bun install -g @tobilu/qmd
+# 1. Install the supported QMD target
+npm install -g @tobilu/qmd@2.5.1
+# or: bun install -g @tobilu/qmd@2.5.1
 
 # 2. If native bindings need repair, rebuild better-sqlite3 manually
 cd ~/.bun/install/global/node_modules/better-sqlite3
 npm rebuild better-sqlite3
 
 # 3. Verify
-qmd --version       # 2.0.0+
+qmd --version       # 2.5.1
+qmd doctor          # available on QMD 2.5+
 qmd status           # should show existing collections
 
 # 4. Restart the gateway
 launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 
-# 5. Verify Remnic picked up QMD 2.0
+# 5. Verify Remnic picked up the new QMD version
 grep "cliVersion" ~/.openclaw/logs/gateway.log | tail -1
-# Should show: cliVersion=qmd 2.0.x
+# Should show: cliVersion=qmd 2.5.1
 ```
+
+To let Remnic perform this upgrade for PATH/fallback installs, set
+`qmdAutoUpgradeEnabled: true`. Remnic will install
+`@tobilu/qmd@qmdSupportedVersion` at most once per
+`qmdAutoUpgradeCheckIntervalMs`. Explicit `qmdPath` installs are never
+auto-upgraded.
 
 **Note:** If you used the OpenClaw patcher for QMD patches, those patches target QMD 1.x source paths that no longer exist in 2.0. The patcher will harmlessly skip them. You can remove old QMD patch entries from the patcher config.
 

--- a/docs/search-backends.md
+++ b/docs/search-backends.md
@@ -19,10 +19,13 @@ QMD provides the highest quality retrieval through hybrid BM25 + vector + LLM re
 
 ### Setup
 
-Install QMD:
+Install QMD. Remnic currently supports QMD `2.5.1` and detects the installed
+version with `qmd --version` at runtime:
 
 ```bash
-bun install -g github:tobi/qmd
+npm install -g @tobilu/qmd@2.5.1
+# or: bun install -g @tobilu/qmd@2.5.1
+qmd --version
 ```
 
 Add your memory directory to `~/.config/qmd/index.yml`:
@@ -47,11 +50,39 @@ qmd update && qmd embed
   "qmdEnabled": true,
   "qmdCollection": "openclaw-engram",
   "qmdMaxResults": 8,
+  "qmdSupportedVersion": "2.5.1",
+  "qmdAutoUpgradeEnabled": false, // opt-in: npm install -g @tobilu/qmd@2.5.1
+  "qmdChunkStrategy": "auto",
+  "qmdIndexName": "remnic",
+  "qmdForceCpu": false,
   "qmdDaemonEnabled": true,      // Keep the shared MCP session warm for fast queries
   "qmdIntentHintsEnabled": false,
   "qmdExplainEnabled": false
 }
 ```
+
+When QMD `2.5.1` is installed, Remnic uses the newer capability set when
+available: `qmd doctor` diagnostics, version-matched skill metadata, structured
+MCP `lex`/`vec`/`hyde` searches, candidate-limit forwarding, rerank toggles,
+AST-aware chunking for CLI/embed paths, scoped collection embedding, model/env
+overrides (`QMD_EMBED_MODEL`, `QMD_RERANK_MODEL`, `QMD_GENERATE_MODEL`,
+`QMD_FORCE_CPU`, `QMD_LLAMA_GPU`, `QMD_EMBED_PARALLELISM`), named index selection
+via `qmdIndexName`, and absolute snippet line numbers. Older QMD installs
+continue to work with unsupported flags omitted.
+
+Auto-upgrade is intentionally disabled by default. Set
+`qmdAutoUpgradeEnabled: true` to let Remnic upgrade PATH/fallback QMD installs to
+`qmdSupportedVersion`. Remnic does not auto-upgrade an explicitly configured
+`qmdPath`; install the supported package manually for that path.
+
+QMD version coverage:
+
+| QMD version | Remnic behavior |
+|-------------|-----------------|
+| `2.0.0` | Uses the v2 MCP `query` tool shape and unified search semantics; legacy `search`/`vsearch` daemon tools are avoided. |
+| `2.0.1` | Detects the skill-install generation, but leaves user/global agent skill installation explicit. |
+| `2.1.0` | Enables AST chunk strategy on CLI/embed paths, rerank toggles, candidate limits, per-collection model config compatibility, and JSON line capture. |
+| `2.5.1` | Enables doctor/status diagnostics, version-matched skills, structured MCP `lex`/`vec`/`hyde` searches, absolute snippet lines, scoped embed behavior, and QMD model/GPU env controls. |
 
 ### QMD Daemon Mode
 
@@ -66,6 +97,12 @@ Engram automatically prefers the shared MCP session when available and falls bac
 | `qmdDaemonRecheckIntervalMs` | `60000` | Re-probe interval after failure |
 | `qmdIntentHintsEnabled` | `false` | Forward inferred recall intent into QMD unified search when supported |
 | `qmdExplainEnabled` | `false` | Capture QMD explain traces into `memory_qmd_debug` snapshots |
+| `qmdSupportedVersion` | `2.5.1` | Highest QMD version this Remnic build will auto-install |
+| `qmdAutoUpgradeEnabled` | `false` | Opt-in auto-upgrade for PATH/fallback QMD installs |
+| `qmdAutoUpgradeCheckIntervalMs` | `86400000` | Minimum interval between auto-upgrade attempts |
+| `qmdChunkStrategy` | `auto` | Forward QMD's AST-aware chunk strategy when supported |
+| `qmdCandidateLimit` | `(none)` | Optional QMD candidate limit forwarded when supported |
+| `qmdQueryRerankEnabled` | `true` | Set `false` to pass QMD's rerank-disable flag when supported |
 
 ## Orama
 

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -436,9 +436,11 @@ Reliability / load:
   - Populate `cronRecallAllowlist` with only context-heavy cron job ids/patterns (`*:cron:<job-id>:*`).
   - Keep ingestion/integration script crons out of the allowlist unless they genuinely need memory context.
 - QMD version:
-  - **QMD 2.0+ is recommended.** All 1.x patches (PRs #166, #112, #117) are resolved natively in 2.0. QMD 1.x still works but requires manual patches.
+  - **QMD 2.5.1 is the current supported target.** Remnic detects the installed version with `qmd --version` and gates 2.5 features such as `qmd doctor`, version-matched skills, scoped embed behavior, named index selection, model/GPU env controls, and absolute snippet line numbers.
+  - **QMD 2.0+ is the minimum practical baseline.** All 1.x patches (PRs #166, #112, #117) are resolved natively in 2.0. QMD 1.x still works but requires manual patches.
+  - Set `qmdAutoUpgradeEnabled: true` to let Remnic upgrade PATH/fallback installs to `qmdSupportedVersion`; explicit `qmdPath` installs must be upgraded manually.
   - The QMD daemon keeps models warm — queries drop from ~13s to ~30ms after the first call.
-  - See [Getting Started](getting-started.md#upgrading-from-qmd-1x-to-20) for upgrade steps.
+  - See [Getting Started](getting-started.md#upgrading-qmd) for upgrade steps.
 - Local LLM failure damping:
   - `localLlmRetry5xxCount: 1`
   - `localLlmRetryBackoffMs: 400`

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -288,6 +288,83 @@
         "default": false,
         "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
       },
+      "qmdSupportedVersion": {
+        "type": "string",
+        "default": "2.5.1",
+        "description": "Highest QMD version this Remnic build will auto-install"
+      },
+      "qmdAutoUpgradeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
+      },
+      "qmdAutoUpgradeCheckIntervalMs": {
+        "type": "number",
+        "minimum": 60000,
+        "default": 86400000,
+        "description": "Minimum interval between QMD auto-upgrade checks"
+      },
+      "qmdChunkStrategy": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "regex"
+        ],
+        "default": "auto",
+        "description": "QMD chunk strategy forwarded when the installed QMD supports it"
+      },
+      "qmdCandidateLimit": {
+        "type": "number",
+        "minimum": 1,
+        "description": "Optional candidate limit forwarded to supported QMD query paths"
+      },
+      "qmdQueryRerankEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When false, ask supported QMD versions to skip the built-in rerank step"
+      },
+      "qmdIndexName": {
+        "type": "string",
+        "description": "Optional QMD named index forwarded as qmd --index <name> when supported"
+      },
+      "qmdForceCpu": {
+        "type": "boolean",
+        "default": false,
+        "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
+      },
+      "qmdGpuBackend": {
+        "type": [
+          "string",
+          "boolean"
+        ],
+        "enum": [
+          "auto",
+          "metal",
+          "cuda",
+          "vulkan",
+          "false",
+          false
+        ],
+        "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
+      },
+      "qmdEmbedParallelism": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 8,
+        "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
+      },
+      "qmdEmbedModel": {
+        "type": "string",
+        "description": "Optional QMD_EMBED_MODEL override"
+      },
+      "qmdRerankModel": {
+        "type": "string",
+        "description": "Optional QMD_RERANK_MODEL override"
+      },
+      "qmdGenerateModel": {
+        "type": "string",
+        "description": "Optional QMD_GENERATE_MODEL override"
+      },
       "embeddingFallbackEnabled": {
         "type": "boolean",
         "default": true,
@@ -4872,6 +4949,66 @@
       "label": "Tier Auto Backfill",
       "advanced": true,
       "help": "Enable automated cold-tier backfill runs for parity repair"
+    },
+    "qmdSupportedVersion": {
+      "label": "QMD Supported Version",
+      "advanced": true,
+      "placeholder": "2.5.1"
+    },
+    "qmdAutoUpgradeEnabled": {
+      "label": "QMD Auto Upgrade",
+      "advanced": true,
+      "help": "Upgrade PATH/fallback QMD installs to the supported version; explicit qmdPath installs are skipped"
+    },
+    "qmdAutoUpgradeCheckIntervalMs": {
+      "label": "QMD Auto Upgrade Interval",
+      "advanced": true,
+      "placeholder": "86400000"
+    },
+    "qmdChunkStrategy": {
+      "label": "QMD Chunk Strategy",
+      "advanced": true,
+      "placeholder": "auto"
+    },
+    "qmdCandidateLimit": {
+      "label": "QMD Candidate Limit",
+      "advanced": true
+    },
+    "qmdQueryRerankEnabled": {
+      "label": "QMD Query Rerank",
+      "advanced": true
+    },
+    "qmdIndexName": {
+      "label": "QMD Index Name",
+      "advanced": true,
+      "help": "Use a named QMD index when QMD 2.5+ supports --index"
+    },
+    "qmdForceCpu": {
+      "label": "QMD Force CPU",
+      "advanced": true,
+      "help": "Set QMD_FORCE_CPU=1 for QMD child processes"
+    },
+    "qmdGpuBackend": {
+      "label": "QMD GPU Backend",
+      "advanced": true,
+      "placeholder": "metal"
+    },
+    "qmdEmbedParallelism": {
+      "label": "QMD Embed Parallelism",
+      "advanced": true,
+      "placeholder": "4"
+    },
+    "qmdEmbedModel": {
+      "label": "QMD Embed Model",
+      "advanced": true
+    },
+    "qmdRerankModel": {
+      "label": "QMD Rerank Model",
+      "advanced": true
+    },
+    "qmdGenerateModel": {
+      "label": "QMD Generate Model",
+      "advanced": true
     },
     "embeddingFallbackEnabled": {
       "label": "Embedding Fallback",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -288,6 +288,83 @@
         "default": false,
         "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
       },
+      "qmdSupportedVersion": {
+        "type": "string",
+        "default": "2.5.1",
+        "description": "Highest QMD version this Remnic build will auto-install"
+      },
+      "qmdAutoUpgradeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
+      },
+      "qmdAutoUpgradeCheckIntervalMs": {
+        "type": "number",
+        "minimum": 60000,
+        "default": 86400000,
+        "description": "Minimum interval between QMD auto-upgrade checks"
+      },
+      "qmdChunkStrategy": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "regex"
+        ],
+        "default": "auto",
+        "description": "QMD chunk strategy forwarded when the installed QMD supports it"
+      },
+      "qmdCandidateLimit": {
+        "type": "number",
+        "minimum": 1,
+        "description": "Optional candidate limit forwarded to supported QMD query paths"
+      },
+      "qmdQueryRerankEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When false, ask supported QMD versions to skip the built-in rerank step"
+      },
+      "qmdIndexName": {
+        "type": "string",
+        "description": "Optional QMD named index forwarded as qmd --index <name> when supported"
+      },
+      "qmdForceCpu": {
+        "type": "boolean",
+        "default": false,
+        "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
+      },
+      "qmdGpuBackend": {
+        "type": [
+          "string",
+          "boolean"
+        ],
+        "enum": [
+          "auto",
+          "metal",
+          "cuda",
+          "vulkan",
+          "false",
+          false
+        ],
+        "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
+      },
+      "qmdEmbedParallelism": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 8,
+        "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
+      },
+      "qmdEmbedModel": {
+        "type": "string",
+        "description": "Optional QMD_EMBED_MODEL override"
+      },
+      "qmdRerankModel": {
+        "type": "string",
+        "description": "Optional QMD_RERANK_MODEL override"
+      },
+      "qmdGenerateModel": {
+        "type": "string",
+        "description": "Optional QMD_GENERATE_MODEL override"
+      },
       "embeddingFallbackEnabled": {
         "type": "boolean",
         "default": true,
@@ -4872,6 +4949,66 @@
       "label": "Tier Auto Backfill",
       "advanced": true,
       "help": "Enable automated cold-tier backfill runs for parity repair"
+    },
+    "qmdSupportedVersion": {
+      "label": "QMD Supported Version",
+      "advanced": true,
+      "placeholder": "2.5.1"
+    },
+    "qmdAutoUpgradeEnabled": {
+      "label": "QMD Auto Upgrade",
+      "advanced": true,
+      "help": "Upgrade PATH/fallback QMD installs to the supported version; explicit qmdPath installs are skipped"
+    },
+    "qmdAutoUpgradeCheckIntervalMs": {
+      "label": "QMD Auto Upgrade Interval",
+      "advanced": true,
+      "placeholder": "86400000"
+    },
+    "qmdChunkStrategy": {
+      "label": "QMD Chunk Strategy",
+      "advanced": true,
+      "placeholder": "auto"
+    },
+    "qmdCandidateLimit": {
+      "label": "QMD Candidate Limit",
+      "advanced": true
+    },
+    "qmdQueryRerankEnabled": {
+      "label": "QMD Query Rerank",
+      "advanced": true
+    },
+    "qmdIndexName": {
+      "label": "QMD Index Name",
+      "advanced": true,
+      "help": "Use a named QMD index when QMD 2.5+ supports --index"
+    },
+    "qmdForceCpu": {
+      "label": "QMD Force CPU",
+      "advanced": true,
+      "help": "Set QMD_FORCE_CPU=1 for QMD child processes"
+    },
+    "qmdGpuBackend": {
+      "label": "QMD GPU Backend",
+      "advanced": true,
+      "placeholder": "metal"
+    },
+    "qmdEmbedParallelism": {
+      "label": "QMD Embed Parallelism",
+      "advanced": true,
+      "placeholder": "4"
+    },
+    "qmdEmbedModel": {
+      "label": "QMD Embed Model",
+      "advanced": true
+    },
+    "qmdRerankModel": {
+      "label": "QMD Rerank Model",
+      "advanced": true
+    },
+    "qmdGenerateModel": {
+      "label": "QMD Generate Model",
+      "advanced": true
     },
     "embeddingFallbackEnabled": {
       "label": "Embedding Fallback",

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -68,6 +68,82 @@ function parseBoundedIntegerMs(
   return Math.min(max, Math.max(min, Math.floor(coerced)));
 }
 
+function parsePositiveInteger(value: unknown, keyName: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const coerced = coerceNumber(value);
+  if (
+    coerced === undefined ||
+    !Number.isFinite(coerced) ||
+    !Number.isInteger(coerced) ||
+    coerced <= 0
+  ) {
+    throw new Error(
+      `${keyName} must be a positive integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return coerced;
+}
+
+function parseBoundedPositiveInteger(
+  value: unknown,
+  min: number,
+  max: number,
+  keyName: string,
+): number | undefined {
+  const parsed = parsePositiveInteger(value, keyName);
+  if (parsed === undefined) return undefined;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function parseQmdSupportedVersion(value: unknown): string {
+  if (value === undefined || value === null) return "2.5.1";
+  if (typeof value !== "string") {
+    throw new Error(`qmdSupportedVersion must be a semantic version string; got ${JSON.stringify(value)}`);
+  }
+  const normalized = value.trim();
+  if (!/^\d+\.\d+\.\d+$/.test(normalized)) {
+    throw new Error(
+      `qmdSupportedVersion must be a semantic version string like "2.5.1"; got ${JSON.stringify(value)}`,
+    );
+  }
+  return normalized;
+}
+
+function parseQmdGpuBackend(value: unknown): "auto" | "metal" | "cuda" | "vulkan" | "false" | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (value === false) return "false";
+  if (typeof value !== "string") {
+    throw new Error(`qmdGpuBackend must be one of "auto", "metal", "cuda", "vulkan", or false; got ${JSON.stringify(value)}`);
+  }
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized === "auto" ||
+    normalized === "metal" ||
+    normalized === "cuda" ||
+    normalized === "vulkan" ||
+    normalized === "false"
+  ) {
+    return normalized;
+  }
+  throw new Error(`qmdGpuBackend must be one of "auto", "metal", "cuda", "vulkan", or false; got ${JSON.stringify(value)}`);
+}
+
+function parseQmdChunkStrategy(value: unknown): "auto" | "regex" {
+  if (value === undefined || value === null) return "auto";
+  if (typeof value !== "string") {
+    throw new Error(`qmdChunkStrategy must be "auto" or "regex"; got ${JSON.stringify(value)}`);
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "auto" || normalized === "regex") return normalized;
+  throw new Error(`qmdChunkStrategy must be "auto" or "regex"; got ${JSON.stringify(value)}`);
+}
+
+function parseOptionalNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 function parseIntegerAtLeast(
   value: unknown,
   fallback: number,
@@ -1246,6 +1322,29 @@ export function parseConfig(raw: unknown): PluginConfig {
     qmdTierParityGraphEnabled: cfg.qmdTierParityGraphEnabled !== false,
     qmdTierParityHiMemEnabled: cfg.qmdTierParityHiMemEnabled !== false,
     qmdTierAutoBackfillEnabled: cfg.qmdTierAutoBackfillEnabled === true,
+    qmdSupportedVersion: parseQmdSupportedVersion(cfg.qmdSupportedVersion),
+    qmdAutoUpgradeEnabled: coerceBool(cfg.qmdAutoUpgradeEnabled) === true,
+    qmdAutoUpgradeCheckIntervalMs: parseBoundedIntegerMs(
+      cfg.qmdAutoUpgradeCheckIntervalMs,
+      24 * 60 * 60_000,
+      60_000,
+      30 * 24 * 60 * 60_000,
+    ),
+    qmdChunkStrategy: parseQmdChunkStrategy(cfg.qmdChunkStrategy),
+    qmdCandidateLimit: parsePositiveInteger(cfg.qmdCandidateLimit, "qmdCandidateLimit"),
+    qmdQueryRerankEnabled: coerceBooleanLike(cfg.qmdQueryRerankEnabled) ?? true,
+    qmdIndexName: parseOptionalNonEmptyString(cfg.qmdIndexName),
+    qmdForceCpu: coerceBooleanLike(cfg.qmdForceCpu) ?? false,
+    qmdGpuBackend: parseQmdGpuBackend(cfg.qmdGpuBackend),
+    qmdEmbedParallelism: parseBoundedPositiveInteger(
+      cfg.qmdEmbedParallelism,
+      1,
+      8,
+      "qmdEmbedParallelism",
+    ),
+    qmdEmbedModel: parseOptionalNonEmptyString(cfg.qmdEmbedModel),
+    qmdRerankModel: parseOptionalNonEmptyString(cfg.qmdRerankModel),
+    qmdGenerateModel: parseOptionalNonEmptyString(cfg.qmdGenerateModel),
     embeddingFallbackEnabled: cfg.embeddingFallbackEnabled !== false,
     embeddingFallbackProvider:
       cfg.embeddingFallbackProvider === "openai"

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14663,7 +14663,8 @@ export class Orchestrator {
       const snippet = r.snippet
         ? r.snippet.slice(0, 500).replace(/\n/g, " ")
         : "(no preview)";
-      return `[${i + 1}] ${r.path} (score: ${r.score.toFixed(3)})\n${snippet}`;
+      const source = typeof r.line === "number" ? `${r.path}:${r.line}` : r.path;
+      return `[${i + 1}] ${source} (score: ${r.score.toFixed(3)})\n${snippet}`;
     });
     return `## ${title}\n\n${lines.join("\n\n")}`;
   }

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import {
+  getQmdCommandName,
+  getQmdPostInstallProbeTargets,
+  parseQmdVersionOutput,
+  parseQmdVersion,
+  parseQmdExplain,
+  resolveQmdCapabilities,
+  shouldAutoUpgradeQmd,
+} from "./qmd.js";
+
+test("parseQmdVersion extracts semantic version from qmd output", () => {
+  assert.deepEqual(parseQmdVersion("qmd 2.5.1 (abcdef)"), [2, 5, 1]);
+  assert.deepEqual(parseQmdVersion("v2.1.0"), [2, 1, 0]);
+  assert.equal(parseQmdVersion("Unknown command: doctor"), null);
+});
+
+test("parseQmdVersionOutput prefers qmd-labelled semantic version lines", () => {
+  assert.equal(
+    parseQmdVersionOutput("bun 1.2.0\nqmd 2.5.1 (abcdef)", ""),
+    "qmd 2.5.1 (abcdef)",
+  );
+  assert.equal(parseQmdVersionOutput("wrapper ready", "v2.1.0"), "v2.1.0");
+  assert.equal(parseQmdVersionOutput("", ""), null);
+});
+
+test("resolveQmdCapabilities gates qmd 2.5 features by installed version", () => {
+  const current = resolveQmdCapabilities("qmd 2.5.1 (abcdef)");
+  assert.equal(current.v2McpQueryTool, true);
+  assert.equal(current.structuredSearches, true);
+  assert.equal(current.chunkStrategy, true);
+  assert.equal(current.doctor, true);
+  assert.equal(current.versionedSkills, true);
+  assert.equal(current.absoluteSnippetLines, true);
+  assert.equal(current.fullQueryOutput, true);
+  assert.equal(current.forceCpu, true);
+  assert.equal(current.gpuBackendOverride, true);
+  assert.equal(current.embedParallelism, true);
+  assert.equal(current.modelEnvConsistency, true);
+  assert.equal(current.scopedEmbed, true);
+
+  const older = resolveQmdCapabilities("qmd 2.1.0 (abcdef)");
+  assert.equal(older.v2McpQueryTool, true);
+  assert.equal(older.structuredSearches, true);
+  assert.equal(older.chunkStrategy, true);
+  assert.equal(older.doctor, false);
+  assert.equal(older.versionedSkills, false);
+  assert.equal(older.absoluteSnippetLines, false);
+  assert.equal(older.forceCpu, false);
+  assert.equal(older.scopedEmbed, false);
+
+  const v20 = resolveQmdCapabilities("qmd 2.0.0");
+  assert.equal(v20.stableSdk, true);
+  assert.equal(v20.unifiedSearch, true);
+  assert.equal(v20.legacySkillInstall, false);
+
+  const v201 = resolveQmdCapabilities("qmd 2.0.1");
+  assert.equal(v201.legacySkillInstall, true);
+});
+
+test("shouldAutoUpgradeQmd only upgrades below Remnic supported version", () => {
+  assert.equal(shouldAutoUpgradeQmd("qmd 2.1.0", "2.5.1"), true);
+  assert.equal(shouldAutoUpgradeQmd("qmd 2.5.1", "2.5.1"), false);
+  assert.equal(shouldAutoUpgradeQmd("qmd 2.6.0", "2.5.1"), false);
+  assert.equal(shouldAutoUpgradeQmd("not installed", "2.5.1"), false);
+});
+
+test("getQmdCommandName preserves write command detection behind qmd 2.5 index prefix", () => {
+  assert.equal(getQmdCommandName(["embed", "-c", "memory"]), "embed");
+  assert.equal(getQmdCommandName(["--index", "remnic-prod", "embed", "-c", "memory"]), "embed");
+  assert.equal(getQmdCommandName(["--index=remnic-prod", "update", "-c", "memory"]), "update");
+  assert.equal(getQmdCommandName(["--version"]), "");
+});
+
+test("post-install auto-upgrade probes PATH qmd before stale fallback paths", () => {
+  assert.deepEqual(getQmdPostInstallProbeTargets("qmd", "auto-path"), [
+    { qmdPath: "qmd", source: "auto-path" },
+  ]);
+  assert.deepEqual(getQmdPostInstallProbeTargets("/Users/test/.bun/bin/qmd", "auto-fallback"), [
+    { qmdPath: "qmd", source: "auto-path" },
+    { qmdPath: "/Users/test/.bun/bin/qmd", source: "auto-fallback" },
+  ]);
+  assert.deepEqual(getQmdPostInstallProbeTargets("/custom/qmd", "configured"), [
+    { qmdPath: "qmd", source: "auto-path" },
+  ]);
+});
+
+test("QmdClient applies chunk strategy to normal and forced embed args", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const client = new QmdClient("test", 5, {
+    qmdChunkStrategy: "regex",
+  });
+  (client as any).qmdCapabilities = resolveQmdCapabilities("qmd 2.5.1");
+  assert.deepEqual((client as any).buildEmbedArgs("memory"), [
+    "embed",
+    "-c",
+    "memory",
+    "--chunk-strategy",
+    "regex",
+  ]);
+  assert.deepEqual((client as any).buildEmbedArgs("memory", true), [
+    "embed",
+    "-f",
+    "-c",
+    "memory",
+    "--chunk-strategy",
+    "regex",
+  ]);
+});
+
+test("parseQmdExplain preserves qmd 2.5 nested RRF trace fields", () => {
+  assert.deepEqual(
+    parseQmdExplain({
+      ftsScores: [0.4],
+      vectorScores: [0.2],
+      rrf: {
+        rank: 2,
+        positionScore: 0.7,
+        baseScore: 0.6,
+        topRankBonus: 0.1,
+        totalScore: 0.7,
+      },
+      rerankScore: 0.9,
+      blendedScore: 0.82,
+    }),
+    {
+      ftsScores: [0.4],
+      vectorScores: [0.2],
+      rrf: 0.7,
+      rrfRank: 2,
+      rrfPositionScore: 0.7,
+      rrfBaseScore: 0.6,
+      rrfTopRankBonus: 0.1,
+      rerankScore: 0.9,
+      blendedScore: 0.82,
+    },
+  );
+});
+
+test("QmdClient runtime env maps qmd 2.5 model and GPU controls", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const client = new QmdClient("test", 5, {
+    qmdForceCpu: true,
+    qmdGpuBackend: "metal",
+    qmdEmbedParallelism: 12,
+    qmdEmbedModel: "hf:embed",
+    qmdRerankModel: "hf:rerank",
+    qmdGenerateModel: "hf:generate",
+  });
+  assert.deepEqual((client as any).qmdRuntimeEnv, {
+    QMD_FORCE_CPU: "1",
+    QMD_LLAMA_GPU: "metal",
+    QMD_EMBED_PARALLELISM: "8",
+    QMD_EMBED_MODEL: "hf:embed",
+    QMD_RERANK_MODEL: "hf:rerank",
+    QMD_GENERATE_MODEL: "hf:generate",
+  });
+});
+
+test("QmdClient auto-upgrade throttle key is scoped by qmd target", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const base = new QmdClient("test", 5, {
+    qmdAutoUpgradeEnabled: true,
+    qmdIndexName: "default",
+    qmdEmbedModel: "hf:embed-a",
+  });
+  const otherIndex = new QmdClient("test", 5, {
+    qmdAutoUpgradeEnabled: true,
+    qmdIndexName: "other",
+    qmdEmbedModel: "hf:embed-a",
+  });
+  const otherRuntime = new QmdClient("test", 5, {
+    qmdAutoUpgradeEnabled: true,
+    qmdIndexName: "default",
+    qmdEmbedModel: "hf:embed-b",
+  });
+
+  assert.notEqual((base as any).autoUpgradeTargetKey(), (otherIndex as any).autoUpgradeTargetKey());
+  assert.notEqual((base as any).autoUpgradeTargetKey(), (otherRuntime as any).autoUpgradeTargetKey());
+});
+
+test("parseConfig exposes qmd 2.5 integration defaults and opt-in auto upgrade", () => {
+  const defaults = parseConfig({});
+  assert.equal(defaults.qmdSupportedVersion, "2.5.1");
+  assert.equal(defaults.qmdAutoUpgradeEnabled, false);
+  assert.equal(defaults.qmdChunkStrategy, "auto");
+  assert.equal(defaults.qmdQueryRerankEnabled, true);
+  assert.equal(defaults.qmdCandidateLimit, undefined);
+
+  const configured = parseConfig({
+    qmdAutoUpgradeEnabled: "true",
+    qmdAutoUpgradeCheckIntervalMs: "60000",
+    qmdChunkStrategy: "regex",
+    qmdCandidateLimit: "25",
+    qmdQueryRerankEnabled: "false",
+    qmdIndexName: "remnic-prod",
+    qmdForceCpu: "true",
+    qmdGpuBackend: "metal",
+    qmdEmbedParallelism: "4",
+    qmdEmbedModel: "hf:custom/embed.gguf",
+    qmdRerankModel: "hf:custom/rerank.gguf",
+    qmdGenerateModel: "hf:custom/generate.gguf",
+  });
+  assert.equal(configured.qmdAutoUpgradeEnabled, true);
+  assert.equal(configured.qmdAutoUpgradeCheckIntervalMs, 60_000);
+  assert.equal(configured.qmdChunkStrategy, "regex");
+  assert.equal(configured.qmdCandidateLimit, 25);
+  assert.equal(configured.qmdQueryRerankEnabled, false);
+  assert.equal(configured.qmdIndexName, "remnic-prod");
+  assert.equal(configured.qmdForceCpu, true);
+  assert.equal(configured.qmdGpuBackend, "metal");
+  assert.equal(configured.qmdEmbedParallelism, 4);
+  assert.equal(configured.qmdEmbedModel, "hf:custom/embed.gguf");
+  assert.equal(configured.qmdRerankModel, "hf:custom/rerank.gguf");
+  assert.equal(configured.qmdGenerateModel, "hf:custom/generate.gguf");
+
+  const falseGpuBackend = parseConfig({ qmdGpuBackend: false });
+  assert.equal(falseGpuBackend.qmdGpuBackend, "false");
+});
+
+test("parseConfig rejects invalid qmd version and integer config values", () => {
+  assert.throws(
+    () => parseConfig({ qmdSupportedVersion: "latest" }),
+    /qmdSupportedVersion must be a semantic version string/,
+  );
+  assert.throws(
+    () => parseConfig({ qmdSupportedVersion: "2.6" }),
+    /qmdSupportedVersion must be a semantic version string/,
+  );
+  assert.throws(
+    () => parseConfig({ qmdCandidateLimit: "1.9" }),
+    /qmdCandidateLimit must be a positive integer/,
+  );
+  assert.throws(
+    () => parseConfig({ qmdEmbedParallelism: 0.5 }),
+    /qmdEmbedParallelism must be a positive integer/,
+  );
+  assert.throws(
+    () => parseConfig({ qmdChunkStrategy: "regx" }),
+    /qmdChunkStrategy must be "auto" or "regex"/,
+  );
+  assert.throws(
+    () => parseConfig({ qmdChunkStrategy: false }),
+    /qmdChunkStrategy must be "auto" or "regex"/,
+  );
+  assert.throws(
+    () => parseConfig({ qmdGpuBackend: "opengl" }),
+    /qmdGpuBackend must be one of/,
+  );
+  assert.throws(
+    () => parseConfig({ qmdGpuBackend: true }),
+    /qmdGpuBackend must be one of/,
+  );
+});

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -20,6 +20,76 @@ export interface QmdClientOptions {
   qmdPath?: string;
   daemonUrl?: string;
   daemonRecheckIntervalMs?: number;
+  qmdSupportedVersion?: string;
+  qmdAutoUpgradeEnabled?: boolean;
+  qmdAutoUpgradeCheckIntervalMs?: number;
+  qmdChunkStrategy?: QmdChunkStrategy;
+  qmdCandidateLimit?: number;
+  qmdQueryRerankEnabled?: boolean;
+  qmdIndexName?: string;
+  qmdForceCpu?: boolean;
+  qmdGpuBackend?: "auto" | "metal" | "cuda" | "vulkan" | "false";
+  qmdEmbedParallelism?: number;
+  qmdEmbedModel?: string;
+  qmdRerankModel?: string;
+  qmdGenerateModel?: string;
+}
+
+export type QmdVersionTuple = [number, number, number];
+export type QmdChunkStrategy = "auto" | "regex";
+export type QmdStructuredSearchType = "lex" | "vec" | "hyde";
+export interface QmdStructuredSearch {
+  type: QmdStructuredSearchType;
+  query: string;
+}
+
+export interface QmdCapabilities {
+  version: string | null;
+  parsedVersion: QmdVersionTuple | null;
+  stableSdk: boolean;
+  unifiedSearch: boolean;
+  getDocumentBody: boolean;
+  maintenanceApi: boolean;
+  legacySkillInstall: boolean;
+  intentHints: boolean;
+  explainTraces: boolean;
+  candidateLimit: boolean;
+  v2McpQueryTool: boolean;
+  structuredSearches: boolean;
+  queryRerankToggle: boolean;
+  chunkStrategy: boolean;
+  qmdBench: boolean;
+  perCollectionModels: boolean;
+  jsonLineNumbers: boolean;
+  editorLinks: boolean;
+  doctor: boolean;
+  versionedSkills: boolean;
+  absoluteSnippetLines: boolean;
+  fullQueryOutput: boolean;
+  forceCpu: boolean;
+  gpuBackendOverride: boolean;
+  embedParallelism: boolean;
+  modelEnvConsistency: boolean;
+  scopedEmbed: boolean;
+  safeStatusDeviceProbe: boolean;
+  mcpIndexSelection: boolean;
+}
+
+export interface QmdVersionStatus {
+  installedVersion: string | null;
+  supportedVersion: string;
+  supported: boolean;
+  newerThanSupported: boolean;
+  upgradeAvailable: boolean;
+  capabilities: QmdCapabilities;
+}
+
+export interface QmdDoctorReport {
+  available: boolean;
+  skipped?: string;
+  report?: unknown;
+  raw?: string;
+  error?: string;
 }
 
 const QMD_TIMEOUT_MS = 30_000;
@@ -34,6 +104,11 @@ const QMD_PROBE_TIMEOUT_MS = 8_000;
 const QMD_UPDATE_BACKOFF_MS = 15 * 60 * 1000; // 15m
 const QMD_EMBED_BACKOFF_MS = 60 * 60 * 1000; // 60m
 const QMD_CLI_WARN_THROTTLE_MS = 15 * 60 * 1000; // 15m
+export const QMD_SUPPORTED_VERSION = "2.5.1";
+const QMD_PACKAGE_NAME = "@tobilu/qmd";
+const QMD_AUTO_UPGRADE_TIMEOUT_MS = 120_000;
+const QMD_AUTO_UPGRADE_CHECK_INTERVAL_MS = 24 * 60 * 60_000;
+const QMD_STRUCTURED_HYDE_MAX_CHARS = 320;
 const QMD_FALLBACK_PATHS = [
   path.join(os.homedir(), ".bun", "bin", "qmd"),
   "/usr/local/bin/qmd",
@@ -52,7 +127,13 @@ type QmdGlobalState = {
   lastUpdateFailByCollectionMs: Record<string, number>;
   lastEmbedByCollectionMs: Record<string, number>;
   lastEmbedFailByCollectionMs: Record<string, number>;
+  lastAutoUpgradeCheckAtMs: number | null;
+  lastAutoUpgradeStatus: string | null;
+  lastAutoUpgradeCheckByTargetMs: Record<string, number>;
+  lastAutoUpgradeStatusByTarget: Record<string, string>;
 };
+
+type QmdRuntimeEnv = Record<string, string | undefined>;
 
 function getGlobalQmdState(): QmdGlobalState {
   const g = globalThis as any;
@@ -68,9 +149,16 @@ function getGlobalQmdState(): QmdGlobalState {
       lastUpdateFailByCollectionMs: {},
       lastEmbedByCollectionMs: {},
       lastEmbedFailByCollectionMs: {},
+      lastAutoUpgradeCheckAtMs: null,
+      lastAutoUpgradeStatus: null,
+      lastAutoUpgradeCheckByTargetMs: {},
+      lastAutoUpgradeStatusByTarget: {},
     } satisfies QmdGlobalState;
   }
-  return g[QMD_GLOBAL_STATE_KEY] as QmdGlobalState;
+  const state = g[QMD_GLOBAL_STATE_KEY] as QmdGlobalState;
+  state.lastAutoUpgradeCheckByTargetMs ??= {};
+  state.lastAutoUpgradeStatusByTarget ??= {};
+  return state;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -148,7 +236,7 @@ function isVectorDimensionMismatchError(err: unknown): boolean {
   );
 }
 
-function parseQmdVersion(version: string | null): [number, number, number] | null {
+export function parseQmdVersion(version: string | null): QmdVersionTuple | null {
   if (!version) return null;
   const match = version.match(/v?(\d{1,10})\.(\d{1,10})\.(\d{1,10})/i);
   if (!match) return null;
@@ -159,16 +247,104 @@ function parseQmdVersion(version: string | null): [number, number, number] | nul
   ];
 }
 
-function versionAtLeast(
-  current: [number, number, number] | null,
-  target: [number, number, number],
-): boolean {
-  if (!current) return false;
+export function parseQmdVersionOutput(stdout: string, stderr: string): string | null {
+  const lines = `${stdout}\n${stderr}`
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (lines.length === 0) return null;
+  const semanticLines = lines.filter((line) => parseQmdVersion(line) !== null);
+  if (semanticLines.length === 0) return lines[0] ?? null;
+  return semanticLines.find((line) => /\bqmd\b/i.test(line)) ?? semanticLines[0] ?? null;
+}
+
+export function compareQmdVersions(
+  left: QmdVersionTuple | null,
+  right: QmdVersionTuple | null,
+): number {
+  if (!left && !right) return 0;
+  if (!left) return -1;
+  if (!right) return 1;
   for (let i = 0; i < 3; i += 1) {
-    if ((current[i] ?? 0) > target[i]) return true;
-    if ((current[i] ?? 0) < target[i]) return false;
+    if ((left[i] ?? 0) > (right[i] ?? 0)) return 1;
+    if ((left[i] ?? 0) < (right[i] ?? 0)) return -1;
   }
-  return true;
+  return 0;
+}
+
+export function versionAtLeast(
+  current: QmdVersionTuple | null,
+  target: QmdVersionTuple,
+): boolean {
+  return compareQmdVersions(current, target) >= 0;
+}
+
+export function resolveQmdCapabilities(version: string | null): QmdCapabilities {
+  const parsedVersion = parseQmdVersion(version);
+  const atLeast = (target: QmdVersionTuple): boolean => versionAtLeast(parsedVersion, target);
+  return {
+    version,
+    parsedVersion,
+    stableSdk: atLeast([2, 0, 0]),
+    unifiedSearch: atLeast([2, 0, 0]),
+    getDocumentBody: atLeast([2, 0, 0]),
+    maintenanceApi: atLeast([2, 0, 0]),
+    legacySkillInstall: atLeast([2, 0, 1]),
+    intentHints: atLeast([1, 1, 5]),
+    explainTraces: atLeast([1, 1, 2]),
+    candidateLimit: atLeast([1, 1, 2]),
+    v2McpQueryTool: atLeast([2, 0, 0]),
+    structuredSearches: atLeast([2, 0, 0]),
+    queryRerankToggle: atLeast([2, 1, 0]),
+    chunkStrategy: atLeast([2, 1, 0]),
+    qmdBench: atLeast([2, 1, 0]),
+    perCollectionModels: atLeast([2, 1, 0]),
+    jsonLineNumbers: atLeast([2, 1, 0]),
+    editorLinks: atLeast([2, 1, 0]),
+    doctor: atLeast([2, 5, 0]),
+    versionedSkills: atLeast([2, 5, 0]),
+    absoluteSnippetLines: atLeast([2, 5, 0]),
+    fullQueryOutput: atLeast([2, 5, 0]),
+    forceCpu: atLeast([2, 5, 0]),
+    gpuBackendOverride: atLeast([2, 5, 0]),
+    embedParallelism: atLeast([2, 5, 0]),
+    modelEnvConsistency: atLeast([2, 5, 0]),
+    scopedEmbed: atLeast([2, 5, 0]),
+    safeStatusDeviceProbe: atLeast([2, 5, 0]),
+    mcpIndexSelection: atLeast([2, 5, 0]),
+  };
+}
+
+export function shouldAutoUpgradeQmd(
+  installedVersion: string | null,
+  supportedVersion: string = QMD_SUPPORTED_VERSION,
+): boolean {
+  const installed = parseQmdVersion(installedVersion);
+  const supported = parseQmdVersion(supportedVersion);
+  if (!installed || !supported) return false;
+  return compareQmdVersions(installed, supported) < 0;
+}
+
+export function getQmdPostInstallProbeTargets(
+  qmdPath: string,
+  qmdPathSource: "configured" | "auto-path" | "auto-fallback",
+): Array<{ qmdPath: string; source: "auto-path" | "auto-fallback" }> {
+  const targets: Array<{ qmdPath: string; source: "auto-path" | "auto-fallback" }> = [
+    { qmdPath: "qmd", source: "auto-path" },
+  ];
+  const normalizedPath = qmdPath.trim();
+  if (
+    qmdPathSource === "auto-fallback" &&
+    normalizedPath.length > 0 &&
+    normalizedPath !== "qmd"
+  ) {
+    targets.push({ qmdPath: normalizedPath, source: "auto-fallback" });
+  }
+  return targets;
+}
+
+function qmdVersionToString(version: QmdVersionTuple): string {
+  return `${version[0]}.${version[1]}.${version[2]}`;
 }
 
 function normalizeSearchOptions(options?: SearchQueryOptions): SearchQueryOptions | undefined {
@@ -181,7 +357,64 @@ function normalizeSearchOptions(options?: SearchQueryOptions): SearchQueryOption
   if (options.explain === true) {
     normalized.explain = true;
   }
+  if (options.rerank === false) {
+    normalized.rerank = false;
+  }
+  if (options.chunkStrategy === "auto" || options.chunkStrategy === "regex") {
+    normalized.chunkStrategy = options.chunkStrategy;
+  }
+  if (
+    typeof options.candidateLimit === "number" &&
+    Number.isFinite(options.candidateLimit) &&
+    options.candidateLimit > 0
+  ) {
+    normalized.candidateLimit = Math.floor(options.candidateLimit);
+  }
+  const structuredSearches = normalizeStructuredSearches(options.structuredSearches);
+  if (structuredSearches.length > 0) {
+    normalized.structuredSearches = structuredSearches;
+  }
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeStructuredSearches(value: unknown): QmdStructuredSearch[] {
+  if (!Array.isArray(value)) return [];
+  const normalized: QmdStructuredSearch[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as { type?: unknown; query?: unknown };
+    const type = candidate.type;
+    const query = typeof candidate.query === "string" ? candidate.query.trim() : "";
+    if ((type === "lex" || type === "vec" || type === "hyde") && query.length > 0) {
+      normalized.push({ type, query });
+    }
+    if (normalized.length >= 10) break;
+  }
+  return normalized;
+}
+
+function buildSyntheticHydeQuery(query: string, intent?: string): string {
+  const base = intent && intent.trim().length > 0
+    ? `A relevant Remnic memory for ${intent.trim()} would answer: ${query.trim()}`
+    : `A relevant Remnic memory would answer: ${query.trim()}`;
+  return base.length > QMD_STRUCTURED_HYDE_MAX_CHARS
+    ? base.slice(0, QMD_STRUCTURED_HYDE_MAX_CHARS)
+    : base;
+}
+
+function buildDefaultStructuredSearches(
+  query: string,
+  options?: SearchQueryOptions,
+): QmdStructuredSearch[] {
+  const explicit = normalizeStructuredSearches(options?.structuredSearches);
+  if (explicit.length > 0) return explicit;
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  return [
+    { type: "lex", query: trimmed },
+    { type: "vec", query: trimmed },
+    { type: "hyde", query: buildSyntheticHydeQuery(trimmed, options?.intent) },
+  ];
 }
 
 function parseExplainScores(value: unknown): number[] | undefined {
@@ -193,10 +426,27 @@ function parseExplainScores(value: unknown): number[] | undefined {
 export function parseQmdExplain(value: unknown): QmdSearchExplain | undefined {
   if (!value || typeof value !== "object") return undefined;
   const candidate = value as Record<string, unknown>;
+  const rrf =
+    typeof candidate.rrf === "number"
+      ? candidate.rrf
+      : candidate.rrf && typeof candidate.rrf === "object" &&
+        typeof (candidate.rrf as Record<string, unknown>).totalScore === "number"
+      ? ((candidate.rrf as Record<string, unknown>).totalScore as number)
+      : undefined;
+  const rrfObj =
+    candidate.rrf && typeof candidate.rrf === "object"
+      ? (candidate.rrf as Record<string, unknown>)
+      : undefined;
   const parsed: QmdSearchExplain = {
     ftsScores: parseExplainScores(candidate.ftsScores),
     vectorScores: parseExplainScores(candidate.vectorScores),
-    rrf: typeof candidate.rrf === "number" ? candidate.rrf : undefined,
+    rrf,
+    rrfRank: typeof rrfObj?.rank === "number" ? rrfObj.rank : undefined,
+    rrfPositionScore:
+      typeof rrfObj?.positionScore === "number" ? rrfObj.positionScore : undefined,
+    rrfBaseScore: typeof rrfObj?.baseScore === "number" ? rrfObj.baseScore : undefined,
+    rrfTopRankBonus:
+      typeof rrfObj?.topRankBonus === "number" ? rrfObj.topRankBonus : undefined,
     rerankScore: typeof candidate.rerankScore === "number" ? candidate.rerankScore : undefined,
     blendedScore: typeof candidate.blendedScore === "number" ? candidate.blendedScore : undefined,
   };
@@ -273,6 +523,7 @@ function runQmd(
   timeoutMs: number = QMD_TIMEOUT_MS,
   qmdPath: string = "qmd",
   signal?: AbortSignal,
+  runtimeEnv?: QmdRuntimeEnv,
 ): Promise<{ stdout: string; stderr: string }> {
   // Serialize all qmd calls. This avoids SQLite lock contention when multiple
   // channels/agents trigger QMD operations at nearly the same time.
@@ -281,7 +532,7 @@ function runQmd(
     const maxAttempts = isLikelyWriteCommand(args) ? 3 : 1;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
-        return await runQmdOnce(args, timeoutMs, qmdPath, signal);
+        return await runQmdOnce(args, timeoutMs, qmdPath, signal, runtimeEnv);
       } catch (err) {
         if (isAbortError(err)) throw err;
         const msg = err instanceof Error ? err.message : String(err);
@@ -300,8 +551,26 @@ function runQmd(
 }
 
 function isLikelyWriteCommand(args: string[]): boolean {
-  const cmd = args[0] ?? "";
+  const cmd = getQmdCommandName(args);
   return cmd === "update" || cmd === "embed" || cmd === "cleanup" || cmd === "collection";
+}
+
+export function getQmdCommandName(args: string[]): string {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i] ?? "";
+    if (arg === "--index") {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--index=")) {
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    return arg;
+  }
+  return "";
 }
 
 function runQmdOnce(
@@ -309,15 +578,39 @@ function runQmdOnce(
   timeoutMs: number,
   qmdPath: string,
   signal?: AbortSignal,
+  runtimeEnv?: QmdRuntimeEnv,
 ): Promise<{ stdout: string; stderr: string }> {
+  const isVersionCheck = args.length === 1 && args[0] === "--version";
+  return runCommandWithTimeout(qmdPath, args, {
+    timeoutMs,
+    signal,
+    env: runtimeEnv,
+    label: `qmd ${args.join(" ")}`,
+    isSuccessExitCode: (code) => code === 0 || (isVersionCheck && code === 1),
+  });
+}
+
+function runCommandWithTimeout(
+  command: string,
+  args: string[],
+  options: {
+    timeoutMs: number;
+    signal?: AbortSignal;
+    env?: QmdRuntimeEnv;
+    label?: string;
+    isSuccessExitCode?: (code: number | null) => boolean;
+  },
+): Promise<{ stdout: string; stderr: string }> {
+  const label = options.label ?? `${command} ${args.join(" ")}`;
+  const isSuccessExitCode = options.isSuccessExitCode ?? ((code: number | null) => code === 0);
   return new Promise((resolve, reject) => {
-    throwIfAborted(signal, `qmd ${args.join(" ")} aborted before spawn`);
-    const child = launchProcess(qmdPath, args, {
-      env: mergeEnv({ NO_COLOR: "1" }),
+    throwIfAborted(options.signal, `${label} aborted before spawn`);
+    const child = launchProcess(command, args, {
+      env: mergeEnv({ NO_COLOR: "1", ...options.env }),
       stdio: ["ignore", "pipe", "pipe"],
     });
     if (!child.stdout || !child.stderr) {
-      reject(new Error(`qmd ${args.join(" ")} failed to open stdio pipes`));
+      reject(new Error(`${label} failed to open stdio pipes`));
       return;
     }
 
@@ -329,20 +622,20 @@ function runQmdOnce(
       settled = true;
       cleanup();
       child.kill("SIGKILL");
-      reject(new Error(`qmd ${args.join(" ")} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
+      reject(new Error(`${label} timed out after ${options.timeoutMs}ms`));
+    }, options.timeoutMs);
     const onAbort = () => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       cleanup();
       child.kill("SIGKILL");
-      reject(abortError(`qmd ${args.join(" ")} aborted`));
+      reject(abortError(`${label} aborted`));
     };
     const cleanup = () => {
-      signal?.removeEventListener("abort", onAbort);
+      options.signal?.removeEventListener("abort", onAbort);
     };
-    signal?.addEventListener("abort", onAbort, { once: true });
+    options.signal?.addEventListener("abort", onAbort, { once: true });
 
     child.stdout.on("data", (data: Buffer) => {
       stdout += data.toString();
@@ -362,18 +655,28 @@ function runQmdOnce(
       settled = true;
       clearTimeout(timer);
       cleanup();
-      // QMD returns exit code 1 for --version (shows usage), but that's ok
-      const isVersionCheck = args.length === 1 && args[0] === "--version";
-      if (code === 0 || (isVersionCheck && code === 1)) {
+      if (isSuccessExitCode(code)) {
         resolve({ stdout, stderr });
       } else {
         reject(
           new Error(
-            `qmd ${args.join(" ")} failed (code ${code}): ${truncateForLog(stderr || stdout)}`,
+            `${label} failed (code ${code}): ${truncateForLog(stderr || stdout)}`,
           ),
         );
       }
     });
+  });
+}
+
+function runProcessCommand(
+  command: string,
+  args: string[],
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<{ stdout: string; stderr: string }> {
+  return runCommandWithTimeout(command, args, {
+    timeoutMs,
+    signal,
   });
 }
 
@@ -398,9 +701,13 @@ class QmdDaemonSession {
     }
   >();
   private readonly qmdPath: string;
+  private readonly runtimeEnv: QmdRuntimeEnv;
+  private readonly indexName?: string;
 
-  constructor(qmdPath: string) {
+  constructor(qmdPath: string, runtimeEnv: QmdRuntimeEnv = {}, indexName?: string) {
     this.qmdPath = qmdPath;
+    this.runtimeEnv = runtimeEnv;
+    this.indexName = indexName?.trim() || undefined;
   }
 
   /** Spawn the qmd mcp child process and perform MCP handshake. */
@@ -422,8 +729,9 @@ class QmdDaemonSession {
           this.cleanup({ killChild: true });
         }
         try {
-          const child = launchProcess(this.qmdPath, ["mcp"], {
-            env: mergeEnv({ NO_COLOR: "1" }),
+          const args = this.indexName ? ["--index", this.indexName, "mcp"] : ["mcp"];
+          const child = launchProcess(this.qmdPath, args, {
+            env: mergeEnv({ NO_COLOR: "1", ...this.runtimeEnv }),
             stdio: ["pipe", "pipe", "pipe"],
           });
           this.child = child;
@@ -727,6 +1035,9 @@ function parseMcpSearchResult(
           : (typeof d.docid === "string" ? d.docid.replace(/^#/, "") : "unknown"),
         snippet: typeof d.snippet === "string" ? d.snippet : "",
         score: typeof d.score === "number" ? d.score : 0,
+        line: typeof d.line === "number" && Number.isFinite(d.line)
+          ? Math.max(1, Math.floor(d.line))
+          : undefined,
         explain: parseQmdExplain(d.explain),
         transport,
       });
@@ -781,6 +1092,9 @@ function parseQmdSearchStdout(
         "unknown",
       snippet: (entry.snippet as string) ?? "",
       score: typeof entry.score === "number" ? entry.score : 0,
+      line: typeof entry.line === "number" && Number.isFinite(entry.line)
+        ? Math.max(1, Math.floor(entry.line))
+        : undefined,
       explain: parseQmdExplain(entry.explain),
       transport,
     }),
@@ -794,16 +1108,41 @@ type SharedDaemonSessionEntry = {
 
 const SHARED_DAEMON_SESSIONS = new Map<string, SharedDaemonSessionEntry>();
 
-function retainSharedDaemonSession(qmdPath: string): QmdDaemonSession {
+function stableRuntimeEnvKey(runtimeEnv: QmdRuntimeEnv): string {
+  return JSON.stringify(
+    Object.keys(runtimeEnv)
+      .sort()
+      .map((key) => [key, runtimeEnv[key]]),
+  );
+}
+
+function recordAutoUpgradeStatus(
+  state: QmdGlobalState,
+  targetKey: string,
+  status: string,
+): void {
+  state.lastAutoUpgradeStatusByTarget[targetKey] = status;
+  state.lastAutoUpgradeStatus = status;
+}
+
+function retainSharedDaemonSession(
+  qmdPath: string,
+  runtimeEnv: QmdRuntimeEnv = {},
+  indexName?: string,
+  cliVersion?: string | null,
+): QmdDaemonSession {
   const normalizedPath = qmdPath.trim() || "qmd";
-  const existing = SHARED_DAEMON_SESSIONS.get(normalizedPath);
+  const normalizedIndex = indexName?.trim() || "";
+  const normalizedVersion = cliVersion?.trim() || "";
+  const sessionKey = `${normalizedPath}\0${normalizedIndex}\0${normalizedVersion}\0${stableRuntimeEnvKey(runtimeEnv)}`;
+  const existing = SHARED_DAEMON_SESSIONS.get(sessionKey);
   if (existing) {
     existing.refs += 1;
     return existing.session;
   }
 
-  const session = new QmdDaemonSession(normalizedPath);
-  SHARED_DAEMON_SESSIONS.set(normalizedPath, {
+  const session = new QmdDaemonSession(normalizedPath, runtimeEnv, normalizedIndex || undefined);
+  SHARED_DAEMON_SESSIONS.set(sessionKey, {
     refs: 1,
     session,
   });
@@ -854,9 +1193,18 @@ export class QmdClient implements SearchBackend {
   private readonly updateMinIntervalMs: number;
   private readonly slowLog?: { enabled: boolean; thresholdMs: number };
   private readonly configuredQmdPath?: string;
+  private readonly qmdSupportedVersion: string;
+  private readonly qmdAutoUpgradeEnabled: boolean;
+  private readonly qmdAutoUpgradeCheckIntervalMs: number;
+  private readonly qmdChunkStrategy?: QmdChunkStrategy;
+  private readonly qmdCandidateLimit?: number;
+  private readonly qmdQueryRerankEnabled: boolean;
+  private readonly qmdIndexName?: string;
+  private readonly qmdRuntimeEnv: QmdRuntimeEnv;
   private qmdPathSource: "auto-path" | "auto-fallback" | "configured" = "auto-path";
   private cliVersion: string | null = null;
   private lastCliProbeError: string | null = null;
+  private qmdCapabilities: QmdCapabilities = resolveQmdCapabilities(null);
 
   // Daemon mode fields
   private daemonSession: QmdDaemonSession | null = null;
@@ -878,6 +1226,28 @@ export class QmdClient implements SearchBackend {
     this.updateTimeoutMs = opts?.updateTimeoutMs ?? 120_000;
     this.updateMinIntervalMs = Math.max(0, opts?.updateMinIntervalMs ?? 15 * 60_000);
     this.configuredQmdPath = opts?.qmdPath?.trim() ? opts.qmdPath.trim() : undefined;
+    this.qmdSupportedVersion =
+      parseQmdVersion(opts?.qmdSupportedVersion ?? null) !== null
+        ? (opts?.qmdSupportedVersion ?? QMD_SUPPORTED_VERSION)
+        : QMD_SUPPORTED_VERSION;
+    this.qmdAutoUpgradeEnabled = opts?.qmdAutoUpgradeEnabled === true;
+    this.qmdAutoUpgradeCheckIntervalMs = Math.max(
+      60_000,
+      Math.floor(opts?.qmdAutoUpgradeCheckIntervalMs ?? QMD_AUTO_UPGRADE_CHECK_INTERVAL_MS),
+    );
+    this.qmdChunkStrategy =
+      opts?.qmdChunkStrategy === "auto" || opts?.qmdChunkStrategy === "regex"
+        ? opts.qmdChunkStrategy
+        : undefined;
+    this.qmdCandidateLimit =
+      typeof opts?.qmdCandidateLimit === "number" &&
+      Number.isFinite(opts.qmdCandidateLimit) &&
+      opts.qmdCandidateLimit > 0
+        ? Math.floor(opts.qmdCandidateLimit)
+        : undefined;
+    this.qmdQueryRerankEnabled = opts?.qmdQueryRerankEnabled !== false;
+    this.qmdIndexName = opts?.qmdIndexName?.trim() || undefined;
+    this.qmdRuntimeEnv = this.buildRuntimeEnv(opts);
     if (this.configuredQmdPath) {
       this.qmdPath = this.configuredQmdPath;
       this.qmdPathSource = "configured";
@@ -887,6 +1257,33 @@ export class QmdClient implements SearchBackend {
   }
 
   private qmdPath: string = "qmd";
+
+  private buildRuntimeEnv(opts?: QmdClientOptions): QmdRuntimeEnv {
+    const env: QmdRuntimeEnv = {};
+    if (opts?.qmdForceCpu === true) {
+      env.QMD_FORCE_CPU = "1";
+    }
+    if (opts?.qmdGpuBackend) {
+      env.QMD_LLAMA_GPU = opts.qmdGpuBackend;
+    }
+    if (
+      typeof opts?.qmdEmbedParallelism === "number" &&
+      Number.isFinite(opts.qmdEmbedParallelism) &&
+      opts.qmdEmbedParallelism > 0
+    ) {
+      env.QMD_EMBED_PARALLELISM = String(Math.min(8, Math.max(1, Math.floor(opts.qmdEmbedParallelism))));
+    }
+    if (opts?.qmdEmbedModel?.trim()) {
+      env.QMD_EMBED_MODEL = opts.qmdEmbedModel.trim();
+    }
+    if (opts?.qmdRerankModel?.trim()) {
+      env.QMD_RERANK_MODEL = opts.qmdRerankModel.trim();
+    }
+    if (opts?.qmdGenerateModel?.trim()) {
+      env.QMD_GENERATE_MODEL = opts.qmdGenerateModel.trim();
+    }
+    return env;
+  }
 
   async probe(): Promise<boolean> {
     const cliOk = await this.probeCli();
@@ -899,10 +1296,20 @@ export class QmdClient implements SearchBackend {
   private async probeDaemon(): Promise<boolean> {
     this.lastDaemonCheckAtMs = Date.now();
     const normalizedPath = this.qmdPath.trim() || "qmd";
-    if (!this.daemonSession || this.daemonSessionPath !== normalizedPath) {
+    const daemonIndexName =
+      this.qmdIndexName && this.qmdCapabilities.mcpIndexSelection
+        ? this.qmdIndexName
+        : undefined;
+    const daemonSessionPath = `${normalizedPath}\0${daemonIndexName ?? ""}\0${this.cliVersion ?? ""}`;
+    if (!this.daemonSession || this.daemonSessionPath !== daemonSessionPath) {
       await releaseSharedDaemonSession(this.daemonSession);
-      this.daemonSession = retainSharedDaemonSession(normalizedPath);
-      this.daemonSessionPath = normalizedPath;
+      this.daemonSession = retainSharedDaemonSession(
+        normalizedPath,
+        this.qmdRuntimeEnv,
+        daemonIndexName,
+        this.cliVersion,
+      );
+      this.daemonSessionPath = daemonSessionPath;
     }
     try {
       // Race start() against a short window: if the session is already initialized
@@ -934,28 +1341,27 @@ export class QmdClient implements SearchBackend {
   }
 
   private async probeCli(): Promise<boolean> {
-    const parseVersion = (stdout: string, stderr: string): string | null => {
-      const lines = `${stdout}\n${stderr}`
-        .split("\n")
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-      if (lines.length === 0) return null;
-      const semanticLines = lines.filter((line) => parseQmdVersion(line) !== null);
-      if (semanticLines.length === 0) return lines[0] ?? null;
-      return semanticLines.find((line) => /\bqmd\b/i.test(line)) ?? semanticLines[0] ?? null;
-    };
     const markProbeFailure = (err: unknown): void => {
       this.lastCliProbeError = err instanceof Error ? err.message : String(err);
+    };
+    const recordProbeSuccess = async (
+      result: { stdout: string; stderr: string },
+      qmdPath: string,
+      source: typeof this.qmdPathSource,
+    ): Promise<void> => {
+      this.available = true;
+      this.qmdPath = qmdPath;
+      this.qmdPathSource = source;
+      this.cliVersion = parseQmdVersionOutput(result.stdout, result.stderr);
+      this.qmdCapabilities = resolveQmdCapabilities(this.cliVersion);
+      this.lastCliProbeError = null;
+      await this.maybeAutoUpgradeQmd();
     };
 
     if (this.configuredQmdPath) {
       try {
-        const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, this.configuredQmdPath);
-        this.available = true;
-        this.qmdPath = this.configuredQmdPath;
-        this.qmdPathSource = "configured";
-        this.cliVersion = parseVersion(result.stdout, result.stderr);
-        this.lastCliProbeError = null;
+        const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, this.configuredQmdPath, undefined, this.qmdRuntimeEnv);
+        await recordProbeSuccess(result, this.configuredQmdPath, "configured");
         return true;
       } catch (err) {
         markProbeFailure(err);
@@ -969,24 +1375,16 @@ export class QmdClient implements SearchBackend {
 
     // Try PATH first
     try {
-      const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, "qmd");
-      this.available = true;
-      this.qmdPath = "qmd";
-      this.qmdPathSource = "auto-path";
-      this.cliVersion = parseVersion(result.stdout, result.stderr);
-      this.lastCliProbeError = null;
+      const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, "qmd", undefined, this.qmdRuntimeEnv);
+      await recordProbeSuccess(result, "qmd", "auto-path");
       return true;
     } catch (err) {
       markProbeFailure(err);
       // Try fallback paths
       for (const fallbackPath of QMD_FALLBACK_PATHS) {
         try {
-          const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, fallbackPath);
-          this.available = true;
-          this.qmdPath = fallbackPath;
-          this.qmdPathSource = "auto-fallback";
-          this.cliVersion = parseVersion(result.stdout, result.stderr);
-          this.lastCliProbeError = null;
+          const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, fallbackPath, undefined, this.qmdRuntimeEnv);
+          await recordProbeSuccess(result, fallbackPath, "auto-fallback");
           log.info(`QMD: found at ${fallbackPath}`);
           return true;
         } catch (fallbackErr) {
@@ -997,6 +1395,128 @@ export class QmdClient implements SearchBackend {
       this.available = false;
       return false;
     }
+  }
+
+  private async maybeAutoUpgradeQmd(): Promise<void> {
+    if (!this.qmdAutoUpgradeEnabled) return;
+    const state = getGlobalQmdState();
+    const targetKey = this.autoUpgradeTargetKey();
+    const now = Date.now();
+    const lastCheckAtMs = state.lastAutoUpgradeCheckByTargetMs[targetKey];
+    if (
+      Number.isFinite(lastCheckAtMs) &&
+      now - lastCheckAtMs < this.qmdAutoUpgradeCheckIntervalMs
+    ) {
+      return;
+    }
+    state.lastAutoUpgradeCheckByTargetMs[targetKey] = now;
+    state.lastAutoUpgradeCheckAtMs = now;
+
+    const installed = parseQmdVersion(this.cliVersion);
+    const supported = parseQmdVersion(this.qmdSupportedVersion);
+    if (!installed || !supported) {
+      const status = `skipped: unable to parse installed=${this.cliVersion ?? "unknown"} supported=${this.qmdSupportedVersion}`;
+      recordAutoUpgradeStatus(state, targetKey, status);
+      log.warn(`QMD auto-upgrade skipped: ${status}`);
+      return;
+    }
+    if (compareQmdVersions(installed, supported) >= 0) {
+      recordAutoUpgradeStatus(
+        state,
+        targetKey,
+        `current: installed=${qmdVersionToString(installed)} supported=${qmdVersionToString(supported)}`,
+      );
+      return;
+    }
+    if (this.qmdPathSource === "configured") {
+      const status = `skipped: configured qmdPath=${this.qmdPath}`;
+      recordAutoUpgradeStatus(state, targetKey, status);
+      log.warn(
+        `QMD auto-upgrade skipped because qmdPath is explicitly configured (${this.qmdPath}); install ${QMD_PACKAGE_NAME}@${this.qmdSupportedVersion} manually for that path.`,
+      );
+      return;
+    }
+
+    const packageSpec = `${QMD_PACKAGE_NAME}@${this.qmdSupportedVersion}`;
+    try {
+      log.warn(
+        `QMD auto-upgrade: installed=${qmdVersionToString(installed)} supported=${qmdVersionToString(supported)}; running npm install -g ${packageSpec}`,
+      );
+      await runProcessCommand(
+        "npm",
+        ["install", "-g", packageSpec],
+        QMD_AUTO_UPGRADE_TIMEOUT_MS,
+      );
+      const postInstall = await this.probePostInstallQmdVersion(supported);
+      this.qmdPath = postInstall.qmdPath;
+      this.qmdPathSource = postInstall.source;
+      this.cliVersion = postInstall.version;
+      this.qmdCapabilities = resolveQmdCapabilities(this.cliVersion);
+      await releaseSharedDaemonSession(this.daemonSession);
+      this.daemonSession = null;
+      this.daemonSessionPath = null;
+      this.daemonAvailable = false;
+      this.daemonTransientFailures = 0;
+      const upgraded = parseQmdVersion(this.cliVersion);
+      if (!upgraded || compareQmdVersions(upgraded, supported) < 0) {
+        const status = `failed: post-install version=${this.cliVersion ?? "unknown"} target=${this.qmdSupportedVersion}`;
+        recordAutoUpgradeStatus(state, targetKey, status);
+        log.warn(`QMD auto-upgrade did not reach supported version: ${status}`);
+        return;
+      }
+      recordAutoUpgradeStatus(
+        state,
+        targetKey,
+        `upgraded: installed=${this.cliVersion ?? "unknown"} target=${this.qmdSupportedVersion}`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      recordAutoUpgradeStatus(state, targetKey, `failed: ${msg}`);
+      log.warn(`QMD auto-upgrade failed: ${msg}`);
+    }
+  }
+
+  private async probePostInstallQmdVersion(supported: QmdVersionTuple): Promise<{
+    qmdPath: string;
+    source: "auto-path" | "auto-fallback";
+    version: string | null;
+  }> {
+    let lastErr: unknown;
+    let lastResult: { qmdPath: string; source: "auto-path" | "auto-fallback"; version: string | null } | null = null;
+    for (const candidate of getQmdPostInstallProbeTargets(this.qmdPath, this.qmdPathSource)) {
+      try {
+        const result = await runQmd(
+          ["--version"],
+          QMD_PROBE_TIMEOUT_MS,
+          candidate.qmdPath,
+          undefined,
+          this.qmdRuntimeEnv,
+        );
+        const postInstall = {
+          ...candidate,
+          version: parseQmdVersionOutput(result.stdout, result.stderr),
+        };
+        lastResult = postInstall;
+        const parsed = parseQmdVersion(postInstall.version);
+        if (parsed && compareQmdVersions(parsed, supported) >= 0) {
+          return postInstall;
+        }
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    if (lastResult) return lastResult;
+    throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+  }
+
+  private autoUpgradeTargetKey(): string {
+    return JSON.stringify({
+      path: this.qmdPath.trim() || "qmd",
+      source: this.qmdPathSource,
+      index: this.qmdIndexName ?? "",
+      supportedVersion: this.qmdSupportedVersion,
+      runtimeEnv: stableRuntimeEnvKey(this.qmdRuntimeEnv),
+    });
   }
 
   private logCliProbeWarning(message: string): void {
@@ -1039,8 +1559,58 @@ export class QmdClient implements SearchBackend {
   debugStatus(): string {
     const cliPath = this.available ? this.qmdPath : (this.configuredQmdPath ?? "unavailable");
     const cliVersion = this.cliVersion ?? "unknown";
+    const status = this.getVersionStatus();
+    const enabledFeatures = Object.entries(status.capabilities)
+      .filter(([key, value]) => key !== "version" && key !== "parsedVersion" && value === true)
+      .map(([key]) => key)
+      .join(",");
+    const globalState = getGlobalQmdState();
+    const autoUpgradeStatus =
+      globalState.lastAutoUpgradeStatusByTarget[this.autoUpgradeTargetKey()] ??
+      globalState.lastAutoUpgradeStatus;
     const probeError = this.lastCliProbeError ? ` cliProbeError=${this.lastCliProbeError}` : "";
-    return `cli=${this.available} daemon=${this.daemonAvailable} session=${!!this.daemonSession} cliPath=${cliPath} cliPathSource=${this.qmdPathSource} cliVersion=${cliVersion}${probeError}`;
+    return `cli=${this.available} daemon=${this.daemonAvailable} session=${!!this.daemonSession} cliPath=${cliPath} cliPathSource=${this.qmdPathSource} cliVersion=${cliVersion} supportedVersion=${status.supportedVersion} upgradeAvailable=${status.upgradeAvailable} qmdFeatures=${enabledFeatures || "none"}${autoUpgradeStatus ? ` autoUpgrade=${autoUpgradeStatus}` : ""}${probeError}`;
+  }
+
+  getVersionStatus(): QmdVersionStatus {
+    const installed = parseQmdVersion(this.cliVersion);
+    const supported = parseQmdVersion(this.qmdSupportedVersion) ?? parseQmdVersion(QMD_SUPPORTED_VERSION)!;
+    const cmp = compareQmdVersions(installed, supported);
+    return {
+      installedVersion: this.cliVersion,
+      supportedVersion: qmdVersionToString(supported),
+      supported: installed !== null && cmp >= 0,
+      newerThanSupported: installed !== null && cmp > 0,
+      upgradeAvailable: installed !== null && cmp < 0,
+      capabilities: this.qmdCapabilities,
+    };
+  }
+
+  async doctor(): Promise<QmdDoctorReport> {
+    if (!this.isAvailable()) {
+      return { available: false, skipped: "qmd unavailable" };
+    }
+    if (!this.qmdCapabilities.doctor) {
+      return {
+        available: false,
+        skipped: `qmd doctor requires qmd >=2.5.0; installed ${this.cliVersion ?? "unknown"}`,
+      };
+    }
+    try {
+      const { stdout } = await this.runQmdCommand(["doctor", "--json"], QMD_TIMEOUT_MS);
+      const trimmed = stdout.trim();
+      if (!trimmed) return { available: true, report: null };
+      try {
+        return { available: true, report: JSON.parse(trimmed) };
+      } catch {
+        return { available: true, raw: trimmed };
+      }
+    } catch (err) {
+      return {
+        available: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
   }
 
   isDaemonMode(): boolean {
@@ -1092,15 +1662,31 @@ export class QmdClient implements SearchBackend {
     timeoutMs: number,
     signal?: AbortSignal,
   ): Promise<{ stdout: string; stderr: string }> {
-    return runQmd(args, timeoutMs, this.qmdPath, signal);
+    const commandArgs =
+      this.qmdIndexName && this.qmdCapabilities.mcpIndexSelection
+        ? ["--index", this.qmdIndexName, ...args]
+        : args;
+    return runQmd(commandArgs, timeoutMs, this.qmdPath, signal, this.qmdRuntimeEnv);
   }
 
   private supportsIntentHints(): boolean {
-    return versionAtLeast(parseQmdVersion(this.cliVersion), [1, 1, 5]);
+    return this.qmdCapabilities.intentHints;
   }
 
   private supportsExplainTraces(): boolean {
-    return versionAtLeast(parseQmdVersion(this.cliVersion), [1, 1, 2]);
+    return this.qmdCapabilities.explainTraces;
+  }
+
+  private supportsCandidateLimit(): boolean {
+    return this.qmdCapabilities.candidateLimit;
+  }
+
+  private supportsRerankToggle(): boolean {
+    return this.qmdCapabilities.queryRerankToggle;
+  }
+
+  private supportsChunkStrategy(): boolean {
+    return this.qmdCapabilities.chunkStrategy;
   }
 
   /**
@@ -1111,24 +1697,100 @@ export class QmdClient implements SearchBackend {
    * - `collection` (singular) → `collections` (plural array)
    */
   private isQmdV2(): boolean {
-    return versionAtLeast(parseQmdVersion(this.cliVersion), [2, 0, 0]);
+    return this.qmdCapabilities.v2McpQueryTool;
   }
 
   private resolveSearchOptions(options?: SearchQueryOptions): SearchQueryOptions | undefined {
     const normalized = normalizeSearchOptions(options);
-    if (!normalized) return undefined;
-    const resolved: SearchQueryOptions = {};
-    if (normalized.intent && this.supportsIntentHints()) {
-      resolved.intent = normalized.intent;
+    const withDefaults: SearchQueryOptions = { ...(normalized ?? {}) };
+    if (this.qmdCandidateLimit !== undefined && withDefaults.candidateLimit === undefined) {
+      withDefaults.candidateLimit = this.qmdCandidateLimit;
     }
-    if (normalized.explain === true && this.supportsExplainTraces()) {
+    if (!this.qmdQueryRerankEnabled && withDefaults.rerank === undefined) {
+      withDefaults.rerank = false;
+    }
+    if (this.qmdChunkStrategy && withDefaults.chunkStrategy === undefined) {
+      withDefaults.chunkStrategy = this.qmdChunkStrategy;
+    }
+    const resolved: SearchQueryOptions = {};
+    if (withDefaults.intent && this.supportsIntentHints()) {
+      resolved.intent = withDefaults.intent;
+    }
+    if (withDefaults.explain === true && this.supportsExplainTraces()) {
       resolved.explain = true;
+    }
+    if (
+      typeof withDefaults.candidateLimit === "number" &&
+      withDefaults.candidateLimit > 0 &&
+      this.supportsCandidateLimit()
+    ) {
+      resolved.candidateLimit = Math.floor(withDefaults.candidateLimit);
+    }
+    if (withDefaults.rerank === false && this.supportsRerankToggle()) {
+      resolved.rerank = false;
+    }
+    if (withDefaults.chunkStrategy && this.supportsChunkStrategy()) {
+      resolved.chunkStrategy = withDefaults.chunkStrategy;
+    }
+    if (this.qmdCapabilities.structuredSearches) {
+      const structuredSearches = normalizeStructuredSearches(withDefaults.structuredSearches);
+      if (structuredSearches.length > 0) {
+        resolved.structuredSearches = structuredSearches;
+      }
     }
     return Object.keys(resolved).length > 0 ? resolved : undefined;
   }
 
   resolveSupportedSearchOptions(options?: SearchQueryOptions): SearchQueryOptions | undefined {
     return this.resolveSearchOptions(options);
+  }
+
+  private addResolvedSearchOptionsToArgs(args: string[], options?: SearchQueryOptions): void {
+    if (options?.intent) {
+      args.push("--intent", options.intent);
+    }
+    if (options?.explain === true) {
+      args.push("--explain");
+    }
+    if (typeof options?.candidateLimit === "number" && options.candidateLimit > 0) {
+      args.push("--candidate-limit", String(Math.floor(options.candidateLimit)));
+    }
+    if (options?.rerank === false) {
+      args.push("--no-rerank");
+    }
+    if (options?.chunkStrategy) {
+      args.push("--chunk-strategy", options.chunkStrategy);
+    }
+  }
+
+  private addResolvedSearchOptionsToMcpArgs(
+    args: Record<string, unknown>,
+    options?: SearchQueryOptions,
+  ): void {
+    if (options?.intent) {
+      args.intent = options.intent;
+    }
+    if (options?.explain === true) {
+      args.explain = true;
+    }
+    if (typeof options?.candidateLimit === "number" && options.candidateLimit > 0) {
+      args.candidateLimit = Math.floor(options.candidateLimit);
+    }
+    if (options?.rerank === false) {
+      args.rerank = false;
+    }
+    // QMD 2.5.1 MCP query does not expose chunkStrategy even though CLI/SDK
+    // search and embed do. Keep chunk strategy on CLI/embed paths only.
+  }
+
+  private buildEmbedArgs(collection: string, force = false): string[] {
+    const args = ["embed"];
+    if (force) args.push("-f");
+    args.push("-c", collection);
+    if (this.qmdChunkStrategy && this.qmdCapabilities.chunkStrategy) {
+      args.push("--chunk-strategy", this.qmdChunkStrategy);
+    }
+    return args;
   }
 
   async search(
@@ -1213,6 +1875,7 @@ export class QmdClient implements SearchBackend {
     if (!trimmed) return [];
 
     const n = maxResults ?? 6;
+    const searchOptions = this.resolveSearchOptions();
 
     // Try daemon first
     await this.maybeProbeDaemon();
@@ -1220,7 +1883,7 @@ export class QmdClient implements SearchBackend {
       // Global search: no collection filter
       let results: QmdSearchResult[] | null;
       try {
-        results = await this.searchViaDaemon(trimmed, undefined, n, undefined, execution?.signal);
+        results = await this.searchViaDaemon(trimmed, undefined, n, searchOptions, execution?.signal);
       } catch (err) {
         if (isCallerCancellation(err, execution?.signal)) {
           throw isAbortError(err) ? err : abortError("QMD daemon global search aborted");
@@ -1245,7 +1908,7 @@ export class QmdClient implements SearchBackend {
     }
 
     // Subprocess fallback (only reached when daemon is unavailable and not loading)
-    return this.searchGlobalViaSubprocess(trimmed, n, execution?.signal);
+    return this.searchGlobalViaSubprocess(trimmed, n, searchOptions, execution?.signal);
   }
 
   /**
@@ -1391,32 +2054,22 @@ export class QmdClient implements SearchBackend {
       let args: Record<string, unknown>;
       if (v2) {
         // QMD v2: query tool expects { searches: [...], collections?: [...] }
-        // A plain query without type prefix uses LLM auto-expansion on the daemon side
-        const searches: Array<{ type: string; query: string }> = [{ type: "lex", query }];
-        // Add a vec sub-query for hybrid recall (mirrors v1 behavior)
-        searches.push({ type: "vec", query });
+        // The MCP tool is structured-only in 2.x; use lex+vec+hyde by default
+        // to exercise QMD's RRF + rerank path and let callers override when
+        // they have stronger query-document structure.
+        const searches = buildDefaultStructuredSearches(query, options);
         args = { searches, limit: maxResults };
         if (collection) {
           args.collections = [collection];
         }
-        if (options?.intent) {
-          args.intent = options.intent;
-        }
-        if (options?.explain === true) {
-          args.explain = true;
-        }
+        this.addResolvedSearchOptionsToMcpArgs(args, options);
       } else {
         // QMD v1: query tool accepts { query, collection?, limit }
         args = { query, limit: maxResults };
         if (collection) {
           args.collection = collection;
         }
-        if (options?.intent) {
-          args.intent = options.intent;
-        }
-        if (options?.explain === true) {
-          args.explain = true;
-        }
+        this.addResolvedSearchOptionsToMcpArgs(args, options);
       }
 
       const result = await this.daemonSession.callTool("query", args, QMD_DAEMON_TIMEOUT_MS, signal);
@@ -1568,18 +2221,8 @@ export class QmdClient implements SearchBackend {
     const startedAtMs = Date.now();
     try {
       const args = ["query", query, "-c", collection, "--json", "-n", String(maxResults)];
-      if (options?.intent) {
-        args.push("--intent", options.intent);
-      }
-      if (options?.explain === true) {
-        args.push("--explain");
-      }
-      const { stdout } = await runQmd(
-        args,
-        QMD_TIMEOUT_MS,
-        this.qmdPath,
-        signal,
-      );
+      this.addResolvedSearchOptionsToArgs(args, options);
+      const { stdout } = await this.runQmdCommand(args, QMD_TIMEOUT_MS, signal);
       const durationMs = Date.now() - startedAtMs;
       if (this.slowLog?.enabled && durationMs >= this.slowLog.thresholdMs) {
         log.warn(
@@ -1606,10 +2249,9 @@ export class QmdClient implements SearchBackend {
     if (this.available === false) return [];
     const startedAtMs = Date.now();
     try {
-      const { stdout } = await runQmd(
+      const { stdout } = await this.runQmdCommand(
         ["search", query, "-c", collection, "--json", "-n", String(maxResults)],
         QMD_TIMEOUT_MS,
-        this.qmdPath,
         signal,
       );
       log.debug(`QMD bm25: ${Date.now() - startedAtMs}ms`);
@@ -1632,10 +2274,9 @@ export class QmdClient implements SearchBackend {
     if (this.available === false) return [];
     const startedAtMs = Date.now();
     try {
-      const { stdout } = await runQmd(
+      const { stdout } = await this.runQmdCommand(
         ["vsearch", query, "-c", collection, "--json", "-n", String(maxResults)],
         QMD_TIMEOUT_MS,
-        this.qmdPath,
         signal,
       );
       log.debug(`QMD vsearch: ${Date.now() - startedAtMs}ms`);
@@ -1652,18 +2293,16 @@ export class QmdClient implements SearchBackend {
   private async searchGlobalViaSubprocess(
     query: string,
     maxResults: number,
+    options?: SearchQueryOptions,
     signal?: AbortSignal,
   ): Promise<QmdSearchResult[]> {
     if (this.available === false) return [];
 
     const startedAtMs = Date.now();
     try {
-      const { stdout } = await runQmd(
-        ["query", query, "--json", "-n", String(maxResults)],
-        QMD_TIMEOUT_MS,
-        this.qmdPath,
-        signal,
-      );
+      const args = ["query", query, "--json", "-n", String(maxResults)];
+      this.addResolvedSearchOptionsToArgs(args, options);
+      const { stdout } = await this.runQmdCommand(args, QMD_TIMEOUT_MS, signal);
       const durationMs = Date.now() - startedAtMs;
       if (this.slowLog?.enabled && durationMs >= this.slowLog.thresholdMs) {
         log.warn(
@@ -1854,7 +2493,7 @@ export class QmdClient implements SearchBackend {
     }
     try {
       const startedAtMs = Date.now();
-      await this.runQmdCommand(["embed", "-c", this.collection], 300_000);
+      await this.runQmdCommand(this.buildEmbedArgs(this.collection), 300_000);
       const durationMs = Date.now() - startedAtMs;
       if (this.slowLog?.enabled && durationMs >= this.slowLog.thresholdMs) {
         log.warn(`SLOW QMD embed: durationMs=${durationMs}`);
@@ -1865,7 +2504,7 @@ export class QmdClient implements SearchBackend {
       if (isVectorDimensionMismatchError(err)) {
         try {
           log.warn("QMD embed hit a vector dimension mismatch; retrying with force re-embed");
-          await this.runQmdCommand(["embed", "-f", "-c", this.collection], 300_000);
+          await this.runQmdCommand(this.buildEmbedArgs(this.collection, true), 300_000);
           globalState.lastGlobalEmbedRunAtMs = Date.now();
           this.lastEmbedFailAtMs = null;
           globalState.lastGlobalEmbedFailAtMs = null;
@@ -1914,7 +2553,7 @@ export class QmdClient implements SearchBackend {
       return;
     }
     try {
-      await this.runQmdCommand(["embed", "-c", name], 300_000);
+      await this.runQmdCommand(this.buildEmbedArgs(name), 300_000);
       const at = Date.now();
       globalState.lastEmbedByCollectionMs[name] = at;
       globalState.lastGlobalEmbedRunAtMs = at;
@@ -1922,7 +2561,7 @@ export class QmdClient implements SearchBackend {
       if (isVectorDimensionMismatchError(err)) {
         try {
           log.warn(`QMD embed for collection ${name} hit a vector dimension mismatch; retrying with force re-embed`);
-          await this.runQmdCommand(["embed", "-f", "-c", name], 300_000);
+          await this.runQmdCommand(this.buildEmbedArgs(name, true), 300_000);
           const recoveredAt = Date.now();
           globalState.lastEmbedByCollectionMs[name] = recoveredAt;
           globalState.lastGlobalEmbedRunAtMs = recoveredAt;
@@ -1948,11 +2587,7 @@ export class QmdClient implements SearchBackend {
     // If only daemon is available (no CLI), skip collection check
     if (this.available === false) return "skipped";
     try {
-      const { stdout } = await runQmd(
-        ["collection", "list"],
-        QMD_TIMEOUT_MS,
-        this.qmdPath,
-      );
+      const { stdout } = await this.runQmdCommand(["collection", "list"], QMD_TIMEOUT_MS);
       // Parse text output: "openclaw-engram (qmd://openclaw-engram/)"
       const collectionRegex = new RegExp(
         `^${this.collection}\\s+\\(qmd://`,

--- a/packages/remnic-core/src/search/factory.ts
+++ b/packages/remnic-core/src/search/factory.ts
@@ -88,6 +88,19 @@ function qmdOptions(config: PluginConfig): QmdClientOptions {
     qmdPath: config.qmdPath,
     daemonUrl: config.qmdDaemonEnabled ? config.qmdDaemonUrl : undefined,
     daemonRecheckIntervalMs: config.qmdDaemonRecheckIntervalMs,
+    qmdSupportedVersion: config.qmdSupportedVersion,
+    qmdAutoUpgradeEnabled: config.qmdAutoUpgradeEnabled,
+    qmdAutoUpgradeCheckIntervalMs: config.qmdAutoUpgradeCheckIntervalMs,
+    qmdChunkStrategy: config.qmdChunkStrategy,
+    qmdCandidateLimit: config.qmdCandidateLimit,
+    qmdQueryRerankEnabled: config.qmdQueryRerankEnabled,
+    qmdIndexName: config.qmdIndexName,
+    qmdForceCpu: config.qmdForceCpu,
+    qmdGpuBackend: config.qmdGpuBackend,
+    qmdEmbedParallelism: config.qmdEmbedParallelism,
+    qmdEmbedModel: config.qmdEmbedModel,
+    qmdRerankModel: config.qmdRerankModel,
+    qmdGenerateModel: config.qmdGenerateModel,
   };
 }
 

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -6,6 +6,10 @@ export type SearchResult = QmdSearchResult;
 export interface SearchQueryOptions {
   intent?: string;
   explain?: boolean;
+  candidateLimit?: number;
+  rerank?: boolean;
+  chunkStrategy?: "auto" | "regex";
+  structuredSearches?: Array<{ type: "lex" | "vec" | "hyde"; query: string }>;
 }
 
 export interface SearchExecutionOptions {

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -570,6 +570,19 @@ export interface PluginConfig {
   qmdTierParityGraphEnabled: boolean;
   qmdTierParityHiMemEnabled: boolean;
   qmdTierAutoBackfillEnabled: boolean;
+  qmdSupportedVersion: string;
+  qmdAutoUpgradeEnabled: boolean;
+  qmdAutoUpgradeCheckIntervalMs: number;
+  qmdChunkStrategy: "auto" | "regex";
+  qmdCandidateLimit?: number;
+  qmdQueryRerankEnabled: boolean;
+  qmdIndexName?: string;
+  qmdForceCpu: boolean;
+  qmdGpuBackend?: "auto" | "metal" | "cuda" | "vulkan" | "false";
+  qmdEmbedParallelism?: number;
+  qmdEmbedModel?: string;
+  qmdRerankModel?: string;
+  qmdGenerateModel?: string;
   embeddingFallbackEnabled: boolean;
   embeddingFallbackProvider: "auto" | "openai" | "local";
   /**
@@ -2622,6 +2635,7 @@ export interface QmdSearchResult {
   path: string;
   snippet: string;
   score: number;
+  line?: number;
   explain?: QmdSearchExplain;
   transport?: "daemon" | "subprocess" | "hybrid" | "scoped_prefilter";
 }
@@ -2629,7 +2643,12 @@ export interface QmdSearchResult {
 export interface QmdSearchExplain {
   ftsScores?: number[];
   vectorScores?: number[];
+  /** QMD 2.5 nested RRF `totalScore`, or legacy numeric RRF score. */
   rrf?: number;
+  rrfRank?: number;
+  rrfPositionScore?: number;
+  rrfBaseScore?: number;
+  rrfTopRankBonus?: number;
   rerankScore?: number;
   blendedScore?: number;
   /** Additive boost applied from `reinforcement_count` frontmatter (issue #687 PR 3/4). */

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -288,6 +288,83 @@
         "default": false,
         "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
       },
+      "qmdSupportedVersion": {
+        "type": "string",
+        "default": "2.5.1",
+        "description": "Highest QMD version this Remnic build will auto-install"
+      },
+      "qmdAutoUpgradeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in auto-upgrade for PATH/fallback QMD installs"
+      },
+      "qmdAutoUpgradeCheckIntervalMs": {
+        "type": "number",
+        "minimum": 60000,
+        "default": 86400000,
+        "description": "Minimum interval between QMD auto-upgrade checks"
+      },
+      "qmdChunkStrategy": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "regex"
+        ],
+        "default": "auto",
+        "description": "QMD chunk strategy forwarded when the installed QMD supports it"
+      },
+      "qmdCandidateLimit": {
+        "type": "number",
+        "minimum": 1,
+        "description": "Optional candidate limit forwarded to supported QMD query paths"
+      },
+      "qmdQueryRerankEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When false, ask supported QMD versions to skip the built-in rerank step"
+      },
+      "qmdIndexName": {
+        "type": "string",
+        "description": "Optional QMD named index forwarded as qmd --index <name> when supported"
+      },
+      "qmdForceCpu": {
+        "type": "boolean",
+        "default": false,
+        "description": "Set QMD_FORCE_CPU=1 for QMD child processes to bypass GPU probing and run predictably on CPU"
+      },
+      "qmdGpuBackend": {
+        "type": [
+          "string",
+          "boolean"
+        ],
+        "enum": [
+          "auto",
+          "metal",
+          "cuda",
+          "vulkan",
+          "false",
+          false
+        ],
+        "description": "Optional QMD_LLAMA_GPU override for QMD child processes"
+      },
+      "qmdEmbedParallelism": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 8,
+        "description": "Optional QMD_EMBED_PARALLELISM override, clamped to 1-8"
+      },
+      "qmdEmbedModel": {
+        "type": "string",
+        "description": "Optional QMD_EMBED_MODEL override"
+      },
+      "qmdRerankModel": {
+        "type": "string",
+        "description": "Optional QMD_RERANK_MODEL override"
+      },
+      "qmdGenerateModel": {
+        "type": "string",
+        "description": "Optional QMD_GENERATE_MODEL override"
+      },
       "embeddingFallbackEnabled": {
         "type": "boolean",
         "default": true,
@@ -4872,6 +4949,66 @@
       "label": "Tier Auto Backfill",
       "advanced": true,
       "help": "Enable automated cold-tier backfill runs for parity repair"
+    },
+    "qmdSupportedVersion": {
+      "label": "QMD Supported Version",
+      "advanced": true,
+      "placeholder": "2.5.1"
+    },
+    "qmdAutoUpgradeEnabled": {
+      "label": "QMD Auto Upgrade",
+      "advanced": true,
+      "help": "Upgrade PATH/fallback QMD installs to the supported version; explicit qmdPath installs are skipped"
+    },
+    "qmdAutoUpgradeCheckIntervalMs": {
+      "label": "QMD Auto Upgrade Interval",
+      "advanced": true,
+      "placeholder": "86400000"
+    },
+    "qmdChunkStrategy": {
+      "label": "QMD Chunk Strategy",
+      "advanced": true,
+      "placeholder": "auto"
+    },
+    "qmdCandidateLimit": {
+      "label": "QMD Candidate Limit",
+      "advanced": true
+    },
+    "qmdQueryRerankEnabled": {
+      "label": "QMD Query Rerank",
+      "advanced": true
+    },
+    "qmdIndexName": {
+      "label": "QMD Index Name",
+      "advanced": true,
+      "help": "Use a named QMD index when QMD 2.5+ supports --index"
+    },
+    "qmdForceCpu": {
+      "label": "QMD Force CPU",
+      "advanced": true,
+      "help": "Set QMD_FORCE_CPU=1 for QMD child processes"
+    },
+    "qmdGpuBackend": {
+      "label": "QMD GPU Backend",
+      "advanced": true,
+      "placeholder": "metal"
+    },
+    "qmdEmbedParallelism": {
+      "label": "QMD Embed Parallelism",
+      "advanced": true,
+      "placeholder": "4"
+    },
+    "qmdEmbedModel": {
+      "label": "QMD Embed Model",
+      "advanced": true
+    },
+    "qmdRerankModel": {
+      "label": "QMD Rerank Model",
+      "advanced": true
+    },
+    "qmdGenerateModel": {
+      "label": "QMD Generate Model",
+      "advanced": true
     },
     "embeddingFallbackEnabled": {
       "label": "Embedding Fallback",

--- a/tests/qmd-sync-after-store.test.ts
+++ b/tests/qmd-sync-after-store.test.ts
@@ -38,8 +38,14 @@ test("QmdClient.update() passes collection flag to qmd subprocess", async () => 
   // embed() must pass -c collection
   assert.match(
     qmdSource,
-    /runQmd(?:Command)?\(\["embed",\s*"-c",\s*this\.collection\]/,
+    /runQmd(?:Command)?\(this\.buildEmbedArgs\(this\.collection\)/,
     "embed() should pass -c this.collection to scope embedding to the remnic collection",
+  );
+
+  assert.match(
+    qmdSource,
+    /private buildEmbedArgs\(collection: string,\s*force = false\): string\[\]\s*\{\s*const args = \["embed"\];[\s\S]*?args\.push\("-c",\s*collection\);/,
+    "buildEmbedArgs() should pass -c collection to scope embedding to the target collection",
   );
 });
 

--- a/tests/search-backends.test.ts
+++ b/tests/search-backends.test.ts
@@ -62,6 +62,7 @@ describe("search backend factory", () => {
     const { QmdClient } = await import("../src/qmd.js");
     const client = new QmdClient("test-collection", 10);
     (client as any).cliVersion = "warning: experimental build\nqmd 1.1.5";
+    (client as any).qmdCapabilities = (await import("../src/qmd.js")).resolveQmdCapabilities((client as any).cliVersion);
     assert.deepEqual(
       client.resolveSupportedSearchOptions({
         intent: "goal:review",
@@ -99,6 +100,39 @@ describe("search backend factory", () => {
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("QMD 2.x supported options include structured searches but keep MCP-unsupported chunking out of args", async () => {
+    const { QmdClient, resolveQmdCapabilities } = await import("../src/qmd.js");
+    const client = new QmdClient("test-collection", 10);
+    (client as any).cliVersion = "qmd 2.5.1";
+    (client as any).qmdCapabilities = resolveQmdCapabilities("qmd 2.5.1");
+    assert.deepEqual(
+      client.resolveSupportedSearchOptions({
+        intent: "goal:review",
+        explain: true,
+        candidateLimit: 12,
+        rerank: false,
+        chunkStrategy: "auto",
+        structuredSearches: [
+          { type: "lex", query: "review" },
+          { type: "vec", query: "review current work" },
+          { type: "hyde", query: "A memory about reviewing the current work." },
+        ],
+      }),
+      {
+        intent: "goal:review",
+        explain: true,
+        candidateLimit: 12,
+        rerank: false,
+        chunkStrategy: "auto",
+        structuredSearches: [
+          { type: "lex", query: "review" },
+          { type: "vec", query: "review current work" },
+          { type: "hyde", query: "A memory about reviewing the current work." },
+        ],
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- detect QMD versions/capabilities through 2.5.1 and expose version status/doctor support
- use QMD 2.x structured MCP searches with lex/vec/hyde, line numbers, nested RRF explain data, rerank/candidate/chunk controls, named indexes, and model/GPU env overrides
- add opt-in auto-upgrade for PATH/fallback QMD installs to the Remnic-supported QMD version
- document the supported 2.0.0, 2.0.1, 2.1.0, and 2.5.1 feature coverage

## Verification
- pnpm --filter @remnic/core exec tsx --test src/qmd.test.ts src/qmd-recall-cache.test.ts
- ./node_modules/.bin/tsx --test tests/search-backends.test.ts
- npm run check-config-contract
- pnpm --filter @remnic/core run check-types
- pnpm --filter @remnic/core build
- npm run test:entity-hardening
- npm run check-types
- git diff --check
- git diff --cached --check

## Notes
- Verified published QMD 2.x releases between 2.0 and 2.5 via npm metadata: 2.0.0, 2.0.1, 2.1.0, 2.5.1. The upstream changelog also documents 2.5.0, with 2.5.1 as the published package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: expands QMD integration and config surface area, including optional `npm install -g` auto-upgrades and new CLI/MCP flags/env overrides that could affect search behavior and runtime stability if misconfigured.
> 
> **Overview**
> Updates Remnic’s QMD integration to target **QMD `2.5.1`** with runtime version parsing and capability gating, enabling richer 2.x behavior (structured `lex`/`vec`/`hyde` MCP searches, candidate limits, rerank toggles, and absolute snippet line numbers carried through to result formatting).
> 
> Adds new QMD-focused config options (and plugin schema/UI docs) for **supported version pinning**, opt-in **PATH/fallback auto-upgrade**, named index selection (`--index`), chunking strategy, and model/GPU/runtime env overrides (`QMD_FORCE_CPU`, `QMD_LLAMA_GPU`, `QMD_*_MODEL`, `QMD_EMBED_PARALLELISM`). Includes new tests covering version parsing/capabilities, config validation, structured search option handling, and embed arg construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b11de1068bb89d348b6b9bf37d6ff9b2384b90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->