### PR TITLE
Fix offline sync LCM SQLite payloads

### DIFF
--- a/.changeset/offline-sync-lcm-sqlite-exclude.md
+++ b/.changeset/offline-sync-lcm-sqlite-exclude.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Exclude live LCM SQLite WAL artifacts from offline sync snapshots so large runtime databases are not transferred through JSON sync or deleted from older local caches.

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -39,6 +40,9 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
     await write(root, ".offline-sync/state/local.json", "state");
     await write(root, "state/fact-hashes.txt", "derived");
     await write(root, "state/fact-hashes.ready", "v1");
+    await write(root, "state/lcm.sqlite", "live db");
+    await write(root, "state/lcm.sqlite-shm", "live shm");
+    await write(root, "state/lcm.sqlite-wal", "live wal");
 
     const snapshot = await buildOfflineSyncSnapshot({
       root,
@@ -63,6 +67,51 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
       withoutTranscripts.files.map((file) => file.path),
       ["assets/blob.bin", "facts/a.md", "facts/fact-hashes.txt"],
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline sync excludes live LCM sqlite artifacts without deleting existing local copies", async () => {
+  const root = await tempDir("remnic-offline-lcm-sqlite");
+  try {
+    await write(root, "facts/a.md", "alpha");
+    await write(root, "state/lcm.sqlite", "live db");
+    await write(root, "state/lcm.sqlite-shm", "live shm");
+    await write(root, "state/lcm.sqlite-wal", "live wal");
+
+    const snapshot = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "remote",
+      includeContent: true,
+    });
+
+    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
+    await assert.rejects(
+      () =>
+        buildOfflineSyncSnapshotForPaths({
+          root,
+          sourceId: "remote",
+          paths: ["state/lcm.sqlite"],
+          includeContent: true,
+        }),
+      /offline sync snapshot path is excluded: state\/lcm\.sqlite/,
+    );
+
+    const oldDb = Buffer.from("old live db");
+    const pull = await applyOfflineSyncSnapshot({
+      root,
+      snapshot,
+      baseFiles: [{
+        path: "state/lcm.sqlite",
+        sha256: createHash("sha256").update(oldDb).digest("hex"),
+        bytes: oldDb.byteLength,
+        mtimeMs: 0,
+      }],
+    });
+
+    assert.equal(pull.deleted, 0);
+    assert.equal(await readUtf8(root, "state/lcm.sqlite"), "live db");
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -143,6 +143,9 @@ const EXCLUDED_FILE_NAMES = new Set([
 const EXCLUDED_REL_PATHS = new Set([
   "state/fact-hashes.ready",
   "state/fact-hashes.txt",
+  "state/lcm.sqlite",
+  "state/lcm.sqlite-shm",
+  "state/lcm.sqlite-wal",
 ]);
 
 const EXCLUDED_FILE_PREFIXES = [


### PR DESCRIPTION
## Summary
- exclude live LCM SQLite/WAL/SHM artifacts from offline sync snapshots and path hydration
- keep older local caches from deleting existing `state/lcm.sqlite` when their saved base still mentions it
- add a patch changeset for `@remnic/core`

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/offline-sync.test.ts packages/remnic-core/src/access-service-namespace.test.ts packages/remnic-core/src/access-http.test.ts`
- `pnpm --filter @remnic/core check-types`
- `pnpm --filter @remnic/cli check-types`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline sync’s inclusion/exclusion rules, which can affect what files are transferred and when local files are deleted during snapshot application. While scoped to `state/lcm.sqlite*`, mistakes could impact sync correctness or leave stale artifacts behind.
> 
> **Overview**
> Offline sync snapshots now **exclude live LCM SQLite runtime artifacts** (the `state/lcm.sqlite`, `state/lcm.sqlite-wal`, and `state/lcm.sqlite-shm` files) so they aren’t transferred via JSON sync or hydrated via `buildOfflineSyncSnapshotForPaths`.
> 
> Tests are updated/added to assert these paths are omitted from snapshots, explicitly rejected when requested by path, and **not deleted** on `applyOfflineSyncSnapshot` even if older `baseFiles` still reference them. Includes a patch changeset for `@remnic/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead3a0d2a8cf7c1e610fe73529db16a46b1fa636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->