### PR TITLE
fix(plugin-pi): publish core dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/plugin-pi/package.json
+++ b/packages/plugin-pi/package.json
@@ -15,23 +15,11 @@
       "types": "./dist/publisher.d.ts"
     }
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "pi": {
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
-  "keywords": [
-    "remnic",
-    "pi-package",
-    "pi",
-    "memory",
-    "ai-agent",
-    "coding-agent"
-  ],
+  "keywords": ["remnic", "pi-package", "pi", "memory", "ai-agent", "coding-agent"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/plugin-pi/scripts/check-packed-imports.mjs
+++ b/packages/plugin-pi/scripts/check-packed-imports.mjs
@@ -1,18 +1,23 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const distRoot = path.join(packageRoot, "dist");
 const entrypoints = ["dist/index.js", "dist/publisher.js"];
+const packRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-plugin-pi-pack-"));
 
-const packOutput = execFileSync("npm", ["pack", "--dry-run", "--json"], {
-  cwd: packageRoot,
-  encoding: "utf8",
-});
-const [pack] = JSON.parse(packOutput);
-const packedFiles = new Set(pack.files.map((file) => file.path));
+let packedFiles;
+
+try {
+  const tarballPath = packPackage();
+  packedFiles = new Set(listPackedFiles(tarballPath));
+  assertPublishableDependencyRanges(tarballPath);
+} finally {
+  fs.rmSync(packRoot, { recursive: true, force: true });
+}
 
 for (const entrypoint of entrypoints) {
   assertPacked(entrypoint);
@@ -38,6 +43,47 @@ function assertPackedRelativeImports(entrypoint) {
     const specifier = match[1] ?? match[2];
     const importedPath = resolveRelativeImport(entrypoint, specifier);
     assertPacked(importedPath);
+  }
+}
+
+function packPackage() {
+  const packOutput = execFileSync("pnpm", ["pack", "--json", "--out", path.join(packRoot, "%s-%v.tgz")], {
+    cwd: packageRoot,
+    encoding: "utf8",
+  });
+  const pack = parsePackOutput(packOutput);
+  const tarballPath = pack?.tarball ?? pack?.filename ?? pack?.tarballPath;
+  if (!tarballPath || typeof tarballPath !== "string") {
+    throw new Error("Unable to locate packed @remnic/plugin-pi tarball path");
+  }
+  return path.isAbsolute(tarballPath) ? tarballPath : path.resolve(packRoot, tarballPath);
+}
+
+function parsePackOutput(output) {
+  const parsed = JSON.parse(output);
+  return Array.isArray(parsed) ? parsed[0] : parsed;
+}
+
+function listPackedFiles(tarballPath) {
+  const tarOutput = execFileSync("tar", ["-tf", tarballPath], { encoding: "utf8" });
+  return tarOutput
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((entry) => entry.replace(/^package\//, ""));
+}
+
+function assertPublishableDependencyRanges(tarballPath) {
+  const packageJson = JSON.parse(
+    execFileSync("tar", ["-xOf", tarballPath, "package/package.json"], { encoding: "utf8" })
+  );
+  for (const section of ["dependencies", "peerDependencies", "optionalDependencies"]) {
+    const dependencies = packageJson[section];
+    if (!dependencies || typeof dependencies !== "object" || Array.isArray(dependencies)) continue;
+    for (const [name, range] of Object.entries(dependencies)) {
+      if (typeof range === "string" && range.startsWith("workspace:")) {
+        throw new Error(`Packed @remnic/plugin-pi ${section}.${name} uses non-publishable range ${range}`);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the packed Pi plugin runtime dependency on `@remnic/core` from `workspace:^` to the publishable `^9.3.521` range
- extend the packed-import guard to fail on `workspace:` ranges in published dependency sections
- update `pnpm-lock.yaml` for the dependency spec change

## ClawPatch
- Addresses high finding: Published package metadata keeps an unresolved workspace dependency
- Targeted review run: 20260602T022952-e28f05 no longer reports that high finding
- Remaining targeted finding is medium severity and intentionally left for the medium pass

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/plugin-pi check-packed-imports
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/plugin-pi check-types
- PATH=/opt/homebrew/opt/node@22/bin:$PATH NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm --filter @remnic/plugin-pi test
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/plugin-pi/package.json packages/plugin-pi/scripts/check-packed-imports.mjs pnpm-lock.yaml
- PATH=/opt/homebrew/opt/node@22/bin:$PATH /Users/joshuawarren/.local/bin/clawpatch-monorepo --root /Users/joshuawarren/src/remnic/.worktrees/clawpatch-pi-publishable-core-range review --feature feat_library_8d0e467c83 --jobs 1 --json
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release/pack validation and JSON formatting; no runtime auth or data-path logic is modified in the diff.
> 
> **Overview**
> **@remnic/plugin-pi** publish checks now build a real **`pnpm pack`** tarball (with temp cleanup) instead of relying on **`npm pack --dry-run`**, then validate packed file lists from that archive.
> 
> The **`check-packed-imports`** script adds **`assertPublishableDependencyRanges`**, which reads **`package/package.json`** from the tarball and **fails if any `dependencies`, `peerDependencies`, or `optionalDependencies` entry still uses a `workspace:` range**—so published metadata cannot ship unresolved workspace specs.
> 
> Root and **`plugin-pi`** **`package.json`** files only change **array formatting** (single-line lists) for fields like **`workspaces`**, **`files`**, **`extensions`**, **`keywords`**, and **`pnpm.onlyBuiltDependencies`**; no functional script or dependency edits appear in the shown **`plugin-pi`** manifest diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 325d0944b985ed0a6a15a03c974dbf680610cb5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->