### PR TITLE
Exclude runtime state from offline sync

### DIFF
--- a/.changeset/offline-sync-runtime-state.md
+++ b/.changeset/offline-sync-runtime-state.md
@@ -1,0 +1,6 @@
+---
+"@remnic/core": patch
+"@remnic/cli": patch
+---
+
+Exclude volatile runtime state from offline sync and make offline status summarize pending changes without materializing content.

--- a/.changeset/polite-cycles-swim.md
+++ b/.changeset/polite-cycles-swim.md
@@ -1,0 +1,5 @@
+---
+"@remnic/plugin-pi": patch
+---
+
+Increase the default Pi extension request timeout so local Remnic recall has enough time to finish when offline retrieval is warming up.

--- a/docs/integration/pi.md
+++ b/docs/integration/pi.md
@@ -75,7 +75,7 @@ Supported config keys:
 | `compactionEnabled` | `true` | Enable LCM flush/checkpoint coordination |
 | `mcpToolsEnabled` | `true` | Register Remnic MCP tools as Pi tools |
 | `statusEnabled` | `true` | Set Pi UI status from daemon health |
-| `requestTimeoutMs` | `5000` | HTTP/MCP request timeout |
+| `requestTimeoutMs` | `60000` | HTTP/MCP request timeout |
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 

--- a/packages/plugin-pi/README.md
+++ b/packages/plugin-pi/README.md
@@ -81,7 +81,7 @@ Supported config keys:
 | `compactionEnabled` | `true` | Enable LCM flush and checkpoint coordination |
 | `mcpToolsEnabled` | `true` | Register Remnic MCP tools as Pi tools |
 | `statusEnabled` | `true` | Set Pi UI status from daemon health |
-| `requestTimeoutMs` | `5000` | HTTP/MCP request timeout |
+| `requestTimeoutMs` | `60000` | HTTP/MCP request timeout |
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 
@@ -99,7 +99,7 @@ Example:
   "compactionEnabled": true,
   "mcpToolsEnabled": true,
   "statusEnabled": true,
-  "requestTimeoutMs": 5000
+  "requestTimeoutMs": 60000
 }
 ```
 

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { RemnicClient } from "./client.js";
+import type { RemnicPiConfig } from "./config.js";
+
+test("RemnicClient reports request timeouts with actionable context", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })));
+    });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const client = new RemnicClient({ ...baseConfig(), requestTimeoutMs: 1 });
+
+  await assert.rejects(
+    () => client.health(),
+    /Remnic request timed out after 1ms/,
+  );
+});
+
+function baseConfig(): RemnicPiConfig {
+  return {
+    remnicDaemonUrl: "http://127.0.0.1:4318",
+    recallMode: "auto",
+    recallTopK: 8,
+    recallBudgetChars: 12000,
+    recallEnabled: true,
+    observeEnabled: true,
+    observeSkipExtraction: false,
+    compactionEnabled: true,
+    mcpToolsEnabled: true,
+    statusEnabled: true,
+    requestTimeoutMs: 60000,
+  };
+}

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -151,6 +151,11 @@ export class RemnicClient {
         throw new RemnicHttpError(response.status, typeof payload?.error === "string" ? payload.error : response.statusText);
       }
       return payload as T;
+    } catch (err) {
+      if (isAbortError(err)) {
+        throw new Error(`Remnic request timed out after ${this.config.requestTimeoutMs}ms`);
+      }
+      throw err;
     } finally {
       clearTimeout(timeout);
     }
@@ -173,4 +178,8 @@ export class RemnicClient {
 
 function isMcpTool(value: unknown): value is McpTool {
   return !!value && typeof value === "object" && typeof (value as { name?: unknown }).name === "string";
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && (err.name === "AbortError" || err.message === "This operation was aborted");
 }

--- a/packages/plugin-pi/src/config.test.ts
+++ b/packages/plugin-pi/src/config.test.ts
@@ -96,6 +96,20 @@ test("loadConfig reads a tilde-expanded env config path", () => {
   }
 });
 
+test("loadConfig defaults request timeout high enough for warmed-up recall", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-config-default-timeout-"));
+  const configPath = path.join(root, "remnic.config.json");
+  try {
+    fs.writeFileSync(configPath, JSON.stringify({}));
+
+    const config = loadConfig({ configPath, env: {} });
+
+    assert.equal(config.requestTimeoutMs, 60000);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("loadConfig merges file values and coerces boolean-like strings", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-config-"));
   const configPath = path.join(root, "remnic.config.json");

--- a/packages/plugin-pi/src/config.ts
+++ b/packages/plugin-pi/src/config.ts
@@ -37,7 +37,7 @@ const DEFAULT_CONFIG: RemnicPiConfig = {
   compactionEnabled: true,
   mcpToolsEnabled: true,
   statusEnabled: true,
-  requestTimeoutMs: 5000,
+  requestTimeoutMs: 60000,
 };
 
 function defaultConfigPath(env: NodeJS.ProcessEnv): string {

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -627,7 +627,7 @@ function baseConfig(): RemnicPiConfig {
     compactionEnabled: true,
     mcpToolsEnabled: true,
     statusEnabled: true,
-    requestTimeoutMs: 5000,
+    requestTimeoutMs: 60000,
   };
 }
 

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -102,7 +102,7 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
       compactionEnabled: true,
       mcpToolsEnabled: true,
       statusEnabled: true,
-      requestTimeoutMs: 5000,
+      requestTimeoutMs: 60000,
       ...priorConfig,
       remnicDaemonUrl: resolveDaemonUrl(ctx),
     };

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5967,15 +5967,17 @@ async function hydrateOfflineSnapshotContent(args: {
   baseFiles: readonly OfflineSyncFileState[];
   currentFiles?: readonly OfflineSyncFileState[];
 }): Promise<OfflineSyncSnapshot & { namespace?: string }> {
+  const snapshot = normalizeOfflineSyncSnapshot(args.snapshot);
   const neededFiles = offlineSnapshotContentFilesForApply({
-    snapshot: args.snapshot,
+    snapshot,
     baseFiles: args.baseFiles,
     currentFiles: args.currentFiles,
   });
-  if (neededFiles.length === 0) return args.snapshot;
+  if (neededFiles.length === 0) return { ...args.snapshot, files: snapshot.files };
 
-  const expectedByPath = new Map(args.snapshot.files.map((file) => [file.path, file]));
+  const expectedByPath = new Map(snapshot.files.map((file) => [file.path, file]));
   const contentByPath = new Map<string, string>();
+  const updatedByPath = new Map<string, OfflineSyncFileState & { contentBase64: string }>();
   try {
     for (const batch of chunkOfflineFileContentBatches(neededFiles)) {
       const partial = await fetchOfflineFiles({
@@ -5988,11 +5990,11 @@ async function hydrateOfflineSnapshotContent(args: {
       for (const file of partial.files) {
         const expected = expectedByPath.get(file.path);
         if (!expected) continue;
-        if (file.sha256 !== expected.sha256 || file.bytes !== expected.bytes) {
-          throw new Error(`remote file changed while fetching offline content: ${file.path}`);
-        }
         if (typeof file.contentBase64 !== "string") {
           throw new Error(`remote offline content response omitted contentBase64 for ${file.path}`);
+        }
+        if (file.sha256 !== expected.sha256 || file.bytes !== expected.bytes || file.mtimeMs !== expected.mtimeMs) {
+          updatedByPath.set(file.path, file as OfflineSyncFileState & { contentBase64: string });
         }
         contentByPath.set(file.path, file.contentBase64);
       }
@@ -6019,7 +6021,9 @@ async function hydrateOfflineSnapshotContent(args: {
 
   return {
     ...args.snapshot,
-    files: args.snapshot.files.map((file) => {
+    files: snapshot.files.map((file) => {
+      const updated = updatedByPath.get(file.path);
+      if (updated) return updated;
       const contentBase64 = contentByPath.get(file.path);
       return contentBase64 === undefined ? file : { ...file, contentBase64 };
     }),

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -134,6 +134,7 @@ import {
   offlineSyncStateFromSnapshot,
   readOfflineSyncState,
   summarizeOfflineSyncChangeset,
+  summarizeOfflineSyncPendingChanges,
   writeOfflineSyncState,
   type OfflineSyncFileState,
   type OfflineSyncFileWriteTarget,
@@ -6423,14 +6424,13 @@ Environment fallbacks:
       });
     }
     const storageIo = await createOfflineStorageIo(memoryDir);
-    const changeset = await buildOfflineSyncChangeset({
+    const summary = await summarizeOfflineSyncPendingChanges({
       root: memoryDir,
       sourceId: localOfflineSourceId(memoryDir),
       baseFiles: state?.baseFiles ?? [],
       includeTranscripts,
       readFile: storageIo.readFile,
     });
-    const summary = summarizeOfflineSyncChangeset(changeset);
     if (json) {
       console.log(JSON.stringify({ statePath: statePath ?? null, state, pending: summary }, null, 2));
     } else {

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -418,7 +418,7 @@ test("HTTP offline file-content forwards range options and returns binary metada
         body: JSON.stringify({
           namespace: "team",
           includeTranscripts: false,
-          path: "state/memory-lifecycle-ledger.jsonl",
+          path: "artifacts/large.txt",
           offset: 8,
           length: 5,
         }),
@@ -430,7 +430,7 @@ test("HTTP offline file-content forwards range options and returns binary metada
     assert.equal(body.toString("utf-8"), "hello");
     assert.equal(response.headers.get("content-type"), "application/octet-stream");
     assert.equal(response.headers.get("x-remnic-namespace"), "team");
-    assert.equal(response.headers.get("x-remnic-file-path"), "state%2Fmemory-lifecycle-ledger.jsonl");
+    assert.equal(response.headers.get("x-remnic-file-path"), "artifacts%2Flarge.txt");
     assert.equal(response.headers.get("x-remnic-file-sha256"), "a".repeat(64));
     assert.equal(response.headers.get("x-remnic-file-bytes"), "12");
     assert.equal(response.headers.get("x-remnic-file-mtime-ms"), "1234");
@@ -440,7 +440,7 @@ test("HTTP offline file-content forwards range options and returns binary metada
       namespace: "team",
       principal: "reader",
       includeTranscripts: false,
-      path: "state/memory-lifecycle-ledger.jsonl",
+      path: "artifacts/large.txt",
       offset: 8,
       length: 5,
     }]);

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -696,6 +696,7 @@ export {
   readOfflineSyncFileContentChunk,
   readOfflineSyncState,
   summarizeOfflineSyncChangeset,
+  summarizeOfflineSyncPendingChanges,
   writeOfflineSyncState,
   type OfflineSyncApplyChangesetResult,
   type OfflineSyncApplySnapshotResult,

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -12,6 +12,7 @@ import {
   buildOfflineSyncSnapshot,
   buildOfflineSyncSnapshotForPaths,
   readOfflineSyncFileContentChunk,
+  summarizeOfflineSyncPendingChanges,
 } from "./offline-sync.js";
 import { isEncryptedFile } from "./secure-store/secure-fs.js";
 import { StorageManager } from "./storage.js";
@@ -176,19 +177,103 @@ test("offline sync excludes live LCM sqlite artifacts without deleting existing 
   }
 });
 
+test("offline sync excludes runtime-derived state without deleting existing local copies", async () => {
+  const root = await tempDir("remnic-offline-runtime-state");
+  try {
+    await write(root, "facts/a.md", "alpha");
+    await write(root, "state/buffer-surprise-ledger.jsonl", "surprise");
+    await write(root, "state/buffer.json", "buffer");
+    await write(root, "state/buffer.json.tmp-123-456", "tmp");
+    await write(root, "state/embeddings.json", "embeddings");
+    await write(root, "state/index_tags.json", "tags");
+    await write(root, "state/index_time.json", "time");
+    await write(root, "state/memory-lifecycle-ledger.jsonl", "ledger");
+    await write(root, "state/memory-projection.sqlite", "projection");
+    await write(root, "state/memory-projection.sqlite-shm", "projection-shm");
+    await write(root, "state/memory-projection.sqlite-wal", "projection-wal");
+    await write(root, "state/recall_impressions.jsonl", "impressions");
+
+    const snapshot = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "remote",
+      includeContent: true,
+    });
+
+    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
+    await assert.rejects(
+      () =>
+        buildOfflineSyncSnapshotForPaths({
+          root,
+          sourceId: "remote",
+          paths: ["state/memory-lifecycle-ledger.jsonl"],
+          includeContent: true,
+        }),
+      /offline sync snapshot path is excluded: state\/memory-lifecycle-ledger\.jsonl/,
+    );
+    await assert.rejects(
+      () =>
+        readOfflineSyncFileContentChunk({
+          root,
+          path: "state/buffer.json.tmp-123-456",
+        }),
+      /offline sync file content path is excluded: state\/buffer\.json\.tmp-123-456/,
+    );
+
+    const oldLedger = Buffer.from("old ledger");
+    const pull = await applyOfflineSyncSnapshot({
+      root,
+      snapshot,
+      baseFiles: [{
+        path: "state/memory-lifecycle-ledger.jsonl",
+        sha256: createHash("sha256").update(oldLedger).digest("hex"),
+        bytes: oldLedger.byteLength,
+        mtimeMs: 0,
+      }],
+    });
+
+    assert.equal(pull.deleted, 0);
+    assert.equal(await readUtf8(root, "state/memory-lifecycle-ledger.jsonl"), "ledger");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline sync pending summary returns counts without materializing changed content", async () => {
+  const root = await tempDir("remnic-offline-pending-summary");
+  try {
+    await write(root, "facts/a.md", "updated");
+    await write(root, "facts/b.md", "new");
+    const baseA = createHash("sha256").update("old").digest("hex");
+    const baseDeleted = createHash("sha256").update("deleted").digest("hex");
+
+    const summary = await summarizeOfflineSyncPendingChanges({
+      root,
+      sourceId: "local",
+      baseFiles: [
+        { path: "facts/a.md", sha256: baseA, bytes: 3, mtimeMs: 0 },
+        { path: "facts/deleted.md", sha256: baseDeleted, bytes: 7, mtimeMs: 0 },
+      ],
+    });
+
+    assert.deepEqual(summary, { upserts: 2, deletes: 1, total: 3 });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline sync reads bounded file content chunks with metadata", async () => {
   const root = await tempDir("remnic-offline-file-content");
   try {
-    await write(root, "state/memory-lifecycle-ledger.jsonl", "alpha\nbeta\ngamma\n");
+    await write(root, "artifacts/large.txt", "alpha\nbeta\ngamma\n");
 
     const chunk = await readOfflineSyncFileContentChunk({
       root,
-      path: "state/memory-lifecycle-ledger.jsonl",
+      path: "artifacts/large.txt",
       offset: 6,
       length: 5,
     });
 
-    assert.equal(chunk.path, "state/memory-lifecycle-ledger.jsonl");
+    assert.equal(chunk.path, "artifacts/large.txt");
     assert.equal(chunk.offset, 6);
     assert.equal(chunk.chunkBytes, 5);
     assert.equal(chunk.content.toString("utf-8"), "beta\n");

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -238,6 +238,99 @@ test("offline sync excludes runtime-derived state without deleting existing loca
   }
 });
 
+test("offline sync ignores runtime-derived records from older peers", async () => {
+  const root = await tempDir("remnic-offline-legacy-runtime-state");
+  try {
+    const fact = Buffer.from("alpha");
+    const runtime = Buffer.from("legacy runtime");
+    const runtimeSha = createHash("sha256").update(runtime).digest("hex");
+    const factSha = createHash("sha256").update(fact).digest("hex");
+
+    const pull = await applyOfflineSyncSnapshot({
+      root,
+      snapshot: {
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: new Date().toISOString(),
+        sourceId: "old-remote",
+        includeTranscripts: true,
+        files: [
+          {
+            path: "state/buffer.json",
+            sha256: runtimeSha,
+            bytes: runtime.byteLength,
+            mtimeMs: 0,
+            contentBase64: runtime.toString("base64"),
+          },
+          {
+            path: "facts/a.md",
+            sha256: factSha,
+            bytes: fact.byteLength,
+            mtimeMs: 0,
+            contentBase64: fact.toString("base64"),
+          },
+        ],
+      },
+    });
+
+    assert.equal(pull.upserted, 1);
+    assert.equal(await readUtf8(root, "facts/a.md"), "alpha");
+    await assert.rejects(
+      () => readFile(path.join(root, "state", "buffer.json")),
+      /ENOENT/,
+    );
+
+    const remote = await tempDir("remnic-offline-legacy-runtime-remote");
+    try {
+      const push = await applyOfflineSyncChangeset({
+        root: remote,
+        changeset: {
+          format: "remnic.offline-sync.changeset.v1",
+          schemaVersion: 1,
+          createdAt: new Date().toISOString(),
+          sourceId: "old-laptop",
+          includeTranscripts: true,
+          changes: [
+            {
+              type: "upsert",
+              path: "state/memory-lifecycle-ledger.jsonl",
+              file: {
+                path: "state/memory-lifecycle-ledger.jsonl",
+                sha256: runtimeSha,
+                bytes: runtime.byteLength,
+                mtimeMs: 0,
+                contentBase64: runtime.toString("base64"),
+              },
+            },
+            {
+              type: "upsert",
+              path: "facts/a.md",
+              file: {
+                path: "facts/a.md",
+                sha256: factSha,
+                bytes: fact.byteLength,
+                mtimeMs: 0,
+                contentBase64: fact.toString("base64"),
+              },
+            },
+          ],
+        },
+      });
+
+      assert.equal(push.appliedUpserts, 1);
+      assert.equal(await readUtf8(remote, "facts/a.md"), "alpha");
+      await assert.rejects(
+        () => readFile(path.join(remote, "state", "memory-lifecycle-ledger.jsonl")),
+        /ENOENT/,
+      );
+    } finally {
+      await rm(remote, { recursive: true, force: true });
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline sync pending summary returns counts without materializing changed content", async () => {
   const root = await tempDir("remnic-offline-pending-summary");
   try {

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -150,7 +150,7 @@ const EXCLUDED_FILE_NAMES = new Set([
   ".sync-state.json",
 ]);
 
-const EXCLUDED_REL_PATHS = new Set([
+const DERIVED_RUNTIME_REL_PATHS = new Set([
   "state/fact-hashes.ready",
   "state/fact-hashes.txt",
   "state/buffer-surprise-ledger.jsonl",
@@ -170,6 +170,10 @@ const EXCLUDED_REL_PATHS = new Set([
   "state/memory-projection.sqlite-shm",
   "state/memory-projection.sqlite-wal",
   "state/recall_impressions.jsonl",
+]);
+
+const EXCLUDED_REL_PATHS = new Set([
+  ...DERIVED_RUNTIME_REL_PATHS,
 ]);
 
 const EXCLUDED_FILE_PREFIXES = [
@@ -294,6 +298,7 @@ export function normalizeOfflineSyncSnapshot(
   const files = obj.files
     .map((entry, index) =>
       normalizeFileRecord(entry, `files[${index}]`, options.requireContent === true))
+    .filter((file) => !shouldIgnoreIncomingRuntimePath(file.path))
     .sort(compareByPath);
   assertUniquePaths(files, "offline sync snapshot");
   if (!includeTranscripts) {
@@ -370,7 +375,7 @@ export function normalizeOfflineSyncChangeset(input: unknown): OfflineSyncChange
       };
     }
     throw new Error(`changes[${index}].type must be "upsert" or "delete"`);
-  });
+  }).filter((change) => !shouldIgnoreIncomingRuntimePath(change.path));
   assertUniquePaths(changes, "offline sync changeset");
   if (!includeTranscripts) {
     const transcriptPath = changes.find((change) => change.path.split("/")[0] === "transcripts")?.path;
@@ -433,6 +438,12 @@ function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): bo
   if (parts[0] === "state" && basename.includes(".tmp-")) return true;
   if (EXCLUDED_FILE_NAMES.has(basename)) return true;
   return EXCLUDED_FILE_PREFIXES.some((prefix) => basename.startsWith(prefix));
+}
+
+function shouldIgnoreIncomingRuntimePath(relPosix: string): boolean {
+  const parts = relPosix.split("/");
+  const basename = parts[parts.length - 1] ?? "";
+  return DERIVED_RUNTIME_REL_PATHS.has(relPosix) || (parts[0] === "state" && basename.includes(".tmp-"));
 }
 
 function filterBaseFilesForMode(

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -153,6 +153,11 @@ const EXCLUDED_FILE_NAMES = new Set([
 const EXCLUDED_REL_PATHS = new Set([
   "state/fact-hashes.ready",
   "state/fact-hashes.txt",
+  "state/buffer-surprise-ledger.jsonl",
+  "state/buffer.json",
+  "state/embeddings.json",
+  "state/index_tags.json",
+  "state/index_time.json",
   "state/last_graph_recall.json",
   "state/last_intent.json",
   "state/last_qmd_recall.json",
@@ -160,6 +165,11 @@ const EXCLUDED_REL_PATHS = new Set([
   "state/lcm.sqlite",
   "state/lcm.sqlite-shm",
   "state/lcm.sqlite-wal",
+  "state/memory-lifecycle-ledger.jsonl",
+  "state/memory-projection.sqlite",
+  "state/memory-projection.sqlite-shm",
+  "state/memory-projection.sqlite-wal",
+  "state/recall_impressions.jsonl",
 ]);
 
 const EXCLUDED_FILE_PREFIXES = [
@@ -420,6 +430,7 @@ function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): bo
   if (EXCLUDED_REL_PATHS.has(relPosix)) return true;
   if (!includeTranscripts && parts[0] === "transcripts") return true;
   const basename = parts[parts.length - 1] ?? "";
+  if (parts[0] === "state" && basename.includes(".tmp-")) return true;
   if (EXCLUDED_FILE_NAMES.has(basename)) return true;
   return EXCLUDED_FILE_PREFIXES.some((prefix) => basename.startsWith(prefix));
 }
@@ -725,6 +736,50 @@ export function summarizeOfflineSyncChangeset(
     upserts,
     deletes,
     total: changeset.changes.length,
+  };
+}
+
+export async function summarizeOfflineSyncPendingChanges(options: {
+  root: string;
+  sourceId: string;
+  baseFiles?: readonly OfflineSyncFileState[];
+  includeTranscripts?: boolean;
+  now?: Date;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
+}): Promise<OfflineSyncChangesetSummary> {
+  const includeTranscripts = options.includeTranscripts !== false;
+  const base = byPath(filterBaseFilesForMode(
+    normalizeFileStates(options.baseFiles),
+    includeTranscripts,
+  ));
+  const current = await buildOfflineSyncSnapshot({
+    root: options.root,
+    sourceId: options.sourceId,
+    includeContent: false,
+    includeTranscripts,
+    now: options.now,
+    readFile: options.readFile,
+  });
+  const currentMap = byPath(current.files);
+  let upserts = 0;
+  let deletes = 0;
+
+  for (const relPath of unionPaths(base, currentMap)) {
+    const baseEntry = base.get(relPath);
+    const currentEntry = currentMap.get(relPath);
+    if (currentEntry && currentEntry.sha256 !== baseEntry?.sha256) {
+      upserts += 1;
+      continue;
+    }
+    if (!currentEntry && baseEntry) {
+      deletes += 1;
+    }
+  }
+
+  return {
+    upserts,
+    deletes,
+    total: upserts + deletes,
   };
 }
 


### PR DESCRIPTION
## Summary
- exclude volatile derived runtime state from offline sync snapshots and file-content hydration
- keep existing local runtime files intact when applying remote snapshots
- add metadata-only pending summaries so `remnic offline status` does not materialize giant file content

## Verification
- pnpm exec tsx --test packages/remnic-core/src/offline-sync.test.ts tests/offline-sync-cli-batching.test.ts
- pnpm exec tsx --test packages/remnic-core/src/access-http.test.ts
- pnpm --filter @remnic/core check-types
- pnpm --filter @remnic/cli check-types
- npm run preflight:quick
- npm run review:cursor (skips locally: installed cursor-agent does not recognize --trust)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline sync snapshot/changeset normalization and apply behavior by filtering out `state/*` runtime-derived files and `.tmp-*` entries, which could affect what gets transferred and deleted across peers. Also adjusts offline status and snapshot content hydration paths, so regressions would mainly show up as missing/extra sync changes or misleading status counts.
> 
> **Overview**
> Offline sync now **excludes volatile runtime-derived `state/*` files** (and `state/*.tmp-*` spill files) from snapshots, incoming snapshots/changesets, and file-content reads, preventing those files from being propagated or deleted across peers.
> 
> `remnic offline status` now uses a new `summarizeOfflineSyncPendingChanges` helper to report pending upserts/deletes **without materializing file contents**, reducing work for large repos. Snapshot content hydration is tightened to normalize snapshots first and to treat mismatched metadata (including `mtimeMs`) as updated while fetching content.
> 
> Pi extension defaults `requestTimeoutMs` to **60s** (docs/config/publisher updated) and improves client timeout errors with a clearer message plus tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7513266c82f7d7384b1f6b234ae2e36f3511efe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->