### PR TITLE
Harden public SOTA gh resolution

### DIFF
--- a/scripts/bench/public-sota/audit-public-sota-completion.mjs
+++ b/scripts/bench/public-sota/audit-public-sota-completion.mjs
@@ -23,6 +23,53 @@ const branchRef = process.env.BRANCH_REF ?? 'origin/bench/public-matrix-codex';
 const auditWorktree = process.env.AUDIT_WORKTREE ?? path.join(os.tmpdir(), 'remnic-public-sota-completion-audit');
 const targetMapPath = process.env.TARGET_MAP ?? path.join(os.tmpdir(), 'remnic-public-sota-audit-target-map.json');
 
+function isExecutable(file) {
+  try {
+    fs.accessSync(file, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathGhCandidates() {
+  return (process.env.PATH ?? '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((entry) => path.join(entry, 'gh'));
+}
+
+function isWorkingGh(candidate) {
+  try {
+    execFileSync(candidate, ['--version'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveGhBin() {
+  const candidates = [
+    process.env.GH_BIN,
+    '/opt/homebrew/opt/gh/bin/gh',
+    ...pathGhCandidates(),
+    '/opt/homebrew/bin/gh',
+  ].filter(Boolean);
+  const seen = new Set();
+  for (const candidate of candidates) {
+    if (seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    if (isExecutable(candidate) && isWorkingGh(candidate)) {
+      return candidate;
+    }
+  }
+  return 'gh';
+}
+
+const ghBin = resolveGhBin();
+
 function fetchBranchRef() {
   if (!branchRef.startsWith('origin/')) {
     return;
@@ -86,7 +133,7 @@ function findManifest(manifestName) {
 
 function ghJson(args) {
   try {
-    return JSON.parse(execFileSync('gh', args, { encoding: 'utf8' }));
+    return JSON.parse(execFileSync(ghBin, args, { encoding: 'utf8' }));
   } catch {
     return undefined;
   }
@@ -345,7 +392,7 @@ function runPublicMatrixVerifier(row, item) {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: {
         ...process.env,
-        PATH: `/opt/homebrew/bin:/opt/homebrew/sbin:${process.env.PATH ?? ''}`,
+        PATH: `/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${process.env.PATH ?? ''}`,
       },
     });
     const report = JSON.parse(output);

--- a/scripts/bench/public-sota/complete-public-benchmark-if-ready.sh
+++ b/scripts/bench/public-sota/complete-public-benchmark-if-ready.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT_DEFAULT="$(git -C "${SCRIPT_DIR}/../../.." rev-parse --show-toplevel 2>/dev/null || (cd "${SCRIPT_DIR}/../../.." && pwd))"

--- a/scripts/bench/public-sota/generate-public-benchmark-evidence-doc.mjs
+++ b/scripts/bench/public-sota/generate-public-benchmark-evidence-doc.mjs
@@ -126,7 +126,7 @@ ${comparisonRows(comparison.checks)}
 Run the benchmark from the publication branch:
 
 \`\`\`bash
-PATH=/opt/homebrew/bin:/opt/homebrew/sbin:$PATH \\
+PATH=/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:$PATH \\
 node packages/remnic-cli/bin/remnic.cjs bench published \\
   --name ${benchmark} \\
   --dataset evals/datasets/${benchmark} \\

--- a/scripts/bench/public-sota/launch-next-after-memoryarena.sh
+++ b/scripts/bench/public-sota/launch-next-after-memoryarena.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT_DEFAULT="$(git -C "${SCRIPT_DIR}/../../.." rev-parse --show-toplevel 2>/dev/null || (cd "${SCRIPT_DIR}/../../.." && pwd))"

--- a/scripts/bench/public-sota/launch-next-public-benchmark.sh
+++ b/scripts/bench/public-sota/launch-next-public-benchmark.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT_DEFAULT="$(git -C "${SCRIPT_DIR}/../../.." rev-parse --show-toplevel 2>/dev/null || (cd "${SCRIPT_DIR}/../../.." && pwd))"
@@ -167,7 +167,7 @@ if [[ "${benchmark}" == "memory-arena" ]]; then
 fi
 session="${run_id}"
 tmux new-session -d -s "${session}" -c "${LAUNCH_REPO_ROOT}" \
-  "PATH=/opt/homebrew/bin:/opt/homebrew/sbin:\$PATH; export REMNIC_BENCH_RUN_ID=${run_id_quoted};${webshop_export} cd ${repo_quoted}; (${cmd_quoted}) >> ${log_quoted} 2>&1; rc=\$?; if [ \$rc -eq 0 ]; then printf '%s\tsuccess\t%s\n' ${benchmark_quoted} \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> ${status_quoted}; else printf '%s\tfail:%s\t%s\n' ${benchmark_quoted} \"\$rc\" \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> ${status_quoted}; fi; exit \$rc"
+  "PATH=/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:\$PATH; export REMNIC_BENCH_RUN_ID=${run_id_quoted};${webshop_export} cd ${repo_quoted}; (${cmd_quoted}) >> ${log_quoted} 2>&1; rc=\$?; if [ \$rc -eq 0 ]; then printf '%s\tsuccess\t%s\n' ${benchmark_quoted} \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> ${status_quoted}; else printf '%s\tfail:%s\t%s\n' ${benchmark_quoted} \"\$rc\" \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> ${status_quoted}; fi; exit \$rc"
 
 cat <<EOF
 launched=${session}

--- a/scripts/bench/public-sota/memoryarena/complete-memoryarena-if-ready.sh
+++ b/scripts/bench/public-sota/memoryarena/complete-memoryarena-if-ready.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PUBLIC_SOTA_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/scripts/bench/public-sota/memoryarena/generate-memoryarena-evidence-doc.mjs
+++ b/scripts/bench/public-sota/memoryarena/generate-memoryarena-evidence-doc.mjs
@@ -107,7 +107,7 @@ ${comparisonRows(comparison.checks)}
 Run the benchmark from the publication branch:
 
 \`\`\`bash
-PATH=/opt/homebrew/bin:/opt/homebrew/sbin:$PATH \\
+PATH=/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:$PATH \\
 node packages/remnic-cli/bin/remnic.cjs bench published \\
   --name memory-arena \\
   --dataset evals/datasets/memory-arena \\

--- a/scripts/bench/public-sota/memoryarena/publish-memoryarena-evidence-pr.sh
+++ b/scripts/bench/public-sota/memoryarena/publish-memoryarena-evidence-pr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_ROOT="${TMPDIR:-/tmp}"
@@ -143,7 +143,7 @@ The PR includes:
 node scripts/bench/verify-public-memoryarena-sota-evidence.mjs \
   __RESULTS_REL__
 
-PATH=/opt/homebrew/bin:/opt/homebrew/sbin:$PATH npx tsx scripts/bench/verify-public-matrix.ts \
+PATH=/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:$PATH npx tsx scripts/bench/verify-public-matrix.ts \
   --results-dir __RESULTS_REL__ \
   --manifest __MANIFEST_REL__ \
   --benchmarks memory-arena \

--- a/scripts/bench/public-sota/memoryarena/stage-memoryarena-evidence-pr.sh
+++ b/scripts/bench/public-sota/memoryarena/stage-memoryarena-evidence-pr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PUBLIC_SOTA_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -117,7 +117,7 @@ node "${DOC_GENERATOR}" \
 (
   cd "${WORKTREE}"
   node "${VERIFY_SCRIPT_REL}" "${RESULTS_REL}"
-  PATH=/opt/homebrew/bin:/opt/homebrew/sbin:${PATH} npx tsx scripts/bench/verify-public-matrix.ts \
+  PATH=/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH} npx tsx scripts/bench/verify-public-matrix.ts \
     --results-dir "${RESULTS_REL}" \
     --manifest "${RESULTS_REL}/MANIFEST.memory-arena.json" \
     --benchmarks memory-arena \

--- a/scripts/bench/public-sota/memoryarena/watch-and-publish-memoryarena.sh
+++ b/scripts/bench/public-sota/memoryarena/watch-and-publish-memoryarena.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_ROOT="${TMPDIR:-/tmp}"

--- a/scripts/bench/public-sota/publish-public-benchmark-evidence-pr.sh
+++ b/scripts/bench/public-sota/publish-public-benchmark-evidence-pr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_ROOT="${TMPDIR:-/tmp}"

--- a/scripts/bench/public-sota/stage-public-benchmark-evidence-pr.sh
+++ b/scripts/bench/public-sota/stage-public-benchmark-evidence-pr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT_DEFAULT="$(git -C "${SCRIPT_DIR}/../../.." rev-parse --show-toplevel 2>/dev/null || (cd "${SCRIPT_DIR}/../../.." && pwd))"
@@ -152,7 +152,7 @@ node "${DOC_GENERATOR}" \
 (
   cd "${WORKTREE}"
   node "${VERIFY_SCRIPT_REL}" "${RESULTS_REL}" "${benchmark}"
-  PATH=/opt/homebrew/bin:/opt/homebrew/sbin:${PATH} npx tsx scripts/bench/verify-public-matrix.ts \
+  PATH=/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH} npx tsx scripts/bench/verify-public-matrix.ts \
     --results-dir "${RESULTS_REL}" \
     --manifest "${RESULTS_REL}/MANIFEST.${benchmark}.json" \
     --benchmarks "${benchmark}" \

--- a/scripts/bench/public-sota/start-remaining-queue-watchers.sh
+++ b/scripts/bench/public-sota/start-remaining-queue-watchers.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/bench/public-sota/verify-pr-clean.mjs
+++ b/scripts/bench/public-sota/verify-pr-clean.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const args = process.argv.slice(2);
 let repo = process.env.REPO;
@@ -37,6 +39,53 @@ const [owner, name] = repo.split('/');
 if (!owner || !name) {
   throw new Error(`Invalid repo: ${repo}`);
 }
+
+function isExecutable(file) {
+  try {
+    fs.accessSync(file, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathGhCandidates() {
+  return (process.env.PATH ?? '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((entry) => path.join(entry, 'gh'));
+}
+
+function isWorkingGh(candidate) {
+  try {
+    execFileSync(candidate, ['--version'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveGhBin() {
+  const candidates = [
+    process.env.GH_BIN,
+    '/opt/homebrew/opt/gh/bin/gh',
+    ...pathGhCandidates(),
+    '/opt/homebrew/bin/gh',
+  ].filter(Boolean);
+  const seen = new Set();
+  for (const candidate of candidates) {
+    if (seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    if (isExecutable(candidate) && isWorkingGh(candidate)) {
+      return candidate;
+    }
+  }
+  return 'gh';
+}
+
+const ghBin = resolveGhBin();
 
 const query = `
 query($owner:String!,$name:String!,$number:Int!){
@@ -84,7 +133,7 @@ query($owner:String!,$name:String!,$number:Int!,$after:String){
 }`;
 
 function fetchPr() {
-  const raw = execFileSync('gh', [
+  const raw = execFileSync(ghBin, [
     'api',
     'graphql',
     '-f', `owner=${owner}`,
@@ -120,7 +169,7 @@ function fetchReviewThreads() {
     if (after) {
       command.push('-f', `after=${after}`);
     }
-    const raw = execFileSync('gh', command, { encoding: 'utf8' });
+    const raw = execFileSync(ghBin, command, { encoding: 'utf8' });
     const payload = JSON.parse(raw);
     const page = payload.data?.repository?.pullRequest?.reviewThreads;
     if (!page) {

--- a/scripts/bench/public-sota/watch-next-after-benchmark.sh
+++ b/scripts/bench/public-sota/watch-next-after-benchmark.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/bench/public-sota/watch-next-after-memoryarena.sh
+++ b/scripts/bench/public-sota/watch-next-after-memoryarena.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/bench/public-sota/watch-public-benchmark-publish.sh
+++ b/scripts/bench/public-sota/watch-public-benchmark-publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
+export PATH="/opt/homebrew/opt/gh/bin:/opt/homebrew/bin:/opt/homebrew/sbin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_ROOT="${TMPDIR:-/tmp}"


### PR DESCRIPTION
## Summary
- Prefer GH_BIN or Homebrew opt/gh in public SOTA PR verifiers before falling back to gh
- Put /opt/homebrew/opt/gh/bin ahead of the stale /opt/homebrew/bin shim in public SOTA watcher/publish PATH setup
- Keep generated evidence reproduction commands aligned with the hardened PATH

## Verification
- node scripts/bench/public-sota/verify-pr-clean.mjs --repo joshuaswarren/remnic --pr 1005 --require-merged
- node scripts/bench/public-sota/audit-public-sota-completion.mjs
- bash -n scripts/bench/public-sota/*.sh scripts/bench/public-sota/memoryarena/*.sh
- git diff --check
- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only PATH and CLI resolution changes for benchmark publish/audit scripts; no product runtime, auth, or data-path changes.
> 
> **Overview**
> Hardens **GitHub CLI (`gh`) discovery** for public SOTA automation so PR audits and verifiers don’t pick a broken Homebrew shim.
> 
> **Node helpers** (`verify-pr-clean.mjs`, `audit-public-sota-completion.mjs`) now resolve `gh` via `GH_BIN`, then `/opt/homebrew/opt/gh/bin/gh`, then `PATH`, with an executable + `gh --version` check before falling back to `gh`.
> 
> **Shell watchers, launch/stage/publish scripts, tmux sessions, and generated evidence docs** prepend `/opt/homebrew/opt/gh/bin` ahead of `/opt/homebrew/bin` in `PATH` (including `npx verify-public-matrix` invocations) so subprocesses see the real `gh` binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805915a8cd84b2004a895f4c2223d6b2394a04c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->