### PR TITLE
Match review-thread guard to merge ruleset

### DIFF
--- a/.github/workflows/review-thread-guard.yml
+++ b/.github/workflows/review-thread-guard.yml
@@ -81,8 +81,8 @@ jobs:
               if (!conn.pageInfo?.hasNextPage) break;
               after = conn.pageInfo.endCursor;
             }
-            const unresolvedActive = threads.filter((t) => {
-              if (t.isResolved !== false || t.isOutdated !== false) return false;
+            const unresolvedThreads = threads.filter((t) => {
+              if (t.isResolved !== false) return false;
               // Exclude github-advanced-security (CodeQL) threads — these cannot be resolved
               // via the GitHub API and must be addressed through CodeQL configuration.
               const author = t.comments?.nodes?.[0]?.author?.login;
@@ -90,22 +90,23 @@ jobs:
               return true;
             });
 
-            if (unresolvedActive.length === 0) {
-              core.notice("No unresolved active review threads.");
+            if (unresolvedThreads.length === 0) {
+              core.notice("No unresolved review threads.");
               return;
             }
 
-            const summary = unresolvedActive
+            const summary = unresolvedThreads
               .slice(0, 10)
               .map((t, i) => {
                 const c = t.comments?.nodes?.[0];
                 const author = c?.author?.login ?? "unknown";
                 const path = c?.path ?? "unknown-file";
+                const state = t.isOutdated === true ? "outdated" : "active";
                 const url = c?.url ?? "";
-                return `${i + 1}. ${author} on ${path}${url ? ` (${url})` : ""}`;
+                return `${i + 1}. ${author} on ${path} (${state})${url ? ` ${url}` : ""}`;
               })
               .join("\n");
 
             core.setFailed(
-              `Found ${unresolvedActive.length} unresolved review thread(s). Resolve them before merge.\n${summary}`,
+              `Found ${unresolvedThreads.length} unresolved review thread(s). Resolve them before merge.\n${summary}`,
             );


### PR DESCRIPTION
## Summary
- make the review-thread guard fail on all unresolved PR review threads, including outdated ones
- keep the existing GitHub Advanced Security exclusion for non-resolvable CodeQL threads
- include active/outdated state in the guard failure summary

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/review-thread-guard.yml"); puts "yaml ok"'
- extracted github-script wrapped in an async function and checked with node --check --input-type=module

## Context
PR #1240 was blocked by the repository ruleset even after the existing unresolved-review-threads check passed, because GitHub counted unresolved outdated review threads while the workflow ignored them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI script change in `.github/workflows/review-thread-guard.yml` with no runtime or security impact.
> 
> **Overview**
> Aligns the **review-thread guard** workflow with the repo merge ruleset so CI fails when **any** unresolved review thread remains, not only active ones.
> 
> The guard no longer skips threads where `isOutdated` is true. **GitHub Advanced Security** (CodeQL) threads stay excluded because they cannot be resolved via the API. Failure output now labels each listed thread as **(active)** or **(outdated)**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dacb915a746384dbb9dd6add63b3f4b10496c34e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->