### PR TITLE
Fix offline sync hydration for large state files

### DIFF
--- a/.changeset/offline-sync-large-file-hydration.md
+++ b/.changeset/offline-sync-large-file-hydration.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Add chunked large-file hydration for offline sync so append-heavy lifecycle state can sync without forcing multi-hundred-megabyte payloads through one JSON response.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5814,6 +5814,16 @@ function shouldDirectHydrateOfflineFile(options: {
   return !options.current && !options.base;
 }
 
+function resolveOfflineDirectHydrationPath(memoryDir: string, relPath: string): string {
+  const base = path.resolve(memoryDir);
+  const target = path.resolve(base, relPath);
+  const relative = path.relative(base, target);
+  if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`offline sync direct hydration path escapes memory dir: ${relPath}`);
+  }
+  return target;
+}
+
 async function fetchOfflineFileContent(args: {
   remoteUrl: string;
   token: string;
@@ -5897,7 +5907,7 @@ async function directHydrateLargeOfflineFiles(args: {
     await args.writeFile({
       root: args.memoryDir,
       path: incoming.path,
-      filePath: path.resolve(args.memoryDir, incoming.path),
+      filePath: resolveOfflineDirectHydrationPath(args.memoryDir, incoming.path),
       content,
     });
     hydrated.add(incoming.path);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5655,7 +5655,7 @@ async function fetchOfflineFiles(args: {
 
 interface OfflineFileContentChunk {
   path: string;
-  sha256: string;
+  sha256?: string;
   bytes: number;
   mtimeMs: number;
   offset: number;
@@ -5716,12 +5716,13 @@ async function fetchOfflineFileContentChunk(args: {
   const relPath = encodedPath ? decodeURIComponent(encodedPath) : args.path;
   const content = Buffer.from(await response.arrayBuffer());
   const chunkBytes = parseOfflineHeaderNumber(response.headers, "x-remnic-chunk-bytes");
+  const sha256 = response.headers.get("x-remnic-file-sha256") ?? undefined;
   if (content.length !== chunkBytes) {
     throw new Error(`offline file content response length mismatch for ${relPath}`);
   }
   return {
     path: relPath,
-    sha256: response.headers.get("x-remnic-file-sha256") ?? "",
+    ...(sha256 ? { sha256 } : {}),
     bytes: parseOfflineHeaderNumber(response.headers, "x-remnic-file-bytes"),
     mtimeMs: parseOfflineHeaderNumber(response.headers, "x-remnic-file-mtime-ms"),
     offset: parseOfflineHeaderNumber(response.headers, "x-remnic-chunk-offset"),
@@ -5849,7 +5850,7 @@ async function fetchOfflineFileContent(args: {
     });
     if (
       chunk.path !== args.expected.path ||
-      chunk.sha256 !== args.expected.sha256 ||
+      (chunk.sha256 !== undefined && chunk.sha256 !== args.expected.sha256) ||
       chunk.bytes !== args.expected.bytes ||
       chunk.mtimeMs !== args.expected.mtimeMs ||
       chunk.offset !== offset ||

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -125,6 +125,7 @@ import {
   formatProcedureStatsText,
   parseXrayCliOptions,
   renderXray,
+  OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
   applyOfflineSyncSnapshot,
   buildOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
@@ -134,6 +135,7 @@ import {
   summarizeOfflineSyncChangeset,
   writeOfflineSyncState,
   type OfflineSyncFileState,
+  type OfflineSyncFileWriteTarget,
   type OfflineSyncSnapshot,
   type OfflineSyncState,
   buildActionConfidenceInputFromOptions,
@@ -5650,6 +5652,83 @@ async function fetchOfflineFiles(args: {
   );
 }
 
+interface OfflineFileContentChunk {
+  path: string;
+  sha256: string;
+  bytes: number;
+  mtimeMs: number;
+  offset: number;
+  chunkBytes: number;
+  content: Buffer;
+}
+
+const OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES = 16 * 1024 * 1024;
+
+function parseOfflineHeaderNumber(headers: Headers, name: string): number {
+  const raw = headers.get(name);
+  if (raw === null) throw new Error(`offline file content response omitted ${name}`);
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`offline file content response had invalid ${name}: ${raw}`);
+  }
+  return parsed;
+}
+
+async function fetchOfflineFileContentChunk(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+  path: string;
+  offset: number;
+  length: number;
+}): Promise<OfflineFileContentChunk> {
+  const response = await fetch(
+    offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/file-content"),
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${args.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        namespace: args.namespace,
+        includeTranscripts: args.includeTranscripts,
+        path: args.path,
+        offset: args.offset,
+        length: args.length,
+      }),
+    },
+  );
+  if (!response.ok) {
+    let detail = "";
+    try {
+      detail = await response.text();
+    } catch {
+      detail = "";
+    }
+    throw new Error(
+      `offline sync file-content request failed: ${response.status} ${response.statusText}${detail ? ` - ${detail.slice(0, 500)}` : ""}`,
+    );
+  }
+  const encodedPath = response.headers.get("x-remnic-file-path");
+  const relPath = encodedPath ? decodeURIComponent(encodedPath) : args.path;
+  const content = Buffer.from(await response.arrayBuffer());
+  const chunkBytes = parseOfflineHeaderNumber(response.headers, "x-remnic-chunk-bytes");
+  if (content.length !== chunkBytes) {
+    throw new Error(`offline file content response length mismatch for ${relPath}`);
+  }
+  return {
+    path: relPath,
+    sha256: response.headers.get("x-remnic-file-sha256") ?? "",
+    bytes: parseOfflineHeaderNumber(response.headers, "x-remnic-file-bytes"),
+    mtimeMs: parseOfflineHeaderNumber(response.headers, "x-remnic-file-mtime-ms"),
+    offset: parseOfflineHeaderNumber(response.headers, "x-remnic-chunk-offset"),
+    chunkBytes,
+    content,
+  };
+}
+
 function resolvedOfflineSnapshotNamespace(
   snapshot: { namespace?: string },
   requestedNamespace?: string,
@@ -5719,6 +5798,109 @@ function offlineSnapshotContentPathsForApply(options: {
     paths.push(incoming.path);
   }
   return paths.sort();
+}
+
+function shouldDirectHydrateOfflineFile(options: {
+  incoming: OfflineSyncFileState;
+  base?: OfflineSyncFileState;
+  current?: OfflineSyncFileState;
+}): boolean {
+  if (options.incoming.bytes < OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES) return false;
+  if (options.current?.sha256 === options.incoming.sha256) return false;
+  if (options.current && options.base && options.current.sha256 === options.base.sha256) {
+    return true;
+  }
+  return !options.current && !options.base;
+}
+
+async function fetchOfflineFileContent(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+  expected: OfflineSyncFileState;
+}): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  const hash = createHash("sha256");
+  let offset = 0;
+  while (offset < args.expected.bytes) {
+    const chunk = await fetchOfflineFileContentChunk({
+      remoteUrl: args.remoteUrl,
+      token: args.token,
+      namespace: args.namespace,
+      includeTranscripts: args.includeTranscripts,
+      path: args.expected.path,
+      offset,
+      length: Math.min(
+        OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+        args.expected.bytes - offset,
+      ),
+    });
+    if (
+      chunk.path !== args.expected.path ||
+      chunk.sha256 !== args.expected.sha256 ||
+      chunk.bytes !== args.expected.bytes ||
+      chunk.mtimeMs !== args.expected.mtimeMs ||
+      chunk.offset !== offset ||
+      chunk.chunkBytes !== chunk.content.length
+    ) {
+      throw new Error(`remote file changed while fetching offline content: ${args.expected.path}`);
+    }
+    if (chunk.chunkBytes === 0) {
+      throw new Error(`remote offline content chunk was empty before EOF: ${args.expected.path}`);
+    }
+    chunks.push(chunk.content);
+    hash.update(chunk.content);
+    offset += chunk.chunkBytes;
+  }
+  const content = Buffer.concat(chunks, offset);
+  const digest = hash.digest("hex");
+  if (digest !== args.expected.sha256 || content.length !== args.expected.bytes) {
+    throw new Error(`remote offline content checksum mismatch for ${args.expected.path}`);
+  }
+  return content;
+}
+
+async function directHydrateLargeOfflineFiles(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+  snapshot: OfflineSyncSnapshot & { namespace?: string };
+  baseFiles: readonly OfflineSyncFileState[];
+  currentFiles: readonly OfflineSyncFileState[];
+  memoryDir: string;
+  writeFile?: (target: OfflineSyncFileWriteTarget) => Promise<void>;
+}): Promise<Set<string>> {
+  if (!args.writeFile) return new Set();
+  const base = offlineFileStateMap(args.baseFiles);
+  const current = offlineFileStateMap(args.currentFiles);
+  const hydrated = new Set<string>();
+  const candidates = args.snapshot.files
+    .filter((incoming) =>
+      shouldDirectHydrateOfflineFile({
+        incoming,
+        base: base.get(incoming.path),
+        current: current.get(incoming.path),
+      }))
+    .sort((left, right) => right.bytes - left.bytes || left.path.localeCompare(right.path));
+  for (const incoming of candidates) {
+    const content = await fetchOfflineFileContent({
+      remoteUrl: args.remoteUrl,
+      token: args.token,
+      namespace: args.namespace,
+      includeTranscripts: args.includeTranscripts,
+      expected: incoming,
+    });
+    await args.writeFile({
+      root: args.memoryDir,
+      path: incoming.path,
+      filePath: path.resolve(args.memoryDir, incoming.path),
+      content,
+    });
+    hydrated.add(incoming.path);
+  }
+  return hydrated;
 }
 
 function chunkOfflineFilePaths(paths: readonly string[]): string[][] {
@@ -5973,7 +6155,7 @@ async function runOfflineSyncOnce(options: {
     includeTranscripts: options.includeTranscripts,
     readFile: storageIo.readFile,
   });
-  const remoteSnapshot = await hydrateOfflineSnapshotContent({
+  const directHydratedPaths = await directHydrateLargeOfflineFiles({
     remoteUrl: options.remoteUrl,
     token: options.token,
     namespace: syncNamespace,
@@ -5981,6 +6163,26 @@ async function runOfflineSyncOnce(options: {
     snapshot: remoteSnapshotMetadata,
     baseFiles,
     currentFiles: currentSnapshot.files,
+    memoryDir: options.memoryDir,
+    writeFile: storageIo.writeFile,
+  });
+  const applyCurrentSnapshot = directHydratedPaths.size > 0
+    ? await buildOfflineSyncSnapshot({
+        root: options.memoryDir,
+        sourceId: localOfflineSourceId(options.memoryDir),
+        includeContent: false,
+        includeTranscripts: options.includeTranscripts,
+        readFile: storageIo.readFile,
+      })
+    : currentSnapshot;
+  const remoteSnapshot = await hydrateOfflineSnapshotContent({
+    remoteUrl: options.remoteUrl,
+    token: options.token,
+    namespace: syncNamespace,
+    includeTranscripts: options.includeTranscripts,
+    snapshot: remoteSnapshotMetadata,
+    baseFiles,
+    currentFiles: applyCurrentSnapshot.files,
   });
   const resolvedNamespace = resolvedOfflineSnapshotNamespace(remoteSnapshot, syncNamespace);
   let pull: Awaited<ReturnType<typeof applyOfflineSyncSnapshot>>;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -130,6 +130,7 @@ import {
   buildOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
   defaultOfflineSyncStatePath,
+  normalizeOfflineSyncSnapshot,
   offlineSyncStateFromSnapshot,
   readOfflineSyncState,
   summarizeOfflineSyncChangeset,
@@ -5873,10 +5874,11 @@ async function directHydrateLargeOfflineFiles(args: {
   writeFile?: (target: OfflineSyncFileWriteTarget) => Promise<void>;
 }): Promise<Set<string>> {
   if (!args.writeFile) return new Set();
+  const snapshot = normalizeOfflineSyncSnapshot(args.snapshot);
   const base = offlineFileStateMap(args.baseFiles);
   const current = offlineFileStateMap(args.currentFiles);
   const hydrated = new Set<string>();
-  const candidates = args.snapshot.files
+  const candidates = snapshot.files
     .filter((incoming) =>
       shouldDirectHydrateOfflineFile({
         incoming,

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -359,6 +359,96 @@ test("HTTP offline files forwards namespace and requested paths", async () => {
   }
 });
 
+test("HTTP offline file-content forwards range options and returns binary metadata", async () => {
+  const calls: Array<{
+    namespace: string | undefined;
+    principal: string | undefined;
+    includeTranscripts: boolean | undefined;
+    path: string;
+    offset: number | undefined;
+    length: number | undefined;
+  }> = [];
+  const service = {
+    offlineSyncFileContent: async (options: {
+      namespace?: string;
+      principal?: string;
+      includeTranscripts?: boolean;
+      path: string;
+      offset?: number;
+      length?: number;
+    }) => {
+      calls.push({
+        namespace: options.namespace,
+        principal: options.principal,
+        includeTranscripts: options.includeTranscripts,
+        path: options.path,
+        offset: options.offset,
+        length: options.length,
+      });
+      return {
+        namespace: options.namespace ?? "default",
+        path: options.path,
+        sha256: "a".repeat(64),
+        bytes: 12,
+        mtimeMs: 1234,
+        offset: options.offset ?? 0,
+        chunkBytes: 5,
+        content: Buffer.from("hello"),
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/remnic/v1/offline-sync/file-content`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          namespace: "team",
+          includeTranscripts: false,
+          path: "state/memory-lifecycle-ledger.jsonl",
+          offset: 8,
+          length: 5,
+        }),
+      },
+    );
+    const body = Buffer.from(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(body.toString("utf-8"), "hello");
+    assert.equal(response.headers.get("content-type"), "application/octet-stream");
+    assert.equal(response.headers.get("x-remnic-namespace"), "team");
+    assert.equal(response.headers.get("x-remnic-file-path"), "state%2Fmemory-lifecycle-ledger.jsonl");
+    assert.equal(response.headers.get("x-remnic-file-sha256"), "a".repeat(64));
+    assert.equal(response.headers.get("x-remnic-file-bytes"), "12");
+    assert.equal(response.headers.get("x-remnic-file-mtime-ms"), "1234");
+    assert.equal(response.headers.get("x-remnic-chunk-offset"), "8");
+    assert.equal(response.headers.get("x-remnic-chunk-bytes"), "5");
+    assert.deepEqual(calls, [{
+      namespace: "team",
+      principal: "reader",
+      includeTranscripts: false,
+      path: "state/memory-lifecycle-ledger.jsonl",
+      offset: 8,
+      length: 5,
+    }]);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("HTTP offline snapshot rejects invalid boolean query values", async () => {
   let calls = 0;
   const service = {

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -660,11 +660,11 @@ export class EngramAccessHttpServer {
       this.respondBinary(res, 200, result.content, {
         "x-remnic-namespace": encodeURIComponent(result.namespace),
         "x-remnic-file-path": encodeURIComponent(result.path),
-        "x-remnic-file-sha256": result.sha256,
         "x-remnic-file-bytes": String(result.bytes),
         "x-remnic-file-mtime-ms": String(result.mtimeMs),
         "x-remnic-chunk-offset": String(result.offset),
         "x-remnic-chunk-bytes": String(result.chunkBytes),
+        ...(result.sha256 ? { "x-remnic-file-sha256": result.sha256 } : {}),
       });
       return;
     }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -643,6 +643,34 @@ export class EngramAccessHttpServer {
 
     if (
       req.method === "POST" &&
+      (
+        pathname === "/engram/v1/offline-sync/file-content" ||
+        pathname === "/remnic/v1/offline-sync/file-content"
+      )
+    ) {
+      const body = await this.readValidatedBody(req, "offlineSyncFileContent");
+      const result = await this.service.offlineSyncFileContent({
+        namespace: this.resolveNamespace(req, body.namespace),
+        principal: this.resolveRequestPrincipal(req),
+        includeTranscripts: body.includeTranscripts,
+        path: body.path,
+        offset: body.offset,
+        length: body.length,
+      });
+      this.respondBinary(res, 200, result.content, {
+        "x-remnic-namespace": encodeURIComponent(result.namespace),
+        "x-remnic-file-path": encodeURIComponent(result.path),
+        "x-remnic-file-sha256": result.sha256,
+        "x-remnic-file-bytes": String(result.bytes),
+        "x-remnic-file-mtime-ms": String(result.mtimeMs),
+        "x-remnic-chunk-offset": String(result.offset),
+        "x-remnic-chunk-bytes": String(result.chunkBytes),
+      });
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
       (pathname === "/engram/v1/offline-sync/apply" || pathname === "/remnic/v1/offline-sync/apply")
     ) {
       const body = await this.readValidatedBody(req, "offlineSyncApply");
@@ -1796,6 +1824,25 @@ export class EngramAccessHttpServer {
     res.statusCode = status;
     res.setHeader("content-type", "application/json; charset=utf-8");
     res.setHeader("content-length", String(Buffer.byteLength(body)));
+    const cid = correlationIdStore.getStore();
+    if (cid) {
+      res.setHeader("x-request-id", cid);
+    }
+    res.end(body);
+  }
+
+  private respondBinary(
+    res: ServerResponse,
+    status: number,
+    body: Buffer,
+    headers: Record<string, string> = {},
+  ): void {
+    res.statusCode = status;
+    res.setHeader("content-type", "application/octet-stream");
+    res.setHeader("content-length", String(body.length));
+    for (const [key, value] of Object.entries(headers)) {
+      res.setHeader(key, value);
+    }
     const cid = correlationIdStore.getStore();
     if (cid) {
       res.setHeader("x-request-id", cid);

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -10,6 +10,7 @@ import {
 } from "./action-confidence.js";
 import { isValidCapsuleSince } from "./transfer/capsule-export.js";
 import { CAPSULE_ID_PATTERN } from "./transfer/types.js";
+import { OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES } from "./offline-sync.js";
 
 // ---------------------------------------------------------------------------
 // Error formatting
@@ -386,6 +387,14 @@ export const offlineSyncFilesRequestSchema = z.object({
     .max(5000, "paths must contain 5000 or fewer entries"),
 });
 
+export const offlineSyncFileContentRequestSchema = z.object({
+  namespace: namespaceSchema,
+  includeTranscripts: z.boolean().optional(),
+  path: z.string().trim().min(1, "path must be non-empty").max(4096),
+  offset: z.number().int().min(0).optional(),
+  length: z.number().int().min(1).max(OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES).optional(),
+});
+
 // ---------------------------------------------------------------------------
 // Action confidence
 // ---------------------------------------------------------------------------
@@ -453,6 +462,7 @@ export type CapsuleImportRequest = z.infer<typeof capsuleImportRequestSchema>;
 export type CapsuleListRequest = z.infer<typeof capsuleListRequestSchema>;
 export type OfflineSyncApplyRequest = z.infer<typeof offlineSyncApplyRequestSchema>;
 export type OfflineSyncFilesRequest = z.infer<typeof offlineSyncFilesRequestSchema>;
+export type OfflineSyncFileContentRequest = z.infer<typeof offlineSyncFileContentRequestSchema>;
 export type ActionConfidenceRequest = z.infer<typeof actionConfidenceRequestSchema>;
 
 // ---------------------------------------------------------------------------
@@ -477,6 +487,7 @@ export type SchemaName =
   | "capsuleImport"
   | "capsuleList"
   | "offlineSyncFiles"
+  | "offlineSyncFileContent"
   | "offlineSyncApply"
   | "actionConfidence";
 
@@ -498,6 +509,7 @@ export type SchemaTypeFor<N extends SchemaName> =
   : N extends "capsuleImport" ? CapsuleImportRequest
   : N extends "capsuleList" ? CapsuleListRequest
   : N extends "offlineSyncFiles" ? OfflineSyncFilesRequest
+  : N extends "offlineSyncFileContent" ? OfflineSyncFileContentRequest
   : N extends "offlineSyncApply" ? OfflineSyncApplyRequest
   : N extends "actionConfidence" ? ActionConfidenceRequest
   : never;
@@ -520,6 +532,7 @@ const schemas: Record<SchemaName, z.ZodTypeAny> = {
   capsuleImport: capsuleImportRequestSchema,
   capsuleList: capsuleListRequestSchema,
   offlineSyncFiles: offlineSyncFilesRequestSchema,
+  offlineSyncFileContent: offlineSyncFileContentRequestSchema,
   offlineSyncApply: offlineSyncApplyRequestSchema,
   actionConfidence: actionConfidenceRequestSchema,
 };

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -139,7 +139,9 @@ import {
   applyOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
   buildOfflineSyncSnapshotForPaths,
+  readOfflineSyncFileContentChunk,
   type OfflineSyncApplyChangesetResult,
+  type OfflineSyncFileContentChunk,
   type OfflineSyncSnapshot,
 } from "./offline-sync.js";
 import {
@@ -624,6 +626,15 @@ export interface EngramAccessOfflineSyncFilesRequest {
   paths: string[];
 }
 
+export interface EngramAccessOfflineSyncFileContentRequest {
+  namespace?: string;
+  principal?: string;
+  includeTranscripts?: boolean;
+  path: string;
+  offset?: number;
+  length?: number;
+}
+
 export interface EngramAccessOfflineSyncApplyRequest {
   namespace?: string;
   principal?: string;
@@ -635,6 +646,10 @@ export interface EngramAccessOfflineSyncSnapshotResponse extends OfflineSyncSnap
 }
 
 export interface EngramAccessOfflineSyncFilesResponse extends OfflineSyncSnapshot {
+  namespace: string;
+}
+
+export interface EngramAccessOfflineSyncFileContentResponse extends OfflineSyncFileContentChunk {
   namespace: string;
 }
 
@@ -5605,6 +5620,39 @@ export class EngramAccessService {
         message.startsWith("paths[]:") ||
         message.startsWith("buildOfflineSyncSnapshotForPaths: record path ") ||
         message.startsWith("offline sync snapshot path is excluded:")
+      ) {
+        throw new EngramAccessInputError(message);
+      }
+      throw error;
+    }
+  }
+
+  async offlineSyncFileContent(
+    options: EngramAccessOfflineSyncFileContentRequest,
+  ): Promise<EngramAccessOfflineSyncFileContentResponse> {
+    const resolvedNamespace = this.resolveReadableNamespace(options.namespace, options.principal);
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    try {
+      const chunk = await readOfflineSyncFileContentChunk({
+        root: storage.dir,
+        path: options.path,
+        offset: options.offset,
+        length: options.length,
+        includeTranscripts: options.includeTranscripts !== false,
+        readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
+      });
+      return {
+        namespace: resolvedNamespace,
+        ...chunk,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.startsWith("path:") ||
+        message.startsWith("offset ") ||
+        message.startsWith("offset must ") ||
+        message.startsWith("length ") ||
+        message.startsWith("offline sync file content ")
       ) {
         throw new EngramAccessInputError(message);
       }

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -680,6 +680,7 @@ export {
 
 export {
   OFFLINE_SYNC_CHANGESET_FORMAT,
+  OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
   OFFLINE_SYNC_SNAPSHOT_FORMAT,
   OFFLINE_SYNC_STATE_VERSION,
   applyOfflineSyncChangeset,
@@ -692,6 +693,7 @@ export {
   normalizeOfflineSyncChangeset,
   normalizeOfflineSyncSnapshot,
   offlineSyncStateFromSnapshot,
+  readOfflineSyncFileContentChunk,
   readOfflineSyncState,
   summarizeOfflineSyncChangeset,
   writeOfflineSyncState,
@@ -701,6 +703,7 @@ export {
   type OfflineSyncChangeset,
   type OfflineSyncConflict,
   type OfflineSyncFileRecord,
+  type OfflineSyncFileContentChunk,
   type OfflineSyncFileState,
   type OfflineSyncFileTarget,
   type OfflineSyncFileWriteTarget,

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -135,10 +135,6 @@ test("offline sync reads bounded file content chunks with metadata", async () =>
     assert.equal(chunk.chunkBytes, 5);
     assert.equal(chunk.content.toString("utf-8"), "beta\n");
     assert.equal(chunk.bytes, Buffer.byteLength("alpha\nbeta\ngamma\n"));
-    assert.equal(
-      chunk.sha256,
-      createHash("sha256").update("alpha\nbeta\ngamma\n").digest("hex"),
-    );
 
     await assert.rejects(
       () =>

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -11,6 +11,7 @@ import {
   buildOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
   buildOfflineSyncSnapshotForPaths,
+  readOfflineSyncFileContentChunk,
 } from "./offline-sync.js";
 import { isEncryptedFile } from "./secure-store/secure-fs.js";
 import { StorageManager } from "./storage.js";
@@ -112,6 +113,41 @@ test("offline sync excludes live LCM sqlite artifacts without deleting existing 
 
     assert.equal(pull.deleted, 0);
     assert.equal(await readUtf8(root, "state/lcm.sqlite"), "live db");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline sync reads bounded file content chunks with metadata", async () => {
+  const root = await tempDir("remnic-offline-file-content");
+  try {
+    await write(root, "state/memory-lifecycle-ledger.jsonl", "alpha\nbeta\ngamma\n");
+
+    const chunk = await readOfflineSyncFileContentChunk({
+      root,
+      path: "state/memory-lifecycle-ledger.jsonl",
+      offset: 6,
+      length: 5,
+    });
+
+    assert.equal(chunk.path, "state/memory-lifecycle-ledger.jsonl");
+    assert.equal(chunk.offset, 6);
+    assert.equal(chunk.chunkBytes, 5);
+    assert.equal(chunk.content.toString("utf-8"), "beta\n");
+    assert.equal(chunk.bytes, Buffer.byteLength("alpha\nbeta\ngamma\n"));
+    assert.equal(
+      chunk.sha256,
+      createHash("sha256").update("alpha\nbeta\ngamma\n").digest("hex"),
+    );
+
+    await assert.rejects(
+      () =>
+        readOfflineSyncFileContentChunk({
+          root,
+          path: "state/lcm.sqlite",
+        }),
+      /offline sync file content path is excluded: state\/lcm\.sqlite/,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -25,6 +25,7 @@ import { parseFlexibleIsoTimestamp } from "./utils/iso-timestamp.js";
 export const OFFLINE_SYNC_SNAPSHOT_FORMAT = "remnic.offline-sync.snapshot.v1";
 export const OFFLINE_SYNC_CHANGESET_FORMAT = "remnic.offline-sync.changeset.v1";
 export const OFFLINE_SYNC_STATE_VERSION = 1;
+export const OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES = 64 * 1024 * 1024;
 
 export interface OfflineSyncFileState {
   path: string;
@@ -124,6 +125,12 @@ export interface OfflineSyncFileTarget {
 }
 
 export interface OfflineSyncFileWriteTarget extends OfflineSyncFileTarget {
+  content: Buffer;
+}
+
+export interface OfflineSyncFileContentChunk extends OfflineSyncFileState {
+  offset: number;
+  chunkBytes: number;
   content: Buffer;
 }
 
@@ -527,6 +534,60 @@ export async function buildOfflineSyncSnapshotForPaths(options: {
     sourceId: normalizeSourceId(options.sourceId, "sourceId"),
     includeTranscripts,
     files: files.sort(compareByPath),
+  };
+}
+
+export async function readOfflineSyncFileContentChunk(options: {
+  root: string;
+  path: string;
+  offset?: number;
+  length?: number;
+  includeTranscripts?: boolean;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
+}): Promise<OfflineSyncFileContentChunk> {
+  const rootAbs = path.resolve(options.root);
+  const root = await prepareSafeArchiveRoot(rootAbs, "readOfflineSyncFileContentChunk", "root");
+  const includeTranscripts = options.includeTranscripts !== false;
+  const relPath = normalizeRelativePath(options.path, "path");
+  if (shouldExcludeRelPath(relPath, includeTranscripts)) {
+    throw new Error(`offline sync file content path is excluded: ${relPath}`);
+  }
+  const offset = options.offset === undefined
+    ? 0
+    : assertNonNegativeInteger(options.offset, "offset");
+  const requestedLength = options.length === undefined
+    ? OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES
+    : assertNonNegativeInteger(options.length, "length");
+  if (requestedLength < 1 || requestedLength > OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES) {
+    throw new Error(
+      `length must be an integer from 1 to ${OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES}`,
+    );
+  }
+  const filePath = await resolveSafeArchiveTarget(root, relPath);
+  const st = await lstat(filePath).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  });
+  if (!st || st.isSymbolicLink() || !st.isFile()) {
+    throw new Error(`offline sync file content path not found: ${relPath}`);
+  }
+  const content = options.readFile
+    ? await options.readFile({ root: root.abs, path: relPath, filePath })
+    : await readFile(filePath);
+  if (offset > content.length) {
+    throw new Error(`offset must be <= file size for ${relPath}`);
+  }
+  const digest = sha256Buffer(content);
+  const end = Math.min(content.length, offset + requestedLength);
+  const chunk = content.subarray(offset, end);
+  return {
+    path: relPath,
+    sha256: digest.sha256,
+    bytes: digest.bytes,
+    mtimeMs: st.mtimeMs,
+    offset,
+    chunkBytes: chunk.length,
+    content: Buffer.from(chunk),
   };
 }
 

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   lstat,
   mkdir,
+  open,
   readdir,
   readFile,
   rename,
@@ -13,6 +14,7 @@ import path from "node:path";
 import {
   DEFAULT_TRANSFER_EXCLUDE_DIRS,
 } from "./transfer/exclusions.js";
+import { isEncryptedFile, MAGIC_HEADER_SIZE } from "./secure-store/secure-fs.js";
 import {
   prepareSafeArchiveRoot,
   resolveSafeArchiveTarget,
@@ -128,7 +130,8 @@ export interface OfflineSyncFileWriteTarget extends OfflineSyncFileTarget {
   content: Buffer;
 }
 
-export interface OfflineSyncFileContentChunk extends OfflineSyncFileState {
+export interface OfflineSyncFileContentChunk extends Omit<OfflineSyncFileState, "sha256"> {
+  sha256?: string;
   offset: number;
   chunkBytes: number;
   content: Buffer;
@@ -442,6 +445,35 @@ async function readOfflineSyncFileRecord(
   };
 }
 
+async function fileIsSecureStoreEncrypted(filePath: string): Promise<boolean> {
+  const handle = await open(filePath, "r");
+  try {
+    const header = Buffer.alloc(MAGIC_HEADER_SIZE);
+    const { bytesRead } = await handle.read(header, 0, header.length, 0);
+    return bytesRead >= MAGIC_HEADER_SIZE && isEncryptedFile(header);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readPlainFileContentChunk(options: {
+  filePath: string;
+  offset: number;
+  length: number;
+  bytes: number;
+}): Promise<Buffer> {
+  const chunkBytes = Math.min(options.length, options.bytes - options.offset);
+  const chunk = Buffer.alloc(chunkBytes);
+  if (chunkBytes === 0) return chunk;
+  const handle = await open(options.filePath, "r");
+  try {
+    const { bytesRead } = await handle.read(chunk, 0, chunk.length, options.offset);
+    return bytesRead === chunk.length ? chunk : chunk.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
 export async function buildOfflineSyncSnapshot(options: {
   root: string;
   sourceId: string;
@@ -571,9 +603,30 @@ export async function readOfflineSyncFileContentChunk(options: {
   if (!st || st.isSymbolicLink() || !st.isFile()) {
     throw new Error(`offline sync file content path not found: ${relPath}`);
   }
-  const content = options.readFile
-    ? await options.readFile({ root: root.abs, path: relPath, filePath })
-    : await readFile(filePath);
+  const encrypted = await fileIsSecureStoreEncrypted(filePath);
+  if (!encrypted) {
+    if (offset > st.size) {
+      throw new Error(`offset must be <= file size for ${relPath}`);
+    }
+    const chunk = await readPlainFileContentChunk({
+      filePath,
+      offset,
+      length: requestedLength,
+      bytes: st.size,
+    });
+    return {
+      path: relPath,
+      bytes: st.size,
+      mtimeMs: st.mtimeMs,
+      offset,
+      chunkBytes: chunk.length,
+      content: chunk,
+    };
+  }
+  if (!options.readFile) {
+    throw new Error(`offline sync file content requires a secure-store read hook: ${relPath}`);
+  }
+  const content = await options.readFile({ root: root.abs, path: relPath, filePath });
   if (offset > content.length) {
     throw new Error(`offset must be <= file size for ${relPath}`);
   }


### PR DESCRIPTION
## Summary
- add a chunked offline file-content endpoint for large file hydration
- have the CLI directly hydrate large remote files before the normal snapshot apply when the local copy is still at the shared base
- cover the new range endpoint and core chunk reader with tests

## Verification
- pnpm exec tsx --test packages/remnic-core/src/offline-sync.test.ts packages/remnic-core/src/access-http.test.ts
- pnpm --filter @remnic/core check-types
- pnpm --filter @remnic/cli check-types
- npm run preflight:quick
- npm run review:cursor (skipped: cursor-agent rejects --trust on this machine)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new binary HTTP endpoint and new chunked file-read logic used during offline sync, which could affect correctness/performance of syncing large state files and introduces new validation and path-safety checks.
> 
> **Overview**
> Improves offline sync handling for very large, append-heavy state files by introducing **chunked file content hydration** instead of forcing full file contents through JSON snapshots.
> 
> Adds a new `POST /remnic/v1/offline-sync/file-content` endpoint that returns an `application/octet-stream` chunk plus metadata headers, with schema validation and a core implementation (`readOfflineSyncFileContentChunk`) that supports `offset`/`length`, enforces max chunk size, and handles secure-store encrypted files via a read hook.
> 
> Updates the CLI to **pre-hydrate large remote files directly to disk** (with path escape protection and checksum/mtime/size verification) before running the existing snapshot content hydration/apply flow, and includes new tests covering the endpoint forwarding and chunk reader behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6f88a6fca267e25d9fe177510d9bc1a238e73e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->