### PR TITLE
Skip huge offline snapshot fast-base posts

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5618,6 +5618,7 @@ function offlineEndpoint(
 }
 
 export const OFFLINE_SYNC_REQUEST_TIMEOUT_DEFAULT_MS = 15 * 60_000;
+export const OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES = 16 * 1024 * 1024;
 
 export function parseOfflineSyncRequestTimeoutMs(
   raw: string | undefined,
@@ -5804,7 +5805,9 @@ export function offlineSnapshotBasePostBody(args: {
 }
 
 export function offlineSnapshotBasePostBodyFits(body: string): boolean {
-  return Buffer.byteLength(body, "utf-8") <= OFFLINE_SYNC_SNAPSHOT_BASE_MAX_BODY_BYTES;
+  const bytes = Buffer.byteLength(body, "utf-8");
+  return bytes <= OFFLINE_SYNC_SNAPSHOT_BASE_MAX_BODY_BYTES &&
+    bytes <= OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES;
 }
 
 export function isOfflineSnapshotPostFallbackError(error: unknown): boolean {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -146,6 +146,7 @@ import {
   writeOfflineSyncState,
   type OfflineSyncApplyFileContentChunkResult,
   type OfflineSyncFileDigest,
+  type OfflineSyncFileRecord,
   type OfflineSyncFileState,
   type OfflineSyncFileTarget,
   type OfflineSyncFileWriteTarget,
@@ -5748,7 +5749,104 @@ async function fetchOfflineJson<T>(
   );
 }
 
-async function fetchOfflineSnapshot(args: {
+interface OfflineSnapshotStreamHeader {
+  namespace?: string;
+  format: OfflineSyncSnapshot["format"];
+  schemaVersion: OfflineSyncSnapshot["schemaVersion"];
+  createdAt: string;
+  sourceId: string;
+  includeTranscripts: boolean;
+}
+
+async function parseOfflineSnapshotStreamResponse(
+  response: Response,
+): Promise<OfflineSyncSnapshot & { namespace?: string }> {
+  if (!response.body) {
+    throw new Error("offline sync snapshot stream response omitted body");
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  let header: OfflineSnapshotStreamHeader | null = null;
+  const files: OfflineSyncFileRecord[] = [];
+  const handleLine = (line: string): void => {
+    if (line.trim().length === 0) return;
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    if (parsed.type === "snapshot") {
+      if (header) throw new Error("offline sync snapshot stream repeated header");
+      header = {
+        ...(typeof parsed.namespace === "string" && parsed.namespace.length > 0 ? { namespace: parsed.namespace } : {}),
+        format: parsed.format as OfflineSyncSnapshot["format"],
+        schemaVersion: parsed.schemaVersion as OfflineSyncSnapshot["schemaVersion"],
+        createdAt: parsed.createdAt as string,
+        sourceId: parsed.sourceId as string,
+        includeTranscripts: parsed.includeTranscripts as boolean,
+      };
+      return;
+    }
+    if (parsed.type === "file") {
+      if (!header) throw new Error("offline sync snapshot stream file arrived before header");
+      files.push(parsed.file as OfflineSyncFileRecord);
+      return;
+    }
+    throw new Error("offline sync snapshot stream contained unknown event");
+  };
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffered += decoder.decode(value, { stream: true });
+    for (;;) {
+      const newline = buffered.indexOf("\n");
+      if (newline < 0) break;
+      const line = buffered.slice(0, newline);
+      buffered = buffered.slice(newline + 1);
+      handleLine(line);
+    }
+  }
+  buffered += decoder.decode();
+  handleLine(buffered);
+  const finalHeader = header as OfflineSnapshotStreamHeader | null;
+  if (!finalHeader) throw new Error("offline sync snapshot stream omitted header");
+  const snapshot = normalizeOfflineSyncSnapshot({
+    format: finalHeader.format,
+    schemaVersion: finalHeader.schemaVersion,
+    createdAt: finalHeader.createdAt,
+    sourceId: finalHeader.sourceId,
+    includeTranscripts: finalHeader.includeTranscripts,
+    files,
+  });
+  return {
+    ...(finalHeader.namespace ? { namespace: finalHeader.namespace } : {}),
+    ...snapshot,
+  };
+}
+
+async function fetchOfflineSnapshotStream(args: {
+  remoteUrl: string;
+  token: string;
+  namespace?: string;
+  includeTranscripts: boolean;
+}): Promise<OfflineSyncSnapshot & { namespace?: string }> {
+  const url = offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/snapshot-stream", {
+    namespace: args.namespace,
+    include_transcripts: args.includeTranscripts ? "true" : "false",
+    content: "false",
+  });
+  return fetchOfflineWithResponse(
+    url,
+    args.token,
+    {},
+    {},
+    async (response) => {
+      if (!response.ok) {
+        await throwOfflineResponseError(response, url, {}, "offline sync snapshot-stream request");
+      }
+      return parseOfflineSnapshotStreamResponse(response);
+    },
+  );
+}
+
+export async function fetchOfflineSnapshot(args: {
   remoteUrl: string;
   token: string;
   namespace?: string;
@@ -5757,6 +5855,7 @@ async function fetchOfflineSnapshot(args: {
   baseFiles?: readonly OfflineSyncFileState[];
   baseCapturedAt?: Date;
 }): Promise<OfflineSyncSnapshot & { namespace?: string }> {
+  let tryStreamSnapshot = false;
   if (args.includeContent === false && args.baseFiles && args.baseFiles.length > 0) {
     const postBody = offlineSnapshotBasePostBody({
       namespace: args.namespace,
@@ -5776,7 +5875,22 @@ async function fetchOfflineSnapshot(args: {
         );
       } catch (error) {
         if (!isOfflineSnapshotPostFallbackError(error)) throw error;
+        tryStreamSnapshot = true;
       }
+    } else {
+      tryStreamSnapshot = true;
+    }
+  }
+  if (tryStreamSnapshot) {
+    try {
+      return await fetchOfflineSnapshotStream({
+        remoteUrl: args.remoteUrl,
+        token: args.token,
+        namespace: args.namespace,
+        includeTranscripts: args.includeTranscripts,
+      });
+    } catch (error) {
+      if (!isOfflineSnapshotStreamFallbackError(error)) throw error;
     }
   }
   return fetchOfflineJson(
@@ -5813,6 +5927,11 @@ export function offlineSnapshotBasePostBodyFits(body: string): boolean {
 export function isOfflineSnapshotPostFallbackError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /offline-sync\/snapshot\b.* returned (404|405|413)\b/.test(message);
+}
+
+function isOfflineSnapshotStreamFallbackError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /offline-sync\/snapshot-stream\b.* returned (404|405)\b/.test(message);
 }
 
 async function fetchOfflineFiles(args: {

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -287,6 +287,80 @@ test("HTTP offline snapshot forwards namespace and transfer options", async () =
   }
 });
 
+test("HTTP offline snapshot stream emits metadata records as NDJSON", async () => {
+  const calls: Array<{
+    namespace: string | undefined;
+    principal: string | undefined;
+    includeTranscripts: boolean | undefined;
+    includeContent: boolean | undefined;
+  }> = [];
+  const service = {
+    offlineSyncSnapshotStream: async (options: {
+      namespace?: string;
+      principal?: string;
+      includeTranscripts?: boolean;
+      includeContent?: boolean;
+    }) => {
+      calls.push({
+        namespace: options.namespace,
+        principal: options.principal,
+        includeTranscripts: options.includeTranscripts,
+        includeContent: options.includeContent,
+      });
+      return {
+        namespace: options.namespace ?? "default",
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: new Date("2026-05-21T00:00:00Z").toISOString(),
+        sourceId: "remote:test",
+        includeTranscripts: options.includeTranscripts !== false,
+        files: (async function* () {
+          yield {
+            path: "facts/a.md",
+            sha256: "a".repeat(64),
+            bytes: 12,
+            mtimeMs: 1234,
+          };
+        })(),
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/remnic/v1/offline-sync/snapshot-stream?namespace=team&include_transcripts=false&content=false`,
+      { headers: { authorization: "Bearer test-token" } },
+    );
+    const lines = (await response.text())
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "application/x-ndjson; charset=utf-8");
+    assert.equal(lines[0]?.type, "snapshot");
+    assert.equal(lines[0]?.namespace, "team");
+    assert.equal(lines[1]?.type, "file");
+    assert.deepEqual((lines[1]?.file as { path?: string }).path, "facts/a.md");
+    assert.deepEqual(calls, [{
+      namespace: "team",
+      principal: "reader",
+      includeTranscripts: false,
+      includeContent: false,
+    }]);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("HTTP offline files forwards namespace and requested paths", async () => {
   const calls: Array<{
     namespace: string | undefined;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1,7 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
-import { once } from "node:events";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -1953,12 +1952,35 @@ export class EngramAccessHttpServer {
     if (cid) {
       res.setHeader("x-request-id", cid);
     }
-    const writeLine = async (payload: unknown): Promise<void> => {
-      if (!res.write(`${JSON.stringify(payload)}\n`)) {
-        await once(res, "drain");
-      }
+    const waitForDrainOrClose = async (): Promise<boolean> => new Promise((resolve, reject) => {
+      const cleanup = () => {
+        res.off("drain", onDrain);
+        res.off("close", onClose);
+        res.off("error", onError);
+      };
+      const onDrain = () => {
+        cleanup();
+        resolve(true);
+      };
+      const onClose = () => {
+        cleanup();
+        resolve(false);
+      };
+      const onError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+      res.once("drain", onDrain);
+      res.once("close", onClose);
+      res.once("error", onError);
+    });
+    const writeLine = async (payload: unknown): Promise<boolean> => {
+      if (res.destroyed || res.writableEnded) return false;
+      if (res.write(`${JSON.stringify(payload)}\n`)) return true;
+      if (res.destroyed || res.writableEnded) return false;
+      return waitForDrainOrClose();
     };
-    await writeLine({
+    if (!await writeLine({
       type: "snapshot",
       namespace: snapshot.namespace,
       format: snapshot.format,
@@ -1966,11 +1988,13 @@ export class EngramAccessHttpServer {
       createdAt: snapshot.createdAt,
       sourceId: snapshot.sourceId,
       includeTranscripts: snapshot.includeTranscripts,
-    });
+    })) return;
     for await (const file of snapshot.files) {
-      await writeLine({ type: "file", file });
+      if (!await writeLine({ type: "file", file })) return;
     }
-    res.end();
+    if (!res.destroyed && !res.writableEnded) {
+      res.end();
+    }
   }
 
   private respondBinary(

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { once } from "node:events";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -642,6 +643,42 @@ export class EngramAccessHttpServer {
         includeContent: includeContentRaw !== "false",
       });
       this.respondJson(res, 200, result);
+      return;
+    }
+
+    if (
+      req.method === "GET" &&
+      (pathname === "/engram/v1/offline-sync/snapshot-stream" ||
+        pathname === "/remnic/v1/offline-sync/snapshot-stream")
+    ) {
+      const includeTranscriptsRaw = parsed.searchParams.get("include_transcripts");
+      const includeContentRaw = parsed.searchParams.get("content");
+      if (
+        includeTranscriptsRaw !== null &&
+        includeTranscriptsRaw !== "true" &&
+        includeTranscriptsRaw !== "false"
+      ) {
+        throw new EngramAccessInputError(
+          `include_transcripts must be one of: true, false (got: ${includeTranscriptsRaw})`,
+        );
+      }
+      if (
+        includeContentRaw !== null &&
+        includeContentRaw !== "false"
+      ) {
+        throw new EngramAccessInputError("snapshot-stream content must be false");
+      }
+      const namespaceParam = parsed.searchParams.get("namespace");
+      const result = await this.service.offlineSyncSnapshotStream({
+        namespace: this.resolveNamespace(
+          req,
+          namespaceParam && namespaceParam.length > 0 ? namespaceParam : undefined,
+        ),
+        principal: this.resolveRequestPrincipal(req),
+        includeTranscripts: includeTranscriptsRaw !== "false",
+        includeContent: false,
+      });
+      await this.respondOfflineSnapshotStream(res, result);
       return;
     }
 
@@ -1903,6 +1940,37 @@ export class EngramAccessHttpServer {
       res.setHeader("x-request-id", cid);
     }
     res.end(body);
+  }
+
+  private async respondOfflineSnapshotStream(
+    res: ServerResponse,
+    snapshot: Awaited<ReturnType<EngramAccessService["offlineSyncSnapshotStream"]>>,
+  ): Promise<void> {
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/x-ndjson; charset=utf-8");
+    res.setHeader("cache-control", "no-store");
+    const cid = correlationIdStore.getStore();
+    if (cid) {
+      res.setHeader("x-request-id", cid);
+    }
+    const writeLine = async (payload: unknown): Promise<void> => {
+      if (!res.write(`${JSON.stringify(payload)}\n`)) {
+        await once(res, "drain");
+      }
+    };
+    await writeLine({
+      type: "snapshot",
+      namespace: snapshot.namespace,
+      format: snapshot.format,
+      schemaVersion: snapshot.schemaVersion,
+      createdAt: snapshot.createdAt,
+      sourceId: snapshot.sourceId,
+      includeTranscripts: snapshot.includeTranscripts,
+    });
+    for await (const file of snapshot.files) {
+      await writeLine({ type: "file", file });
+    }
+    res.end();
   }
 
   private respondBinary(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -141,9 +141,12 @@ import {
   buildOfflineSyncSnapshot,
   buildOfflineSyncSnapshotFromBase,
   buildOfflineSyncSnapshotForPaths,
+  iterateOfflineSyncSnapshotFileRecords,
+  OFFLINE_SYNC_SNAPSHOT_FORMAT,
   readOfflineSyncFileContentChunk,
   type OfflineSyncApplyFileContentChunkResult,
   type OfflineSyncApplyChangesetResult,
+  type OfflineSyncFileRecord,
   type OfflineSyncFileContentChunk,
   type OfflineSyncFileState,
   type OfflineSyncSnapshot,
@@ -664,6 +667,11 @@ export interface EngramAccessOfflineSyncApplyRequest {
 
 export interface EngramAccessOfflineSyncSnapshotResponse extends OfflineSyncSnapshot {
   namespace: string;
+}
+
+export interface EngramAccessOfflineSyncSnapshotStreamResponse extends Omit<OfflineSyncSnapshot, "files"> {
+  namespace: string;
+  files: AsyncIterable<OfflineSyncFileRecord>;
 }
 
 export interface EngramAccessOfflineSyncFilesResponse extends OfflineSyncSnapshot {
@@ -5624,6 +5632,29 @@ export class EngramAccessService {
     return {
       namespace: resolvedNamespace,
       ...snapshot,
+    };
+  }
+
+  async offlineSyncSnapshotStream(
+    options: Omit<EngramAccessOfflineSyncSnapshotRequest, "baseCapturedAt" | "baseFiles"> = {},
+  ): Promise<EngramAccessOfflineSyncSnapshotStreamResponse> {
+    const resolvedNamespace = this.resolveReadableNamespace(options.namespace, options.principal);
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const storageHash = createHash("sha256").update(storage.dir).digest("hex").slice(0, 16);
+    return {
+      namespace: resolvedNamespace,
+      format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
+      schemaVersion: 1,
+      createdAt: new Date().toISOString(),
+      sourceId: `remnic:${resolvedNamespace}:${storageHash}`,
+      includeTranscripts: options.includeTranscripts !== false,
+      files: iterateOfflineSyncSnapshotFileRecords({
+        root: storage.dir,
+        includeContent: options.includeContent === true,
+        includeTranscripts: options.includeTranscripts !== false,
+        readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
+        readFileDigest: async ({ filePath }) => storage.digestOfflineSyncFile(filePath),
+      }),
     };
   }
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -696,6 +696,7 @@ export {
   buildOfflineSyncSnapshotForPaths,
   defaultOfflineSyncStatePath,
   fileStatesFromSnapshot,
+  iterateOfflineSyncSnapshotFileRecords,
   normalizeOfflineSyncChangeset,
   normalizeOfflineSyncSnapshot,
   offlineSyncStateFromSnapshot,

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -594,6 +594,44 @@ async function readPlainFileContentChunk(options: {
   }
 }
 
+export async function* iterateOfflineSyncSnapshotFileRecords(options: {
+  root: string;
+  includeContent?: boolean;
+  includeTranscripts?: boolean;
+  readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
+  readFileDigest?: (target: OfflineSyncFileTarget) => Promise<OfflineSyncFileDigest>;
+}): AsyncIterable<OfflineSyncFileRecord> {
+  const rootAbs = path.resolve(options.root);
+  const root = await prepareSafeArchiveRoot(rootAbs, "iterateOfflineSyncSnapshotFileRecords", "root");
+  const includeTranscripts = options.includeTranscripts !== false;
+
+  async function* walk(dirAbs: string): AsyncIterable<OfflineSyncFileRecord> {
+    let entries = await readdir(dirAbs, { withFileTypes: true });
+    entries = entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const abs = path.join(dirAbs, entry.name);
+      const relPosix = path.relative(root.abs, abs).split(path.sep).join("/");
+      if (shouldExcludeRelPath(relPosix, includeTranscripts)) continue;
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        yield* walk(abs);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      yield await readOfflineSyncFileRecord({
+        root,
+        relPath: relPosix,
+        filePath: abs,
+        includeContent: options.includeContent === true,
+        readFile: options.readFile,
+        readFileDigest: options.readFileDigest,
+      });
+    }
+  }
+
+  yield* walk(root.abs);
+}
+
 export async function buildOfflineSyncSnapshot(options: {
   root: string;
   sourceId: string;
@@ -603,36 +641,9 @@ export async function buildOfflineSyncSnapshot(options: {
   readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
   readFileDigest?: (target: OfflineSyncFileTarget) => Promise<OfflineSyncFileDigest>;
 }): Promise<OfflineSyncSnapshot> {
-  const rootAbs = path.resolve(options.root);
-  const root = await prepareSafeArchiveRoot(rootAbs, "buildOfflineSyncSnapshot", "root");
   const includeTranscripts = options.includeTranscripts !== false;
   const files: OfflineSyncFileRecord[] = [];
-
-  async function walk(dirAbs: string): Promise<void> {
-    let entries = await readdir(dirAbs, { withFileTypes: true });
-    entries = entries.sort((left, right) => left.name.localeCompare(right.name));
-    for (const entry of entries) {
-      const abs = path.join(dirAbs, entry.name);
-      const relPosix = path.relative(root.abs, abs).split(path.sep).join("/");
-      if (shouldExcludeRelPath(relPosix, includeTranscripts)) continue;
-      if (entry.isSymbolicLink()) continue;
-      if (entry.isDirectory()) {
-        await walk(abs);
-        continue;
-      }
-      if (!entry.isFile()) continue;
-      files.push(await readOfflineSyncFileRecord({
-        root,
-        relPath: relPosix,
-        filePath: abs,
-        includeContent: options.includeContent === true,
-        readFile: options.readFile,
-        readFileDigest: options.readFileDigest,
-      }));
-    }
-  }
-
-  await walk(root.abs);
+  for await (const file of iterateOfflineSyncSnapshotFileRecords(options)) files.push(file);
 
   return {
     format: OFFLINE_SYNC_SNAPSHOT_FORMAT,

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -25,6 +25,7 @@ import {
   chunkOfflineChangesetApplyBatches,
   chunkOfflineFileContentBatches,
   directHydrateLargeOfflineFiles,
+  fetchOfflineSnapshot,
   formatOfflineRequestForError,
   formatOfflineLargeFilePushFailureMessage,
   isOfflineSnapshotPostFallbackError,
@@ -255,6 +256,54 @@ test("offline sync snapshot post falls back when base payload is too large", () 
     ),
     false,
   );
+});
+
+test("offline sync uses snapshot stream when fast-base payload is too large", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    const baseFiles = Array.from({ length: 150_000 }, (_, index) =>
+      file(`facts/${String(index).padStart(6, "0")}.md`, index + 1));
+    const remoteFile = file("facts/remote.md", 42, "b");
+    const calls: string[] = [];
+    globalThis.fetch = (async (input) => {
+      const url = new URL(String(input));
+      calls.push(`${url.pathname}${url.search}`);
+      assert.equal(url.pathname, "/remnic/v1/offline-sync/snapshot-stream");
+      const body = [
+        JSON.stringify({
+          type: "snapshot",
+          namespace: "generalist",
+          format: "remnic.offline-sync.snapshot.v1",
+          schemaVersion: 1,
+          createdAt: "2026-05-31T00:01:00.000Z",
+          sourceId: "remote",
+          includeTranscripts: true,
+        }),
+        JSON.stringify({ type: "file", file: remoteFile }),
+      ].join("\n");
+      return new Response(`${body}\n`, {
+        status: 200,
+        headers: { "content-type": "application/x-ndjson" },
+      });
+    }) as typeof fetch;
+
+    const snapshot = await fetchOfflineSnapshot({
+      remoteUrl: "http://remnic.test",
+      token: "test-token",
+      namespace: "generalist",
+      includeTranscripts: true,
+      includeContent: false,
+      baseFiles,
+    });
+
+    assert.equal(snapshot.namespace, "generalist");
+    assert.deepEqual(snapshot.files, [remoteFile]);
+    assert.deepEqual(calls, [
+      "/remnic/v1/offline-sync/snapshot-stream?namespace=generalist&include_transcripts=true&content=false",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("offline sync large-file push failures are explicit", () => {

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -20,6 +20,7 @@ import {
   OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES,
   OFFLINE_SYNC_FILE_CONTENT_UPLOAD_CHUNK_BYTES,
   OFFLINE_SYNC_REQUEST_TIMEOUT_DEFAULT_MS,
+  OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES,
   advanceOfflineBaseFilesForSuccessfulPush,
   chunkOfflineChangesetApplyBatches,
   chunkOfflineFileContentBatches,
@@ -231,6 +232,11 @@ test("offline sync snapshot post falls back when base payload is too large", () 
     baseFiles: [file("facts/a.md", 1)],
   });
   assert.equal(offlineSnapshotBasePostBodyFits(smallBody), true);
+
+  const hugeButServerAcceptedBody = JSON.stringify({
+    baseFiles: "x".repeat(OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES),
+  });
+  assert.equal(offlineSnapshotBasePostBodyFits(hugeButServerAcceptedBody), false);
 
   const largeBody = JSON.stringify({
     baseFiles: "x".repeat(OFFLINE_SYNC_SNAPSHOT_BASE_MAX_BODY_BYTES),


### PR DESCRIPTION
## Summary
- skip offline snapshot fast-base POSTs when the cached base payload is above a 16 MiB preferred client cap
- add a streaming NDJSON snapshot metadata endpoint and make the CLI use it for oversized fast-base states
- keep older-server fallbacks: small states still use POST fast-base, unsupported stream endpoints fall back to the existing snapshot GET path
- cover the stream endpoint and CLI stream selection in tests

## Validation
- git diff --check
- NODE_OPTIONS="--conditions=remnic-source" pnpm exec tsx --test tests/offline-sync-cli-batching.test.ts
- NODE_OPTIONS="--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/access-http.test.ts
- node scripts/check-test-types.mjs
- npm run preflight:quick

## Context
The live laptop cache is about 155k files / 1.7 GB of content and its fast-base metadata POST body was about 34 MB. That POST path took 239s in curl and the CLI fetch failed. A monolithic GET can still fail on flaky Wi-Fi, so this now streams metadata records as NDJSON and avoids both giant request bodies and giant JSON responses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches offline sync fetch fallbacks and a new HTTP streaming path for namespace file metadata; mistakes could break sync on large caches or older servers, but behavior is guarded by explicit fallbacks and tests.
> 
> **Overview**
> Large offline caches can produce **multi‑tens‑of‑MB fast-base POST bodies** that are slow or rejected; this PR **stops using that path when the serialized base exceeds a new 16 MiB client “preferred” cap** (still bounded by the existing server max).
> 
> It adds **`GET …/offline-sync/snapshot-stream`**, which returns **NDJSON** (`snapshot` header line, then `file` records) with **metadata only** (`content=false`). The access service walks the namespace via a new **`iterateOfflineSyncSnapshotFileRecords`** async iterator so the server does not materialize the full file list before responding; the HTTP layer **backpressures** on `drain` while writing lines.
> 
> The CLI **`fetchOfflineSnapshot`** path becomes **POST fast-base → NDJSON stream → legacy snapshot GET**, with **404/405 fallbacks** on the stream route for older servers. **`fetchOfflineSnapshot`** is exported for tests.
> 
> Tests cover the HTTP stream shape and CLI selection when the base payload is too large for the preferred POST cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41fc61e2972c280ae53935f9364e163ad0c25eb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->