### PR TITLE
Fix offline sync content scaling

### DIFF
--- a/.changeset/offline-sync-scale-fix.md
+++ b/.changeset/offline-sync-scale-fix.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Make offline sync diff metadata first and transfer file content only for changed paths.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -133,6 +133,8 @@ import {
   readOfflineSyncState,
   summarizeOfflineSyncChangeset,
   writeOfflineSyncState,
+  type OfflineSyncFileState,
+  type OfflineSyncSnapshot,
   type OfflineSyncState,
   buildActionConfidenceInputFromOptions,
   evaluateActionConfidence,
@@ -5615,14 +5617,36 @@ async function fetchOfflineSnapshot(args: {
   token: string;
   namespace?: string;
   includeTranscripts: boolean;
-}): Promise<Awaited<ReturnType<typeof buildOfflineSyncSnapshot>> & { namespace?: string }> {
+  includeContent?: boolean;
+}): Promise<OfflineSyncSnapshot & { namespace?: string }> {
   return fetchOfflineJson(
     offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/snapshot", {
       namespace: args.namespace,
       include_transcripts: args.includeTranscripts ? "true" : "false",
-      content: "true",
+      content: args.includeContent === false ? "false" : "true",
     }),
     args.token,
+  );
+}
+
+async function fetchOfflineFiles(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+  paths: readonly string[];
+}): Promise<OfflineSyncSnapshot & { namespace?: string }> {
+  return fetchOfflineJson(
+    offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/files"),
+    args.token,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        namespace: args.namespace,
+        includeTranscripts: args.includeTranscripts,
+        paths: args.paths,
+      }),
+    },
   );
 }
 
@@ -5673,6 +5697,122 @@ async function readFirstOfflineSyncState(
     if (state) return { statePath, state };
   }
   return null;
+}
+
+function offlineFileStateMap(
+  files: readonly OfflineSyncFileState[],
+): Map<string, OfflineSyncFileState> {
+  return new Map(files.map((file) => [file.path, file]));
+}
+
+function offlineSnapshotContentPathsForApply(options: {
+  snapshot: OfflineSyncSnapshot;
+  baseFiles: readonly OfflineSyncFileState[];
+  currentFiles?: readonly OfflineSyncFileState[];
+}): string[] {
+  const base = offlineFileStateMap(options.baseFiles);
+  const current = options.currentFiles ? offlineFileStateMap(options.currentFiles) : null;
+  const paths: string[] = [];
+  for (const incoming of options.snapshot.files) {
+    if (current?.get(incoming.path)?.sha256 === incoming.sha256) continue;
+    if (base.get(incoming.path)?.sha256 === incoming.sha256) continue;
+    paths.push(incoming.path);
+  }
+  return paths.sort();
+}
+
+function chunkOfflineFilePaths(paths: readonly string[]): string[][] {
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentBytes = 256;
+  for (const relPath of paths) {
+    const cost = Buffer.byteLength(JSON.stringify(relPath), "utf-8") + 1;
+    if (current.length > 0 && (current.length >= 1000 || currentBytes + cost > 96_000)) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 256;
+    }
+    current.push(relPath);
+    currentBytes += cost;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+function isOfflineFilesUnsupportedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /offline sync request failed: 404\b/.test(message);
+}
+
+function isMissingOfflineContentError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /^missing decoded content for /.test(message);
+}
+
+async function hydrateOfflineSnapshotContent(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+  snapshot: OfflineSyncSnapshot & { namespace?: string };
+  baseFiles: readonly OfflineSyncFileState[];
+  currentFiles?: readonly OfflineSyncFileState[];
+}): Promise<OfflineSyncSnapshot & { namespace?: string }> {
+  const neededPaths = offlineSnapshotContentPathsForApply({
+    snapshot: args.snapshot,
+    baseFiles: args.baseFiles,
+    currentFiles: args.currentFiles,
+  });
+  if (neededPaths.length === 0) return args.snapshot;
+
+  const expectedByPath = new Map(args.snapshot.files.map((file) => [file.path, file]));
+  const contentByPath = new Map<string, string>();
+  try {
+    for (const batch of chunkOfflineFilePaths(neededPaths)) {
+      const partial = await fetchOfflineFiles({
+        remoteUrl: args.remoteUrl,
+        token: args.token,
+        namespace: args.namespace,
+        includeTranscripts: args.includeTranscripts,
+        paths: batch,
+      });
+      for (const file of partial.files) {
+        const expected = expectedByPath.get(file.path);
+        if (!expected) continue;
+        if (file.sha256 !== expected.sha256 || file.bytes !== expected.bytes) {
+          throw new Error(`remote file changed while fetching offline content: ${file.path}`);
+        }
+        if (typeof file.contentBase64 !== "string") {
+          throw new Error(`remote offline content response omitted contentBase64 for ${file.path}`);
+        }
+        contentByPath.set(file.path, file.contentBase64);
+      }
+    }
+  } catch (error) {
+    if (!isOfflineFilesUnsupportedError(error)) throw error;
+    return fetchOfflineSnapshot({
+      remoteUrl: args.remoteUrl,
+      token: args.token,
+      namespace: args.namespace,
+      includeTranscripts: args.includeTranscripts,
+      includeContent: true,
+    });
+  }
+
+  const missing = neededPaths.filter((relPath) => !contentByPath.has(relPath));
+  if (missing.length > 0) {
+    throw new Error(
+      `remote offline content response omitted ${missing.length} changed file${missing.length === 1 ? "" : "s"}; retry sync`,
+    );
+  }
+
+  return {
+    ...args.snapshot,
+    files: args.snapshot.files.map((file) => {
+      const contentBase64 = contentByPath.get(file.path);
+      return contentBase64 === undefined ? file : { ...file, contentBase64 };
+    }),
+  };
 }
 
 async function pushOfflineChanges(args: {
@@ -5776,6 +5916,7 @@ async function runOfflineSyncOnce(options: {
       token: options.token,
       namespace: options.namespace,
       includeTranscripts: options.includeTranscripts,
+      includeContent: false,
     });
     syncNamespace = resolvedOfflineSnapshotNamespace(namespaceProbe, options.namespace);
   }
@@ -5818,21 +5959,59 @@ async function runOfflineSyncOnce(options: {
         changeset,
       })
     : null;
-  const remoteSnapshot = await fetchOfflineSnapshot({
+  const remoteSnapshotMetadata = await fetchOfflineSnapshot({
     remoteUrl: options.remoteUrl,
     token: options.token,
     namespace: syncNamespace,
     includeTranscripts: options.includeTranscripts,
+    includeContent: false,
+  });
+  const currentSnapshot = await buildOfflineSyncSnapshot({
+    root: options.memoryDir,
+    sourceId: localOfflineSourceId(options.memoryDir),
+    includeContent: false,
+    includeTranscripts: options.includeTranscripts,
+    readFile: storageIo.readFile,
+  });
+  const remoteSnapshot = await hydrateOfflineSnapshotContent({
+    remoteUrl: options.remoteUrl,
+    token: options.token,
+    namespace: syncNamespace,
+    includeTranscripts: options.includeTranscripts,
+    snapshot: remoteSnapshotMetadata,
+    baseFiles,
+    currentFiles: currentSnapshot.files,
   });
   const resolvedNamespace = resolvedOfflineSnapshotNamespace(remoteSnapshot, syncNamespace);
-  const pull = await applyOfflineSyncSnapshot({
-    root: options.memoryDir,
-    snapshot: remoteSnapshot,
-    baseFiles,
-    readFile: storageIo.readFile,
-    writeFile: storageIo.writeFile,
-    deleteFile: storageIo.deleteFile,
-  });
+  let pull: Awaited<ReturnType<typeof applyOfflineSyncSnapshot>>;
+  try {
+    pull = await applyOfflineSyncSnapshot({
+      root: options.memoryDir,
+      snapshot: remoteSnapshot,
+      baseFiles,
+      readFile: storageIo.readFile,
+      writeFile: storageIo.writeFile,
+      deleteFile: storageIo.deleteFile,
+    });
+  } catch (error) {
+    if (!isMissingOfflineContentError(error)) throw error;
+    const retrySnapshot = await hydrateOfflineSnapshotContent({
+      remoteUrl: options.remoteUrl,
+      token: options.token,
+      namespace: syncNamespace,
+      includeTranscripts: options.includeTranscripts,
+      snapshot: remoteSnapshotMetadata,
+      baseFiles,
+    });
+    pull = await applyOfflineSyncSnapshot({
+      root: options.memoryDir,
+      snapshot: retrySnapshot,
+      baseFiles,
+      readFile: storageIo.readFile,
+      writeFile: storageIo.writeFile,
+      deleteFile: storageIo.deleteFile,
+    });
+  }
   const state = offlineSyncStateFromSnapshot({
     remoteId: options.remoteUrl,
     namespace: resolvedNamespace,

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -286,6 +286,79 @@ test("HTTP offline snapshot forwards namespace and transfer options", async () =
   }
 });
 
+test("HTTP offline files forwards namespace and requested paths", async () => {
+  const calls: Array<{
+    namespace: string | undefined;
+    principal: string | undefined;
+    includeTranscripts: boolean | undefined;
+    paths: string[];
+  }> = [];
+  const service = {
+    offlineSyncFiles: async (options: {
+      namespace?: string;
+      principal?: string;
+      includeTranscripts?: boolean;
+      paths: string[];
+    }) => {
+      calls.push({
+        namespace: options.namespace,
+        principal: options.principal,
+        includeTranscripts: options.includeTranscripts,
+        paths: options.paths,
+      });
+      return {
+        namespace: options.namespace ?? "default",
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: new Date("2026-05-21T00:00:00Z").toISOString(),
+        sourceId: "remote:test",
+        includeTranscripts: options.includeTranscripts !== false,
+        files: [],
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/remnic/v1/offline-sync/files`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          namespace: "team",
+          includeTranscripts: false,
+          paths: ["facts/a.md"],
+        }),
+      },
+    );
+    const body = await response.json() as { namespace?: string; includeTranscripts?: boolean; files?: unknown[] };
+
+    assert.equal(response.status, 200);
+    assert.equal(body.namespace, "team");
+    assert.equal(body.includeTranscripts, false);
+    assert.deepEqual(body.files, []);
+    assert.deepEqual(calls, [{
+      namespace: "team",
+      principal: "reader",
+      includeTranscripts: false,
+      paths: ["facts/a.md"],
+    }]);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("HTTP offline snapshot rejects invalid boolean query values", async () => {
   let calls = 0;
   const service = {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -628,6 +628,21 @@ export class EngramAccessHttpServer {
 
     if (
       req.method === "POST" &&
+      (pathname === "/engram/v1/offline-sync/files" || pathname === "/remnic/v1/offline-sync/files")
+    ) {
+      const body = await this.readValidatedBody(req, "offlineSyncFiles");
+      const result = await this.service.offlineSyncFiles({
+        namespace: this.resolveNamespace(req, body.namespace),
+        principal: this.resolveRequestPrincipal(req),
+        includeTranscripts: body.includeTranscripts,
+        paths: body.paths,
+      });
+      this.respondJson(res, 200, result);
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
       (pathname === "/engram/v1/offline-sync/apply" || pathname === "/remnic/v1/offline-sync/apply")
     ) {
       const body = await this.readValidatedBody(req, "offlineSyncApply");

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -378,6 +378,14 @@ export const offlineSyncApplyRequestSchema = z
     path: ["changeset"],
   });
 
+export const offlineSyncFilesRequestSchema = z.object({
+  namespace: namespaceSchema,
+  includeTranscripts: z.boolean().optional(),
+  paths: z
+    .array(z.string().trim().min(1, "path must be non-empty").max(4096))
+    .max(5000, "paths must contain 5000 or fewer entries"),
+});
+
 // ---------------------------------------------------------------------------
 // Action confidence
 // ---------------------------------------------------------------------------
@@ -444,6 +452,7 @@ export type CapsuleExportRequest = z.infer<typeof capsuleExportRequestSchema>;
 export type CapsuleImportRequest = z.infer<typeof capsuleImportRequestSchema>;
 export type CapsuleListRequest = z.infer<typeof capsuleListRequestSchema>;
 export type OfflineSyncApplyRequest = z.infer<typeof offlineSyncApplyRequestSchema>;
+export type OfflineSyncFilesRequest = z.infer<typeof offlineSyncFilesRequestSchema>;
 export type ActionConfidenceRequest = z.infer<typeof actionConfidenceRequestSchema>;
 
 // ---------------------------------------------------------------------------
@@ -467,6 +476,7 @@ export type SchemaName =
   | "capsuleExport"
   | "capsuleImport"
   | "capsuleList"
+  | "offlineSyncFiles"
   | "offlineSyncApply"
   | "actionConfidence";
 
@@ -487,6 +497,7 @@ export type SchemaTypeFor<N extends SchemaName> =
   : N extends "capsuleExport" ? CapsuleExportRequest
   : N extends "capsuleImport" ? CapsuleImportRequest
   : N extends "capsuleList" ? CapsuleListRequest
+  : N extends "offlineSyncFiles" ? OfflineSyncFilesRequest
   : N extends "offlineSyncApply" ? OfflineSyncApplyRequest
   : N extends "actionConfidence" ? ActionConfidenceRequest
   : never;
@@ -508,6 +519,7 @@ const schemas: Record<SchemaName, z.ZodTypeAny> = {
   capsuleExport: capsuleExportRequestSchema,
   capsuleImport: capsuleImportRequestSchema,
   capsuleList: capsuleListRequestSchema,
+  offlineSyncFiles: offlineSyncFilesRequestSchema,
   offlineSyncApply: offlineSyncApplyRequestSchema,
   actionConfidence: actionConfidenceRequestSchema,
 };

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
-import { EngramAccessService } from "./access-service.js";
+import { EngramAccessInputError, EngramAccessService } from "./access-service.js";
 import type { StorageManager } from "./storage.js";
 import type { PluginConfig } from "./types.js";
 
@@ -120,4 +123,64 @@ test("memoryBrowse resolves namespace storage for read principals", async () => 
   assert.equal(result.namespace, "team");
   assert.equal(result.count, 0);
   assert.deepEqual(getStorageCalls, ["team"]);
+});
+
+test("offlineSyncFiles reports invalid requested paths as input errors", async () => {
+  const { service } = makeService();
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator.getStorage = async () => ({
+    dir: os.tmpdir(),
+    async readOfflineSyncFile() {
+      throw new Error("should not read invalid paths");
+    },
+  } as unknown as StorageManager);
+
+  await assert.rejects(
+    () =>
+      service.offlineSyncFiles({
+        namespace: "team",
+        principal: "reader",
+        paths: ["../escape"],
+      }),
+    (error: unknown) =>
+      error instanceof EngramAccessInputError &&
+      /paths\[\]: record path contains unsafe segments/.test(error.message),
+  );
+});
+
+test("offlineSyncFiles reports symlink requested paths as input errors", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-offline-files-symlink-"));
+  try {
+    await symlink("/tmp", path.join(root, "linked"));
+    const { service } = makeService();
+    (service as unknown as {
+      orchestrator: {
+        config: PluginConfig;
+        getStorage(namespace: string): Promise<StorageManager>;
+      };
+    }).orchestrator.getStorage = async () => ({
+      dir: root,
+      async readOfflineSyncFile() {
+        throw new Error("should not read symlink paths");
+      },
+    } as unknown as StorageManager);
+
+    await assert.rejects(
+      () =>
+        service.offlineSyncFiles({
+          namespace: "team",
+          principal: "reader",
+          paths: ["linked"],
+        }),
+      (error: unknown) =>
+        error instanceof EngramAccessInputError &&
+        /buildOfflineSyncSnapshotForPaths: record path targets a symlink/.test(error.message),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -138,6 +138,7 @@ import {
 import {
   applyOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
+  buildOfflineSyncSnapshotForPaths,
   type OfflineSyncApplyChangesetResult,
   type OfflineSyncSnapshot,
 } from "./offline-sync.js";
@@ -616,6 +617,13 @@ export interface EngramAccessOfflineSyncSnapshotRequest {
   includeContent?: boolean;
 }
 
+export interface EngramAccessOfflineSyncFilesRequest {
+  namespace?: string;
+  principal?: string;
+  includeTranscripts?: boolean;
+  paths: string[];
+}
+
 export interface EngramAccessOfflineSyncApplyRequest {
   namespace?: string;
   principal?: string;
@@ -623,6 +631,10 @@ export interface EngramAccessOfflineSyncApplyRequest {
 }
 
 export interface EngramAccessOfflineSyncSnapshotResponse extends OfflineSyncSnapshot {
+  namespace: string;
+}
+
+export interface EngramAccessOfflineSyncFilesResponse extends OfflineSyncSnapshot {
   namespace: string;
 }
 
@@ -5566,6 +5578,38 @@ export class EngramAccessService {
       namespace: resolvedNamespace,
       ...snapshot,
     };
+  }
+
+  async offlineSyncFiles(
+    options: EngramAccessOfflineSyncFilesRequest,
+  ): Promise<EngramAccessOfflineSyncFilesResponse> {
+    const resolvedNamespace = this.resolveReadableNamespace(options.namespace, options.principal);
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const storageHash = createHash("sha256").update(storage.dir).digest("hex").slice(0, 16);
+    try {
+      const snapshot = await buildOfflineSyncSnapshotForPaths({
+        root: storage.dir,
+        sourceId: `remnic:${resolvedNamespace}:${storageHash}`,
+        paths: options.paths,
+        includeContent: true,
+        includeTranscripts: options.includeTranscripts !== false,
+        readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
+      });
+      return {
+        namespace: resolvedNamespace,
+        ...snapshot,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.startsWith("paths[]:") ||
+        message.startsWith("buildOfflineSyncSnapshotForPaths: record path ") ||
+        message.startsWith("offline sync snapshot path is excluded:")
+      ) {
+        throw new EngramAccessInputError(message);
+      }
+      throw error;
+    }
   }
 
   async offlineSyncApply(

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -686,6 +686,7 @@ export {
   applyOfflineSyncSnapshot,
   buildOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
+  buildOfflineSyncSnapshotForPaths,
   defaultOfflineSyncStatePath,
   fileStatesFromSnapshot,
   normalizeOfflineSyncChangeset,

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -9,6 +9,7 @@ import {
   applyOfflineSyncSnapshot,
   buildOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
+  buildOfflineSyncSnapshotForPaths,
 } from "./offline-sync.js";
 import { isEncryptedFile } from "./secure-store/secure-fs.js";
 import { StorageManager } from "./storage.js";
@@ -100,6 +101,130 @@ test("offline changeset pushes local edits when the remote is still at the share
     assert.equal(push.conflicts.length, 0);
     assert.equal(await readUtf8(remote, "facts/base.md"), "base plus local");
     assert.equal(await readUtf8(remote, "facts/local-only.md"), "new local fact");
+  } finally {
+    await rm(remote, { recursive: true, force: true });
+    await rm(local, { recursive: true, force: true });
+  }
+});
+
+test("offline changeset only carries content for changed local files", async () => {
+  const local = await tempDir("remnic-offline-changeset-content");
+  try {
+    await write(local, "facts/unchanged.md", "same");
+    await write(local, "facts/changed.md", "before");
+    const base = await buildOfflineSyncSnapshot({
+      root: local,
+      sourceId: "remote",
+      includeContent: false,
+    });
+
+    await write(local, "facts/changed.md", "after");
+    await write(local, "facts/empty.md", "");
+    const changeset = await buildOfflineSyncChangeset({
+      root: local,
+      sourceId: "laptop",
+      baseFiles: base.files,
+    });
+
+    assert.deepEqual(
+      changeset.changes.map((change) => change.path),
+      ["facts/changed.md", "facts/empty.md"],
+    );
+    const empty = changeset.changes.find((change) => change.path === "facts/empty.md");
+    assert.equal(empty?.type, "upsert");
+    if (empty?.type === "upsert") {
+      assert.equal(empty.file.contentBase64, "");
+    }
+    assert.equal(JSON.stringify(changeset).includes("same"), false);
+  } finally {
+    await rm(local, { recursive: true, force: true });
+  }
+});
+
+test("offline pull accepts metadata-only snapshots when files are unchanged", async () => {
+  const remote = await tempDir("remnic-offline-metadata-remote");
+  const local = await tempDir("remnic-offline-metadata-local");
+  try {
+    await write(remote, "facts/shared.md", "base");
+    const initial = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: true,
+    });
+    const firstPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: initial,
+    });
+    const metadataOnly = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: false,
+    });
+
+    const secondPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: metadataOnly,
+      baseFiles: firstPull.nextBaseFiles,
+    });
+
+    assert.equal(secondPull.conflicts.length, 0);
+    assert.equal(secondPull.upserted, 0);
+    assert.equal(secondPull.skipped, 1);
+  } finally {
+    await rm(remote, { recursive: true, force: true });
+    await rm(local, { recursive: true, force: true });
+  }
+});
+
+test("offline pull applies snapshots with content only for remote-changed files", async () => {
+  const remote = await tempDir("remnic-offline-partial-remote");
+  const local = await tempDir("remnic-offline-partial-local");
+  try {
+    await write(remote, "facts/shared.md", "base");
+    await write(remote, "facts/stable.md", "unchanged");
+    const initial = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: true,
+    });
+    const firstPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: initial,
+    });
+
+    await write(remote, "facts/shared.md", "remote edit");
+    const metadataOnly = await buildOfflineSyncSnapshot({
+      root: remote,
+      sourceId: "remote",
+      includeContent: false,
+    });
+    const changedContent = await buildOfflineSyncSnapshotForPaths({
+      root: remote,
+      sourceId: "remote",
+      paths: ["facts/shared.md"],
+      includeContent: true,
+    });
+    const contentByPath = new Map(
+      changedContent.files.map((file) => [file.path, file.contentBase64]),
+    );
+    const hydrated = {
+      ...metadataOnly,
+      files: metadataOnly.files.map((file) => {
+        const contentBase64 = contentByPath.get(file.path);
+        return contentBase64 === undefined ? file : { ...file, contentBase64 };
+      }),
+    };
+
+    const secondPull = await applyOfflineSyncSnapshot({
+      root: local,
+      snapshot: hydrated,
+      baseFiles: firstPull.nextBaseFiles,
+    });
+
+    assert.equal(secondPull.upserted, 1);
+    assert.equal(secondPull.conflicts.length, 0);
+    assert.equal(await readUtf8(local, "facts/shared.md"), "remote edit");
+    assert.equal(await readUtf8(local, "facts/stable.md"), "unchanged");
   } finally {
     await rm(remote, { recursive: true, force: true });
     await rm(local, { recursive: true, force: true });

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -127,6 +127,14 @@ export interface OfflineSyncFileWriteTarget extends OfflineSyncFileTarget {
   content: Buffer;
 }
 
+interface OfflineSyncFileRecordOptions {
+  root: SafeArchiveRoot;
+  relPath: string;
+  filePath: string;
+  includeContent: boolean;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
+}
+
 const SYNC_INTERNAL_DIR = ".offline-sync";
 const EXCLUDED_FILE_NAMES = new Set([
   ".sync-state.json",
@@ -406,6 +414,24 @@ function filterBaseFilesForMode(
   return files.filter((file) => !shouldExcludeRelPath(file.path, includeTranscripts));
 }
 
+async function readOfflineSyncFileRecord(
+  options: OfflineSyncFileRecordOptions,
+): Promise<OfflineSyncFileRecord> {
+  const relPath = validateArchiveRelativePath(options.relPath, "offlineSyncFile.path");
+  const bytes = options.readFile
+    ? await options.readFile({ root: options.root.abs, path: relPath, filePath: options.filePath })
+    : await readFile(options.filePath);
+  const digest = sha256Buffer(bytes);
+  const st = await stat(options.filePath);
+  return {
+    path: relPath,
+    sha256: digest.sha256,
+    bytes: digest.bytes,
+    mtimeMs: st.mtimeMs,
+    ...(options.includeContent ? { contentBase64: bytes.toString("base64") } : {}),
+  };
+}
+
 export async function buildOfflineSyncSnapshot(options: {
   root: string;
   sourceId: string;
@@ -432,22 +458,64 @@ export async function buildOfflineSyncSnapshot(options: {
         continue;
       }
       if (!entry.isFile()) continue;
-      const bytes = options.readFile
-        ? await options.readFile({ root: root.abs, path: relPosix, filePath: abs })
-        : await readFile(abs);
-      const digest = sha256Buffer(bytes);
-      const st = await stat(abs);
-      files.push({
-        path: validateArchiveRelativePath(relPosix, "buildOfflineSyncSnapshot"),
-        sha256: digest.sha256,
-        bytes: digest.bytes,
-        mtimeMs: st.mtimeMs,
-        ...(options.includeContent === true ? { contentBase64: bytes.toString("base64") } : {}),
-      });
+      files.push(await readOfflineSyncFileRecord({
+        root,
+        relPath: relPosix,
+        filePath: abs,
+        includeContent: options.includeContent === true,
+        readFile: options.readFile,
+      }));
     }
   }
 
   await walk(root.abs);
+
+  return {
+    format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
+    schemaVersion: 1,
+    createdAt: (options.now ?? new Date()).toISOString(),
+    sourceId: normalizeSourceId(options.sourceId, "sourceId"),
+    includeTranscripts,
+    files: files.sort(compareByPath),
+  };
+}
+
+export async function buildOfflineSyncSnapshotForPaths(options: {
+  root: string;
+  sourceId: string;
+  paths: readonly string[];
+  includeContent?: boolean;
+  includeTranscripts?: boolean;
+  now?: Date;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
+}): Promise<OfflineSyncSnapshot> {
+  const rootAbs = path.resolve(options.root);
+  const root = await prepareSafeArchiveRoot(rootAbs, "buildOfflineSyncSnapshotForPaths", "root");
+  const includeTranscripts = options.includeTranscripts !== false;
+  const files: OfflineSyncFileRecord[] = [];
+  const seen = new Set<string>();
+
+  for (const rawPath of options.paths) {
+    const relPath = normalizeRelativePath(rawPath, "paths[]");
+    if (seen.has(relPath)) continue;
+    seen.add(relPath);
+    if (shouldExcludeRelPath(relPath, includeTranscripts)) {
+      throw new Error(`offline sync snapshot path is excluded: ${relPath}`);
+    }
+    const filePath = await resolveSafeArchiveTarget(root, relPath);
+    const st = await lstat(filePath).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    });
+    if (!st || st.isSymbolicLink() || !st.isFile()) continue;
+    files.push(await readOfflineSyncFileRecord({
+      root,
+      relPath,
+      filePath,
+      includeContent: options.includeContent === true,
+      readFile: options.readFile,
+    }));
+  }
 
   return {
     format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
@@ -475,7 +543,7 @@ export async function buildOfflineSyncChangeset(options: {
   const current = await buildOfflineSyncSnapshot({
     root: options.root,
     sourceId: options.sourceId,
-    includeContent: true,
+    includeContent: false,
     includeTranscripts,
     now: options.now,
     readFile: options.readFile,
@@ -487,11 +555,24 @@ export async function buildOfflineSyncChangeset(options: {
     const baseEntry = base.get(relPath);
     const currentEntry = currentMap.get(relPath);
     if (currentEntry && currentEntry.sha256 !== baseEntry?.sha256) {
+      const file = await buildOfflineSyncSnapshotForPaths({
+        root: options.root,
+        sourceId: options.sourceId,
+        paths: [relPath],
+        includeContent: true,
+        includeTranscripts,
+        now: options.now,
+        readFile: options.readFile,
+      });
+      const record = file.files[0];
+      if (!record || typeof record.contentBase64 !== "string" || record.sha256 !== currentEntry.sha256) {
+        throw new Error(`offline sync file changed while building changeset: ${relPath}`);
+      }
       changes.push({
         type: "upsert",
         path: relPath,
         ...(baseEntry ? { baseSha256: baseEntry.sha256 } : {}),
-        file: currentEntry as OfflineSyncFileRecord & { contentBase64: string },
+        file: record as OfflineSyncFileRecord & { contentBase64: string },
       });
       continue;
     }
@@ -535,13 +616,15 @@ export async function applyOfflineSyncSnapshot(options: {
   writeFile?: (target: OfflineSyncFileWriteTarget) => Promise<void>;
   deleteFile?: (target: OfflineSyncFileTarget) => Promise<void>;
 }): Promise<OfflineSyncApplySnapshotResult> {
-  const snapshot = normalizeOfflineSyncSnapshot(options.snapshot, { requireContent: true });
+  const snapshot = normalizeOfflineSyncSnapshot(options.snapshot);
   const baseMap = byPath(filterBaseFilesForMode(
     normalizeFileStates(options.baseFiles),
     snapshot.includeTranscripts,
   ));
   const incomingMap = byPath(snapshot.files);
-  const incomingBuffers = verifyRecordContents(snapshot.files, "offline sync snapshot");
+  const incomingBuffers = verifyRecordContents(snapshot.files, "offline sync snapshot", {
+    requireContent: false,
+  });
   const root = await ensureSyncRoot(options.root, "applyOfflineSyncSnapshot");
   const current = await buildOfflineSyncSnapshot({
     root: root.abs,
@@ -582,7 +665,9 @@ export async function applyOfflineSyncSnapshot(options: {
           reason: "local_deleted_remote_modified",
           baseSha256: base.sha256,
           incomingSha256: incoming.sha256,
-          incomingBuffer: incomingBuffers.get(relPath),
+          incomingBuffer: options.writeConflictCopies === false
+            ? incomingBuffers.get(relPath)
+            : requiredBuffer(incomingBuffers, relPath),
           writeConflictCopies: options.writeConflictCopies !== false,
           sourceId: snapshot.sourceId,
           writeFile: options.writeFile,
@@ -615,7 +700,9 @@ export async function applyOfflineSyncSnapshot(options: {
         baseSha256: base?.sha256,
         localSha256: currentEntry?.sha256,
         incomingSha256: incoming.sha256,
-        incomingBuffer: incomingBuffers.get(relPath),
+        incomingBuffer: options.writeConflictCopies === false
+          ? incomingBuffers.get(relPath)
+          : requiredBuffer(incomingBuffers, relPath),
         writeConflictCopies: options.writeConflictCopies !== false,
         sourceId: snapshot.sourceId,
         writeFile: options.writeFile,
@@ -774,10 +861,12 @@ export async function applyOfflineSyncChangeset(options: {
 function verifyRecordContents(
   records: readonly OfflineSyncFileRecord[],
   context: string,
+  options: { requireContent?: boolean } = {},
 ): Map<string, Buffer> {
   const buffers = new Map<string, Buffer>();
   for (const record of records) {
     if (typeof record.contentBase64 !== "string") {
+      if (options.requireContent === false) continue;
       throw new Error(`${context}: contentBase64 is required for ${record.path}`);
     }
     const buffer = Buffer.from(record.contentBase64, "base64");


### PR DESCRIPTION
## Summary
- make offline changeset generation diff metadata first, then read/base64 only changed upsert files
- allow snapshot apply to consume metadata-only records and require content only for paths that must be written or conflict-copied
- add `/offline-sync/files` API and have the CLI hydrate remote content only for changed pull paths

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/offline-sync.test.ts packages/remnic-core/src/access-http.test.ts`
- `pnpm --filter @remnic/core check-types`
- `pnpm --filter @remnic/cli check-types`
- `npm run preflight:quick`
- real laptop cache: `offline status` on `/Users/joshuawarren/.openclaw/workspace/memory/local` reported 0 pending changes without the previous string-size failure

## Notes
- `npm run review:cursor` attempted to run, but the installed cursor-agent rejected the script option: `unknown option '--trust'`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline sync snapshot/apply and introduces a new `/offline-sync/files` endpoint; mistakes could cause missing content during pulls or incorrect conflict handling. Backward-compat fallback paths reduce risk but the logic is more complex and touches core sync flows.
> 
> **Overview**
> Improves offline sync scalability by **making snapshots/changesets metadata-first** and only reading/transferring `contentBase64` for files that actually changed.
> 
> Adds a new `/remnic/v1/offline-sync/files` POST endpoint (schema + service + HTTP wiring) to fetch content for a requested set of paths, and updates the CLI to pull a metadata-only remote snapshot, compute which paths need content, batch-fetch just those files, and fall back to the legacy full-snapshot content mode on 404.
> 
> Updates `applyOfflineSyncSnapshot` to accept metadata-only records (only requiring content when writing files or conflict copies are needed) and adds tests covering partial-content pulls, metadata-only pulls, and input validation for unsafe/symlink paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915d3c9bc8b09b5e676469872d06315e70d5c0f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->