### PR TITLE
Harden offline sync for live large bases

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/plugin-claude-code/.claude-plugin/plugin.json
+++ b/packages/plugin-claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remnic",
   "description": "Universal memory for AI agents — automatic recall, observation, and cross-agent knowledge sharing",
-  "version": "1.0.1",
+  "version": "9.3.515",
   "author": "Joshua Warren",
   "homepage": "https://github.com/joshuaswarren/remnic",
   "repository": "https://github.com/joshuaswarren/remnic"

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -5580,9 +5580,10 @@ function normalizeOfflineRemoteUrl(raw: string): string {
   return parsed.toString().replace(/\/$/, "");
 }
 
-function resolveOptionalOfflineRemoteUrl(args: string[]): string | undefined {
+export function resolveOptionalOfflineRemoteUrl(args: string[]): string | undefined {
   const raw =
     resolveRequiredValueFlag(args, "--remote-url") ??
+    resolveRequiredValueFlag(args, "--remote") ??
     process.env.REMNIC_OFFLINE_REMOTE_URL ??
     process.env.ENGRAM_OFFLINE_REMOTE_URL;
   if (!raw || raw.trim().length === 0) return undefined;
@@ -5659,6 +5660,14 @@ function offlineRequestTimeoutMs(): number {
   return parseOfflineSyncRequestTimeoutMs(
     process.env.REMNIC_OFFLINE_REQUEST_TIMEOUT_MS ??
       process.env.ENGRAM_OFFLINE_REQUEST_TIMEOUT_MS,
+  );
+}
+
+function offlineSnapshotPostTimeoutMs(): number {
+  return parseOfflineSyncRequestTimeoutMs(
+    process.env.REMNIC_OFFLINE_SNAPSHOT_POST_TIMEOUT_MS ??
+      process.env.ENGRAM_OFFLINE_SNAPSHOT_POST_TIMEOUT_MS,
+    Math.min(offlineRequestTimeoutMs(), 60_000),
   );
 }
 
@@ -5882,18 +5891,23 @@ export async function fetchOfflineSnapshot(args: {
       if (postRequest) {
         const postRequestUsesGzip =
           new Headers(postRequest.headers).get("content-encoding")?.toLowerCase() === "gzip";
+        const postAbort = new AbortController();
+        const postTimeout = setTimeout(() => postAbort.abort(), offlineSnapshotPostTimeoutMs());
         try {
           return await fetchOfflineJson(
             offlineEndpoint(args.remoteUrl, "/remnic/v1/offline-sync/snapshot"),
             args.token,
             {
               method: "POST",
+              signal: postAbort.signal,
               ...postRequest,
             },
           );
         } catch (error) {
           if (!isOfflineSnapshotPostFallbackError(error, { compressed: postRequestUsesGzip })) throw error;
           tryStreamSnapshot = true;
+        } finally {
+          clearTimeout(postTimeout);
         }
       } else {
         tryStreamSnapshot = true;
@@ -5969,6 +5983,13 @@ export function isOfflineSnapshotPostFallbackError(
 ): boolean {
   const message = error instanceof Error ? error.message : String(error);
   if (/offline-sync\/snapshot\b.* returned (404|405|413)\b/.test(message)) return true;
+  if (
+    /^offline sync request timed out after \d+ms: POST .*\/offline-sync\/snapshot\b/.test(message) ||
+    /^offline sync request failed before response: POST .*\/offline-sync\/snapshot\b/.test(message) ||
+    /^(This operation was aborted|The operation was aborted|AbortError)/i.test(message)
+  ) {
+    return true;
+  }
   if (!options.compressed) return false;
   return /offline-sync\/snapshot\b.* returned (400|415)\b/.test(message) &&
     /\b(unsupported_content_encoding|invalid_gzip_body|invalid_json)\b/.test(message);
@@ -6024,6 +6045,8 @@ export const OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES = Math.min(
 );
 export const OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES = OFFLINE_SYNC_DIRECT_PUSH_MIN_BYTES;
 export const OFFLINE_SYNC_CHANGESET_RETRY_MAX = 1_024;
+export const OFFLINE_SYNC_CONTENT_MISSING_RETRY_MAX = 3;
+export const OFFLINE_SYNC_CONTENT_MISSING_RETRY_DELAY_MS = 250;
 
 class OfflineRemoteFileChangedError extends Error {
   readonly path: string;
@@ -6724,12 +6747,65 @@ function isOfflineFilesUnsupportedError(error: unknown): boolean {
   return /offline sync request failed: .* returned 404\b/.test(message);
 }
 
+class OfflineMissingContentError extends Error {
+  readonly missing: readonly OfflineSyncFileState[];
+
+  constructor(missing: readonly OfflineSyncFileState[]) {
+    const preview = missing.slice(0, 8).map((file) => file.path).join(", ");
+    const suffix = missing.length > 8 ? `, ... +${missing.length - 8} more` : "";
+    super(
+      `remote offline content response omitted ${missing.length} changed file${missing.length === 1 ? "" : "s"}: ${preview}${suffix}; retry sync`,
+    );
+    this.name = "OfflineMissingContentError";
+    this.missing = missing;
+  }
+}
+
 function isMissingOfflineContentError(error: unknown): boolean {
+  if (error instanceof OfflineMissingContentError) return true;
   const message = error instanceof Error ? error.message : String(error);
   return /^missing decoded content for /.test(message);
 }
 
-async function hydrateOfflineSnapshotContent(args: {
+function formatMissingOfflineContentError(missing: readonly OfflineSyncFileState[]): Error {
+  return new OfflineMissingContentError(missing);
+}
+
+export function isOfflineMissingContentDeferrablePath(relPath: string): boolean {
+  const parts = relPath.split("/");
+  return parts[0] === "profiling" || (parts[0] === "namespaces" && parts[2] === "profiling");
+}
+
+function deferMissingOfflineContent(
+  missing: readonly OfflineSyncFileState[],
+  deferredPaths: Set<string> | undefined,
+): OfflineSyncFileState[] {
+  if (!deferredPaths) return [...missing];
+  const stillMissing: OfflineSyncFileState[] = [];
+  for (const file of missing) {
+    if (isOfflineMissingContentDeferrablePath(file.path)) {
+      deferredPaths.add(file.path);
+    } else {
+      stillMissing.push(file);
+    }
+  }
+  return stillMissing;
+}
+
+function formatMissingDecodedContentError(missing: readonly OfflineSyncFileState[]): Error {
+  const preview = missing.slice(0, 8).map((file) => file.path).join(", ");
+  const suffix = missing.length > 8 ? `, ... +${missing.length - 8} more` : "";
+  return new Error(
+    `remote offline content response omitted ${missing.length} changed file${missing.length === 1 ? "" : "s"}: ${preview}${suffix}; retry sync`,
+  );
+}
+
+async function waitForMissingOfflineContentRetry(delayMs: number): Promise<void> {
+  if (delayMs <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+export async function hydrateOfflineSnapshotContent(args: {
   remoteUrl: string;
   token: string;
   namespace?: string;
@@ -6738,6 +6814,10 @@ async function hydrateOfflineSnapshotContent(args: {
   baseFiles: readonly OfflineSyncFileState[];
   currentFiles?: readonly OfflineSyncFileState[];
   deferredPaths?: readonly string[];
+  missingContentDeferredPaths?: Set<string>;
+  fetchFiles?: typeof fetchOfflineFiles;
+  missingContentRetryMax?: number;
+  missingContentRetryDelayMs?: number;
 }): Promise<OfflineSyncSnapshot & { namespace?: string }> {
   const snapshot = normalizeOfflineSyncSnapshot(args.snapshot);
   const neededFiles = offlineSnapshotContentFilesForApply({
@@ -6752,26 +6832,47 @@ async function hydrateOfflineSnapshotContent(args: {
   const expectedByPath = new Map(snapshot.files.map((file) => [file.path, file]));
   const contentByPath = new Map<string, string>();
   const updatedByPath = new Map<string, OfflineSyncFileState & { contentBase64: string }>();
+  const fetchFiles = args.fetchFiles ?? fetchOfflineFiles;
+  const retryMax = args.missingContentRetryMax ?? OFFLINE_SYNC_CONTENT_MISSING_RETRY_MAX;
+  const retryDelayMs = args.missingContentRetryDelayMs ?? OFFLINE_SYNC_CONTENT_MISSING_RETRY_DELAY_MS;
+  if (!Number.isInteger(retryMax) || retryMax < 0) {
+    throw new Error("offline sync missing content retry max must be an integer >= 0");
+  }
+  if (!Number.isInteger(retryDelayMs) || retryDelayMs < 0) {
+    throw new Error("offline sync missing content retry delay must be an integer >= 0");
+  }
   try {
-    for (const batch of chunkOfflineFileContentBatches(neededFiles)) {
-      const partial = await fetchOfflineFiles({
-        remoteUrl: args.remoteUrl,
-        token: args.token,
-        namespace: args.namespace,
-        includeTranscripts: args.includeTranscripts,
-        paths: batch.map((file) => file.path),
-      });
-      for (const file of partial.files) {
-        const expected = expectedByPath.get(file.path);
-        if (!expected) continue;
-        if (typeof file.contentBase64 !== "string") {
-          throw new Error(`remote offline content response omitted contentBase64 for ${file.path}`);
+    let pendingFiles = neededFiles;
+    for (let attempt = 0; ; attempt += 1) {
+      for (const batch of chunkOfflineFileContentBatches(pendingFiles)) {
+        const partial = await fetchFiles({
+          remoteUrl: args.remoteUrl,
+          token: args.token,
+          namespace: args.namespace,
+          includeTranscripts: args.includeTranscripts,
+          paths: batch.map((file) => file.path),
+        });
+        for (const file of partial.files) {
+          const expected = expectedByPath.get(file.path);
+          if (!expected) continue;
+          if (typeof file.contentBase64 !== "string") {
+            throw new Error(`remote offline content response omitted contentBase64 for ${file.path}`);
+          }
+          if (file.sha256 !== expected.sha256 || file.bytes !== expected.bytes || file.mtimeMs !== expected.mtimeMs) {
+            updatedByPath.set(file.path, file as OfflineSyncFileState & { contentBase64: string });
+          }
+          contentByPath.set(file.path, file.contentBase64);
         }
-        if (file.sha256 !== expected.sha256 || file.bytes !== expected.bytes || file.mtimeMs !== expected.mtimeMs) {
-          updatedByPath.set(file.path, file as OfflineSyncFileState & { contentBase64: string });
-        }
-        contentByPath.set(file.path, file.contentBase64);
       }
+      const missing = pendingFiles.filter((file) => !contentByPath.has(file.path));
+      if (missing.length === 0) break;
+      if (attempt >= retryMax) {
+        const stillMissing = deferMissingOfflineContent(missing, args.missingContentDeferredPaths);
+        if (stillMissing.length > 0) throw formatMissingOfflineContentError(stillMissing);
+        break;
+      }
+      pendingFiles = missing;
+      await waitForMissingOfflineContentRetry(retryDelayMs);
     }
   } catch (error) {
     if (!isOfflineFilesUnsupportedError(error)) throw error;
@@ -6786,10 +6887,10 @@ async function hydrateOfflineSnapshotContent(args: {
 
   const missing = neededFiles
     .map((file) => file.path)
-    .filter((relPath) => !contentByPath.has(relPath));
+    .filter((relPath) => !contentByPath.has(relPath) && !args.missingContentDeferredPaths?.has(relPath));
   if (missing.length > 0) {
-    throw new Error(
-      `remote offline content response omitted ${missing.length} changed file${missing.length === 1 ? "" : "s"}; retry sync`,
+    throw formatMissingDecodedContentError(
+      neededFiles.filter((file) => missing.includes(file.path)),
     );
   }
 
@@ -7583,6 +7684,7 @@ export async function runOfflineSyncOnce(options: {
       baseFiles,
       currentFiles: applyCurrentSnapshot.files,
       deferredPaths: [...remoteDeferredPaths],
+      missingContentDeferredPaths: remoteDeferredPaths,
     });
   } catch (error) {
     if (pushed || partialHydration.hydratedFiles.length > 0) {
@@ -7627,6 +7729,7 @@ export async function runOfflineSyncOnce(options: {
         baseFiles,
         currentFiles: applyCurrentSnapshot.files,
         deferredPaths: [...remoteDeferredPaths],
+        missingContentDeferredPaths: remoteDeferredPaths,
       });
     } catch (retryError) {
       if (pushed || partialHydration.hydratedFiles.length > 0) {
@@ -7764,7 +7867,7 @@ async function cmdOffline(action: string, rest: string[], json: boolean): Promis
     console.log(`Usage: remnic offline <prepare|sync|status|watch> [options]
 
 Options:
-  --remote-url <url>       Remote Remnic server URL, e.g. http://home:4242
+  --remote-url <url>       Remote Remnic server URL, e.g. http://home:4242 (--remote alias accepted)
   --token <token>          Bearer token for the remote server
   --namespace <name>       Namespace to sync
   --memory-dir <dir>       Local memory dir (defaults to resolved memoryDir)

--- a/packages/remnic-cli/src/offline-sync-hydrate.test.ts
+++ b/packages/remnic-cli/src/offline-sync-hydrate.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import {
+  OFFLINE_SYNC_SNAPSHOT_FORMAT,
+  type OfflineSyncFileRecord,
+  type OfflineSyncFileState,
+  type OfflineSyncSnapshot,
+} from "@remnic/core";
+import {
+  OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES,
+  fetchOfflineSnapshot,
+  hydrateOfflineSnapshotContent,
+  isOfflineMissingContentDeferrablePath,
+  isOfflineSnapshotPostFallbackError,
+  resolveOptionalOfflineRemoteUrl,
+} from "./index.js";
+
+function fileState(relPath: string, content: string, mtimeMs = 1): OfflineSyncFileState {
+  const buffer = Buffer.from(content);
+  return {
+    path: relPath,
+    sha256: createHash("sha256").update(buffer).digest("hex"),
+    bytes: buffer.byteLength,
+    mtimeMs,
+  };
+}
+
+function withContent(file: OfflineSyncFileState, content: string): OfflineSyncFileRecord & { contentBase64: string } {
+  return {
+    ...file,
+    contentBase64: Buffer.from(content).toString("base64"),
+  };
+}
+
+function snapshot(files: readonly OfflineSyncFileRecord[]): OfflineSyncSnapshot & { namespace: string } {
+  return {
+    namespace: "generalist",
+    format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
+    schemaVersion: 1,
+    createdAt: new Date(0).toISOString(),
+    sourceId: "remote",
+    includeTranscripts: true,
+    files: [...files],
+  };
+}
+
+test("hydrateOfflineSnapshotContent retries omitted changed file content", async () => {
+  const remoteFile = fileState("state/buffer.json", "remote-buffer");
+  let calls = 0;
+
+  const hydrated = await hydrateOfflineSnapshotContent({
+    remoteUrl: "http://example.invalid",
+    token: "token",
+    namespace: "generalist",
+    includeTranscripts: true,
+    snapshot: snapshot([remoteFile]),
+    baseFiles: [],
+    currentFiles: [],
+    missingContentRetryMax: 1,
+    missingContentRetryDelayMs: 0,
+    fetchFiles: async ({ paths }) => {
+      calls += 1;
+      assert.deepEqual(paths, ["state/buffer.json"]);
+      return calls === 1
+        ? snapshot([])
+        : snapshot([withContent(remoteFile, "remote-buffer")]);
+    },
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(hydrated.files[0]?.contentBase64, Buffer.from("remote-buffer").toString("base64"));
+});
+
+test("hydrateOfflineSnapshotContent reports omitted paths after retry budget", async () => {
+  const remoteFile = fileState("state/buffer.json", "remote-buffer");
+  let calls = 0;
+
+  await assert.rejects(
+    hydrateOfflineSnapshotContent({
+      remoteUrl: "http://example.invalid",
+      token: "token",
+      namespace: "generalist",
+      includeTranscripts: true,
+      snapshot: snapshot([remoteFile]),
+      baseFiles: [],
+      currentFiles: [],
+      missingContentRetryMax: 1,
+      missingContentRetryDelayMs: 0,
+      fetchFiles: async ({ paths }) => {
+        calls += 1;
+        assert.deepEqual(paths, ["state/buffer.json"]);
+        return snapshot([]);
+      },
+    }),
+    /remote offline content response omitted 1 changed file: state\/buffer\.json; retry sync/,
+  );
+  assert.equal(calls, 2);
+});
+
+test("hydrateOfflineSnapshotContent defers missing live profiling content", async () => {
+  const remoteFile = fileState("profiling/recall-live.jsonl", "profile-row");
+  const deferredPaths = new Set<string>();
+
+  const hydrated = await hydrateOfflineSnapshotContent({
+    remoteUrl: "http://example.invalid",
+    token: "token",
+    namespace: "generalist",
+    includeTranscripts: true,
+    snapshot: snapshot([remoteFile]),
+    baseFiles: [],
+    currentFiles: [],
+    missingContentDeferredPaths: deferredPaths,
+    missingContentRetryMax: 1,
+    missingContentRetryDelayMs: 0,
+    fetchFiles: async ({ paths }) => {
+      assert.deepEqual(paths, ["profiling/recall-live.jsonl"]);
+      return snapshot([]);
+    },
+  });
+
+  assert.deepEqual([...deferredPaths], ["profiling/recall-live.jsonl"]);
+  assert.equal(hydrated.files[0]?.contentBase64, undefined);
+});
+
+test("isOfflineMissingContentDeferrablePath recognizes namespace profiling logs", () => {
+  assert.equal(isOfflineMissingContentDeferrablePath("profiling/recall-live.jsonl"), true);
+  assert.equal(
+    isOfflineMissingContentDeferrablePath("namespaces/generalist/profiling/recall-live.jsonl"),
+    true,
+  );
+  assert.equal(isOfflineMissingContentDeferrablePath("facts/profile.md"), false);
+});
+
+test("fetchOfflineSnapshot uses base-aware POST at the cached file cutoff", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestedPath = "";
+  try {
+    const baseFiles = Array.from(
+      { length: OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES },
+      (_, index): OfflineSyncFileState => ({
+        path: `facts/${index}.md`,
+        sha256: "a".repeat(64),
+        bytes: 1,
+        mtimeMs: 1,
+      }),
+    );
+    globalThis.fetch = (async (input, init = {}) => {
+      const url = new URL(String(input));
+      requestedPath = url.pathname;
+      assert.equal(url.pathname, "/remnic/v1/offline-sync/snapshot");
+      assert.equal(init.method, "POST");
+      return new Response(JSON.stringify(snapshot([])), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await fetchOfflineSnapshot({
+      remoteUrl: "http://example.invalid",
+      token: "token",
+      namespace: "generalist",
+      includeTranscripts: true,
+      includeContent: false,
+      baseFiles,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(requestedPath, "/remnic/v1/offline-sync/snapshot");
+});
+
+test("base-aware snapshot POST transport failures can fall back to stream", () => {
+  assert.equal(
+    isOfflineSnapshotPostFallbackError(
+      new Error("offline sync request failed before response: POST /remnic/v1/offline-sync/snapshot - fetch failed"),
+    ),
+    true,
+  );
+  assert.equal(
+    isOfflineSnapshotPostFallbackError(
+      new Error("offline sync request timed out after 420000ms: POST /remnic/v1/offline-sync/snapshot"),
+    ),
+    true,
+  );
+  assert.equal(
+    isOfflineSnapshotPostFallbackError(
+      new Error("offline sync request timed out after 420000ms: POST /api/remnic/v1/offline-sync/snapshot"),
+    ),
+    true,
+  );
+  assert.equal(
+    isOfflineSnapshotPostFallbackError(
+      new Error("offline sync request failed before response: POST /api/remnic/v1/offline-sync/snapshot - fetch failed"),
+    ),
+    true,
+  );
+});
+
+test("offline remote URL accepts --remote as an alias", () => {
+  assert.equal(
+    resolveOptionalOfflineRemoteUrl(["--remote", "http://example.invalid/remnic/"]),
+    "http://example.invalid/remnic",
+  );
+  assert.equal(
+    resolveOptionalOfflineRemoteUrl([
+      "--remote-url",
+      "http://primary.example.invalid",
+      "--remote",
+      "http://alias.example.invalid",
+    ]),
+    "http://primary.example.invalid",
+  );
+});

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -735,6 +735,7 @@ export class EngramAccessHttpServer {
         principal: this.resolveRequestPrincipal(req),
         includeTranscripts: includeTranscriptsRaw !== "false",
         includeContent: false,
+        signal: this.createRequestAbortSignal(req, res),
       });
       await this.respondOfflineSnapshotStream(res, result);
       return;
@@ -756,6 +757,7 @@ export class EngramAccessHttpServer {
         includeContent: body.includeContent,
         baseFiles: body.baseFiles,
         ...(body.baseCapturedAt ? { baseCapturedAt: new Date(body.baseCapturedAt) } : {}),
+        signal: this.createRequestAbortSignal(req, res),
       });
       this.respondJson(res, 200, result);
       return;
@@ -1784,6 +1786,18 @@ export class EngramAccessHttpServer {
     }
 
     this.respondJson(res, 404, { error: "not_found", code: "not_found" });
+  }
+
+  private createRequestAbortSignal(req: IncomingMessage, res: ServerResponse): AbortSignal {
+    const controller = new AbortController();
+    const abort = () => {
+      if (!controller.signal.aborted) controller.abort();
+    };
+    req.once("aborted", abort);
+    res.once("close", () => {
+      if (!res.writableEnded) abort();
+    });
+    return controller.signal;
   }
 
   /**

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -186,27 +186,25 @@ test("offlineSyncFiles reports symlink requested paths as input errors", async (
   }
 });
 
-test("offlineSyncSnapshot ignores client capture time for server fast-base scans", async () => {
+test("offlineSyncSnapshot does not trust client base capture time for server fast-base scans", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-offline-snapshot-client-clock-"));
   try {
     const relPath = "facts/a.md";
     const filePath = path.join(root, relPath);
-    const oldContent = Buffer.from("alpha");
-    const newContent = Buffer.from("bravo");
+    const content = Buffer.from("alpha");
     const mtimeMs = 1_700_000_000_000;
     await mkdir(path.dirname(filePath), { recursive: true });
-    await writeFile(filePath, oldContent);
+    await writeFile(filePath, content);
     await utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
     const baseFile = {
       path: relPath,
-      sha256: createHash("sha256").update(oldContent).digest("hex"),
-      bytes: oldContent.byteLength,
+      sha256: createHash("sha256").update(content).digest("hex"),
+      bytes: content.byteLength,
       mtimeMs,
     };
-    await writeFile(filePath, newContent);
-    await utimes(filePath, mtimeMs / 1000, mtimeMs / 1000);
 
     const { service } = makeService();
+    let digestReads = 0;
     (service as unknown as {
       orchestrator: {
         config: PluginConfig;
@@ -218,6 +216,7 @@ test("offlineSyncSnapshot ignores client capture time for server fast-base scans
         return readFile(targetPath);
       },
       async digestOfflineSyncFile(targetPath: string) {
+        digestReads += 1;
         const content = await readFile(targetPath);
         return {
           sha256: createHash("sha256").update(content).digest("hex"),
@@ -234,7 +233,8 @@ test("offlineSyncSnapshot ignores client capture time for server fast-base scans
       baseCapturedAt: new Date(Date.now() + 60_000),
     });
 
-    assert.equal(snapshot.files[0]?.sha256, createHash("sha256").update(newContent).digest("hex"));
+    assert.equal(digestReads, 1);
+    assert.deepEqual(snapshot.files, [baseFile]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5611,7 +5611,7 @@ export class EngramAccessService {
   }
 
   async offlineSyncSnapshot(
-    options: EngramAccessOfflineSyncSnapshotRequest = {},
+    options: EngramAccessOfflineSyncSnapshotRequest & { signal?: AbortSignal } = {},
   ): Promise<EngramAccessOfflineSyncSnapshotResponse> {
     const resolvedNamespace = this.resolveReadableNamespace(options.namespace, options.principal);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
@@ -5623,12 +5623,11 @@ export class EngramAccessService {
       root: storage.dir,
       sourceId: `remnic:${resolvedNamespace}:${storageHash}`,
       ...(options.baseFiles && options.baseFiles.length > 0 ? { baseFiles: options.baseFiles } : {}),
-      // Client clocks are not authoritative for server-side ctime reuse. A
-      // future client timestamp can hide same-size, preserved-mtime rewrites.
       includeContent: options.includeContent !== false,
       includeTranscripts: options.includeTranscripts !== false,
       readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
       readFileDigest: async ({ filePath }) => storage.digestOfflineSyncFile(filePath),
+      signal: options.signal,
     });
     return {
       namespace: resolvedNamespace,
@@ -5637,7 +5636,7 @@ export class EngramAccessService {
   }
 
   async offlineSyncSnapshotStream(
-    options: Omit<EngramAccessOfflineSyncSnapshotRequest, "baseCapturedAt" | "baseFiles"> = {},
+    options: Omit<EngramAccessOfflineSyncSnapshotRequest, "baseCapturedAt" | "baseFiles"> & { signal?: AbortSignal } = {},
   ): Promise<EngramAccessOfflineSyncSnapshotStreamResponse> {
     const resolvedNamespace = this.resolveReadableNamespace(options.namespace, options.principal);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
@@ -5655,6 +5654,7 @@ export class EngramAccessService {
         includeTranscripts: options.includeTranscripts !== false,
         readFile: async ({ filePath }) => storage.readOfflineSyncFile(filePath),
         readFileDigest: async ({ filePath }) => storage.digestOfflineSyncFile(filePath),
+        signal: options.signal,
       }),
     };
   }

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -7,6 +7,7 @@ import type { PluginConfig, QmdSearchResult } from "../types.js";
 class FakeBackend implements SearchBackend {
   updates = 0;
   calls: Array<{ method: string; collection: string | undefined }> = [];
+  ensureSignals: Array<AbortSignal | undefined> = [];
 
   constructor(
     private readonly globalUpdate: boolean,
@@ -63,7 +64,8 @@ class FakeBackend implements SearchBackend {
 
   async embedCollection(): Promise<void> {}
 
-  async ensureCollection(): Promise<"present"> {
+  async ensureCollection(_memoryDir?: string, execution?: { signal?: AbortSignal }): Promise<"present"> {
+    this.ensureSignals.push(execution?.signal);
     return "present";
   }
 }
@@ -172,4 +174,21 @@ test("searchAcrossNamespaces passes scoped collection to backend search methods"
       mode,
     );
   }
+});
+
+test("ensureNamespaceCollection forwards abort signals to backend collection checks", async () => {
+  const backend = new FakeBackend(false);
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async (namespace: string) => ({ dir: `/tmp/remnic/${namespace}` }) },
+    () => backend,
+  );
+  const controller = new AbortController();
+
+  const state = await router.ensureNamespaceCollection("main", {
+    signal: controller.signal,
+  });
+
+  assert.equal(state, "present");
+  assert.deepEqual(backend.ensureSignals, [controller.signal]);
 });

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -144,8 +144,11 @@ export class NamespaceSearchRouter {
     );
   }
 
-  async ensureNamespaceCollection(namespace: string): Promise<"present" | "missing" | "unknown" | "skipped"> {
-    const record = await this.backendRecordFor(namespace);
+  async ensureNamespaceCollection(
+    namespace: string,
+    execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped"> {
+    const record = await this.backendRecordFor(namespace, execution);
     return record.collectionState;
   }
 
@@ -168,7 +171,10 @@ export class NamespaceSearchRouter {
     );
   }
 
-  private async backendRecordFor(namespace: string): Promise<NamespaceBackendRecord> {
+  private async backendRecordFor(
+    namespace: string,
+    execution?: SearchExecutionOptions,
+  ): Promise<NamespaceBackendRecord> {
     const key = namespace.trim() || this.config.defaultNamespace;
     const existing = this.cache.get(key);
     if (existing) return await existing;
@@ -189,7 +195,7 @@ export class NamespaceSearchRouter {
       const backend = this.createBackend(scopedConfig);
       const available = await backend.probe().catch(() => false);
       const collectionState = available
-        ? await backend.ensureCollection(storage.dir).catch(() => "unknown" as const)
+        ? await backend.ensureCollection(storage.dir, execution).catch(() => "unknown" as const)
         : "unknown";
       return {
         backend,

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -16,6 +16,7 @@ import {
   buildOfflineSyncSnapshotForPaths,
   OFFLINE_SYNC_MAX_MTIME_MS,
   readOfflineSyncFileContentChunk,
+  shouldPreferIncomingOfflineRuntimeFile,
   summarizeOfflineSyncPendingChanges,
   summarizeOfflineSyncPendingFiles,
 } from "./offline-sync.js";
@@ -104,6 +105,32 @@ test("offline snapshot captures source-of-truth files and excludes private/inter
         "state/lcm.sqlite-shm",
         "state/lcm.sqlite-wal",
       ],
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline snapshot abort signal stops filesystem snapshot work", async () => {
+  const root = await tempDir("remnic-offline-snapshot-abort");
+  try {
+    await write(root, "facts/a.md", "alpha");
+    const controller = new AbortController();
+
+    await assert.rejects(
+      buildOfflineSyncSnapshot({
+        root,
+        sourceId: "remote",
+        signal: controller.signal,
+        readFileDigest: async () => {
+          controller.abort();
+          return {
+            sha256: createHash("sha256").update("alpha").digest("hex"),
+            bytes: Buffer.byteLength("alpha"),
+          };
+        },
+      }),
+      /offline sync request aborted/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -313,7 +340,7 @@ test("offline snapshot from base avoids rehashing unchanged files", async () => 
       sourceId: "remote",
       includeContent: false,
     });
-    const baseCapturedAt = new Date(Date.now() + 60_000);
+    const baseCapturedAt = new Date();
     let readCount = 0;
 
     const unchanged = await buildOfflineSyncSnapshotFromBase({
@@ -438,7 +465,7 @@ test("offline snapshot from base trusts mtime precision drift without rehashing"
       root,
       sourceId: "remote",
       baseFiles: [driftedBase],
-      baseCapturedAt: new Date(Date.now() + 60_000),
+      baseCapturedAt: new Date(),
       includeContent: false,
       readFileDigest: async () => {
         throw new Error("unchanged file should reuse trusted mtime metadata");
@@ -446,6 +473,47 @@ test("offline snapshot from base trusts mtime precision drift without rehashing"
     });
 
     assert.deepEqual(reused.files, [driftedBase]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("offline snapshot from base rehashes metadata-only ctime churn", async () => {
+  const root = await tempDir("remnic-offline-fast-base-ctime-only");
+  try {
+    await write(root, "facts/a.md", "alpha");
+    const filePath = path.join(root, "facts/a.md");
+    const baseSnapshot = await buildOfflineSyncSnapshot({
+      root,
+      sourceId: "remote",
+      includeContent: false,
+    });
+    const baseFile = baseSnapshot.files.find((file) => file.path === "facts/a.md");
+    assert.ok(baseFile);
+    const baseCapturedAt = new Date();
+    await new Promise<void>((resolve) => setTimeout(resolve, 1_100));
+    await chmod(filePath, 0o600);
+    await chmod(filePath, 0o644);
+
+    let digestReadCount = 0;
+    const rehashed = await buildOfflineSyncSnapshotFromBase({
+      root,
+      sourceId: "remote",
+      baseFiles: baseSnapshot.files,
+      baseCapturedAt,
+      includeContent: false,
+      readFileDigest: async ({ filePath }) => {
+        digestReadCount += 1;
+        const bytes = await readFile(filePath);
+        return {
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+          bytes: bytes.byteLength,
+        };
+      },
+    });
+
+    assert.equal(digestReadCount, 1);
+    assert.equal(rehashed.files[0]?.sha256, baseFile.sha256);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -463,6 +531,8 @@ test("offline snapshot from base rehashes preserved-mtime rewrites when ctime ch
     });
     const baseFile = baseSnapshot.files[0];
     assert.ok(baseFile);
+    const baseCapturedAt = new Date();
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
     await write(root, "facts/a.md", "bravo");
     await utimes(filePath, baseFile.mtimeMs / 1000, baseFile.mtimeMs / 1000);
 
@@ -471,7 +541,7 @@ test("offline snapshot from base rehashes preserved-mtime rewrites when ctime ch
       root,
       sourceId: "remote",
       baseFiles: baseSnapshot.files,
-      baseCapturedAt: new Date(0),
+      baseCapturedAt,
       includeContent: false,
       readFileDigest: async ({ filePath }) => {
         digestReadCount += 1;
@@ -525,7 +595,7 @@ test("offline snapshot apply preserves incoming mtime for future fast-base reuse
       root,
       sourceId: "local",
       baseFiles: applied.nextBaseFiles,
-      baseCapturedAt: new Date(capturedAtMs),
+      baseCapturedAt: new Date(),
       includeContent: false,
       readFileDigest: async () => {
         throw new Error("applied file should reuse preserved mtime metadata");
@@ -1526,6 +1596,50 @@ test("offline pull skips local runtime drift when remote still matches base", as
   }
 });
 
+test("offline pull treats last intent as remote-authoritative runtime state", async () => {
+  const root = await tempDir("remnic-offline-runtime-last-intent");
+  try {
+    const relPath = "state/last_intent.json";
+    const baseContent = Buffer.from("{\"intent\":\"base\"}");
+    const localContent = Buffer.from("{\"intent\":\"local\"}");
+    const remoteContent = Buffer.from("{\"intent\":\"remote\"}");
+    await write(root, relPath, localContent);
+    const baseFile = {
+      path: relPath,
+      sha256: createHash("sha256").update(baseContent).digest("hex"),
+      bytes: baseContent.byteLength,
+      mtimeMs: 1,
+    };
+    const incomingFile = {
+      path: relPath,
+      sha256: createHash("sha256").update(remoteContent).digest("hex"),
+      bytes: remoteContent.byteLength,
+      mtimeMs: 2,
+      contentBase64: remoteContent.toString("base64"),
+    };
+
+    assert.equal(shouldPreferIncomingOfflineRuntimeFile(relPath), true);
+    const pull = await applyOfflineSyncSnapshot({
+      root,
+      snapshot: {
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: new Date().toISOString(),
+        sourceId: "remote",
+        includeTranscripts: true,
+        files: [incomingFile],
+      },
+      baseFiles: [baseFile],
+    });
+
+    assert.equal(pull.upserted, 1);
+    assert.equal(pull.conflicts.length, 0);
+    assert.equal(await readUtf8(root, relPath), remoteContent.toString("utf-8"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline pull applies snapshots with content only for remote-changed files", async () => {
   const remote = await tempDir("remnic-offline-partial-remote");
   const local = await tempDir("remnic-offline-partial-local");
@@ -2108,14 +2222,13 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
   }
 });
 
-test("offline snapshot fast-base rehashes when encrypted header probe fails", async () => {
-  const root = await tempDir("remnic-offline-fast-base-probe-error");
+test("offline snapshot fast-base does not probe file headers for trusted metadata", async () => {
+  const root = await tempDir("remnic-offline-fast-base-no-header-probe");
   const relPath = "facts/same-size.md";
-  const oldContent = Buffer.from("old!");
-  const newContent = Buffer.from("new!");
+  const content = Buffer.from("fact");
   const filePath = path.join(root, relPath);
   try {
-    await write(root, relPath, newContent);
+    await write(root, relPath, content);
     await chmod(filePath, 0o000);
     const st = await stat(filePath);
     let digestReads = 0;
@@ -2125,24 +2238,21 @@ test("offline snapshot fast-base rehashes when encrypted header probe fails", as
       sourceId: "remote",
       baseFiles: [{
         path: relPath,
-        sha256: createHash("sha256").update(oldContent).digest("hex"),
-        bytes: newContent.byteLength,
+        sha256: createHash("sha256").update(content).digest("hex"),
+        bytes: content.byteLength,
         mtimeMs: st.mtimeMs,
       }],
-      baseCapturedAt: new Date(),
+      baseCapturedAt: new Date(Date.now() + 60_000),
       readFileDigest: async ({ path: targetPath, filePath: targetFilePath }) => {
         assert.equal(targetPath, relPath);
         assert.equal(targetFilePath, filePath);
         digestReads += 1;
-        return {
-          sha256: createHash("sha256").update(newContent).digest("hex"),
-          bytes: newContent.byteLength,
-        };
+        throw new Error("trusted metadata should not read the file header or digest");
       },
     });
 
-    assert.equal(digestReads, 1);
-    assert.equal(snapshot.files[0]?.sha256, createHash("sha256").update(newContent).digest("hex"));
+    assert.equal(digestReads, 0);
+    assert.equal(snapshot.files[0]?.sha256, createHash("sha256").update(content).digest("hex"));
   } finally {
     await chmod(filePath, 0o600).catch(() => {});
     await rm(root, { recursive: true, force: true });

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -183,11 +183,13 @@ interface OfflineSyncFileRecordOptions {
   includeContent: boolean;
   readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
   readFileDigest?: (target: OfflineSyncFileTarget) => Promise<OfflineSyncFileDigest>;
+  signal?: AbortSignal;
 }
 
 const SYNC_INTERNAL_DIR = ".offline-sync";
 const OFFLINE_SYNC_UPLOAD_STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const OFFLINE_SYNC_FAST_BASE_MTIME_TOLERANCE_MS = 1_000;
+const OFFLINE_SYNC_FAST_BASE_CTIME_TOLERANCE_MS = 1;
 const EXCLUDED_FILE_NAMES = new Set([
   ".sync-state.json",
 ]);
@@ -203,6 +205,11 @@ function hashText(value: string): string {
 
 function sha256Buffer(buffer: Buffer): { sha256: string; bytes: number } {
   return sha256Bytes(buffer);
+}
+
+function throwIfOfflineSyncAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  throw new Error("offline sync request aborted");
 }
 
 function compareByPath<T extends { path: string }>(left: T, right: T): number {
@@ -480,6 +487,7 @@ const REMOTE_AUTHORITATIVE_RUNTIME_STATE_FILES = new Set([
   "buffer.json",
   "embeddings.json",
   "index_time.json",
+  "last_intent.json",
   "last_recall.json",
   "memory-lifecycle-ledger.jsonl",
   "recall_impressions.jsonl",
@@ -508,22 +516,23 @@ function canReuseFastBaseFileState(
     return false;
   }
   if (baseCapturedAtMs === null) return false;
-  return st.ctimeMs - baseCapturedAtMs <= OFFLINE_SYNC_FAST_BASE_MTIME_TOLERANCE_MS;
+  // Node reports stat times as fractional milliseconds while Date snapshots are
+  // whole milliseconds, so allow only a tiny precision window around capture.
+  return st.ctimeMs - baseCapturedAtMs <= OFFLINE_SYNC_FAST_BASE_CTIME_TOLERANCE_MS;
 }
 
 async function canReuseFastBaseFileStateFromDisk(
   baseEntry: OfflineSyncFileState,
-  filePath: string,
   st: { size: number; mtimeMs: number; ctimeMs: number },
   baseCapturedAtMs: number | null,
 ): Promise<boolean> {
-  if (!canReuseFastBaseFileState(baseEntry, st, baseCapturedAtMs)) return false;
-  return !(await fileIsSecureStoreEncrypted(filePath).catch(() => true));
+  return canReuseFastBaseFileState(baseEntry, st, baseCapturedAtMs);
 }
 
 async function readOfflineSyncFileRecord(
   options: OfflineSyncFileRecordOptions,
 ): Promise<OfflineSyncFileRecord> {
+  throwIfOfflineSyncAborted(options.signal);
   const relPath = validateArchiveRelativePath(options.relPath, "offlineSyncFile.path");
   let content: Buffer | null = null;
   let digest: OfflineSyncFileDigest;
@@ -531,16 +540,20 @@ async function readOfflineSyncFileRecord(
     content = options.readFile
       ? await options.readFile({ root: options.root.abs, path: relPath, filePath: options.filePath })
       : await readFile(options.filePath);
+    throwIfOfflineSyncAborted(options.signal);
     digest = sha256Buffer(content);
   } else if (options.readFileDigest) {
     digest = await options.readFileDigest({ root: options.root.abs, path: relPath, filePath: options.filePath });
+    throwIfOfflineSyncAborted(options.signal);
   } else if (options.readFile) {
     content = await options.readFile({ root: options.root.abs, path: relPath, filePath: options.filePath });
+    throwIfOfflineSyncAborted(options.signal);
     digest = sha256Buffer(content);
     content = null;
   } else {
-    digest = await sha256File(options.filePath);
+    digest = await sha256File(options.filePath, options.signal);
   }
+  throwIfOfflineSyncAborted(options.signal);
   const st = await stat(options.filePath);
   return {
     path: relPath,
@@ -551,14 +564,16 @@ async function readOfflineSyncFileRecord(
   };
 }
 
-async function sha256File(filePath: string): Promise<OfflineSyncFileDigest> {
+async function sha256File(filePath: string, signal?: AbortSignal): Promise<OfflineSyncFileDigest> {
   const hash = createHash("sha256");
   let bytes = 0;
   for await (const chunk of createReadStream(filePath)) {
+    throwIfOfflineSyncAborted(signal);
     const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
     hash.update(buffer);
     bytes += buffer.length;
   }
+  throwIfOfflineSyncAborted(signal);
   return {
     sha256: hash.digest("hex"),
     bytes,
@@ -600,15 +615,19 @@ export async function* iterateOfflineSyncSnapshotFileRecords(options: {
   includeTranscripts?: boolean;
   readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
   readFileDigest?: (target: OfflineSyncFileTarget) => Promise<OfflineSyncFileDigest>;
+  signal?: AbortSignal;
 }): AsyncIterable<OfflineSyncFileRecord> {
+  throwIfOfflineSyncAborted(options.signal);
   const rootAbs = path.resolve(options.root);
   const root = await prepareSafeArchiveRoot(rootAbs, "iterateOfflineSyncSnapshotFileRecords", "root");
   const includeTranscripts = options.includeTranscripts !== false;
 
   async function* walk(dirAbs: string): AsyncIterable<OfflineSyncFileRecord> {
+    throwIfOfflineSyncAborted(options.signal);
     let entries = await readdir(dirAbs, { withFileTypes: true });
     entries = entries.sort((left, right) => left.name.localeCompare(right.name));
     for (const entry of entries) {
+      throwIfOfflineSyncAborted(options.signal);
       const abs = path.join(dirAbs, entry.name);
       const relPosix = path.relative(root.abs, abs).split(path.sep).join("/");
       if (shouldExcludeRelPath(relPosix, includeTranscripts)) continue;
@@ -625,6 +644,7 @@ export async function* iterateOfflineSyncSnapshotFileRecords(options: {
         includeContent: options.includeContent === true,
         readFile: options.readFile,
         readFileDigest: options.readFileDigest,
+        signal: options.signal,
       });
     }
   }
@@ -640,10 +660,13 @@ export async function buildOfflineSyncSnapshot(options: {
   now?: Date;
   readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
   readFileDigest?: (target: OfflineSyncFileTarget) => Promise<OfflineSyncFileDigest>;
+  signal?: AbortSignal;
 }): Promise<OfflineSyncSnapshot> {
+  throwIfOfflineSyncAborted(options.signal);
   const includeTranscripts = options.includeTranscripts !== false;
   const files: OfflineSyncFileRecord[] = [];
   for await (const file of iterateOfflineSyncSnapshotFileRecords(options)) files.push(file);
+  throwIfOfflineSyncAborted(options.signal);
 
   return {
     format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
@@ -665,7 +688,9 @@ export async function buildOfflineSyncSnapshotFromBase(options: {
   now?: Date;
   readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
   readFileDigest?: (target: OfflineSyncFileTarget) => Promise<OfflineSyncFileDigest>;
+  signal?: AbortSignal;
 }): Promise<OfflineSyncSnapshot> {
+  throwIfOfflineSyncAborted(options.signal);
   const rootAbs = path.resolve(options.root);
   const root = await prepareSafeArchiveRoot(rootAbs, "buildOfflineSyncSnapshotFromBase", "root");
   const includeTranscripts = options.includeTranscripts !== false;
@@ -680,9 +705,11 @@ export async function buildOfflineSyncSnapshotFromBase(options: {
   const files: OfflineSyncFileRecord[] = [];
 
   async function walk(dirAbs: string): Promise<void> {
+    throwIfOfflineSyncAborted(options.signal);
     let entries = await readdir(dirAbs, { withFileTypes: true });
     entries = entries.sort((left, right) => left.name.localeCompare(right.name));
     for (const entry of entries) {
+      throwIfOfflineSyncAborted(options.signal);
       const abs = path.join(dirAbs, entry.name);
       const relPosix = path.relative(root.abs, abs).split(path.sep).join("/");
       if (shouldExcludeRelPath(relPosix, includeTranscripts)) continue;
@@ -698,7 +725,7 @@ export async function buildOfflineSyncSnapshotFromBase(options: {
         options.includeContent !== true &&
         baseEntry &&
         baseCapturedAtMs !== null &&
-        await canReuseFastBaseFileStateFromDisk(baseEntry, abs, st, baseCapturedAtMs)
+        await canReuseFastBaseFileStateFromDisk(baseEntry, st, baseCapturedAtMs)
       ) {
         files.push(baseEntry);
         continue;
@@ -710,11 +737,13 @@ export async function buildOfflineSyncSnapshotFromBase(options: {
         includeContent: options.includeContent === true,
         readFile: options.readFile,
         readFileDigest: options.readFileDigest,
+        signal: options.signal,
       }));
     }
   }
 
   await walk(root.abs);
+  throwIfOfflineSyncAborted(options.signal);
 
   return {
     format: OFFLINE_SYNC_SNAPSHOT_FORMAT,
@@ -735,7 +764,9 @@ export async function buildOfflineSyncSnapshotForPaths(options: {
   now?: Date;
   readFile?: (target: OfflineSyncFileTarget) => Promise<Buffer>;
   readFileDigest?: (target: OfflineSyncFileTarget) => Promise<OfflineSyncFileDigest>;
+  signal?: AbortSignal;
 }): Promise<OfflineSyncSnapshot> {
+  throwIfOfflineSyncAborted(options.signal);
   const rootAbs = path.resolve(options.root);
   const root = await prepareSafeArchiveRoot(rootAbs, "buildOfflineSyncSnapshotForPaths", "root");
   const includeTranscripts = options.includeTranscripts !== false;
@@ -743,6 +774,7 @@ export async function buildOfflineSyncSnapshotForPaths(options: {
   const seen = new Set<string>();
 
   for (const rawPath of options.paths) {
+    throwIfOfflineSyncAborted(options.signal);
     const relPath = normalizeRelativePath(rawPath, "paths[]");
     if (seen.has(relPath)) continue;
     seen.add(relPath);
@@ -762,8 +794,10 @@ export async function buildOfflineSyncSnapshotForPaths(options: {
       includeContent: options.includeContent === true,
       readFile: options.readFile,
       readFileDigest: options.readFileDigest,
+      signal: options.signal,
     }));
   }
+  throwIfOfflineSyncAborted(options.signal);
 
   return {
     format: OFFLINE_SYNC_SNAPSHOT_FORMAT,

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -87,7 +87,10 @@ function resolveOpenClawRemnicPluginEntry(raw: unknown): Record<string, unknown>
 interface QmdRuntimeLike {
   probe(): Promise<boolean>;
   isAvailable(): boolean;
-  ensureCollection(memoryDir: string): Promise<"present" | "missing" | "unknown" | "skipped">;
+  ensureCollection(
+    memoryDir: string,
+    execution?: { signal?: AbortSignal },
+  ): Promise<"present" | "missing" | "unknown" | "skipped">;
   debugStatus(): string;
 }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -680,6 +680,56 @@ async function raceRecallAbort<T>(
 
 /** Maximum age (ms) before a compaction-reset signal file is considered stale and removed. */
 const COMPACTION_SIGNAL_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
+const DEFAULT_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS = 10_000;
+
+type SearchCollectionState = "present" | "missing" | "unknown" | "skipped";
+
+function qmdStartupCollectionCheckTimeoutMs(): number {
+  const raw =
+    process.env.REMNIC_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS ??
+    process.env.ENGRAM_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS;
+  if (raw === undefined) return DEFAULT_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 1_000
+    ? Math.floor(parsed)
+    : DEFAULT_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS;
+}
+
+async function qmdStartupCollectionCheckWithTimeout(
+  promise: Promise<SearchCollectionState>,
+  controller: AbortController,
+  label: string,
+): Promise<SearchCollectionState> {
+  const timeoutMs = qmdStartupCollectionCheckTimeoutMs();
+  let timer: NodeJS.Timeout | undefined;
+  let settled = false;
+
+  const timeoutPromise = new Promise<SearchCollectionState>((resolve) => {
+    timer = setTimeout(() => {
+      if (settled) return;
+      controller.abort();
+      log.warn(
+        `QMD startup collection check for ${label} timed out after ${timeoutMs}ms; keeping search enabled fail-open`,
+      );
+      resolve("unknown");
+    }, timeoutMs);
+    timer.unref?.();
+  });
+
+  const checkedPromise = promise
+    .catch((err): SearchCollectionState => {
+      log.warn(
+        `QMD startup collection check for ${label} failed; keeping search enabled fail-open: ${err}`,
+      );
+      return "unknown";
+    })
+    .finally(() => {
+      settled = true;
+      if (timer) clearTimeout(timer);
+    });
+
+  return await Promise.race([checkedPromise, timeoutPromise]);
+}
 
 /** Default workspace directory when no per-agent or config workspace is available. */
 export function defaultWorkspaceDir(): string {
@@ -2453,14 +2503,22 @@ export class Orchestrator {
             ? this.configuredNamespaces()
             : [this.config.defaultNamespace];
           const states = await Promise.all(
-            namespaces.map(async (namespace) => ({
-              namespace,
-              state: this.config.namespacesEnabled
-                ? await this.namespaceSearchRouter.ensureNamespaceCollection(
-                    namespace,
-                  )
-                : await this.qmd.ensureCollection(this.config.memoryDir),
-            })),
+            namespaces.map(async (namespace) => {
+              const collectionCheckAbort = new AbortController();
+              const state = await qmdStartupCollectionCheckWithTimeout(
+                this.config.namespacesEnabled
+                  ? this.namespaceSearchRouter.ensureNamespaceCollection(
+                      namespace,
+                      { signal: collectionCheckAbort.signal },
+                    )
+                  : this.qmd.ensureCollection(this.config.memoryDir, {
+                      signal: collectionCheckAbort.signal,
+                    }),
+                collectionCheckAbort,
+                namespace,
+              );
+              return { namespace, state };
+            }),
           );
           const defaultState =
             states.find(
@@ -2800,8 +2858,8 @@ export class Orchestrator {
       namespaces.map(async (namespace) => ({
         namespace,
         state: this.config.namespacesEnabled
-          ? await this.namespaceSearchRouter.ensureNamespaceCollection(namespace)
-          : await this.qmd.ensureCollection(this.config.memoryDir),
+          ? await this.namespaceSearchRouter.ensureNamespaceCollection(namespace, { signal })
+          : await this.qmd.ensureCollection(this.config.memoryDir, { signal }),
       })),
     );
 

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -2595,12 +2595,15 @@ export class QmdClient implements SearchBackend {
     }
   }
 
-  async ensureCollection(memoryDir: string): Promise<"present" | "missing" | "unknown" | "skipped"> {
+  async ensureCollection(
+    memoryDir: string,
+    execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped"> {
     if (this.available === false && !this.daemonAvailable) return "unknown";
     // If only daemon is available (no CLI), skip collection check
     if (this.available === false) return "skipped";
     try {
-      const { stdout } = await this.runQmdCommand(["collection", "list"], QMD_TIMEOUT_MS);
+      const { stdout } = await this.runQmdCommand(["collection", "list"], QMD_TIMEOUT_MS, execution?.signal);
       // Parse text output: "openclaw-engram (qmd://openclaw-engram/)"
       const collectionRegex = new RegExp(
         `^${this.collection}\\s+\\(qmd://`,

--- a/packages/remnic-core/src/search/lancedb-backend.ts
+++ b/packages/remnic-core/src/search/lancedb-backend.ts
@@ -218,7 +218,10 @@ export class LanceDbBackend implements SearchBackend {
     }
   }
 
-  async ensureCollection(_memoryDir: string): Promise<"present" | "missing" | "unknown" | "skipped"> {
+  async ensureCollection(
+    _memoryDir: string,
+    _execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped"> {
     try {
       await this.ensureTable();
       return "present";

--- a/packages/remnic-core/src/search/meilisearch-backend.ts
+++ b/packages/remnic-core/src/search/meilisearch-backend.ts
@@ -189,7 +189,10 @@ export class MeilisearchBackend implements SearchBackend {
     // manages embeddings server-side per index (collection).
   }
 
-  async ensureCollection(_memoryDir: string): Promise<"present" | "missing" | "unknown" | "skipped"> {
+  async ensureCollection(
+    _memoryDir: string,
+    _execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped"> {
     if (!this.available) return "skipped";
     try {
       const client = await this.ensureClient();

--- a/packages/remnic-core/src/search/noop-backend.ts
+++ b/packages/remnic-core/src/search/noop-backend.ts
@@ -51,7 +51,7 @@ export class NoopSearchBackend implements SearchBackend {
   async embed(): Promise<void> {}
   async embedCollection(_collection: string): Promise<void> {}
 
-  async ensureCollection(_memoryDir: string): Promise<"skipped"> {
+  async ensureCollection(_memoryDir: string, _execution?: SearchExecutionOptions): Promise<"skipped"> {
     return "skipped";
   }
 }

--- a/packages/remnic-core/src/search/orama-backend.ts
+++ b/packages/remnic-core/src/search/orama-backend.ts
@@ -251,7 +251,10 @@ export class OramaBackend implements SearchBackend {
     await this.persistDbForCollection(db, collection);
   }
 
-  async ensureCollection(_memoryDir: string): Promise<"present" | "missing" | "unknown" | "skipped"> {
+  async ensureCollection(
+    _memoryDir: string,
+    _execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped"> {
     try {
       await this.ensureModules();
       await this.ensureDb();

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -82,5 +82,8 @@ export interface SearchBackend {
   embedCollection(collection: string): Promise<void>;
 
   // ── Collection management ──
-  ensureCollection(memoryDir: string): Promise<"present" | "missing" | "unknown" | "skipped">;
+  ensureCollection(
+    memoryDir: string,
+    execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped">;
 }

--- a/packages/remnic-core/src/search/remote-backend.ts
+++ b/packages/remnic-core/src/search/remote-backend.ts
@@ -82,7 +82,7 @@ export class RemoteSearchBackend implements SearchBackend {
   async embed(): Promise<void> {}
   async embedCollection(_collection: string): Promise<void> {}
 
-  async ensureCollection(_memoryDir: string): Promise<"skipped"> {
+  async ensureCollection(_memoryDir: string, _execution?: SearchExecutionOptions): Promise<"skipped"> {
     return "skipped";
   }
 

--- a/tests/offline-sync-cli-batching.test.ts
+++ b/tests/offline-sync-cli-batching.test.ts
@@ -69,6 +69,8 @@ function compressibleBaseFiles(count: number): OfflineSyncFileState[] {
     file(`facts/${String(index).padStart(6, "0")}-${pathPadding}.md`, index + 1));
 }
 
+const COMPRESSIBLE_FAST_BASE_POST_FILE_COUNT = 40_000;
+
 test("offline sync file content batches are bounded by expected bytes", () => {
   const batches = chunkOfflineFileContentBatches([
     file("facts/a.md", 5 * 1024 * 1024),
@@ -292,7 +294,7 @@ test("offline sync snapshot post falls back when base payload is too large", () 
 test("offline sync compresses oversized fast-base payloads before stream fallback", async () => {
   const originalFetch = globalThis.fetch;
   try {
-    const baseFiles = compressibleBaseFiles(OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES - 1);
+    const baseFiles = compressibleBaseFiles(COMPRESSIBLE_FAST_BASE_POST_FILE_COUNT);
     const remoteFile = file("facts/remote.md", 42, "b");
     const calls: string[] = [];
     globalThis.fetch = (async (input, init) => {
@@ -341,7 +343,7 @@ test("offline sync compresses oversized fast-base payloads before stream fallbac
 test("offline sync falls back to stream when compressed fast-base POST is unsupported", async () => {
   const originalFetch = globalThis.fetch;
   try {
-    const baseFiles = compressibleBaseFiles(OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES - 1);
+    const baseFiles = compressibleBaseFiles(COMPRESSIBLE_FAST_BASE_POST_FILE_COUNT);
     const remoteFile = file("facts/remote.md", 42, "b");
     const calls: string[] = [];
     globalThis.fetch = (async (input, init) => {


### PR DESCRIPTION
## Summary
- propagate offline snapshot request aborts through HTTP/core snapshot builders and backend collection checks
- make large-base snapshots reuse trusted base metadata via mtime without per-file secure-store header probes
- retry/defer volatile live content during hydration, treat last_intent as remote-authoritative runtime state, and allow large base-aware POST snapshots
- bound QMD startup collection checks so Remnic daemons can bind HTTP even when QMD collection listing is slow or wedged

## Validation
- `pnpm --filter @remnic/core exec tsx --test src/offline-sync.test.ts`
- `pnpm --filter @remnic/core exec tsx --test src/access-service-namespace.test.ts`
- `pnpm --filter @remnic/core exec tsx --test src/namespaces/search.test.ts`
- `pnpm --filter @remnic/core run check-types`
- `pnpm --filter @remnic/cli exec tsx --test src/offline-sync-hydrate.test.ts`
- `pnpm --filter @remnic/cli run check-types`
- `npm run preflight:quick`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches offline sync correctness, snapshot fast-path metadata, and pull semantics for runtime state; changes are defensive but affect how local and remote memory converge.
> 
> **Overview**
> **Hardens offline sync and startup** for large, live memory bases so clients and servers stay responsive and converge more reliably.
> 
> Offline snapshot work now **honors request abort** end-to-end (HTTP disconnect → service → filesystem walks/digests), and the CLI adds a **dedicated timeout** on base-aware snapshot POSTs with **stream fallback** on timeout, pre-response failures, and aborts. **`--remote`** is accepted as an alias for **`--remote-url`**.
> 
> **Fast-base snapshot reuse** no longer trusts future client `baseCapturedAt` clocks or per-file secure-store header probes; reuse keys off **mtime/ctime** with tighter ctime tolerance, and tests cover ctime-only churn and preserved-mtime rewrites. **`last_intent.json`** is treated as **remote-authoritative** runtime state on pull (like other canonical state files).
> 
> CLI **hydration** retries omitted file content (bounded delay), surfaces clearer missing-path errors, and can **defer** missing live **profiling** paths instead of failing the whole sync.
> 
> **QMD startup collection checks** are bounded (env-configurable timeout, abort forwarded through `ensureCollection`) so a slow `collection list` does not block the daemon from binding HTTP.
> 
> Also bumps workspace/plugin versions to **9.3.515** and adds focused hydrate/offline tests; root `package.json` formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa8014a3cab480979458dab17c71ea9f4b2f413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->