### PR TITLE
Guard public MemoryArena reruns with WebShop sidecar

### DIFF
--- a/scripts/bench/public-sota/launch-next-public-benchmark.sh
+++ b/scripts/bench/public-sota/launch-next-public-benchmark.sh
@@ -14,9 +14,9 @@ OUT_ROOT="${OUT_ROOT:-${RESULTS_ROOT}}"
 
 benchmark="${1:-amemgym}"
 case "${benchmark}" in
-  amemgym|longmemeval|locomo|beam|memoryagentbench|membench|personamem) ;;
+  memory-arena|amemgym|longmemeval|locomo|beam|memoryagentbench|membench|personamem) ;;
   *)
-    echo "Usage: $0 [amemgym|longmemeval|locomo|beam|memoryagentbench|membench|personamem]" >&2
+    echo "Usage: $0 [memory-arena|amemgym|longmemeval|locomo|beam|memoryagentbench|membench|personamem]" >&2
     exit 2
     ;;
 esac
@@ -75,6 +75,47 @@ if [[ ! -d "${LAUNCH_REPO_ROOT}/evals/datasets/${benchmark}" ]]; then
   exit 2
 fi
 
+if [[ "${benchmark}" == "memory-arena" ]]; then
+  webshop_sidecar=""
+  configured_webshop_sidecar="$(printf '%s' "${REMNIC_BENCH_MEMORY_ARENA_WEBSHOP_PRODUCTS:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  if [[ -n "${configured_webshop_sidecar}" ]]; then
+    case "${configured_webshop_sidecar}" in
+      "~")
+        webshop_sidecar="${HOME}"
+        ;;
+      "~/"*)
+        webshop_sidecar="${HOME}/${configured_webshop_sidecar#"~/"}"
+        ;;
+      /*)
+        webshop_sidecar="${configured_webshop_sidecar}"
+        ;;
+      *)
+        webshop_sidecar="${LAUNCH_REPO_ROOT}/${configured_webshop_sidecar}"
+        ;;
+    esac
+  else
+    for candidate in \
+      "${LAUNCH_REPO_ROOT}/evals/datasets/${benchmark}/webshop-products.jsonl" \
+      "${LAUNCH_REPO_ROOT}/evals/datasets/${benchmark}/webshop-products.json" \
+      "${LAUNCH_REPO_ROOT}/evals/datasets/${benchmark}/memory-arena-webshop-products.jsonl" \
+      "${LAUNCH_REPO_ROOT}/evals/datasets/${benchmark}/memory-arena-webshop-products.json"; do
+      if [[ -f "${candidate}" ]]; then
+        webshop_sidecar="${candidate}"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "${webshop_sidecar}" ]]; then
+    echo "MemoryArena WebShop sidecar missing under ${LAUNCH_REPO_ROOT}/evals/datasets/${benchmark}; refusing to launch a catalog-less public run." >&2
+    exit 2
+  fi
+  if [[ ! -f "${webshop_sidecar}" ]]; then
+    echo "MemoryArena WebShop sidecar is not a file: ${webshop_sidecar}" >&2
+    exit 2
+  fi
+fi
+
 git_sha="$(git -C "${LAUNCH_REPO_ROOT}" rev-parse HEAD)"
 short_sha="${git_sha:0:8}"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -87,6 +128,9 @@ log_file="${results_dir}/run.log"
 mkdir -p "${results_dir}" "${out_dir}"
 printf 'benchmark\tstatus\ttimestamp\n' > "${status_file}"
 printf '%s\tstart\t%s\n' "${benchmark}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${status_file}"
+if [[ "${benchmark}" == "memory-arena" ]]; then
+  printf 'memory-arena-webshop-sidecar=%s\n' "${webshop_sidecar}" >> "${log_file}"
+fi
 
 cmd=(
   node packages/remnic-cli/bin/remnic.cjs bench published
@@ -116,9 +160,14 @@ printf -v log_quoted '%q' "${log_file}"
 printf -v status_quoted '%q' "${status_file}"
 printf -v benchmark_quoted '%q' "${benchmark}"
 printf -v run_id_quoted '%q' "${run_id}"
+webshop_export=""
+if [[ "${benchmark}" == "memory-arena" ]]; then
+  printf -v webshop_sidecar_quoted '%q' "${webshop_sidecar}"
+  webshop_export=" export REMNIC_BENCH_MEMORY_ARENA_WEBSHOP_PRODUCTS=${webshop_sidecar_quoted};"
+fi
 session="${run_id}"
 tmux new-session -d -s "${session}" -c "${LAUNCH_REPO_ROOT}" \
-  "PATH=/opt/homebrew/bin:/opt/homebrew/sbin:\$PATH; export REMNIC_BENCH_RUN_ID=${run_id_quoted}; cd ${repo_quoted}; (${cmd_quoted}) >> ${log_quoted} 2>&1; rc=\$?; if [ \$rc -eq 0 ]; then printf '%s\tsuccess\t%s\n' ${benchmark_quoted} \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> ${status_quoted}; else printf '%s\tfail:%s\t%s\n' ${benchmark_quoted} \"\$rc\" \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> ${status_quoted}; fi; exit \$rc"
+  "PATH=/opt/homebrew/bin:/opt/homebrew/sbin:\$PATH; export REMNIC_BENCH_RUN_ID=${run_id_quoted};${webshop_export} cd ${repo_quoted}; (${cmd_quoted}) >> ${log_quoted} 2>&1; rc=\$?; if [ \$rc -eq 0 ]; then printf '%s\tsuccess\t%s\n' ${benchmark_quoted} \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> ${status_quoted}; else printf '%s\tfail:%s\t%s\n' ${benchmark_quoted} \"\$rc\" \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> ${status_quoted}; fi; exit \$rc"
 
 cat <<EOF
 launched=${session}


### PR DESCRIPTION
## Summary
- allow the guarded public benchmark launcher to start MemoryArena reruns
- refuse MemoryArena public launches when the WebShop product sidecar is missing
- record the sidecar path in the run log for reproducibility

## Live run
- launched `public-memory-arena-codex-ac785290-20260531T192012Z` from the guarded path
- monitor: `public-memory-arena-codex-ac785290-20260531T192012Z-monitor`
- publish watcher: `remnic-memoryarena-publish-watcher-ac785290`
- transition watcher: `remnic-memoryarena-to-amemgym-watcher-ac785290`

## Verification
- `bash -n scripts/bench/public-sota/launch-next-public-benchmark.sh`
- `pnpm --filter @remnic/bench build`
- `pnpm exec tsx --test packages/bench/src/benchmarks/published/memory-arena/runner.test.ts --test-name-pattern WebShop`
- `pnpm --filter @remnic/cli build`
- `node packages/remnic-cli/bin/remnic.cjs bench published --name memory-arena --dataset evals/datasets/memory-arena --runtime-profile real --provider codex-cli --model gpt-5.5 --system-codex-reasoning-effort xhigh --judge-provider codex-cli --judge-model gpt-5.5 --judge-codex-reasoning-effort xhigh --internal-provider codex-cli --internal-model gpt-5.5 --internal-codex-reasoning-effort xhigh --seed 1 --limit 1 --dry-run`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark launch scripting only; fails closed when the sidecar is missing and does not change runtime scoring logic.
> 
> **Overview**
> The guarded public SOTA launcher now accepts **`memory-arena`** as a benchmark name alongside the existing public matrix benchmarks.
> 
> For **MemoryArena** runs only, it **requires** a WebShop product sidecar before starting: it resolves `REMNIC_BENCH_MEMORY_ARENA_WEBSHOP_PRODUCTS` (with `~` / absolute / repo-relative paths) or searches default filenames under `evals/datasets/memory-arena`, and **exits** if no valid file is found so catalog-less public reruns cannot start.
> 
> When a run launches, it **logs** the resolved sidecar path and **exports** the same path into the tmux session so the bench harness picks up the catalog for reproducible shopping tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17233843e48b54326f9f5fe44e21584dd744313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->