### PR TITLE
fix(plugin-pi): verify packed build imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/plugin-pi/package.json
+++ b/packages/plugin-pi/package.json
@@ -15,33 +15,23 @@
       "types": "./dist/publisher.d.ts"
     }
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "pi": {
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
-  "keywords": [
-    "remnic",
-    "pi-package",
-    "pi",
-    "memory",
-    "ai-agent",
-    "coding-agent"
-  ],
+  "keywords": ["remnic", "pi-package", "pi", "memory", "ai-agent", "coding-agent"],
   "publishConfig": {
     "access": "public",
     "provenance": true
   },
   "scripts": {
-    "build": "tsup src/index.ts src/publisher.ts --format esm --dts",
+    "build": "tsup --config tsup.config.ts",
+    "precheck-packed-imports": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-packed-imports": "npm run build && node scripts/check-packed-imports.mjs",
     "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "tsx --test 'src/**/*.test.ts'",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run check-packed-imports"
   },
   "dependencies": {
     "@remnic/core": "workspace:^",

--- a/packages/plugin-pi/scripts/check-packed-imports.mjs
+++ b/packages/plugin-pi/scripts/check-packed-imports.mjs
@@ -1,0 +1,50 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const distRoot = path.join(packageRoot, "dist");
+const entrypoints = ["dist/index.js", "dist/publisher.js"];
+
+const packOutput = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+  cwd: packageRoot,
+  encoding: "utf8",
+});
+const [pack] = JSON.parse(packOutput);
+const packedFiles = new Set(pack.files.map((file) => file.path));
+
+for (const entrypoint of entrypoints) {
+  assertPacked(entrypoint);
+  assertPackedRelativeImports(entrypoint);
+  await import(pathToFileURL(path.join(packageRoot, entrypoint)).href);
+}
+
+console.log("plugin-pi packed imports OK");
+
+function assertPacked(filePath) {
+  if (!packedFiles.has(filePath)) {
+    throw new Error(`Packed @remnic/plugin-pi artifact is missing ${filePath}`);
+  }
+}
+
+function assertPackedRelativeImports(entrypoint) {
+  const filePath = path.join(packageRoot, entrypoint);
+  const source = fs.readFileSync(filePath, "utf8");
+  const importPattern =
+    /\b(?:import|export)\s+(?:[^'"]*?\s+from\s+)?["'](\.[^"']+)["']|import\(\s*["'](\.[^"']+)["']\s*\)/g;
+
+  for (const match of source.matchAll(importPattern)) {
+    const specifier = match[1] ?? match[2];
+    const importedPath = resolveRelativeImport(entrypoint, specifier);
+    assertPacked(importedPath);
+  }
+}
+
+function resolveRelativeImport(fromFile, specifier) {
+  const resolved = path.relative(distRoot, path.resolve(packageRoot, path.dirname(fromFile), specifier));
+  if (resolved.startsWith("..") || path.isAbsolute(resolved)) {
+    throw new Error(`Packed @remnic/plugin-pi import escapes dist: ${fromFile} -> ${specifier}`);
+  }
+  return path.posix.join("dist", resolved.split(path.sep).join(path.posix.sep));
+}

--- a/packages/plugin-pi/tsup.config.ts
+++ b/packages/plugin-pi/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/publisher.ts"],
+  format: ["esm"],
+  target: "es2022",
+  platform: "node",
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  dts: true,
+  bundle: true,
+  external: ["@remnic/core", "@sinclair/typebox"],
+});


### PR DESCRIPTION
## Summary
- add package-local tsup config for explicit bundled Pi entrypoint builds
- add a packed-import guard that validates tarball relative imports and dynamically imports both exported entrypoints
- run the packed-import guard from prepublishOnly

## ClawPatch
- Addresses high finding: Published package cannot import its config and message helper modules
- Targeted review run: 20260602T015314-0abf14 no longer reports that high finding
- Remaining findings in the same feature are medium severity and intentionally left for the medium pass

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/plugin-pi test
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/plugin-pi check-types
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/plugin-pi check-packed-imports
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/plugin-pi/package.json packages/plugin-pi/tsup.config.ts packages/plugin-pi/scripts/check-packed-imports.mjs
- PATH=/opt/homebrew/opt/node@22/bin:$PATH /Users/joshuawarren/.local/bin/clawpatch-monorepo --root /Users/joshuawarren/src/remnic/.worktrees/clawpatch-pi-package-imports review --feature feat_library_8d0e467c83 --jobs 1 --json
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/packaging guardrails for the Pi plugin only; no auth, data, or core runtime logic changes.
> 
> **Overview**
> **@remnic/plugin-pi** now builds through a dedicated **`tsup.config.ts`** that bundles `index` and `publisher` as ESM with **`@remnic/core`** and **`@sinclair/typebox`** left external, instead of an inline `tsup` CLI invocation.
> 
> A new **`check-packed-imports`** script dry-runs **`npm pack`**, ensures every relative import from **`dist/index.js`** and **`dist/publisher.js`** is included in the tarball, dynamically imports both entrypoints, and **`prepublishOnly`** runs that guard so published installs cannot miss helper modules.
> 
> Root and **`plugin-pi`** **`package.json`** files only collapse multi-line arrays to single lines (formatting). No runtime behavior change there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80f6a2c2369d30cb4220004f5794ee80a65cec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->