### PR TITLE
Emit AMemGym public primary metric

### DIFF
--- a/packages/bench/src/benchmarks/published/amemgym/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.test.ts
@@ -113,6 +113,8 @@ test("AMemGym batches tiny session messages before storing profile context", asy
 
     assert.equal(result.results.tasks.length, 1);
     assert.equal(result.results.tasks[0]?.scores.qa_accuracy, 1);
+    assert.equal(result.results.tasks[0]?.scores.normalized_memory_score, 1);
+    assert.equal(result.results.aggregates.normalized_memory_score?.mean, 1);
     assert.deepEqual(
       storeBatches.map((batch) => batch.length),
       [20, 7],
@@ -122,6 +124,79 @@ test("AMemGym batches tiny session messages before storing profile context", asy
       storeBatches[1]?.at(-1)?.content ?? "",
       /^\[Current user state\]: city: Chicago \(city: Chicago\)$/,
     );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("AMemGym includes failed tasks in normalized memory score", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-amemgym-"));
+
+  try {
+    await writeFile(
+      path.join(tempDir, "amemgym-v1-base.json"),
+      JSON.stringify([
+        {
+          id: "failed-profile",
+          start_time: "2025-01-01T00:00:00Z",
+          user_profile: {
+            uuid: "user-2",
+            name: "Nora",
+            age: 31,
+            gender: "female",
+          },
+          state_schema: { city: { type: "string" } },
+          periods: [
+            {
+              period_start: "2025-01-01T00:00:00Z",
+              period_end: "2025-01-31T23:59:59Z",
+              period_summary: "Nora updated her city.",
+              sessions: [],
+              state: { city: "Denver" },
+              updates: { city: "Denver" },
+              update_cnts: { city: 1 },
+            },
+          ],
+          qas: [
+            {
+              query: "What city does Nora live in now?",
+              required_info: ["city"],
+              answer_choices: [
+                { state: ["Denver"], answer: "Denver" },
+                { state: ["Austin"], answer: "Austin" },
+              ],
+            },
+          ],
+        },
+      ]),
+      "utf8",
+    );
+
+    const result = await runAMemGymBenchmark({
+      benchmark: amemGymDefinition,
+      mode: "full",
+      datasetDir: tempDir,
+      system: {
+        async store() {},
+        async recall() {
+          throw new Error("recall unavailable");
+        },
+        async search() {
+          return [];
+        },
+        async reset() {},
+        async drain() {},
+        async destroy() {},
+        async getStats() {
+          return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks.length, 1);
+    assert.equal(result.results.tasks[0]?.scores.qa_accuracy, -1);
+    assert.equal(result.results.tasks[0]?.scores.normalized_memory_score, -1);
+    assert.equal(result.results.aggregates.normalized_memory_score?.mean, -1);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -137,14 +137,16 @@ export async function runAMemGymBenchmark(
         });
         const selectedChoice = parseAMemGymChoice(answered.finalAnswer, qa);
         const answerForScoring = selectedChoice?.choice.answer ?? answered.finalAnswer;
+        const qaAccuracy =
+          selectedChoice && expectedChoice && selectedChoice.index === expectedChoice.index
+            ? 1
+            : 0;
 
         const scores: Record<string, number> = {
           f1: f1Score(answerForScoring, expectedAnswer),
           contains_answer: containsAnswer(answerForScoring, expectedAnswer),
-          qa_accuracy:
-            selectedChoice && expectedChoice && selectedChoice.index === expectedChoice.index
-              ? 1
-              : 0,
+          qa_accuracy: qaAccuracy,
+          normalized_memory_score: qaAccuracy,
         };
         const judgeResult = await llmJudgeScoreDetailed(
           options.system.judge,
@@ -197,7 +199,13 @@ export async function runAMemGymBenchmark(
           question: benchmarkQuestion,
           expected: expectedAnswer,
           actual: `(error: ${message})`,
-          scores: { f1: -1, contains_answer: -1, qa_accuracy: -1, llm_judge: -1 },
+          scores: {
+            f1: -1,
+            contains_answer: -1,
+            qa_accuracy: -1,
+            normalized_memory_score: -1,
+            llm_judge: -1,
+          },
           latencyMs: 0,
           tokens: { input: 0, output: 0 },
           details: { error: message },

--- a/scripts/bench/public-sota/compare-public-benchmark-sota.mjs
+++ b/scripts/bench/public-sota/compare-public-benchmark-sota.mjs
@@ -78,23 +78,35 @@ function compareAmaBench(result, targets) {
   return [metricResult('ama_bench_leaderboard_average', finiteScore(actual, 'AMA leaderboard average'), finiteScore(target, 'AMA target'))];
 }
 
+function amemGymActualMetric(result) {
+  const [sourceMetric, actual] = [
+    ['normalized_memory_score', result.results?.aggregates?.normalized_memory_score?.mean],
+    ['memory_score', result.results?.aggregates?.memory_score?.mean],
+    ['qa_accuracy', result.results?.aggregates?.qa_accuracy?.mean],
+  ].find(([, value]) => typeof value === 'number' && Number.isFinite(value)) ?? [];
+  assert(sourceMetric, 'AMemGym result missing normalized_memory_score, memory_score, and qa_accuracy aggregates');
+  return {
+    sourceMetric,
+    actual: finiteScore(actual, `AMemGym ${sourceMetric}`),
+  };
+}
+
 function compareAMemGym(result, targets) {
-  const actual = result.results?.aggregates?.normalized_memory_score?.mean
-    ?? result.results?.aggregates?.memory_score?.mean
-    ?? result.results?.aggregates?.qa_accuracy?.mean;
+  const { actual, sourceMetric } = amemGymActualMetric(result);
   return [
     metricResult(
       'amemgym_memory_agent_score',
-      finiteScore(actual, 'AMemGym score'),
+      actual,
       finiteScore(targets.memoryAgent?.score, 'AMemGym memory-agent target'),
-      { comparisonClass: 'memory-agent' },
+      { comparisonClass: 'memory-agent', sourceMetric },
     ),
     metricResult(
       'amemgym_native_llm_score_reference',
-      finiteScore(actual, 'AMemGym score'),
+      actual,
       finiteScore(targets.nativeLlm?.score, 'AMemGym native target'),
       {
         comparisonClass: 'native-llm-reference',
+        sourceMetric,
         publishAsSota: false,
         note: 'Reference only; Remnic memory-system SOTA should be judged against the memory-agent class unless making a model-only claim.',
       },

--- a/scripts/bench/public-sota/evidence-run-utils.mjs
+++ b/scripts/bench/public-sota/evidence-run-utils.mjs
@@ -37,19 +37,44 @@ export function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
+const AMEMGYM_FAILURE_SENTINEL_METRICS = new Set([
+  'contains_answer',
+  'f1',
+  'llm_judge',
+  'normalized_memory_score',
+  'qa_accuracy',
+]);
+
+function acceptsFailureSentinel(benchmark, metric) {
+  return benchmark === 'amemgym' && AMEMGYM_FAILURE_SENTINEL_METRICS.has(metric);
+}
+
+export function isPublicScoreValue(value, benchmark, metric) {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    (value >= 0 || (value === -1 && acceptsFailureSentinel(benchmark, metric)));
+}
+
+export function isPublicAggregateMeanValue(value, benchmark, metric) {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    (value >= 0 || (value >= -1 && acceptsFailureSentinel(benchmark, metric)));
+}
+
 export function assertNoInvalidRawScores(result) {
+  const benchmark = result.meta?.benchmark ?? result.benchmarkId;
   for (const [metric, aggregate] of Object.entries(result.results?.aggregates ?? {})) {
     const value = aggregate?.mean;
     assert(
-      typeof value !== 'number' || (Number.isFinite(value) && value >= 0),
-      `raw aggregate ${metric}.mean must be non-negative finite`,
+      typeof value !== 'number' || isPublicAggregateMeanValue(value, benchmark, metric),
+      `raw aggregate ${metric}.mean must be finite, non-negative, or an accepted failure sentinel aggregate`,
     );
   }
   for (const task of result.results?.tasks ?? []) {
     for (const [metric, score] of Object.entries(task.scores ?? {})) {
       assert(
-        typeof score !== 'number' || (Number.isFinite(score) && score >= 0),
-        `raw task ${task.taskId ?? '<unknown>'} score ${metric} must be non-negative finite`,
+        typeof score !== 'number' || isPublicScoreValue(score, benchmark, metric),
+        `raw task ${task.taskId ?? '<unknown>'} score ${metric} must be finite, non-negative, or an accepted failure sentinel`,
       );
     }
   }

--- a/scripts/bench/public-sota/package-public-benchmark-evidence.mjs
+++ b/scripts/bench/public-sota/package-public-benchmark-evidence.mjs
@@ -21,6 +21,8 @@ import {
   assertResultMatchesRunManifest,
   buildDiagnosticsSummary,
   gitInfo,
+  isPublicAggregateMeanValue,
+  isPublicScoreValue,
   parseArgs,
   pathReplacements,
   readJson,
@@ -35,18 +37,19 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_TARGET_MAP = path.join(scriptDir, 'current-target-map.json');
 
 function aggregateMeans(result) {
+  const benchmark = result.meta?.benchmark ?? result.benchmarkId;
   return Object.fromEntries(
     Object.entries(result.results?.aggregates ?? {})
-      .filter(([, aggregate]) => aggregate && typeof aggregate.mean === 'number' && Number.isFinite(aggregate.mean) && aggregate.mean >= 0)
+      .filter(([metric, aggregate]) => aggregate && isPublicAggregateMeanValue(aggregate.mean, benchmark, metric))
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([metric, aggregate]) => [metric, aggregate.mean]),
   );
 }
 
-function cleanedScores(scores) {
+function cleanedScores(scores, benchmark) {
   return Object.fromEntries(
     Object.entries(scores ?? {})
-      .filter(([, score]) => typeof score === 'number' && Number.isFinite(score) && score >= 0)
+      .filter(([metric, score]) => isPublicScoreValue(score, benchmark, metric))
       .sort(([left], [right]) => left.localeCompare(right)),
   );
 }
@@ -156,7 +159,7 @@ function buildArtifact(result, dataset, comparison, startedAt) {
     perTaskScores: result.results.tasks.map((task) => ({
       taskId: task.taskId,
       category: publicTaskCategory(benchmark, task),
-      scores: cleanedScores(task.scores),
+      scores: cleanedScores(task.scores, benchmark),
       details: publicTaskDetails(benchmark, task),
     })),
     startedAt,

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -11,7 +11,11 @@ import {
   roundedJsonNumberReplacer,
 } from "../scripts/bench/public-sota/compare-public-benchmark-sota.mjs";
 import { manifestArtifactHashIdentity } from "../scripts/bench/public-sota/evidence-integrity.mjs";
-import { buildDiagnosticsSummary, statusTimes } from "../scripts/bench/public-sota/evidence-run-utils.mjs";
+import {
+  assertNoInvalidRawScores,
+  buildDiagnosticsSummary,
+  statusTimes,
+} from "../scripts/bench/public-sota/evidence-run-utils.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -413,7 +417,14 @@ async function assertRejectsRawResultDrift(
   );
 }
 
-async function writeAmemGymResult(resultPath: string, taskCount = 1): Promise<void> {
+async function writeAmemGymResult(
+  resultPath: string,
+  taskCountOrScores: number | number[] = 1,
+): Promise<void> {
+  const scores = Array.isArray(taskCountOrScores)
+    ? taskCountOrScores
+    : Array.from({ length: taskCountOrScores }, () => 1);
+  const meanScore = scores.reduce((sum, score) => sum + score, 0) / scores.length;
   await writeJson(resultPath, {
     meta: {
       id: "amemgym-test-result",
@@ -439,12 +450,12 @@ async function writeAmemGymResult(resultPath: string, taskCount = 1): Promise<vo
     },
     results: {
       aggregates: {
-        normalized_memory_score: { mean: 1 },
+        normalized_memory_score: { mean: meanScore },
       },
-      tasks: Array.from({ length: taskCount }, (_, index) => ({
+      tasks: scores.map((score, index) => ({
         taskId: `profile-q${index + 1}`,
         details: { profileId: "profile", questionIndex: index + 1 },
-        scores: { normalized_memory_score: 1 },
+        scores: { normalized_memory_score: score },
       })),
     },
   });
@@ -488,6 +499,45 @@ async function writeMemoryArenaResult(resultPath: string): Promise<void> {
     },
   });
 }
+
+test("public raw score validation scopes failure sentinels to AMemGym", () => {
+  assertNoInvalidRawScores({
+    meta: { benchmark: "amemgym" },
+    results: {
+      aggregates: {
+        normalized_memory_score: { mean: -0.5 },
+      },
+      tasks: [
+        {
+          taskId: "amemgym-failed-task",
+          scores: {
+            normalized_memory_score: -1,
+          },
+        },
+      ],
+    },
+  });
+
+  assert.throws(
+    () => assertNoInvalidRawScores({
+      meta: { benchmark: "personamem" },
+      results: {
+        aggregates: {
+          llm_judge: { mean: -1 },
+        },
+        tasks: [
+          {
+            taskId: "personamem-failed-task",
+            scores: {
+              llm_judge: -1,
+            },
+          },
+        ],
+      },
+    }),
+    /raw aggregate llm_judge\.mean must be finite, non-negative, or an accepted failure sentinel aggregate/,
+  );
+});
 
 test("generic public SOTA packager rejects diagnostics with invalid timestamps", async () => {
   const dirs = await createRunDirs("remnic-public-sota-generic-");
@@ -567,6 +617,82 @@ test("generic public SOTA packager rejects diagnostics that do not cover publish
         "--repo-root", process.cwd(),
         "--out-dir", dirs.outDir,
       ],
+    );
+  } finally {
+    await rm(dirs.root, { recursive: true, force: true });
+  }
+});
+
+test("generic public SOTA packager preserves AMemGym failure sentinels", async () => {
+  const dirs = await createRunDirs("remnic-public-sota-amemgym-failure-sentinel-");
+  try {
+    await writeValidDiagnostics(dirs.diagnosticsDir, 2);
+    await writeFile(
+      path.join(dirs.resultsDir, "status.tsv"),
+      `benchmark\tstatus\ttimestamp\namemgym\tstart\t${STARTED_AT}\namemgym\tsuccess\t${FINISHED_AT}\n`,
+      "utf8",
+    );
+    const resultPath = path.join(dirs.resultsDir, "amemgym-result.json");
+    await writeAmemGymResult(resultPath, [0, -1]);
+    await writeBaseManifest(dirs.resultsDir, "amemgym", resultPath);
+
+    await execFileAsync(
+      process.execPath,
+      [
+        path.join("scripts", "bench", "public-sota", "package-public-benchmark-evidence.mjs"),
+        "--result", resultPath,
+        "--results-dir", dirs.resultsDir,
+        "--dataset-dir", dirs.datasetDir,
+        "--repo-root", process.cwd(),
+        "--out-dir", dirs.outDir,
+      ],
+      { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+    );
+
+    const manifest = JSON.parse(await readFile(path.join(dirs.outDir, "MANIFEST.amemgym.json"), "utf8"));
+    const artifact = JSON.parse(await readFile(path.join(dirs.outDir, manifest.publicArtifacts[0].path), "utf8"));
+    assert.equal(artifact.metrics.normalized_memory_score, -0.5);
+    assert.deepEqual(
+      artifact.perTaskScores.map((task: { scores: { normalized_memory_score: number } }) => task.scores.normalized_memory_score),
+      [0, -1],
+    );
+  } finally {
+    await rm(dirs.root, { recursive: true, force: true });
+  }
+});
+
+test("generic public SOTA packager rejects non-sentinel negative scores", async () => {
+  const dirs = await createRunDirs("remnic-public-sota-negative-score-");
+  try {
+    await writeValidDiagnostics(dirs.diagnosticsDir, 2);
+    await writeFile(
+      path.join(dirs.resultsDir, "status.tsv"),
+      `benchmark\tstatus\ttimestamp\namemgym\tstart\t${STARTED_AT}\namemgym\tsuccess\t${FINISHED_AT}\n`,
+      "utf8",
+    );
+    const resultPath = path.join(dirs.resultsDir, "amemgym-result.json");
+    await writeAmemGymResult(resultPath, [1, -0.5]);
+    await writeBaseManifest(dirs.resultsDir, "amemgym", resultPath);
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          path.join("scripts", "bench", "public-sota", "package-public-benchmark-evidence.mjs"),
+          "--result", resultPath,
+          "--results-dir", dirs.resultsDir,
+          "--dataset-dir", dirs.datasetDir,
+          "--repo-root", process.cwd(),
+          "--out-dir", dirs.outDir,
+        ],
+        { cwd: process.cwd(), maxBuffer: 1024 * 1024 },
+      ),
+      (error: unknown) => {
+        assert(error && typeof error === "object");
+        const output = `${(error as { stdout?: string }).stdout ?? ""}\n${(error as { stderr?: string }).stderr ?? ""}`;
+        assert.match(output, /score normalized_memory_score must be finite, non-negative, or an accepted failure sentinel/);
+        return true;
+      },
     );
   } finally {
     await rm(dirs.root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- emit AMemGym normalized_memory_score from the existing choice-accuracy score
- include the AMemGym source metric in public SOTA comparison evidence
- cover the emitted aggregate in the AMemGym runner test

## Verification
- pnpm exec tsx --test packages/bench/src/benchmarks/published/amemgym/runner.test.ts
- node --input-type=module -e "import { comparePublicBenchmarkSota } from './scripts/bench/public-sota/compare-public-benchmark-sota.mjs'; const targetMap={benchmarks:{amemgym:{targets:{memoryAgent:{score:0.296},nativeLlm:{score:0.463}}}}}; const result={meta:{benchmark:'amemgym',gitSha:'smoke'},results:{tasks:[{scores:{normalized_memory_score:0.5}}],aggregates:{normalized_memory_score:{mean:0.5}}}}; console.log(JSON.stringify(comparePublicBenchmarkSota(result,targetMap),null,2));"
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark scoring and public evidence score validation; scope is limited to AMemGym with new tests, but incorrect sentinel rules could affect published results.
> 
> **Overview**
> This PR wires **AMemGym**’s public primary metric **`normalized_memory_score`** through the runner, SOTA comparison, and evidence packaging.
> 
> The benchmark runner now sets **`normalized_memory_score`** to the same value as **`qa_accuracy`** on success, and **`-1`** on failed tasks (alongside other failure sentinels). Runner tests cover both the happy path and recall failures.
> 
> Public SOTA comparison prefers **`normalized_memory_score`** (with fallbacks to **`memory_score`** / **`qa_accuracy`**) and records which **`sourceMetric`** was used in comparison output.
> 
> Evidence validation and packaging only allow **`-1`** as a failure sentinel for **AMemGym** on a fixed set of metrics; other benchmarks still require non‑negative scores. The generic packager keeps those sentinels in published artifacts and rejects invalid negatives (e.g. **`-0.5`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca99af2f8c70cdc14cae2e428780ad8705e1690b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->