### PR TITLE
docs(qmd): guard against empty index switches

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -125,7 +125,7 @@ See [Search Backends](search-backends.md) for detailed configuration and compari
 | `qmdChunkStrategy` | `auto` | QMD chunk strategy to forward when the installed QMD supports it (`auto` or `regex`) |
 | `qmdCandidateLimit` | `(none)` | Optional QMD candidate limit forwarded to supported QMD query paths |
 | `qmdQueryRerankEnabled` | `true` | Set `false` to ask QMD to skip its built-in rerank step when supported |
-| `qmdIndexName` | `(none)` | Optional QMD named index forwarded as `qmd --index <name> ...` when QMD 2.5+ supports named index selection |
+| `qmdIndexName` | `(none)` | Optional QMD named index forwarded as `qmd --index <name> ...` when QMD 2.5+ supports named index selection. Leave unset during upgrades unless existing QMD data is already in that named index; QMD's default data lives in `~/.cache/qmd/index.sqlite`, and changing this can point Remnic at an empty DB. |
 | `qmdForceCpu` | `false` | Set `QMD_FORCE_CPU=1` for QMD child processes to bypass GPU probing |
 | `qmdGpuBackend` | `(none)` | Optional `QMD_LLAMA_GPU` override (`auto`, `metal`, `cuda`, `vulkan`, or `false`) |
 | `qmdEmbedParallelism` | `(none)` | Optional `QMD_EMBED_PARALLELISM` override, clamped to 1-8 |

--- a/docs/search-backends.md
+++ b/docs/search-backends.md
@@ -53,7 +53,8 @@ qmd update && qmd embed
   "qmdSupportedVersion": "2.5.1",
   "qmdAutoUpgradeEnabled": false, // opt-in: npm install -g @tobilu/qmd@2.5.1
   "qmdChunkStrategy": "auto",
-  "qmdIndexName": "remnic",
+  // Leave qmdIndexName unset unless you intentionally use a separate QMD DB.
+  // Existing Remnic/OpenClaw installs usually keep data in QMD's default "index".
   "qmdForceCpu": false,
   "qmdDaemonEnabled": true,      // Keep the shared MCP session warm for fast queries
   "qmdIntentHintsEnabled": false,
@@ -69,6 +70,14 @@ overrides (`QMD_EMBED_MODEL`, `QMD_RERANK_MODEL`, `QMD_GENERATE_MODEL`,
 `QMD_FORCE_CPU`, `QMD_LLAMA_GPU`, `QMD_EMBED_PARALLELISM`), named index selection
 via `qmdIndexName`, and absolute snippet line numbers. Older QMD installs
 continue to work with unsupported flags omitted.
+
+Do not set `qmdIndexName` during upgrades unless you have confirmed the existing
+QMD data lives in that named index. QMD's default index is named `index` and is
+stored at `~/.cache/qmd/index.sqlite`; changing `qmdIndexName` to a new value
+creates or selects a different SQLite database, which can make existing memories
+appear missing even though the old QMD database is still intact. Before changing
+it, compare `qmd collection list` or inspect `~/.cache/qmd/*.sqlite` and preserve
+the index that contains the current `openclaw-engram*` collections.
 
 Auto-upgrade is intentionally disabled by default. Set
 `qmdAutoUpgradeEnabled: true` to let Remnic upgrade PATH/fallback QMD installs to

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -325,7 +325,7 @@
       },
       "qmdIndexName": {
         "type": "string",
-        "description": "Optional QMD named index forwarded as qmd --index <name> when supported"
+        "description": "Optional QMD named index forwarded as qmd --index <name> when supported. Leave unset during upgrades unless existing QMD data already lives in that named index."
       },
       "qmdForceCpu": {
         "type": "boolean",
@@ -4981,7 +4981,7 @@
     "qmdIndexName": {
       "label": "QMD Index Name",
       "advanced": true,
-      "help": "Use a named QMD index when QMD 2.5+ supports --index"
+      "help": "Use a named QMD index when QMD 2.5+ supports --index. Changing this selects a different SQLite DB; keep it unset for existing default-index installs."
     },
     "qmdForceCpu": {
       "label": "QMD Force CPU",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -325,7 +325,7 @@
       },
       "qmdIndexName": {
         "type": "string",
-        "description": "Optional QMD named index forwarded as qmd --index <name> when supported"
+        "description": "Optional QMD named index forwarded as qmd --index <name> when supported. Leave unset during upgrades unless existing QMD data already lives in that named index."
       },
       "qmdForceCpu": {
         "type": "boolean",
@@ -4981,7 +4981,7 @@
     "qmdIndexName": {
       "label": "QMD Index Name",
       "advanced": true,
-      "help": "Use a named QMD index when QMD 2.5+ supports --index"
+      "help": "Use a named QMD index when QMD 2.5+ supports --index. Changing this selects a different SQLite DB; keep it unset for existing default-index installs."
     },
     "qmdForceCpu": {
       "label": "QMD Force CPU",

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -189,6 +189,7 @@ test("parseConfig exposes qmd 2.5 integration defaults and opt-in auto upgrade",
   assert.equal(defaults.qmdChunkStrategy, "auto");
   assert.equal(defaults.qmdQueryRerankEnabled, true);
   assert.equal(defaults.qmdCandidateLimit, undefined);
+  assert.equal(defaults.qmdIndexName, undefined);
 
   const configured = parseConfig({
     qmdAutoUpgradeEnabled: "true",


### PR DESCRIPTION
## Summary
- remove the misleading `qmdIndexName: "remnic"` example from QMD docs
- document that existing installs usually use QMD's default `index` database at `~/.cache/qmd/index.sqlite`
- add OpenClaw manifest help text and a regression assertion that the parsed default leaves `qmdIndexName` unset

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/qmd.test.ts`
- `pnpm run check:openclaw-plugin-sync`
- `npm run preflight:quick`

Note: the first quick preflight attempt exposed a fresh-worktree `better-sqlite3` native binding issue; `npm rebuild better-sqlite3 --ignore-scripts=false --foreground-scripts` repaired the local binding, and the rerun passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/metadata copy plus a small test assertion to ensure the default `qmdIndexName` remains unset, with no runtime behavior changes.
> 
> **Overview**
> Clarifies QMD `qmdIndexName` guidance to prevent accidental switches to an empty named index/SQLite DB during upgrades, and removes the misleading docs example that set it by default.
> 
> Updates the OpenClaw plugin manifest schema/help text to carry the same warning, and adds a regression assertion in `qmd.test.ts` that `parseConfig({})` leaves `qmdIndexName` `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bebb803fa9e771b1a733cf6f5f5a4a14ba35478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->