### PR TITLE
Fix binary lifecycle cleanup containment

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/binary-lifecycle/backend.ts
+++ b/packages/remnic-core/src/binary-lifecycle/backend.ts
@@ -45,10 +45,9 @@ export class FilesystemBackend implements BinaryStorageBackend {
   }
 
   private resolveRemotePath(remotePath: string): string {
-    if (path.isAbsolute(remotePath)) {
-      throw new Error(`FilesystemBackend remotePath must be relative: ${JSON.stringify(remotePath)}`);
-    }
-    const resolved = path.resolve(this.basePath, remotePath);
+    const resolved = path.isAbsolute(remotePath)
+      ? path.resolve(remotePath)
+      : path.resolve(this.basePath, remotePath);
     const relative = path.relative(this.basePath, resolved);
     if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
       throw new Error(`FilesystemBackend remotePath escapes basePath: ${JSON.stringify(remotePath)}`);
@@ -183,6 +182,9 @@ export class FilesystemBackend implements BinaryStorageBackend {
   }
 
   async upload(localPath: string, remotePath: string): Promise<string> {
+    if (path.isAbsolute(remotePath)) {
+      throw new Error(`FilesystemBackend upload remotePath must be relative: ${JSON.stringify(remotePath)}`);
+    }
     const dest = this.resolveRemotePath(remotePath);
     const realBase = await this.ensureSafeParentDirectory(dest);
     try {
@@ -200,7 +202,7 @@ export class FilesystemBackend implements BinaryStorageBackend {
     if (!this.isInsideBase(realDest, realBase)) {
       throw new Error(`FilesystemBackend remotePath escapes basePath: ${JSON.stringify(remotePath)}`);
     }
-    return dest;
+    return remotePath;
   }
 
   async exists(remotePath: string): Promise<boolean> {

--- a/packages/remnic-core/src/binary-lifecycle/backend.ts
+++ b/packages/remnic-core/src/binary-lifecycle/backend.ts
@@ -167,6 +167,9 @@ export class FilesystemBackend implements BinaryStorageBackend {
       if (stat.isSymbolicLink()) {
         throw new Error(`FilesystemBackend remotePath points to symlink: ${dest}`);
       }
+      if (!stat.isFile()) {
+        return null;
+      }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         return null;

--- a/packages/remnic-core/src/binary-lifecycle/backend.ts
+++ b/packages/remnic-core/src/binary-lifecycle/backend.ts
@@ -59,7 +59,7 @@ export class FilesystemBackend implements BinaryStorageBackend {
 
   private isInsideBase(candidate: string, realBase: string): boolean {
     const relative = path.relative(realBase, candidate);
-    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+    return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
   }
 
   private async realBasePathIfExists(): Promise<string | null> {

--- a/packages/remnic-core/src/binary-lifecycle/backend.ts
+++ b/packages/remnic-core/src/binary-lifecycle/backend.ts
@@ -6,7 +6,7 @@
  * so swapping storage providers requires no pipeline changes.
  */
 
-import fs from "node:fs";
+import type { Stats } from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import type { BinaryStorageBackendConfig } from "./types.js";
@@ -56,26 +56,163 @@ export class FilesystemBackend implements BinaryStorageBackend {
     return resolved;
   }
 
+  private isInsideBase(candidate: string, realBase: string): boolean {
+    const relative = path.relative(realBase, candidate);
+    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  }
+
+  private async realBasePathIfExists(): Promise<string | null> {
+    try {
+      const stat = await fsp.lstat(this.basePath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`FilesystemBackend basePath must not be a symlink: ${this.basePath}`);
+      }
+      if (!stat.isDirectory()) {
+        throw new Error(`FilesystemBackend basePath must be a directory: ${this.basePath}`);
+      }
+      return await fsp.realpath(this.basePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  private async ensureBaseDirectory(): Promise<string> {
+    await fsp.mkdir(this.basePath, { recursive: true });
+    const realBase = await this.realBasePathIfExists();
+    if (realBase === null) {
+      throw new Error(`FilesystemBackend failed to create basePath: ${this.basePath}`);
+    }
+    return realBase;
+  }
+
+  private async ensureSafeParentDirectory(dest: string): Promise<string> {
+    const realBase = await this.ensureBaseDirectory();
+    const destDir = path.dirname(dest);
+    const relativeDir = path.relative(this.basePath, destDir);
+    const segments = relativeDir === "" ? [] : relativeDir.split(path.sep);
+    let current = this.basePath;
+
+    for (const segment of segments) {
+      if (segment === "." || segment === "") continue;
+      current = path.join(current, segment);
+      try {
+        const stat = await fsp.lstat(current);
+        if (stat.isSymbolicLink()) {
+          throw new Error(`FilesystemBackend remotePath traverses symlink: ${current}`);
+        }
+        if (!stat.isDirectory()) {
+          throw new Error(`FilesystemBackend remotePath parent is not a directory: ${current}`);
+        }
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw err;
+        }
+        await fsp.mkdir(current);
+      }
+    }
+
+    const realParent = await fsp.realpath(destDir);
+    if (!this.isInsideBase(realParent, realBase)) {
+      throw new Error(`FilesystemBackend remotePath parent escapes basePath: ${dest}`);
+    }
+    return realBase;
+  }
+
+  private async resolveExistingRemotePath(remotePath: string): Promise<string | null> {
+    const dest = this.resolveRemotePath(remotePath);
+    const realBase = await this.realBasePathIfExists();
+    if (realBase === null) {
+      return null;
+    }
+
+    const destDir = path.dirname(dest);
+    const relativeDir = path.relative(this.basePath, destDir);
+    const segments = relativeDir === "" ? [] : relativeDir.split(path.sep);
+    let current = this.basePath;
+    for (const segment of segments) {
+      if (segment === "." || segment === "") continue;
+      current = path.join(current, segment);
+      let stat: Stats;
+      try {
+        stat = await fsp.lstat(current);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          return null;
+        }
+        throw err;
+      }
+      if (stat.isSymbolicLink()) {
+        throw new Error(`FilesystemBackend remotePath traverses symlink: ${current}`);
+      }
+      if (!stat.isDirectory()) {
+        return null;
+      }
+    }
+
+    const realParent = await fsp.realpath(destDir).catch((err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") return null;
+      throw err;
+    });
+    if (realParent === null) {
+      return null;
+    }
+    if (!this.isInsideBase(realParent, realBase)) {
+      throw new Error(`FilesystemBackend remotePath parent escapes basePath: ${JSON.stringify(remotePath)}`);
+    }
+
+    try {
+      const stat = await fsp.lstat(dest);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`FilesystemBackend remotePath points to symlink: ${dest}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    }
+
+    const realDest = await fsp.realpath(dest);
+    if (!this.isInsideBase(realDest, realBase)) {
+      throw new Error(`FilesystemBackend remotePath escapes basePath: ${JSON.stringify(remotePath)}`);
+    }
+    return dest;
+  }
+
   async upload(localPath: string, remotePath: string): Promise<string> {
     const dest = this.resolveRemotePath(remotePath);
-    const destDir = path.dirname(dest);
-    await fsp.mkdir(destDir, { recursive: true });
+    const realBase = await this.ensureSafeParentDirectory(dest);
+    try {
+      const stat = await fsp.lstat(dest);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`FilesystemBackend remotePath points to symlink: ${dest}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+    }
     await fsp.copyFile(localPath, dest);
+    const realDest = await fsp.realpath(dest);
+    if (!this.isInsideBase(realDest, realBase)) {
+      throw new Error(`FilesystemBackend remotePath escapes basePath: ${JSON.stringify(remotePath)}`);
+    }
     return dest;
   }
 
   async exists(remotePath: string): Promise<boolean> {
-    const dest = this.resolveRemotePath(remotePath);
-    try {
-      await fsp.access(dest, fs.constants.F_OK);
-      return true;
-    } catch {
-      return false;
-    }
+    const dest = await this.resolveExistingRemotePath(remotePath);
+    return dest !== null;
   }
 
   async delete(remotePath: string): Promise<void> {
-    const dest = this.resolveRemotePath(remotePath);
+    const dest = await this.resolveExistingRemotePath(remotePath);
+    if (dest === null) {
+      return;
+    }
     try {
       await fsp.unlink(dest);
     } catch (err: unknown) {

--- a/packages/remnic-core/src/binary-lifecycle/backend.ts
+++ b/packages/remnic-core/src/binary-lifecycle/backend.ts
@@ -27,6 +27,8 @@ export interface BinaryStorageBackend {
   exists(remotePath: string): Promise<boolean>;
   /** Delete a file from the backend. */
   delete(remotePath: string): Promise<void>;
+  /** Return the user-resolvable markdown target for a stored backend path. */
+  getRedirectTarget?(remotePath: string): string;
 }
 
 // ---------------------------------------------------------------------------
@@ -224,6 +226,10 @@ export class FilesystemBackend implements BinaryStorageBackend {
       // Ignore ENOENT (already deleted); rethrow everything else.
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     }
+  }
+
+  getRedirectTarget(remotePath: string): string {
+    return this.resolveRemotePath(remotePath);
   }
 }
 

--- a/packages/remnic-core/src/binary-lifecycle/manifest.ts
+++ b/packages/remnic-core/src/binary-lifecycle/manifest.ts
@@ -24,25 +24,37 @@ export function manifestPath(memoryDir: string): string {
 
 /**
  * Read the manifest from disk. Returns a fresh empty manifest if the file
- * does not exist or contains invalid JSON (CLAUDE.md #18).
+ * does not exist. Existing invalid manifests fail closed so the pipeline does
+ * not overwrite state needed for safe cleanup.
  */
 export async function readManifest(memoryDir: string): Promise<BinaryLifecycleManifest> {
   const filePath = manifestPath(memoryDir);
+  let raw: string;
   try {
-    const raw = await fsp.readFile(filePath, "utf-8");
-    const parsed: unknown = JSON.parse(raw);
-    // CLAUDE.md #18: validate the parsed result is a non-null object.
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    raw = await fsp.readFile(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return emptyManifest();
     }
-    const obj = parsed as Record<string, unknown>;
-    if (obj.version !== 1 || !Array.isArray(obj.assets)) {
-      return emptyManifest();
-    }
-    return parsed as BinaryLifecycleManifest;
-  } catch {
-    return emptyManifest();
+    throw new Error(`Failed to read binary lifecycle manifest at ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
   }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Invalid binary lifecycle manifest JSON at ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // CLAUDE.md #18: validate the parsed result is a non-null object.
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Invalid binary lifecycle manifest shape at ${filePath}: expected object`);
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.version !== 1 || !Array.isArray(obj.assets)) {
+    throw new Error(`Invalid binary lifecycle manifest shape at ${filePath}: expected version 1 with assets array`);
+  }
+  return parsed as BinaryLifecycleManifest;
 }
 
 /**

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import { runBinaryLifecyclePipeline } from "./pipeline.js";
-import { writeManifest } from "./manifest.js";
+import { manifestPath, writeManifest } from "./manifest.js";
 import type { BinaryLifecycleConfig } from "./types.js";
 import type { BinaryStorageBackend } from "./backend.js";
 
@@ -129,6 +129,314 @@ test("binary lifecycle blocks cleanup when local hash no longer matches manifest
   }
 });
 
+test("binary lifecycle blocks manifest cleanup paths outside memoryDir", async () => {
+  const parentDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-escape-parent-"));
+  const memoryDir = path.join(parentDir, "memory");
+  const victimPath = path.join(parentDir, "victim.png");
+  try {
+    await mkdir(memoryDir);
+    await writeFile(victimPath, "victim", "utf8");
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "../victim.png",
+          mirroredPath: "remote/victim.png",
+          contentHash: sha256("victim"),
+          sizeBytes: "victim".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          redirectedAt: "2026-01-01T00:00:00.000Z",
+          status: "redirected",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ originalPath: string; status: string }> };
+
+    assert.equal(result.cleaned, 0);
+    assert.match(result.errors.join("\n"), /manifest path is outside memoryDir/);
+    assert.equal(await readFile(victimPath, "utf8"), "victim");
+    assert.equal(manifest.assets[0]?.originalPath, "../victim.png");
+    assert.equal(manifest.assets[0]?.status, "error");
+  } finally {
+    await rm(parentDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle dry-run does not mark missing redirected assets cleaned", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-dry-clean-"));
+  try {
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "missing.png",
+          mirroredPath: "remote/missing.png",
+          contentHash: sha256("missing"),
+          sizeBytes: "missing".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          redirectedAt: "2026-01-01T00:00:00.000Z",
+          status: "redirected",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(
+      memoryDir,
+      baseConfig,
+      noUploadBackend,
+      noopLogger,
+      { dryRun: true },
+    );
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string; cleanedAt?: string }> };
+
+    assert.equal(result.cleaned, 0);
+    assert.equal(manifest.assets[0]?.status, "redirected");
+    assert.equal(manifest.assets[0]?.cleanedAt, undefined);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle blocks cleanup when manifest mirroredAt is invalid", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-invalid-timestamp-"));
+  try {
+    await writeFile(path.join(memoryDir, "image.png"), "image", "utf8");
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "image.png",
+          mirroredPath: "remote/image.png",
+          contentHash: sha256("image"),
+          sizeBytes: "image".length,
+          mimeType: "image/png",
+          mirroredAt: "not-a-date",
+          redirectedAt: "2026-01-01T00:00:00.000Z",
+          status: "redirected",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string }> };
+
+    assert.equal(result.cleaned, 0);
+    assert.match(result.errors.join("\n"), /manifest mirroredAt is invalid/);
+    assert.equal(await readFile(path.join(memoryDir, "image.png"), "utf8"), "image");
+    assert.equal(manifest.assets[0]?.status, "error");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle blocks cleanup when mirrored copy is missing", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-missing-remote-"));
+  try {
+    await writeFile(path.join(memoryDir, "image.png"), "image", "utf8");
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "image.png",
+          mirroredPath: "remote/image.png",
+          contentHash: sha256("image"),
+          sizeBytes: "image".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          redirectedAt: "2026-01-01T00:00:00.000Z",
+          status: "redirected",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(
+      memoryDir,
+      baseConfig,
+      missingRemoteBackend,
+      noopLogger,
+    );
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string; cleanedAt?: string }> };
+
+    assert.equal(result.cleaned, 0);
+    assert.match(result.errors.join("\n"), /mirrored copy is missing/);
+    assert.equal(await readFile(path.join(memoryDir, "image.png"), "utf8"), "image");
+    assert.equal(manifest.assets[0]?.status, "redirected");
+    assert.equal(manifest.assets[0]?.cleanedAt, undefined);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle blocks cleanup when mirrored copy verification fails", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-remote-error-"));
+  try {
+    await writeFile(path.join(memoryDir, "image.png"), "image", "utf8");
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "image.png",
+          mirroredPath: "remote/image.png",
+          contentHash: sha256("image"),
+          sizeBytes: "image".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          redirectedAt: "2026-01-01T00:00:00.000Z",
+          status: "redirected",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(
+      memoryDir,
+      baseConfig,
+      failingRemoteBackend,
+      noopLogger,
+    );
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string; cleanedAt?: string }> };
+
+    assert.equal(result.cleaned, 0);
+    assert.match(result.errors.join("\n"), /failed to verify mirrored copy/);
+    assert.equal(await readFile(path.join(memoryDir, "image.png"), "utf8"), "image");
+    assert.equal(manifest.assets[0]?.status, "redirected");
+    assert.equal(manifest.assets[0]?.cleanedAt, undefined);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle retries partial redirect failures before cleanup", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-partial-redirect-"));
+  const imagePath = path.join(memoryDir, "image.png");
+  const firstNote = path.join(memoryDir, "first.md");
+  const secondNote = path.join(memoryDir, "second.md");
+  try {
+    await writeFile(imagePath, "image", "utf8");
+    await writeFile(firstNote, "![img](image.png)", "utf8");
+    await writeFile(secondNote, "![img](image.png)", "utf8");
+    await chmod(secondNote, 0o444);
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "image.png",
+          mirroredPath: "remote/image.png",
+          contentHash: sha256("image"),
+          sizeBytes: "image".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          status: "mirrored",
+        },
+      ],
+    });
+
+    const firstResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    let manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string }> };
+
+    assert.equal(firstResult.cleaned, 0);
+    assert.match(firstResult.errors.join("\n"), /redirect write failed/);
+    assert.equal(await readFile(imagePath, "utf8"), "image");
+    assert.equal(await readFile(firstNote, "utf8"), "![img](remote/image.png)");
+    assert.equal(await readFile(secondNote, "utf8"), "![img](image.png)");
+    assert.equal(manifest.assets[0]?.status, "error");
+
+    await chmod(secondNote, 0o644);
+    const secondResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string }> };
+
+    assert.equal(secondResult.errors.length, 0);
+    assert.equal(secondResult.redirected, 1);
+    assert.equal(secondResult.cleaned, 1);
+    assert.equal(await readFile(firstNote, "utf8"), "![img](remote/image.png)");
+    assert.equal(await readFile(secondNote, "utf8"), "![img](remote/image.png)");
+    assert.equal(manifest.assets[0]?.status, "cleaned");
+  } finally {
+    await chmod(secondNote, 0o644).catch(() => {});
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle rewrites nested asset references before cleanup", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-nested-redirect-"));
+  const assetDir = path.join(memoryDir, "assets");
+  const noteDir = path.join(memoryDir, "notes");
+  const imagePath = path.join(assetDir, "photo.png");
+  const rootNote = path.join(memoryDir, "note.md");
+  const nestedNote = path.join(noteDir, "nested.md");
+  try {
+    await mkdir(assetDir);
+    await mkdir(noteDir);
+    await writeFile(imagePath, "image", "utf8");
+    await writeFile(rootNote, "![img](assets/photo.png)", "utf8");
+    await writeFile(
+      nestedNote,
+      ["![relative](../assets/photo.png)", "![root](assets/photo.png)"].join("\n"),
+      "utf8",
+    );
+
+    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, nestedRemoteBackend, noopLogger);
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.redirected, 1);
+    assert.equal(result.cleaned, 1);
+    assert.equal(await readFile(rootNote, "utf8"), "![img](remote/assets/photo.png)");
+    assert.equal(
+      await readFile(nestedNote, "utf8"),
+      ["![relative](remote/assets/photo.png)", "![root](remote/assets/photo.png)"].join("\n"),
+    );
+    await assert.rejects(() => readFile(imagePath, "utf8"), /ENOENT/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle fails closed without overwriting an invalid manifest", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-invalid-manifest-"));
+  let uploaded = false;
+  try {
+    await writeFile(path.join(memoryDir, "image.png"), "image", "utf8");
+    const mPath = manifestPath(memoryDir);
+    await mkdir(path.dirname(mPath), { recursive: true });
+    await writeFile(mPath, '{"version":1,"assets":[', "utf8");
+    const backend = {
+      type: "test",
+      upload: async () => {
+        uploaded = true;
+        return "remote/image.png";
+      },
+      exists: async () => false,
+      delete: async () => {},
+    } satisfies BinaryStorageBackend;
+
+    await assert.rejects(
+      () => runBinaryLifecyclePipeline(memoryDir, baseConfig, backend, noopLogger),
+      /Invalid binary lifecycle manifest JSON/,
+    );
+    assert.equal(uploaded, false);
+    assert.equal(await readFile(mPath, "utf8"), '{"version":1,"assets":[');
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 const noopLogger = {
   info: () => {},
   warn: () => {},
@@ -140,7 +448,34 @@ const noUploadBackend = {
   upload: async () => {
     throw new Error("upload should not run");
   },
+  exists: async () => true,
+  delete: async () => {},
+} satisfies BinaryStorageBackend;
+
+const missingRemoteBackend = {
+  type: "test",
+  upload: async () => {
+    throw new Error("upload should not run");
+  },
   exists: async () => false,
+  delete: async () => {},
+} satisfies BinaryStorageBackend;
+
+const failingRemoteBackend = {
+  type: "test",
+  upload: async () => {
+    throw new Error("upload should not run");
+  },
+  exists: async () => {
+    throw new Error("remote unavailable");
+  },
+  delete: async () => {},
+} satisfies BinaryStorageBackend;
+
+const nestedRemoteBackend = {
+  type: "test",
+  upload: async (_localPath: string, remotePath: string) => `remote/${remotePath}`,
+  exists: async () => true,
   delete: async () => {},
 } satisfies BinaryStorageBackend;
 

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
@@ -328,7 +328,6 @@ test("binary lifecycle retries partial redirect failures before cleanup", async 
     await writeFile(imagePath, "image", "utf8");
     await writeFile(firstNote, "![img](image.png)", "utf8");
     await writeFile(secondNote, "![img](image.png)", "utf8");
-    await chmod(secondNote, 0o444);
     await writeManifest(memoryDir, {
       version: 1,
       assets: [
@@ -344,7 +343,20 @@ test("binary lifecycle retries partial redirect failures before cleanup", async 
       ],
     });
 
-    const firstResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    const firstResult = await runBinaryLifecyclePipeline(
+      memoryDir,
+      baseConfig,
+      noUploadBackend,
+      noopLogger,
+      {
+        writeMarkdownFile: async (file, data, options) => {
+          if (file === secondNote) {
+            throw new Error("injected write failure");
+          }
+          await writeFile(file, data, options);
+        },
+      },
+    );
     let manifest = JSON.parse(
       await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
     ) as { assets: Array<{ status: string }> };
@@ -356,7 +368,6 @@ test("binary lifecycle retries partial redirect failures before cleanup", async 
     assert.equal(await readFile(secondNote, "utf8"), "![img](image.png)");
     assert.equal(manifest.assets[0]?.status, "error");
 
-    await chmod(secondNote, 0o644);
     const secondResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
     manifest = JSON.parse(
       await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
@@ -369,7 +380,6 @@ test("binary lifecycle retries partial redirect failures before cleanup", async 
     assert.equal(await readFile(secondNote, "utf8"), "![img](remote/image.png)");
     assert.equal(manifest.assets[0]?.status, "cleaned");
   } finally {
-    await chmod(secondNote, 0o644).catch(() => {});
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
@@ -388,7 +398,7 @@ test("binary lifecycle rewrites nested asset references before cleanup", async (
     await writeFile(rootNote, "![img](assets/photo.png)", "utf8");
     await writeFile(
       nestedNote,
-      ["![relative](../assets/photo.png)", "![root](assets/photo.png)"].join("\n"),
+      ["![relative](../assets/photo.png)", "![root](/assets/photo.png)"].join("\n"),
       "utf8",
     );
 
@@ -403,6 +413,27 @@ test("binary lifecycle rewrites nested asset references before cleanup", async (
       ["![relative](remote/assets/photo.png)", "![root](remote/assets/photo.png)"].join("\n"),
     );
     await assert.rejects(() => readFile(imagePath, "utf8"), /ENOENT/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle does not rewrite ambiguous nested bare links for root assets", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-ambiguous-link-"));
+  const subDir = path.join(memoryDir, "sub");
+  const nestedNote = path.join(subDir, "note.md");
+  try {
+    await mkdir(subDir);
+    await writeFile(path.join(memoryDir, "image.png"), "root", "utf8");
+    await writeFile(path.join(subDir, "image.png"), "nested", "utf8");
+    await writeFile(nestedNote, "![img](image.png)", "utf8");
+
+    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, nestedRemoteBackend, noopLogger);
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.mirrored, 2);
+    assert.equal(result.redirected, 1);
+    assert.equal(await readFile(nestedNote, "utf8"), "![img](remote/sub/image.png)");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -445,6 +445,41 @@ test("binary lifecycle resumes errored assets with no remaining local references
   }
 });
 
+test("binary lifecycle keeps unreferenced errored assets mirrored-only", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-error-unreferenced-"));
+  try {
+    await writeFile(path.join(memoryDir, "image.png"), "image", "utf8");
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "image.png",
+          mirroredPath: "remote/image.png",
+          contentHash: sha256("image"),
+          sizeBytes: "image".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          status: "error",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string; cleanedAt?: string }> };
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.redirected, 0);
+    assert.equal(result.cleaned, 0);
+    assert.equal(manifest.assets[0]?.status, "mirrored");
+    assert.equal(manifest.assets[0]?.cleanedAt, undefined);
+    assert.equal(await readFile(path.join(memoryDir, "image.png"), "utf8"), "image");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("binary lifecycle fails closed without overwriting an invalid manifest", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-invalid-manifest-"));
   let uploaded = false;

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -167,6 +167,40 @@ test("binary lifecycle blocks manifest cleanup paths outside memoryDir", async (
   }
 });
 
+test("binary lifecycle allows hidden asset names that remain inside memoryDir", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-hidden-clean-"));
+  try {
+    await writeFile(path.join(memoryDir, "..hidden.png"), "hidden", "utf8");
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "..hidden.png",
+          mirroredPath: "remote/..hidden.png",
+          contentHash: sha256("hidden"),
+          sizeBytes: "hidden".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          redirectedAt: "2026-01-01T00:00:00.000Z",
+          status: "redirected",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string; cleanedAt?: string }> };
+
+    assert.equal(result.cleaned, 1);
+    assert.deepEqual(result.errors, []);
+    assert.equal(manifest.assets[0]?.status, "cleaned");
+    assert.equal(typeof manifest.assets[0]?.cleanedAt, "string");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("binary lifecycle dry-run does not mark missing redirected assets cleaned", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-dry-clean-"));
   try {

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -408,6 +408,43 @@ test("binary lifecycle rewrites nested asset references before cleanup", async (
   }
 });
 
+test("binary lifecycle resumes errored assets with no remaining local references", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-resume-error-"));
+  try {
+    await writeFile(path.join(memoryDir, "image.png"), "image", "utf8");
+    await writeFile(path.join(memoryDir, "note.md"), "![img](remote/image.png)", "utf8");
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: "image.png",
+          mirroredPath: "remote/image.png",
+          contentHash: sha256("image"),
+          sizeBytes: "image".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          redirectedAt: "2026-01-01T00:00:00.000Z",
+          status: "error",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string; cleanedAt?: string }> };
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.redirected, 1);
+    assert.equal(result.cleaned, 1);
+    assert.equal(manifest.assets[0]?.status, "cleaned");
+    assert.equal(typeof manifest.assets[0]?.cleanedAt, "string");
+    await assert.rejects(() => readFile(path.join(memoryDir, "image.png"), "utf8"), /ENOENT/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("binary lifecycle fails closed without overwriting an invalid manifest", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-invalid-manifest-"));
   let uploaded = false;

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -189,7 +189,7 @@ test("binary lifecycle dry-run does not mark missing redirected assets cleaned",
     const result = await runBinaryLifecyclePipeline(
       memoryDir,
       baseConfig,
-      noUploadBackend,
+      nestedRemoteBackend,
       noopLogger,
       { dryRun: true },
     );
@@ -346,14 +346,14 @@ test("binary lifecycle retries partial redirect failures before cleanup", async 
     const firstResult = await runBinaryLifecyclePipeline(
       memoryDir,
       baseConfig,
-      noUploadBackend,
+      nestedRemoteBackend,
       noopLogger,
       {
-        writeMarkdownFile: async (file, data, options) => {
+        writeMarkdownFile: async (file, data) => {
           if (file === secondNote) {
             throw new Error("injected write failure");
           }
-          await writeFile(file, data, options);
+          await writeFile(file, data, "utf8");
         },
       },
     );
@@ -368,7 +368,7 @@ test("binary lifecycle retries partial redirect failures before cleanup", async 
     assert.equal(await readFile(secondNote, "utf8"), "![img](image.png)");
     assert.equal(manifest.assets[0]?.status, "error");
 
-    const secondResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    const secondResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, nestedRemoteBackend, noopLogger);
     manifest = JSON.parse(
       await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
     ) as { assets: Array<{ status: string }> };
@@ -471,6 +471,52 @@ test("binary lifecycle resumes errored assets with no remaining local references
     assert.equal(manifest.assets[0]?.status, "cleaned");
     assert.equal(typeof manifest.assets[0]?.cleanedAt, "string");
     await assert.rejects(() => readFile(path.join(memoryDir, "image.png"), "utf8"), /ENOENT/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("binary lifecycle resumes redirects after verification read failures", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-verify-read-error-"));
+  const notePath = path.join(memoryDir, "note.md");
+  let noteReads = 0;
+  try {
+    await writeFile(path.join(memoryDir, "image.png"), "image", "utf8");
+    await writeFile(notePath, "![img](image.png)", "utf8");
+
+    const firstResult = await runBinaryLifecyclePipeline(
+      memoryDir,
+      baseConfig,
+      nestedRemoteBackend,
+      noopLogger,
+      {
+        readMarkdownFile: async (file) => {
+          if (file === notePath && noteReads++ > 0) {
+            throw new Error("injected verification read failure");
+          }
+          return readFile(file, "utf8");
+        },
+      },
+    );
+    let manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string; redirectedAt?: string }> };
+
+    assert.equal(firstResult.cleaned, 0);
+    assert.match(firstResult.errors.join("\n"), /injected verification read failure/);
+    assert.equal(await readFile(notePath, "utf8"), "![img](remote/image.png)");
+    assert.equal(manifest.assets[0]?.status, "error");
+    assert.equal(typeof manifest.assets[0]?.redirectedAt, "string");
+
+    const secondResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, nestedRemoteBackend, noopLogger);
+    manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string; cleanedAt?: string }> };
+
+    assert.equal(secondResult.errors.length, 0);
+    assert.equal(secondResult.redirected, 1);
+    assert.equal(secondResult.cleaned, 1);
+    assert.equal(manifest.assets[0]?.status, "cleaned");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -259,14 +259,24 @@ test("binary lifecycle blocks cleanup when manifest mirroredAt is invalid", asyn
       ],
     });
 
-    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
-    const manifest = JSON.parse(
+    const firstResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    let manifest = JSON.parse(
       await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
     ) as { assets: Array<{ status: string }> };
 
-    assert.equal(result.cleaned, 0);
-    assert.match(result.errors.join("\n"), /manifest mirroredAt is invalid/);
+    assert.equal(firstResult.cleaned, 0);
+    assert.match(firstResult.errors.join("\n"), /manifest mirroredAt is invalid/);
     assert.equal(await readFile(path.join(memoryDir, "image.png"), "utf8"), "image");
+    assert.equal(manifest.assets[0]?.status, "error");
+
+    const secondResult = await runBinaryLifecyclePipeline(memoryDir, baseConfig, noUploadBackend, noopLogger);
+    manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string }> };
+
+    assert.equal(secondResult.redirected, 0);
+    assert.equal(secondResult.cleaned, 0);
+    assert.match(secondResult.errors.join("\n"), /manifest mirroredAt is invalid/);
     assert.equal(manifest.assets[0]?.status, "error");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.test.ts
@@ -452,6 +452,42 @@ test("binary lifecycle rewrites nested asset references before cleanup", async (
   }
 });
 
+test("binary lifecycle rewrites dot-slash hidden asset references before cleanup", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-hidden-redirect-"));
+  try {
+    await writeFile(path.join(memoryDir, ".photo.png"), "hidden", "utf8");
+    await writeFile(path.join(memoryDir, "note.md"), "![img](./.photo.png)", "utf8");
+    await writeManifest(memoryDir, {
+      version: 1,
+      assets: [
+        {
+          originalPath: ".photo.png",
+          mirroredPath: "remote/.photo.png",
+          contentHash: sha256("hidden"),
+          sizeBytes: "hidden".length,
+          mimeType: "image/png",
+          mirroredAt: "2026-01-01T00:00:00.000Z",
+          status: "mirrored",
+        },
+      ],
+    });
+
+    const result = await runBinaryLifecyclePipeline(memoryDir, baseConfig, nestedRemoteBackend, noopLogger);
+    const manifest = JSON.parse(
+      await readFile(path.join(memoryDir, ".binary-lifecycle", "manifest.json"), "utf8"),
+    ) as { assets: Array<{ status: string }> };
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.redirected, 1);
+    assert.equal(result.cleaned, 1);
+    assert.equal(await readFile(path.join(memoryDir, "note.md"), "utf8"), "![img](remote/.photo.png)");
+    assert.equal(manifest.assets[0]?.status, "cleaned");
+    await assert.rejects(() => readFile(path.join(memoryDir, ".photo.png"), "utf8"), /ENOENT/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("binary lifecycle does not rewrite ambiguous nested bare links for root assets", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-binary-ambiguous-link-"));
   const subDir = path.join(memoryDir, "sub");

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -84,7 +84,7 @@ function resolveManifestAssetPath(memoryDir: string, originalPath: string): stri
   const memoryRoot = path.resolve(memoryDir);
   const fullPath = path.resolve(memoryRoot, originalPath);
   const relative = path.relative(memoryRoot, fullPath);
-  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
     return null;
   }
 

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -63,6 +63,27 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function resolveManifestAssetPath(memoryDir: string, originalPath: string): string | null {
+  if (
+    originalPath.length === 0 ||
+    originalPath.includes("\0") ||
+    originalPath.includes("\\") ||
+    path.isAbsolute(originalPath) ||
+    path.win32.isAbsolute(originalPath)
+  ) {
+    return null;
+  }
+
+  const memoryRoot = path.resolve(memoryDir);
+  const fullPath = path.resolve(memoryRoot, originalPath);
+  const relative = path.relative(memoryRoot, fullPath);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return null;
+  }
+
+  return fullPath;
+}
+
 function validateBinaryLifecycleConfig(config: BinaryLifecycleConfig): void {
   if (
     typeof config.gracePeriodDays !== "number" ||
@@ -141,89 +162,178 @@ async function stageRedirect(
   let redirected = 0;
   const errors: string[] = [];
 
-  // Only redirect assets that are mirrored but not yet redirected.
-  const candidates = assets.filter((a) => a.status === "mirrored");
+  // Redirect mirrored assets and retry prior redirect errors. Clean-stage errors
+  // remain safe because the redirect path validation below will keep rejecting
+  // invalid manifest records.
+  const candidates = assets.filter((a) => a.status === "mirrored" || a.status === "error");
   if (candidates.length === 0) return { redirected, errors };
 
   // Find all markdown files in memoryDir (recursive).
   const mdFiles = await findMarkdownFiles(memoryDir);
 
   for (const asset of candidates) {
-    let matchCount = 0;
-    let writeFailCount = 0;
+    const assetAbsolute = resolveManifestAssetPath(memoryDir, asset.originalPath);
+    if (assetAbsolute === null) {
+      const msg = `redirect blocked for ${asset.originalPath}: manifest path is outside memoryDir`;
+      log.error(`[binary-lifecycle] ${msg}`);
+      errors.push(msg);
+      if (!dryRun) {
+        asset.status = "error";
+      }
+      continue;
+    }
+
+    const updates: Array<{ mdPath: string; content: string }> = [];
+    let scanFailCount = 0;
     for (const mdPath of mdFiles) {
       try {
         const content = await fsp.readFile(mdPath, "utf-8");
 
-        // Build the match path relative to this markdown file's directory.
-        // Markdown links like `![img](./image.png)` are file-relative, but
-        // asset.originalPath is memory-root relative (e.g. `sub/image.png`).
-        // Resolve the asset path relative to the markdown file's directory
-        // so both forms match correctly.
-        const mdDir = path.dirname(mdPath);
-        const assetAbsolute = path.join(memoryDir, asset.originalPath);
-        const relativeToMd = path.relative(mdDir, assetAbsolute);
-        // Normalise to forward slashes for regex matching (markdown uses /).
-        const relativeForward = relativeToMd.split(path.sep).join("/");
-        const escaped = escapeRegex(relativeForward);
-
-        // Build a regex that matches markdown image/link references to the file.
-        // Handles: ![alt](./path) , ![alt](path) , [text](./path)
-        const pattern = new RegExp(
-          `(!?\\[[^\\]]*\\]\\()(\\.\\/)?(${escaped})(\\))`,
-          "g",
-        );
+        const pattern = markdownReferencePattern(asset, assetAbsolute, mdPath);
 
         if (!pattern.test(content)) continue;
-        matchCount++;
 
-        if (!dryRun) {
-          // Reset lastIndex after test().
-          pattern.lastIndex = 0;
-          const updated = content.replace(pattern, (_match, open, _dotSlash, _file, close) => {
-            return `${open as string}${asset.mirroredPath}${close as string}`;
-          });
-          await fsp.writeFile(mdPath, updated, "utf-8");
-        }
+        // Reset lastIndex after test().
+        pattern.lastIndex = 0;
+        const updated = content.replace(pattern, (_match, open, _target, close) => {
+          return `${open as string}${asset.mirroredPath}${close as string}`;
+        });
+        updates.push({ mdPath, content: updated });
       } catch (err) {
-        // Track write failures separately so we don't transition status
-        // when some markdown rewrites failed (P1: block redirect on failure).
-        writeFailCount++;
+        scanFailCount++;
         const msg = `redirect scan failed for ${mdPath}: ${err instanceof Error ? err.message : String(err)}`;
         log.error(`[binary-lifecycle] ${msg}`);
         errors.push(msg);
       }
     }
 
-    // Only transition to "redirected" when at least one reference was found
-    // AND all matched files were rewritten successfully.
-    if (matchCount > 0 && writeFailCount === 0) {
-      if (!dryRun) {
-        asset.status = "redirected";
-        asset.redirectedAt = new Date().toISOString();
-      }
-      redirected++;
-      log.info(`[binary-lifecycle] redirected: ${asset.originalPath}${dryRun ? " [dry-run]" : ""}`);
-    } else if (matchCount > 0 && writeFailCount > 0) {
-      // Some rewrites failed — set error status so the asset is not cleaned
-      // prematurely. It can be retried on the next pipeline run.
+    if (scanFailCount > 0) {
       if (!dryRun) {
         asset.status = "error";
       }
       log.warn(
-        `[binary-lifecycle] redirect partial failure for ${asset.originalPath}: ` +
-          `${matchCount} match(es), ${writeFailCount} write failure(s)` +
+        `[binary-lifecycle] redirect blocked for ${asset.originalPath}: ` +
+          `${scanFailCount} markdown scan failure(s)` +
           `${dryRun ? "" : " — status set to error"}`,
       );
+      continue;
     }
+
+    if (updates.length === 0) {
+      continue;
+    }
+
+    if (dryRun) {
+      redirected++;
+      log.info(`[binary-lifecycle] redirected: ${asset.originalPath} [dry-run]`);
+      continue;
+    }
+
+    let writeFailCount = 0;
+    for (const update of updates) {
+      try {
+        await fsp.writeFile(update.mdPath, update.content, "utf-8");
+      } catch (err) {
+        writeFailCount++;
+        const msg = `redirect write failed for ${update.mdPath}: ${err instanceof Error ? err.message : String(err)}`;
+        log.error(`[binary-lifecycle] ${msg}`);
+        errors.push(msg);
+      }
+    }
+
+    if (writeFailCount > 0) {
+      if (!dryRun) {
+        asset.status = "error";
+      }
+      log.warn(
+        `[binary-lifecycle] redirect write failure for ${asset.originalPath}: ` +
+          `${writeFailCount} write failure(s) — status set to error`,
+      );
+      continue;
+    }
+
+    const verifyResult = await countRemainingLocalReferences(memoryDir, asset, assetAbsolute, mdFiles);
+    if (verifyResult.errors.length > 0 || verifyResult.remaining > 0) {
+      asset.status = "error";
+      for (const msg of verifyResult.errors) {
+        log.error(`[binary-lifecycle] ${msg}`);
+        errors.push(msg);
+      }
+      if (verifyResult.remaining > 0) {
+        const msg = `redirect verification failed for ${asset.originalPath}: ${verifyResult.remaining} local reference(s) remain`;
+        log.warn(`[binary-lifecycle] ${msg}`);
+        errors.push(msg);
+      }
+      continue;
+    }
+
+    asset.status = "redirected";
+    asset.redirectedAt = new Date().toISOString();
+    redirected++;
+    log.info(`[binary-lifecycle] redirected: ${asset.originalPath}`);
   }
 
   return { redirected, errors };
 }
 
+async function countRemainingLocalReferences(
+  memoryDir: string,
+  asset: BinaryAssetRecord,
+  assetAbsolute: string,
+  mdFiles: string[],
+): Promise<{ remaining: number; errors: string[] }> {
+  let remaining = 0;
+  const errors: string[] = [];
+
+  for (const mdPath of mdFiles) {
+    try {
+      const content = await fsp.readFile(mdPath, "utf-8");
+      const pattern = markdownReferencePattern(asset, assetAbsolute, mdPath);
+      if (pattern.test(content)) {
+        remaining++;
+      }
+    } catch (err) {
+      errors.push(`redirect verification failed for ${mdPath}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { remaining, errors };
+}
+
+function markdownReferencePattern(
+  asset: BinaryAssetRecord,
+  assetAbsolute: string,
+  mdPath: string,
+): RegExp {
+  const mdDir = path.dirname(mdPath);
+  const candidates = new Set<string>();
+  const addCandidate = (candidate: string): void => {
+    const normalized = candidate.split(path.sep).join("/");
+    if (normalized.length === 0) return;
+    candidates.add(normalized);
+    if (!normalized.startsWith(".") && !normalized.startsWith("/")) {
+      candidates.add(`./${normalized}`);
+    }
+  };
+
+  // Markdown links may be file-relative to the note or memory-root-relative in
+  // Remnic notes. Match both forms so verification cannot miss a live local ref.
+  addCandidate(path.relative(mdDir, assetAbsolute));
+  addCandidate(asset.originalPath);
+  addCandidate(`/${asset.originalPath.split(path.sep).join("/")}`);
+
+  const alternatives = [...candidates]
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegex)
+    .join("|");
+
+  return new RegExp(`(!?\\[[^\\]]*\\]\\()(${alternatives})(\\))`, "g");
+}
+
 async function stageClean(
   memoryDir: string,
   assets: BinaryAssetRecord[],
+  backend: BinaryStorageBackend,
   gracePeriodDays: number,
   log: PipelineLogger,
   dryRun: boolean,
@@ -243,6 +353,15 @@ async function stageClean(
 
   for (const asset of candidates) {
     const mirroredMs = new Date(asset.mirroredAt).getTime();
+    if (!Number.isFinite(mirroredMs)) {
+      const msg = `clean blocked for ${asset.originalPath}: manifest mirroredAt is invalid`;
+      log.error(`[binary-lifecycle] ${msg}`);
+      errors.push(msg);
+      if (!dryRun) {
+        asset.status = "error";
+      }
+      continue;
+    }
     const ageMs = now - mirroredMs;
 
     if (!forceClean && ageMs < graceMs) {
@@ -250,7 +369,34 @@ async function stageClean(
       continue;
     }
 
-    const fullPath = path.join(memoryDir, asset.originalPath);
+    const fullPath = resolveManifestAssetPath(memoryDir, asset.originalPath);
+    if (fullPath === null) {
+      const msg = `clean blocked for ${asset.originalPath}: manifest path is outside memoryDir`;
+      log.error(`[binary-lifecycle] ${msg}`);
+      errors.push(msg);
+      if (!dryRun) {
+        asset.status = "error";
+      }
+      continue;
+    }
+
+    let remoteExists: boolean;
+    try {
+      remoteExists = await backend.exists(asset.mirroredPath);
+    } catch (err) {
+      const msg = `clean blocked for ${asset.originalPath}: failed to verify mirrored copy: ${err instanceof Error ? err.message : String(err)}`;
+      log.error(`[binary-lifecycle] ${msg}`);
+      errors.push(msg);
+      continue;
+    }
+
+    if (!remoteExists) {
+      const msg = `clean blocked for ${asset.originalPath}: mirrored copy is missing`;
+      log.error(`[binary-lifecycle] ${msg}`);
+      errors.push(msg);
+      continue;
+    }
+
     try {
       const currentHash = await hashFile(fullPath);
       if (currentHash !== asset.contentHash) {
@@ -269,9 +415,11 @@ async function stageClean(
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         // Already gone — mark as cleaned.
-        asset.status = "cleaned";
-        asset.cleanedAt = new Date().toISOString();
-        cleaned++;
+        if (!dryRun) {
+          asset.status = "cleaned";
+          asset.cleanedAt = new Date().toISOString();
+          cleaned++;
+        }
       } else {
         const msg = `clean failed for ${asset.originalPath}: ${err instanceof Error ? err.message : String(err)}`;
         log.error(`[binary-lifecycle] ${msg}`);
@@ -365,6 +513,7 @@ export async function runBinaryLifecyclePipeline(
   const cleanResult = await stageClean(
     memoryDir,
     manifest.assets,
+    backend,
     config.gracePeriodDays,
     log,
     dryRun,

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -275,6 +275,16 @@ async function stageRedirect(
           continue;
         }
 
+        if (!Number.isFinite(new Date(asset.mirroredAt).getTime())) {
+          const msg = `redirect blocked for ${asset.originalPath}: manifest mirroredAt is invalid`;
+          log.error(`[binary-lifecycle] ${msg}`);
+          errors.push(msg);
+          if (!dryRun) {
+            asset.status = "error";
+          }
+          continue;
+        }
+
         if (!dryRun) {
           asset.status = "redirected";
           asset.redirectedAt = new Date().toISOString();

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -103,6 +103,10 @@ function remotePathForAsset(backend: BinaryStorageBackend, relPath: string): str
   return normalized;
 }
 
+function markdownTargetForAsset(asset: BinaryAssetRecord): string {
+  return asset.redirectPath ?? asset.mirroredPath;
+}
+
 // ---------------------------------------------------------------------------
 // Pipeline stages
 // ---------------------------------------------------------------------------
@@ -131,10 +135,12 @@ async function stageMirror(
       if (!dryRun) {
         backendLocation = await backend.upload(fullPath, remotePath);
       }
+      const redirectPath = backend.getRedirectTarget?.(backendLocation);
 
       const record: BinaryAssetRecord = {
         originalPath: relPath,
         mirroredPath: backendLocation,
+        ...(redirectPath ? { redirectPath } : {}),
         contentHash,
         sizeBytes: stat.size,
         mimeType,
@@ -204,7 +210,7 @@ async function stageRedirect(
         // Reset lastIndex after test().
         pattern.lastIndex = 0;
         const updated = content.replace(pattern, (_match, open, _target, close) => {
-          return `${open as string}${asset.mirroredPath}${close as string}`;
+          return `${open as string}${markdownTargetForAsset(asset)}${close as string}`;
         });
         updates.push({ mdPath, content: updated });
       } catch (err) {

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -26,12 +26,17 @@ interface PipelineLogger {
   error(msg: string): void;
 }
 
+type ReadMarkdownFile = (filePath: string) => Promise<string>;
+type WriteMarkdownFile = (filePath: string, content: string) => Promise<void>;
+
 interface PipelineOptions {
   dryRun?: boolean;
   /** Force-clean all files past grace period, ignoring redirect status. */
   forceClean?: boolean;
+  /** Test hook for deterministic markdown read failures. */
+  readMarkdownFile?: ReadMarkdownFile;
   /** Test hook for deterministic markdown write failures. */
-  writeMarkdownFile?: typeof fsp.writeFile;
+  writeMarkdownFile?: WriteMarkdownFile;
 }
 
 // ---------------------------------------------------------------------------
@@ -174,7 +179,8 @@ async function stageRedirect(
   assets: BinaryAssetRecord[],
   log: PipelineLogger,
   dryRun: boolean,
-  writeMarkdownFile: typeof fsp.writeFile,
+  readMarkdownFile: ReadMarkdownFile,
+  writeMarkdownFile: WriteMarkdownFile,
 ): Promise<{ redirected: number; errors: string[] }> {
   let redirected = 0;
   const errors: string[] = [];
@@ -204,7 +210,7 @@ async function stageRedirect(
     let scanFailCount = 0;
     for (const mdPath of mdFiles) {
       try {
-        const content = await fsp.readFile(mdPath, "utf-8");
+        const content = await readMarkdownFile(mdPath);
 
         const pattern = markdownReferencePattern(asset, assetAbsolute, mdPath);
 
@@ -238,7 +244,13 @@ async function stageRedirect(
 
     if (updates.length === 0) {
       if (asset.status === "error") {
-        const verifyResult = await countRemainingLocalReferences(memoryDir, asset, assetAbsolute, mdFiles);
+        const verifyResult = await countRemainingLocalReferences(
+          memoryDir,
+          asset,
+          assetAbsolute,
+          mdFiles,
+          readMarkdownFile,
+        );
         if (verifyResult.errors.length > 0 || verifyResult.remaining > 0) {
           if (!dryRun) {
             asset.status = "error";
@@ -282,7 +294,7 @@ async function stageRedirect(
     let writeFailCount = 0;
     for (const update of updates) {
       try {
-        await writeMarkdownFile(update.mdPath, update.content, "utf-8");
+        await writeMarkdownFile(update.mdPath, update.content);
       } catch (err) {
         writeFailCount++;
         const msg = `redirect write failed for ${update.mdPath}: ${err instanceof Error ? err.message : String(err)}`;
@@ -302,7 +314,16 @@ async function stageRedirect(
       continue;
     }
 
-    const verifyResult = await countRemainingLocalReferences(memoryDir, asset, assetAbsolute, mdFiles);
+    const redirectedAt = new Date().toISOString();
+    asset.redirectedAt = redirectedAt;
+
+    const verifyResult = await countRemainingLocalReferences(
+      memoryDir,
+      asset,
+      assetAbsolute,
+      mdFiles,
+      readMarkdownFile,
+    );
     if (verifyResult.errors.length > 0 || verifyResult.remaining > 0) {
       asset.status = "error";
       for (const msg of verifyResult.errors) {
@@ -316,9 +337,8 @@ async function stageRedirect(
       }
       continue;
     }
-
     asset.status = "redirected";
-    asset.redirectedAt = new Date().toISOString();
+    asset.redirectedAt = redirectedAt;
     redirected++;
     log.info(`[binary-lifecycle] redirected: ${asset.originalPath}`);
   }
@@ -331,13 +351,14 @@ async function countRemainingLocalReferences(
   asset: BinaryAssetRecord,
   assetAbsolute: string,
   mdFiles: string[],
+  readMarkdownFile: ReadMarkdownFile,
 ): Promise<{ remaining: number; errors: string[] }> {
   let remaining = 0;
   const errors: string[] = [];
 
   for (const mdPath of mdFiles) {
     try {
-      const content = await fsp.readFile(mdPath, "utf-8");
+      const content = await readMarkdownFile(mdPath);
       const pattern = markdownReferencePattern(asset, assetAbsolute, mdPath);
       if (pattern.test(content)) {
         remaining++;
@@ -566,7 +587,8 @@ export async function runBinaryLifecyclePipeline(
     manifest.assets,
     log,
     dryRun,
-    opts?.writeMarkdownFile ?? fsp.writeFile,
+    opts?.readMarkdownFile ?? ((filePath: string) => fsp.readFile(filePath, "utf-8")),
+    opts?.writeMarkdownFile ?? ((filePath: string, content: string) => fsp.writeFile(filePath, content, "utf-8")),
   );
 
   // Stage 3: Clean

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -382,7 +382,8 @@ function markdownReferencePattern(
     const normalized = candidate.split(path.sep).join("/");
     if (normalized.length === 0) return;
     candidates.add(normalized);
-    if (!normalized.startsWith(".") && !normalized.startsWith("/")) {
+    const isParentTraversal = normalized === ".." || normalized.startsWith("../");
+    if (!normalized.startsWith("./") && !normalized.startsWith("/") && !isParentTraversal) {
       candidates.add(`./${normalized}`);
     }
   };

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -95,6 +95,14 @@ function validateBinaryLifecycleConfig(config: BinaryLifecycleConfig): void {
   }
 }
 
+function remotePathForAsset(backend: BinaryStorageBackend, relPath: string): string {
+  const normalized = relPath.split(path.sep).join("/");
+  if (backend.type === "filesystem") {
+    return `.binary-lifecycle/mirrors/${normalized}`;
+  }
+  return normalized;
+}
+
 // ---------------------------------------------------------------------------
 // Pipeline stages
 // ---------------------------------------------------------------------------
@@ -117,7 +125,7 @@ async function stageMirror(
       const contentHash = await hashFile(fullPath);
       const ext = path.extname(relPath);
       const mimeType = guessMimeType(ext);
-      const remotePath = relPath;
+      const remotePath = remotePathForAsset(backend, relPath);
 
       let backendLocation = remotePath;
       if (!dryRun) {
@@ -220,6 +228,31 @@ async function stageRedirect(
     }
 
     if (updates.length === 0) {
+      if (asset.status === "error") {
+        const verifyResult = await countRemainingLocalReferences(memoryDir, asset, assetAbsolute, mdFiles);
+        if (verifyResult.errors.length > 0 || verifyResult.remaining > 0) {
+          if (!dryRun) {
+            asset.status = "error";
+          }
+          for (const msg of verifyResult.errors) {
+            log.error(`[binary-lifecycle] ${msg}`);
+            errors.push(msg);
+          }
+          if (verifyResult.remaining > 0) {
+            const msg = `redirect verification failed for ${asset.originalPath}: ${verifyResult.remaining} local reference(s) remain`;
+            log.warn(`[binary-lifecycle] ${msg}`);
+            errors.push(msg);
+          }
+          continue;
+        }
+
+        if (!dryRun) {
+          asset.status = "redirected";
+          asset.redirectedAt = new Date().toISOString();
+        }
+        redirected++;
+        log.info(`[binary-lifecycle] redirected: ${asset.originalPath}${dryRun ? " [dry-run]" : ""}`);
+      }
       continue;
     }
 

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -30,6 +30,8 @@ interface PipelineOptions {
   dryRun?: boolean;
   /** Force-clean all files past grace period, ignoring redirect status. */
   forceClean?: boolean;
+  /** Test hook for deterministic markdown write failures. */
+  writeMarkdownFile?: typeof fsp.writeFile;
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +174,7 @@ async function stageRedirect(
   assets: BinaryAssetRecord[],
   log: PipelineLogger,
   dryRun: boolean,
+  writeMarkdownFile: typeof fsp.writeFile,
 ): Promise<{ redirected: number; errors: string[] }> {
   let redirected = 0;
   const errors: string[] = [];
@@ -279,7 +282,7 @@ async function stageRedirect(
     let writeFailCount = 0;
     for (const update of updates) {
       try {
-        await fsp.writeFile(update.mdPath, update.content, "utf-8");
+        await writeMarkdownFile(update.mdPath, update.content, "utf-8");
       } catch (err) {
         writeFailCount++;
         const msg = `redirect write failed for ${update.mdPath}: ${err instanceof Error ? err.message : String(err)}`;
@@ -366,8 +369,12 @@ function markdownReferencePattern(
   // Markdown links may be file-relative to the note or memory-root-relative in
   // Remnic notes. Match both forms so verification cannot miss a live local ref.
   addCandidate(path.relative(mdDir, assetAbsolute));
-  addCandidate(asset.originalPath);
-  addCandidate(`/${asset.originalPath.split(path.sep).join("/")}`);
+  const originalPath = asset.originalPath.split(path.sep).join("/");
+  const originalAsFileRelative = path.resolve(mdDir, ...originalPath.split("/"));
+  if (path.resolve(originalAsFileRelative) === path.resolve(assetAbsolute)) {
+    addCandidate(originalPath);
+  }
+  addCandidate(`/${originalPath}`);
 
   const alternatives = [...candidates]
     .sort((a, b) => b.length - a.length)
@@ -554,7 +561,13 @@ export async function runBinaryLifecyclePipeline(
   );
 
   // Stage 2: Redirect
-  const redirectResult = await stageRedirect(memoryDir, manifest.assets, log, dryRun);
+  const redirectResult = await stageRedirect(
+    memoryDir,
+    manifest.assets,
+    log,
+    dryRun,
+    opts?.writeMarkdownFile ?? fsp.writeFile,
+  );
 
   // Stage 3: Clean
   const cleanResult = await stageClean(

--- a/packages/remnic-core/src/binary-lifecycle/pipeline.ts
+++ b/packages/remnic-core/src/binary-lifecycle/pipeline.ts
@@ -252,6 +252,14 @@ async function stageRedirect(
           continue;
         }
 
+        if (asset.redirectedAt === undefined) {
+          if (!dryRun) {
+            asset.status = "mirrored";
+          }
+          log.info(`[binary-lifecycle] preserved mirrored asset without redirected marker: ${asset.originalPath}${dryRun ? " [dry-run]" : ""}`);
+          continue;
+        }
+
         if (!dryRun) {
           asset.status = "redirected";
           asset.redirectedAt = new Date().toISOString();

--- a/packages/remnic-core/src/binary-lifecycle/types.ts
+++ b/packages/remnic-core/src/binary-lifecycle/types.ts
@@ -43,6 +43,8 @@ export interface BinaryAssetRecord {
   originalPath: string;
   /** Path (or URL) in the backend storage. */
   mirroredPath: string;
+  /** Optional user-resolvable target to write into markdown links. */
+  redirectPath?: string;
   /** SHA-256 hex digest of file content. */
   contentHash: string;
   /** File size in bytes. */

--- a/tests/binary-lifecycle.test.ts
+++ b/tests/binary-lifecycle.test.ts
@@ -364,7 +364,7 @@ test("mirror stage creates manifest entry with status 'mirrored'", async () => {
       manifest.assets[0].mirroredPath,
       ".binary-lifecycle/mirrors/photo.png",
     );
-    assert.equal(fs.existsSync(path.join(backendDir, ".binary-lifecycle", "mirrors", "photo.png")), true);
+    assert.equal(manifest.assets[0].redirectPath, path.join(backendDir, ".binary-lifecycle", "mirrors", "photo.png"));
   } finally {
     await rm(dir, { recursive: true, force: true });
     await rm(backendDir, { recursive: true, force: true });
@@ -403,7 +403,7 @@ test("redirect stage replaces ![img](./screenshot.png) with redirect path", asyn
     // Verify the markdown was updated.
     const mdContent = await readFile(path.join(dir, "notes.md"), "utf-8");
     assert.ok(!mdContent.includes("./screenshot.png"), "original ref should be replaced");
-    assert.ok(mdContent.includes(".binary-lifecycle/mirrors/screenshot.png"), "redirect path should be present");
+    assert.ok(mdContent.includes(path.join(backendDir, ".binary-lifecycle", "mirrors", "screenshot.png")), "redirect path should be present");
   } finally {
     await rm(dir, { recursive: true, force: true });
     await rm(backendDir, { recursive: true, force: true });
@@ -784,7 +784,7 @@ test("redirect stage resolves asset paths relative to markdown file directory", 
     // Verify the markdown was updated.
     const mdContent = await readFile(path.join(dir, "sub", "note.md"), "utf-8");
     assert.ok(!mdContent.includes("./image.png"), "original file-relative ref should be replaced");
-    assert.ok(mdContent.includes(".binary-lifecycle/mirrors/sub/image.png"), "redirect path should be present");
+    assert.ok(mdContent.includes(path.join(backendDir, ".binary-lifecycle", "mirrors", "sub", "image.png")), "redirect path should be present");
   } finally {
     await rm(dir, { recursive: true, force: true });
     await rm(backendDir, { recursive: true, force: true });

--- a/tests/binary-lifecycle.test.ts
+++ b/tests/binary-lifecycle.test.ts
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
 import crypto from "node:crypto";
-import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, mkdir, readFile, symlink } from "node:fs/promises";
 
 import {
   scanForBinaries,
@@ -305,27 +305,27 @@ test("readManifest returns empty manifest for missing file", async () => {
   }
 });
 
-test("readManifest returns empty manifest for invalid JSON", async () => {
+test("readManifest rejects invalid JSON without overwriting it", async () => {
   const dir = await mkdtemp(tmpPrefix());
   try {
     const mPath = manifestPath(dir);
     await mkdir(path.dirname(mPath), { recursive: true });
     await writeFile(mPath, "not json at all");
-    const manifest = await readManifest(dir);
-    assert.deepEqual(manifest, { version: 1, assets: [] });
+    await assert.rejects(() => readManifest(dir), /Invalid binary lifecycle manifest JSON/);
+    assert.equal(await readFile(mPath, "utf8"), "not json at all");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
 
-test("readManifest returns empty manifest for JSON null", async () => {
+test("readManifest rejects invalid manifest shape without overwriting it", async () => {
   const dir = await mkdtemp(tmpPrefix());
   try {
     const mPath = manifestPath(dir);
     await mkdir(path.dirname(mPath), { recursive: true });
     await writeFile(mPath, "null");
-    const manifest = await readManifest(dir);
-    assert.deepEqual(manifest, { version: 1, assets: [] });
+    await assert.rejects(() => readManifest(dir), /Invalid binary lifecycle manifest shape/);
+    assert.equal(await readFile(mPath, "utf8"), "null");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -820,5 +820,36 @@ test("redirect stage handles markdown in parent dir referencing asset in subdir"
   } finally {
     await rm(dir, { recursive: true, force: true });
     await rm(backendDir, { recursive: true, force: true });
+  }
+});
+
+test("FilesystemBackend rejects uploads through symlinked directories", async () => {
+  const srcDir = await mkdtemp(tmpPrefix());
+  const destDir = await mkdtemp(tmpPrefix());
+  const outsideDir = await mkdtemp(tmpPrefix());
+  try {
+    const srcFile = path.join(srcDir, "test.png");
+    const outsideFile = path.join(outsideDir, "test.png");
+    await writeFile(srcFile, Buffer.from("PNG_DATA"));
+    await symlink(outsideDir, path.join(destDir, "sub"), "dir");
+
+    const backend = new FilesystemBackend(destDir);
+    await assert.rejects(
+      () => backend.upload(srcFile, "sub/test.png"),
+      /traverses symlink/,
+    );
+    await assert.rejects(
+      () => backend.exists("sub/test.png"),
+      /traverses symlink/,
+    );
+    await assert.rejects(
+      () => backend.delete("sub/test.png"),
+      /traverses symlink/,
+    );
+    assert.equal(fs.existsSync(outsideFile), false);
+  } finally {
+    await rm(srcDir, { recursive: true, force: true });
+    await rm(destDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
   }
 });

--- a/tests/binary-lifecycle.test.ts
+++ b/tests/binary-lifecycle.test.ts
@@ -853,3 +853,17 @@ test("FilesystemBackend rejects uploads through symlinked directories", async ()
     await rm(outsideDir, { recursive: true, force: true });
   }
 });
+
+test("FilesystemBackend does not treat directories as mirrored files", async () => {
+  const destDir = await mkdtemp(tmpPrefix());
+  try {
+    await mkdir(path.join(destDir, "remote.png"));
+    const backend = new FilesystemBackend(destDir);
+
+    assert.equal(await backend.exists("remote.png"), false);
+    await backend.delete("remote.png");
+    assert.equal(fs.existsSync(path.join(destDir, "remote.png")), true);
+  } finally {
+    await rm(destDir, { recursive: true, force: true });
+  }
+});

--- a/tests/binary-lifecycle.test.ts
+++ b/tests/binary-lifecycle.test.ts
@@ -156,8 +156,8 @@ test("FilesystemBackend copies file correctly, exists() returns true", async () 
     const backend = new FilesystemBackend(destDir);
     const result = await backend.upload(srcFile, "subdir/test.png");
 
-    assert.ok(result.includes("test.png"));
-    assert.equal(await backend.exists("subdir/test.png"), true);
+    assert.equal(result, "subdir/test.png");
+    assert.equal(await backend.exists("subdir/test.png"), true); assert.equal(await backend.exists(result), true);
     assert.equal(await backend.exists("nonexistent.png"), false);
 
     // Verify content was copied correctly.
@@ -360,11 +360,11 @@ test("mirror stage creates manifest entry with status 'mirrored'", async () => {
     assert.equal(manifest.assets[0].status, "mirrored");
     assert.equal(manifest.assets[0].originalPath, "photo.png");
     assert.ok(manifest.assets[0].contentHash.length > 0);
-    // mirroredPath should reflect actual backend location, not the original relative path.
-    assert.ok(
-      manifest.assets[0].mirroredPath.includes(backendDir),
-      "mirroredPath should contain the backend base path",
+    assert.equal(
+      manifest.assets[0].mirroredPath,
+      ".binary-lifecycle/mirrors/photo.png",
     );
+    assert.equal(fs.existsSync(path.join(backendDir, ".binary-lifecycle", "mirrors", "photo.png")), true);
   } finally {
     await rm(dir, { recursive: true, force: true });
     await rm(backendDir, { recursive: true, force: true });
@@ -403,7 +403,7 @@ test("redirect stage replaces ![img](./screenshot.png) with redirect path", asyn
     // Verify the markdown was updated.
     const mdContent = await readFile(path.join(dir, "notes.md"), "utf-8");
     assert.ok(!mdContent.includes("./screenshot.png"), "original ref should be replaced");
-    assert.ok(mdContent.includes("screenshot.png"), "redirect path should be present");
+    assert.ok(mdContent.includes(".binary-lifecycle/mirrors/screenshot.png"), "redirect path should be present");
   } finally {
     await rm(dir, { recursive: true, force: true });
     await rm(backendDir, { recursive: true, force: true });
@@ -591,7 +591,7 @@ test("dry-run mode preserves existing manifest lifecycle state", async () => {
   try {
     await writeFile(path.join(dir, "image.png"), Buffer.alloc(64));
     await writeFile(path.join(dir, "old.png"), Buffer.alloc(64));
-    await writeFile(path.join(dir, "notes.md"), "![img](./image.png)");
+    await writeFile(path.join(dir, "notes.md"), "![img](./image.png)"); await mkdir(path.join(backendDir, "remote"), { recursive: true }).then(() => writeFile(path.join(backendDir, "remote", "old.png"), Buffer.alloc(64)));
 
     const originalManifest: BinaryLifecycleManifest = {
       version: 1,
@@ -784,7 +784,7 @@ test("redirect stage resolves asset paths relative to markdown file directory", 
     // Verify the markdown was updated.
     const mdContent = await readFile(path.join(dir, "sub", "note.md"), "utf-8");
     assert.ok(!mdContent.includes("./image.png"), "original file-relative ref should be replaced");
-    assert.ok(mdContent.includes(backendDir), "redirect path should contain backend path");
+    assert.ok(mdContent.includes(".binary-lifecycle/mirrors/sub/image.png"), "redirect path should be present");
   } finally {
     await rm(dir, { recursive: true, force: true });
     await rm(backendDir, { recursive: true, force: true });

--- a/tests/binary-lifecycle.test.ts
+++ b/tests/binary-lifecycle.test.ts
@@ -867,3 +867,24 @@ test("FilesystemBackend does not treat directories as mirrored files", async () 
     await rm(destDir, { recursive: true, force: true });
   }
 });
+
+test("FilesystemBackend accepts remote filenames that start with two dots", async () => {
+  const srcDir = await mkdtemp(tmpPrefix());
+  const destDir = await mkdtemp(tmpPrefix());
+  try {
+    const srcFile = path.join(srcDir, "hidden.png");
+    await writeFile(srcFile, Buffer.from("PNG_DATA"));
+
+    const backend = new FilesystemBackend(destDir);
+    const result = await backend.upload(srcFile, "..hidden.png");
+
+    assert.equal(result, "..hidden.png");
+    assert.equal(await backend.exists("..hidden.png"), true);
+    assert.equal(await readFile(path.join(destDir, "..hidden.png"), "utf-8"), "PNG_DATA");
+    await backend.delete("..hidden.png");
+    assert.equal(await backend.exists("..hidden.png"), false);
+  } finally {
+    await rm(srcDir, { recursive: true, force: true });
+    await rm(destDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- block manifest asset paths from escaping memoryDir during redirect and cleanup
- harden filesystem backend paths against symlink and realpath escapes
- fail closed on invalid manifests and cleanup metadata before deleting local binaries
- verify mirrored objects exist and all local markdown references are rewritten before cleanup

## Validation
- `tsx --test packages/remnic-core/src/binary-lifecycle/pipeline.test.ts` (11/11)
- `tsx --test tests/binary-lifecycle.test.ts` (29/29)
- `pnpm --filter @remnic/core check-types`
- `node scripts/check-test-types.mjs`
- `npm run preflight:quick`
- focused ClawPatch fresh run `20260601T200823-d8643b`: no high findings remain for `feat_library_e999795ad7`; 2 medium findings remain queued for the medium pass

ClawPatch high findings addressed include manifest cleanup path escape, partial redirect cleanup risk, backend symlink traversal, manifest fail-open behavior, missing remote verification, and missed local markdown reference forms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes control when local binaries are deleted and how paths are resolved; mistakes could break links or touch files outside the memory directory, though the PR adds explicit containment and verification gates.
> 
> **Overview**
> Hardens **binary lifecycle** so mirror → redirect → clean cannot delete local files or rewrite markdown unsafely.
> 
> **Manifest:** Invalid or corrupt `manifest.json` now **errors** instead of being treated as empty, so the pipeline will not overwrite lifecycle state needed for safe cleanup.
> 
> **Filesystem backend:** Upload/exists/delete use **realpath** checks, reject **symlink** traversal and path escape, distinguish files from directories, and expose **`redirectPath`** (absolute mirror location) for markdown links while storing stable relative **`mirroredPath`** under `.binary-lifecycle/mirrors/`.
> 
> **Pipeline:** Redirect/clean **reject manifest `originalPath` values outside `memoryDir`**, verify **all local markdown references** are rewritten (including nested and root-relative forms) before marking redirected, **retry** partial redirect failures, and block cleanup unless **`mirroredAt` is valid**, the **remote copy exists**, and the **local hash** still matches. Dry-run no longer advances cleanup state for missing files.
> 
> Extensive new tests cover escape paths, symlinks, invalid manifests, and partial redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5a7ffc65c117e886d04622faffb1d894aebc1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->