### PR TITLE
Harden public SOTA git credential usage

### DIFF
--- a/scripts/bench/public-sota/memoryarena/publish-memoryarena-evidence-pr.sh
+++ b/scripts/bench/public-sota/memoryarena/publish-memoryarena-evidence-pr.sh
@@ -46,29 +46,36 @@ publish_or_update_pr() {
   node "${SCRIPT_DIR}/../verify-pr-clean.mjs" --repo "${REPO}" --pr "${pr_number}" --wait-seconds 1800
 }
 
+git_with_github_auth() {
+  git \
+    -c credential.https://github.com.helper= \
+    -c 'credential.https://github.com.helper=!gh auth git-credential' \
+    "$@"
+}
+
 push_evidence_branch() {
   (
     cd "${WORKTREE}"
 
     local_head="$(git rev-parse HEAD)"
-    remote_head="$(git ls-remote --heads origin "${BRANCH}" | awk 'NR == 1 { print $1 }')"
+    remote_head="$(git_with_github_auth ls-remote --heads origin "${BRANCH}" | awk 'NR == 1 { print $1 }')"
 
     if [[ -z "${remote_head}" ]]; then
-      git push -u origin "HEAD:refs/heads/${BRANCH}"
+      git_with_github_auth push -u origin "HEAD:refs/heads/${BRANCH}"
       return
     fi
 
     if [[ "${remote_head}" == "${local_head}" ]]; then
-      git push -u origin "HEAD:refs/heads/${BRANCH}"
+      git_with_github_auth push -u origin "HEAD:refs/heads/${BRANCH}"
       return
     fi
 
-    git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+    git_with_github_auth fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
     if git merge-base --is-ancestor "origin/${BRANCH}" HEAD; then
-      git push -u origin "HEAD:refs/heads/${BRANCH}"
+      git_with_github_auth push -u origin "HEAD:refs/heads/${BRANCH}"
     else
       echo "remote ${BRANCH} is not an ancestor of local evidence commit; updating with --force-with-lease" >&2
-      git push -u --force-with-lease="refs/heads/${BRANCH}:${remote_head}" origin "HEAD:refs/heads/${BRANCH}"
+      git_with_github_auth push -u --force-with-lease="refs/heads/${BRANCH}:${remote_head}" origin "HEAD:refs/heads/${BRANCH}"
     fi
   )
 }

--- a/scripts/bench/public-sota/publish-public-benchmark-evidence-pr.sh
+++ b/scripts/bench/public-sota/publish-public-benchmark-evidence-pr.sh
@@ -86,29 +86,36 @@ publish_or_update_pr() {
   node "${SCRIPT_DIR}/verify-pr-clean.mjs" --repo "${REPO}" --pr "${pr_number}" --wait-seconds 1800
 }
 
+git_with_github_auth() {
+  git \
+    -c credential.https://github.com.helper= \
+    -c 'credential.https://github.com.helper=!gh auth git-credential' \
+    "$@"
+}
+
 push_evidence_branch() {
   (
     cd "${WORKTREE}"
 
     local_head="$(git rev-parse HEAD)"
-    remote_head="$(git ls-remote --heads origin "${BRANCH}" | awk 'NR == 1 { print $1 }')"
+    remote_head="$(git_with_github_auth ls-remote --heads origin "${BRANCH}" | awk 'NR == 1 { print $1 }')"
 
     if [[ -z "${remote_head}" ]]; then
-      git push -u origin "HEAD:refs/heads/${BRANCH}"
+      git_with_github_auth push -u origin "HEAD:refs/heads/${BRANCH}"
       return
     fi
 
     if [[ "${remote_head}" == "${local_head}" ]]; then
-      git push -u origin "HEAD:refs/heads/${BRANCH}"
+      git_with_github_auth push -u origin "HEAD:refs/heads/${BRANCH}"
       return
     fi
 
-    git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+    git_with_github_auth fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
     if git merge-base --is-ancestor "origin/${BRANCH}" HEAD; then
-      git push -u origin "HEAD:refs/heads/${BRANCH}"
+      git_with_github_auth push -u origin "HEAD:refs/heads/${BRANCH}"
     else
       echo "remote ${BRANCH} is not an ancestor of local evidence commit; updating with --force-with-lease" >&2
-      git push -u --force-with-lease="refs/heads/${BRANCH}:${remote_head}" origin "HEAD:refs/heads/${BRANCH}"
+      git_with_github_auth push -u --force-with-lease="refs/heads/${BRANCH}:${remote_head}" origin "HEAD:refs/heads/${BRANCH}"
     fi
   )
 }


### PR DESCRIPTION
## Summary

- route public SOTA evidence git network operations through a command-local GitHub credential helper
- ignore stale user-level GitHub credential helper entries for evidence branch fetch/push operations
- keep ordinary local git commands untouched

## Verification

- bash -n scripts/bench/public-sota/publish-public-benchmark-evidence-pr.sh scripts/bench/public-sota/memoryarena/publish-memoryarena-evidence-pr.sh
- git diff --check
- git -c credential.https://github.com.helper= -c 'credential.https://github.com.helper=!gh auth git-credential' ls-remote --heads origin bench/public-matrix-codex\n- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts\n- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, duplicated bash helper change in benchmark publish automation only; no app runtime, auth, or data-path changes.
> 
> **Overview**
> Both public SOTA evidence publish scripts now route **remote** git work (`ls-remote`, `fetch`, `push`, including `--force-with-lease`) through a new `git_with_github_auth` helper that clears the default `credential.https://github.com.helper` and uses `gh auth git-credential` instead.
> 
> That change is scoped to `push_evidence_branch` in `publish-public-benchmark-evidence-pr.sh` and `publish-memoryarena-evidence-pr.sh`; local git and `gh` PR commands are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bca4a6b1855a5af051aff961b20bf130d30e777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->