### PR TITLE
Exclude volatile offline sync debug snapshots

### DIFF
--- a/.changeset/offline-sync-debug-snapshots.md
+++ b/.changeset/offline-sync-debug-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Exclude volatile retrieval debug snapshots from offline sync payloads.

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -41,6 +41,10 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
     await write(root, ".offline-sync/state/local.json", "state");
     await write(root, "state/fact-hashes.txt", "derived");
     await write(root, "state/fact-hashes.ready", "v1");
+    await write(root, "state/last_graph_recall.json", "{}");
+    await write(root, "state/last_intent.json", "{}");
+    await write(root, "state/last_qmd_recall.json", "{}");
+    await write(root, "state/last_recall.json", "{}");
     await write(root, "state/lcm.sqlite", "live db");
     await write(root, "state/lcm.sqlite-shm", "live shm");
     await write(root, "state/lcm.sqlite-wal", "live wal");
@@ -68,6 +72,60 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
       withoutTranscripts.files.map((file) => file.path),
       ["assets/blob.bin", "facts/a.md", "facts/fact-hashes.txt"],
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline sync excludes volatile retrieval debug snapshots without deleting existing local copies", async () => {
+  const root = await tempDir("remnic-offline-debug-snapshots");
+  try {
+    await write(root, "facts/a.md", "alpha");
+    await write(root, "state/last_graph_recall.json", "graph");
+    await write(root, "state/last_intent.json", "intent");
+    await write(root, "state/last_qmd_recall.json", "qmd");
+    await write(root, "state/last_recall.json", "recall");
+
+    const snapshot = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "remote",
+      includeContent: true,
+    });
+
+    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
+    await assert.rejects(
+      () =>
+        buildOfflineSyncSnapshotForPaths({
+          root,
+          sourceId: "remote",
+          paths: ["state/last_graph_recall.json"],
+          includeContent: true,
+        }),
+      /offline sync snapshot path is excluded: state\/last_graph_recall\.json/,
+    );
+    await assert.rejects(
+      () =>
+        readOfflineSyncFileContentChunk({
+          root,
+          path: "state/last_graph_recall.json",
+        }),
+      /offline sync file content path is excluded: state\/last_graph_recall\.json/,
+    );
+
+    const oldGraph = Buffer.from("old graph");
+    const pull = await applyOfflineSyncSnapshot({
+      root,
+      snapshot,
+      baseFiles: [{
+        path: "state/last_graph_recall.json",
+        sha256: createHash("sha256").update(oldGraph).digest("hex"),
+        bytes: oldGraph.byteLength,
+        mtimeMs: 0,
+      }],
+    });
+
+    assert.equal(pull.deleted, 0);
+    assert.equal(await readUtf8(root, "state/last_graph_recall.json"), "graph");
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -153,6 +153,10 @@ const EXCLUDED_FILE_NAMES = new Set([
 const EXCLUDED_REL_PATHS = new Set([
   "state/fact-hashes.ready",
   "state/fact-hashes.txt",
+  "state/last_graph_recall.json",
+  "state/last_intent.json",
+  "state/last_qmd_recall.json",
+  "state/last_recall.json",
   "state/lcm.sqlite",
   "state/lcm.sqlite-shm",
   "state/lcm.sqlite-wal",


### PR DESCRIPTION
## Summary
- exclude volatile retrieval debug snapshots from offline sync payloads
- reject direct path/file-content requests for those debug snapshots
- preserve existing local debug snapshot files during pull

## Verification
- pnpm exec tsx --test packages/remnic-core/src/offline-sync.test.ts
- pnpm --filter @remnic/core check-types
- npm run preflight:quick
- npm run review:cursor (skipped: local cursor-agent does not support --trust)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to expanding the offline-sync exclusion list and adding tests; main impact is that specific debug snapshot files will no longer sync or be fetchable via the offline sync content APIs.
> 
> **Overview**
> **Offline sync now excludes volatile retrieval debug snapshots** (e.g. `state/last_*_recall.json`, `state/last_intent.json`) from snapshot/changeset payload generation.
> 
> Direct requests to include or read these paths via `buildOfflineSyncSnapshotForPaths` and `readOfflineSyncFileContentChunk` are now rejected, and pulls are validated to *not* delete any existing local copies of these excluded debug files (covered by a new test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1464991a3f7e7aa2bf6a207e534251cf79dedaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->