### PR TITLE
fix(workflows): pin AMB checkout secret scope

### DIFF
--- a/.github/workflows/amb-beam-remnic.yml
+++ b/.github/workflows/amb-beam-remnic.yml
@@ -32,12 +32,12 @@ jobs:
       REMNIC_AMB_RECALL_BUDGET_CHARS: "49152"
       REMNIC_AMB_DRAIN_TIMEOUT_MS: "28800000"
       UV_CACHE_DIR: /tmp/uv-cache
+      AMB_REPO_URL: https://github.com/vectorize-io/agent-memory-benchmark.git
+      AMB_REF: 45fa380523afab9b1acd667a03de51c5ea63f4d2
       OMB_ANSWER_LLM: gemini
       OMB_ANSWER_MODEL: gemini-3.1-pro-preview
       OMB_JUDGE_LLM: gemini
       OMB_JUDGE_MODEL: gemini-2.5-flash-lite
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       BEAM_SPLIT: ${{ inputs.split }}
       BEAM_QUERY_LIMIT: ${{ inputs.query_limit }}
     steps:
@@ -63,9 +63,22 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Checkout public AMB
-        run: git clone https://github.com/vectorize-io/agent-memory-benchmark.git "$AMB_DIR"
+        run: |
+          mkdir -p "$AMB_DIR"
+          git -C "$AMB_DIR" init
+          git -C "$AMB_DIR" remote add origin "$AMB_REPO_URL"
+          git -C "$AMB_DIR" fetch --depth 1 origin "$AMB_REF"
+          git -C "$AMB_DIR" checkout --detach FETCH_HEAD
+          actual_ref="$(git -C "$AMB_DIR" rev-parse HEAD)"
+          if [ "$actual_ref" != "$AMB_REF" ]; then
+            echo "::error::AMB checkout resolved to $actual_ref, expected $AMB_REF."
+            exit 1
+          fi
 
       - name: Require official judge credentials
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           if [ -z "${GEMINI_API_KEY}${GOOGLE_API_KEY}" ]; then
             echo "::error::Set a GEMINI_API_KEY or GOOGLE_API_KEY repository secret before running this workflow."
@@ -76,10 +89,16 @@ jobs:
         run: node integrations/amb/install-remnic-provider.mjs "$AMB_DIR"
 
       - name: Check public-comparable setup
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: node integrations/amb/check-remnic-run.mjs "$AMB_DIR"
 
       - name: Run AMB BEAM
         working-directory: ${{ env.AMB_DIR }}
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           case "$BEAM_SPLIT" in
             100k|10m) ;;

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/tests/dreams-ledger.test.ts
+++ b/tests/dreams-ledger.test.ts
@@ -296,11 +296,12 @@ test("runDreamsPhase lightSleep counts recent observation ledger timestamps", as
     "rebuilt-observations.jsonl",
   );
   await mkdir(path.dirname(ledgerPath), { recursive: true });
-  const recentTs = new Date().toISOString();
-  const recentHourDate = new Date(Date.now() - 60 * 60 * 1000);
+  const nowMs = Date.now();
+  const recentTs = new Date(nowMs - 60_000).toISOString();
+  const recentHourDate = new Date(nowMs - 60 * 60 * 1000);
   recentHourDate.setUTCMinutes(0, 0, 0);
   const recentHour = recentHourDate.toISOString();
-  const oldTs = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+  const oldTs = new Date(nowMs - 48 * 60 * 60 * 1000).toISOString();
   await writeFile(
     ledgerPath,
     [


### PR DESCRIPTION
## Summary
- pin the AMB benchmark repository checkout to a reviewed commit and verify the resolved HEAD
- move Gemini/Google API secrets out of job-level workflow env and onto only the credential-dependent steps
- format root package.json so the current main preflight lint gate passes
- make the dreams-ledger recent timestamp test deterministic after CI exposed a same-millisecond boundary failure

## ClawPatch
- resolves high finding fnd_sig-feat-config-80f324e02e-e4538_87d05326c0 for feat_config_80f324e02e
- targeted fixed-branch review: `clawpatch review --feature feat_config_80f324e02e --jobs 1 --json` -> 0 findings

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/amb-beam-remnic.yml"); puts "yaml ok"'`\n- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/dreams-ledger.test.ts`\n- `npm run preflight:quick`\n- `clawpatch review --feature feat_config_80f324e02e --jobs 1 --json`\n\n## Notes\n- Local full `pnpm test` was attempted and stopped after an unrelated local AMB test returned exit 127; the CI failure being addressed here was the deterministic dreams-ledger boundary test.\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/supply-chain hardening and test stability only; no production auth or runtime behavior changes beyond the benchmark workflow.
> 
> **Overview**
> The **AMB BEAM Remnic** workflow now checks out **agent-memory-benchmark** at a **pinned commit** (`AMB_REF`), with a shallow fetch and a **HEAD mismatch guard**, instead of cloning whatever is on the default branch. **Gemini/Google API keys** are removed from **job-level** `env` and injected only on the steps that need them (credential check, setup check, and the BEAM run).
> 
> Root **`package.json`** changes are **formatting-only** (single-line arrays) so the repo’s lint/preflight gate passes.
> 
> **`dreams-ledger`** test data uses one fixed **`nowMs`** anchor so “recent” vs “old” ledger timestamps stay stable across the test run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e054ff8c6a102d7eb9e1f3251d5b8867ffc663d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->