### PR TITLE
feat: add offline mode sync

### DIFF
--- a/.changeset/offline-mode-sync.md
+++ b/.changeset/offline-mode-sync.md
@@ -1,0 +1,17 @@
+---
+"@remnic/core": minor
+"@remnic/cli": minor
+---
+
+Add offline mode for laptop-first Remnic usage.
+
+Core now exposes a snapshot/changeset sync protocol plus HTTP endpoints for
+pulling a remote storage snapshot and applying local changes back to a Remnic
+daemon. The protocol tracks a shared base, syncs changed files only after the
+initial snapshot, preserves both sides on conflicts, and excludes private
+process-local directories such as `.secure-store/` and `.offline-sync/`.
+
+The CLI now includes `remnic offline prepare`, `remnic offline sync`,
+`remnic offline status`, and `remnic offline watch` so agents can keep talking
+to a local laptop daemon while a background sync bridges to the home daemon
+whenever the network is available.

--- a/docs/guides/offline-mode.md
+++ b/docs/guides/offline-mode.md
@@ -1,0 +1,140 @@
+# Offline Mode
+
+Offline mode lets a laptop keep using Remnic when the home Remnic daemon is
+unreachable, then sync local changes back when the network returns.
+
+The recommended topology is:
+
+1. Run the main Remnic daemon at home.
+2. Run a local Remnic daemon on the laptop.
+3. Point laptop agents at the laptop daemon, not directly at the home daemon.
+4. Run `remnic offline watch` on the laptop to sync with the home daemon over
+   Tailscale, hotel Wi-Fi, LAN, or any other reachable route.
+
+With that shape, a laptop can move from home Wi-Fi to sleep to an airplane or a
+cruise cabin without reconfiguring agents. If the home daemon is reachable, the
+watcher pushes and pulls. If it is not reachable, Remnic stays local and the
+watcher retries until the connection comes back.
+
+## Before Travel
+
+Start or verify the home daemon:
+
+```bash
+export REMNIC_AUTH_TOKEN=...
+remnic daemon start
+remnic status
+```
+
+On the laptop, install local agent/model support and run a local Remnic daemon:
+
+```bash
+remnic init
+remnic connectors install pi
+remnic daemon start
+```
+
+Seed the laptop from the home daemon:
+
+```bash
+export REMNIC_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4317"
+export REMNIC_OFFLINE_TOKEN="$REMNIC_AUTH_TOKEN"
+remnic offline prepare --namespace default
+```
+
+`prepare` downloads a full snapshot from the remote namespace and writes the
+offline sync state under `<memoryDir>/.offline-sync/state/`.
+
+## Stay Synced
+
+Keep this running on the laptop before you leave:
+
+```bash
+remnic offline watch --namespace default --interval-ms 60000
+```
+
+The watcher performs the same work as `remnic offline sync`:
+
+1. Build a changeset from local files changed since the last shared base.
+2. Push that changeset to the remote daemon.
+3. Pull the latest remote snapshot.
+4. Apply remote changes locally.
+5. Update the shared-base state.
+
+Network failures do not clear local state or block local Remnic use. The next
+watch iteration tries again.
+
+## Manual Sync
+
+Use `sync` when you want a one-shot transfer:
+
+```bash
+remnic offline sync --namespace default
+```
+
+Use `status` to see how many local upserts/deletes are pending relative to the
+last shared base:
+
+```bash
+remnic offline status --namespace default
+remnic offline status --namespace default --json
+```
+
+## Multiple Namespaces
+
+Sync each namespace independently:
+
+```bash
+remnic offline prepare --namespace personal
+remnic offline prepare --namespace work
+remnic offline watch --namespace personal
+remnic offline watch --namespace work --interval-ms 120000
+```
+
+The state file key includes the remote identity and namespace, so separate
+namespaces do not overwrite each other's sync base.
+
+## Conflict Handling
+
+Offline mode uses a shared-base merge protocol. A file is applied only when the
+target side is still at the base version the sender last saw.
+
+If both laptop and home changed the same file, Remnic preserves the local file
+and writes the incoming version under:
+
+```text
+<memoryDir>/.offline-sync/conflicts/<timestamp>-<source>/<original-path>
+```
+
+The sync result reports the conflict path so you can inspect or merge it later.
+Remote-side conflicts behave the same way on the home daemon.
+
+## What Syncs
+
+Offline sync operates at the Remnic storage directory layer. That means it works
+for core memories, retrieval indices, governance metadata, review queues,
+continuity state, and other persisted Remnic files without adding host-specific
+fallback logic to OpenClaw, Pi, Codex, Hermes, or future adapters.
+
+By default, transcript files are included. Use `--no-transcripts` when preparing
+or syncing a namespace if you want to exclude `transcripts/` from the transfer.
+
+The transfer intentionally excludes private or process-local directories such
+as `.secure-store/`, `.offline-sync/`, `.capsules/`, `node_modules/`, and `.git/`.
+Auth tokens stay local and must be provisioned separately on each machine.
+
+## Environment Variables
+
+The CLI reads these values when flags are omitted:
+
+```bash
+export REMNIC_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4317"
+export REMNIC_OFFLINE_TOKEN="..."
+```
+
+Legacy fallbacks are also accepted:
+
+```bash
+export ENGRAM_OFFLINE_REMOTE_URL="http://home-remnic.tailnet-name.ts.net:4317"
+export ENGRAM_AUTH_TOKEN="..."
+```

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -35,6 +35,7 @@ remnic query "hello" --explain  # Test query with tier breakdown
 | `remnic curate` | Interactive memory curation |
 | `remnic dedup` | Find and merge duplicate memories |
 | `remnic sync` | Diff-aware sync with external sources |
+| `remnic offline prepare/sync/status/watch` | Use a local memory cache and sync with a remote Remnic daemon |
 | `remnic spaces` | Manage memory namespaces |
 | `remnic bench list` | List published benchmark packs |
 | `remnic bench datasets status/download` | Check or download local benchmark datasets |
@@ -47,6 +48,11 @@ remnic query "hello" --explain  # Test query with tier breakdown
 | `remnic bench publish --target remnic-ai` | Build the Remnic.ai benchmark feed from stored results |
 
 Run `remnic --help` for the full command list.
+
+Offline mode is intended for laptops that need Remnic on flights, cruises, or
+other disconnected stretches. Point agents at the laptop daemon, then run
+`remnic offline watch` to sync with the home daemon whenever it is reachable.
+See [Offline Mode](../../docs/guides/offline-mode.md).
 
 ## Benchmarks
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5514,16 +5514,7 @@ function localOfflineSourceId(memoryDir: string): string {
   return `remnic-local:${host}:${dirHash}`;
 }
 
-function resolveOfflineRemoteUrl(args: string[]): string {
-  const raw =
-    resolveRequiredValueFlag(args, "--remote-url") ??
-    process.env.REMNIC_OFFLINE_REMOTE_URL ??
-    process.env.ENGRAM_OFFLINE_REMOTE_URL;
-  if (!raw || raw.trim().length === 0) {
-    throw new Error(
-      "offline mode requires --remote-url <url> or REMNIC_OFFLINE_REMOTE_URL",
-    );
-  }
+function normalizeOfflineRemoteUrl(raw: string): string {
   let parsed: URL;
   try {
     parsed = new URL(raw.trim());
@@ -5537,6 +5528,25 @@ function resolveOfflineRemoteUrl(args: string[]): string {
   parsed.search = "";
   parsed.hash = "";
   return parsed.toString().replace(/\/$/, "");
+}
+
+function resolveOptionalOfflineRemoteUrl(args: string[]): string | undefined {
+  const raw =
+    resolveRequiredValueFlag(args, "--remote-url") ??
+    process.env.REMNIC_OFFLINE_REMOTE_URL ??
+    process.env.ENGRAM_OFFLINE_REMOTE_URL;
+  if (!raw || raw.trim().length === 0) return undefined;
+  return normalizeOfflineRemoteUrl(raw);
+}
+
+function resolveOfflineRemoteUrl(args: string[]): string {
+  const parsed = resolveOptionalOfflineRemoteUrl(args);
+  if (!parsed) {
+    throw new Error(
+      "offline mode requires --remote-url <url> or REMNIC_OFFLINE_REMOTE_URL",
+    );
+  }
+  return parsed;
 }
 
 function resolveOfflineToken(args: string[]): string {
@@ -5646,6 +5656,23 @@ function parseOfflineIntervalMs(args: string[]): number {
     throw new Error("--interval-ms must be an integer >= 1000");
   }
   return parsed;
+}
+
+function waitForOfflineInterval(
+  ms: number,
+  setCancel: (cancel: (() => void) | null) => void,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      setCancel(null);
+      resolve();
+    }, ms);
+    setCancel(() => {
+      clearTimeout(timer);
+      setCancel(null);
+      resolve();
+    });
+  });
 }
 
 async function runOfflineSyncOnce(options: {
@@ -5766,17 +5793,18 @@ Environment fallbacks:
   const includeTranscripts = !hasFlag(rest, "--no-transcripts");
   const stateOverride = resolveRequiredValueFlag(rest, "--state");
   const needsRemote = action === "prepare" || action === "sync" || action === "watch";
-  const remoteUrl = needsRemote || stateOverride === undefined
+  const remoteUrl = needsRemote
     ? resolveOfflineRemoteUrl(rest)
-    : undefined;
+    : resolveOptionalOfflineRemoteUrl(rest);
   const token = needsRemote ? resolveOfflineToken(rest) : undefined;
-  const statePath = path.resolve(expandTilde(
-    stateOverride ??
-      defaultOfflineSyncStatePath(memoryDir, remoteUrl ?? resolveOfflineRemoteUrl(rest), namespace),
-  ));
+  const statePath = stateOverride !== undefined
+    ? path.resolve(expandTilde(stateOverride))
+    : remoteUrl !== undefined
+      ? defaultOfflineSyncStatePath(memoryDir, remoteUrl, namespace)
+      : undefined;
 
   if (action === "prepare") {
-    if (!remoteUrl || !token) throw new Error("offline prepare requires remote URL and token");
+    if (!remoteUrl || !token || !statePath) throw new Error("offline prepare requires remote URL and token");
     fs.mkdirSync(memoryDir, { recursive: true });
     const remoteSnapshot = await fetchOfflineSnapshot({
       remoteUrl,
@@ -5818,7 +5846,7 @@ Environment fallbacks:
   }
 
   if (action === "sync") {
-    if (!remoteUrl || !token) throw new Error("offline sync requires remote URL and token");
+    if (!remoteUrl || !token || !statePath) throw new Error("offline sync requires remote URL and token");
     const result = await runOfflineSyncOnce({
       memoryDir,
       remoteUrl,
@@ -5841,8 +5869,8 @@ Environment fallbacks:
 
   if (action === "status") {
     fs.mkdirSync(memoryDir, { recursive: true });
-    const state = await readOfflineSyncState(statePath);
-    if (state && remoteUrl) {
+    const state = statePath ? await readOfflineSyncState(statePath) : null;
+    if (state && remoteUrl && statePath) {
       assertOfflineStateMatches({
         state,
         remoteUrl,
@@ -5859,10 +5887,10 @@ Environment fallbacks:
     });
     const summary = summarizeOfflineSyncChangeset(changeset);
     if (json) {
-      console.log(JSON.stringify({ statePath, state, pending: summary }, null, 2));
+      console.log(JSON.stringify({ statePath: statePath ?? null, state, pending: summary }, null, 2));
     } else {
       console.log(`Offline state: ${state ? "ready" : "not prepared"}`);
-      console.log(`State: ${statePath}`);
+      console.log(`State: ${statePath ?? "(not selected; pass --state or --remote-url to inspect a prepared remote state)"}`);
       if (state) console.log(`Last synced: ${state.lastSyncedAt}`);
       console.log(`Pending local changes: ${summary.total} (${summary.upserts} upserts, ${summary.deletes} deletes)`);
     }
@@ -5870,12 +5898,14 @@ Environment fallbacks:
   }
 
   if (action === "watch") {
-    if (!remoteUrl || !token) throw new Error("offline watch requires remote URL and token");
+    if (!remoteUrl || !token || !statePath) throw new Error("offline watch requires remote URL and token");
     const intervalMs = parseOfflineIntervalMs(rest);
     console.log(`Watching offline sync every ${intervalMs}ms. Press Ctrl+C to stop.`);
     let stopped = false;
+    let cancelSleep: (() => void) | null = null;
     process.once("SIGINT", () => {
       stopped = true;
+      cancelSleep?.();
       console.log("Stopping offline sync watcher.");
     });
     while (!stopped) {
@@ -5894,7 +5924,10 @@ Environment fallbacks:
       } catch (error) {
         console.log(`[${new Date().toISOString()}] sync waiting: ${error instanceof Error ? error.message : String(error)}`);
       }
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      if (stopped) break;
+      await waitForOfflineInterval(intervalMs, (cancel) => {
+        cancelSleep = cancel;
+      });
     }
     return;
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5624,6 +5624,16 @@ async function fetchOfflineSnapshot(args: {
   );
 }
 
+function resolvedOfflineSnapshotNamespace(
+  snapshot: { namespace?: string },
+  requestedNamespace?: string,
+): string | undefined {
+  const resolved = typeof snapshot.namespace === "string" && snapshot.namespace.trim().length > 0
+    ? snapshot.namespace.trim()
+    : undefined;
+  return resolved ?? requestedNamespace;
+}
+
 async function pushOfflineChanges(args: {
   remoteUrl: string;
   token: string;
@@ -5706,6 +5716,7 @@ async function runOfflineSyncOnce(options: {
   statePath: string;
 }): Promise<{
   statePath: string;
+  namespace?: string;
   prepared: boolean;
   pushed: Awaited<ReturnType<typeof pushOfflineChanges>> | null;
   pull: Awaited<ReturnType<typeof applyOfflineSyncSnapshot>>;
@@ -5714,11 +5725,22 @@ async function runOfflineSyncOnce(options: {
 }> {
   fs.mkdirSync(options.memoryDir, { recursive: true });
   const priorState = await readOfflineSyncState(options.statePath);
+  let syncNamespace = options.namespace ?? priorState?.namespace;
+  let namespaceProbe: Awaited<ReturnType<typeof fetchOfflineSnapshot>> | null = null;
+  if (syncNamespace === undefined) {
+    namespaceProbe = await fetchOfflineSnapshot({
+      remoteUrl: options.remoteUrl,
+      token: options.token,
+      namespace: options.namespace,
+      includeTranscripts: options.includeTranscripts,
+    });
+    syncNamespace = resolvedOfflineSnapshotNamespace(namespaceProbe, options.namespace);
+  }
   if (priorState) {
     assertOfflineStateMatches({
       state: priorState,
       remoteUrl: options.remoteUrl,
-      namespace: options.namespace,
+      namespace: syncNamespace,
       includeTranscripts: options.includeTranscripts,
       statePath: options.statePath,
     });
@@ -5737,16 +5759,19 @@ async function runOfflineSyncOnce(options: {
     ? await pushOfflineChanges({
         remoteUrl: options.remoteUrl,
         token: options.token,
-        namespace: options.namespace,
+        namespace: syncNamespace,
         changeset,
       })
     : null;
-  const remoteSnapshot = await fetchOfflineSnapshot({
-    remoteUrl: options.remoteUrl,
-    token: options.token,
-    namespace: options.namespace,
-    includeTranscripts: options.includeTranscripts,
-  });
+  const remoteSnapshot = pushed === null && namespaceProbe !== null
+    ? namespaceProbe
+    : await fetchOfflineSnapshot({
+        remoteUrl: options.remoteUrl,
+        token: options.token,
+        namespace: syncNamespace,
+        includeTranscripts: options.includeTranscripts,
+      });
+  const resolvedNamespace = resolvedOfflineSnapshotNamespace(remoteSnapshot, syncNamespace);
   const pull = await applyOfflineSyncSnapshot({
     root: options.memoryDir,
     snapshot: remoteSnapshot,
@@ -5757,13 +5782,14 @@ async function runOfflineSyncOnce(options: {
   });
   const state = offlineSyncStateFromSnapshot({
     remoteId: options.remoteUrl,
-    namespace: options.namespace,
+    namespace: resolvedNamespace,
     snapshot: remoteSnapshot,
     baseFiles: pull.nextBaseFiles,
   });
   await writeOfflineSyncState(options.statePath, state);
   return {
     statePath: options.statePath,
+    namespace: resolvedNamespace,
     prepared: priorState === null,
     pushed,
     pull,
@@ -5839,12 +5865,13 @@ Environment fallbacks:
       namespace,
       includeTranscripts,
     });
+    const resolvedNamespace = resolvedOfflineSnapshotNamespace(remoteSnapshot, namespace);
     const existingState = await readOfflineSyncState(statePath);
     if (existingState) {
       assertOfflineStateMatches({
         state: existingState,
         remoteUrl,
-        namespace,
+        namespace: resolvedNamespace,
         includeTranscripts,
         statePath,
       });
@@ -5860,15 +5887,16 @@ Environment fallbacks:
     });
     const state = offlineSyncStateFromSnapshot({
       remoteId: remoteUrl,
-      namespace,
+      namespace: resolvedNamespace,
       snapshot: remoteSnapshot,
       baseFiles: pull.nextBaseFiles,
     });
     await writeOfflineSyncState(statePath, state);
     if (json) {
-      console.log(JSON.stringify({ statePath, remoteFiles: remoteSnapshot.files.length, pull }, null, 2));
+      console.log(JSON.stringify({ statePath, namespace: resolvedNamespace, remoteFiles: remoteSnapshot.files.length, pull }, null, 2));
     } else {
       console.log(`Offline cache prepared: ${memoryDir}`);
+      console.log(`Namespace: ${resolvedNamespace ?? "(default)"}`);
       console.log(`Remote files: ${remoteSnapshot.files.length}`);
       console.log(`Pulled: ${pull.upserted} upserted, ${pull.deleted} deleted, ${pull.conflicts.length} conflicts`);
       console.log(`State: ${statePath}`);
@@ -5893,6 +5921,7 @@ Environment fallbacks:
       console.log(`Pushed: ${result.pushed ? `${result.pushed.appliedUpserts} upserts, ${result.pushed.appliedDeletes} deletes, ${result.pushed.conflicts.length} conflicts` : "nothing pending"}`);
       console.log(`Pulled: ${result.pull.upserted} upserts, ${result.pull.deleted} deletes, ${result.pull.conflicts.length} conflicts`);
       console.log(`Pending local before push: ${result.pendingSummary.total}`);
+      console.log(`Namespace: ${result.namespace ?? "(default)"}`);
       console.log(`State: ${result.statePath}`);
     }
     return;
@@ -5905,7 +5934,7 @@ Environment fallbacks:
       assertOfflineStateMatches({
         state,
         remoteUrl,
-        namespace,
+        namespace: namespace ?? state.namespace,
         includeTranscripts,
         statePath,
       });

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5670,6 +5670,7 @@ async function runOfflineSyncOnce(options: {
       state: priorState,
       remoteUrl: options.remoteUrl,
       namespace: options.namespace,
+      includeTranscripts: options.includeTranscripts,
       statePath: options.statePath,
     });
   }
@@ -5721,6 +5722,7 @@ function assertOfflineStateMatches(options: {
   state: OfflineSyncState;
   remoteUrl: string;
   namespace?: string;
+  includeTranscripts: boolean;
   statePath: string;
 }): void {
   if (options.state.remoteId !== options.remoteUrl) {
@@ -5731,6 +5733,11 @@ function assertOfflineStateMatches(options: {
   if ((options.state.namespace ?? undefined) !== (options.namespace ?? undefined)) {
     throw new Error(
       `offline state ${options.statePath} belongs to namespace ${options.state.namespace ?? "(default)"}; run prepare with a fresh state file before syncing namespace ${options.namespace ?? "(default)"}`,
+    );
+  }
+  if (options.state.includeTranscripts !== options.includeTranscripts) {
+    throw new Error(
+      `offline state ${options.statePath} was prepared with transcripts ${options.state.includeTranscripts ? "included" : "excluded"}; run prepare with a fresh state file before syncing with transcripts ${options.includeTranscripts ? "included" : "excluded"}`,
     );
   }
 }
@@ -5783,6 +5790,7 @@ Environment fallbacks:
         state: existingState,
         remoteUrl,
         namespace,
+        includeTranscripts,
         statePath,
       });
     }
@@ -5839,6 +5847,7 @@ Environment fallbacks:
         state,
         remoteUrl,
         namespace,
+        includeTranscripts,
         statePath,
       });
     }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5526,6 +5526,8 @@ function normalizeOfflineRemoteUrl(raw: string): string {
     throw new Error("--remote-url must use http:// or https://");
   }
   parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.username = "";
+  parsed.password = "";
   parsed.search = "";
   parsed.hash = "";
   return parsed.toString().replace(/\/$/, "");
@@ -5634,6 +5636,45 @@ function resolvedOfflineSnapshotNamespace(
   return resolved ?? requestedNamespace;
 }
 
+function uniqueOfflineStatePaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const filePath of paths) {
+    if (seen.has(filePath)) continue;
+    seen.add(filePath);
+    out.push(filePath);
+  }
+  return out;
+}
+
+function offlineStatePathsForNamespace(options: {
+  memoryDir: string;
+  remoteUrl: string;
+  requestedNamespace?: string;
+  resolvedNamespace?: string;
+  explicitStatePath?: string;
+}): string[] {
+  if (options.explicitStatePath) return [options.explicitStatePath];
+  const primaryNamespace = options.resolvedNamespace ?? options.requestedNamespace;
+  const paths = [
+    defaultOfflineSyncStatePath(options.memoryDir, options.remoteUrl, primaryNamespace),
+  ];
+  if (options.requestedNamespace !== primaryNamespace) {
+    paths.push(defaultOfflineSyncStatePath(options.memoryDir, options.remoteUrl, options.requestedNamespace));
+  }
+  return uniqueOfflineStatePaths(paths);
+}
+
+async function readFirstOfflineSyncState(
+  paths: readonly string[],
+): Promise<{ statePath: string; state: OfflineSyncState } | null> {
+  for (const statePath of paths) {
+    const state = await readOfflineSyncState(statePath);
+    if (state) return { statePath, state };
+  }
+  return null;
+}
+
 async function pushOfflineChanges(args: {
   remoteUrl: string;
   token: string;
@@ -5714,6 +5755,7 @@ async function runOfflineSyncOnce(options: {
   namespace?: string;
   includeTranscripts: boolean;
   statePath: string;
+  statePathExplicit: boolean;
 }): Promise<{
   statePath: string;
   namespace?: string;
@@ -5724,7 +5766,8 @@ async function runOfflineSyncOnce(options: {
   remoteFileCount: number;
 }> {
   fs.mkdirSync(options.memoryDir, { recursive: true });
-  const priorState = await readOfflineSyncState(options.statePath);
+  let activeStatePath = options.statePath;
+  let priorState = await readOfflineSyncState(activeStatePath);
   let syncNamespace = options.namespace ?? priorState?.namespace;
   let namespaceProbe: Awaited<ReturnType<typeof fetchOfflineSnapshot>> | null = null;
   if (syncNamespace === undefined) {
@@ -5736,13 +5779,25 @@ async function runOfflineSyncOnce(options: {
     });
     syncNamespace = resolvedOfflineSnapshotNamespace(namespaceProbe, options.namespace);
   }
+  if (!priorState && !options.statePathExplicit && syncNamespace !== undefined) {
+    const resolvedState = await readFirstOfflineSyncState(offlineStatePathsForNamespace({
+      memoryDir: options.memoryDir,
+      remoteUrl: options.remoteUrl,
+      requestedNamespace: options.namespace,
+      resolvedNamespace: syncNamespace,
+    }));
+    if (resolvedState) {
+      activeStatePath = resolvedState.statePath;
+      priorState = resolvedState.state;
+    }
+  }
   if (priorState) {
     assertOfflineStateMatches({
       state: priorState,
       remoteUrl: options.remoteUrl,
       namespace: syncNamespace,
       includeTranscripts: options.includeTranscripts,
-      statePath: options.statePath,
+      statePath: activeStatePath,
     });
   }
   const baseFiles = priorState?.baseFiles ?? [];
@@ -5786,9 +5841,18 @@ async function runOfflineSyncOnce(options: {
     snapshot: remoteSnapshot,
     baseFiles: pull.nextBaseFiles,
   });
-  await writeOfflineSyncState(options.statePath, state);
+  const stateWritePaths = offlineStatePathsForNamespace({
+    memoryDir: options.memoryDir,
+    remoteUrl: options.remoteUrl,
+    requestedNamespace: options.namespace,
+    resolvedNamespace,
+    explicitStatePath: options.statePathExplicit ? activeStatePath : undefined,
+  });
+  for (const statePath of stateWritePaths) {
+    await writeOfflineSyncState(statePath, state);
+  }
   return {
-    statePath: options.statePath,
+    statePath: stateWritePaths[0] ?? activeStatePath,
     namespace: resolvedNamespace,
     prepared: priorState === null,
     pushed,
@@ -5845,12 +5909,13 @@ Environment fallbacks:
   const namespace = resolveRequiredValueFlag(rest, "--namespace");
   const includeTranscripts = !hasFlag(rest, "--no-transcripts");
   const stateOverride = resolveRequiredValueFlag(rest, "--state");
+  const statePathExplicit = stateOverride !== undefined;
   const needsRemote = action === "prepare" || action === "sync" || action === "watch";
   const remoteUrl = needsRemote
     ? resolveOfflineRemoteUrl(rest)
     : resolveOptionalOfflineRemoteUrl(rest);
   const token = needsRemote ? resolveOfflineToken(rest) : undefined;
-  const statePath = stateOverride !== undefined
+  const statePath = statePathExplicit
     ? path.resolve(expandTilde(stateOverride))
     : remoteUrl !== undefined
       ? defaultOfflineSyncStatePath(memoryDir, remoteUrl, namespace)
@@ -5866,21 +5931,29 @@ Environment fallbacks:
       includeTranscripts,
     });
     const resolvedNamespace = resolvedOfflineSnapshotNamespace(remoteSnapshot, namespace);
-    const existingState = await readOfflineSyncState(statePath);
+    const stateWritePaths = offlineStatePathsForNamespace({
+      memoryDir,
+      remoteUrl,
+      requestedNamespace: namespace,
+      resolvedNamespace,
+      explicitStatePath: statePathExplicit ? statePath : undefined,
+    });
+    const activeStatePath = stateWritePaths[0] ?? statePath;
+    const existingState = await readFirstOfflineSyncState(stateWritePaths);
     if (existingState) {
       assertOfflineStateMatches({
-        state: existingState,
+        state: existingState.state,
         remoteUrl,
         namespace: resolvedNamespace,
         includeTranscripts,
-        statePath,
+        statePath: existingState.statePath,
       });
     }
     const storageIo = await createOfflineStorageIo(memoryDir);
     const pull = await applyOfflineSyncSnapshot({
       root: memoryDir,
       snapshot: remoteSnapshot,
-      baseFiles: existingState?.baseFiles ?? [],
+      baseFiles: existingState?.state.baseFiles ?? [],
       readFile: storageIo.readFile,
       writeFile: storageIo.writeFile,
       deleteFile: storageIo.deleteFile,
@@ -5891,15 +5964,17 @@ Environment fallbacks:
       snapshot: remoteSnapshot,
       baseFiles: pull.nextBaseFiles,
     });
-    await writeOfflineSyncState(statePath, state);
+    for (const pathToWrite of stateWritePaths) {
+      await writeOfflineSyncState(pathToWrite, state);
+    }
     if (json) {
-      console.log(JSON.stringify({ statePath, namespace: resolvedNamespace, remoteFiles: remoteSnapshot.files.length, pull }, null, 2));
+      console.log(JSON.stringify({ statePath: activeStatePath, namespace: resolvedNamespace, remoteFiles: remoteSnapshot.files.length, pull }, null, 2));
     } else {
       console.log(`Offline cache prepared: ${memoryDir}`);
       console.log(`Namespace: ${resolvedNamespace ?? "(default)"}`);
       console.log(`Remote files: ${remoteSnapshot.files.length}`);
       console.log(`Pulled: ${pull.upserted} upserted, ${pull.deleted} deleted, ${pull.conflicts.length} conflicts`);
-      console.log(`State: ${statePath}`);
+      console.log(`State: ${activeStatePath}`);
     }
     return;
   }
@@ -5913,6 +5988,7 @@ Environment fallbacks:
       namespace,
       includeTranscripts,
       statePath,
+      statePathExplicit,
     });
     if (json) {
       console.log(JSON.stringify(result, null, 2));
@@ -5979,6 +6055,7 @@ Environment fallbacks:
           namespace,
           includeTranscripts,
           statePath,
+          statePathExplicit,
         });
         console.log(
           `[${new Date().toISOString()}] sync ok: pushed=${result.pushed ? result.pushed.appliedUpserts + result.pushed.appliedDeletes : 0}, pulled=${result.pull.upserted + result.pull.deleted}, conflicts=${(result.pushed?.conflicts.length ?? 0) + result.pull.conflicts.length}`,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -133,6 +133,7 @@ import {
   readOfflineSyncState,
   summarizeOfflineSyncChangeset,
   writeOfflineSyncState,
+  type OfflineSyncState,
   buildActionConfidenceInputFromOptions,
   evaluateActionConfidence,
   renderActionConfidenceText,
@@ -5664,6 +5665,14 @@ async function runOfflineSyncOnce(options: {
 }> {
   fs.mkdirSync(options.memoryDir, { recursive: true });
   const priorState = await readOfflineSyncState(options.statePath);
+  if (priorState) {
+    assertOfflineStateMatches({
+      state: priorState,
+      remoteUrl: options.remoteUrl,
+      namespace: options.namespace,
+      statePath: options.statePath,
+    });
+  }
   const baseFiles = priorState?.baseFiles ?? [];
   const changeset = await buildOfflineSyncChangeset({
     root: options.memoryDir,
@@ -5706,6 +5715,24 @@ async function runOfflineSyncOnce(options: {
     pendingSummary,
     remoteFileCount: remoteSnapshot.files.length,
   };
+}
+
+function assertOfflineStateMatches(options: {
+  state: OfflineSyncState;
+  remoteUrl: string;
+  namespace?: string;
+  statePath: string;
+}): void {
+  if (options.state.remoteId !== options.remoteUrl) {
+    throw new Error(
+      `offline state ${options.statePath} belongs to ${options.state.remoteId}; run prepare with a fresh state file before syncing ${options.remoteUrl}`,
+    );
+  }
+  if ((options.state.namespace ?? undefined) !== (options.namespace ?? undefined)) {
+    throw new Error(
+      `offline state ${options.statePath} belongs to namespace ${options.state.namespace ?? "(default)"}; run prepare with a fresh state file before syncing namespace ${options.namespace ?? "(default)"}`,
+    );
+  }
 }
 
 async function cmdOffline(action: string, rest: string[], json: boolean): Promise<void> {
@@ -5751,6 +5778,14 @@ Environment fallbacks:
       includeTranscripts,
     });
     const existingState = await readOfflineSyncState(statePath);
+    if (existingState) {
+      assertOfflineStateMatches({
+        state: existingState,
+        remoteUrl,
+        namespace,
+        statePath,
+      });
+    }
     const pull = await applyOfflineSyncSnapshot({
       root: memoryDir,
       snapshot: remoteSnapshot,
@@ -5799,6 +5834,14 @@ Environment fallbacks:
   if (action === "status") {
     fs.mkdirSync(memoryDir, { recursive: true });
     const state = await readOfflineSyncState(statePath);
+    if (state && remoteUrl) {
+      assertOfflineStateMatches({
+        state,
+        remoteUrl,
+        namespace,
+        statePath,
+      });
+    }
     const changeset = await buildOfflineSyncChangeset({
       root: memoryDir,
       sourceId: localOfflineSourceId(memoryDir),

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5818,14 +5818,12 @@ async function runOfflineSyncOnce(options: {
         changeset,
       })
     : null;
-  const remoteSnapshot = pushed === null && namespaceProbe !== null
-    ? namespaceProbe
-    : await fetchOfflineSnapshot({
-        remoteUrl: options.remoteUrl,
-        token: options.token,
-        namespace: syncNamespace,
-        includeTranscripts: options.includeTranscripts,
-      });
+  const remoteSnapshot = await fetchOfflineSnapshot({
+    remoteUrl: options.remoteUrl,
+    token: options.token,
+    namespace: syncNamespace,
+    includeTranscripts: options.includeTranscripts,
+  });
   const resolvedNamespace = resolvedOfflineSnapshotNamespace(remoteSnapshot, syncNamespace);
   const pull = await applyOfflineSyncSnapshot({
     root: options.memoryDir,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5557,7 +5557,10 @@ function offlineEndpoint(
   pathname: string,
   params: Record<string, string | undefined> = {},
 ): string {
-  const url = new URL(pathname, `${remoteUrl}/`);
+  const url = new URL(remoteUrl);
+  const basePath = url.pathname.replace(/\/+$/, "");
+  const endpointPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  url.pathname = `${basePath}${endpointPath}`;
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined && value.length > 0) {
       url.searchParams.set(key, value);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -35,6 +35,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import * as childProcess from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -124,6 +125,14 @@ import {
   formatProcedureStatsText,
   parseXrayCliOptions,
   renderXray,
+  applyOfflineSyncSnapshot,
+  buildOfflineSyncChangeset,
+  buildOfflineSyncSnapshot,
+  defaultOfflineSyncStatePath,
+  offlineSyncStateFromSnapshot,
+  readOfflineSyncState,
+  summarizeOfflineSyncChangeset,
+  writeOfflineSyncState,
   buildActionConfidenceInputFromOptions,
   evaluateActionConfidence,
   renderActionConfidenceText,
@@ -330,7 +339,8 @@ type CommandName =
   | "import-lossless-claw"
   | "action-confidence"
   | "xray"
-  | "capsule";
+  | "capsule"
+  | "offline";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
 type TokenAction = "generate" | "list" | "revoke";
@@ -5497,6 +5507,347 @@ async function cmdSync(action: string, rest: string[], json: boolean): Promise<v
   }
 }
 
+function localOfflineSourceId(memoryDir: string): string {
+  const host = os.hostname() || "unknown-host";
+  const dirHash = createHash("sha256").update(path.resolve(memoryDir)).digest("hex").slice(0, 16);
+  return `remnic-local:${host}:${dirHash}`;
+}
+
+function resolveOfflineRemoteUrl(args: string[]): string {
+  const raw =
+    resolveRequiredValueFlag(args, "--remote-url") ??
+    process.env.REMNIC_OFFLINE_REMOTE_URL ??
+    process.env.ENGRAM_OFFLINE_REMOTE_URL;
+  if (!raw || raw.trim().length === 0) {
+    throw new Error(
+      "offline mode requires --remote-url <url> or REMNIC_OFFLINE_REMOTE_URL",
+    );
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    throw new Error(`invalid --remote-url: ${raw}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("--remote-url must use http:// or https://");
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function resolveOfflineToken(args: string[]): string {
+  const token =
+    resolveRequiredValueFlag(args, "--token") ??
+    process.env.REMNIC_OFFLINE_TOKEN ??
+    process.env.REMNIC_AUTH_TOKEN ??
+    process.env.ENGRAM_AUTH_TOKEN;
+  if (!token || token.trim().length === 0) {
+    throw new Error(
+      "offline mode requires --token <token>, REMNIC_OFFLINE_TOKEN, or REMNIC_AUTH_TOKEN",
+    );
+  }
+  return token.trim();
+}
+
+function offlineEndpoint(
+  remoteUrl: string,
+  pathname: string,
+  params: Record<string, string | undefined> = {},
+): string {
+  const url = new URL(pathname, `${remoteUrl}/`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value.length > 0) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
+}
+
+async function fetchOfflineJson<T>(
+  url: string,
+  token: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(init.body !== undefined ? { "content-type": "application/json" } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    let detail = "";
+    try {
+      detail = await response.text();
+    } catch {
+      detail = "";
+    }
+    throw new Error(
+      `offline sync request failed: ${response.status} ${response.statusText}${detail ? ` - ${detail.slice(0, 500)}` : ""}`,
+    );
+  }
+  return await response.json() as T;
+}
+
+async function fetchOfflineSnapshot(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+}): Promise<Awaited<ReturnType<typeof buildOfflineSyncSnapshot>> & { namespace?: string }> {
+  return fetchOfflineJson(
+    offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/snapshot", {
+      namespace: args.namespace,
+      include_transcripts: args.includeTranscripts ? "true" : "false",
+      content: "true",
+    }),
+    args.token,
+  );
+}
+
+async function pushOfflineChanges(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  changeset: Awaited<ReturnType<typeof buildOfflineSyncChangeset>>;
+}): Promise<{
+  namespace: string;
+  appliedUpserts: number;
+  appliedDeletes: number;
+  skipped: number;
+  conflicts: Array<{ path: string; reason: string; conflictPath?: string }>;
+}> {
+  return fetchOfflineJson(
+    offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/apply"),
+    args.token,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        namespace: args.namespace,
+        changeset: args.changeset,
+      }),
+    },
+  );
+}
+
+function parseOfflineIntervalMs(args: string[]): number {
+  const raw = resolveRequiredValueFlag(args, "--interval-ms");
+  if (raw === undefined) return 60_000;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1000) {
+    throw new Error("--interval-ms must be an integer >= 1000");
+  }
+  return parsed;
+}
+
+async function runOfflineSyncOnce(options: {
+  memoryDir: string;
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+  statePath: string;
+}): Promise<{
+  statePath: string;
+  prepared: boolean;
+  pushed: Awaited<ReturnType<typeof pushOfflineChanges>> | null;
+  pull: Awaited<ReturnType<typeof applyOfflineSyncSnapshot>>;
+  pendingSummary: ReturnType<typeof summarizeOfflineSyncChangeset>;
+  remoteFileCount: number;
+}> {
+  fs.mkdirSync(options.memoryDir, { recursive: true });
+  const priorState = await readOfflineSyncState(options.statePath);
+  const baseFiles = priorState?.baseFiles ?? [];
+  const changeset = await buildOfflineSyncChangeset({
+    root: options.memoryDir,
+    sourceId: localOfflineSourceId(options.memoryDir),
+    baseFiles,
+    includeTranscripts: options.includeTranscripts,
+  });
+  const pendingSummary = summarizeOfflineSyncChangeset(changeset);
+  const pushed = changeset.changes.length > 0
+    ? await pushOfflineChanges({
+        remoteUrl: options.remoteUrl,
+        token: options.token,
+        namespace: options.namespace,
+        changeset,
+      })
+    : null;
+  const remoteSnapshot = await fetchOfflineSnapshot({
+    remoteUrl: options.remoteUrl,
+    token: options.token,
+    namespace: options.namespace,
+    includeTranscripts: options.includeTranscripts,
+  });
+  const pull = await applyOfflineSyncSnapshot({
+    root: options.memoryDir,
+    snapshot: remoteSnapshot,
+    baseFiles,
+  });
+  const state = offlineSyncStateFromSnapshot({
+    remoteId: options.remoteUrl,
+    namespace: options.namespace,
+    snapshot: remoteSnapshot,
+    baseFiles: pull.nextBaseFiles,
+  });
+  await writeOfflineSyncState(options.statePath, state);
+  return {
+    statePath: options.statePath,
+    prepared: priorState === null,
+    pushed,
+    pull,
+    pendingSummary,
+    remoteFileCount: remoteSnapshot.files.length,
+  };
+}
+
+async function cmdOffline(action: string, rest: string[], json: boolean): Promise<void> {
+  if (action === "help" || action === "--help" || action === "-h" || rest.includes("--help") || rest.includes("-h")) {
+    console.log(`Usage: remnic offline <prepare|sync|status|watch> [options]
+
+Options:
+  --remote-url <url>       Remote Remnic server URL, e.g. http://home:4242
+  --token <token>          Bearer token for the remote server
+  --namespace <name>       Namespace to sync
+  --memory-dir <dir>       Local memory dir (defaults to resolved memoryDir)
+  --state <path>           Override offline sync state file
+  --no-transcripts         Exclude transcripts/ from the offline cache
+  --interval-ms <ms>       Watch interval (default 60000)
+  --json                   JSON output
+
+Environment fallbacks:
+  REMNIC_OFFLINE_REMOTE_URL, REMNIC_OFFLINE_TOKEN, REMNIC_AUTH_TOKEN`);
+    return;
+  }
+
+  const memoryDir = path.resolve(expandTilde(resolveRequiredValueFlag(rest, "--memory-dir") ?? resolveMemoryDir()));
+  const namespace = resolveRequiredValueFlag(rest, "--namespace");
+  const includeTranscripts = !hasFlag(rest, "--no-transcripts");
+  const stateOverride = resolveRequiredValueFlag(rest, "--state");
+  const needsRemote = action === "prepare" || action === "sync" || action === "watch";
+  const remoteUrl = needsRemote || stateOverride === undefined
+    ? resolveOfflineRemoteUrl(rest)
+    : undefined;
+  const token = needsRemote ? resolveOfflineToken(rest) : undefined;
+  const statePath = path.resolve(expandTilde(
+    stateOverride ??
+      defaultOfflineSyncStatePath(memoryDir, remoteUrl ?? resolveOfflineRemoteUrl(rest), namespace),
+  ));
+
+  if (action === "prepare") {
+    if (!remoteUrl || !token) throw new Error("offline prepare requires remote URL and token");
+    fs.mkdirSync(memoryDir, { recursive: true });
+    const remoteSnapshot = await fetchOfflineSnapshot({
+      remoteUrl,
+      token,
+      namespace,
+      includeTranscripts,
+    });
+    const existingState = await readOfflineSyncState(statePath);
+    const pull = await applyOfflineSyncSnapshot({
+      root: memoryDir,
+      snapshot: remoteSnapshot,
+      baseFiles: existingState?.baseFiles ?? [],
+    });
+    const state = offlineSyncStateFromSnapshot({
+      remoteId: remoteUrl,
+      namespace,
+      snapshot: remoteSnapshot,
+      baseFiles: pull.nextBaseFiles,
+    });
+    await writeOfflineSyncState(statePath, state);
+    if (json) {
+      console.log(JSON.stringify({ statePath, remoteFiles: remoteSnapshot.files.length, pull }, null, 2));
+    } else {
+      console.log(`Offline cache prepared: ${memoryDir}`);
+      console.log(`Remote files: ${remoteSnapshot.files.length}`);
+      console.log(`Pulled: ${pull.upserted} upserted, ${pull.deleted} deleted, ${pull.conflicts.length} conflicts`);
+      console.log(`State: ${statePath}`);
+    }
+    return;
+  }
+
+  if (action === "sync") {
+    if (!remoteUrl || !token) throw new Error("offline sync requires remote URL and token");
+    const result = await runOfflineSyncOnce({
+      memoryDir,
+      remoteUrl,
+      token,
+      namespace,
+      includeTranscripts,
+      statePath,
+    });
+    if (json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`Offline sync complete${result.prepared ? " (initialized state)" : ""}.`);
+      console.log(`Pushed: ${result.pushed ? `${result.pushed.appliedUpserts} upserts, ${result.pushed.appliedDeletes} deletes, ${result.pushed.conflicts.length} conflicts` : "nothing pending"}`);
+      console.log(`Pulled: ${result.pull.upserted} upserts, ${result.pull.deleted} deletes, ${result.pull.conflicts.length} conflicts`);
+      console.log(`Pending local before push: ${result.pendingSummary.total}`);
+      console.log(`State: ${result.statePath}`);
+    }
+    return;
+  }
+
+  if (action === "status") {
+    fs.mkdirSync(memoryDir, { recursive: true });
+    const state = await readOfflineSyncState(statePath);
+    const changeset = await buildOfflineSyncChangeset({
+      root: memoryDir,
+      sourceId: localOfflineSourceId(memoryDir),
+      baseFiles: state?.baseFiles ?? [],
+      includeTranscripts,
+    });
+    const summary = summarizeOfflineSyncChangeset(changeset);
+    if (json) {
+      console.log(JSON.stringify({ statePath, state, pending: summary }, null, 2));
+    } else {
+      console.log(`Offline state: ${state ? "ready" : "not prepared"}`);
+      console.log(`State: ${statePath}`);
+      if (state) console.log(`Last synced: ${state.lastSyncedAt}`);
+      console.log(`Pending local changes: ${summary.total} (${summary.upserts} upserts, ${summary.deletes} deletes)`);
+    }
+    return;
+  }
+
+  if (action === "watch") {
+    if (!remoteUrl || !token) throw new Error("offline watch requires remote URL and token");
+    const intervalMs = parseOfflineIntervalMs(rest);
+    console.log(`Watching offline sync every ${intervalMs}ms. Press Ctrl+C to stop.`);
+    let stopped = false;
+    process.once("SIGINT", () => {
+      stopped = true;
+      console.log("Stopping offline sync watcher.");
+    });
+    while (!stopped) {
+      try {
+        const result = await runOfflineSyncOnce({
+          memoryDir,
+          remoteUrl,
+          token,
+          namespace,
+          includeTranscripts,
+          statePath,
+        });
+        console.log(
+          `[${new Date().toISOString()}] sync ok: pushed=${result.pushed ? result.pushed.appliedUpserts + result.pushed.appliedDeletes : 0}, pulled=${result.pull.upserted + result.pull.deleted}, conflicts=${(result.pushed?.conflicts.length ?? 0) + result.pull.conflicts.length}`,
+        );
+      } catch (error) {
+        console.log(`[${new Date().toISOString()}] sync waiting: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    return;
+  }
+
+  console.log("Usage: remnic offline <prepare|sync|status|watch> [--remote-url <url>] [--token <token>]");
+  process.exit(1);
+}
+
 function cmdDedup(json: boolean): void {
   const memoryDir = resolveMemoryDir();
   const result = findDuplicates({ memoryDir });
@@ -8603,6 +8954,13 @@ Options:
       break;
     }
 
+    case "offline": {
+      const action = rest[0] ?? "help";
+      const json = rest.includes("--json");
+      await cmdOffline(action, rest.slice(1), json);
+      break;
+    }
+
     case "dedup": {
       const json = rest.includes("--json");
       cmdDedup(json);
@@ -8967,6 +9325,7 @@ Usage:
   remnic curate <path> [--json]  Curate files into memory
   remnic review <list|approve|dismiss|flag> [id]  Review inbox
   remnic sync <run|watch> [--source <dir>] Diff-aware sync
+  remnic offline <prepare|sync|status|watch> Remote/offline memory sync
   remnic dedup [--json]             Find duplicate memories
   remnic connectors <list|install|remove|doctor|marketplace> [id]  Manage connectors
     marketplace generate    Generate marketplace.json for Codex

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -142,6 +142,7 @@ import {
   forkCapsule,
   readForkLineage,
 } from "@remnic/core";
+import { keyring, readHeader, secureStoreDir } from "@remnic/core/secure-store";
 // @remnic/export-weclone is an optional install surface (training:export
 // only uses it). Load lazily so the CLI works without it — see
 // optional-weclone-export.ts for the install-hint behaviour.
@@ -5675,6 +5676,27 @@ function waitForOfflineInterval(
   });
 }
 
+async function createOfflineStorageIo(memoryDir: string): Promise<{
+  readFile: Parameters<typeof buildOfflineSyncChangeset>[0]["readFile"];
+  writeFile: Parameters<typeof applyOfflineSyncSnapshot>[0]["writeFile"];
+  deleteFile: Parameters<typeof applyOfflineSyncSnapshot>[0]["deleteFile"];
+}> {
+  const storage = new StorageManager(memoryDir);
+  const header = await readHeader(memoryDir);
+  if (header) {
+    storage.setSecureStoreRequired(true);
+    const key = keyring.getKey(secureStoreDir(memoryDir));
+    if (key) {
+      storage.setSecureStoreKey(key);
+    }
+  }
+  return {
+    readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
+    writeFile: async ({ filePath, content }) => storage.writeOfflineSyncFile(filePath, content),
+    deleteFile: async ({ filePath }) => storage.deleteOfflineSyncFile(filePath),
+  };
+}
+
 async function runOfflineSyncOnce(options: {
   memoryDir: string;
   remoteUrl: string;
@@ -5702,11 +5724,13 @@ async function runOfflineSyncOnce(options: {
     });
   }
   const baseFiles = priorState?.baseFiles ?? [];
+  const storageIo = await createOfflineStorageIo(options.memoryDir);
   const changeset = await buildOfflineSyncChangeset({
     root: options.memoryDir,
     sourceId: localOfflineSourceId(options.memoryDir),
     baseFiles,
     includeTranscripts: options.includeTranscripts,
+    readFile: storageIo.readFile,
   });
   const pendingSummary = summarizeOfflineSyncChangeset(changeset);
   const pushed = changeset.changes.length > 0
@@ -5727,6 +5751,9 @@ async function runOfflineSyncOnce(options: {
     root: options.memoryDir,
     snapshot: remoteSnapshot,
     baseFiles,
+    readFile: storageIo.readFile,
+    writeFile: storageIo.writeFile,
+    deleteFile: storageIo.deleteFile,
   });
   const state = offlineSyncStateFromSnapshot({
     remoteId: options.remoteUrl,
@@ -5822,10 +5849,14 @@ Environment fallbacks:
         statePath,
       });
     }
+    const storageIo = await createOfflineStorageIo(memoryDir);
     const pull = await applyOfflineSyncSnapshot({
       root: memoryDir,
       snapshot: remoteSnapshot,
       baseFiles: existingState?.baseFiles ?? [],
+      readFile: storageIo.readFile,
+      writeFile: storageIo.writeFile,
+      deleteFile: storageIo.deleteFile,
     });
     const state = offlineSyncStateFromSnapshot({
       remoteId: remoteUrl,
@@ -5879,11 +5910,13 @@ Environment fallbacks:
         statePath,
       });
     }
+    const storageIo = await createOfflineStorageIo(memoryDir);
     const changeset = await buildOfflineSyncChangeset({
       root: memoryDir,
       sourceId: localOfflineSourceId(memoryDir),
       baseFiles: state?.baseFiles ?? [],
       includeTranscripts,
+      readFile: storageIo.readFile,
     });
     const summary = summarizeOfflineSyncChangeset(changeset);
     if (json) {

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -419,6 +419,22 @@ test("HTTP offline apply requires a changeset", async () => {
     assert.equal(body.code, "validation_error");
     assert.equal(body.details?.[0]?.field, "changeset");
     assert.equal(calls, 0);
+
+    const nullResponse = await fetch(`http://127.0.0.1:${status.port}/engram/v1/offline-sync/apply`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ namespace: "team", changeset: null }),
+    });
+    const nullBody = await nullResponse.json() as { code?: string; details?: Array<{ field?: string; message?: string }> };
+
+    assert.equal(nullResponse.status, 400);
+    assert.equal(nullBody.code, "validation_error");
+    assert.equal(nullBody.details?.[0]?.field, "changeset");
+    assert.equal(nullBody.details?.[0]?.message, "changeset is required");
+    assert.equal(calls, 0);
   } finally {
     await server.stop();
   }

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -223,3 +223,203 @@ test("HTTP review show hides namespace denial as pair_not_found", async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("HTTP offline snapshot forwards namespace and transfer options", async () => {
+  const calls: Array<{
+    namespace: string | undefined;
+    principal: string | undefined;
+    includeTranscripts: boolean | undefined;
+    includeContent: boolean | undefined;
+  }> = [];
+  const service = {
+    offlineSyncSnapshot: async (options: {
+      namespace?: string;
+      principal?: string;
+      includeTranscripts?: boolean;
+      includeContent?: boolean;
+    }) => {
+      calls.push({
+        namespace: options.namespace,
+        principal: options.principal,
+        includeTranscripts: options.includeTranscripts,
+        includeContent: options.includeContent,
+      });
+      return {
+        namespace: options.namespace ?? "default",
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: new Date("2026-05-21T00:00:00Z").toISOString(),
+        sourceId: "remote:test",
+        includeTranscripts: options.includeTranscripts !== false,
+        files: [],
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/remnic/v1/offline-sync/snapshot?namespace=team&include_transcripts=false&content=false`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    const body = await response.json() as { namespace?: string; includeTranscripts?: boolean; files?: unknown[] };
+
+    assert.equal(response.status, 200);
+    assert.equal(body.namespace, "team");
+    assert.equal(body.includeTranscripts, false);
+    assert.deepEqual(body.files, []);
+    assert.deepEqual(calls, [{
+      namespace: "team",
+      principal: "reader",
+      includeTranscripts: false,
+      includeContent: false,
+    }]);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP offline snapshot rejects invalid boolean query values", async () => {
+  let calls = 0;
+  const service = {
+    offlineSyncSnapshot: async () => {
+      calls += 1;
+      return {};
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/engram/v1/offline-sync/snapshot?include_transcripts=maybe`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    const body = await response.json() as { error?: string; code?: string };
+
+    assert.equal(response.status, 400);
+    assert.match(body.error ?? "", /include_transcripts must be one of: true, false/);
+    assert.equal(body.code, "input_error");
+    assert.equal(calls, 0);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP offline apply validates and forwards changesets", async () => {
+  const calls: Array<{
+    namespace: string | undefined;
+    principal: string | undefined;
+    changeset: unknown;
+  }> = [];
+  const changeset = {
+    format: "remnic.offline-sync.changeset.v1",
+    schemaVersion: 1,
+    createdAt: new Date("2026-05-21T00:00:00Z").toISOString(),
+    sourceId: "laptop:test",
+    includeTranscripts: true,
+    changes: [],
+  };
+  const service = {
+    offlineSyncApply: async (options: {
+      namespace?: string;
+      principal?: string;
+      changeset: unknown;
+    }) => {
+      calls.push({
+        namespace: options.namespace,
+        principal: options.principal,
+        changeset: options.changeset,
+      });
+      return {
+        namespace: options.namespace ?? "default",
+        appliedUpserts: 0,
+        appliedDeletes: 0,
+        skipped: 0,
+        conflicts: [],
+        currentFiles: [],
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "writer",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/remnic/v1/offline-sync/apply`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ namespace: "team", changeset }),
+    });
+    const body = await response.json() as { namespace?: string; appliedUpserts?: number };
+
+    assert.equal(response.status, 200);
+    assert.equal(body.namespace, "team");
+    assert.equal(body.appliedUpserts, 0);
+    assert.deepEqual(calls, [{
+      namespace: "team",
+      principal: "writer",
+      changeset,
+    }]);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP offline apply requires a changeset", async () => {
+  let calls = 0;
+  const service = {
+    offlineSyncApply: async () => {
+      calls += 1;
+      return {};
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "writer",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/engram/v1/offline-sync/apply`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ namespace: "team" }),
+    });
+    const body = await response.json() as { code?: string; details?: Array<{ field?: string; message?: string }> };
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, "validation_error");
+    assert.equal(body.details?.[0]?.field, "changeset");
+    assert.equal(calls, 0);
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -588,6 +588,60 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    if (
+      req.method === "GET" &&
+      (pathname === "/engram/v1/offline-sync/snapshot" || pathname === "/remnic/v1/offline-sync/snapshot")
+    ) {
+      const includeTranscriptsRaw = parsed.searchParams.get("include_transcripts");
+      const includeContentRaw = parsed.searchParams.get("content");
+      if (
+        includeTranscriptsRaw !== null &&
+        includeTranscriptsRaw !== "true" &&
+        includeTranscriptsRaw !== "false"
+      ) {
+        throw new EngramAccessInputError(
+          `include_transcripts must be one of: true, false (got: ${includeTranscriptsRaw})`,
+        );
+      }
+      if (
+        includeContentRaw !== null &&
+        includeContentRaw !== "true" &&
+        includeContentRaw !== "false"
+      ) {
+        throw new EngramAccessInputError(
+          `content must be one of: true, false (got: ${includeContentRaw})`,
+        );
+      }
+      const namespaceParam = parsed.searchParams.get("namespace");
+      const result = await this.service.offlineSyncSnapshot({
+        namespace: this.resolveNamespace(
+          req,
+          namespaceParam && namespaceParam.length > 0 ? namespaceParam : undefined,
+        ),
+        principal: this.resolveRequestPrincipal(req),
+        includeTranscripts: includeTranscriptsRaw !== "false",
+        includeContent: includeContentRaw !== "false",
+      });
+      this.respondJson(res, 200, result);
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      (pathname === "/engram/v1/offline-sync/apply" || pathname === "/remnic/v1/offline-sync/apply")
+    ) {
+      const body = await this.readValidatedBody(req, "offlineSyncApply");
+      this.ensureWriteRateLimitAvailable();
+      const result = await this.service.offlineSyncApply({
+        namespace: this.resolveNamespace(req, body.namespace),
+        principal: this.resolveRequestPrincipal(req),
+        changeset: body.changeset,
+      });
+      this.recordWriteRateLimitHit();
+      this.respondJson(res, 200, result);
+      return;
+    }
+
     if (req.method === "POST" && pathname === "/engram/v1/recall/explain") {
       const body = await this.readValidatedBody(req, "recallExplain");
       const response = await this.service.recallExplain({

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -373,7 +373,7 @@ export const offlineSyncApplyRequestSchema = z
     namespace: namespaceSchema,
     changeset: z.unknown(),
   })
-  .refine((value) => value.changeset !== undefined, {
+  .refine((value) => value.changeset !== undefined && value.changeset !== null, {
     message: "changeset is required",
     path: ["changeset"],
   });

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -365,6 +365,20 @@ export const capsuleListRequestSchema = z
   });
 
 // ---------------------------------------------------------------------------
+// Offline sync
+// ---------------------------------------------------------------------------
+
+export const offlineSyncApplyRequestSchema = z
+  .object({
+    namespace: namespaceSchema,
+    changeset: z.unknown(),
+  })
+  .refine((value) => value.changeset !== undefined, {
+    message: "changeset is required",
+    path: ["changeset"],
+  });
+
+// ---------------------------------------------------------------------------
 // Action confidence
 // ---------------------------------------------------------------------------
 
@@ -429,6 +443,7 @@ export type DaySummaryRequest = z.infer<typeof daySummaryRequestSchema>;
 export type CapsuleExportRequest = z.infer<typeof capsuleExportRequestSchema>;
 export type CapsuleImportRequest = z.infer<typeof capsuleImportRequestSchema>;
 export type CapsuleListRequest = z.infer<typeof capsuleListRequestSchema>;
+export type OfflineSyncApplyRequest = z.infer<typeof offlineSyncApplyRequestSchema>;
 export type ActionConfidenceRequest = z.infer<typeof actionConfidenceRequestSchema>;
 
 // ---------------------------------------------------------------------------
@@ -452,6 +467,7 @@ export type SchemaName =
   | "capsuleExport"
   | "capsuleImport"
   | "capsuleList"
+  | "offlineSyncApply"
   | "actionConfidence";
 
 export type SchemaTypeFor<N extends SchemaName> =
@@ -471,6 +487,7 @@ export type SchemaTypeFor<N extends SchemaName> =
   : N extends "capsuleExport" ? CapsuleExportRequest
   : N extends "capsuleImport" ? CapsuleImportRequest
   : N extends "capsuleList" ? CapsuleListRequest
+  : N extends "offlineSyncApply" ? OfflineSyncApplyRequest
   : N extends "actionConfidence" ? ActionConfidenceRequest
   : never;
 
@@ -491,6 +508,7 @@ const schemas: Record<SchemaName, z.ZodTypeAny> = {
   capsuleExport: capsuleExportRequestSchema,
   capsuleImport: capsuleImportRequestSchema,
   capsuleList: capsuleListRequestSchema,
+  offlineSyncApply: offlineSyncApplyRequestSchema,
   actionConfidence: actionConfidenceRequestSchema,
 };
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -136,6 +136,12 @@ import {
   type CapsuleListEntry,
 } from "./capsule-cli.js";
 import {
+  applyOfflineSyncChangeset,
+  buildOfflineSyncSnapshot,
+  type OfflineSyncApplyChangesetResult,
+  type OfflineSyncSnapshot,
+} from "./offline-sync.js";
+import {
   evaluateActionConfidence,
   type ActionConfidenceInput,
   type ActionConfidenceResult,
@@ -601,6 +607,27 @@ export interface EngramAccessCapsuleListResponse {
   namespace: string;
   capsulesDir: string;
   capsules: CapsuleListEntry[];
+}
+
+export interface EngramAccessOfflineSyncSnapshotRequest {
+  namespace?: string;
+  principal?: string;
+  includeTranscripts?: boolean;
+  includeContent?: boolean;
+}
+
+export interface EngramAccessOfflineSyncApplyRequest {
+  namespace?: string;
+  principal?: string;
+  changeset: unknown;
+}
+
+export interface EngramAccessOfflineSyncSnapshotResponse extends OfflineSyncSnapshot {
+  namespace: string;
+}
+
+export interface EngramAccessOfflineSyncApplyResponse extends OfflineSyncApplyChangesetResult {
+  namespace: string;
 }
 
 export type EngramAccessActionConfidenceRequest = ActionConfidenceInput;
@@ -5520,6 +5547,51 @@ export class EngramAccessService {
     }
 
     return { namespace: resolvedNamespace, capsulesDir, capsules };
+  }
+
+  async offlineSyncSnapshot(
+    options: EngramAccessOfflineSyncSnapshotRequest = {},
+  ): Promise<EngramAccessOfflineSyncSnapshotResponse> {
+    const resolvedNamespace = this.resolveReadableNamespace(options.namespace, options.principal);
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const storageHash = createHash("sha256").update(storage.dir).digest("hex").slice(0, 16);
+    const snapshot = await buildOfflineSyncSnapshot({
+      root: storage.dir,
+      sourceId: `remnic:${resolvedNamespace}:${storageHash}`,
+      includeContent: options.includeContent !== false,
+      includeTranscripts: options.includeTranscripts !== false,
+    });
+    return {
+      namespace: resolvedNamespace,
+      ...snapshot,
+    };
+  }
+
+  async offlineSyncApply(
+    options: EngramAccessOfflineSyncApplyRequest,
+  ): Promise<EngramAccessOfflineSyncApplyResponse> {
+    const resolvedNamespace = this.resolveWritableNamespace(
+      options.namespace,
+      undefined,
+      options.principal,
+    );
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    try {
+      const result = await applyOfflineSyncChangeset({
+        root: storage.dir,
+        changeset: options.changeset,
+      });
+      return {
+        namespace: resolvedNamespace,
+        ...result,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.startsWith("offline sync")) {
+        throw new EngramAccessInputError(message);
+      }
+      throw error;
+    }
   }
 
   // ── Dreams pipeline telemetry surfaces (issue #678 PR 3+4) ──────────────

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5560,6 +5560,7 @@ export class EngramAccessService {
       sourceId: `remnic:${resolvedNamespace}:${storageHash}`,
       includeContent: options.includeContent !== false,
       includeTranscripts: options.includeTranscripts !== false,
+      readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
     });
     return {
       namespace: resolvedNamespace,
@@ -5580,6 +5581,9 @@ export class EngramAccessService {
       const result = await applyOfflineSyncChangeset({
         root: storage.dir,
         changeset: options.changeset,
+        readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
+        writeFile: async ({ filePath, content }) => storage.writeOfflineSyncFile(filePath, content),
+        deleteFile: async ({ filePath }) => storage.deleteOfflineSyncFile(filePath),
       });
       return {
         namespace: resolvedNamespace,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -701,6 +701,8 @@ export {
   type OfflineSyncConflict,
   type OfflineSyncFileRecord,
   type OfflineSyncFileState,
+  type OfflineSyncFileTarget,
+  type OfflineSyncFileWriteTarget,
   type OfflineSyncSnapshot,
   type OfflineSyncState,
 } from "./offline-sync.js";

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -675,6 +675,37 @@ export {
 } from "./sync/index.js";
 
 // ---------------------------------------------------------------------------
+// Offline Sync
+// ---------------------------------------------------------------------------
+
+export {
+  OFFLINE_SYNC_CHANGESET_FORMAT,
+  OFFLINE_SYNC_SNAPSHOT_FORMAT,
+  OFFLINE_SYNC_STATE_VERSION,
+  applyOfflineSyncChangeset,
+  applyOfflineSyncSnapshot,
+  buildOfflineSyncChangeset,
+  buildOfflineSyncSnapshot,
+  defaultOfflineSyncStatePath,
+  fileStatesFromSnapshot,
+  normalizeOfflineSyncChangeset,
+  normalizeOfflineSyncSnapshot,
+  offlineSyncStateFromSnapshot,
+  readOfflineSyncState,
+  summarizeOfflineSyncChangeset,
+  writeOfflineSyncState,
+  type OfflineSyncApplyChangesetResult,
+  type OfflineSyncApplySnapshotResult,
+  type OfflineSyncChange,
+  type OfflineSyncChangeset,
+  type OfflineSyncConflict,
+  type OfflineSyncFileRecord,
+  type OfflineSyncFileState,
+  type OfflineSyncSnapshot,
+  type OfflineSyncState,
+} from "./offline-sync.js";
+
+// ---------------------------------------------------------------------------
 // Memory Extension Host (#382)
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -316,6 +316,44 @@ test("offline snapshot rejects transcript records when transcripts are excluded"
   }
 });
 
+test("offline payloads require explicit includeTranscripts booleans", async () => {
+  const root = await tempDir("remnic-offline-include-transcripts-invalid");
+  try {
+    await assert.rejects(
+      () =>
+        applyOfflineSyncSnapshot({
+          root,
+          snapshot: {
+            format: "remnic.offline-sync.snapshot.v1",
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "remote",
+            files: [],
+          },
+        }),
+      /includeTranscripts must be a boolean/,
+    );
+
+    await assert.rejects(
+      () =>
+        applyOfflineSyncChangeset({
+          root,
+          changeset: {
+            format: "remnic.offline-sync.changeset.v1",
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "laptop",
+            includeTranscripts: "false",
+            changes: [],
+          },
+        }),
+      /includeTranscripts must be a boolean/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline payloads reject excluded internal paths", async () => {
   const root = await tempDir("remnic-offline-internal-path-invalid");
   try {

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -35,6 +35,8 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
     await write(root, "assets/blob.bin", Buffer.from([0, 1, 2, 255]));
     await write(root, ".secure-store/header.json", "secret");
     await write(root, ".offline-sync/state/local.json", "state");
+    await write(root, "state/fact-hashes.txt", "derived");
+    await write(root, "state/fact-hashes.ready", "v1");
 
     const snapshot = await buildOfflineSyncSnapshot({
       root,
@@ -323,6 +325,47 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
       "secret fact",
     );
     assert.equal(snapshot.files[0]?.bytes, Buffer.byteLength("secret fact"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(source, { recursive: true, force: true });
+  }
+});
+
+test("offline storage writes invalidate fact hash readiness for rebuild", async () => {
+  const root = await tempDir("remnic-offline-hash-index-local");
+  const source = await tempDir("remnic-offline-hash-index-source");
+  try {
+    const localStorage = new StorageManager(root);
+    await localStorage.writeMemory("fact", "alpha fact");
+    assert.equal(await localStorage.hasFactContentHash("alpha fact"), true);
+    assert.equal(await localStorage.hasFactContentHash("beta fact"), false);
+
+    const sourceStorage = new StorageManager(source);
+    await sourceStorage.writeMemory("fact", "beta fact");
+    const sourceChangeset = await buildOfflineSyncChangeset({
+      root: source,
+      sourceId: "remote",
+    });
+
+    assert.equal(
+      sourceChangeset.changes.some((change) => change.path.startsWith("state/fact-hashes")),
+      false,
+    );
+
+    const factChangeset = {
+      ...sourceChangeset,
+      changes: sourceChangeset.changes.filter((change) => change.path.startsWith("facts/")),
+    };
+    const apply = await applyOfflineSyncChangeset({
+      root,
+      changeset: factChangeset,
+      readFile: async ({ filePath }) => localStorage.readOfflineSyncFile(filePath),
+      writeFile: async ({ filePath, content }) => localStorage.writeOfflineSyncFile(filePath, content),
+      deleteFile: async ({ filePath }) => localStorage.deleteOfflineSyncFile(filePath),
+    });
+
+    assert.equal(apply.conflicts.length, 0);
+    assert.equal(await localStorage.hasFactContentHash("beta fact"), true);
   } finally {
     await rm(root, { recursive: true, force: true });
     await rm(source, { recursive: true, force: true });

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -285,6 +285,92 @@ test("offline changeset rejects transcript changes when transcripts are excluded
   }
 });
 
+test("offline snapshot rejects transcript records when transcripts are excluded", async () => {
+  const root = await tempDir("remnic-offline-snapshot-transcript-invalid");
+  try {
+    const transcript = Buffer.from("turn");
+    await assert.rejects(
+      () =>
+        applyOfflineSyncSnapshot({
+          root,
+          snapshot: {
+            format: "remnic.offline-sync.snapshot.v1",
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "remote",
+            includeTranscripts: false,
+            files: [{
+              path: "transcripts/session.jsonl",
+              sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+              bytes: transcript.byteLength,
+              mtimeMs: 0,
+              contentBase64: transcript.toString("base64"),
+            }],
+          },
+        }),
+      /offline sync snapshot includeTranscripts is false but contains transcript path/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline payloads reject excluded internal paths", async () => {
+  const root = await tempDir("remnic-offline-internal-path-invalid");
+  try {
+    const header = Buffer.from("secret");
+    await assert.rejects(
+      () =>
+        applyOfflineSyncSnapshot({
+          root,
+          snapshot: {
+            format: "remnic.offline-sync.snapshot.v1",
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "remote",
+            includeTranscripts: true,
+            files: [{
+              path: ".secure-store/header.json",
+              sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+              bytes: header.byteLength,
+              mtimeMs: 0,
+              contentBase64: header.toString("base64"),
+            }],
+          },
+        }),
+      /offline sync snapshot contains excluded path: \.secure-store\/header\.json/,
+    );
+
+    await assert.rejects(
+      () =>
+        applyOfflineSyncChangeset({
+          root,
+          changeset: {
+            format: "remnic.offline-sync.changeset.v1",
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "laptop",
+            includeTranscripts: true,
+            changes: [{
+              type: "upsert",
+              path: ".secure-store/header.json",
+              file: {
+                path: ".secure-store/header.json",
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+                bytes: header.byteLength,
+                mtimeMs: 0,
+                contentBase64: header.toString("base64"),
+              },
+            }],
+          },
+        }),
+      /offline sync changeset contains excluded path: \.secure-store\/header\.json/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline sync applies and snapshots through secure storage hooks", async () => {
   const root = await tempDir("remnic-offline-secure-store");
   const source = await tempDir("remnic-offline-secure-source");

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -31,6 +31,7 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
   const root = await tempDir("remnic-offline-snapshot");
   try {
     await write(root, "facts/a.md", "alpha");
+    await write(root, "facts/fact-hashes.txt", "user-authored memory file");
     await write(root, "transcripts/session.jsonl", "turn");
     await write(root, "assets/blob.bin", Buffer.from([0, 1, 2, 255]));
     await write(root, ".secure-store/header.json", "secret");
@@ -46,7 +47,7 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
 
     assert.deepEqual(
       snapshot.files.map((file) => file.path),
-      ["assets/blob.bin", "facts/a.md", "transcripts/session.jsonl"],
+      ["assets/blob.bin", "facts/a.md", "facts/fact-hashes.txt", "transcripts/session.jsonl"],
     );
     const binary = snapshot.files.find((file) => file.path === "assets/blob.bin");
     assert.equal(Buffer.from(binary?.contentBase64 ?? "", "base64")[3], 255);
@@ -59,7 +60,7 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
     });
     assert.deepEqual(
       withoutTranscripts.files.map((file) => file.path),
-      ["assets/blob.bin", "facts/a.md"],
+      ["assets/blob.bin", "facts/a.md", "facts/fact-hashes.txt"],
     );
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -10,6 +10,8 @@ import {
   buildOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
 } from "./offline-sync.js";
+import { isEncryptedFile } from "./secure-store/secure-fs.js";
+import { StorageManager } from "./storage.js";
 
 async function tempDir(name: string): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), `${name}-`));
@@ -218,6 +220,77 @@ test("offline pull applies remote deletion when the local file is unchanged", as
   } finally {
     await rm(remote, { recursive: true, force: true });
     await rm(local, { recursive: true, force: true });
+  }
+});
+
+test("offline changeset does not delete transcript baselines when transcripts are excluded", async () => {
+  const root = await tempDir("remnic-offline-transcript-mode");
+  try {
+    await write(root, "facts/a.md", "alpha");
+    await write(root, "transcripts/session.jsonl", "turn");
+    const base = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "remote",
+      includeContent: true,
+    });
+
+    await rm(path.join(root, "transcripts"), { recursive: true, force: true });
+    const changeset = await buildOfflineSyncChangeset({
+      root,
+      sourceId: "laptop",
+      baseFiles: base.files,
+      includeTranscripts: false,
+    });
+
+    assert.deepEqual(changeset.changes, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline sync applies and snapshots through secure storage hooks", async () => {
+  const root = await tempDir("remnic-offline-secure-store");
+  const source = await tempDir("remnic-offline-secure-source");
+  try {
+    await write(source, "facts/secure.md", "secret fact");
+    const changeset = await buildOfflineSyncChangeset({
+      root: source,
+      sourceId: "laptop",
+    });
+    const storage = new StorageManager(root);
+    storage.setSecureStoreKey(Buffer.alloc(32, 7));
+    storage.setSecureStoreRequired(true);
+
+    const apply = await applyOfflineSyncChangeset({
+      root,
+      changeset,
+      readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
+      writeFile: async ({ filePath, content }) => storage.writeOfflineSyncFile(filePath, content),
+      deleteFile: async ({ filePath }) => storage.deleteOfflineSyncFile(filePath),
+    });
+
+    assert.equal(apply.appliedUpserts, 1);
+    const raw = await readFile(path.join(root, "facts", "secure.md"));
+    assert.equal(isEncryptedFile(raw), true);
+    assert.equal(
+      (await storage.readOfflineSyncFile(path.join(root, "facts", "secure.md"))).toString("utf8"),
+      "secret fact",
+    );
+
+    const snapshot = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "remote",
+      includeContent: true,
+      readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
+    });
+    assert.equal(
+      Buffer.from(snapshot.files[0]?.contentBase64 ?? "", "base64").toString("utf8"),
+      "secret fact",
+    );
+    assert.equal(snapshot.files[0]?.bytes, Buffer.byteLength("secret fact"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(source, { recursive: true, force: true });
   }
 });
 

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -1,0 +1,245 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  applyOfflineSyncChangeset,
+  applyOfflineSyncSnapshot,
+  buildOfflineSyncChangeset,
+  buildOfflineSyncSnapshot,
+} from "./offline-sync.js";
+
+async function tempDir(name: string): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), `${name}-`));
+}
+
+async function write(root: string, relPath: string, content: string | Buffer): Promise<void> {
+  const filePath = path.join(root, relPath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content);
+}
+
+async function readUtf8(root: string, relPath: string): Promise<string> {
+  return readFile(path.join(root, relPath), "utf-8");
+}
+
+test("offline snapshot captures source-of-truth files and excludes private/internal paths", async () => {
+  const root = await tempDir("remnic-offline-snapshot");
+  try {
+    await write(root, "facts/a.md", "alpha");
+    await write(root, "transcripts/session.jsonl", "turn");
+    await write(root, "assets/blob.bin", Buffer.from([0, 1, 2, 255]));
+    await write(root, ".secure-store/header.json", "secret");
+    await write(root, ".offline-sync/state/local.json", "state");
+
+    const snapshot = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "remote",
+      includeContent: true,
+    });
+
+    assert.deepEqual(
+      snapshot.files.map((file) => file.path),
+      ["assets/blob.bin", "facts/a.md", "transcripts/session.jsonl"],
+    );
+    const binary = snapshot.files.find((file) => file.path === "assets/blob.bin");
+    assert.equal(Buffer.from(binary?.contentBase64 ?? "", "base64")[3], 255);
+
+    const withoutTranscripts = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "remote",
+      includeContent: false,
+      includeTranscripts: false,
+    });
+    assert.deepEqual(
+      withoutTranscripts.files.map((file) => file.path),
+      ["assets/blob.bin", "facts/a.md"],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline changeset pushes local edits when the remote is still at the shared base", async () => {
+  const remote = await tempDir("remnic-offline-remote");
+  const local = await tempDir("remnic-offline-local");
+  try {
+    await write(remote, "facts/base.md", "base");
+    const initial = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: true,
+    });
+    const pull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: initial,
+    });
+
+    await write(local, "facts/base.md", "base plus local");
+    await write(local, "facts/local-only.md", "new local fact");
+    const changeset = await buildOfflineSyncChangeset({
+      root: local,
+      sourceId: "laptop",
+      baseFiles: pull.nextBaseFiles,
+    });
+
+    assert.equal(changeset.changes.length, 2);
+    const push = await applyOfflineSyncChangeset({
+      root: remote,
+      changeset,
+    });
+
+    assert.equal(push.appliedUpserts, 2);
+    assert.equal(push.conflicts.length, 0);
+    assert.equal(await readUtf8(remote, "facts/base.md"), "base plus local");
+    assert.equal(await readUtf8(remote, "facts/local-only.md"), "new local fact");
+  } finally {
+    await rm(remote, { recursive: true, force: true });
+    await rm(local, { recursive: true, force: true });
+  }
+});
+
+test("offline pull preserves local edits when both sides changed since the base", async () => {
+  const remote = await tempDir("remnic-offline-conflict-remote");
+  const local = await tempDir("remnic-offline-conflict-local");
+  try {
+    await write(remote, "facts/shared.md", "base");
+    const initial = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: true,
+    });
+    const firstPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: initial,
+    });
+
+    await write(local, "facts/shared.md", "local edit");
+    await write(remote, "facts/shared.md", "remote edit");
+    const remoteSnapshot = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: true,
+    });
+
+    const secondPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: remoteSnapshot,
+      baseFiles: firstPull.nextBaseFiles,
+    });
+
+    assert.equal(secondPull.conflicts.length, 1);
+    assert.equal(secondPull.conflicts[0]?.reason, "both_modified");
+    assert.equal(await readUtf8(local, "facts/shared.md"), "local edit");
+    const conflictPath = secondPull.conflicts[0]?.conflictPath;
+    assert.ok(conflictPath);
+    assert.equal(await readUtf8(local, conflictPath), "remote edit");
+  } finally {
+    await rm(remote, { recursive: true, force: true });
+    await rm(local, { recursive: true, force: true });
+  }
+});
+
+test("offline push preserves remote edits when both sides changed since the base", async () => {
+  const remote = await tempDir("remnic-offline-push-conflict-remote");
+  const local = await tempDir("remnic-offline-push-conflict-local");
+  try {
+    await write(remote, "facts/shared.md", "base");
+    const initial = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: true,
+    });
+    const firstPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: initial,
+    });
+
+    await write(local, "facts/shared.md", "local edit");
+    await write(remote, "facts/shared.md", "remote edit");
+    const changeset = await buildOfflineSyncChangeset({
+      root: local,
+      sourceId: "laptop",
+      baseFiles: firstPull.nextBaseFiles,
+    });
+
+    const push = await applyOfflineSyncChangeset({
+      root: remote,
+      changeset,
+    });
+
+    assert.equal(push.appliedUpserts, 0);
+    assert.equal(push.conflicts.length, 1);
+    assert.equal(push.conflicts[0]?.reason, "remote_changed_for_local_update");
+    assert.equal(await readUtf8(remote, "facts/shared.md"), "remote edit");
+    const conflictPath = push.conflicts[0]?.conflictPath;
+    assert.ok(conflictPath);
+    assert.equal(await readUtf8(remote, conflictPath), "local edit");
+  } finally {
+    await rm(remote, { recursive: true, force: true });
+    await rm(local, { recursive: true, force: true });
+  }
+});
+
+test("offline pull applies remote deletion when the local file is unchanged", async () => {
+  const remote = await tempDir("remnic-offline-delete-remote");
+  const local = await tempDir("remnic-offline-delete-local");
+  try {
+    await write(remote, "facts/deleted.md", "soon gone");
+    const initial = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: true,
+    });
+    const firstPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: initial,
+    });
+
+    await rm(path.join(remote, "facts/deleted.md"), { force: true });
+    const remoteSnapshot = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: true,
+    });
+    const secondPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: remoteSnapshot,
+      baseFiles: firstPull.nextBaseFiles,
+    });
+
+    assert.equal(secondPull.deleted, 1);
+    await assert.rejects(
+      () => readFile(path.join(local, "facts/deleted.md")),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(remote, { recursive: true, force: true });
+    await rm(local, { recursive: true, force: true });
+  }
+});
+
+test("offline changeset validation reports client input errors with an offline sync prefix", async () => {
+  const root = await tempDir("remnic-offline-invalid-changeset");
+  try {
+    await assert.rejects(
+      () =>
+        applyOfflineSyncChangeset({
+          root,
+          changeset: {
+            format: "remnic.offline-sync.changeset.v1",
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "laptop",
+            includeTranscripts: true,
+            changes: [{ type: "delete", path: "../escape", baseSha256: "nope" }],
+          },
+        }),
+      /offline sync changeset invalid:/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -248,6 +248,41 @@ test("offline changeset does not delete transcript baselines when transcripts ar
   }
 });
 
+test("offline changeset rejects transcript changes when transcripts are excluded", async () => {
+  const root = await tempDir("remnic-offline-transcript-invalid");
+  try {
+    await write(root, "facts/a.md", "alpha");
+    const transcript = Buffer.from("turn");
+    await assert.rejects(
+      () =>
+        applyOfflineSyncChangeset({
+          root,
+          changeset: {
+            format: "remnic.offline-sync.changeset.v1",
+            schemaVersion: 1,
+            createdAt: new Date().toISOString(),
+            sourceId: "laptop",
+            includeTranscripts: false,
+            changes: [{
+              type: "upsert",
+              path: "transcripts/session.jsonl",
+              file: {
+                path: "transcripts/session.jsonl",
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+                bytes: transcript.byteLength,
+                mtimeMs: 0,
+                contentBase64: transcript.toString("base64"),
+              },
+            }],
+          },
+        }),
+      /offline sync changeset includeTranscripts is false but contains transcript path/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline sync applies and snapshots through secure storage hooks", async () => {
   const root = await tempDir("remnic-offline-secure-store");
   const source = await tempDir("remnic-offline-secure-source");

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -312,6 +312,14 @@ export function normalizeOfflineSyncChangeset(input: unknown): OfflineSyncChange
     throw new Error(`changes[${index}].type must be "upsert" or "delete"`);
   });
   assertUniquePaths(changes, "offline sync changeset");
+  if (!includeTranscripts) {
+    const transcriptPath = changes.find((change) => change.path.split("/")[0] === "transcripts")?.path;
+    if (transcriptPath) {
+      throw new Error(
+        `offline sync changeset includeTranscripts is false but contains transcript path: ${transcriptPath}`,
+      );
+    }
+  }
   return {
     format: OFFLINE_SYNC_CHANGESET_FORMAT,
     schemaVersion: 1,

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -1,0 +1,921 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import {
+  DEFAULT_TRANSFER_EXCLUDE_DIRS,
+} from "./transfer/exclusions.js";
+import {
+  fromPosixRelPath,
+  prepareSafeArchiveRoot,
+  resolveSafeArchiveTarget,
+  sha256Bytes,
+  validateArchiveRelativePath,
+  type SafeArchiveRoot,
+} from "./transfer/fs-utils.js";
+import { parseFlexibleIsoTimestamp } from "./utils/iso-timestamp.js";
+
+export const OFFLINE_SYNC_SNAPSHOT_FORMAT = "remnic.offline-sync.snapshot.v1";
+export const OFFLINE_SYNC_CHANGESET_FORMAT = "remnic.offline-sync.changeset.v1";
+export const OFFLINE_SYNC_STATE_VERSION = 1;
+
+export interface OfflineSyncFileState {
+  path: string;
+  sha256: string;
+  bytes: number;
+  mtimeMs: number;
+}
+
+export interface OfflineSyncFileRecord extends OfflineSyncFileState {
+  contentBase64?: string;
+}
+
+export interface OfflineSyncSnapshot {
+  format: typeof OFFLINE_SYNC_SNAPSHOT_FORMAT;
+  schemaVersion: 1;
+  createdAt: string;
+  sourceId: string;
+  includeTranscripts: boolean;
+  files: OfflineSyncFileRecord[];
+}
+
+export type OfflineSyncChange =
+  | {
+      type: "upsert";
+      path: string;
+      baseSha256?: string;
+      file: OfflineSyncFileRecord & { contentBase64: string };
+    }
+  | {
+      type: "delete";
+      path: string;
+      baseSha256: string;
+    };
+
+export interface OfflineSyncChangeset {
+  format: typeof OFFLINE_SYNC_CHANGESET_FORMAT;
+  schemaVersion: 1;
+  createdAt: string;
+  sourceId: string;
+  includeTranscripts: boolean;
+  changes: OfflineSyncChange[];
+}
+
+export interface OfflineSyncState {
+  version: typeof OFFLINE_SYNC_STATE_VERSION;
+  remoteId: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+  lastSyncedAt: string;
+  baseFiles: OfflineSyncFileState[];
+}
+
+export interface OfflineSyncConflict {
+  path: string;
+  reason:
+    | "both_modified"
+    | "local_deleted_remote_modified"
+    | "local_modified_remote_deleted"
+    | "remote_exists_for_local_create"
+    | "remote_changed_for_local_update"
+    | "remote_deleted_for_local_update"
+    | "remote_changed_for_local_delete";
+  baseSha256?: string;
+  localSha256?: string;
+  incomingSha256?: string;
+  conflictPath?: string;
+}
+
+export interface OfflineSyncApplySnapshotResult {
+  upserted: number;
+  deleted: number;
+  skipped: number;
+  pendingLocal: number;
+  conflicts: OfflineSyncConflict[];
+  nextBaseFiles: OfflineSyncFileState[];
+}
+
+export interface OfflineSyncApplyChangesetResult {
+  appliedUpserts: number;
+  appliedDeletes: number;
+  skipped: number;
+  conflicts: OfflineSyncConflict[];
+  currentFiles: OfflineSyncFileState[];
+}
+
+export interface OfflineSyncChangesetSummary {
+  upserts: number;
+  deletes: number;
+  total: number;
+}
+
+const SYNC_INTERNAL_DIR = ".offline-sync";
+const EXCLUDED_FILE_NAMES = new Set([
+  ".sync-state.json",
+]);
+
+const EXCLUDED_FILE_PREFIXES = [
+  ".remnic-sync.",
+  ".remnic-sync-state.",
+];
+
+function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function sha256Buffer(buffer: Buffer): { sha256: string; bytes: number } {
+  return sha256Bytes(buffer);
+}
+
+function compareByPath<T extends { path: string }>(left: T, right: T): number {
+  return left.path.localeCompare(right.path);
+}
+
+function assertSha256(value: unknown, field: string): string {
+  if (typeof value !== "string" || !/^[a-f0-9]{64}$/i.test(value)) {
+    throw new Error(`${field} must be a 64-character sha256 hex string`);
+  }
+  return value.toLowerCase();
+}
+
+function assertNonNegativeInteger(value: unknown, field: string): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function assertNonNegativeFinite(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative finite number`);
+  }
+  return value;
+}
+
+function normalizeSourceId(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0 || value.length > 512) {
+    throw new Error(`${field} must be a non-empty string no longer than 512 characters`);
+  }
+  return value.trim();
+}
+
+function normalizeFileState(input: unknown, fieldPrefix: string): OfflineSyncFileState {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`${fieldPrefix} must be an object`);
+  }
+  const obj = input as Record<string, unknown>;
+  const relPath = normalizeRelativePath(obj.path, `${fieldPrefix}.path`);
+  return {
+    path: relPath,
+    sha256: assertSha256(obj.sha256, `${fieldPrefix}.sha256`),
+    bytes: assertNonNegativeInteger(obj.bytes, `${fieldPrefix}.bytes`),
+    mtimeMs: assertNonNegativeFinite(obj.mtimeMs, `${fieldPrefix}.mtimeMs`),
+  };
+}
+
+function normalizeFileRecord(
+  input: unknown,
+  fieldPrefix: string,
+  requireContent: boolean,
+): OfflineSyncFileRecord {
+  const state = normalizeFileState(input, fieldPrefix);
+  const obj = input as Record<string, unknown>;
+  const contentBase64 = obj.contentBase64;
+  if (requireContent && typeof contentBase64 !== "string") {
+    throw new Error(`${fieldPrefix}.contentBase64 is required`);
+  }
+  if (contentBase64 !== undefined && typeof contentBase64 !== "string") {
+    throw new Error(`${fieldPrefix}.contentBase64 must be a base64 string`);
+  }
+  return {
+    ...state,
+    ...(contentBase64 !== undefined ? { contentBase64 } : {}),
+  };
+}
+
+function normalizeFileStates(input: readonly unknown[] | undefined): OfflineSyncFileState[] {
+  if (!input) return [];
+  if (!Array.isArray(input)) {
+    throw new Error("baseFiles must be an array");
+  }
+  return input.map((entry, index) => normalizeFileState(entry, `baseFiles[${index}]`));
+}
+
+export function normalizeOfflineSyncSnapshot(
+  input: unknown,
+  options: { requireContent?: boolean } = {},
+): OfflineSyncSnapshot {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("offline sync snapshot must be an object");
+  }
+  const obj = input as Record<string, unknown>;
+  if (obj.format !== OFFLINE_SYNC_SNAPSHOT_FORMAT) {
+    throw new Error(`offline sync snapshot format must be ${OFFLINE_SYNC_SNAPSHOT_FORMAT}`);
+  }
+  if (obj.schemaVersion !== 1) {
+    throw new Error("offline sync snapshot schemaVersion must be 1");
+  }
+  const createdAt = normalizeIsoString(obj.createdAt, "createdAt");
+  const sourceId = normalizeSourceId(obj.sourceId, "sourceId");
+  const includeTranscripts = obj.includeTranscripts === true;
+  if (!Array.isArray(obj.files)) {
+    throw new Error("offline sync snapshot files must be an array");
+  }
+  const files = obj.files
+    .map((entry, index) =>
+      normalizeFileRecord(entry, `files[${index}]`, options.requireContent === true))
+    .sort(compareByPath);
+  assertUniquePaths(files, "offline sync snapshot");
+  return {
+    format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
+    schemaVersion: 1,
+    createdAt,
+    sourceId,
+    includeTranscripts,
+    files,
+  };
+}
+
+export function normalizeOfflineSyncChangeset(input: unknown): OfflineSyncChangeset {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("offline sync changeset must be an object");
+  }
+  const obj = input as Record<string, unknown>;
+  if (obj.format !== OFFLINE_SYNC_CHANGESET_FORMAT) {
+    throw new Error(`offline sync changeset format must be ${OFFLINE_SYNC_CHANGESET_FORMAT}`);
+  }
+  if (obj.schemaVersion !== 1) {
+    throw new Error("offline sync changeset schemaVersion must be 1");
+  }
+  const createdAt = normalizeIsoString(obj.createdAt, "createdAt");
+  const sourceId = normalizeSourceId(obj.sourceId, "sourceId");
+  const includeTranscripts = obj.includeTranscripts === true;
+  if (!Array.isArray(obj.changes)) {
+    throw new Error("offline sync changeset changes must be an array");
+  }
+  const changes = obj.changes.map((entry, index): OfflineSyncChange => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`changes[${index}] must be an object`);
+    }
+    const change = entry as Record<string, unknown>;
+    const type = change.type;
+    const relPath = normalizeRelativePath(change.path, `changes[${index}].path`);
+    if (type === "upsert") {
+      const file = normalizeFileRecord(
+        change.file,
+        `changes[${index}].file`,
+        true,
+      ) as OfflineSyncFileRecord & { contentBase64: string };
+      if (file.path !== relPath) {
+        throw new Error(`changes[${index}].file.path must match changes[${index}].path`);
+      }
+      const baseSha256 =
+        change.baseSha256 === undefined
+          ? undefined
+          : assertSha256(change.baseSha256, `changes[${index}].baseSha256`);
+      return {
+        type: "upsert",
+        path: relPath,
+        ...(baseSha256 ? { baseSha256 } : {}),
+        file,
+      };
+    }
+    if (type === "delete") {
+      return {
+        type: "delete",
+        path: relPath,
+        baseSha256: assertSha256(change.baseSha256, `changes[${index}].baseSha256`),
+      };
+    }
+    throw new Error(`changes[${index}].type must be "upsert" or "delete"`);
+  });
+  assertUniquePaths(changes, "offline sync changeset");
+  return {
+    format: OFFLINE_SYNC_CHANGESET_FORMAT,
+    schemaVersion: 1,
+    createdAt,
+    sourceId,
+    includeTranscripts,
+    changes: changes.sort(compareByPath),
+  };
+}
+
+function normalizeIsoString(input: unknown, field: string): string {
+  if (typeof input !== "string" || input.trim().length === 0) {
+    throw new Error(`${field} must be an ISO timestamp string`);
+  }
+  const parsed = parseFlexibleIsoTimestamp(input.trim());
+  if (parsed === null) {
+    throw new Error(`${field} must be a parseable ISO timestamp`);
+  }
+  return new Date(parsed).toISOString();
+}
+
+function normalizeRelativePath(input: unknown, field: string): string {
+  if (typeof input !== "string") {
+    throw new Error(`${field} must be a POSIX relative path string`);
+  }
+  return validateArchiveRelativePath(input, field);
+}
+
+function assertUniquePaths(entries: readonly { path: string }[], context: string): void {
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const key = entry.path.toLowerCase();
+    if (seen.has(key)) {
+      throw new Error(`${context} contains duplicate path: ${entry.path}`);
+    }
+    seen.add(key);
+  }
+}
+
+function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): boolean {
+  const parts = relPosix.split("/");
+  if (parts.some((part) => DEFAULT_TRANSFER_EXCLUDE_DIRS.has(part))) return true;
+  if (parts.some((part) => part === SYNC_INTERNAL_DIR)) return true;
+  if (!includeTranscripts && parts[0] === "transcripts") return true;
+  const basename = parts[parts.length - 1] ?? "";
+  if (EXCLUDED_FILE_NAMES.has(basename)) return true;
+  return EXCLUDED_FILE_PREFIXES.some((prefix) => basename.startsWith(prefix));
+}
+
+export async function buildOfflineSyncSnapshot(options: {
+  root: string;
+  sourceId: string;
+  includeContent?: boolean;
+  includeTranscripts?: boolean;
+  now?: Date;
+}): Promise<OfflineSyncSnapshot> {
+  const rootAbs = path.resolve(options.root);
+  const root = await prepareSafeArchiveRoot(rootAbs, "buildOfflineSyncSnapshot", "root");
+  const includeTranscripts = options.includeTranscripts !== false;
+  const files: OfflineSyncFileRecord[] = [];
+
+  async function walk(dirAbs: string): Promise<void> {
+    let entries = await readdir(dirAbs, { withFileTypes: true });
+    entries = entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const abs = path.join(dirAbs, entry.name);
+      const relPosix = path.relative(root.abs, abs).split(path.sep).join("/");
+      if (shouldExcludeRelPath(relPosix, includeTranscripts)) continue;
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        await walk(abs);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const bytes = await readFile(abs);
+      const digest = sha256Buffer(bytes);
+      const st = await stat(abs);
+      files.push({
+        path: validateArchiveRelativePath(relPosix, "buildOfflineSyncSnapshot"),
+        sha256: digest.sha256,
+        bytes: digest.bytes,
+        mtimeMs: st.mtimeMs,
+        ...(options.includeContent === true ? { contentBase64: bytes.toString("base64") } : {}),
+      });
+    }
+  }
+
+  await walk(root.abs);
+
+  return {
+    format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
+    schemaVersion: 1,
+    createdAt: (options.now ?? new Date()).toISOString(),
+    sourceId: normalizeSourceId(options.sourceId, "sourceId"),
+    includeTranscripts,
+    files: files.sort(compareByPath),
+  };
+}
+
+export async function buildOfflineSyncChangeset(options: {
+  root: string;
+  sourceId: string;
+  baseFiles?: readonly OfflineSyncFileState[];
+  includeTranscripts?: boolean;
+  now?: Date;
+}): Promise<OfflineSyncChangeset> {
+  const base = byPath(normalizeFileStates(options.baseFiles));
+  const current = await buildOfflineSyncSnapshot({
+    root: options.root,
+    sourceId: options.sourceId,
+    includeContent: true,
+    includeTranscripts: options.includeTranscripts,
+    now: options.now,
+  });
+  const currentMap = byPath(current.files);
+  const changes: OfflineSyncChange[] = [];
+
+  for (const relPath of unionPaths(base, currentMap)) {
+    const baseEntry = base.get(relPath);
+    const currentEntry = currentMap.get(relPath);
+    if (currentEntry && currentEntry.sha256 !== baseEntry?.sha256) {
+      changes.push({
+        type: "upsert",
+        path: relPath,
+        ...(baseEntry ? { baseSha256: baseEntry.sha256 } : {}),
+        file: currentEntry as OfflineSyncFileRecord & { contentBase64: string },
+      });
+      continue;
+    }
+    if (!currentEntry && baseEntry) {
+      changes.push({
+        type: "delete",
+        path: relPath,
+        baseSha256: baseEntry.sha256,
+      });
+    }
+  }
+
+  return {
+    format: OFFLINE_SYNC_CHANGESET_FORMAT,
+    schemaVersion: 1,
+    createdAt: (options.now ?? new Date()).toISOString(),
+    sourceId: normalizeSourceId(options.sourceId, "sourceId"),
+    includeTranscripts: current.includeTranscripts,
+    changes: changes.sort(compareByPath),
+  };
+}
+
+export function summarizeOfflineSyncChangeset(
+  changeset: OfflineSyncChangeset,
+): OfflineSyncChangesetSummary {
+  const upserts = changeset.changes.filter((change) => change.type === "upsert").length;
+  const deletes = changeset.changes.filter((change) => change.type === "delete").length;
+  return {
+    upserts,
+    deletes,
+    total: changeset.changes.length,
+  };
+}
+
+export async function applyOfflineSyncSnapshot(options: {
+  root: string;
+  snapshot: unknown;
+  baseFiles?: readonly OfflineSyncFileState[];
+  writeConflictCopies?: boolean;
+}): Promise<OfflineSyncApplySnapshotResult> {
+  const snapshot = normalizeOfflineSyncSnapshot(options.snapshot, { requireContent: true });
+  const baseMap = byPath(normalizeFileStates(options.baseFiles));
+  const incomingMap = byPath(snapshot.files);
+  const incomingBuffers = verifyRecordContents(snapshot.files, "offline sync snapshot");
+  const root = await ensureSyncRoot(options.root, "applyOfflineSyncSnapshot");
+  const current = await buildOfflineSyncSnapshot({
+    root: root.abs,
+    sourceId: "local",
+    includeContent: false,
+    includeTranscripts: snapshot.includeTranscripts,
+  });
+  const currentMap = byPath(current.files);
+  const nextBase = new Map(baseMap);
+  const conflicts: OfflineSyncConflict[] = [];
+  let upserted = 0;
+  let deleted = 0;
+  let skipped = 0;
+  let pendingLocal = 0;
+
+  for (const relPath of unionPaths(baseMap, incomingMap, currentMap)) {
+    const base = baseMap.get(relPath);
+    const incoming = incomingMap.get(relPath);
+    const currentEntry = currentMap.get(relPath);
+
+    if (incoming) {
+      if (currentEntry?.sha256 === incoming.sha256) {
+        nextBase.set(relPath, toFileState(incoming));
+        skipped += 1;
+        continue;
+      }
+      if (!currentEntry && base && incoming.sha256 === base.sha256) {
+        nextBase.set(relPath, base);
+        pendingLocal += 1;
+        skipped += 1;
+        continue;
+      }
+      if (!currentEntry && base && incoming.sha256 !== base.sha256) {
+        conflicts.push(await recordConflict({
+          root,
+          relPath,
+          reason: "local_deleted_remote_modified",
+          baseSha256: base.sha256,
+          incomingSha256: incoming.sha256,
+          incomingBuffer: incomingBuffers.get(relPath),
+          writeConflictCopies: options.writeConflictCopies !== false,
+          sourceId: snapshot.sourceId,
+        }));
+        nextBase.set(relPath, base);
+        continue;
+      }
+      if (!currentEntry && !base) {
+        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath));
+        nextBase.set(relPath, toFileState(incoming));
+        upserted += 1;
+        continue;
+      }
+      if (base && currentEntry && currentEntry.sha256 === base.sha256) {
+        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath));
+        nextBase.set(relPath, toFileState(incoming));
+        upserted += 1;
+        continue;
+      }
+      if (base && incoming.sha256 === base.sha256) {
+        nextBase.set(relPath, base);
+        pendingLocal += 1;
+        skipped += 1;
+        continue;
+      }
+      conflicts.push(await recordConflict({
+        root,
+        relPath,
+        reason: base ? "both_modified" : "remote_exists_for_local_create",
+        baseSha256: base?.sha256,
+        localSha256: currentEntry?.sha256,
+        incomingSha256: incoming.sha256,
+        incomingBuffer: incomingBuffers.get(relPath),
+        writeConflictCopies: options.writeConflictCopies !== false,
+        sourceId: snapshot.sourceId,
+      }));
+      if (base) nextBase.set(relPath, base);
+      continue;
+    }
+
+    if (!currentEntry) {
+      nextBase.delete(relPath);
+      skipped += 1;
+      continue;
+    }
+    if (base && currentEntry.sha256 === base.sha256) {
+      await deleteSafeFile(root, relPath);
+      nextBase.delete(relPath);
+      deleted += 1;
+      continue;
+    }
+    if (base) {
+      conflicts.push({
+        path: relPath,
+        reason: "local_modified_remote_deleted",
+        baseSha256: base.sha256,
+        localSha256: currentEntry.sha256,
+      });
+      nextBase.set(relPath, base);
+      continue;
+    }
+    pendingLocal += 1;
+    skipped += 1;
+  }
+
+  return {
+    upserted,
+    deleted,
+    skipped,
+    pendingLocal,
+    conflicts,
+    nextBaseFiles: [...nextBase.values()].sort(compareByPath),
+  };
+}
+
+export async function applyOfflineSyncChangeset(options: {
+  root: string;
+  changeset: unknown;
+  writeConflictCopies?: boolean;
+}): Promise<OfflineSyncApplyChangesetResult> {
+  let changeset: OfflineSyncChangeset;
+  try {
+    changeset = normalizeOfflineSyncChangeset(options.changeset);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      message.startsWith("offline sync")
+        ? message
+        : `offline sync changeset invalid: ${message}`,
+    );
+  }
+  const root = await ensureSyncRoot(options.root, "applyOfflineSyncChangeset");
+  const records = changeset.changes
+    .filter((change): change is Extract<OfflineSyncChange, { type: "upsert" }> => change.type === "upsert")
+    .map((change) => change.file);
+  const incomingBuffers = verifyRecordContents(records, "offline sync changeset");
+  const current = await buildOfflineSyncSnapshot({
+    root: root.abs,
+    sourceId: "local",
+    includeContent: false,
+    includeTranscripts: changeset.includeTranscripts,
+  });
+  const currentMap = byPath(current.files);
+  const conflicts: OfflineSyncConflict[] = [];
+  let appliedUpserts = 0;
+  let appliedDeletes = 0;
+  let skipped = 0;
+
+  for (const change of changeset.changes) {
+    const currentEntry = currentMap.get(change.path);
+    if (change.type === "upsert") {
+      if (currentEntry?.sha256 === change.file.sha256) {
+        skipped += 1;
+        continue;
+      }
+      if (!change.baseSha256) {
+        if (!currentEntry) {
+          await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path));
+          currentMap.set(change.path, toFileState(change.file));
+          appliedUpserts += 1;
+          continue;
+        }
+        conflicts.push(await recordConflict({
+          root,
+          relPath: change.path,
+          reason: "remote_exists_for_local_create",
+          localSha256: currentEntry.sha256,
+          incomingSha256: change.file.sha256,
+          incomingBuffer: incomingBuffers.get(change.path),
+          writeConflictCopies: options.writeConflictCopies !== false,
+          sourceId: changeset.sourceId,
+        }));
+        continue;
+      }
+      if (currentEntry?.sha256 === change.baseSha256) {
+        await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path));
+        currentMap.set(change.path, toFileState(change.file));
+        appliedUpserts += 1;
+        continue;
+      }
+      conflicts.push(await recordConflict({
+        root,
+        relPath: change.path,
+        reason: currentEntry ? "remote_changed_for_local_update" : "remote_deleted_for_local_update",
+        baseSha256: change.baseSha256,
+        localSha256: currentEntry?.sha256,
+        incomingSha256: change.file.sha256,
+        incomingBuffer: incomingBuffers.get(change.path),
+        writeConflictCopies: options.writeConflictCopies !== false,
+        sourceId: changeset.sourceId,
+      }));
+      continue;
+    }
+
+    if (!currentEntry) {
+      skipped += 1;
+      continue;
+    }
+    if (currentEntry.sha256 === change.baseSha256) {
+      await deleteSafeFile(root, change.path);
+      currentMap.delete(change.path);
+      appliedDeletes += 1;
+      continue;
+    }
+    conflicts.push({
+      path: change.path,
+      reason: "remote_changed_for_local_delete",
+      baseSha256: change.baseSha256,
+      localSha256: currentEntry.sha256,
+    });
+  }
+
+  return {
+    appliedUpserts,
+    appliedDeletes,
+    skipped,
+    conflicts,
+    currentFiles: [...currentMap.values()].sort(compareByPath),
+  };
+}
+
+function verifyRecordContents(
+  records: readonly OfflineSyncFileRecord[],
+  context: string,
+): Map<string, Buffer> {
+  const buffers = new Map<string, Buffer>();
+  for (const record of records) {
+    if (typeof record.contentBase64 !== "string") {
+      throw new Error(`${context}: contentBase64 is required for ${record.path}`);
+    }
+    const buffer = Buffer.from(record.contentBase64, "base64");
+    const digest = sha256Buffer(buffer);
+    if (digest.sha256 !== record.sha256 || digest.bytes !== record.bytes) {
+      throw new Error(
+        `${context}: content checksum mismatch for ${record.path}`,
+      );
+    }
+    buffers.set(record.path, buffer);
+  }
+  return buffers;
+}
+
+function requiredBuffer(buffers: Map<string, Buffer>, relPath: string): Buffer {
+  const buffer = buffers.get(relPath);
+  if (!buffer) {
+    throw new Error(`missing decoded content for ${relPath}`);
+  }
+  return buffer;
+}
+
+async function ensureSyncRoot(rootPath: string, errorPrefix: string): Promise<SafeArchiveRoot> {
+  const rootAbs = path.resolve(rootPath);
+  await mkdir(rootAbs, { recursive: true });
+  return prepareSafeArchiveRoot(rootAbs, errorPrefix, "root");
+}
+
+function byPath<T extends OfflineSyncFileState>(files: readonly T[]): Map<string, T> {
+  const out = new Map<string, T>();
+  for (const file of files) {
+    out.set(validateArchiveRelativePath(file.path, "offlineSync"), file);
+  }
+  return out;
+}
+
+function unionPaths(...maps: Array<Map<string, unknown>>): string[] {
+  const paths = new Set<string>();
+  for (const map of maps) {
+    for (const key of map.keys()) paths.add(key);
+  }
+  return [...paths].sort();
+}
+
+function toFileState(file: OfflineSyncFileState): OfflineSyncFileState {
+  return {
+    path: file.path,
+    sha256: file.sha256,
+    bytes: file.bytes,
+    mtimeMs: file.mtimeMs,
+  };
+}
+
+async function writeSafeFile(
+  root: SafeArchiveRoot,
+  relPath: string,
+  content: Buffer,
+): Promise<void> {
+  const target = await resolveSafeArchiveTarget(root, relPath);
+  await mkdir(path.dirname(target), { recursive: true });
+  const tmp = path.join(
+    path.dirname(target),
+    `.remnic-sync.${process.pid}.${randomUUID()}.tmp`,
+  );
+  await writeFile(tmp, content);
+  try {
+    const targetStat = await lstat(target).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    });
+    if (targetStat?.isSymbolicLink()) {
+      throw new Error(`offline sync target is a symlink: ${relPath}`);
+    }
+    await rename(tmp, target);
+  } catch (error) {
+    await unlink(tmp).catch(() => {});
+    throw error;
+  }
+}
+
+async function deleteSafeFile(root: SafeArchiveRoot, relPath: string): Promise<void> {
+  const target = await resolveSafeArchiveTarget(root, relPath);
+  await unlink(target).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  });
+}
+
+async function recordConflict(options: {
+  root: SafeArchiveRoot;
+  relPath: string;
+  reason: OfflineSyncConflict["reason"];
+  baseSha256?: string;
+  localSha256?: string;
+  incomingSha256?: string;
+  incomingBuffer?: Buffer;
+  writeConflictCopies: boolean;
+  sourceId: string;
+}): Promise<OfflineSyncConflict> {
+  let conflictPath: string | undefined;
+  if (options.writeConflictCopies && options.incomingBuffer) {
+    const sourceHash = hashText(options.sourceId).slice(0, 12);
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    conflictPath = `${SYNC_INTERNAL_DIR}/conflicts/${stamp}-${sourceHash}/${options.relPath}`;
+    await writeSafeFile(options.root, conflictPath, options.incomingBuffer);
+  }
+  return {
+    path: options.relPath,
+    reason: options.reason,
+    baseSha256: options.baseSha256,
+    localSha256: options.localSha256,
+    incomingSha256: options.incomingSha256,
+    ...(conflictPath ? { conflictPath } : {}),
+  };
+}
+
+export function defaultOfflineSyncStatePath(
+  memoryDir: string,
+  remoteId: string,
+  namespace?: string,
+): string {
+  const key = hashText(`${remoteId}\0${namespace ?? ""}`).slice(0, 16);
+  return path.join(path.resolve(memoryDir), SYNC_INTERNAL_DIR, "state", `${key}.json`);
+}
+
+export async function readOfflineSyncState(
+  statePath: string,
+): Promise<OfflineSyncState | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path.resolve(statePath), "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  const parsed = JSON.parse(raw) as unknown;
+  return normalizeOfflineSyncState(parsed);
+}
+
+export async function writeOfflineSyncState(
+  statePath: string,
+  state: OfflineSyncState,
+): Promise<void> {
+  const normalized = normalizeOfflineSyncState(state);
+  const target = path.resolve(statePath);
+  await mkdir(path.dirname(target), { recursive: true });
+  const tmp = path.join(
+    path.dirname(target),
+    `.remnic-sync-state.${process.pid}.${randomUUID()}.tmp`,
+  );
+  await writeFile(tmp, JSON.stringify(normalized, null, 2) + "\n", "utf-8");
+  try {
+    await rename(tmp, target);
+  } catch (error) {
+    await unlink(tmp).catch(() => {});
+    throw error;
+  }
+}
+
+export function offlineSyncStateFromSnapshot(options: {
+  remoteId: string;
+  namespace?: string;
+  snapshot: OfflineSyncSnapshot;
+  baseFiles?: readonly OfflineSyncFileState[];
+}): OfflineSyncState {
+  const snapshot = normalizeOfflineSyncSnapshot(options.snapshot);
+  return normalizeOfflineSyncState({
+    version: OFFLINE_SYNC_STATE_VERSION,
+    remoteId: options.remoteId,
+    namespace: options.namespace,
+    includeTranscripts: snapshot.includeTranscripts,
+    lastSyncedAt: new Date().toISOString(),
+    baseFiles: options.baseFiles ?? snapshot.files.map(toFileState),
+  });
+}
+
+export function normalizeOfflineSyncState(input: unknown): OfflineSyncState {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("offline sync state must be an object");
+  }
+  const obj = input as Record<string, unknown>;
+  if (obj.version !== OFFLINE_SYNC_STATE_VERSION) {
+    throw new Error(`offline sync state version must be ${OFFLINE_SYNC_STATE_VERSION}`);
+  }
+  const namespace =
+    typeof obj.namespace === "string" && obj.namespace.trim().length > 0
+      ? obj.namespace.trim()
+      : undefined;
+  const baseFiles = normalizeFileStates(obj.baseFiles as readonly unknown[] | undefined)
+    .sort(compareByPath);
+  assertUniquePaths(baseFiles, "offline sync state");
+  return {
+    version: OFFLINE_SYNC_STATE_VERSION,
+    remoteId: normalizeSourceId(obj.remoteId, "remoteId"),
+    ...(namespace ? { namespace } : {}),
+    includeTranscripts: obj.includeTranscripts === true,
+    lastSyncedAt: normalizeIsoString(obj.lastSyncedAt, "lastSyncedAt"),
+    baseFiles,
+  };
+}
+
+export function fileStatesFromSnapshot(snapshot: OfflineSyncSnapshot): OfflineSyncFileState[] {
+  return normalizeOfflineSyncSnapshot(snapshot).files.map(toFileState).sort(compareByPath);
+}
+
+export async function readOfflineSyncFileIfExists(root: string, relPath: string): Promise<Buffer | null> {
+  const safeRoot = await prepareSafeArchiveRoot(path.resolve(root), "readOfflineSyncFileIfExists", "root");
+  const target = await resolveSafeArchiveTarget(safeRoot, relPath);
+  try {
+    return await readFile(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+export function fromOfflineSyncPosixPath(root: string, relPath: string): string {
+  return path.resolve(path.resolve(root), fromPosixRelPath(validateArchiveRelativePath(relPath, "fromOfflineSyncPosixPath")));
+}

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -250,6 +250,18 @@ export function normalizeOfflineSyncSnapshot(
       normalizeFileRecord(entry, `files[${index}]`, options.requireContent === true))
     .sort(compareByPath);
   assertUniquePaths(files, "offline sync snapshot");
+  if (!includeTranscripts) {
+    const transcriptPath = files.find((file) => file.path.split("/")[0] === "transcripts")?.path;
+    if (transcriptPath) {
+      throw new Error(
+        `offline sync snapshot includeTranscripts is false but contains transcript path: ${transcriptPath}`,
+      );
+    }
+  }
+  const excludedPath = files.find((file) => shouldExcludeRelPath(file.path, true))?.path;
+  if (excludedPath) {
+    throw new Error(`offline sync snapshot contains excluded path: ${excludedPath}`);
+  }
   return {
     format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
     schemaVersion: 1,
@@ -321,6 +333,10 @@ export function normalizeOfflineSyncChangeset(input: unknown): OfflineSyncChange
         `offline sync changeset includeTranscripts is false but contains transcript path: ${transcriptPath}`,
       );
     }
+  }
+  const excludedPath = changes.find((change) => shouldExcludeRelPath(change.path, true))?.path;
+  if (excludedPath) {
+    throw new Error(`offline sync changeset contains excluded path: ${excludedPath}`);
   }
   return {
     format: OFFLINE_SYNC_CHANGESET_FORMAT,

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -129,6 +129,8 @@ export interface OfflineSyncFileWriteTarget extends OfflineSyncFileTarget {
 const SYNC_INTERNAL_DIR = ".offline-sync";
 const EXCLUDED_FILE_NAMES = new Set([
   ".sync-state.json",
+  "fact-hashes.ready",
+  "fact-hashes.txt",
 ]);
 
 const EXCLUDED_FILE_PREFIXES = [

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -29,6 +29,7 @@ export const OFFLINE_SYNC_STATE_VERSION = 1;
 export interface OfflineSyncFileState {
   path: string;
   sha256: string;
+  /** Byte length of the transferable content, after any readFile hook such as secure-store decryption. */
   bytes: number;
   mtimeMs: number;
 }
@@ -129,8 +130,11 @@ export interface OfflineSyncFileWriteTarget extends OfflineSyncFileTarget {
 const SYNC_INTERNAL_DIR = ".offline-sync";
 const EXCLUDED_FILE_NAMES = new Set([
   ".sync-state.json",
-  "fact-hashes.ready",
-  "fact-hashes.txt",
+]);
+
+const EXCLUDED_REL_PATHS = new Set([
+  "state/fact-hashes.ready",
+  "state/fact-hashes.txt",
 ]);
 
 const EXCLUDED_FILE_PREFIXES = [
@@ -381,6 +385,7 @@ function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): bo
   const parts = relPosix.split("/");
   if (parts.some((part) => DEFAULT_TRANSFER_EXCLUDE_DIRS.has(part))) return true;
   if (parts.some((part) => part === SYNC_INTERNAL_DIR)) return true;
+  if (EXCLUDED_REL_PATHS.has(relPosix)) return true;
   if (!includeTranscripts && parts[0] === "transcripts") return true;
   const basename = parts[parts.length - 1] ?? "";
   if (EXCLUDED_FILE_NAMES.has(basename)) return true;

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -14,7 +14,6 @@ import {
   DEFAULT_TRANSFER_EXCLUDE_DIRS,
 } from "./transfer/exclusions.js";
 import {
-  fromPosixRelPath,
   prepareSafeArchiveRoot,
   resolveSafeArchiveTarget,
   sha256Bytes,
@@ -903,19 +902,4 @@ export function normalizeOfflineSyncState(input: unknown): OfflineSyncState {
 
 export function fileStatesFromSnapshot(snapshot: OfflineSyncSnapshot): OfflineSyncFileState[] {
   return normalizeOfflineSyncSnapshot(snapshot).files.map(toFileState).sort(compareByPath);
-}
-
-export async function readOfflineSyncFileIfExists(root: string, relPath: string): Promise<Buffer | null> {
-  const safeRoot = await prepareSafeArchiveRoot(path.resolve(root), "readOfflineSyncFileIfExists", "root");
-  const target = await resolveSafeArchiveTarget(safeRoot, relPath);
-  try {
-    return await readFile(target);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw error;
-  }
-}
-
-export function fromOfflineSyncPosixPath(root: string, relPath: string): string {
-  return path.resolve(path.resolve(root), fromPosixRelPath(validateArchiveRelativePath(relPath, "fromOfflineSyncPosixPath")));
 }

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -116,6 +116,16 @@ export interface OfflineSyncChangesetSummary {
   total: number;
 }
 
+export interface OfflineSyncFileTarget {
+  root: string;
+  path: string;
+  filePath: string;
+}
+
+export interface OfflineSyncFileWriteTarget extends OfflineSyncFileTarget {
+  content: Buffer;
+}
+
 const SYNC_INTERNAL_DIR = ".offline-sync";
 const EXCLUDED_FILE_NAMES = new Set([
   ".sync-state.json",
@@ -351,12 +361,20 @@ function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): bo
   return EXCLUDED_FILE_PREFIXES.some((prefix) => basename.startsWith(prefix));
 }
 
+function filterBaseFilesForMode(
+  files: readonly OfflineSyncFileState[],
+  includeTranscripts: boolean,
+): OfflineSyncFileState[] {
+  return files.filter((file) => !shouldExcludeRelPath(file.path, includeTranscripts));
+}
+
 export async function buildOfflineSyncSnapshot(options: {
   root: string;
   sourceId: string;
   includeContent?: boolean;
   includeTranscripts?: boolean;
   now?: Date;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
 }): Promise<OfflineSyncSnapshot> {
   const rootAbs = path.resolve(options.root);
   const root = await prepareSafeArchiveRoot(rootAbs, "buildOfflineSyncSnapshot", "root");
@@ -376,7 +394,9 @@ export async function buildOfflineSyncSnapshot(options: {
         continue;
       }
       if (!entry.isFile()) continue;
-      const bytes = await readFile(abs);
+      const bytes = options.readFile
+        ? await options.readFile({ root: root.abs, path: relPosix, filePath: abs })
+        : await readFile(abs);
       const digest = sha256Buffer(bytes);
       const st = await stat(abs);
       files.push({
@@ -407,14 +427,20 @@ export async function buildOfflineSyncChangeset(options: {
   baseFiles?: readonly OfflineSyncFileState[];
   includeTranscripts?: boolean;
   now?: Date;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
 }): Promise<OfflineSyncChangeset> {
-  const base = byPath(normalizeFileStates(options.baseFiles));
+  const includeTranscripts = options.includeTranscripts !== false;
+  const base = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.baseFiles),
+    includeTranscripts,
+  ));
   const current = await buildOfflineSyncSnapshot({
     root: options.root,
     sourceId: options.sourceId,
     includeContent: true,
-    includeTranscripts: options.includeTranscripts,
+    includeTranscripts,
     now: options.now,
+    readFile: options.readFile,
   });
   const currentMap = byPath(current.files);
   const changes: OfflineSyncChange[] = [];
@@ -467,9 +493,15 @@ export async function applyOfflineSyncSnapshot(options: {
   snapshot: unknown;
   baseFiles?: readonly OfflineSyncFileState[];
   writeConflictCopies?: boolean;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
+  writeFile?: (target: OfflineSyncFileWriteTarget) => Promise<void>;
+  deleteFile?: (target: OfflineSyncFileTarget) => Promise<void>;
 }): Promise<OfflineSyncApplySnapshotResult> {
   const snapshot = normalizeOfflineSyncSnapshot(options.snapshot, { requireContent: true });
-  const baseMap = byPath(normalizeFileStates(options.baseFiles));
+  const baseMap = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.baseFiles),
+    snapshot.includeTranscripts,
+  ));
   const incomingMap = byPath(snapshot.files);
   const incomingBuffers = verifyRecordContents(snapshot.files, "offline sync snapshot");
   const root = await ensureSyncRoot(options.root, "applyOfflineSyncSnapshot");
@@ -478,6 +510,7 @@ export async function applyOfflineSyncSnapshot(options: {
     sourceId: "local",
     includeContent: false,
     includeTranscripts: snapshot.includeTranscripts,
+    readFile: options.readFile,
   });
   const currentMap = byPath(current.files);
   const nextBase = new Map(baseMap);
@@ -514,18 +547,19 @@ export async function applyOfflineSyncSnapshot(options: {
           incomingBuffer: incomingBuffers.get(relPath),
           writeConflictCopies: options.writeConflictCopies !== false,
           sourceId: snapshot.sourceId,
+          writeFile: options.writeFile,
         }));
         nextBase.set(relPath, base);
         continue;
       }
       if (!currentEntry && !base) {
-        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath));
+        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath), options.writeFile);
         nextBase.set(relPath, toFileState(incoming));
         upserted += 1;
         continue;
       }
       if (base && currentEntry && currentEntry.sha256 === base.sha256) {
-        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath));
+        await writeSafeFile(root, relPath, requiredBuffer(incomingBuffers, relPath), options.writeFile);
         nextBase.set(relPath, toFileState(incoming));
         upserted += 1;
         continue;
@@ -546,6 +580,7 @@ export async function applyOfflineSyncSnapshot(options: {
         incomingBuffer: incomingBuffers.get(relPath),
         writeConflictCopies: options.writeConflictCopies !== false,
         sourceId: snapshot.sourceId,
+        writeFile: options.writeFile,
       }));
       if (base) nextBase.set(relPath, base);
       continue;
@@ -557,7 +592,7 @@ export async function applyOfflineSyncSnapshot(options: {
       continue;
     }
     if (base && currentEntry.sha256 === base.sha256) {
-      await deleteSafeFile(root, relPath);
+      await deleteSafeFile(root, relPath, options.deleteFile);
       nextBase.delete(relPath);
       deleted += 1;
       continue;
@@ -590,6 +625,9 @@ export async function applyOfflineSyncChangeset(options: {
   root: string;
   changeset: unknown;
   writeConflictCopies?: boolean;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
+  writeFile?: (target: OfflineSyncFileWriteTarget) => Promise<void>;
+  deleteFile?: (target: OfflineSyncFileTarget) => Promise<void>;
 }): Promise<OfflineSyncApplyChangesetResult> {
   let changeset: OfflineSyncChangeset;
   try {
@@ -612,6 +650,7 @@ export async function applyOfflineSyncChangeset(options: {
     sourceId: "local",
     includeContent: false,
     includeTranscripts: changeset.includeTranscripts,
+    readFile: options.readFile,
   });
   const currentMap = byPath(current.files);
   const conflicts: OfflineSyncConflict[] = [];
@@ -628,7 +667,7 @@ export async function applyOfflineSyncChangeset(options: {
       }
       if (!change.baseSha256) {
         if (!currentEntry) {
-          await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path));
+          await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path), options.writeFile);
           currentMap.set(change.path, toFileState(change.file));
           appliedUpserts += 1;
           continue;
@@ -642,11 +681,12 @@ export async function applyOfflineSyncChangeset(options: {
           incomingBuffer: incomingBuffers.get(change.path),
           writeConflictCopies: options.writeConflictCopies !== false,
           sourceId: changeset.sourceId,
+          writeFile: options.writeFile,
         }));
         continue;
       }
       if (currentEntry?.sha256 === change.baseSha256) {
-        await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path));
+        await writeSafeFile(root, change.path, requiredBuffer(incomingBuffers, change.path), options.writeFile);
         currentMap.set(change.path, toFileState(change.file));
         appliedUpserts += 1;
         continue;
@@ -661,6 +701,7 @@ export async function applyOfflineSyncChangeset(options: {
         incomingBuffer: incomingBuffers.get(change.path),
         writeConflictCopies: options.writeConflictCopies !== false,
         sourceId: changeset.sourceId,
+        writeFile: options.writeFile,
       }));
       continue;
     }
@@ -670,7 +711,7 @@ export async function applyOfflineSyncChangeset(options: {
       continue;
     }
     if (currentEntry.sha256 === change.baseSha256) {
-      await deleteSafeFile(root, change.path);
+      await deleteSafeFile(root, change.path, options.deleteFile);
       currentMap.delete(change.path);
       appliedDeletes += 1;
       continue;
@@ -756,8 +797,13 @@ async function writeSafeFile(
   root: SafeArchiveRoot,
   relPath: string,
   content: Buffer,
+  writeFileHook?: (target: OfflineSyncFileWriteTarget) => Promise<void>,
 ): Promise<void> {
   const target = await resolveSafeArchiveTarget(root, relPath);
+  if (writeFileHook) {
+    await writeFileHook({ root: root.abs, path: relPath, filePath: target, content });
+    return;
+  }
   await mkdir(path.dirname(target), { recursive: true });
   const tmp = path.join(
     path.dirname(target),
@@ -779,8 +825,16 @@ async function writeSafeFile(
   }
 }
 
-async function deleteSafeFile(root: SafeArchiveRoot, relPath: string): Promise<void> {
+async function deleteSafeFile(
+  root: SafeArchiveRoot,
+  relPath: string,
+  deleteFile?: (target: OfflineSyncFileTarget) => Promise<void>,
+): Promise<void> {
   const target = await resolveSafeArchiveTarget(root, relPath);
+  if (deleteFile) {
+    await deleteFile({ root: root.abs, path: relPath, filePath: target });
+    return;
+  }
   await unlink(target).catch((error: unknown) => {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
     throw error;
@@ -797,13 +851,14 @@ async function recordConflict(options: {
   incomingBuffer?: Buffer;
   writeConflictCopies: boolean;
   sourceId: string;
+  writeFile?: (target: OfflineSyncFileWriteTarget) => Promise<void>;
 }): Promise<OfflineSyncConflict> {
   let conflictPath: string | undefined;
   if (options.writeConflictCopies && options.incomingBuffer) {
     const sourceHash = hashText(options.sourceId).slice(0, 12);
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
     conflictPath = `${SYNC_INTERNAL_DIR}/conflicts/${stamp}-${sourceHash}/${options.relPath}`;
-    await writeSafeFile(options.root, conflictPath, options.incomingBuffer);
+    await writeSafeFile(options.root, conflictPath, options.incomingBuffer, options.writeFile);
   }
   return {
     path: options.relPath,

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -180,6 +180,13 @@ function assertNonNegativeFinite(value: unknown, field: string): number {
   return value;
 }
 
+function assertBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${field} must be a boolean`);
+  }
+  return value;
+}
+
 function normalizeSourceId(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim().length === 0 || value.length > 512) {
     throw new Error(`${field} must be a non-empty string no longer than 512 characters`);
@@ -245,7 +252,7 @@ export function normalizeOfflineSyncSnapshot(
   }
   const createdAt = normalizeIsoString(obj.createdAt, "createdAt");
   const sourceId = normalizeSourceId(obj.sourceId, "sourceId");
-  const includeTranscripts = obj.includeTranscripts === true;
+  const includeTranscripts = assertBoolean(obj.includeTranscripts, "includeTranscripts");
   if (!Array.isArray(obj.files)) {
     throw new Error("offline sync snapshot files must be an array");
   }
@@ -289,7 +296,7 @@ export function normalizeOfflineSyncChangeset(input: unknown): OfflineSyncChange
   }
   const createdAt = normalizeIsoString(obj.createdAt, "createdAt");
   const sourceId = normalizeSourceId(obj.sourceId, "sourceId");
-  const includeTranscripts = obj.includeTranscripts === true;
+  const includeTranscripts = assertBoolean(obj.includeTranscripts, "includeTranscripts");
   if (!Array.isArray(obj.changes)) {
     throw new Error("offline sync changeset changes must be an array");
   }
@@ -980,7 +987,7 @@ export function normalizeOfflineSyncState(input: unknown): OfflineSyncState {
     version: OFFLINE_SYNC_STATE_VERSION,
     remoteId: normalizeSourceId(obj.remoteId, "remoteId"),
     ...(namespace ? { namespace } : {}),
-    includeTranscripts: obj.includeTranscripts === true,
+    includeTranscripts: assertBoolean(obj.includeTranscripts, "includeTranscripts"),
     lastSyncedAt: normalizeIsoString(obj.lastSyncedAt, "lastSyncedAt"),
     baseFiles,
   };

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -204,15 +204,15 @@ export function filePathAad(filePath: string, memoryDir?: string): Buffer {
  * @param key       32-byte AES-256 key, or null when the store is locked.
  * @param memoryDir Memory root for path-bound AAD.  Should be absolute.
  */
-export async function readMaybeEncryptedFile(
+export async function readMaybeEncryptedFileBuffer(
   filePath: string,
   key: Buffer | null,
   memoryDir?: string,
-): Promise<string> {
+): Promise<Buffer> {
   const buf = await readFile(filePath);
   if (!isEncryptedFile(buf)) {
-    // Plain UTF-8 file — legacy or unencrypted store.
-    return buf.toString("utf8");
+    // Plain file — legacy or unencrypted store.
+    return buf;
   }
   // Encrypted — key required.
   if (key === null) {
@@ -222,8 +222,15 @@ export async function readMaybeEncryptedFile(
     );
   }
   const aad = filePathAad(filePath, memoryDir);
-  const plain = decryptFileBody(buf, key, aad);
-  return plain.toString("utf8");
+  return decryptFileBody(buf, key, aad);
+}
+
+export async function readMaybeEncryptedFile(
+  filePath: string,
+  key: Buffer | null,
+  memoryDir?: string,
+): Promise<string> {
+  return (await readMaybeEncryptedFileBuffer(filePath, key, memoryDir)).toString("utf8");
 }
 
 export interface WriteMaybeEncryptedFileOptions {
@@ -251,7 +258,7 @@ export interface WriteMaybeEncryptedFileOptions {
  */
 export async function writeMaybeEncryptedFile(
   filePath: string,
-  content: string,
+  content: string | Buffer,
   key: Buffer | null,
   options: WriteMaybeEncryptedFileOptions = {},
   memoryDir?: string,

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2512,6 +2512,8 @@ export class StorageManager {
 
   private invalidateAfterOfflineSyncMutation(filePath: string): void {
     this.invalidateAllMemoriesCache();
+    invalidateCachedEntities(this.baseDir);
+    this.invalidateKnowledgeIndexCache();
     if (filePath.includes(`${path.sep}cold${path.sep}`)) {
       this.invalidateColdMemoriesCache();
     }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -11,6 +11,7 @@ import { createVersion as createPageVersion, type VersioningConfig, type Version
 import {
   SecureStoreLockedError,
   isEncryptedFile,
+  readMaybeEncryptedFileBuffer,
   readMaybeEncryptedFile,
   writeMaybeEncryptedFile,
 } from "./secure-store/secure-fs.js";
@@ -2478,6 +2479,48 @@ export class StorageManager {
   private writeStorageSecureFile(filePath: string, content: string): Promise<void> {
     return writeMaybeEncryptedFile(filePath, content, this.resolveWriteKey(), {}, this.baseDir);
   }
+
+  private assertManagedStoragePath(filePath: string, method: string): string {
+    const resolved = path.resolve(filePath);
+    const base = path.resolve(this.baseDir);
+    const rel = path.relative(base, resolved);
+    if (rel === "" || rel === ".." || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+      throw new Error(`${method}: file path escapes memory dir`);
+    }
+    return resolved;
+  }
+
+  async readOfflineSyncFile(filePath: string): Promise<Buffer> {
+    const target = this.assertManagedStoragePath(filePath, "storage.readOfflineSyncFile");
+    return readMaybeEncryptedFileBuffer(target, this._secureStoreKey, this.baseDir);
+  }
+
+  async writeOfflineSyncFile(filePath: string, content: Buffer): Promise<void> {
+    const target = this.assertManagedStoragePath(filePath, "storage.writeOfflineSyncFile");
+    await writeMaybeEncryptedFile(target, content, this.resolveWriteKey(), {}, this.baseDir);
+    this.invalidateAfterOfflineSyncMutation(target);
+  }
+
+  async deleteOfflineSyncFile(filePath: string): Promise<void> {
+    const target = this.assertManagedStoragePath(filePath, "storage.deleteOfflineSyncFile");
+    await unlink(target).catch((error: unknown) => {
+      if (isErrnoCode(error, "ENOENT")) return;
+      throw error;
+    });
+    this.invalidateAfterOfflineSyncMutation(target);
+  }
+
+  private invalidateAfterOfflineSyncMutation(filePath: string): void {
+    this.invalidateAllMemoriesCache();
+    if (filePath.includes(`${path.sep}cold${path.sep}`)) {
+      this.invalidateColdMemoriesCache();
+    }
+    if (filePath.includes(`${path.sep}artifacts${path.sep}`)) {
+      this.bumpArtifactWriteVersion();
+    }
+    this.bumpMemoryStatusVersion();
+  }
+
   createContentHashIndex(): ContentHashIndex {
     return new ContentHashIndex(
       this.stateDir,

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1059,6 +1059,14 @@ export class ContentHashIndex {
     return this.hashes.size;
   }
 
+  /** Clear all loaded hashes so the next save rewrites the index from scratch. */
+  clear(): void {
+    if (this.hashes.size > 0) {
+      this.hashes.clear();
+    }
+    this.dirty = true;
+  }
+
   /** Persist index to disk if changed. */
   async save(): Promise<void> {
     if (!this.dirty) return;
@@ -2498,7 +2506,7 @@ export class StorageManager {
   async writeOfflineSyncFile(filePath: string, content: Buffer): Promise<void> {
     const target = this.assertManagedStoragePath(filePath, "storage.writeOfflineSyncFile");
     await writeMaybeEncryptedFile(target, content, this.resolveWriteKey(), {}, this.baseDir);
-    this.invalidateAfterOfflineSyncMutation(target);
+    await this.invalidateAfterOfflineSyncMutation(target);
   }
 
   async deleteOfflineSyncFile(filePath: string): Promise<void> {
@@ -2507,13 +2515,18 @@ export class StorageManager {
       if (isErrnoCode(error, "ENOENT")) return;
       throw error;
     });
-    this.invalidateAfterOfflineSyncMutation(target);
+    await this.invalidateAfterOfflineSyncMutation(target);
   }
 
-  private invalidateAfterOfflineSyncMutation(filePath: string): void {
+  private async invalidateAfterOfflineSyncMutation(filePath: string): Promise<void> {
     this.invalidateAllMemoriesCache();
     invalidateCachedEntities(this.baseDir);
     this.invalidateKnowledgeIndexCache();
+    this.factHashIndexAuthoritative = false;
+    await unlink(this.factHashIndexReadyPath).catch((error: unknown) => {
+      if (isErrnoCode(error, "ENOENT")) return;
+      throw error;
+    });
     if (filePath.includes(`${path.sep}cold${path.sep}`)) {
       this.invalidateColdMemoriesCache();
     }
@@ -2622,6 +2635,7 @@ export class StorageManager {
       }
 
       const factHashIndex = await this.getFactHashIndex();
+      factHashIndex.clear();
       const existing = await this.readAllMemories();
       let legacyRecovered = 0;
       for (const memory of existing) {


### PR DESCRIPTION
## Summary
- add a core offline sync snapshot/changeset protocol with shared-base conflict handling and private path exclusions
- expose HTTP snapshot/apply endpoints for remote Remnic daemons
- add `remnic offline prepare|sync|status|watch` plus an offline-mode guide for laptop-first usage

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/offline-sync.test.ts packages/remnic-core/src/access-http.test.ts`
- `pnpm --filter @remnic/core check-types`
- `pnpm --filter @remnic/cli exec tsc --noEmit --pretty false`
- CLI smoke: `remnic offline status --memory-dir <tmp>/memory --state <tmp>/state.json`
- CLI smoke: `remnic offline --help`
- `npm run preflight:quick`
- `npm run test:entity-hardening`

Note: `npm run review:cursor` was attempted after commit, but the installed Cursor CLI rejected the script's `--trust` option and the script skipped as unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new bidirectional file sync and remote write endpoints, plus storage-layer mutation hooks; mistakes could cause data loss/conflicts or expose unexpected files if validation/exclusions are wrong.
> 
> **Overview**
> **Adds laptop-first offline mode sync.** Core introduces an `offline-sync` snapshot/changeset protocol with shared-base conflict handling, content hashing, and exclusion rules for private/process-local paths (plus optional transcript inclusion).
> 
> **Exposes remote sync over HTTP and CLI workflows.** The daemon gains `GET /remnic|engram/v1/offline-sync/snapshot` and `POST /.../apply` (with query/body validation), and the CLI adds `remnic offline prepare|sync|status|watch` to seed from a remote, push local changes, pull/apply snapshots, and persist per-remote/namespace state under `.offline-sync/`.
> 
> **Storage/security plumbing updates.** Secure-store reads gain a buffer-returning helper, and `StorageManager` adds offline-sync read/write/delete helpers that route through encryption and invalidate derived caches/index readiness after synced mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25f4f6772c161d8187670e66fe83426a1454bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->