### PR TITLE
Compress offline sync fast-base snapshots

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5866,6 +5866,8 @@ export async function fetchOfflineSnapshot(args: {
     });
     const postRequest = offlineSnapshotBasePostRequest(postBody);
     if (postRequest) {
+      const postRequestUsesGzip =
+        new Headers(postRequest.headers).get("content-encoding")?.toLowerCase() === "gzip";
       try {
         return await fetchOfflineJson(
           offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/snapshot"),
@@ -5876,7 +5878,7 @@ export async function fetchOfflineSnapshot(args: {
           },
         );
       } catch (error) {
-        if (!isOfflineSnapshotPostFallbackError(error)) throw error;
+        if (!isOfflineSnapshotPostFallbackError(error, { compressed: postRequestUsesGzip })) throw error;
         tryStreamSnapshot = true;
       }
     } else {
@@ -5944,9 +5946,15 @@ export function offlineSnapshotBasePostRequest(body: string): Pick<RequestInit, 
   };
 }
 
-export function isOfflineSnapshotPostFallbackError(error: unknown): boolean {
+export function isOfflineSnapshotPostFallbackError(
+  error: unknown,
+  options: { compressed?: boolean } = {},
+): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /offline-sync\/snapshot\b.* returned (404|405|413)\b/.test(message);
+  if (/offline-sync\/snapshot\b.* returned (404|405|413)\b/.test(message)) return true;
+  if (!options.compressed) return false;
+  return /offline-sync\/snapshot\b.* returned (400|415)\b/.test(message) &&
+    /\b(unsupported_content_encoding|invalid_gzip_body|invalid_json)\b/.test(message);
 }
 
 function isOfflineSnapshotStreamFallbackError(error: unknown): boolean {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -38,6 +38,7 @@ import path from "node:path";
 import { createDecipheriv, createHash } from "node:crypto";
 import * as childProcess from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { gzipSync } from "node:zlib";
 import {
   parseConfig,
   isOpenaiApiKeyDisabled,
@@ -5863,14 +5864,15 @@ export async function fetchOfflineSnapshot(args: {
       baseFiles: args.baseFiles,
       baseCapturedAt: args.baseCapturedAt,
     });
-    if (offlineSnapshotBasePostBodyFits(postBody)) {
+    const postRequest = offlineSnapshotBasePostRequest(postBody);
+    if (postRequest) {
       try {
         return await fetchOfflineJson(
           offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/snapshot"),
           args.token,
           {
             method: "POST",
-            body: postBody,
+            ...postRequest,
           },
         );
       } catch (error) {
@@ -5922,6 +5924,24 @@ export function offlineSnapshotBasePostBodyFits(body: string): boolean {
   const bytes = Buffer.byteLength(body, "utf-8");
   return bytes <= OFFLINE_SYNC_SNAPSHOT_BASE_MAX_BODY_BYTES &&
     bytes <= OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES;
+}
+
+export function offlineSnapshotBasePostRequest(body: string): Pick<RequestInit, "body" | "headers"> | null {
+  const bytes = Buffer.byteLength(body, "utf-8");
+  if (bytes > OFFLINE_SYNC_SNAPSHOT_BASE_MAX_BODY_BYTES) return null;
+  if (bytes <= OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES) {
+    return { body };
+  }
+  const compressed = gzipSync(body);
+  if (compressed.byteLength > OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES) {
+    return null;
+  }
+  return {
+    body: compressed,
+    headers: {
+      "content-encoding": "gzip",
+    },
+  };
 }
 
 export function isOfflineSnapshotPostFallbackError(error: unknown): boolean {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5858,31 +5858,35 @@ export async function fetchOfflineSnapshot(args: {
 }): Promise<OfflineSyncSnapshot & { namespace?: string }> {
   let tryStreamSnapshot = false;
   if (args.includeContent === false && args.baseFiles && args.baseFiles.length > 0) {
-    const postBody = offlineSnapshotBasePostBody({
-      namespace: args.namespace,
-      includeTranscripts: args.includeTranscripts,
-      baseFiles: args.baseFiles,
-      baseCapturedAt: args.baseCapturedAt,
-    });
-    const postRequest = offlineSnapshotBasePostRequest(postBody);
-    if (postRequest) {
-      const postRequestUsesGzip =
-        new Headers(postRequest.headers).get("content-encoding")?.toLowerCase() === "gzip";
-      try {
-        return await fetchOfflineJson(
-          offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/snapshot"),
-          args.token,
-          {
-            method: "POST",
-            ...postRequest,
-          },
-        );
-      } catch (error) {
-        if (!isOfflineSnapshotPostFallbackError(error, { compressed: postRequestUsesGzip })) throw error;
+    if (args.baseFiles.length > OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES) {
+      tryStreamSnapshot = true;
+    } else {
+      const postBody = offlineSnapshotBasePostBody({
+        namespace: args.namespace,
+        includeTranscripts: args.includeTranscripts,
+        baseFiles: args.baseFiles,
+        baseCapturedAt: args.baseCapturedAt,
+      });
+      const postRequest = offlineSnapshotBasePostRequest(postBody);
+      if (postRequest) {
+        const postRequestUsesGzip =
+          new Headers(postRequest.headers).get("content-encoding")?.toLowerCase() === "gzip";
+        try {
+          return await fetchOfflineJson(
+            offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/snapshot"),
+            args.token,
+            {
+              method: "POST",
+              ...postRequest,
+            },
+          );
+        } catch (error) {
+          if (!isOfflineSnapshotPostFallbackError(error, { compressed: postRequestUsesGzip })) throw error;
+          tryStreamSnapshot = true;
+        }
+      } else {
         tryStreamSnapshot = true;
       }
-    } else {
-      tryStreamSnapshot = true;
     }
   }
   if (tryStreamSnapshot) {
@@ -5927,6 +5931,8 @@ export function offlineSnapshotBasePostBodyFits(body: string): boolean {
   return bytes <= OFFLINE_SYNC_SNAPSHOT_BASE_MAX_BODY_BYTES &&
     bytes <= OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES;
 }
+
+export const OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES = 50_000;
 
 export function offlineSnapshotBasePostRequest(body: string): Pick<RequestInit, "body" | "headers"> | null {
   const bytes = Buffer.byteLength(body, "utf-8");

--- a/packages/remnic-core/src/access-http.test.ts
+++ b/packages/remnic-core/src/access-http.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { gzipSync } from "node:zlib";
 
 import { EngramAccessHttpServer } from "./access-http.js";
 import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
@@ -282,6 +283,102 @@ test("HTTP offline snapshot forwards namespace and transfer options", async () =
       includeTranscripts: false,
       includeContent: false,
     }]);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP offline snapshot accepts gzipped fast-base bodies", async () => {
+  const calls: Array<{
+    namespace: string | undefined;
+    principal: string | undefined;
+    includeTranscripts: boolean | undefined;
+    includeContent: boolean | undefined;
+    baseFiles: unknown;
+    baseCapturedAt: Date | undefined;
+  }> = [];
+  const service = {
+    offlineSyncSnapshot: async (options: {
+      namespace?: string;
+      principal?: string;
+      includeTranscripts?: boolean;
+      includeContent?: boolean;
+      baseFiles?: unknown;
+      baseCapturedAt?: Date;
+    }) => {
+      calls.push({
+        namespace: options.namespace,
+        principal: options.principal,
+        includeTranscripts: options.includeTranscripts,
+        includeContent: options.includeContent,
+        baseFiles: options.baseFiles,
+        baseCapturedAt: options.baseCapturedAt,
+      });
+      return {
+        namespace: options.namespace ?? "default",
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: new Date("2026-05-21T00:00:00Z").toISOString(),
+        sourceId: "remote:test",
+        includeTranscripts: options.includeTranscripts !== false,
+        files: [],
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    port: 0,
+    authToken: "test-token",
+    principal: "reader",
+    adminConsoleEnabled: false,
+  });
+
+  const status = await server.start();
+  try {
+    const body = gzipSync(JSON.stringify({
+      namespace: "team",
+      includeTranscripts: false,
+      includeContent: false,
+      baseCapturedAt: "2026-05-20T00:00:00.000Z",
+      baseFiles: [{
+        path: "facts/a.md",
+        sha256: "a".repeat(64),
+        bytes: 12,
+        mtimeMs: 1234,
+      }],
+    }));
+    const response = await fetch(
+      `http://127.0.0.1:${status.port}/remnic/v1/offline-sync/snapshot`,
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-token",
+          "content-type": "application/json",
+          "content-encoding": "gzip",
+        },
+        body,
+      },
+    );
+    const responseBody = await response.json() as { namespace?: string };
+
+    assert.equal(response.status, 200);
+    assert.equal(responseBody.namespace, "team");
+    assert.equal(calls.length, 1);
+    const call = calls[0];
+    assert.ok(call);
+    assert.deepEqual(call, {
+      namespace: "team",
+      principal: "reader",
+      includeTranscripts: false,
+      includeContent: false,
+      baseFiles: [{
+        path: "facts/a.md",
+        sha256: "a".repeat(64),
+        bytes: 12,
+        mtimeMs: 1234,
+      }],
+      baseCapturedAt: new Date("2026-05-20T00:00:00.000Z"),
+    });
   } finally {
     await server.stop();
   }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -5,6 +5,7 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, URL } from "node:url";
+import { gunzipSync } from "node:zlib";
 import { log } from "./logger.js";
 import { EngramAccessInputError, type EngramAccessService } from "./access-service.js";
 import { EngramMcpServer } from "./access-mcp.js";
@@ -2055,6 +2056,10 @@ export class EngramAccessHttpServer {
     req: IncomingMessage,
     maxBodyBytes = this.maxBodyBytes,
   ): Promise<Record<string, unknown>> {
+    const encoding = (this.readOptionalHeader(req, "content-encoding") ?? "identity").toLowerCase();
+    if (encoding !== "identity" && encoding !== "gzip") {
+      throw new HttpError(415, "unsupported_content_encoding", "unsupported_content_encoding");
+    }
     const chunks: Buffer[] = [];
     let total = 0;
     for await (const chunk of req) {
@@ -2066,7 +2071,21 @@ export class EngramAccessHttpServer {
       chunks.push(buffer);
     }
     if (chunks.length === 0) return {};
-    const raw = Buffer.concat(chunks).toString("utf-8").trim();
+    let body = Buffer.concat(chunks, total);
+    if (encoding === "gzip") {
+      try {
+        body = gunzipSync(body, { maxOutputLength: maxBodyBytes });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE") {
+          throw new HttpError(413, "request_body_too_large", "request_body_too_large");
+        }
+        throw new HttpError(400, "invalid_gzip_body", "invalid_gzip_body");
+      }
+      if (body.byteLength > maxBodyBytes) {
+        throw new HttpError(413, "request_body_too_large", "request_body_too_large");
+      }
+    }
+    const raw = body.toString("utf-8").trim();
     if (raw.length === 0) return {};
     let parsed: unknown;
     try {

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -260,6 +260,26 @@ test("offline sync snapshot post falls back when base payload is too large", () 
     ),
     false,
   );
+  assert.equal(
+    isOfflineSnapshotPostFallbackError(
+      new Error("offline sync request failed: POST /remnic/v1/offline-sync/snapshot returned 415 Unsupported Media Type - {\"error\":\"unsupported_content_encoding\"}"),
+    ),
+    false,
+  );
+  assert.equal(
+    isOfflineSnapshotPostFallbackError(
+      new Error("offline sync request failed: POST /remnic/v1/offline-sync/snapshot returned 415 Unsupported Media Type - {\"error\":\"unsupported_content_encoding\"}"),
+      { compressed: true },
+    ),
+    true,
+  );
+  assert.equal(
+    isOfflineSnapshotPostFallbackError(
+      new Error("offline sync request failed: POST /remnic/v1/offline-sync/snapshot returned 400 Bad Request - {\"error\":\"invalid_json\"}"),
+      { compressed: true },
+    ),
+    true,
+  );
 });
 
 test("offline sync compresses oversized fast-base payloads before stream fallback", async () => {
@@ -306,6 +326,66 @@ test("offline sync compresses oversized fast-base payloads before stream fallbac
     assert.deepEqual(snapshot.files, [remoteFile]);
     assert.deepEqual(calls, [
       "/remnic/v1/offline-sync/snapshot",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("offline sync falls back to stream when compressed fast-base POST is unsupported", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    const baseFiles = Array.from({ length: 150_000 }, (_, index) =>
+      file(`facts/${String(index).padStart(6, "0")}.md`, index + 1));
+    const remoteFile = file("facts/remote.md", 42, "b");
+    const calls: string[] = [];
+    globalThis.fetch = (async (input, init) => {
+      const url = new URL(String(input));
+      calls.push(`${init?.method ?? "GET"} ${url.pathname}${url.search}`);
+      if (url.pathname === "/remnic/v1/offline-sync/snapshot") {
+        assert.equal(init?.method, "POST");
+        const headers = new Headers(init?.headers);
+        assert.equal(headers.get("content-encoding"), "gzip");
+        return new Response(JSON.stringify({ error: "unsupported_content_encoding" }), {
+          status: 415,
+          statusText: "Unsupported Media Type",
+          headers: { "content-type": "application/json" },
+        });
+      }
+      assert.equal(url.pathname, "/remnic/v1/offline-sync/snapshot-stream");
+      assert.equal(url.searchParams.get("content"), "false");
+      return new Response([
+        JSON.stringify({
+          type: "snapshot",
+          namespace: "generalist",
+          format: "remnic.offline-sync.snapshot.v1",
+          schemaVersion: 1,
+          createdAt: "2026-05-31T00:01:00.000Z",
+          sourceId: "remote",
+          includeTranscripts: true,
+        }),
+        JSON.stringify({ type: "file", file: remoteFile }),
+        "",
+      ].join("\n"), {
+        status: 200,
+        headers: { "content-type": "application/x-ndjson" },
+      });
+    }) as typeof fetch;
+
+    const snapshot = await fetchOfflineSnapshot({
+      remoteUrl: "http://remnic.test",
+      token: "test-token",
+      namespace: "generalist",
+      includeTranscripts: true,
+      includeContent: false,
+      baseFiles,
+    });
+
+    assert.equal(snapshot.namespace, "generalist");
+    assert.deepEqual(snapshot.files, [remoteFile]);
+    assert.deepEqual(calls, [
+      "POST /remnic/v1/offline-sync/snapshot",
+      "GET /remnic/v1/offline-sync/snapshot-stream?namespace=generalist&include_transcripts=true&content=false",
     ]);
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -21,6 +21,7 @@ import {
   OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES,
   OFFLINE_SYNC_FILE_CONTENT_UPLOAD_CHUNK_BYTES,
   OFFLINE_SYNC_REQUEST_TIMEOUT_DEFAULT_MS,
+  OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES,
   OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES,
   advanceOfflineBaseFilesForSuccessfulPush,
   chunkOfflineChangesetApplyBatches,
@@ -60,6 +61,12 @@ function contentFile(path: string, content: Buffer | string, mtimeMs = 0): Offli
     sha256: createHash("sha256").update(buffer).digest("hex"),
     mtimeMs,
   };
+}
+
+function compressibleBaseFiles(count: number): OfflineSyncFileState[] {
+  const pathPadding = "x".repeat(360);
+  return Array.from({ length: count }, (_, index) =>
+    file(`facts/${String(index).padStart(6, "0")}-${pathPadding}.md`, index + 1));
 }
 
 test("offline sync file content batches are bounded by expected bytes", () => {
@@ -285,8 +292,7 @@ test("offline sync snapshot post falls back when base payload is too large", () 
 test("offline sync compresses oversized fast-base payloads before stream fallback", async () => {
   const originalFetch = globalThis.fetch;
   try {
-    const baseFiles = Array.from({ length: 150_000 }, (_, index) =>
-      file(`facts/${String(index).padStart(6, "0")}.md`, index + 1));
+    const baseFiles = compressibleBaseFiles(OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES - 1);
     const remoteFile = file("facts/remote.md", 42, "b");
     const calls: string[] = [];
     globalThis.fetch = (async (input, init) => {
@@ -335,8 +341,7 @@ test("offline sync compresses oversized fast-base payloads before stream fallbac
 test("offline sync falls back to stream when compressed fast-base POST is unsupported", async () => {
   const originalFetch = globalThis.fetch;
   try {
-    const baseFiles = Array.from({ length: 150_000 }, (_, index) =>
-      file(`facts/${String(index).padStart(6, "0")}.md`, index + 1));
+    const baseFiles = compressibleBaseFiles(OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES - 1);
     const remoteFile = file("facts/remote.md", 42, "b");
     const calls: string[] = [];
     globalThis.fetch = (async (input, init) => {
@@ -385,6 +390,55 @@ test("offline sync falls back to stream when compressed fast-base POST is unsupp
     assert.deepEqual(snapshot.files, [remoteFile]);
     assert.deepEqual(calls, [
       "POST /remnic/v1/offline-sync/snapshot",
+      "GET /remnic/v1/offline-sync/snapshot-stream?namespace=generalist&include_transcripts=true&content=false",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("offline sync streams huge fast-base file lists instead of posting them", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    const baseFiles = Array.from({ length: OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES + 1 }, (_, index) =>
+      file(`facts/${String(index).padStart(6, "0")}.md`, index + 1));
+    const remoteFile = file("facts/remote.md", 42, "b");
+    const calls: string[] = [];
+    globalThis.fetch = (async (input, init) => {
+      const url = new URL(String(input));
+      calls.push(`${init?.method ?? "GET"} ${url.pathname}${url.search}`);
+      assert.equal(url.pathname, "/remnic/v1/offline-sync/snapshot-stream");
+      assert.equal(url.searchParams.get("content"), "false");
+      return new Response([
+        JSON.stringify({
+          type: "snapshot",
+          namespace: "generalist",
+          format: "remnic.offline-sync.snapshot.v1",
+          schemaVersion: 1,
+          createdAt: "2026-05-31T00:01:00.000Z",
+          sourceId: "remote",
+          includeTranscripts: true,
+        }),
+        JSON.stringify({ type: "file", file: remoteFile }),
+        "",
+      ].join("\n"), {
+        status: 200,
+        headers: { "content-type": "application/x-ndjson" },
+      });
+    }) as typeof fetch;
+
+    const snapshot = await fetchOfflineSnapshot({
+      remoteUrl: "http://remnic.test",
+      token: "test-token",
+      namespace: "generalist",
+      includeTranscripts: true,
+      includeContent: false,
+      baseFiles,
+    });
+
+    assert.equal(snapshot.namespace, "generalist");
+    assert.deepEqual(snapshot.files, [remoteFile]);
+    assert.deepEqual(calls, [
       "GET /remnic/v1/offline-sync/snapshot-stream?namespace=generalist&include_transcripts=true&content=false",
     ]);
   } finally {

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -4,6 +4,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/p
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { gunzipSync } from "node:zlib";
 
 import {
   OFFLINE_SYNC_APPLY_MAX_BODY_BYTES,
@@ -32,6 +33,7 @@ import {
   offlinePartialHydrationForPaths,
   offlineSnapshotBasePostBody,
   offlineSnapshotBasePostBodyFits,
+  offlineSnapshotBasePostRequest,
   offlineSnapshotContentFilesForApply,
   parseOfflineSyncRequestTimeoutMs,
   pushOfflineFileContent,
@@ -233,6 +235,7 @@ test("offline sync snapshot post falls back when base payload is too large", () 
     baseFiles: [file("facts/a.md", 1)],
   });
   assert.equal(offlineSnapshotBasePostBodyFits(smallBody), true);
+  assert.deepEqual(offlineSnapshotBasePostRequest(smallBody), { body: smallBody });
 
   const hugeButServerAcceptedBody = JSON.stringify({
     baseFiles: "x".repeat(OFFLINE_SYNC_SNAPSHOT_BASE_POST_PREFERRED_MAX_BODY_BYTES),
@@ -243,6 +246,7 @@ test("offline sync snapshot post falls back when base payload is too large", () 
     baseFiles: "x".repeat(OFFLINE_SYNC_SNAPSHOT_BASE_MAX_BODY_BYTES),
   });
   assert.equal(offlineSnapshotBasePostBodyFits(largeBody), false);
+  assert.equal(offlineSnapshotBasePostRequest(largeBody), null);
 
   assert.equal(
     isOfflineSnapshotPostFallbackError(
@@ -258,32 +262,34 @@ test("offline sync snapshot post falls back when base payload is too large", () 
   );
 });
 
-test("offline sync uses snapshot stream when fast-base payload is too large", async () => {
+test("offline sync compresses oversized fast-base payloads before stream fallback", async () => {
   const originalFetch = globalThis.fetch;
   try {
     const baseFiles = Array.from({ length: 150_000 }, (_, index) =>
       file(`facts/${String(index).padStart(6, "0")}.md`, index + 1));
     const remoteFile = file("facts/remote.md", 42, "b");
     const calls: string[] = [];
-    globalThis.fetch = (async (input) => {
+    globalThis.fetch = (async (input, init) => {
       const url = new URL(String(input));
       calls.push(`${url.pathname}${url.search}`);
-      assert.equal(url.pathname, "/remnic/v1/offline-sync/snapshot-stream");
-      const body = [
-        JSON.stringify({
-          type: "snapshot",
-          namespace: "generalist",
-          format: "remnic.offline-sync.snapshot.v1",
-          schemaVersion: 1,
-          createdAt: "2026-05-31T00:01:00.000Z",
-          sourceId: "remote",
-          includeTranscripts: true,
-        }),
-        JSON.stringify({ type: "file", file: remoteFile }),
-      ].join("\n");
-      return new Response(`${body}\n`, {
+      assert.equal(url.pathname, "/remnic/v1/offline-sync/snapshot");
+      assert.equal(init?.method, "POST");
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("content-encoding"), "gzip");
+      const compressed = Buffer.from(await new Response(init?.body).arrayBuffer());
+      const parsed = JSON.parse(gunzipSync(compressed).toString("utf8")) as { baseFiles?: unknown[] };
+      assert.equal(parsed.baseFiles?.length, baseFiles.length);
+      return new Response(JSON.stringify({
+        namespace: "generalist",
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: "2026-05-31T00:01:00.000Z",
+        sourceId: "remote",
+        includeTranscripts: true,
+        files: [remoteFile],
+      }), {
         status: 200,
-        headers: { "content-type": "application/x-ndjson" },
+        headers: { "content-type": "application/json" },
       });
     }) as typeof fetch;
 
@@ -299,7 +305,7 @@ test("offline sync uses snapshot stream when fast-base payload is too large", as
     assert.equal(snapshot.namespace, "generalist");
     assert.deepEqual(snapshot.files, [remoteFile]);
     assert.deepEqual(calls, [
-      "/remnic/v1/offline-sync/snapshot-stream?namespace=generalist&include_transcripts=true&content=false",
+      "/remnic/v1/offline-sync/snapshot",
     ]);
   } finally {
     globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary
- gzip oversized offline fast-base snapshot POST bodies before falling back to full snapshot streaming
- teach the HTTP server to decode gzipped JSON request bodies while enforcing the decompressed size cap
- add CLI and HTTP coverage for the compressed fast-base path

## Validation
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" node --import tsx/esm tests/offline-sync-cli-batching.test.ts
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" node --import tsx/esm packages/remnic-core/src/access-http.test.ts
- node scripts/check-test-types.mjs
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request body handling on the HTTP API (gzip decompression and size limits) and offline sync transport fallbacks; bounded by existing max body caps and tests.
> 
> **Overview**
> Offline sync can keep using the **fast-base** `POST /offline-sync/snapshot` path for large local file lists by **gzip-compressing** JSON bodies that exceed the preferred size limit but still fit after compression, instead of immediately falling back to full snapshot streaming.
> 
> The CLI adds `offlineSnapshotBasePostRequest`, a **50k file cap** on POST base lists, and smarter fallback when compressed POSTs fail (e.g. 415/400 from older servers). The access HTTP layer **decodes `Content-Encoding: gzip`** in `readJsonBody` with the same decompressed size limits and explicit errors for unsupported encodings or bad gzip.
> 
> Tests cover gzipped snapshot POSTs on the server and compressed vs stream fallback on the CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b27b1c00bd503f5a54a6e9d1b6527b858136a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->