### PR TITLE
Fix offline sync mid-size pull hydration

### DIFF
--- a/.changeset/offline-sync-mid-size-pull.md
+++ b/.changeset/offline-sync-mid-size-pull.md
@@ -1,0 +1,5 @@
+---
+"@remnic/cli": patch
+---
+
+Route remote mid-size offline sync files through chunked hydration so pull-side sync avoids oversized JSON payloads.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5686,7 +5686,7 @@ interface OfflineFileContentChunk {
   content: Buffer;
 }
 
-const OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES = 16 * 1024 * 1024;
+const OFFLINE_SYNC_DIRECT_DEFAULT_MIN_BYTES = 16 * 1024 * 1024;
 const OFFLINE_SYNC_FILES_CONTENT_MAX_BATCH_BYTES = 8 * 1024 * 1024;
 export const OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES = Math.floor(OFFLINE_SYNC_APPLY_MAX_BODY_BYTES / 2);
 const OFFLINE_SYNC_DIRECT_PUSH_INLINE_MARGIN_BYTES = 256 * 1024;
@@ -5695,9 +5695,10 @@ const OFFLINE_SYNC_INLINE_CONTENT_MAX_BYTES = Math.max(
   Math.floor((OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES - OFFLINE_SYNC_DIRECT_PUSH_INLINE_MARGIN_BYTES) * 3 / 4),
 );
 export const OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES = Math.min(
-  OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES,
+  OFFLINE_SYNC_DIRECT_DEFAULT_MIN_BYTES,
   OFFLINE_SYNC_INLINE_CONTENT_MAX_BYTES,
 );
+export const OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES = OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES;
 
 function parseOfflineHeaderNumber(headers: Headers, name: string): number {
   const raw = headers.get(name);
@@ -5882,7 +5883,7 @@ function offlineSnapshotContentFilesForApply(options: {
   return files.sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function shouldDirectHydrateOfflineFile(options: {
+export function shouldDirectHydrateOfflineFile(options: {
   incoming: OfflineSyncFileState;
   base?: OfflineSyncFileState;
   current?: OfflineSyncFileState;

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -8,11 +8,13 @@ import {
 } from "@remnic/core";
 import {
   OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES,
+  OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES,
   OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES,
   OFFLINE_SYNC_FILE_CONTENT_UPLOAD_CHUNK_BYTES,
   chunkOfflineChangesetApplyBatches,
   chunkOfflineFileContentBatches,
   formatOfflineLargeFilePushFailureMessage,
+  shouldDirectHydrateOfflineFile,
 } from "../packages/remnic-cli/src/index.js";
 import type { OfflineSyncChangeset, OfflineSyncFileState } from "@remnic/core";
 
@@ -118,6 +120,7 @@ test("offline sync apply changesets are split below the daemon JSON body budget"
 
 test("offline sync direct push threshold avoids an inline body-size gap", () => {
   assert.ok(OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES < 16 * 1024 * 1024);
+  assert.equal(OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES, OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES);
   const inlineBytes = OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES - 1;
   const content = Buffer.alloc(inlineBytes, 1);
   const changeset: OfflineSyncChangeset = {
@@ -149,5 +152,27 @@ test("offline sync direct push threshold avoids an inline body-size gap", () => 
       namespace: "generalist",
       changeset: batches[0],
     }), "utf-8") <= OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES,
+  );
+});
+
+test("offline sync direct hydration covers remote mid-size files", () => {
+  const incoming = file("state/remote-mid-size.bin", OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES);
+
+  assert.equal(
+    shouldDirectHydrateOfflineFile({ incoming }),
+    true,
+  );
+  assert.equal(
+    shouldDirectHydrateOfflineFile({
+      incoming,
+      current: { ...incoming },
+    }),
+    false,
+  );
+  assert.equal(
+    shouldDirectHydrateOfflineFile({
+      incoming: file("state/inline.bin", OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES - 1),
+    }),
+    false,
   );
 });


### PR DESCRIPTION
## Summary
- use the safe direct-transfer threshold for pull-side large file hydration as well as push-side uploads
- route remote mid-size changed files through the binary file-content endpoint instead of oversized JSON snapshots
- add regression coverage for remote mid-size direct hydration

## Verification
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/offline-sync-cli-batching.test.ts
- pnpm --filter @remnic/cli check-types
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the threshold used to decide when pull-side offline sync hydrates files via the binary chunk endpoint, which can affect which files are fetched inline vs hydrated and may impact sync performance/behavior around size boundaries.
> 
> **Overview**
> Routes *remote mid-size* offline-sync files through direct (chunked) hydration by aligning `OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES` with the existing safe direct-push threshold, avoiding oversized JSON payloads during pull-side sync.
> 
> Exports `shouldDirectHydrateOfflineFile` and adds regression tests to ensure mid-size files are hydrated when changed remotely, while unchanged/smaller files continue to avoid direct hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f6ddb43f23a8bdda5584c5343ac945d9e03319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->