### PR TITLE
Fix pre-merge review thread pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/scripts/pre-merge-check.sh
+++ b/scripts/pre-merge-check.sh
@@ -20,36 +20,76 @@ REQUIRED_REVIEWERS=("cursor[bot]" "chatgpt-codex-connector[bot]")
 echo "[pre-merge] Checking PR #${PR_NUMBER} on ${REPO}..."
 
 # 1. Check for unresolved review threads
-UNRESOLVED=$(gh api graphql \
-  -f query='query($owner: String!, $name: String!, $pr: Int!) {
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+REVIEW_THREADS_QUERY='query($owner: String!, $name: String!, $pr: Int!, $after: String = null) {
     repository(owner: $owner, name: $name) {
       pullRequest(number: $pr) {
-        reviewThreads(first: 100) {
+        reviewThreads(first: 100, after: $after) {
           totalCount
-          nodes { isResolved }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            isResolved
+          }
         }
       }
     }
-  }' \
-  -f owner="${REPO%%/*}" \
-  -f name="${REPO##*/}" \
-  -F pr="$PR_NUMBER" \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' \
-  2>/dev/null)
+  }'
 
-TOTAL_THREADS=$(gh api graphql \
-  -f query='query($owner: String!, $name: String!, $pr: Int!) {
-    repository(owner: $owner, name: $name) {
-      pullRequest(number: $pr) {
-        reviewThreads(first: 100) { totalCount }
-      }
-    }
-  }' \
-  -f owner="${REPO%%/*}" \
-  -f name="${REPO##*/}" \
-  -F pr="$PR_NUMBER" \
-  --jq '.data.repository.pullRequest.reviewThreads.totalCount' \
-  2>/dev/null)
+UNRESOLVED=0
+TOTAL_THREADS=0
+AFTER=""
+PAGE_INDEX=0
+while true; do
+  THREAD_ARGS=(
+    api graphql
+    -f query="$REVIEW_THREADS_QUERY"
+    -f owner="$OWNER"
+    -f name="$NAME"
+    -F pr="$PR_NUMBER"
+    --jq '.data.repository.pullRequest.reviewThreads as $threads | [($threads.totalCount // 0), ([($threads.nodes // [])[] | select(.isResolved == false)] | length), ($threads.pageInfo.hasNextPage // false), ($threads.pageInfo.endCursor // "")] | @tsv'
+  )
+  if [[ -n "$AFTER" ]]; then
+    THREAD_ARGS+=(-f after="$AFTER")
+  fi
+
+  if ! THREAD_PAGE=$(gh "${THREAD_ARGS[@]}" 2>/dev/null); then
+    echo "[pre-merge] BLOCKED: Failed to read review threads from GitHub."
+    exit 1
+  fi
+
+  if [[ "$THREAD_PAGE" == *$'\n'* ]]; then
+    echo "[pre-merge] BLOCKED: GitHub returned malformed review thread data."
+    exit 1
+  fi
+
+  IFS=$'\t' read -r PAGE_TOTAL PAGE_UNRESOLVED HAS_NEXT END_CURSOR EXTRA_FIELD <<< "$THREAD_PAGE"
+  if [[ -n "${EXTRA_FIELD:-}" || ! "$PAGE_TOTAL" =~ ^[0-9]+$ || ! "$PAGE_UNRESOLVED" =~ ^[0-9]+$ || ! "$HAS_NEXT" =~ ^(true|false)$ ]]; then
+    echo "[pre-merge] BLOCKED: GitHub returned malformed review thread data."
+    exit 1
+  fi
+
+  if [[ "$PAGE_INDEX" -eq 0 ]]; then
+    TOTAL_THREADS="$PAGE_TOTAL"
+  fi
+  PAGE_INDEX=$((PAGE_INDEX + 1))
+  UNRESOLVED=$((UNRESOLVED + PAGE_UNRESOLVED))
+  if [[ "$HAS_NEXT" != "true" ]]; then
+    break
+  fi
+  if [[ -z "$END_CURSOR" ]]; then
+    echo "[pre-merge] BLOCKED: GitHub review thread pagination was incomplete."
+    exit 1
+  fi
+  if [[ "$END_CURSOR" == "$AFTER" ]]; then
+    echo "[pre-merge] BLOCKED: GitHub review thread pagination did not advance."
+    exit 1
+  fi
+  AFTER="$END_CURSOR"
+done
 
 echo "[pre-merge] Review threads: ${TOTAL_THREADS} total, ${UNRESOLVED} unresolved"
 
@@ -59,30 +99,67 @@ if [[ "$UNRESOLVED" -gt 0 ]]; then
 fi
 
 # 2. Check that AI reviewers have actually posted (via reviews, comments, or check runs)
-REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '.[].user.login' 2>/dev/null || echo "")
-COMMENTS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate --jq '.[].user.login' 2>/dev/null || echo "")
+if ! REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '.[].user.login' 2>/dev/null); then
+  echo "[pre-merge] BLOCKED: Failed to read PR reviews from GitHub."
+  exit 1
+fi
+if ! COMMENTS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate --jq '.[].user.login' 2>/dev/null); then
+  echo "[pre-merge] BLOCKED: Failed to read PR comments from GitHub."
+  exit 1
+fi
 
 # Some bots (Cursor Bugbot, Kilo Code Review) post as check runs via GitHub
 # Apps rather than as PR comments. A completed check run counts as reviewer
 # activity. The app.slug field maps to reviewer aliases (e.g. "cursor" matches
 # cursor[bot]).
-HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
-CHECK_RUN_APPS=""
+if ! HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq .headRefOid 2>/dev/null); then
+  echo "[pre-merge] BLOCKED: Failed to read PR head SHA from GitHub."
+  exit 1
+fi
+CHECK_RUNS=""
 if [[ -n "$HEAD_SHA" ]]; then
-  CHECK_RUN_APPS=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-    --jq '.check_runs[] | select(.conclusion == "success" or .conclusion == "failure" or .conclusion == "neutral") | .app.slug' \
-    2>/dev/null || echo "")
+  if ! CHECK_RUNS=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+    --jq '.check_runs[] | select(.conclusion == "success" or .conclusion == "failure" or .conclusion == "neutral") | [.app.slug, .name] | @tsv' \
+    2>/dev/null); then
+    echo "[pre-merge] BLOCKED: Failed to read PR check runs from GitHub."
+    exit 1
+  fi
 fi
 
-ALL_REVIEWERS=$(printf '%s\n%s\n%s' "$REVIEWS" "$COMMENTS" "$CHECK_RUN_APPS" | sort -u)
+ALL_REVIEWERS=$(printf '%s\n%s\n' "$REVIEWS" "$COMMENTS" | sort -u)
+
+has_reviewer_check_run() {
+  local reviewer="$1"
+  local expected_slug=""
+  local expected_name=""
+
+  case "$reviewer" in
+    "cursor[bot]")
+      expected_slug="cursor"
+      expected_name="Cursor Bugbot"
+      ;;
+    "chatgpt-codex-connector[bot]")
+      expected_slug="chatgpt-codex-connector"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  while IFS=$'\t' read -r app_slug check_name _; do
+    if [[ "$app_slug" == "$expected_slug" && ( -z "$expected_name" || "$check_name" == "$expected_name" ) ]]; then
+      return 0
+    fi
+  done <<< "$CHECK_RUNS"
+
+  return 1
+}
 
 MISSING_REVIEWERS=()
 for reviewer in "${REQUIRED_REVIEWERS[@]}"; do
-  # Strip [bot] suffix for matching against check-run app slugs.
-  reviewer_base="${reviewer%%\[bot\]}"
   # Use exact line match (-x) to avoid substring false positives.
   if ! echo "$ALL_REVIEWERS" | grep -qxiF "$reviewer" && \
-     ! echo "$ALL_REVIEWERS" | grep -qxiF "$reviewer_base"; then
+     ! has_reviewer_check_run "$reviewer"; then
     MISSING_REVIEWERS+=("$reviewer")
   fi
 done

--- a/tests/pre-merge-check.test.mjs
+++ b/tests/pre-merge-check.test.mjs
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const scriptPath = path.join(repoRoot, "scripts", "pre-merge-check.sh");
+
+async function writeGhStub(binDir) {
+  const ghPath = path.join(binDir, "gh");
+  await writeFile(
+    ghPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+  if [[ "$*" != *'$after: String = null'* ]]; then
+    echo "graphql query must default after to null" >&2
+    exit 4
+  fi
+  count="$(cat "$GH_STUB_COUNT" 2>/dev/null || echo 0)"
+  count=$((count + 1))
+  printf '%s\\n' "$count" > "$GH_STUB_COUNT"
+  case "$GH_STUB_SCENARIO:$count" in
+    all_resolved:1)
+      printf '150\\t0\\ttrue\\tcursor-1\\n'
+      ;;
+    all_resolved:2)
+      printf '999\\t0\\tfalse\\t\\n'
+      ;;
+    unresolved_second_page:1)
+      printf '150\\t0\\ttrue\\tcursor-1\\n'
+      ;;
+    unresolved_second_page:2)
+      printf '150\\t1\\tfalse\\t\\n'
+      ;;
+    reviews_fail:1)
+      printf '3\\t0\\tfalse\\t\\n'
+      ;;
+    malformed_page:1)
+      printf '5\\t0\\n'
+      ;;
+    cursor_check_ok:1|unrelated_cursor_check:1|all_required_check_runs_ok:1)
+      printf '3\\t0\\tfalse\\t\\n'
+      ;;
+    repeated_cursor:1)
+      printf '150\\t0\\ttrue\\tcursor-1\\n'
+      ;;
+    repeated_cursor:2)
+      printf '150\\t0\\ttrue\\tcursor-1\\n'
+      ;;
+    *)
+      echo "unexpected graphql page $count for $GH_STUB_SCENARIO" >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/reviews" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == "reviews_fail" ]]; then
+    echo "reviews unavailable" >&2
+    exit 3
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "cursor_check_ok" || "$GH_STUB_SCENARIO" == "unrelated_cursor_check" ]]; then
+    printf 'chatgpt-codex-connector[bot]\\n'
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "all_required_check_runs_ok" ]]; then
+    exit 0
+  fi
+  printf 'cursor[bot]\\nchatgpt-codex-connector[bot]\\n'
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/example/repo/pulls/7/comments" ]]; then
+  exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ "$*" != *"--repo example/repo"* ]]; then
+    echo "gh pr view must pass --repo" >&2
+    exit 5
+  fi
+  printf 'deadbeef\\n'
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/example/repo/commits/deadbeef/check-runs" ]]; then
+  if [[ "$GH_STUB_SCENARIO" == "cursor_check_ok" ]]; then
+    printf 'cursor\\tCursor Bugbot\\n'
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "all_required_check_runs_ok" ]]; then
+    printf 'cursor\\tCursor Bugbot\\n'
+    printf 'chatgpt-codex-connector\\tCodex Review\\n'
+    exit 0
+  fi
+  if [[ "$GH_STUB_SCENARIO" == "unrelated_cursor_check" ]]; then
+    printf 'cursor\\tunit tests\\n'
+    exit 0
+  fi
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 2
+`,
+  );
+  await chmod(ghPath, 0o755);
+}
+
+async function withGhStub(scenario, fn) {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "remnic-pre-merge-check-"));
+  try {
+    const binDir = path.join(tmp, "bin");
+    await mkdir(binDir);
+    await writeGhStub(binDir);
+    const countPath = path.join(tmp, "graphql-count");
+    const env = {
+      ...process.env,
+      GH_STUB_COUNT: countPath,
+      GH_STUB_SCENARIO: scenario,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      REMNIC_REPO: "example/repo",
+    };
+    await fn(env, countPath);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+function runPreMergeCheck(env) {
+  return spawnSync("bash", [scriptPath, "7"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+    timeout: 30_000,
+  });
+}
+
+test("pre-merge check scans all review-thread pages before allowing merge", async () => {
+  await withGhStub("all_resolved", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Review threads: 150 total, 0 unresolved/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "2");
+  });
+});
+
+test("pre-merge check blocks unresolved review threads after the first page", async () => {
+  await withGhStub("unresolved_second_page", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Review threads: 150 total, 1 unresolved/);
+    assert.match(result.stdout, /BLOCKED: 1 unresolved review thread/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "2");
+  });
+});
+
+test("pre-merge check reports GitHub API failures separately from missing reviewers", async () => {
+  await withGhStub("reviews_fail", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Review threads: 3 total, 0 unresolved/);
+    assert.match(result.stdout, /BLOCKED: Failed to read PR reviews from GitHub/);
+    assert.doesNotMatch(result.stdout, /Missing reviews/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});
+
+test("pre-merge check rejects malformed review-thread pagination output", async () => {
+  await withGhStub("malformed_page", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /BLOCKED: GitHub returned malformed review thread data/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});
+
+test("pre-merge check fails closed when GitHub pagination does not advance", async () => {
+  await withGhStub("repeated_cursor", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /BLOCKED: GitHub review thread pagination did not advance/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "2");
+  });
+});
+
+test("pre-merge check accepts the Cursor Bugbot check run as reviewer activity", async () => {
+  await withGhStub("cursor_check_ok", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OK: All reviewers posted/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});
+
+test("pre-merge check accepts required reviewer check runs as reviewer activity", async () => {
+  await withGhStub("all_required_check_runs_ok", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /OK: All reviewers posted/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});
+
+test("pre-merge check rejects unrelated checks from a matching app slug", async () => {
+  await withGhStub("unrelated_cursor_check", async (env, countPath) => {
+    const result = runPreMergeCheck(env);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /Missing reviews from: cursor\[bot\]/);
+    assert.equal((await readFile(countPath, "utf8")).trim(), "1");
+  });
+});


### PR DESCRIPTION
## Summary
- paginate GraphQL review thread checks instead of reading only the first page
- fail closed on malformed pagination and GitHub API read failures
- constrain Cursor reviewer activity to the Cursor Bugbot check run and add stubbed regression coverage

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin pnpm exec tsx --test tests/pre-merge-check.test.mjs
- bash -n scripts/pre-merge-check.sh
- focused ClawPatch review: run 20260601T184056-307832, findings=0
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect merge-guard scripting and tests only; stricter checks may block merges until Bugbot/Codex checks complete, which is intentional.
> 
> **Overview**
> **`scripts/pre-merge-check.sh`** now paginates GraphQL review-thread queries so unresolved threads beyond the first 100 are counted, with fail-closed handling for API failures, malformed TSV output, missing cursors, and stuck pagination. Reviewer detection no longer treats any `cursor` app slug as sufficient—**Cursor** must match the **Cursor Bugbot** check name; Codex still maps by slug. **`gh pr view`** and reviews/comments/check-runs reads exit with explicit block messages instead of silently continuing.
> 
> Adds **`tests/pre-merge-check.test.mjs`** with a stubbed `gh` CLI covering multi-page threads, API errors, pagination edge cases, and check-run matching.
> 
> **`package.json`** only reformats a few array fields to single lines (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68626695c93b04aa4ef24a4018a8614fec07f6d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->