### PR TITLE
fix(release): publish only after main has release commit

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -131,15 +131,29 @@ jobs:
           if [ -n "${OVERRIDE}" ]; then
             # Strip leading 'v' if provided
             OVERRIDE="${OVERRIDE#v}"
+            OVERRIDE_TAG="v${OVERRIDE}"
+            if git rev-parse -q --verify "refs/tags/${OVERRIDE_TAG}" >/dev/null; then
+              echo "::error title=Version override tag exists::${OVERRIDE_TAG} already exists locally. Choose a new version override."
+              exit 1
+            fi
+            FETCH_LOG="$(mktemp)"
+            trap 'rm -f "$FETCH_LOG"' EXIT
+            if git fetch --force origin "refs/tags/${OVERRIDE_TAG}:refs/tags/${OVERRIDE_TAG}" 2>"${FETCH_LOG}"; then
+              echo "::error title=Version override tag exists::${OVERRIDE_TAG} already exists on origin. Choose a new version override."
+              exit 1
+            elif ! grep -Eiq "couldn'?t find remote ref|could not find remote ref" "${FETCH_LOG}"; then
+              cat "${FETCH_LOG}" >&2
+              exit 1
+            fi
             {
               echo "tag_exists=false"
-              echo "tag_name=v${OVERRIDE}"
+              echo "tag_name=${OVERRIDE_TAG}"
               echo "new_version=${OVERRIDE}"
               echo "bump_type=override"
             } >> "$GITHUB_OUTPUT"
             node scripts/set-release-version.mjs "${OVERRIDE}"
             pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts
-            git add package.json packages/*/package.json packages/*/openclaw.plugin.json openclaw.plugin.json pnpm-lock.yaml 2>/dev/null || true
+            git add package.json packages/*/package.json packages/*/openclaw.plugin.json packages/*/.claude-plugin/plugin.json openclaw.plugin.json pnpm-lock.yaml 2>/dev/null || true
             if git diff --cached --quiet; then
               echo "::notice title=Release commit skipped::Version already matches v${OVERRIDE}; no package files changed."
             else
@@ -211,7 +225,7 @@ jobs:
             echo "::notice title=Bootstrap release::${BOOTSTRAP_PACKAGE} is not published yet; using package.json version ${PKG_VERSION}."
             node scripts/set-release-version.mjs "${PKG_VERSION}"
             pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts
-            git add package.json packages/*/package.json packages/*/openclaw.plugin.json openclaw.plugin.json pnpm-lock.yaml 2>/dev/null || true
+            git add package.json packages/*/package.json packages/*/openclaw.plugin.json packages/*/.claude-plugin/plugin.json openclaw.plugin.json pnpm-lock.yaml 2>/dev/null || true
             if git diff --cached --quiet; then
               echo "::notice title=Release commit skipped::Version already matches v${PKG_VERSION}; no package files changed."
             else
@@ -259,7 +273,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           node scripts/set-release-version.mjs "${NEXT_VERSION}"
           pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts
-          git add package.json packages/*/package.json packages/*/openclaw.plugin.json openclaw.plugin.json pnpm-lock.yaml 2>/dev/null || true
+          git add package.json packages/*/package.json packages/*/openclaw.plugin.json packages/*/.claude-plugin/plugin.json openclaw.plugin.json pnpm-lock.yaml 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "::notice title=Release commit skipped::Version already matches v${NEXT_VERSION}; no package files changed."
           else
@@ -291,13 +305,13 @@ jobs:
             --head "${SOURCE_MAIN_SHA}" \
             --bump "${PACKAGE_BUMP}"
 
-          if git diff --quiet -- packages/*/package.json packages/*/openclaw.plugin.json openclaw.plugin.json; then
+          if git diff --quiet -- packages/*/package.json packages/*/openclaw.plugin.json packages/*/.claude-plugin/plugin.json openclaw.plugin.json; then
             echo "::notice title=Package version bump skipped::No public workspace package versions changed."
             exit 0
           fi
 
           pnpm install --lockfile-only --no-frozen-lockfile
-          git add packages/*/package.json packages/*/openclaw.plugin.json openclaw.plugin.json pnpm-lock.yaml
+          git add packages/*/package.json packages/*/openclaw.plugin.json packages/*/.claude-plugin/plugin.json openclaw.plugin.json pnpm-lock.yaml
           git commit -m "chore(release): bump changed workspace packages [skip ci]"
 
       - name: Resolve final release metadata
@@ -393,6 +407,36 @@ jobs:
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o StrictHostKeyChecking=no"
           git push "git@github.com:${{ github.repository }}.git" "${RELEASE_COMMIT}:refs/heads/main"
 
+      - name: Prepare publish-order helper
+        run: cp scripts/publish-order.mjs "${RUNNER_TEMP}/publish-order.mjs"
+
+      - name: Checkout release source for publish
+        run: git checkout --detach "${{ steps.release_commit.outputs.release_commit }}"
+
+      - name: Ensure npm supports trusted publishing
+        # Pin npm so provenance/trusted-publishing behavior only changes through review.
+        run: npm install -g npm@11.16.0
+
+      - name: Install dependencies for release source
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate workspace package publish order
+        run: node "${RUNNER_TEMP}/publish-order.mjs" --repo-root "$PWD" --output "${RUNNER_TEMP}/remnic-publish-order.txt"
+
+      - name: Rebuild native modules
+        run: pnpm rebuild better-sqlite3
+
+      - name: Build all packages
+        run: |
+          pnpm -r run build
+          pnpm run build
+
+      - name: Verify root release artifacts
+        run: node scripts/check-release-artifacts.mjs
+
+      - name: Verify OpenClaw ClawHub artifact packlist
+        run: pnpm run verify:openclaw-clawpack
+
       - name: Ensure version tag on release commit
         id: release_tag
         env:
@@ -439,54 +483,40 @@ jobs:
           git push "git@github.com:${{ github.repository }}.git" "refs/tags/${TAG}"
           echo "tag_created=true" >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.release_metadata.outputs.tag_name }}
-          name: ${{ steps.release_metadata.outputs.tag_name }}
-          generate_release_notes: true
-
-      - name: Checkout release tag source for publish
-        run: git checkout --detach "${{ steps.release_metadata.outputs.tag_name }}"
-
-      - name: Ensure npm supports trusted publishing
-        # Pin npm so provenance/trusted-publishing behavior only changes through review.
-        run: npm install -g npm@11.16.0
-
-      - name: Install dependencies for tagged source
-        run: pnpm install --frozen-lockfile
-
-      - name: Rebuild native modules
-        run: pnpm rebuild better-sqlite3
-
-      - name: Build all packages
+      - name: Fail incomplete existing npm release
+        if: steps.release_metadata.outputs.tag_exists == 'true'
         run: |
-          pnpm -r run build
-          pnpm run build
-
-      - name: Verify root release artifacts
-        run: node scripts/check-release-artifacts.mjs
-
-      - name: Verify OpenClaw ClawHub artifact packlist
-        run: pnpm run verify:openclaw-clawpack
-
-      - name: Generate workspace package publish order
-        run: node scripts/publish-order.mjs --output "${RUNNER_TEMP}/remnic-publish-order.txt"
-
-      - name: Publish root package to npm
-        run: |
-          IS_PRIVATE="$(node -p "require('./package.json').private || false")"
-          if [ "$IS_PRIVATE" = "true" ]; then
-            echo "::notice title=NPM publish skipped::Root package is private workspace metadata only."
-            exit 0
-          fi
           VERSION="${{ steps.release_metadata.outputs.new_version }}"
-          PACKAGE_NAME="$(node -p "require('./package.json').name")"
-          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
-            echo "::notice title=NPM publish skipped::${PACKAGE_NAME}@${VERSION} is already published."
-            exit 0
+          missing=0
+          check_package() {
+            local package_name="$1"
+            local package_version="$2"
+            if ! npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+              echo "::error title=Incomplete tagged release::${package_name}@${package_version} is missing from npm for existing tag ${{ steps.release_metadata.outputs.tag_name }}."
+              missing=1
+            fi
+          }
+
+          if [ "$(node -p "require('./package.json').private || false")" != "true" ]; then
+            check_package "$(node -p "require('./package.json').name")" "${VERSION}"
           fi
-          npm publish --access public --provenance
+
+          mapfile -t PUBLISH_ORDER < "${RUNNER_TEMP}/remnic-publish-order.txt"
+          for pkg_dir in "${PUBLISH_ORDER[@]}"; do
+            pkg_json="$pkg_dir/package.json"
+            if [ ! -f "$pkg_json" ]; then
+              continue
+            fi
+            if [ "$(node -p "require('./$pkg_json').private || false")" = "true" ]; then
+              continue
+            fi
+            check_package "$(node -p "require('./$pkg_json').name")" "$(node -p "require('./$pkg_json').version")"
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::Existing release tag ${{ steps.release_metadata.outputs.tag_name }} is incomplete. Resolve the npm publication gap or create a superseding release instead of reusing this tag."
+            exit 1
+          fi
 
       - name: Publish workspace packages to npm
         run: |
@@ -540,6 +570,21 @@ jobs:
               exit $publish_status
             fi
           done
+
+      - name: Publish root package to npm
+        run: |
+          IS_PRIVATE="$(node -p "require('./package.json').private || false")"
+          if [ "$IS_PRIVATE" = "true" ]; then
+            echo "::notice title=NPM publish skipped::Root package is private workspace metadata only."
+            exit 0
+          fi
+          VERSION="${{ steps.release_metadata.outputs.new_version }}"
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "::notice title=NPM publish skipped::${PACKAGE_NAME}@${VERSION} is already published."
+            exit 0
+          fi
+          npm publish --access public --provenance
 
       - name: Publish OpenClaw plugin to ClawHub
         env:
@@ -603,3 +648,10 @@ jobs:
           fi
 
           clawhub package rescan "${CLAWHUB_PACKAGE_NAME}" --yes --json || true
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release_metadata.outputs.tag_name }}
+          name: ${{ steps.release_metadata.outputs.tag_name }}
+          generate_release_notes: true

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -151,7 +151,12 @@ jobs:
           EXISTING_TAG=""
           while IFS= read -r tag; do
             [ -z "${tag}" ] && continue
-            if git cat-file -p "refs/tags/${tag}" | grep -Fq "source-main-sha: ${SOURCE_MAIN_SHA}"; then
+            if git cat-file -e "refs/tags/${tag}^{tag}" 2>/dev/null; then
+              TAG_CONTENT="$(git cat-file -p "refs/tags/${tag}^{tag}")"
+            else
+              TAG_CONTENT="$(git log -1 --format=%B "refs/tags/${tag}")"
+            fi
+            if printf '%s\n' "${TAG_CONTENT}" | grep -Fq "source-main-sha: ${SOURCE_MAIN_SHA}"; then
               EXISTING_TAG="${tag}"
               break
             fi
@@ -329,16 +334,78 @@ jobs:
             git commit -m "docs(changelog): promote [Unreleased] -> v${NEW_VERSION} [skip ci]"
           fi
 
-      - name: Create version tag on release commit
-        if: steps.version.outputs.tag_exists != 'true'
+      - name: Push release commits to main
+        id: release_commit
+        # Uses a deploy key (RELEASE_DEPLOY_KEY secret) for the push.
+        # PAT-based pushes (fine-grained or classic) do not satisfy the RepositoryRole
+        # bypass actor on personal-repo rulesets; a DeployKey bypass actor works reliably.
+        # Commit messages carry [skip ci] to prevent this push from re-triggering
+        # the release workflow (github.actor would be github-actions[bot] for a key push,
+        # so the job-level actor guard would fire — [skip ci] is a belt-and-suspenders guard).
+        env:
+          RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
         run: |
-          git tag -a "${{ steps.version.outputs.tag_name }}" \
-            -m "Release ${{ steps.version.outputs.tag_name }}" \
-            -m "source-main-sha: ${{ steps.version.outputs.source_main_sha }}"
+          TAG="${{ steps.version.outputs.tag_name }}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            RELEASE_COMMIT="$(git rev-parse "refs/tags/${TAG}^{}")"
+          else
+            RELEASE_COMMIT="$(git rev-parse HEAD)"
+          fi
+          echo "release_commit=${RELEASE_COMMIT}" >> "$GITHUB_OUTPUT"
+          git fetch origin main
+          if git merge-base --is-ancestor "${RELEASE_COMMIT}" origin/main; then
+            echo "::notice::Release commit already on main; skipping push."
+            exit 0
+          fi
+          # Configure deploy key for SSH push. Ruleset DeployKey bypass allows this.
+          # Use a trap to ensure the key file is removed even if the push fails.
+          mkdir -p ~/.ssh
+          echo "${RELEASE_DEPLOY_KEY}" > ~/.ssh/release_deploy_key
+          chmod 600 ~/.ssh/release_deploy_key
+          trap 'rm -f ~/.ssh/release_deploy_key' EXIT
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o StrictHostKeyChecking=no"
+          git push "git@github.com:${{ github.repository }}.git" "${RELEASE_COMMIT}:refs/heads/main"
 
-      - name: Push release tag
-        if: steps.version.outputs.tag_exists != 'true'
-        run: git push origin "refs/tags/${{ steps.version.outputs.tag_name }}"
+      - name: Ensure version tag on release commit
+        id: release_tag
+        env:
+          TAG: ${{ steps.version.outputs.tag_name }}
+          RELEASE_COMMIT: ${{ steps.release_commit.outputs.release_commit }}
+          SOURCE_MAIN_SHA: ${{ steps.version.outputs.source_main_sha }}
+        run: |
+          FETCH_LOG="$(mktemp)"
+          trap 'rm -f "$FETCH_LOG"' EXIT
+          REMOTE_TAG_EXISTS=false
+          if git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>"${FETCH_LOG}"; then
+            REMOTE_TAG_EXISTS=true
+          elif grep -Eiq "couldn'?t find remote ref|could not find remote ref" "${FETCH_LOG}"; then
+            echo "::notice::Release tag ${TAG} does not exist on origin yet."
+          else
+            cat "${FETCH_LOG}" >&2
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            TAG_TARGET="$(git rev-parse "refs/tags/${TAG}^{}")"
+            if [ "${TAG_TARGET}" != "${RELEASE_COMMIT}" ]; then
+              echo "::error title=Release tag mismatch::${TAG} points at ${TAG_TARGET}, expected ${RELEASE_COMMIT}."
+              exit 1
+            fi
+            if [ "${REMOTE_TAG_EXISTS}" = "true" ]; then
+              echo "::notice::Release tag ${TAG} already exists on origin and points at ${RELEASE_COMMIT}."
+              echo "tag_created=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::notice::Release tag ${TAG} exists locally and points at ${RELEASE_COMMIT}; pushing missing remote tag."
+          else
+            git tag -a "${TAG}" \
+              "${RELEASE_COMMIT}" \
+              -m "Release ${TAG}" \
+              -m "source-main-sha: ${SOURCE_MAIN_SHA}"
+          fi
+
+          git push origin "refs/tags/${TAG}"
+          echo "tag_created=true" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -458,36 +525,6 @@ jobs:
               exit $publish_status
             fi
           done
-
-      - name: Push release commits to main
-        # Uses a deploy key (RELEASE_DEPLOY_KEY secret) for the push.
-        # PAT-based pushes (fine-grained or classic) do not satisfy the RepositoryRole
-        # bypass actor on personal-repo rulesets; a DeployKey bypass actor works reliably.
-        # Commit messages carry [skip ci] to prevent this push from re-triggering
-        # the release workflow (github.actor would be github-actions[bot] for a key push,
-        # so the job-level actor guard would fire — [skip ci] is a belt-and-suspenders guard).
-        env:
-          RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
-        run: |
-          TAG="${{ steps.version.outputs.tag_name }}"
-          RELEASE_COMMIT="$(git rev-parse "refs/tags/${TAG}^{}" 2>/dev/null || true)"
-          if [ -z "${RELEASE_COMMIT}" ]; then
-            echo "::notice::Tag ${TAG} not found locally; skipping main push."
-            exit 0
-          fi
-          git fetch origin main
-          if git merge-base --is-ancestor "${RELEASE_COMMIT}" origin/main; then
-            echo "::notice::Release commit already on main; skipping push."
-            exit 0
-          fi
-          # Configure deploy key for SSH push. Ruleset DeployKey bypass allows this.
-          # Use a trap to ensure the key file is removed even if the push fails.
-          mkdir -p ~/.ssh
-          echo "${RELEASE_DEPLOY_KEY}" > ~/.ssh/release_deploy_key
-          chmod 600 ~/.ssh/release_deploy_key
-          trap 'rm -f ~/.ssh/release_deploy_key' EXIT
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o StrictHostKeyChecking=no"
-          git push "git@github.com:${{ github.repository }}.git" "${RELEASE_COMMIT}:refs/heads/main"
 
       - name: Publish OpenClaw plugin to ClawHub
         env:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -300,10 +300,32 @@ jobs:
           git add packages/*/package.json packages/*/openclaw.plugin.json openclaw.plugin.json pnpm-lock.yaml
           git commit -m "chore(release): bump changed workspace packages [skip ci]"
 
+      - name: Resolve final release metadata
+        id: release_metadata
+        env:
+          TAG_EXISTS: ${{ steps.version.outputs.tag_exists }}
+          TAG_NAME: ${{ steps.version.outputs.tag_name }}
+        run: |
+          if [ "${TAG_EXISTS}" = "true" ]; then
+            {
+              echo "tag_exists=true"
+              echo "tag_name=${TAG_NAME}"
+              echo "new_version=${TAG_NAME#v}"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FINAL_VERSION="$(node -p "require('./package.json').version")"
+          {
+            echo "tag_exists=false"
+            echo "tag_name=v${FINAL_VERSION}"
+            echo "new_version=${FINAL_VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Promote CHANGELOG.md for release
         if: steps.version.outputs.tag_exists != 'true'
         env:
-          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+          NEW_VERSION: ${{ steps.release_metadata.outputs.new_version }}
         run: |
           python3 - <<'PYEOF'
           import os, re
@@ -344,9 +366,14 @@ jobs:
         # so the job-level actor guard would fire — [skip ci] is a belt-and-suspenders guard).
         env:
           RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          TAG_EXISTS: ${{ steps.release_metadata.outputs.tag_exists }}
         run: |
-          TAG="${{ steps.version.outputs.tag_name }}"
-          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+          TAG="${{ steps.release_metadata.outputs.tag_name }}"
+          if [ "${TAG_EXISTS}" = "true" ]; then
+            if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+              echo "::error title=Release tag missing::Version resolution selected existing tag ${TAG}, but it is not available locally."
+              exit 1
+            fi
             RELEASE_COMMIT="$(git rev-parse "refs/tags/${TAG}^{}")"
           else
             RELEASE_COMMIT="$(git rev-parse HEAD)"
@@ -369,12 +396,13 @@ jobs:
       - name: Ensure version tag on release commit
         id: release_tag
         env:
-          TAG: ${{ steps.version.outputs.tag_name }}
+          RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          TAG: ${{ steps.release_metadata.outputs.tag_name }}
           RELEASE_COMMIT: ${{ steps.release_commit.outputs.release_commit }}
           SOURCE_MAIN_SHA: ${{ steps.version.outputs.source_main_sha }}
         run: |
           FETCH_LOG="$(mktemp)"
-          trap 'rm -f "$FETCH_LOG"' EXIT
+          trap 'rm -f "$FETCH_LOG" ~/.ssh/release_deploy_key' EXIT
           REMOTE_TAG_EXISTS=false
           if git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>"${FETCH_LOG}"; then
             REMOTE_TAG_EXISTS=true
@@ -404,21 +432,26 @@ jobs:
               -m "source-main-sha: ${SOURCE_MAIN_SHA}"
           fi
 
-          git push origin "refs/tags/${TAG}"
+          mkdir -p ~/.ssh
+          echo "${RELEASE_DEPLOY_KEY}" > ~/.ssh/release_deploy_key
+          chmod 600 ~/.ssh/release_deploy_key
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o StrictHostKeyChecking=no"
+          git push "git@github.com:${{ github.repository }}.git" "refs/tags/${TAG}"
           echo "tag_created=true" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.tag_name }}
-          name: ${{ steps.version.outputs.tag_name }}
+          tag_name: ${{ steps.release_metadata.outputs.tag_name }}
+          name: ${{ steps.release_metadata.outputs.tag_name }}
           generate_release_notes: true
 
       - name: Checkout release tag source for publish
-        run: git checkout --detach "${{ steps.version.outputs.tag_name }}"
+        run: git checkout --detach "${{ steps.release_metadata.outputs.tag_name }}"
 
       - name: Ensure npm supports trusted publishing
-        run: npm install -g npm@latest
+        # Pin npm so provenance/trusted-publishing behavior only changes through review.
+        run: npm install -g npm@11.16.0
 
       - name: Install dependencies for tagged source
         run: pnpm install --frozen-lockfile
@@ -437,6 +470,9 @@ jobs:
       - name: Verify OpenClaw ClawHub artifact packlist
         run: pnpm run verify:openclaw-clawpack
 
+      - name: Generate workspace package publish order
+        run: node scripts/publish-order.mjs --output "${RUNNER_TEMP}/remnic-publish-order.txt"
+
       - name: Publish root package to npm
         run: |
           IS_PRIVATE="$(node -p "require('./package.json').private || false")"
@@ -444,7 +480,7 @@ jobs:
             echo "::notice title=NPM publish skipped::Root package is private workspace metadata only."
             exit 0
           fi
-          VERSION="${{ steps.version.outputs.new_version }}"
+          VERSION="${{ steps.release_metadata.outputs.new_version }}"
           PACKAGE_NAME="$(node -p "require('./package.json').name")"
           if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
             echo "::notice title=NPM publish skipped::${PACKAGE_NAME}@${VERSION} is already published."
@@ -464,28 +500,7 @@ jobs:
           # depend on them. Optional/à-la-carte surfaces (bench, weclone,
           # plugins) must ship so end users can install only what they need
           # — see the à-la-carte invariant in CLAUDE.md / AGENTS.md.
-          PUBLISH_ORDER=(
-            packages/remnic-core
-            packages/bench
-            packages/export-weclone
-            packages/import-weclone
-            packages/import-chatgpt
-            packages/import-claude
-            packages/import-gemini
-            packages/import-mem0
-            packages/import-lossless-claw
-            packages/import-supermemory
-            packages/connector-weclone
-            packages/connector-replit
-            packages/hermes-provider
-            packages/remnic-server
-            packages/plugin-pi
-            packages/remnic-cli
-            packages/plugin-openclaw
-            packages/plugin-claude-code
-            packages/plugin-codex
-            packages/shim-openclaw-engram
-          )
+          mapfile -t PUBLISH_ORDER < "${RUNNER_TEMP}/remnic-publish-order.txt"
           for pkg_dir in "${PUBLISH_ORDER[@]}"; do
             pkg_json="$pkg_dir/package.json"
             if [ ! -f "$pkg_json" ]; then
@@ -568,7 +583,7 @@ jobs:
             --version "${package_version}" \
             --host-targets openclaw \
             --source-repo "${GITHUB_REPOSITORY}" \
-            --source-ref "${{ steps.version.outputs.tag_name }}" \
+            --source-ref "${{ steps.release_metadata.outputs.tag_name }}" \
             --source-commit "${source_commit}" \
             --source-path "${NPM_PACKAGE_PATH}" \
             --changelog "Publish ${CLAWHUB_PACKAGE_NAME}@${package_version} from the GitHub release workflow." \

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/plugin-claude-code/.claude-plugin/plugin.json
+++ b/packages/plugin-claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remnic",
   "description": "Universal memory for AI agents — automatic recall, observation, and cross-agent knowledge sharing",
-  "version": "1.0.1",
+  "version": "9.3.515",
   "author": "Joshua Warren",
   "homepage": "https://github.com/joshuaswarren/remnic",
   "repository": "https://github.com/joshuaswarren/remnic"

--- a/scripts/bump-changed-packages.mjs
+++ b/scripts/bump-changed-packages.mjs
@@ -253,7 +253,7 @@ function changedFilesBaseRef(repoRoot, base, head) {
   );
 }
 
-async function syncOpenClawManifestVersion(repoRoot, relativeManifestPath, version, dryRun) {
+async function syncJsonManifestVersion(repoRoot, relativeManifestPath, version, dryRun) {
   const manifestPath = path.join(repoRoot, relativeManifestPath);
   if (!(await pathExists(manifestPath))) {
     return false;
@@ -270,18 +270,25 @@ async function syncCompanionVersions(repoRoot, pkg, version, dryRun) {
   if (pkg.relativeDir === "packages/plugin-openclaw") {
     const packageManifest = "packages/plugin-openclaw/openclaw.plugin.json";
     const rootManifest = "openclaw.plugin.json";
-    if (await syncOpenClawManifestVersion(repoRoot, packageManifest, version, dryRun)) {
+    if (await syncJsonManifestVersion(repoRoot, packageManifest, version, dryRun)) {
       changedFiles.push(packageManifest);
     }
-    if (await syncOpenClawManifestVersion(repoRoot, rootManifest, version, dryRun)) {
+    if (await syncJsonManifestVersion(repoRoot, rootManifest, version, dryRun)) {
       changedFiles.push(rootManifest);
     }
   }
 
   if (pkg.relativeDir === "packages/shim-openclaw-engram") {
     const shimManifest = "packages/shim-openclaw-engram/openclaw.plugin.json";
-    if (await syncOpenClawManifestVersion(repoRoot, shimManifest, version, dryRun)) {
+    if (await syncJsonManifestVersion(repoRoot, shimManifest, version, dryRun)) {
       changedFiles.push(shimManifest);
+    }
+  }
+
+  if (pkg.relativeDir === "packages/plugin-claude-code") {
+    const claudeManifest = "packages/plugin-claude-code/.claude-plugin/plugin.json";
+    if (await syncJsonManifestVersion(repoRoot, claudeManifest, version, dryRun)) {
+      changedFiles.push(claudeManifest);
     }
   }
 

--- a/scripts/bump-changed-packages.test.mjs
+++ b/scripts/bump-changed-packages.test.mjs
@@ -39,6 +39,8 @@ async function withRepo(fn) {
 
     await mkdir(path.join(repo, "packages", "remnic-core", "src"), { recursive: true });
     await mkdir(path.join(repo, "packages", "plugin-openclaw"), { recursive: true });
+    await mkdir(path.join(repo, "packages", "plugin-claude-code", ".claude-plugin"), { recursive: true });
+    await mkdir(path.join(repo, "packages", "plugin-claude-code", "src"), { recursive: true });
     await mkdir(path.join(repo, "packages", "bench-ui"), { recursive: true });
 
     await writeJson(path.join(repo, "package.json"), {
@@ -63,6 +65,18 @@ async function withRepo(fn) {
     await writeJson(path.join(repo, "openclaw.plugin.json"), {
       id: "openclaw-remnic",
       version: "2.0.0",
+    });
+    await writeJson(path.join(repo, "packages", "plugin-claude-code", "package.json"), {
+      name: "@remnic/plugin-claude-code",
+      version: "3.0.0",
+    });
+    await writeFile(
+      path.join(repo, "packages", "plugin-claude-code", "src", "index.ts"),
+      "export {};\n",
+    );
+    await writeJson(path.join(repo, "packages", "plugin-claude-code", ".claude-plugin", "plugin.json"), {
+      name: "Remnic",
+      version: "3.0.0",
     });
     await writeJson(path.join(repo, "packages", "bench-ui", "package.json"), {
       name: "@remnic/bench-ui",
@@ -120,6 +134,26 @@ test("root OpenClaw manifest changes bump plugin package and synced manifests", 
     assert.equal(plugin.version, "2.0.1");
     assert.equal(rootManifest.version, "2.0.1");
     assert.equal(packageManifest.version, "2.0.1");
+  });
+});
+
+test("Claude package changes bump and sync the Claude companion manifest", async () => {
+  await withRepo(async (repo) => {
+    await writeFile(
+      path.join(repo, "packages", "plugin-claude-code", "src", "index.ts"),
+      "export const changed = true;\n",
+    );
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "change claude plugin"]);
+
+    run(repo, "node", [scriptPath, "--base", "v1.0.0"]);
+
+    const plugin = await readJson(path.join(repo, "packages", "plugin-claude-code", "package.json"));
+    const companionManifest = await readJson(
+      path.join(repo, "packages", "plugin-claude-code", ".claude-plugin", "plugin.json"),
+    );
+    assert.equal(plugin.version, "3.0.1");
+    assert.equal(companionManifest.version, "3.0.1");
   });
 });
 

--- a/scripts/publish-order.mjs
+++ b/scripts/publish-order.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (value === undefined || value === "" || value === "--" || value.startsWith("--")) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+function parseArgs(argv) {
+  const args = {
+    repoRoot: process.cwd(),
+    output: "",
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo-root") {
+      args.repoRoot = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--output") {
+      args.output = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function usage() {
+  return [
+    "Usage: node scripts/publish-order.mjs [--repo-root <path>] [--output <path>] [--json]",
+    "",
+    "Prints public workspace package directories in dependency-safe publish order.",
+  ].join("\n");
+}
+
+function normalizeRelativePath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function packageDeps(manifest) {
+  const deps = new Set();
+  for (const field of dependencyFields) {
+    const values = manifest[field];
+    if (!values || typeof values !== "object" || Array.isArray(values)) {
+      continue;
+    }
+    for (const name of Object.keys(values)) {
+      deps.add(name);
+    }
+  }
+  return deps;
+}
+
+export async function discoverWorkspacePackages(repoRoot) {
+  const packagesRoot = path.join(repoRoot, "packages");
+  const entries = await readdir(packagesRoot, { withFileTypes: true });
+  const packages = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const relativeDir = normalizeRelativePath(path.join("packages", entry.name));
+    const packageJsonPath = path.join(repoRoot, relativeDir, "package.json");
+    let manifest;
+    try {
+      manifest = JSON.parse(await readFile(packageJsonPath, "utf8"));
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    if (!manifest.name) {
+      throw new Error(`${relativeDir}/package.json is missing a package name`);
+    }
+    packages.push({
+      dir: relativeDir,
+      name: manifest.name,
+      private: manifest.private === true,
+      deps: packageDeps(manifest),
+    });
+  }
+
+  return packages.sort((left, right) => left.dir.localeCompare(right.dir));
+}
+
+export function resolvePublishOrder(packages) {
+  const byName = new Map(packages.map((pkg) => [pkg.name, pkg]));
+  if (byName.size !== packages.length) {
+    throw new Error("Workspace package names must be unique before generating publish order");
+  }
+
+  const publicPackages = packages.filter((pkg) => !pkg.private);
+  const publicNames = new Set(publicPackages.map((pkg) => pkg.name));
+  const edges = new Map(publicPackages.map((pkg) => [pkg.dir, new Set()]));
+  const indegree = new Map(publicPackages.map((pkg) => [pkg.dir, 0]));
+
+  for (const pkg of publicPackages) {
+    for (const depName of pkg.deps) {
+      const dep = byName.get(depName);
+      if (!dep) {
+        continue;
+      }
+      if (dep.private) {
+        throw new Error(
+          `${pkg.dir} depends on private workspace package ${dep.name}; it cannot be published safely`,
+        );
+      }
+      if (!publicNames.has(dep.name)) {
+        continue;
+      }
+      edges.get(dep.dir).add(pkg.dir);
+      indegree.set(pkg.dir, indegree.get(pkg.dir) + 1);
+    }
+  }
+
+  const ready = [...indegree.entries()]
+    .filter(([, count]) => count === 0)
+    .map(([dir]) => dir)
+    .sort();
+  const order = [];
+
+  while (ready.length > 0) {
+    const dir = ready.shift();
+    order.push(dir);
+    for (const dependent of [...edges.get(dir)].sort()) {
+      const next = indegree.get(dependent) - 1;
+      indegree.set(dependent, next);
+      if (next === 0) {
+        ready.push(dependent);
+        ready.sort();
+      }
+    }
+  }
+
+  if (order.length !== publicPackages.length) {
+    const blocked = [...indegree.entries()]
+      .filter(([, count]) => count > 0)
+      .map(([dir]) => dir)
+      .sort();
+    throw new Error(`Workspace dependency cycle blocks publish order: ${blocked.join(", ")}`);
+  }
+
+  validatePublishOrder(publicPackages, order);
+  return order;
+}
+
+export function validatePublishOrder(publicPackages, order) {
+  const expected = new Map(publicPackages.map((pkg) => [pkg.dir, pkg]));
+  const seen = new Set();
+
+  for (const dir of order) {
+    if (!expected.has(dir)) {
+      throw new Error(`Publish order includes unknown public package directory: ${dir}`);
+    }
+    if (seen.has(dir)) {
+      throw new Error(`Publish order includes duplicate package directory: ${dir}`);
+    }
+    seen.add(dir);
+  }
+
+  const missing = [...expected.keys()].filter((dir) => !seen.has(dir)).sort();
+  if (missing.length > 0) {
+    throw new Error(`Publish order is missing public package directories: ${missing.join(", ")}`);
+  }
+
+  const position = new Map(order.map((dir, index) => [dir, index]));
+  const byName = new Map(publicPackages.map((pkg) => [pkg.name, pkg]));
+  for (const pkg of publicPackages) {
+    for (const depName of pkg.deps) {
+      const dep = byName.get(depName);
+      if (!dep) {
+        continue;
+      }
+      if (position.get(dep.dir) > position.get(pkg.dir)) {
+        throw new Error(`${pkg.dir} appears before dependency ${dep.dir} in publish order`);
+      }
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage());
+    return;
+  }
+
+  const packages = await discoverWorkspacePackages(args.repoRoot);
+  const order = resolvePublishOrder(packages);
+  const output = args.json ? `${JSON.stringify(order, null, 2)}\n` : `${order.join("\n")}\n`;
+  if (args.output) {
+    await writeFile(args.output, output);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/run-root-tests.mjs
+++ b/scripts/run-root-tests.mjs
@@ -10,6 +10,7 @@ const tsxBin = process.platform === "win32" ? "tsx.cmd" : "tsx";
 const testArgs = [
   "--test",
   "tests/**/*.test.ts",
+  "tests/**/*.test.mjs",
   "packages/*/src/**/*.test.ts",
   "packages/*/src/**/*.test.tsx",
   "dashboard/lib/*.test.ts",

--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -31,6 +31,7 @@ function companionManifestPaths(relativePackageJsonPath) {
   const paths = [];
   if (packageDir !== ".") {
     paths.push(path.join(packageDir, "openclaw.plugin.json"));
+    paths.push(path.join(packageDir, ".claude-plugin", "plugin.json"));
   }
   if (packageDir === path.join("packages", "plugin-openclaw")) {
     paths.push("openclaw.plugin.json");

--- a/tests/objective-state-recall.test.ts
+++ b/tests/objective-state-recall.test.ts
@@ -7,6 +7,10 @@ import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 import { recordObjectiveStateSnapshot } from "../src/objective-state.js";
 
+async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+}
+
 async function buildObjectiveStateRecallHarness(options: {
   objectiveStateRecallEnabled: boolean;
   recallSectionEnabled?: boolean;
@@ -207,7 +211,8 @@ test("recall searches objective-state snapshots from the requested namespace sto
       "raw session-key boost should rank the current session first",
     );
   } finally {
-    await rm(memoryDir, { recursive: true, force: true });
+    await orchestrator.destroy();
+    await removeTempDir(memoryDir);
   }
 });
 
@@ -289,7 +294,8 @@ test("recall searches objective-state snapshots from routed default namespace st
     assert.match(context, /namespace store/i);
     assert.equal(context.includes("old default store"), false);
   } finally {
-    await rm(memoryDir, { recursive: true, force: true });
+    await orchestrator.destroy();
+    await removeTempDir(memoryDir);
   }
 });
 
@@ -355,7 +361,8 @@ test("recall searches namespaced objective-state snapshots from configured store
     assert.match(context, /## Objective State/);
     assert.match(context, /configured store/i);
   } finally {
-    await rm(memoryDir, { recursive: true, force: true });
-    await rm(overrideDir, { recursive: true, force: true });
+    await orchestrator.destroy();
+    await removeTempDir(memoryDir);
+    await removeTempDir(overrideDir);
   }
 });

--- a/tests/publish-order.test.mjs
+++ b/tests/publish-order.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  discoverWorkspacePackages,
+  resolvePublishOrder,
+  validatePublishOrder,
+} from "../scripts/publish-order.mjs";
+
+async function createFixture(packages) {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-publish-order-"));
+  for (const pkg of packages) {
+    const packageDir = path.join(repoRoot, pkg.dir);
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      path.join(packageDir, "package.json"),
+      `${JSON.stringify(
+        {
+          name: pkg.name,
+          version: "1.0.0",
+          private: pkg.private,
+          dependencies: pkg.dependencies,
+          optionalDependencies: pkg.optionalDependencies,
+          peerDependencies: pkg.peerDependencies,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+  return repoRoot;
+}
+
+test("publish order is generated with internal dependencies before dependents", async () => {
+  const repoRoot = await createFixture([
+    { dir: "packages/app", name: "@fixture/app", dependencies: { "@fixture/core": "^1.0.0" } },
+    { dir: "packages/core", name: "@fixture/core" },
+    { dir: "packages/plugin", name: "@fixture/plugin", peerDependencies: { "@fixture/core": "^1.0.0" } },
+  ]);
+
+  const packages = await discoverWorkspacePackages(repoRoot);
+  const order = resolvePublishOrder(packages);
+
+  assert.ok(order.indexOf("packages/core") < order.indexOf("packages/app"));
+  assert.ok(order.indexOf("packages/core") < order.indexOf("packages/plugin"));
+});
+
+test("publish order validation rejects missing and duplicate public packages", async () => {
+  const repoRoot = await createFixture([
+    { dir: "packages/a", name: "@fixture/a" },
+    { dir: "packages/b", name: "@fixture/b" },
+  ]);
+  const packages = (await discoverWorkspacePackages(repoRoot)).filter((pkg) => !pkg.private);
+
+  assert.throws(() => validatePublishOrder(packages, ["packages/a"]), /missing public package/);
+  assert.throws(
+    () => validatePublishOrder(packages, ["packages/a", "packages/a", "packages/b"]),
+    /duplicate package/,
+  );
+});
+
+test("publish order validation rejects dependents before dependencies", async () => {
+  const repoRoot = await createFixture([
+    { dir: "packages/app", name: "@fixture/app", dependencies: { "@fixture/core": "^1.0.0" } },
+    { dir: "packages/core", name: "@fixture/core" },
+  ]);
+  const packages = (await discoverWorkspacePackages(repoRoot)).filter((pkg) => !pkg.private);
+
+  assert.throws(
+    () => validatePublishOrder(packages, ["packages/app", "packages/core"]),
+    /appears before dependency/,
+  );
+});
+
+test("publish order rejects public packages that depend on private workspace packages", () => {
+  assert.throws(
+    () =>
+      resolvePublishOrder([
+        {
+          dir: "packages/app",
+          name: "@fixture/app",
+          private: false,
+          deps: new Set(["@fixture/private-core"]),
+        },
+        {
+          dir: "packages/private-core",
+          name: "@fixture/private-core",
+          private: true,
+          deps: new Set(),
+        },
+      ]),
+    /depends on private workspace package/,
+  );
+});

--- a/tests/release-workflow-order.test.ts
+++ b/tests/release-workflow-order.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(".github/workflows/release-and-publish.yml", "utf8");
+
+function stepIndex(name: string): number {
+  const index = workflow.indexOf(`- name: ${name}`);
+  assert.notEqual(index, -1, `missing workflow step: ${name}`);
+  return index;
+}
+
+test("release workflow pushes release commits before public publication", () => {
+  const pushMain = stepIndex("Push release commits to main");
+
+  assert.ok(pushMain < stepIndex("Ensure version tag on release commit"));
+  assert.ok(pushMain < stepIndex("Create GitHub release"));
+  assert.ok(pushMain < stepIndex("Publish root package to npm"));
+  assert.ok(pushMain < stepIndex("Publish workspace packages to npm"));
+  assert.ok(pushMain < stepIndex("Publish OpenClaw plugin to ClawHub"));
+});
+
+test("release workflow tags the same commit pushed to main", () => {
+  assert.match(
+    workflow,
+    /id: release_commit[\s\S]*echo "release_commit=\$\{RELEASE_COMMIT\}" >> "\$GITHUB_OUTPUT"/,
+  );
+  assert.match(
+    workflow,
+    /git tag -a "\$\{TAG\}" \\\s+"\$\{RELEASE_COMMIT\}"/,
+  );
+});
+
+test("release workflow verifies existing tags before publishing", () => {
+  assert.match(
+    workflow,
+    /git fetch --force origin "refs\/tags\/\$\{TAG\}:refs\/tags\/\$\{TAG\}"/,
+  );
+  assert.match(workflow, /trap 'rm -f "\$FETCH_LOG"' EXIT/);
+  assert.match(
+    workflow,
+    /TAG_TARGET="\$\(git rev-parse "refs\/tags\/\$\{TAG\}\^\{\}"\)"/,
+  );
+  assert.match(workflow, /\[ "\$\{TAG_TARGET\}" != "\$\{RELEASE_COMMIT\}" \]/);
+  assert.match(workflow, /git push origin "refs\/tags\/\$\{TAG\}"/);
+});
+
+test("release workflow reads annotated tag metadata without peeling to commits", () => {
+  assert.match(workflow, /git cat-file -e "refs\/tags\/\$\{tag\}\^\{tag\}"/);
+  assert.match(workflow, /git cat-file -p "refs\/tags\/\$\{tag\}\^\{tag\}"/);
+  assert.match(workflow, /printf '%s\\n' "\$\{TAG_CONTENT\}" \| grep -Fq "source-main-sha: \$\{SOURCE_MAIN_SHA\}"/);
+});

--- a/tests/release-workflow-order.test.ts
+++ b/tests/release-workflow-order.test.ts
@@ -13,8 +13,11 @@ function stepIndex(name: string): number {
 test("release workflow pushes release commits before public publication", () => {
   const pushMain = stepIndex("Push release commits to main");
 
+  assert.ok(stepIndex("Bump changed workspace package versions") < stepIndex("Resolve final release metadata"));
+  assert.ok(stepIndex("Resolve final release metadata") < pushMain);
   assert.ok(pushMain < stepIndex("Ensure version tag on release commit"));
   assert.ok(pushMain < stepIndex("Create GitHub release"));
+  assert.ok(stepIndex("Generate workspace package publish order") < stepIndex("Publish root package to npm"));
   assert.ok(pushMain < stepIndex("Publish root package to npm"));
   assert.ok(pushMain < stepIndex("Publish workspace packages to npm"));
   assert.ok(pushMain < stepIndex("Publish OpenClaw plugin to ClawHub"));
@@ -24,6 +27,11 @@ test("release workflow tags the same commit pushed to main", () => {
   assert.match(
     workflow,
     /id: release_commit[\s\S]*echo "release_commit=\$\{RELEASE_COMMIT\}" >> "\$GITHUB_OUTPUT"/,
+  );
+  assert.match(workflow, /TAG_EXISTS: \$\{\{ steps\.release_metadata\.outputs\.tag_exists \}\}/);
+  assert.match(
+    workflow,
+    /if \[ "\$\{TAG_EXISTS\}" = "true" \]; then[\s\S]*RELEASE_COMMIT="\$\(git rev-parse "refs\/tags\/\$\{TAG\}\^\{\}"\)"[\s\S]*else\s+RELEASE_COMMIT="\$\(git rev-parse HEAD\)"/,
   );
   assert.match(
     workflow,
@@ -36,17 +44,41 @@ test("release workflow verifies existing tags before publishing", () => {
     workflow,
     /git fetch --force origin "refs\/tags\/\$\{TAG\}:refs\/tags\/\$\{TAG\}"/,
   );
-  assert.match(workflow, /trap 'rm -f "\$FETCH_LOG"' EXIT/);
+  assert.match(workflow, /trap 'rm -f "\$FETCH_LOG" ~\/\.ssh\/release_deploy_key' EXIT/);
   assert.match(
     workflow,
     /TAG_TARGET="\$\(git rev-parse "refs\/tags\/\$\{TAG\}\^\{\}"\)"/,
   );
   assert.match(workflow, /\[ "\$\{TAG_TARGET\}" != "\$\{RELEASE_COMMIT\}" \]/);
-  assert.match(workflow, /git push origin "refs\/tags\/\$\{TAG\}"/);
+  assert.match(
+    workflow,
+    /git push "git@github\.com:\$\{\{ github\.repository \}\}\.git" "refs\/tags\/\$\{TAG\}"/,
+  );
 });
 
 test("release workflow reads annotated tag metadata without peeling to commits", () => {
   assert.match(workflow, /git cat-file -e "refs\/tags\/\$\{tag\}\^\{tag\}"/);
   assert.match(workflow, /git cat-file -p "refs\/tags\/\$\{tag\}\^\{tag\}"/);
   assert.match(workflow, /printf '%s\\n' "\$\{TAG_CONTENT\}" \| grep -Fq "source-main-sha: \$\{SOURCE_MAIN_SHA\}"/);
+});
+
+test("release workflow derives publish metadata after package bump commits", () => {
+  assert.match(workflow, /- name: Resolve final release metadata[\s\S]*FINAL_VERSION="\$\(node -p "require\('\.\/package\.json'\)\.version"\)"/);
+  assert.match(workflow, /NEW_VERSION: \$\{\{ steps\.release_metadata\.outputs\.new_version \}\}/);
+  assert.match(workflow, /tag_name: \$\{\{ steps\.release_metadata\.outputs\.tag_name \}\}/);
+  assert.match(workflow, /VERSION="\$\{\{ steps\.release_metadata\.outputs\.new_version \}\}"/);
+  assert.match(workflow, /--source-ref "\$\{\{ steps\.release_metadata\.outputs\.tag_name \}\}"/);
+});
+
+test("release workflow validates workspace publish order before publishing", () => {
+  assert.match(
+    workflow,
+    /node scripts\/publish-order\.mjs --output "\$\{RUNNER_TEMP\}\/remnic-publish-order\.txt"/,
+  );
+  assert.match(workflow, /mapfile -t PUBLISH_ORDER < "\$\{RUNNER_TEMP\}\/remnic-publish-order\.txt"/);
+});
+
+test("release workflow pins publish tooling", () => {
+  assert.doesNotMatch(workflow, /npm install -g npm@latest/);
+  assert.match(workflow, /npm install -g npm@11\.16\.0/);
 });

--- a/tests/release-workflow-order.test.ts
+++ b/tests/release-workflow-order.test.ts
@@ -17,10 +17,20 @@ test("release workflow pushes release commits before public publication", () => 
   assert.ok(stepIndex("Resolve final release metadata") < pushMain);
   assert.ok(pushMain < stepIndex("Ensure version tag on release commit"));
   assert.ok(pushMain < stepIndex("Create GitHub release"));
+  assert.ok(stepIndex("Prepare publish-order helper") < stepIndex("Checkout release source for publish"));
+  assert.ok(stepIndex("Checkout release source for publish") < stepIndex("Generate workspace package publish order"));
+  assert.ok(stepIndex("Install dependencies for release source") < stepIndex("Generate workspace package publish order"));
   assert.ok(stepIndex("Generate workspace package publish order") < stepIndex("Publish root package to npm"));
   assert.ok(pushMain < stepIndex("Publish root package to npm"));
   assert.ok(pushMain < stepIndex("Publish workspace packages to npm"));
+  assert.ok(stepIndex("Ensure version tag on release commit") < stepIndex("Fail incomplete existing npm release"));
+  assert.ok(stepIndex("Fail incomplete existing npm release") < stepIndex("Publish root package to npm"));
+  assert.ok(stepIndex("Ensure version tag on release commit") < stepIndex("Publish root package to npm"));
+  assert.ok(stepIndex("Ensure version tag on release commit") < stepIndex("Publish workspace packages to npm"));
+  assert.ok(stepIndex("Publish workspace packages to npm") < stepIndex("Publish root package to npm"));
+  assert.ok(stepIndex("Ensure version tag on release commit") < stepIndex("Publish OpenClaw plugin to ClawHub"));
   assert.ok(pushMain < stepIndex("Publish OpenClaw plugin to ClawHub"));
+  assert.ok(stepIndex("Publish OpenClaw plugin to ClawHub") < stepIndex("Create GitHub release"));
 });
 
 test("release workflow tags the same commit pushed to main", () => {
@@ -70,12 +80,43 @@ test("release workflow derives publish metadata after package bump commits", () 
   assert.match(workflow, /--source-ref "\$\{\{ steps\.release_metadata\.outputs\.tag_name \}\}"/);
 });
 
+test("release workflow rejects version overrides that reuse existing tags before mutation", () => {
+  assert.match(workflow, /OVERRIDE_TAG="v\$\{OVERRIDE\}"/);
+  assert.match(workflow, /git rev-parse -q --verify "refs\/tags\/\$\{OVERRIDE_TAG\}"/);
+  assert.match(workflow, /git fetch --force origin "refs\/tags\/\$\{OVERRIDE_TAG\}:refs\/tags\/\$\{OVERRIDE_TAG\}"/);
+  assert.match(workflow, /Version override tag exists/);
+  assert.ok(workflow.indexOf("Version override tag exists") < workflow.indexOf("node scripts/set-release-version.mjs"));
+});
+
+test("release workflow stages Claude companion manifests during version bumps", () => {
+  assert.match(workflow, /packages\/\*\/\.claude-plugin\/plugin\.json/);
+  assert.match(
+    workflow,
+    /git add package\.json packages\/\*\/package\.json packages\/\*\/openclaw\.plugin\.json packages\/\*\/\.claude-plugin\/plugin\.json openclaw\.plugin\.json pnpm-lock\.yaml/,
+  );
+  assert.match(
+    workflow,
+    /git diff --quiet -- packages\/\*\/package\.json packages\/\*\/openclaw\.plugin\.json packages\/\*\/\.claude-plugin\/plugin\.json openclaw\.plugin\.json/,
+  );
+});
+
 test("release workflow validates workspace publish order before publishing", () => {
   assert.match(
     workflow,
-    /node scripts\/publish-order\.mjs --output "\$\{RUNNER_TEMP\}\/remnic-publish-order\.txt"/,
+    /cp scripts\/publish-order\.mjs "\$\{RUNNER_TEMP\}\/publish-order\.mjs"/,
+  );
+  assert.match(
+    workflow,
+    /node "\$\{RUNNER_TEMP\}\/publish-order\.mjs" --repo-root "\$PWD" --output "\$\{RUNNER_TEMP\}\/remnic-publish-order\.txt"/,
   );
   assert.match(workflow, /mapfile -t PUBLISH_ORDER < "\$\{RUNNER_TEMP\}\/remnic-publish-order\.txt"/);
+});
+
+test("release workflow fails existing tags with incomplete npm publication", () => {
+  assert.match(workflow, /- name: Fail incomplete existing npm release/);
+  assert.match(workflow, /if: steps\.release_metadata\.outputs\.tag_exists == 'true'/);
+  assert.match(workflow, /Incomplete tagged release/);
+  assert.match(workflow, /Existing release tag .* is incomplete/);
 });
 
 test("release workflow pins publish tooling", () => {

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -39,8 +39,12 @@ test("release workflow publish order matches the supported npm install surfaces"
   const publishDirs = JSON.parse(order.stdout) as string[];
 
   assert.deepEqual([...publishDirs].sort(), [...expectedPublishDirs].sort());
-  assert.match(workflow, /Generate workspace package publish order/);
-  assert.match(workflow, /node scripts\/publish-order\.mjs --output/);
+  assert.match(
+    workflow,
+    /Checkout release source for publish[\s\S]*Install dependencies for release source[\s\S]*Generate workspace package publish order/,
+  );
+  assert.match(workflow, /cp scripts\/publish-order\.mjs "\$\{RUNNER_TEMP\}\/publish-order\.mjs"/);
+  assert.match(workflow, /node "\$\{RUNNER_TEMP\}\/publish-order\.mjs" --repo-root "\$PWD" --output/);
   assert.match(workflow, /mapfile -t PUBLISH_ORDER/);
 });
 
@@ -113,13 +117,9 @@ test("@remnic/server build verifies declared bin artifacts", async () => {
 });
 
 test("@remnic/server bin wrapper help includes the CLI environment contract", async () => {
-  // The source-controlled bin helper is plain JavaScript, so this import is
-  // intentionally typed at the call site.
-  // Keep the check here with the release workflow package-surface tests:
-  // the package manifest, published files list, and runtime help text are all
-  // part of the same npm install contract.
-  // If the helper moves to TypeScript later, this import can switch to the
-  // package's declared export surface.
+  // The source-controlled bin helper is plain JavaScript; keep this
+  // test typed at the call site until it grows a declared TypeScript
+  // export surface.
   const { runServerBin } = await import("../packages/remnic-server/bin/server-bin.js") as {
     runServerBin: (
       commandName: string,

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -5,12 +5,8 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
-// Topological publish order: core first, then the à-la-carte companion
-// packages (bench, importer/exporter family, connector-replit) that install
-// surfaces depend on, then the depend-on-core runtimes and plugin bundles.
-// Packages that the CLI depends on, such as plugin-pi, must publish before
-// remnic-cli. The legacy shim lives at the tail. Keep in sync with PUBLISH_ORDER in
-// .github/workflows/release-and-publish.yml and AGENTS.md §44.
+// Supported public workspace packages. The workflow generates dependency-safe
+// publish order from package metadata before any workspace package is published.
 const expectedPublishDirs = [
   "packages/remnic-core",
   "packages/bench",
@@ -36,19 +32,16 @@ const expectedPublishDirs = [
 
 test("release workflow publish order matches the supported npm install surfaces", async () => {
   const workflow = await readFile(".github/workflows/release-and-publish.yml", "utf8");
-  const publishOrderMatch = workflow.match(/PUBLISH_ORDER=\(\s*([\s\S]*?)\s*\)/);
-  assert.ok(publishOrderMatch, "release workflow must define PUBLISH_ORDER");
-  const publishDirs = [...publishOrderMatch[1].matchAll(/packages\/[A-Za-z0-9_-]+/g)].map((match) => match[0]);
+  const order = spawnSync(process.execPath, ["scripts/publish-order.mjs", "--json"], {
+    encoding: "utf8",
+  });
+  assert.equal(order.status, 0, order.stderr);
+  const publishDirs = JSON.parse(order.stdout) as string[];
 
-  assert.deepEqual(publishDirs, [...expectedPublishDirs]);
-
-  for (const pkgDir of expectedPublishDirs) {
-    assert.match(
-      workflow,
-      new RegExp(`\\b${pkgDir.replace("/", "\\/")}\\b`),
-      `release-and-publish.yml must publish ${pkgDir}`,
-    );
-  }
+  assert.deepEqual([...publishDirs].sort(), [...expectedPublishDirs].sort());
+  assert.match(workflow, /Generate workspace package publish order/);
+  assert.match(workflow, /node scripts\/publish-order\.mjs --output/);
+  assert.match(workflow, /mapfile -t PUBLISH_ORDER/);
 });
 
 test("release workflow verifies the OpenClaw ClawHub packlist after build", async () => {
@@ -120,6 +113,13 @@ test("@remnic/server build verifies declared bin artifacts", async () => {
 });
 
 test("@remnic/server bin wrapper help includes the CLI environment contract", async () => {
+  // The source-controlled bin helper is plain JavaScript, so this import is
+  // intentionally typed at the call site.
+  // Keep the check here with the release workflow package-surface tests:
+  // the package manifest, published files list, and runtime help text are all
+  // part of the same npm install contract.
+  // If the helper moves to TypeScript later, this import can switch to the
+  // package's declared export surface.
   const { runServerBin } = await import("../packages/remnic-server/bin/server-bin.js") as {
     runServerBin: (
       commandName: string,

--- a/tests/root-test-build-contract.test.ts
+++ b/tests/root-test-build-contract.test.ts
@@ -46,6 +46,7 @@ test("root test runner applies remnic source conditions and test globs portably"
 
   const script = readFileSync(join(repoRoot, "scripts", "run-root-tests.mjs"), "utf8");
   assert.match(script, /"tests\/\*\*\/\*\.test\.ts"/);
+  assert.match(script, /"tests\/\*\*\/\*\.test\.mjs"/);
   assert.match(script, /"packages\/\*\/src\/\*\*\/\*\.test\.ts"/);
   assert.match(script, /"packages\/\*\/src\/\*\*\/\*\.test\.tsx"/);
   assert.match(script, /"dashboard\/lib\/\*\.test\.ts"/);

--- a/tests/script-cli-arg-validation.test.ts
+++ b/tests/script-cli-arg-validation.test.ts
@@ -72,10 +72,11 @@ test("set-release-version accepts prerelease and build metadata SemVer", () => {
   assert.match(result.stdout, /1\.0\.0-rc\.1\+001/);
 });
 
-test("set-release-version syncs OpenClaw companion manifests", async () => {
+test("set-release-version syncs companion plugin manifests", async () => {
   const repo = await mkdtemp(path.join(os.tmpdir(), "remnic-release-version-"));
   try {
     await mkdir(path.join(repo, "packages", "plugin-openclaw"), { recursive: true });
+    await mkdir(path.join(repo, "packages", "plugin-claude-code", ".claude-plugin"), { recursive: true });
     await mkdir(path.join(repo, "packages", "shim-openclaw-engram"), { recursive: true });
     await writeJson(path.join(repo, "package.json"), {
       private: true,
@@ -91,6 +92,14 @@ test("set-release-version syncs OpenClaw companion manifests", async () => {
     });
     await writeJson(path.join(repo, "openclaw.plugin.json"), {
       id: "openclaw-remnic",
+      version: "1.0.0",
+    });
+    await writeJson(path.join(repo, "packages", "plugin-claude-code", "package.json"), {
+      name: "@remnic/plugin-claude-code",
+      version: "1.0.0",
+    });
+    await writeJson(path.join(repo, "packages", "plugin-claude-code", ".claude-plugin", "plugin.json"), {
+      name: "Remnic",
       version: "1.0.0",
     });
     await writeJson(path.join(repo, "packages", "shim-openclaw-engram", "package.json"), {
@@ -121,6 +130,14 @@ test("set-release-version syncs OpenClaw companion manifests", async () => {
       "1.2.3",
     );
     assert.equal((await readJson(path.join(repo, "openclaw.plugin.json"))).version, "1.2.3");
+    assert.equal(
+      (await readJson(path.join(repo, "packages", "plugin-claude-code", "package.json"))).version,
+      "1.2.3",
+    );
+    assert.equal(
+      (await readJson(path.join(repo, "packages", "plugin-claude-code", ".claude-plugin", "plugin.json"))).version,
+      "1.2.3",
+    );
     assert.equal(
       (await readJson(path.join(repo, "packages", "shim-openclaw-engram", "package.json"))).version,
       "1.2.3",


### PR DESCRIPTION
## Summary
- push the resolved release commit to `main` before creating or publishing release artifacts
- make version tag handling idempotent by verifying local/remote tag targets against the pushed release commit before GitHub/npm/ClawHub publication
- read annotated release tag metadata explicitly when detecting existing `source-main-sha` releases
- add static workflow regression coverage for release ordering, tag target consistency, idempotent tag verification, and annotated tag metadata lookup

## ClawPatch findings
- Resolves high `fnd_sig-feat-config-8bf6e36a2f-06c82_5ca2baffbb`: release artifacts published before release commit reaches `main`
- Resolves high `fnd_sig-feat-config-8bf6e36a2f-4e15b_4e50e8975e`: release tag target can drift from pushed release commit
- Resolves high `fnd_sig-feat-config-8bf6e36a2f-6be51_065ea08c6a`: reruns can create an unpushed/duplicate tag when main push is a no-op
- Resolves medium `fnd_sig-feat-config-8bf6e36a2f-b2edc_a62f220685`: annotated release tag metadata lookup can miss `source-main-sha`
- Resolves low `fnd_sig-feat-config-8bf6e36a2f-6fedc_90d0c4b8b5`: temporary fetch log cleanup on failure paths

## Validation
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec tsx --test tests/release-workflow-order.test.ts`
- ClawPatch focused revalidation: `feat_config_8bf6e36a2f`, 1 reviewed, 0 findings, run `20260601T150721-6809ed`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes ordering and guards for tags, main pushes, and multi-package npm/ClawHub publication—core release infrastructure with high blast radius if misordered.
> 
> **Overview**
> Reworks the **release-and-publish** workflow so **release commits land on `main` before** tags, npm, ClawHub, or the GitHub release. Final version/tag metadata is resolved **after** workspace package bumps (from root `package.json`), and publication uses a **checked-out release commit** with **idempotent** tag create/push that must match that commit.
> 
> Adds **`scripts/publish-order.mjs`** (dependency-safe workspace publish order) and replaces the hardcoded npm list in CI. For **reused tags**, the workflow **fails** if npm publication is incomplete, reads **`source-main-sha`** from **annotated tag** bodies, blocks **version overrides** when the tag already exists, stages **`.claude-plugin/plugin.json`**, and **pins npm** to `11.16.0`. Release/bump scripts and tests cover ordering, manifests, and publish-order behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e76e1653bdb2a24ccdf2f4d86c4af292b4f78ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->