### PR TITLE
Harden offline sync against runtime churn

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -6031,6 +6031,40 @@ interface OfflineFileContentChunk {
   content: Buffer;
 }
 
+const APPEND_TOLERANT_RUNTIME_STATE_FILES = new Set([
+  "memory-lifecycle-ledger.jsonl",
+  "recall_impressions.jsonl",
+]);
+
+function isAppendTolerantOfflineRuntimeFile(relPath: string): boolean {
+  if (!shouldPreferIncomingOfflineRuntimeFile(relPath)) return false;
+  const parts = relPath.split("/");
+  const basename = parts[parts.length - 1] ?? "";
+  return APPEND_TOLERANT_RUNTIME_STATE_FILES.has(basename);
+}
+
+function offlineFileContentChunkMatchesExpected(options: {
+  chunk: OfflineFileContentChunk;
+  expected: OfflineSyncFileState;
+  offset: number;
+}): boolean {
+  const { chunk, expected, offset } = options;
+  if (chunk.path !== expected.path) return false;
+  if (chunk.offset !== offset) return false;
+  if (chunk.chunkBytes !== chunk.content.length) return false;
+  if (offset + chunk.chunkBytes > expected.bytes) return false;
+  if (
+    chunk.bytes === expected.bytes &&
+    chunk.mtimeMs === expected.mtimeMs &&
+    (chunk.sha256 === undefined || chunk.sha256 === expected.sha256)
+  ) {
+    return true;
+  }
+  if (!isAppendTolerantOfflineRuntimeFile(expected.path)) return false;
+  if (chunk.bytes < expected.bytes) return false;
+  return true;
+}
+
 const OFFLINE_SYNC_DIRECT_DEFAULT_MIN_BYTES = 16 * 1024 * 1024;
 const OFFLINE_SYNC_FILES_CONTENT_MAX_BATCH_BYTES = 8 * 1024 * 1024;
 export const OFFLINE_SYNC_APPLY_MAX_REQUEST_BYTES = Math.floor(OFFLINE_SYNC_APPLY_MAX_BODY_BYTES / 2);
@@ -6061,6 +6095,11 @@ class OfflineRemoteFileChangedError extends Error {
 function isOfflineRemoteFileChangedError(error: unknown): error is OfflineRemoteFileChangedError {
   return error instanceof OfflineRemoteFileChangedError ||
     (error instanceof Error && error.message.startsWith("remote file changed while fetching offline content: "));
+}
+
+function isOfflineHydrateChecksumMismatch(error: unknown, relPath: string): boolean {
+  return error instanceof Error &&
+    error.message === `offline sync upload checksum mismatch for ${relPath}`;
 }
 
 function isOfflineLocalFileChangedError(error: unknown): boolean {
@@ -6543,14 +6582,7 @@ async function fetchOfflineFileContent(args: {
         args.expected.bytes - offset,
       ),
     });
-    if (
-      chunk.path !== args.expected.path ||
-      (chunk.sha256 !== undefined && chunk.sha256 !== args.expected.sha256) ||
-      chunk.bytes !== args.expected.bytes ||
-      chunk.mtimeMs !== args.expected.mtimeMs ||
-      chunk.offset !== offset ||
-      chunk.chunkBytes !== chunk.content.length
-    ) {
+    if (!offlineFileContentChunkMatchesExpected({ chunk, expected: args.expected, offset })) {
       throw new OfflineRemoteFileChangedError(args.expected.path);
     }
     if (chunk.chunkBytes === 0) {
@@ -6563,6 +6595,9 @@ async function fetchOfflineFileContent(args: {
   const content = Buffer.concat(chunks, offset);
   const digest = hash.digest("hex");
   if (digest !== args.expected.sha256 || content.length !== args.expected.bytes) {
+    if (isAppendTolerantOfflineRuntimeFile(args.expected.path)) {
+      throw new OfflineRemoteFileChangedError(args.expected.path);
+    }
     throw new Error(`remote offline content checksum mismatch for ${args.expected.path}`);
   }
   return content;
@@ -6598,36 +6633,39 @@ async function hydrateOfflineFileContent(args: {
         Math.max(1, args.expected.bytes - offset),
       ),
     });
-    if (
-      chunk.path !== args.expected.path ||
-      (chunk.sha256 !== undefined && chunk.sha256 !== args.expected.sha256) ||
-      chunk.bytes !== args.expected.bytes ||
-      chunk.mtimeMs !== args.expected.mtimeMs ||
-      chunk.offset !== offset ||
-      chunk.chunkBytes !== chunk.content.length
-    ) {
+    if (!offlineFileContentChunkMatchesExpected({ chunk, expected: args.expected, offset })) {
       throw new OfflineRemoteFileChangedError(args.expected.path);
     }
     if (chunk.chunkBytes === 0 && args.expected.bytes > 0) {
       throw new Error(`remote offline content chunk was empty before EOF: ${args.expected.path}`);
     }
-    finalResult = await applyOfflineSyncFileContentChunk({
-      root: args.memoryDir,
-      sourceId: args.sourceId,
-      path: args.expected.path,
-      sha256: args.expected.sha256,
-      bytes: args.expected.bytes,
-      mtimeMs: args.expected.mtimeMs,
-      offset,
-      content: chunk.content,
-      ...(args.baseSha256 ? { baseSha256: args.baseSha256 } : {}),
-      includeTranscripts: args.includeTranscripts,
-      readFile: args.readFile,
-      readFileDigest: args.readFileDigest,
-      writeFile: args.writeFile,
-      writeStagingFile: args.writeStagingFile,
-      writeFileChunks: args.writeFileChunks,
-    });
+    try {
+      finalResult = await applyOfflineSyncFileContentChunk({
+        root: args.memoryDir,
+        sourceId: args.sourceId,
+        path: args.expected.path,
+        sha256: args.expected.sha256,
+        bytes: args.expected.bytes,
+        mtimeMs: args.expected.mtimeMs,
+        offset,
+        content: chunk.content,
+        ...(args.baseSha256 ? { baseSha256: args.baseSha256 } : {}),
+        includeTranscripts: args.includeTranscripts,
+        readFile: args.readFile,
+        readFileDigest: args.readFileDigest,
+        writeFile: args.writeFile,
+        writeStagingFile: args.writeStagingFile,
+        writeFileChunks: args.writeFileChunks,
+      });
+    } catch (error) {
+      if (
+        isAppendTolerantOfflineRuntimeFile(args.expected.path) &&
+        isOfflineHydrateChecksumMismatch(error, args.expected.path)
+      ) {
+        throw new OfflineRemoteFileChangedError(args.expected.path);
+      }
+      throw error;
+    }
     if (finalResult.conflict) {
       return finalResult;
     }

--- a/packages/remnic-cli/src/offline-sync-hydrate.test.ts
+++ b/packages/remnic-cli/src/offline-sync-hydrate.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -9,6 +12,8 @@ import {
   type OfflineSyncSnapshot,
 } from "@remnic/core";
 import {
+  directHydrateLargeOfflineFiles,
+  OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES,
   OFFLINE_SYNC_SNAPSHOT_BASE_POST_MAX_FILES,
   fetchOfflineSnapshot,
   hydrateOfflineSnapshotContent,
@@ -18,7 +23,10 @@ import {
 } from "./index.js";
 
 function fileState(relPath: string, content: string, mtimeMs = 1): OfflineSyncFileState {
-  const buffer = Buffer.from(content);
+  return fileStateFromBuffer(relPath, Buffer.from(content), mtimeMs);
+}
+
+function fileStateFromBuffer(relPath: string, buffer: Buffer, mtimeMs = 1): OfflineSyncFileState {
   return {
     path: relPath,
     sha256: createHash("sha256").update(buffer).digest("hex"),
@@ -131,6 +139,217 @@ test("isOfflineMissingContentDeferrablePath recognizes namespace profiling logs"
     true,
   );
   assert.equal(isOfflineMissingContentDeferrablePath("facts/profile.md"), false);
+});
+
+test("direct hydration accepts append-only growth for remote-authoritative runtime files", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-offline-direct-hydrate-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const original = Buffer.alloc(OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES + 128, "r");
+    const appended = Buffer.concat([original, Buffer.from("\nappended-after-snapshot")]);
+    const remoteFile = fileStateFromBuffer("state/recall_impressions.jsonl", original, 10);
+    const remoteSnapshot = snapshot([remoteFile]);
+    const writeBuffer = async (filePath: string, content: Buffer): Promise<void> => {
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, content);
+    };
+
+    globalThis.fetch = (async (input, init = {}) => {
+      const url = new URL(String(input));
+      assert.equal(url.pathname, "/remnic/v1/offline-sync/file-content");
+      const body = JSON.parse(String(init.body ?? "{}")) as {
+        path?: string;
+        offset?: number;
+        length?: number;
+      };
+      assert.equal(body.path, remoteFile.path);
+      const offset = body.offset ?? 0;
+      const length = body.length ?? original.byteLength;
+      const chunk = original.subarray(offset, Math.min(original.byteLength, offset + length));
+      return new Response(new Uint8Array(chunk), {
+        status: 200,
+        headers: {
+          "x-remnic-file-path": encodeURIComponent(remoteFile.path),
+          "x-remnic-file-bytes": String(appended.byteLength),
+          "x-remnic-file-mtime-ms": "11",
+          "x-remnic-chunk-offset": String(offset),
+          "x-remnic-chunk-bytes": String(chunk.byteLength),
+        },
+      });
+    }) as typeof fetch;
+
+    const result = await directHydrateLargeOfflineFiles({
+      remoteUrl: "http://example.invalid",
+      token: "token",
+      namespace: "generalist",
+      includeTranscripts: true,
+      snapshot: remoteSnapshot,
+      baseFiles: [],
+      currentFiles: [],
+      memoryDir,
+      readFile: async ({ filePath }) => readFile(filePath),
+      writeFile: async ({ filePath, content }) => writeBuffer(filePath, content),
+      writeStagingFile: async ({ filePath, content }) => writeBuffer(filePath, content),
+      writeFileChunks: async ({ filePath, chunks }) => {
+        const buffers: Buffer[] = [];
+        for await (const chunk of chunks) buffers.push(Buffer.from(chunk));
+        await writeBuffer(filePath, Buffer.concat(buffers));
+      },
+    });
+
+    assert.deepEqual([...result.hydratedPaths], [remoteFile.path]);
+    assert.deepEqual([...result.deferredPaths], []);
+    assert.deepEqual(await readFile(path.join(memoryDir, remoteFile.path)), original);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct hydration defers append-tolerant runtime files when the prefix changes", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-offline-direct-hydrate-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const original = Buffer.alloc(OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES + 128, "r");
+    const changedPrefix = Buffer.concat([
+      Buffer.from("rewritten-prefix\n"),
+      original.subarray("rewritten-prefix\n".length),
+      Buffer.from("\nappended-after-snapshot"),
+    ]);
+    const remoteFile = fileStateFromBuffer("state/recall_impressions.jsonl", original, 10);
+    const remoteSnapshot = snapshot([remoteFile]);
+
+    globalThis.fetch = (async (input, init = {}) => {
+      const url = new URL(String(input));
+      assert.equal(url.pathname, "/remnic/v1/offline-sync/file-content");
+      const body = JSON.parse(String(init.body ?? "{}")) as {
+        path?: string;
+        offset?: number;
+        length?: number;
+      };
+      assert.equal(body.path, remoteFile.path);
+      const offset = body.offset ?? 0;
+      const length = body.length ?? original.byteLength;
+      const chunk = changedPrefix.subarray(offset, Math.min(changedPrefix.byteLength, offset + length));
+      return new Response(new Uint8Array(chunk), {
+        status: 200,
+        headers: {
+          "x-remnic-file-path": encodeURIComponent(remoteFile.path),
+          "x-remnic-file-bytes": String(changedPrefix.byteLength),
+          "x-remnic-file-mtime-ms": "11",
+          "x-remnic-chunk-offset": String(offset),
+          "x-remnic-chunk-bytes": String(chunk.byteLength),
+        },
+      });
+    }) as typeof fetch;
+
+    const result = await directHydrateLargeOfflineFiles({
+      remoteUrl: "http://example.invalid",
+      token: "token",
+      namespace: "generalist",
+      includeTranscripts: true,
+      snapshot: remoteSnapshot,
+      baseFiles: [],
+      currentFiles: [],
+      memoryDir,
+      readFile: async ({ filePath }) => readFile(filePath),
+      writeFile: async ({ filePath, content }) => {
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, content);
+      },
+      writeStagingFile: async ({ filePath, content }) => {
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, content);
+      },
+      writeFileChunks: async ({ filePath, chunks }) => {
+        const buffers: Buffer[] = [];
+        for await (const chunk of chunks) buffers.push(Buffer.from(chunk));
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, Buffer.concat(buffers));
+      },
+    });
+
+    assert.deepEqual([...result.hydratedPaths], []);
+    assert.deepEqual([...result.deferredPaths], [remoteFile.path]);
+    await assert.rejects(
+      readFile(path.join(memoryDir, remoteFile.path)),
+      /ENOENT/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("direct hydration defers changed non-append runtime files", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-offline-direct-hydrate-"));
+  const originalFetch = globalThis.fetch;
+  try {
+    const original = Buffer.alloc(OFFLINE_SYNC_DIRECT_HYDRATE_MIN_BYTES + 128, "b");
+    const changed = Buffer.concat([Buffer.from("changed-after-snapshot\n"), original]);
+    const remoteFile = fileStateFromBuffer("state/buffer.json", original, 10);
+    const remoteSnapshot = snapshot([remoteFile]);
+
+    globalThis.fetch = (async (input, init = {}) => {
+      const url = new URL(String(input));
+      assert.equal(url.pathname, "/remnic/v1/offline-sync/file-content");
+      const body = JSON.parse(String(init.body ?? "{}")) as {
+        path?: string;
+        offset?: number;
+        length?: number;
+      };
+      assert.equal(body.path, remoteFile.path);
+      const offset = body.offset ?? 0;
+      const length = body.length ?? original.byteLength;
+      const chunk = changed.subarray(offset, Math.min(changed.byteLength, offset + length));
+      return new Response(new Uint8Array(chunk), {
+        status: 200,
+        headers: {
+          "x-remnic-file-path": encodeURIComponent(remoteFile.path),
+          "x-remnic-file-bytes": String(changed.byteLength),
+          "x-remnic-file-mtime-ms": "11",
+          "x-remnic-chunk-offset": String(offset),
+          "x-remnic-chunk-bytes": String(chunk.byteLength),
+        },
+      });
+    }) as typeof fetch;
+
+    const result = await directHydrateLargeOfflineFiles({
+      remoteUrl: "http://example.invalid",
+      token: "token",
+      namespace: "generalist",
+      includeTranscripts: true,
+      snapshot: remoteSnapshot,
+      baseFiles: [],
+      currentFiles: [],
+      memoryDir,
+      readFile: async ({ filePath }) => readFile(filePath),
+      writeFile: async ({ filePath, content }) => {
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, content);
+      },
+      writeStagingFile: async ({ filePath, content }) => {
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, content);
+      },
+      writeFileChunks: async ({ filePath, chunks }) => {
+        const buffers: Buffer[] = [];
+        for await (const chunk of chunks) buffers.push(Buffer.from(chunk));
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, Buffer.concat(buffers));
+      },
+    });
+
+    assert.deepEqual([...result.hydratedPaths], []);
+    assert.deepEqual([...result.deferredPaths], [remoteFile.path]);
+    await assert.rejects(
+      readFile(path.join(memoryDir, remoteFile.path)),
+      /ENOENT/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });
 
 test("fetchOfflineSnapshot uses base-aware POST at the cached file cutoff", async () => {

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -211,6 +211,8 @@ test("offline sync includes live LCM sqlite artifacts for full-fidelity offline 
       "state/lcm.sqlite-shm",
       "state/lcm.sqlite-wal",
     ]);
+    assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/lcm.sqlite-shm"), true);
+    assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/lcm.sqlite-wal"), true);
     const focused = await buildOfflineSyncSnapshotForPaths({
       root,
       sourceId: "remote",
@@ -233,6 +235,14 @@ test("offline sync includes live LCM sqlite artifacts for full-fidelity offline 
 
     assert.equal(pull.skipped, 4);
     assert.equal(await readUtf8(root, "state/lcm.sqlite"), "live db");
+
+    await write(root, "state/lcm.sqlite-wal", "local wal churn");
+    const changeset = await buildOfflineSyncChangeset({
+      root,
+      sourceId: "laptop",
+      baseFiles: snapshot.files,
+    });
+    assert.deepEqual(changeset.changes.map((change) => change.path), []);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -1269,6 +1279,43 @@ test("offline snapshot apply preserves new local runtime files without a base", 
   }
 });
 
+test("offline snapshot apply removes current-only sqlite sidecars when absent remotely", async () => {
+  const root = await tempDir("remnic-offline-runtime-sidecar-local-create");
+  try {
+    await write(root, "state/lcm.sqlite-wal", "stale local wal");
+    await write(root, "state/lcm.sqlite-shm", "stale local shm");
+
+    const pull = await applyOfflineSyncSnapshot({
+      root,
+      snapshot: {
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: new Date().toISOString(),
+        sourceId: "remote",
+        includeTranscripts: true,
+        files: [],
+      },
+      baseFiles: [],
+    });
+
+    assert.equal(pull.deleted, 2);
+    assert.equal(pull.pendingLocal, 0);
+    assert.equal(pull.skipped, 0);
+    assert.equal(pull.conflicts.length, 0);
+    assert.deepEqual(pull.nextBaseFiles, []);
+    await assert.rejects(
+      () => readFile(path.join(root, "state/lcm.sqlite-wal")),
+      /ENOENT/,
+    );
+    await assert.rejects(
+      () => readFile(path.join(root, "state/lcm.sqlite-shm")),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline snapshot apply restores locally deleted remote-authoritative runtime files", async () => {
   const root = await tempDir("remnic-offline-runtime-local-delete-restore");
   try {
@@ -2219,6 +2266,43 @@ test("offline sync applies and snapshots through secure storage hooks", async ()
   } finally {
     await rm(root, { recursive: true, force: true });
     await rm(source, { recursive: true, force: true });
+  }
+});
+
+test("offline storage digest cache avoids repeat reads and invalidates on ctime changes", async () => {
+  const root = await tempDir("remnic-offline-digest-cache");
+  const relPath = "facts/cache.md";
+  const filePath = path.join(root, relPath);
+  try {
+    await write(root, relPath, "alpha");
+    const storage = new StorageManager(root);
+    const first = await storage.digestOfflineSyncFile(filePath);
+
+    let headerProbes = 0;
+    (storage as unknown as { offlineSyncFileIsEncrypted: () => Promise<boolean> }).offlineSyncFileIsEncrypted =
+      async () => {
+        headerProbes += 1;
+        throw new Error("cache miss");
+      };
+    assert.deepEqual(await storage.digestOfflineSyncFile(filePath), first);
+    assert.equal(headerProbes, 0);
+
+    const before = await stat(filePath);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await writeFile(filePath, "bravo");
+    await utimes(filePath, before.atime, before.mtime);
+
+    (storage as unknown as { offlineSyncFileIsEncrypted: () => Promise<boolean> }).offlineSyncFileIsEncrypted =
+      async () => {
+        headerProbes += 1;
+        return false;
+      };
+    const second = await storage.digestOfflineSyncFile(filePath);
+    assert.equal(headerProbes, 1);
+    assert.notEqual(second.sha256, first.sha256);
+    assert.equal(second.bytes, first.bytes);
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });
 

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -489,14 +489,27 @@ const REMOTE_AUTHORITATIVE_RUNTIME_STATE_FILES = new Set([
   "index_time.json",
   "last_intent.json",
   "last_recall.json",
+  "lcm.sqlite-shm",
+  "lcm.sqlite-wal",
   "memory-lifecycle-ledger.jsonl",
   "recall_impressions.jsonl",
+]);
+
+const ABSENT_INCOMING_RUNTIME_DELETE_FILES = new Set([
+  "lcm.sqlite-shm",
+  "lcm.sqlite-wal",
 ]);
 
 export function shouldPreferIncomingOfflineRuntimeFile(relPosix: string): boolean {
   const parts = relPosix.split("/");
   const basename = parts[parts.length - 1] ?? "";
   return isCanonicalRuntimeStatePath(parts) && REMOTE_AUTHORITATIVE_RUNTIME_STATE_FILES.has(basename);
+}
+
+function shouldDeleteAbsentIncomingOfflineRuntimeFile(relPosix: string): boolean {
+  const parts = relPosix.split("/");
+  const basename = parts[parts.length - 1] ?? "";
+  return isCanonicalRuntimeStatePath(parts) && ABSENT_INCOMING_RUNTIME_DELETE_FILES.has(basename);
 }
 
 function filterBaseFilesForMode(
@@ -1213,7 +1226,10 @@ export async function applyOfflineSyncSnapshot(options: {
       skipped += 1;
       continue;
     }
-    if (shouldPreferIncomingOfflineRuntimeFile(relPath) && base) {
+    if (
+      shouldPreferIncomingOfflineRuntimeFile(relPath) &&
+      (base || shouldDeleteAbsentIncomingOfflineRuntimeFile(relPath))
+    ) {
       await deleteSafeFile(root, relPath, options.deleteFile);
       nextBase.delete(relPath);
       deleted += 1;

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -135,6 +135,15 @@ const ARTIFACT_SEARCH_STOPWORDS = new Set([
   "with",
 ]);
 
+type OfflineSyncDigestCacheEntry = {
+  statBytes: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  encrypted: boolean;
+  sha256: string;
+  bytes: number;
+};
+
 export interface ReextractJobRequest {
   memoryId: string;
   model: string;
@@ -2236,6 +2245,10 @@ export class StorageManager {
   private factHashIndexAuthoritative: boolean | null = null;
   private factHashIndexAuthoritativePromise: Promise<void> | null = null;
   private readonly secureAppendChains = new Map<string, Promise<void>>();
+  private offlineSyncDigestCache: Map<string, OfflineSyncDigestCacheEntry> | null = null;
+  private offlineSyncDigestCacheLoadPromise: Promise<Map<string, OfflineSyncDigestCacheEntry>> | null = null;
+  private offlineSyncDigestCacheWriteChain: Promise<void> = Promise.resolve();
+  private offlineSyncDigestCacheWriteTimer: ReturnType<typeof setTimeout> | null = null;
   /** Optional: set by the orchestrator after construction to enable template-aware citation stripping during legacy hash rebuild. */
   citationTemplate: string = DEFAULT_CITATION_FORMAT;
 
@@ -2516,24 +2529,152 @@ export class StorageManager {
 
   async digestOfflineSyncFile(filePath: string): Promise<{ sha256: string; bytes: number }> {
     const target = this.assertManagedStoragePath(filePath, "storage.digestOfflineSyncFile");
-    if (await this.offlineSyncFileIsEncrypted(target)) {
-      const content = await readMaybeEncryptedFileBuffer(target, this._secureStoreKey, this.baseDir);
+    const st = await stat(target);
+    const relPath = path.relative(this.baseDir, target).split(path.sep).join("/");
+    const cache = await this.loadOfflineSyncDigestCache();
+    const cached = cache.get(relPath);
+    if (
+      cached &&
+      cached.statBytes === st.size &&
+      cached.mtimeMs === st.mtimeMs &&
+      cached.ctimeMs === st.ctimeMs &&
+      !cached.encrypted
+    ) {
       return {
+        sha256: cached.sha256,
+        bytes: cached.bytes,
+      };
+    }
+
+    const encrypted = await this.offlineSyncFileIsEncrypted(target);
+    let digest: { sha256: string; bytes: number };
+    if (encrypted) {
+      const content = await readMaybeEncryptedFileBuffer(target, this._secureStoreKey, this.baseDir);
+      digest = {
         sha256: createHash("sha256").update(content).digest("hex"),
         bytes: content.byteLength,
       };
+    } else {
+      const hash = createHash("sha256");
+      let bytes = 0;
+      for await (const rawChunk of createReadStream(target)) {
+        const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
+        hash.update(chunk);
+        bytes += chunk.length;
+      }
+      digest = {
+        sha256: hash.digest("hex"),
+        bytes,
+      };
     }
-    const hash = createHash("sha256");
-    let bytes = 0;
-    for await (const rawChunk of createReadStream(target)) {
-      const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
-      hash.update(chunk);
-      bytes += chunk.length;
+    if (!encrypted) {
+      this.rememberOfflineSyncDigest(relPath, st, digest);
     }
-    return {
-      sha256: hash.digest("hex"),
-      bytes,
-    };
+    return digest;
+  }
+
+  private async loadOfflineSyncDigestCache(): Promise<Map<string, OfflineSyncDigestCacheEntry>> {
+    if (this.offlineSyncDigestCache) return this.offlineSyncDigestCache;
+    if (!this.offlineSyncDigestCacheLoadPromise) {
+      this.offlineSyncDigestCacheLoadPromise = this.readOfflineSyncDigestCache();
+    }
+    this.offlineSyncDigestCache = await this.offlineSyncDigestCacheLoadPromise;
+    return this.offlineSyncDigestCache;
+  }
+
+  private async readOfflineSyncDigestCache(): Promise<Map<string, OfflineSyncDigestCacheEntry>> {
+    const cache = new Map<string, OfflineSyncDigestCacheEntry>();
+    try {
+      const raw = await readFile(this.offlineSyncDigestCachePath, "utf-8");
+      const parsed = JSON.parse(raw) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return cache;
+      const entries = (parsed as { entries?: unknown }).entries;
+      if (!Array.isArray(entries)) return cache;
+      for (const entry of entries) {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+        const record = entry as Record<string, unknown>;
+        const cachePath = typeof record.path === "string" ? record.path : "";
+        const statBytes = typeof record.statBytes === "number" ? record.statBytes : NaN;
+        const mtimeMs = typeof record.mtimeMs === "number" ? record.mtimeMs : NaN;
+        const ctimeMs = typeof record.ctimeMs === "number" ? record.ctimeMs : NaN;
+        const bytes = typeof record.bytes === "number" ? record.bytes : NaN;
+        const sha256 = typeof record.sha256 === "string" ? record.sha256 : "";
+        const encrypted = record.encrypted === true;
+        if (
+          cachePath.length === 0 ||
+          cachePath === ".." ||
+          cachePath.startsWith("../") ||
+          path.isAbsolute(cachePath) ||
+          !Number.isFinite(statBytes) ||
+          !Number.isFinite(mtimeMs) ||
+          !Number.isFinite(ctimeMs) ||
+          !Number.isFinite(bytes) ||
+          !/^[a-f0-9]{64}$/i.test(sha256)
+        ) {
+          continue;
+        }
+        cache.set(cachePath, { statBytes, mtimeMs, ctimeMs, encrypted, sha256, bytes });
+      }
+    } catch (err) {
+      if (!isErrnoCode(err, "ENOENT")) {
+        log.warn(
+          `storage.offlineSyncDigestCache: ignoring unreadable cache: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return cache;
+  }
+
+  private rememberOfflineSyncDigest(
+    relPath: string,
+    st: { size: number; mtimeMs: number; ctimeMs: number },
+    digest: { sha256: string; bytes: number },
+  ): void {
+    const cache = this.offlineSyncDigestCache;
+    if (!cache) return;
+    cache.set(relPath, {
+      statBytes: st.size,
+      mtimeMs: st.mtimeMs,
+      ctimeMs: st.ctimeMs,
+      encrypted: false,
+      sha256: digest.sha256,
+      bytes: digest.bytes,
+    });
+    this.scheduleOfflineSyncDigestCacheWrite();
+  }
+
+  private scheduleOfflineSyncDigestCacheWrite(): void {
+    if (this.offlineSyncDigestCacheWriteTimer) {
+      clearTimeout(this.offlineSyncDigestCacheWriteTimer);
+    }
+    this.offlineSyncDigestCacheWriteTimer = setTimeout(() => {
+      this.offlineSyncDigestCacheWriteTimer = null;
+      this.queueOfflineSyncDigestCacheWrite();
+    }, 1_000);
+    this.offlineSyncDigestCacheWriteTimer.unref?.();
+  }
+
+  private queueOfflineSyncDigestCacheWrite(): void {
+    this.offlineSyncDigestCacheWriteChain = this.offlineSyncDigestCacheWriteChain
+      .catch(() => undefined)
+      .then(async () => {
+        const cache = this.offlineSyncDigestCache;
+        if (!cache) return;
+        const entries = [...cache.entries()]
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([entryPath, entry]) => ({ path: entryPath, ...entry }));
+        await mkdir(path.dirname(this.offlineSyncDigestCachePath), { recursive: true });
+        await writeFile(
+          this.offlineSyncDigestCachePath,
+          `${JSON.stringify({ version: 1, entries })}\n`,
+          "utf-8",
+        );
+      })
+      .catch((err) => {
+        log.warn(
+          `storage.offlineSyncDigestCache: failed to write cache: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
   }
 
   private async offlineSyncFileIsEncrypted(filePath: string): Promise<boolean> {
@@ -2643,6 +2784,9 @@ export class StorageManager {
   }
   private get stateDir(): string {
     return path.join(this.baseDir, "state");
+  }
+  private get offlineSyncDigestCachePath(): string {
+    return path.join(this.baseDir, ".offline-sync", "digest-cache.v1.json");
   }
   private get entitySynthesisQueuePath(): string {
     return path.join(this.stateDir, "entity-synthesis-queue.json");


### PR DESCRIPTION
## Summary
- cache offline-sync file digests under the memory root so repeated large-base syncs stop rehashing unchanged remote files
- treat SQLite WAL/SHM sidecars as remote-authoritative runtime state so local/remote live database churn does not create conflicts
- allow direct hydration of remote-authoritative runtime files to accept append-only growth while still verifying the fetched snapshot digest

## Verification
- npm run preflight:quick
- pnpm --filter @remnic/cli exec tsx --test src/offline-sync-hydrate.test.ts
- pnpm --filter @remnic/cli run check-types
- pnpm --filter @remnic/core exec tsx --test src/offline-sync.test.ts
- pnpm --filter @remnic/core run check-types
- Live laptop-to-MacStudio sync via installed global CLI: pending=0, conflicts=0, deferred=0 on two consecutive runs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync conflict resolution, local deletion of SQLite sidecars, and hydration checksum rules for durable runtime state—incorrect logic could drop local WAL data or accept bad remote prefixes, though behavior is covered by new tests.
> 
> **Overview**
> Offline sync is hardened so live runtime churn on laptops and remotes does not spuriously conflict or force full re-hashes.
> 
> **Digest caching** — `StorageManager.digestOfflineSyncFile` now keeps a persisted stat-keyed cache under `.offline-sync/digest-cache.v1.json`, reusing digests when size/mtime/ctime match and skipping repeat full-file reads for large bases.
> 
> **SQLite sidecars** — `lcm.sqlite-wal` and `lcm.sqlite-shm` are treated as remote-authoritative runtime state (like the main DB). Local-only sidecars are removed when absent from the remote snapshot; local WAL churn no longer shows up in changesets.
> 
> **Append-tolerant hydration** — For `memory-lifecycle-ledger.jsonl` and `recall_impressions.jsonl`, direct/large-file hydration accepts remote chunks whose metadata reflects **append-only growth** beyond the snapshot (larger `bytes`, newer `mtime`) while still requiring the fetched prefix to match the snapshot digest. Non-append edits or other runtime files still defer via `OfflineRemoteFileChangedError`. Hydrate checksum mismatches on those paths are mapped to the same defer path.
> 
> Tests cover digest cache behavior, sidecar deletion/authority, and direct-hydrate accept vs defer cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e78f5bd5908c8547fe409ac8e124f1935ba6009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->