### PR TITLE
Exclude derived state from offline sync

### DIFF
--- a/.changeset/tidy-moons-rinse.md
+++ b/.changeset/tidy-moons-rinse.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Exclude additional derived runtime state and namespace-scoped state indexes from offline sync payloads.

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -181,17 +181,24 @@ test("offline sync excludes runtime-derived state without deleting existing loca
   const root = await tempDir("remnic-offline-runtime-state");
   try {
     await write(root, "facts/a.md", "alpha");
+    await write(root, "assets/state/fact-hashes.txt", "durable asset");
     await write(root, "state/buffer-surprise-ledger.jsonl", "surprise");
     await write(root, "state/buffer.json", "buffer");
     await write(root, "state/buffer.json.tmp-123-456", "tmp");
     await write(root, "state/embeddings.json", "embeddings");
+    await write(root, "state/entity-mention-index.json", "entities");
     await write(root, "state/index_tags.json", "tags");
     await write(root, "state/index_time.json", "time");
     await write(root, "state/memory-lifecycle-ledger.jsonl", "ledger");
+    await write(root, "state/.artifact-write-version.log", "version");
+    await write(root, "state/.memory-status-version.log", "version");
     await write(root, "state/memory-projection.sqlite", "projection");
     await write(root, "state/memory-projection.sqlite-shm", "projection-shm");
     await write(root, "state/memory-projection.sqlite-wal", "projection-wal");
     await write(root, "state/recall_impressions.jsonl", "impressions");
+    await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json", "intent");
+    await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/entity-mention-index.json", "entities");
+    await write(root, "namespaces/generalist-project-origin-6ebeaa54/state/.memory-status-version.log", "version");
 
     const snapshot = await buildOfflineSyncSnapshot({
       root,
@@ -199,7 +206,10 @@ test("offline sync excludes runtime-derived state without deleting existing loca
       includeContent: true,
     });
 
-    assert.deepEqual(snapshot.files.map((file) => file.path), ["facts/a.md"]);
+    assert.deepEqual(snapshot.files.map((file) => file.path), [
+      "assets/state/fact-hashes.txt",
+      "facts/a.md",
+    ]);
     await assert.rejects(
       () =>
         buildOfflineSyncSnapshotForPaths({
@@ -217,6 +227,16 @@ test("offline sync excludes runtime-derived state without deleting existing loca
           path: "state/buffer.json.tmp-123-456",
         }),
       /offline sync file content path is excluded: state\/buffer\.json\.tmp-123-456/,
+    );
+    await assert.rejects(
+      () =>
+        buildOfflineSyncSnapshotForPaths({
+          root,
+          sourceId: "remote",
+          paths: ["namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json"],
+          includeContent: true,
+        }),
+      /offline sync snapshot path is excluded: namespaces\/generalist-project-origin-6ebeaa54\/state\/last_intent\.json/,
     );
 
     const oldLedger = Buffer.from("old ledger");
@@ -243,8 +263,10 @@ test("offline sync ignores runtime-derived records from older peers", async () =
   try {
     const fact = Buffer.from("alpha");
     const runtime = Buffer.from("legacy runtime");
+    const asset = Buffer.from("durable asset");
     const runtimeSha = createHash("sha256").update(runtime).digest("hex");
     const factSha = createHash("sha256").update(fact).digest("hex");
+    const assetSha = createHash("sha256").update(asset).digest("hex");
 
     const pull = await applyOfflineSyncSnapshot({
       root,
@@ -263,20 +285,39 @@ test("offline sync ignores runtime-derived records from older peers", async () =
             contentBase64: runtime.toString("base64"),
           },
           {
+            path: "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
+            sha256: runtimeSha,
+            bytes: runtime.byteLength,
+            mtimeMs: 0,
+            contentBase64: runtime.toString("base64"),
+          },
+          {
             path: "facts/a.md",
             sha256: factSha,
             bytes: fact.byteLength,
             mtimeMs: 0,
             contentBase64: fact.toString("base64"),
           },
+          {
+            path: "assets/state/fact-hashes.txt",
+            sha256: assetSha,
+            bytes: asset.byteLength,
+            mtimeMs: 0,
+            contentBase64: asset.toString("base64"),
+          },
         ],
       },
     });
 
-    assert.equal(pull.upserted, 1);
+    assert.equal(pull.upserted, 2);
     assert.equal(await readUtf8(root, "facts/a.md"), "alpha");
+    assert.equal(await readUtf8(root, "assets/state/fact-hashes.txt"), "durable asset");
     await assert.rejects(
       () => readFile(path.join(root, "state", "buffer.json")),
+      /ENOENT/,
+    );
+    await assert.rejects(
+      () => readFile(path.join(root, "namespaces", "generalist-project-origin-6ebeaa54", "state", "last_intent.json")),
       /ENOENT/,
     );
 
@@ -304,6 +345,17 @@ test("offline sync ignores runtime-derived records from older peers", async () =
             },
             {
               type: "upsert",
+              path: "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
+              file: {
+                path: "namespaces/generalist-project-origin-6ebeaa54/state/last_intent.json",
+                sha256: runtimeSha,
+                bytes: runtime.byteLength,
+                mtimeMs: 0,
+                contentBase64: runtime.toString("base64"),
+              },
+            },
+            {
+              type: "upsert",
               path: "facts/a.md",
               file: {
                 path: "facts/a.md",
@@ -313,14 +365,30 @@ test("offline sync ignores runtime-derived records from older peers", async () =
                 contentBase64: fact.toString("base64"),
               },
             },
+            {
+              type: "upsert",
+              path: "assets/state/fact-hashes.txt",
+              file: {
+                path: "assets/state/fact-hashes.txt",
+                sha256: assetSha,
+                bytes: asset.byteLength,
+                mtimeMs: 0,
+                contentBase64: asset.toString("base64"),
+              },
+            },
           ],
         },
       });
 
-      assert.equal(push.appliedUpserts, 1);
+      assert.equal(push.appliedUpserts, 2);
       assert.equal(await readUtf8(remote, "facts/a.md"), "alpha");
+      assert.equal(await readUtf8(remote, "assets/state/fact-hashes.txt"), "durable asset");
       await assert.rejects(
         () => readFile(path.join(remote, "state", "memory-lifecycle-ledger.jsonl")),
+        /ENOENT/,
+      );
+      await assert.rejects(
+        () => readFile(path.join(remote, "namespaces", "generalist-project-origin-6ebeaa54", "state", "last_intent.json")),
         /ENOENT/,
       );
     } finally {

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -150,30 +150,29 @@ const EXCLUDED_FILE_NAMES = new Set([
   ".sync-state.json",
 ]);
 
-const DERIVED_RUNTIME_REL_PATHS = new Set([
-  "state/fact-hashes.ready",
-  "state/fact-hashes.txt",
-  "state/buffer-surprise-ledger.jsonl",
-  "state/buffer.json",
-  "state/embeddings.json",
-  "state/index_tags.json",
-  "state/index_time.json",
-  "state/last_graph_recall.json",
-  "state/last_intent.json",
-  "state/last_qmd_recall.json",
-  "state/last_recall.json",
-  "state/lcm.sqlite",
-  "state/lcm.sqlite-shm",
-  "state/lcm.sqlite-wal",
-  "state/memory-lifecycle-ledger.jsonl",
-  "state/memory-projection.sqlite",
-  "state/memory-projection.sqlite-shm",
-  "state/memory-projection.sqlite-wal",
-  "state/recall_impressions.jsonl",
-]);
-
-const EXCLUDED_REL_PATHS = new Set([
-  ...DERIVED_RUNTIME_REL_PATHS,
+const DERIVED_RUNTIME_STATE_BASENAMES = new Set([
+  ".artifact-write-version.log",
+  ".memory-status-version.log",
+  "fact-hashes.ready",
+  "fact-hashes.txt",
+  "buffer-surprise-ledger.jsonl",
+  "buffer.json",
+  "embeddings.json",
+  "entity-mention-index.json",
+  "index_tags.json",
+  "index_time.json",
+  "last_graph_recall.json",
+  "last_intent.json",
+  "last_qmd_recall.json",
+  "last_recall.json",
+  "lcm.sqlite",
+  "lcm.sqlite-shm",
+  "lcm.sqlite-wal",
+  "memory-lifecycle-ledger.jsonl",
+  "memory-projection.sqlite",
+  "memory-projection.sqlite-shm",
+  "memory-projection.sqlite-wal",
+  "recall_impressions.jsonl",
 ]);
 
 const EXCLUDED_FILE_PREFIXES = [
@@ -432,10 +431,10 @@ function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): bo
   const parts = relPosix.split("/");
   if (parts.some((part) => DEFAULT_TRANSFER_EXCLUDE_DIRS.has(part))) return true;
   if (parts.some((part) => part === SYNC_INTERNAL_DIR)) return true;
-  if (EXCLUDED_REL_PATHS.has(relPosix)) return true;
+  if (isDerivedRuntimeStatePath(parts)) return true;
   if (!includeTranscripts && parts[0] === "transcripts") return true;
   const basename = parts[parts.length - 1] ?? "";
-  if (parts[0] === "state" && basename.includes(".tmp-")) return true;
+  if (isCanonicalRuntimeStatePath(parts) && basename.includes(".tmp-")) return true;
   if (EXCLUDED_FILE_NAMES.has(basename)) return true;
   return EXCLUDED_FILE_PREFIXES.some((prefix) => basename.startsWith(prefix));
 }
@@ -443,7 +442,17 @@ function shouldExcludeRelPath(relPosix: string, includeTranscripts: boolean): bo
 function shouldIgnoreIncomingRuntimePath(relPosix: string): boolean {
   const parts = relPosix.split("/");
   const basename = parts[parts.length - 1] ?? "";
-  return DERIVED_RUNTIME_REL_PATHS.has(relPosix) || (parts[0] === "state" && basename.includes(".tmp-"));
+  return isDerivedRuntimeStatePath(parts) || (isCanonicalRuntimeStatePath(parts) && basename.includes(".tmp-"));
+}
+
+function isDerivedRuntimeStatePath(parts: string[]): boolean {
+  const basename = parts[parts.length - 1] ?? "";
+  return isCanonicalRuntimeStatePath(parts) && DERIVED_RUNTIME_STATE_BASENAMES.has(basename);
+}
+
+function isCanonicalRuntimeStatePath(parts: string[]): boolean {
+  if (parts[0] === "state") return true;
+  return parts[0] === "namespaces" && parts.length >= 4 && parts[2] === "state";
 }
 
 function filterBaseFilesForMode(


### PR DESCRIPTION
## Summary
- exclude additional generated runtime state files from offline sync payloads
- apply the exclusion to namespace-scoped state directories as well as root state
- ignore matching runtime state records from older peers so stale generated files are not reintroduced

## Why
Installed v9.3.502 sync still hit a 413 when large generated state indexes changed locally. This keeps offline sync focused on durable memories and metadata while leaving derived indexes to be rebuilt locally.

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/offline-sync.test.ts tests/offline-sync-cli-batching.test.ts packages/remnic-core/src/access-http.test.ts`
- `pnpm --filter @remnic/core check-types`
- `npm run preflight:quick`
- source `remnic offline sync` completed after this patch with 2 pushed upserts, 1785 pulled upserts, 101 deletes, 0 conflicts
- source `remnic offline status` showed pending local changes: 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the offline sync include/exclude rules and drops more paths (including `namespaces/*/state/*`) from snapshots/changesets; mistakes here could cause missing expected files or unexpected sync behavior. Scope is limited and covered by updated tests.
> 
> **Overview**
> Offline sync payload generation now **excludes more derived runtime state** based on filename, and applies the same exclusion logic to both root `state/*` and `namespaces/*/state/*` paths (including `.tmp-*` artifacts).
> 
> Incoming snapshots/changesets now **drop matching derived runtime records** during normalization so older peers can’t reintroduce generated indexes, and tests were expanded to cover durable `assets/state/*` inclusion alongside the new exclusions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a9be592719a7a202b316a34c8409a852cf5855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->