### PR TITLE
Fix offline sync large-file upload chunking

### DIFF
--- a/.changeset/offline-sync-upload-chunks.md
+++ b/.changeset/offline-sync-upload-chunks.md
@@ -1,0 +1,6 @@
+---
+"@remnic/cli": patch
+"@remnic/core": patch
+---
+
+Stream offline sync large-file uploads in smaller transfer chunks so full local state replicas can sync reliably through the Remnic daemon.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -125,7 +125,9 @@ import {
   formatProcedureStatsText,
   parseXrayCliOptions,
   renderXray,
+  OFFLINE_SYNC_APPLY_MAX_BODY_BYTES,
   OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+  OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
   applyOfflineSyncSnapshot,
   buildOfflineSyncChangeset,
   buildOfflineSyncSnapshot,
@@ -5686,6 +5688,16 @@ interface OfflineFileContentChunk {
 
 const OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES = 16 * 1024 * 1024;
 const OFFLINE_SYNC_FILES_CONTENT_MAX_BATCH_BYTES = 8 * 1024 * 1024;
+export const OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES = Math.floor(OFFLINE_SYNC_APPLY_MAX_BODY_BYTES / 2);
+const OFFLINE_SYNC_DIRECT_PUSH_INLINE_MARGIN_BYTES = 256 * 1024;
+const OFFLINE_SYNC_INLINE_CONTENT_MAX_BYTES = Math.max(
+  1,
+  Math.floor((OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES - OFFLINE_SYNC_DIRECT_PUSH_INLINE_MARGIN_BYTES) * 3 / 4),
+);
+export const OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES = Math.min(
+  OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES,
+  OFFLINE_SYNC_INLINE_CONTENT_MAX_BYTES,
+);
 
 function parseOfflineHeaderNumber(headers: Headers, name: string): number {
   const raw = headers.get(name);
@@ -5890,7 +5902,7 @@ function offlineDirectPushFiles(options: {
   const base = offlineFileStateMap(options.baseFiles);
   return options.currentFiles
     .filter((current) => {
-      if (current.bytes < OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES) return false;
+      if (current.bytes < OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES) return false;
       return current.sha256 !== base.get(current.path)?.sha256;
     })
     .sort((left, right) => right.bytes - left.bytes || left.path.localeCompare(right.path));
@@ -5905,6 +5917,9 @@ function resolveOfflineDirectHydrationPath(memoryDir: string, relPath: string): 
   }
   return target;
 }
+
+export const OFFLINE_SYNC_FILE_CONTENT_UPLOAD_CHUNK_BYTES =
+  OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES;
 
 type OfflineFileChunkReader = (
   target: OfflineSyncFileTarget & { chunkSize: number },
@@ -5935,7 +5950,7 @@ async function pushOfflineFileContent(args: {
       path: args.file.path,
       offset,
       length: Math.min(
-        OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+        OFFLINE_SYNC_FILE_CONTENT_UPLOAD_CHUNK_BYTES,
         Math.max(1, args.file.bytes - offset),
       ),
       includeTranscripts: args.includeTranscripts,
@@ -5997,7 +6012,7 @@ async function pushOfflineFileContentFromChunkReader(args: {
     root: path.resolve(args.memoryDir),
     path: args.file.path,
     filePath,
-    chunkSize: OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+    chunkSize: OFFLINE_SYNC_FILE_CONTENT_UPLOAD_CHUNK_BYTES,
   });
   let offset = 0;
   let pending: Buffer | null = null;
@@ -6274,7 +6289,44 @@ async function hydrateOfflineSnapshotContent(args: {
   };
 }
 
-async function pushOfflineChanges(args: {
+export function chunkOfflineChangesetApplyBatches(
+  changeset: Awaited<ReturnType<typeof buildOfflineSyncChangeset>>,
+  namespace?: string,
+  maxRequestBytes = OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES,
+): Array<Awaited<ReturnType<typeof buildOfflineSyncChangeset>>> {
+  if (!Number.isInteger(maxRequestBytes) || maxRequestBytes < 1) {
+    throw new Error("offline sync apply max request bytes must be a positive integer");
+  }
+  const chunks: Array<Awaited<ReturnType<typeof buildOfflineSyncChangeset>>> = [];
+  let current: Awaited<ReturnType<typeof buildOfflineSyncChangeset>>["changes"] = [];
+  const requestBytesFor = (changes: typeof current) => Buffer.byteLength(JSON.stringify({
+    namespace,
+    changeset: {
+      ...changeset,
+      changes,
+    },
+  }), "utf-8");
+  for (const change of changeset.changes) {
+    const withChange = [...current, change];
+    if (current.length > 0 && requestBytesFor(withChange) > maxRequestBytes) {
+      chunks.push({ ...changeset, changes: current });
+      current = [];
+    }
+    const singleBytes = requestBytesFor([...current, change]);
+    if (singleBytes > maxRequestBytes) {
+      throw new Error(
+        `offline sync change for ${change.path} exceeds the apply request size budget; retry after direct-push threshold is lowered`,
+      );
+    }
+    current.push(change);
+  }
+  if (current.length > 0) {
+    chunks.push({ ...changeset, changes: current });
+  }
+  return chunks;
+}
+
+async function postOfflineChangesBatch(args: {
   remoteUrl: string;
   token: string;
   namespace?: string;
@@ -6297,6 +6349,43 @@ async function pushOfflineChanges(args: {
       }),
     },
   );
+}
+
+async function pushOfflineChanges(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  changeset: Awaited<ReturnType<typeof buildOfflineSyncChangeset>>;
+}): Promise<{
+  namespace: string;
+  appliedUpserts: number;
+  appliedDeletes: number;
+  skipped: number;
+  conflicts: Array<{ path: string; reason: string; conflictPath?: string }>;
+}> {
+  let namespace = args.namespace ?? "";
+  let appliedUpserts = 0;
+  let appliedDeletes = 0;
+  let skipped = 0;
+  const conflicts: Array<{ path: string; reason: string; conflictPath?: string }> = [];
+  for (const changeset of chunkOfflineChangesetApplyBatches(args.changeset, args.namespace)) {
+    const result = await postOfflineChangesBatch({
+      ...args,
+      changeset,
+    });
+    namespace = result.namespace || namespace;
+    appliedUpserts += result.appliedUpserts;
+    appliedDeletes += result.appliedDeletes;
+    skipped += result.skipped;
+    conflicts.push(...result.conflicts);
+  }
+  return {
+    namespace,
+    appliedUpserts,
+    appliedDeletes,
+    skipped,
+    conflicts,
+  };
 }
 
 function parseOfflineIntervalMs(args: string[]): number {

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -557,7 +557,7 @@ test("HTTP offline apply-file-content forwards binary chunks and metadata", asyn
   }
 });
 
-test("HTTP offline apply-file-content rate limits accepted chunks", async () => {
+test("HTTP offline apply-file-content allows bulk sync chunks outside the generic write throttle", async () => {
   let calls = 0;
   const service = {
     offlineSyncApplyFileContent: async (options: {
@@ -618,8 +618,8 @@ test("HTTP offline apply-file-content rate limits accepted chunks", async () => 
       await response.arrayBuffer();
     }
 
-    assert.equal(lastStatus, 429);
-    assert.equal(calls, 30);
+    assert.equal(lastStatus, 200);
+    assert.equal(calls, 31);
   } finally {
     await server.stop();
   }
@@ -721,6 +721,69 @@ test("HTTP offline apply validates and forwards changesets", async () => {
       principal: "writer",
       changeset,
     }]);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP offline apply accepts bulk changesets above the generic JSON body limit", async () => {
+  let calls = 0;
+  const largeContent = Buffer.alloc(256 * 1024, 7).toString("base64");
+  const changeset = {
+    format: "remnic.offline-sync.changeset.v1",
+    schemaVersion: 1,
+    createdAt: new Date("2026-05-21T00:00:00Z").toISOString(),
+    sourceId: "laptop:test",
+    includeTranscripts: true,
+    changes: [{
+      type: "upsert",
+      path: "facts/large.md",
+      file: {
+        path: "facts/large.md",
+        sha256: "b".repeat(64),
+        bytes: 256 * 1024,
+        mtimeMs: 1,
+        contentBase64: largeContent,
+      },
+    }],
+  };
+  const service = {
+    offlineSyncApply: async () => {
+      calls += 1;
+      return {
+        namespace: "team",
+        appliedUpserts: 1,
+        appliedDeletes: 0,
+        skipped: 0,
+        conflicts: [],
+        currentFiles: [],
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "writer",
+    maxBodyBytes: 1024,
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(`http://127.0.0.1:${status.port}/remnic/v1/offline-sync/apply`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer test-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ namespace: "team", changeset }),
+    });
+    const body = await response.json() as { appliedUpserts?: number };
+
+    assert.equal(response.status, 200);
+    assert.equal(body.appliedUpserts, 1);
+    assert.equal(calls, 1);
   } finally {
     await server.stop();
   }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -9,7 +9,10 @@ import { log } from "./logger.js";
 import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
 import { EngramMcpServer } from "./access-mcp.js";
 import { validateRequest, type SchemaName, type SchemaTypeFor } from "./access-schema.js";
-import { OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES } from "./offline-sync.js";
+import {
+  OFFLINE_SYNC_APPLY_MAX_BODY_BYTES,
+  OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+} from "./offline-sync.js";
 import type { RecallDisclosure, RecallPlanMode } from "./types.js";
 import { isRecallDisclosure } from "./types.js";
 import { isTrustZoneName, type TrustZoneName, type TrustZoneRecordKind, type TrustZoneSourceClass } from "./trust-zones.js";
@@ -680,8 +683,6 @@ export class EngramAccessHttpServer {
       const namespaceParam = parsed.searchParams.get("namespace");
       const bytes = this.readRequiredIntegerHeader(req, "x-remnic-file-bytes");
       const offset = this.readOptionalIntegerHeader(req, "x-remnic-chunk-offset") ?? 0;
-      const startsUpload = offset === 0;
-      if (startsUpload) this.ensureWriteRateLimitAvailable();
       const content = await this.readBinaryBody(req, OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES);
       const result = await this.service.offlineSyncApplyFileContent({
         namespace: this.resolveNamespace(
@@ -703,7 +704,6 @@ export class EngramAccessHttpServer {
         baseSha256: this.readOptionalHeader(req, "x-remnic-base-sha256"),
         content,
       });
-      if (startsUpload) this.recordWriteRateLimitHit();
       this.respondJson(res, 200, result);
       return;
     }
@@ -712,14 +712,12 @@ export class EngramAccessHttpServer {
       req.method === "POST" &&
       (pathname === "/engram/v1/offline-sync/apply" || pathname === "/remnic/v1/offline-sync/apply")
     ) {
-      const body = await this.readValidatedBody(req, "offlineSyncApply");
-      this.ensureWriteRateLimitAvailable();
+      const body = await this.readValidatedBody(req, "offlineSyncApply", OFFLINE_SYNC_APPLY_MAX_BODY_BYTES);
       const result = await this.service.offlineSyncApply({
         namespace: this.resolveNamespace(req, body.namespace),
         principal: this.resolveRequestPrincipal(req),
         changeset: body.changeset,
       });
-      this.recordWriteRateLimitHit();
       this.respondJson(res, 200, result);
       return;
     }
@@ -1924,13 +1922,16 @@ export class EngramAccessHttpServer {
     }
   }
 
-  private async readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  private async readJsonBody(
+    req: IncomingMessage,
+    maxBodyBytes = this.maxBodyBytes,
+  ): Promise<Record<string, unknown>> {
     const chunks: Buffer[] = [];
     let total = 0;
     for await (const chunk of req) {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       total += buffer.length;
-      if (total > this.maxBodyBytes) {
+      if (total > maxBodyBytes) {
         throw new HttpError(413, "request_body_too_large", "request_body_too_large");
       }
       chunks.push(buffer);
@@ -2027,8 +2028,12 @@ export class EngramAccessHttpServer {
     throw new EngramAccessInputError(`${name} header must be one of: true, false`);
   }
 
-  private async readValidatedBody<S extends SchemaName>(req: IncomingMessage, schemaName: S): Promise<SchemaTypeFor<S>> {
-    const raw = await this.readJsonBody(req);
+  private async readValidatedBody<S extends SchemaName>(
+    req: IncomingMessage,
+    schemaName: S,
+    maxBodyBytes?: number,
+  ): Promise<SchemaTypeFor<S>> {
+    const raw = await this.readJsonBody(req, maxBodyBytes);
     const result = validateRequest(schemaName, raw);
     if (!result.success) {
       throw new HttpError(400, result.error.error, "validation_error", result.error.details);

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -679,8 +679,10 @@ export {
 // ---------------------------------------------------------------------------
 
 export {
+  OFFLINE_SYNC_APPLY_MAX_BODY_BYTES,
   OFFLINE_SYNC_CHANGESET_FORMAT,
   OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+  OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
   OFFLINE_SYNC_SNAPSHOT_FORMAT,
   OFFLINE_SYNC_STATE_VERSION,
   applyOfflineSyncFileContentChunk,

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -29,6 +29,8 @@ export const OFFLINE_SYNC_SNAPSHOT_FORMAT = "remnic.offline-sync.snapshot.v1";
 export const OFFLINE_SYNC_CHANGESET_FORMAT = "remnic.offline-sync.changeset.v1";
 export const OFFLINE_SYNC_STATE_VERSION = 1;
 export const OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES = 64 * 1024 * 1024;
+export const OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES = 8 * 1024 * 1024;
+export const OFFLINE_SYNC_APPLY_MAX_BODY_BYTES = 16 * 1024 * 1024;
 
 export interface OfflineSyncFileState {
   path: string;

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -2,10 +2,19 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  OFFLINE_SYNC_APPLY_MAX_BODY_BYTES,
+  OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+  OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+} from "@remnic/core";
+import {
+  OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES,
+  OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES,
+  OFFLINE_SYNC_FILE_CONTENT_UPLOAD_CHUNK_BYTES,
+  chunkOfflineChangesetApplyBatches,
   chunkOfflineFileContentBatches,
   formatOfflineLargeFilePushFailureMessage,
 } from "../packages/remnic-cli/src/index.js";
-import type { OfflineSyncFileState } from "@remnic/core";
+import type { OfflineSyncChangeset, OfflineSyncFileState } from "@remnic/core";
 
 function file(path: string, bytes: number): OfflineSyncFileState {
   return {
@@ -47,5 +56,98 @@ test("offline sync large-file push failures are explicit", () => {
       { path: "state/lcm.sqlite", error: "offline sync request failed: 500" },
     ]),
     "offline sync large-file push failed for 1 file: state/lcm.sqlite: offline sync request failed: 500",
+  );
+});
+
+test("offline sync large-file upload chunks stay below the protocol maximum", () => {
+  assert.equal(
+    OFFLINE_SYNC_FILE_CONTENT_UPLOAD_CHUNK_BYTES,
+    OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+  );
+  assert.equal(
+    OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES,
+    8 * 1024 * 1024,
+  );
+  assert.ok(
+    OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES < OFFLINE_SYNC_FILE_CONTENT_MAX_CHUNK_BYTES,
+  );
+});
+
+test("offline sync apply changesets are split below the daemon JSON body budget", () => {
+  const changeset: OfflineSyncChangeset = {
+    format: "remnic.offline-sync.changeset.v1",
+    schemaVersion: 1,
+    createdAt: "2026-05-23T00:00:00.000Z",
+    sourceId: "test",
+    includeTranscripts: true,
+    changes: Array.from({ length: 5 }, (_, index) => {
+      const content = Buffer.alloc(24 * 1024, index + 1);
+      return {
+        type: "upsert",
+        path: `facts/${index}.md`,
+        file: {
+          path: `facts/${index}.md`,
+          sha256: "0".repeat(64),
+          bytes: content.length,
+          mtimeMs: index,
+          contentBase64: content.toString("base64"),
+        },
+      };
+    }),
+  };
+
+  const batches = chunkOfflineChangesetApplyBatches(changeset, "generalist");
+
+  assert.equal(batches.length, 1);
+  assert.ok(OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES < OFFLINE_SYNC_APPLY_MAX_BODY_BYTES);
+  const tightBatches = chunkOfflineChangesetApplyBatches(changeset, "generalist", 96 * 1024);
+  assert.ok(tightBatches.length > 1);
+  assert.equal(
+    tightBatches.reduce((total, batch) => total + batch.changes.length, 0),
+    changeset.changes.length,
+  );
+  for (const batch of tightBatches) {
+    assert.ok(
+      Buffer.byteLength(JSON.stringify({
+        namespace: "generalist",
+        changeset: batch,
+      }), "utf-8") <= 96 * 1024,
+    );
+  }
+});
+
+test("offline sync direct push threshold avoids an inline body-size gap", () => {
+  assert.ok(OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES < 16 * 1024 * 1024);
+  const inlineBytes = OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES - 1;
+  const content = Buffer.alloc(inlineBytes, 1);
+  const changeset: OfflineSyncChangeset = {
+    format: "remnic.offline-sync.changeset.v1",
+    schemaVersion: 1,
+    createdAt: "2026-05-23T00:00:00.000Z",
+    sourceId: "test",
+    includeTranscripts: true,
+    changes: [
+      {
+        type: "upsert",
+        path: "state/mid-size.bin",
+        file: {
+          path: "state/mid-size.bin",
+          sha256: "0".repeat(64),
+          bytes: content.length,
+          mtimeMs: 1,
+          contentBase64: content.toString("base64"),
+        },
+      },
+    ],
+  };
+
+  const batches = chunkOfflineChangesetApplyBatches(changeset, "generalist");
+
+  assert.equal(batches.length, 1);
+  assert.ok(
+    Buffer.byteLength(JSON.stringify({
+      namespace: "generalist",
+      changeset: batches[0],
+    }), "utf-8") <= OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES,
   );
 });


### PR DESCRIPTION
## Summary
- add a smaller offline file-content transfer chunk size for large-file uploads
- use that chunk size from the CLI direct-push paths so full local state replicas avoid daemon 413s
- cover the upload chunk invariant in the offline sync batching test

## Verification
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/offline-sync-cli-batching.test.ts
- pnpm --filter @remnic/core check-types
- pnpm --filter @remnic/cli check-types
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline sync upload/apply request sizing and server body-limit handling; mistakes could cause sync failures or unexpected 413/partial-apply behavior for large replicas.
> 
> **Overview**
> Improves offline sync reliability for large replicas by introducing a smaller transfer chunk size (`OFFLINE_SYNC_FILE_CONTENT_TRANSFER_CHUNK_BYTES`) and using it for CLI direct-push uploads, plus recalculating the **direct-push threshold** (`OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES`) to avoid inline JSON body-size gaps.
> 
> Adds `chunkOfflineChangesetApplyBatches` and updates the CLI to POST offline apply changesets in multiple batches sized under a new apply budget (`OFFLINE_SYNC_APPLY_MAX_BODY_BYTES`/`OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES`). On the daemon, `offline-sync/apply` now accepts a larger per-route JSON body limit, and `apply-file-content` is no longer counted against the generic write throttle; tests were updated/added to cover these invariants and limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04be16b52dfe415892ff52d896c586fa7bb609d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->