### PR TITLE
Rebuild bench package before public benchmark launches

### DIFF
--- a/scripts/bench/public-sota/launch-next-public-benchmark.sh
+++ b/scripts/bench/public-sota/launch-next-public-benchmark.sh
@@ -56,14 +56,22 @@ resolve_launch_repo_root() {
 
 LAUNCH_REPO_ROOT="$(resolve_launch_repo_root)"
 
-active_scoring_session="$(tmux list-sessions -F '#S' 2>/dev/null \
-  | grep -E '^public-.*-codex-.*[0-9]{8}T[0-9]{6}Z$' \
-  | head -1 || true)"
+find_active_scoring_session() {
+  tmux list-sessions -F '#S' 2>/dev/null \
+    | grep -E '^public-.*-codex-.*[0-9]{8}T[0-9]{6}Z$' \
+    | head -1 || true
+}
 
-if [[ -n "${active_scoring_session}" ]]; then
-  echo "Refusing to launch: active public benchmark scoring session ${active_scoring_session} is still running." >&2
-  exit 3
-fi
+refuse_if_active_scoring_session() {
+  local active_scoring_session
+  active_scoring_session="$(find_active_scoring_session)"
+  if [[ -n "${active_scoring_session}" ]]; then
+    echo "Refusing to launch: active public benchmark scoring session ${active_scoring_session} is still running." >&2
+    exit 3
+  fi
+}
+
+refuse_if_active_scoring_session
 
 if ! git -C "${LAUNCH_REPO_ROOT}" rev-parse --show-toplevel >/dev/null 2>&1; then
   echo "Launch repo is not a git checkout: ${LAUNCH_REPO_ROOT}" >&2
@@ -120,6 +128,8 @@ fi
   cd "${LAUNCH_REPO_ROOT}"
   pnpm --filter @remnic/bench build
 )
+
+refuse_if_active_scoring_session
 
 git_sha="$(git -C "${LAUNCH_REPO_ROOT}" rev-parse HEAD)"
 short_sha="${git_sha:0:8}"

--- a/scripts/bench/public-sota/launch-next-public-benchmark.sh
+++ b/scripts/bench/public-sota/launch-next-public-benchmark.sh
@@ -116,6 +116,11 @@ if [[ "${benchmark}" == "memory-arena" ]]; then
   fi
 fi
 
+(
+  cd "${LAUNCH_REPO_ROOT}"
+  pnpm --filter @remnic/bench build
+)
+
 git_sha="$(git -C "${LAUNCH_REPO_ROOT}" rev-parse HEAD)"
 short_sha="${git_sha:0:8}"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -1944,6 +1944,9 @@ test("next public benchmark launcher falls back to a base-branch worktree with d
   assert.match(source, /"\$\{branch\}" == "refs\/heads\/\$\{BASE_BRANCH\}"/);
   assert.match(source, /-d "\$\{worktree\}\/evals\/datasets\/\$\{benchmark\}"/);
   assert.match(source, /LAUNCH_REPO_ROOT="\$\(resolve_launch_repo_root\)"/);
+  assert.match(source, /cd "\$\{LAUNCH_REPO_ROOT\}"/);
+  assert.match(source, /pnpm --filter @remnic\/bench build/);
+  assert.match(source, /pnpm --filter @remnic\/bench build[\s\S]*git_sha="\$\(git -C "\$\{LAUNCH_REPO_ROOT\}" rev-parse HEAD\)"/);
   assert.doesNotMatch(source, /LAUNCH_REPO_ROOT="\$\{LAUNCH_REPO_ROOT:-\$\{REPO_ROOT\}\}"/);
 });
 

--- a/tests/public-sota-diagnostics.test.ts
+++ b/tests/public-sota-diagnostics.test.ts
@@ -1944,9 +1944,11 @@ test("next public benchmark launcher falls back to a base-branch worktree with d
   assert.match(source, /"\$\{branch\}" == "refs\/heads\/\$\{BASE_BRANCH\}"/);
   assert.match(source, /-d "\$\{worktree\}\/evals\/datasets\/\$\{benchmark\}"/);
   assert.match(source, /LAUNCH_REPO_ROOT="\$\(resolve_launch_repo_root\)"/);
+  assert.match(source, /refuse_if_active_scoring_session\(\)[\s\S]*active_scoring_session="\$\(find_active_scoring_session\)"/);
+  assert.match(source, /refuse_if_active_scoring_session\n\nif ! git -C "\$\{LAUNCH_REPO_ROOT\}" rev-parse --show-toplevel/);
   assert.match(source, /cd "\$\{LAUNCH_REPO_ROOT\}"/);
   assert.match(source, /pnpm --filter @remnic\/bench build/);
-  assert.match(source, /pnpm --filter @remnic\/bench build[\s\S]*git_sha="\$\(git -C "\$\{LAUNCH_REPO_ROOT\}" rev-parse HEAD\)"/);
+  assert.match(source, /pnpm --filter @remnic\/bench build\n\)\n\nrefuse_if_active_scoring_session\n\ngit_sha="\$\(git -C "\$\{LAUNCH_REPO_ROOT\}" rev-parse HEAD\)"/);
   assert.doesNotMatch(source, /LAUNCH_REPO_ROOT="\$\{LAUNCH_REPO_ROOT:-\$\{REPO_ROOT\}\}"/);
 });
 


### PR DESCRIPTION
Summary:
- rebuild @remnic/bench in the guarded next-benchmark launcher before run id creation and tmux launch
- keep active-session, dataset, and MemoryArena sidecar guards ahead of the build step
- prevent stale bench dist from breaking downstream public SOTA launches

Verification:
- bash -n scripts/bench/public-sota/launch-next-public-benchmark.sh
- pnpm exec tsx --test tests/public-sota-diagnostics.test.ts
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the public benchmark launch shell script and related diagnostics tests; existing dataset and active-session guards remain, with an extra post-build session check.
> 
> **Overview**
> The next public benchmark launcher now **rebuilds `@remnic/bench`** in the resolved launch repo after dataset and MemoryArena sidecar checks, and **re-checks for an active tmux scoring session** immediately before creating the run id and starting tmux.
> 
> Active-session detection is refactored into **`find_active_scoring_session`** and **`refuse_if_active_scoring_session`**, so the same guard runs at startup and again post-build to avoid overlapping launches if a session appears during the build.
> 
> Diagnostics tests assert the new build step and guard ordering in `launch-next-public-benchmark.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53775493a1ea51ae4f7251413a48a83ea2de5892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->