### PR TITLE
Update QMD compatibility target to 2.5.3

### DIFF
--- a/.changeset/qmd-253-compat.md
+++ b/.changeset/qmd-253-compat.md
@@ -1,0 +1,7 @@
+---
+"@remnic/core": patch
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Update Remnic's QMD supported target to `@tobilu/qmd` 2.5.3 and gate QMD 2.5.3's preferred `--format json` output selector behind runtime version detection while preserving legacy `--json` for older QMD installs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ grep "\[engram\]" ~/.openclaw/logs/gateway.log
 5. **SIGUSR1 doesn't fire gateway_start** — use `launchctl kickstart -k` for full restart
 6. **profile.md injected everywhere** — keep under 600 lines or consolidation triggers
 7. **QMD `query` is intentional** — DO NOT change from `query` to `search` or `vsearch`. The `query` command provides LLM expansion + reranking that Remnic relies on. Remnic's own reranking was disabled because `qmd query` handles it.
-8. **QMD local patches** — PRs #166, #112, #117 are applied locally to `~/.bun/install/global/node_modules/qmd/`. These will be overwritten by `bun install -g github:tobi/qmd` — reapply if needed until merged upstream.
+8. **QMD version gates** — Remnic targets `@tobilu/qmd` 2.5.3, probes `qmd --version`, and must keep older QMD installs working by omitting unsupported flags. Use `--format json` for QMD 2.5.3+ query/search subprocess calls; keep legacy `--json` for older versions.
 9. **Legacy env var fallback chains** — always try `REMNIC_*` first, then fall back to `ENGRAM_*`. This applies to config parsing, hook scripts, and daemon label lookups.
 10. **Never interpolate unsanitized values into shell scripts** — pass host/port/config values via environment variables, never via string interpolation into script command strings.
 11. **Scope globals per plugin ID** — runtime orchestrator mirrors, CLI dedupe guards, and capability caches must be keyed by `serviceId` when multiple instances can coexist.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -119,7 +119,7 @@ See [Search Backends](search-backends.md) for detailed configuration and compari
 | `qmdColdCollection` | `openclaw-engram-cold` | QMD collection name used for cold-tier recall |
 | `qmdColdMaxResults` | `8` | Final result cap for cold-tier recall before merging into the normal ranking pipeline |
 | `qmdPath` | `(auto)` | Absolute path to `qmd` binary (bypasses PATH) |
-| `qmdSupportedVersion` | `2.5.1` | Highest QMD version this Remnic build will auto-install |
+| `qmdSupportedVersion` | `2.5.3` | Highest QMD version this Remnic build will auto-install |
 | `qmdAutoUpgradeEnabled` | `false` | Opt-in auto-upgrade for PATH/fallback QMD installs; explicit `qmdPath` is never overwritten |
 | `qmdAutoUpgradeCheckIntervalMs` | `86400000` | Minimum interval between auto-upgrade attempts |
 | `qmdChunkStrategy` | `auto` | QMD chunk strategy to forward when the installed QMD supports it (`auto` or `regex`) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,18 +79,21 @@ grep '\[engram\]' ~/.openclaw/logs/gateway.log | tail -5
 
 [QMD](https://github.com/tobi/qmd) provides hybrid BM25 + vector + reranking search. Without it, Remnic falls back to semantic embedding search (using your OpenAI key when available) and then recency-ordered file reads.
 
-**QMD 2.5.1 is the current supported target.** QMD 1.x still works, but 2.0+
+**QMD 2.5.3 is the current supported target.** QMD 1.x still works, but 2.0+
 resolves several known issues natively (session ID crash, model override env
-vars, join performance), and 2.5.1 adds runtime diagnostics, structured MCP
+vars, join performance), 2.5.0 adds runtime diagnostics, structured MCP
 searches, safer indexing, model/GPU env controls, and absolute snippet line
-numbers that Remnic can detect and use. Install via npm or bun:
+numbers, and 2.5.3 adds the preferred `--format` selector plus line-range,
+docid-header, full-path, launcher, and Metal-teardown fixes. Remnic detects the
+installed QMD version and only uses newer flags when available. Install via npm
+or bun:
 
 ```bash
-npm install -g @tobilu/qmd@2.5.1
-# or: bun install -g @tobilu/qmd@2.5.1
+npm install -g @tobilu/qmd@2.5.3
+# or: bun install -g @tobilu/qmd@2.5.3
 
 # Verify
-qmd --version  # should show 2.5.1
+qmd --version  # should show 2.5.3
 ```
 
 Add to `~/.config/qmd/index.yml`:
@@ -118,12 +121,21 @@ Enable in your plugin config:
 
 ### Upgrading QMD
 
-QMD 2.5.1 is a drop-in upgrade from older 2.x installs. Existing collections,
+QMD 2.5.3 is a drop-in upgrade from older 2.x installs. Existing collections,
 indexes, and config files work without changes. Remnic detects the installed
 version at startup and enables newer features only when the installed binary
 supports them.
 
 **What changed:**
+- QMD `2.5.3`: `qmd query`/`qmd search` prefer `--format json`; Remnic uses that
+  form only for 2.5.3+ and keeps legacy `--json` for older QMD installs.
+- QMD `2.5.3`: `qmd get`/`qmd multi-get` output is line-numbered by default,
+  includes `#docid` headers, accepts `:from:count` line ranges, and supports
+  `--full-path` for direct filesystem paths. These are useful for humans and
+  agents reading QMD directly; Remnic's search path keeps JSON output with
+  docids for provenance and dedupe.
+- QMD `2.5.2`/`2.5.3`: global launcher fixes improve Windows, pnpm-global,
+  Node/Bun source-mode selection, and macOS Metal teardown behavior.
 - Unified `search()` replaces the old query/search/structuredSearch split internally
 - MCP server rewritten as a clean SDK consumer (same external contract)
 - Source reorganized into `src/cli/` and `src/mcp/` subdirectories
@@ -139,15 +151,15 @@ supports them.
 
 ```bash
 # 1. Install the supported QMD target
-npm install -g @tobilu/qmd@2.5.1
-# or: bun install -g @tobilu/qmd@2.5.1
+npm install -g @tobilu/qmd@2.5.3
+# or: bun install -g @tobilu/qmd@2.5.3
 
 # 2. If native bindings need repair, rebuild better-sqlite3 manually
 cd ~/.bun/install/global/node_modules/better-sqlite3
 npm rebuild better-sqlite3
 
 # 3. Verify
-qmd --version       # 2.5.1
+qmd --version       # 2.5.3
 qmd doctor          # available on QMD 2.5+
 qmd status           # should show existing collections
 
@@ -156,7 +168,7 @@ launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 
 # 5. Verify Remnic picked up the new QMD version
 grep "cliVersion" ~/.openclaw/logs/gateway.log | tail -1
-# Should show: cliVersion=qmd 2.5.1
+# Should show: cliVersion=qmd 2.5.3
 ```
 
 To let Remnic perform this upgrade for PATH/fallback installs, set

--- a/docs/search-backends.md
+++ b/docs/search-backends.md
@@ -19,12 +19,12 @@ QMD provides the highest quality retrieval through hybrid BM25 + vector + LLM re
 
 ### Setup
 
-Install QMD. Remnic currently supports QMD `2.5.1` and detects the installed
+Install QMD. Remnic currently supports QMD `2.5.3` and detects the installed
 version with `qmd --version` at runtime:
 
 ```bash
-npm install -g @tobilu/qmd@2.5.1
-# or: bun install -g @tobilu/qmd@2.5.1
+npm install -g @tobilu/qmd@2.5.3
+# or: bun install -g @tobilu/qmd@2.5.3
 qmd --version
 ```
 
@@ -50,8 +50,8 @@ qmd update && qmd embed
   "qmdEnabled": true,
   "qmdCollection": "openclaw-engram",
   "qmdMaxResults": 8,
-  "qmdSupportedVersion": "2.5.1",
-  "qmdAutoUpgradeEnabled": false, // opt-in: npm install -g @tobilu/qmd@2.5.1
+  "qmdSupportedVersion": "2.5.3",
+  "qmdAutoUpgradeEnabled": false, // opt-in: npm install -g @tobilu/qmd@2.5.3
   "qmdChunkStrategy": "auto",
   // Leave qmdIndexName unset unless you intentionally use a separate QMD DB.
   // Existing Remnic/OpenClaw installs usually keep data in QMD's default "index".
@@ -62,7 +62,7 @@ qmd update && qmd embed
 }
 ```
 
-When QMD `2.5.1` is installed, Remnic uses the newer capability set when
+When QMD `2.5.3` is installed, Remnic uses the newer capability set when
 available: `qmd doctor` diagnostics, version-matched skill metadata, structured
 MCP `lex`/`vec`/`hyde` searches, candidate-limit forwarding, rerank toggles,
 AST-aware chunking for CLI/embed paths, scoped collection embedding, model/env
@@ -70,6 +70,14 @@ overrides (`QMD_EMBED_MODEL`, `QMD_RERANK_MODEL`, `QMD_GENERATE_MODEL`,
 `QMD_FORCE_CPU`, `QMD_LLAMA_GPU`, `QMD_EMBED_PARALLELISM`), named index selection
 via `qmdIndexName`, and absolute snippet line numbers. Older QMD installs
 continue to work with unsupported flags omitted.
+
+Remnic also detects QMD `2.5.3`'s preferred `--format json` output selector
+for `qmd query`/`qmd search` subprocess calls. QMD `2.5.3` adds richer
+human/agent retrieval output (`get` line-range suffixes, default line-numbered
+`get`/`multi-get`, `#docid` headers, and `--full-path` for direct filesystem
+paths), but Remnic keeps its machine-readable search path on QMD's JSON output
+and preserves docids for provenance and dedupe. QMD `2.5.1` and older installs
+continue to receive the legacy `--json` aliases.
 
 Do not set `qmdIndexName` during upgrades unless you have confirmed the existing
 QMD data lives in that named index. QMD's default index is named `index` and is
@@ -91,7 +99,8 @@ QMD version coverage:
 | `2.0.0` | Uses the v2 MCP `query` tool shape and unified search semantics; legacy `search`/`vsearch` daemon tools are avoided. |
 | `2.0.1` | Detects the skill-install generation, but leaves user/global agent skill installation explicit. |
 | `2.1.0` | Enables AST chunk strategy on CLI/embed paths, rerank toggles, candidate limits, per-collection model config compatibility, and JSON line capture. |
-| `2.5.1` | Enables doctor/status diagnostics, version-matched skills, structured MCP `lex`/`vec`/`hyde` searches, absolute snippet lines, scoped embed behavior, and QMD model/GPU env controls. |
+| `2.5.0` | Enables doctor/status diagnostics, version-matched skills, structured MCP `lex`/`vec`/`hyde` searches, absolute snippet lines, scoped embed behavior, and QMD model/GPU env controls. |
+| `2.5.3` | Uses QMD's preferred `--format json` selector for `query`/`search` subprocess calls and inherits QMD's line-range, docid-header, full-path, launcher, and Metal-teardown fixes. Remnic keeps legacy `--json` for older QMD versions. |
 
 ### QMD Daemon Mode
 
@@ -106,7 +115,7 @@ Engram automatically prefers the shared MCP session when available and falls bac
 | `qmdDaemonRecheckIntervalMs` | `60000` | Re-probe interval after failure |
 | `qmdIntentHintsEnabled` | `false` | Forward inferred recall intent into QMD unified search when supported |
 | `qmdExplainEnabled` | `false` | Capture QMD explain traces into `memory_qmd_debug` snapshots |
-| `qmdSupportedVersion` | `2.5.1` | Highest QMD version this Remnic build will auto-install |
+| `qmdSupportedVersion` | `2.5.3` | Highest QMD version this Remnic build will auto-install |
 | `qmdAutoUpgradeEnabled` | `false` | Opt-in auto-upgrade for PATH/fallback QMD installs |
 | `qmdAutoUpgradeCheckIntervalMs` | `86400000` | Minimum interval between auto-upgrade attempts |
 | `qmdChunkStrategy` | `auto` | Forward QMD's AST-aware chunk strategy when supported |

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -436,7 +436,7 @@ Reliability / load:
   - Populate `cronRecallAllowlist` with only context-heavy cron job ids/patterns (`*:cron:<job-id>:*`).
   - Keep ingestion/integration script crons out of the allowlist unless they genuinely need memory context.
 - QMD version:
-  - **QMD 2.5.1 is the current supported target.** Remnic detects the installed version with `qmd --version` and gates 2.5 features such as `qmd doctor`, version-matched skills, scoped embed behavior, named index selection, model/GPU env controls, and absolute snippet line numbers.
+  - **QMD 2.5.3 is the current supported target.** Remnic detects the installed version with `qmd --version` and gates 2.5 features such as `qmd doctor`, version-matched skills, scoped embed behavior, named index selection, model/GPU env controls, absolute snippet line numbers, and QMD 2.5.3's preferred `--format json` output selector for `qmd query`/`qmd search`.
   - **QMD 2.0+ is the minimum practical baseline.** All 1.x patches (PRs #166, #112, #117) are resolved natively in 2.0. QMD 1.x still works but requires manual patches.
   - Set `qmdAutoUpgradeEnabled: true` to let Remnic upgrade PATH/fallback installs to `qmdSupportedVersion`; explicit `qmdPath` installs must be upgraded manually.
   - The QMD daemon keeps models warm — queries drop from ~13s to ~30ms after the first call.

--- a/llms.txt
+++ b/llms.txt
@@ -55,6 +55,9 @@ moment, skill, rule, entity, and more.
 Search: hybrid BM25 + vector + reranking via QMD. Six backend options:
 QMD (default), Orama (embedded JS), LanceDB (embedded native Arrow),
 Meilisearch (server), Remote (HTTP REST), Noop (extraction only).
+Current QMD target: @tobilu/qmd 2.5.3. Remnic probes qmd --version and gates
+newer flags; QMD 2.5.3+ uses --format json for query/search subprocess output,
+while older supported QMD installs keep legacy --json.
 
 KEY FEATURES
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -281,7 +281,7 @@
       },
       "qmdSupportedVersion": {
         "type": "string",
-        "default": "2.5.1",
+        "default": "2.5.3",
         "description": "Highest QMD version this Remnic build will auto-install"
       },
       "qmdAutoUpgradeEnabled": {
@@ -4944,7 +4944,7 @@
     "qmdSupportedVersion": {
       "label": "QMD Supported Version",
       "advanced": true,
-      "placeholder": "2.5.1"
+      "placeholder": "2.5.3"
     },
     "qmdAutoUpgradeEnabled": {
       "label": "QMD Auto Upgrade",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -281,7 +281,7 @@
       },
       "qmdSupportedVersion": {
         "type": "string",
-        "default": "2.5.1",
+        "default": "2.5.3",
         "description": "Highest QMD version this Remnic build will auto-install"
       },
       "qmdAutoUpgradeEnabled": {
@@ -4944,7 +4944,7 @@
     "qmdSupportedVersion": {
       "label": "QMD Supported Version",
       "advanced": true,
-      "placeholder": "2.5.1"
+      "placeholder": "2.5.3"
     },
     "qmdAutoUpgradeEnabled": {
       "label": "QMD Auto Upgrade",

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -96,14 +96,14 @@ function parseBoundedPositiveInteger(
 }
 
 function parseQmdSupportedVersion(value: unknown): string {
-  if (value === undefined || value === null) return "2.5.1";
+  if (value === undefined || value === null) return "2.5.3";
   if (typeof value !== "string") {
     throw new Error(`qmdSupportedVersion must be a semantic version string; got ${JSON.stringify(value)}`);
   }
   const normalized = value.trim();
   if (!/^\d+\.\d+\.\d+$/.test(normalized)) {
     throw new Error(
-      `qmdSupportedVersion must be a semantic version string like "2.5.1"; got ${JSON.stringify(value)}`,
+      `qmdSupportedVersion must be a semantic version string like "2.5.3"; got ${JSON.stringify(value)}`,
     );
   }
   return normalized;

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -13,22 +13,22 @@ import {
 } from "./qmd.js";
 
 test("parseQmdVersion extracts semantic version from qmd output", () => {
-  assert.deepEqual(parseQmdVersion("qmd 2.5.1 (abcdef)"), [2, 5, 1]);
+  assert.deepEqual(parseQmdVersion("qmd 2.5.3 (abcdef)"), [2, 5, 3]);
   assert.deepEqual(parseQmdVersion("v2.1.0"), [2, 1, 0]);
   assert.equal(parseQmdVersion("Unknown command: doctor"), null);
 });
 
 test("parseQmdVersionOutput prefers qmd-labelled semantic version lines", () => {
   assert.equal(
-    parseQmdVersionOutput("bun 1.2.0\nqmd 2.5.1 (abcdef)", ""),
-    "qmd 2.5.1 (abcdef)",
+    parseQmdVersionOutput("bun 1.2.0\nqmd 2.5.3 (abcdef)", ""),
+    "qmd 2.5.3 (abcdef)",
   );
   assert.equal(parseQmdVersionOutput("wrapper ready", "v2.1.0"), "v2.1.0");
   assert.equal(parseQmdVersionOutput("", ""), null);
 });
 
 test("resolveQmdCapabilities gates qmd 2.5 features by installed version", () => {
-  const current = resolveQmdCapabilities("qmd 2.5.1 (abcdef)");
+  const current = resolveQmdCapabilities("qmd 2.5.3 (abcdef)");
   assert.equal(current.v2McpQueryTool, true);
   assert.equal(current.structuredSearches, true);
   assert.equal(current.chunkStrategy, true);
@@ -41,6 +41,7 @@ test("resolveQmdCapabilities gates qmd 2.5 features by installed version", () =>
   assert.equal(current.embedParallelism, true);
   assert.equal(current.modelEnvConsistency, true);
   assert.equal(current.scopedEmbed, true);
+  assert.equal(current.outputFormatFlag, true);
 
   const older = resolveQmdCapabilities("qmd 2.1.0 (abcdef)");
   assert.equal(older.v2McpQueryTool, true);
@@ -51,6 +52,11 @@ test("resolveQmdCapabilities gates qmd 2.5 features by installed version", () =>
   assert.equal(older.absoluteSnippetLines, false);
   assert.equal(older.forceCpu, false);
   assert.equal(older.scopedEmbed, false);
+  assert.equal(older.outputFormatFlag, false);
+
+  const v251 = resolveQmdCapabilities("qmd 2.5.1");
+  assert.equal(v251.doctor, true);
+  assert.equal(v251.outputFormatFlag, false);
 
   const v20 = resolveQmdCapabilities("qmd 2.0.0");
   assert.equal(v20.stableSdk, true);
@@ -62,10 +68,10 @@ test("resolveQmdCapabilities gates qmd 2.5 features by installed version", () =>
 });
 
 test("shouldAutoUpgradeQmd only upgrades below Remnic supported version", () => {
-  assert.equal(shouldAutoUpgradeQmd("qmd 2.1.0", "2.5.1"), true);
-  assert.equal(shouldAutoUpgradeQmd("qmd 2.5.1", "2.5.1"), false);
-  assert.equal(shouldAutoUpgradeQmd("qmd 2.6.0", "2.5.1"), false);
-  assert.equal(shouldAutoUpgradeQmd("not installed", "2.5.1"), false);
+  assert.equal(shouldAutoUpgradeQmd("qmd 2.1.0", "2.5.3"), true);
+  assert.equal(shouldAutoUpgradeQmd("qmd 2.5.3", "2.5.3"), false);
+  assert.equal(shouldAutoUpgradeQmd("qmd 2.6.0", "2.5.3"), false);
+  assert.equal(shouldAutoUpgradeQmd("not installed", "2.5.3"), false);
 });
 
 test("getQmdCommandName preserves write command detection behind qmd 2.5 index prefix", () => {
@@ -93,7 +99,7 @@ test("QmdClient applies chunk strategy to normal and forced embed args", async (
   const client = new QmdClient("test", 5, {
     qmdChunkStrategy: "regex",
   });
-  (client as any).qmdCapabilities = resolveQmdCapabilities("qmd 2.5.1");
+  (client as any).qmdCapabilities = resolveQmdCapabilities("qmd 2.5.3");
   assert.deepEqual((client as any).buildEmbedArgs("memory"), [
     "embed",
     "-c",
@@ -108,6 +114,55 @@ test("QmdClient applies chunk strategy to normal and forced embed args", async (
     "memory",
     "--chunk-strategy",
     "regex",
+  ]);
+});
+
+test("QmdClient uses QMD 2.5.3 --format json for query subprocess output", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const client = new QmdClient("test", 5) as any;
+  client.available = true;
+  client.qmdCapabilities = resolveQmdCapabilities("qmd 2.5.3");
+  let observedArgs: string[] = [];
+  client.runQmdCommand = async (args: string[]) => {
+    observedArgs = args;
+    return { stdout: "[]", stderr: "" };
+  };
+
+  await client.searchViaSubprocess("memory query", "memory", 3);
+
+  assert.deepEqual(observedArgs, [
+    "query",
+    "memory query",
+    "-c",
+    "memory",
+    "--format",
+    "json",
+    "-n",
+    "3",
+  ]);
+});
+
+test("QmdClient keeps legacy --json for older QMD query subprocess output", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const client = new QmdClient("test", 5) as any;
+  client.available = true;
+  client.qmdCapabilities = resolveQmdCapabilities("qmd 2.5.1");
+  let observedArgs: string[] = [];
+  client.runQmdCommand = async (args: string[]) => {
+    observedArgs = args;
+    return { stdout: "[]", stderr: "" };
+  };
+
+  await client.searchViaSubprocess("memory query", "memory", 3);
+
+  assert.deepEqual(observedArgs, [
+    "query",
+    "memory query",
+    "-c",
+    "memory",
+    "--json",
+    "-n",
+    "3",
   ]);
 });
 
@@ -184,7 +239,7 @@ test("QmdClient auto-upgrade throttle key is scoped by qmd target", async () => 
 
 test("parseConfig exposes qmd 2.5 integration defaults and opt-in auto upgrade", () => {
   const defaults = parseConfig({});
-  assert.equal(defaults.qmdSupportedVersion, "2.5.1");
+  assert.equal(defaults.qmdSupportedVersion, "2.5.3");
   assert.equal(defaults.qmdAutoUpgradeEnabled, false);
   assert.equal(defaults.qmdChunkStrategy, "auto");
   assert.equal(defaults.qmdQueryRerankEnabled, true);

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -73,6 +73,7 @@ export interface QmdCapabilities {
   scopedEmbed: boolean;
   safeStatusDeviceProbe: boolean;
   mcpIndexSelection: boolean;
+  outputFormatFlag: boolean;
 }
 
 export interface QmdVersionStatus {
@@ -104,7 +105,7 @@ const QMD_PROBE_TIMEOUT_MS = 8_000;
 const QMD_UPDATE_BACKOFF_MS = 15 * 60 * 1000; // 15m
 const QMD_EMBED_BACKOFF_MS = 60 * 60 * 1000; // 60m
 const QMD_CLI_WARN_THROTTLE_MS = 15 * 60 * 1000; // 15m
-export const QMD_SUPPORTED_VERSION = "2.5.1";
+export const QMD_SUPPORTED_VERSION = "2.5.3";
 const QMD_PACKAGE_NAME = "@tobilu/qmd";
 const QMD_AUTO_UPGRADE_TIMEOUT_MS = 120_000;
 const QMD_AUTO_UPGRADE_CHECK_INTERVAL_MS = 24 * 60 * 60_000;
@@ -312,6 +313,7 @@ export function resolveQmdCapabilities(version: string | null): QmdCapabilities 
     scopedEmbed: atLeast([2, 5, 0]),
     safeStatusDeviceProbe: atLeast([2, 5, 0]),
     mcpIndexSelection: atLeast([2, 5, 0]),
+    outputFormatFlag: atLeast([2, 5, 3]),
   };
 }
 
@@ -1763,6 +1765,14 @@ export class QmdClient implements SearchBackend {
     }
   }
 
+  private addQmdJsonOutputArgs(args: string[]): void {
+    if (this.qmdCapabilities.outputFormatFlag) {
+      args.push("--format", "json");
+    } else {
+      args.push("--json");
+    }
+  }
+
   private addResolvedSearchOptionsToMcpArgs(
     args: Record<string, unknown>,
     options?: SearchQueryOptions,
@@ -1779,7 +1789,7 @@ export class QmdClient implements SearchBackend {
     if (options?.rerank === false) {
       args.rerank = false;
     }
-    // QMD 2.5.1 MCP query does not expose chunkStrategy even though CLI/SDK
+    // QMD MCP query does not expose chunkStrategy even though CLI/SDK
     // search and embed do. Keep chunk strategy on CLI/embed paths only.
   }
 
@@ -2220,7 +2230,9 @@ export class QmdClient implements SearchBackend {
 
     const startedAtMs = Date.now();
     try {
-      const args = ["query", query, "-c", collection, "--json", "-n", String(maxResults)];
+      const args = ["query", query, "-c", collection];
+      this.addQmdJsonOutputArgs(args);
+      args.push("-n", String(maxResults));
       this.addResolvedSearchOptionsToArgs(args, options);
       const { stdout } = await this.runQmdCommand(args, QMD_TIMEOUT_MS, signal);
       const durationMs = Date.now() - startedAtMs;
@@ -2249,11 +2261,10 @@ export class QmdClient implements SearchBackend {
     if (this.available === false) return [];
     const startedAtMs = Date.now();
     try {
-      const { stdout } = await this.runQmdCommand(
-        ["search", query, "-c", collection, "--json", "-n", String(maxResults)],
-        QMD_TIMEOUT_MS,
-        signal,
-      );
+      const args = ["search", query, "-c", collection];
+      this.addQmdJsonOutputArgs(args);
+      args.push("-n", String(maxResults));
+      const { stdout } = await this.runQmdCommand(args, QMD_TIMEOUT_MS, signal);
       log.debug(`QMD bm25: ${Date.now() - startedAtMs}ms`);
       return parseQmdSearchStdout(stdout);
     } catch (err) {
@@ -2300,7 +2311,9 @@ export class QmdClient implements SearchBackend {
 
     const startedAtMs = Date.now();
     try {
-      const args = ["query", query, "--json", "-n", String(maxResults)];
+      const args = ["query", query];
+      this.addQmdJsonOutputArgs(args);
+      args.push("-n", String(maxResults));
       this.addResolvedSearchOptionsToArgs(args, options);
       const { stdout } = await this.runQmdCommand(args, QMD_TIMEOUT_MS, signal);
       const durationMs = Date.now() - startedAtMs;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -281,7 +281,7 @@
       },
       "qmdSupportedVersion": {
         "type": "string",
-        "default": "2.5.1",
+        "default": "2.5.3",
         "description": "Highest QMD version this Remnic build will auto-install"
       },
       "qmdAutoUpgradeEnabled": {
@@ -4944,7 +4944,7 @@
     "qmdSupportedVersion": {
       "label": "QMD Supported Version",
       "advanced": true,
-      "placeholder": "2.5.1"
+      "placeholder": "2.5.3"
     },
     "qmdAutoUpgradeEnabled": {
       "label": "QMD Auto Upgrade",

--- a/tests/search-backends.test.ts
+++ b/tests/search-backends.test.ts
@@ -105,8 +105,8 @@ describe("search backend factory", () => {
   it("QMD 2.x supported options include structured searches but keep MCP-unsupported chunking out of args", async () => {
     const { QmdClient, resolveQmdCapabilities } = await import("../src/qmd.js");
     const client = new QmdClient("test-collection", 10);
-    (client as any).cliVersion = "qmd 2.5.1";
-    (client as any).qmdCapabilities = resolveQmdCapabilities("qmd 2.5.1");
+    (client as any).cliVersion = "qmd 2.5.3";
+    (client as any).qmdCapabilities = resolveQmdCapabilities("qmd 2.5.3");
     assert.deepEqual(
       client.resolveSupportedSearchOptions({
         intent: "goal:review",


### PR DESCRIPTION
## Summary
- update Remnic's supported QMD target/default auto-install version to @tobilu/qmd 2.5.3
- detect QMD 2.5.3+ and use the preferred `--format json` selector for `qmd query`/`qmd search` subprocess calls
- keep older QMD installs compatible by retaining legacy `--json` for versions below 2.5.3
- document the QMD 2.5.2/2.5.3 upstream changes for users and future agents

## Upstream review
- `@tobilu/qmd` latest is 2.5.3, published 2026-05-29
- QMD 2.5.2 is a launcher fix for Windows/global installs
- QMD 2.5.3 adds `--format <kind>`, line-numbered/docid-rich `get`/`multi-get`, `--full-path`, source-mode launcher fixes, and macOS Metal teardown mitigation

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/qmd.test.ts tests/search-backends.test.ts tests/config-qmd-review.test.ts`
- `npm run check:openclaw-plugin-sync`
- `git diff --check`
- `npm run preflight:quick`

Cursor CLI was not available on PATH, so `npm run review:cursor` was not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default QMD subprocess flags on the recall/search fallback path; behavior is version-gated and tested, but a bad version probe could still break JSON parsing for hybrid search.
> 
> **Overview**
> Raises Remnic's QMD compatibility target from **2.5.1** to **`@tobilu/qmd` 2.5.3** across defaults (`QMD_SUPPORTED_VERSION`, `qmdSupportedVersion` in config and plugin manifests), auto-upgrade behavior, and operator docs.
> 
> Runtime changes add an **`outputFormatFlag`** capability (enabled only when `qmd --version` is **≥ 2.5.3**) and route subprocess **`query`**, **`search`**, and global **`query`** calls through a shared helper: **`--format json`** on 2.5.3+, legacy **`--json`** on older installs (including 2.5.1). Tests lock in capability gating and the two CLI argument shapes.
> 
> Documentation and **CLAUDE.md** now describe the version gate and upstream 2.5.2/2.5.3 notes (launcher, `get`/`multi-get` ergonomics); Remnic's machine-readable search path is unchanged aside from the flag selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7abb9eb861a899333cac826c96c606e3f7f35f6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->