### PR TITLE
fix(plugin-pi): preserve unrelated files on rollback

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { loadTokenStore, saveTokenStore, type PublishContext } from "@remnic/core";
+import { type PublishContext, loadTokenStore, saveTokenStore } from "@remnic/core";
 
 import { PiMemoryExtensionPublisher } from "./publisher.js";
 
@@ -13,6 +13,45 @@ class FailingPiPublisher extends PiMemoryExtensionPublisher {
     await super.renderInstructions(ctx);
     throw new Error("readme write failed");
   }
+}
+
+class InterferedFailingPiPublisher extends PiMemoryExtensionPublisher {
+  constructor(private readonly unrelatedPath: string) {
+    super();
+  }
+
+  async renderInstructions(ctx: PublishContext): Promise<string> {
+    await super.renderInstructions(ctx);
+    fs.writeFileSync(this.unrelatedPath, "user-managed content\n");
+    throw new Error("readme write failed");
+  }
+}
+
+class ReplacedRootFailingPiPublisher extends PiMemoryExtensionPublisher {
+  constructor(
+    private readonly extensionRoot: string,
+    private readonly symlinkTarget: string
+  ) {
+    super();
+  }
+
+  async renderInstructions(ctx: PublishContext): Promise<string> {
+    await super.renderInstructions(ctx);
+    fs.rmSync(this.extensionRoot, { recursive: true, force: true });
+    fs.mkdirSync(this.symlinkTarget, { recursive: true });
+    fs.writeFileSync(path.join(this.symlinkTarget, "remnic.config.json"), "external config\n");
+    fs.writeFileSync(path.join(this.symlinkTarget, "index.ts"), "external wrapper\n");
+    fs.symlinkSync(this.symlinkTarget, this.extensionRoot, "dir");
+    throw new Error("readme write failed");
+  }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(process.env, name);
+    return;
+  }
+  process.env[name] = value;
 }
 
 test("Pi publisher honors PI_CODING_AGENT_DIR for extension root", async () => {
@@ -42,7 +81,10 @@ test("Pi publisher restores prior extension files and token-store entry when pub
   const readmePath = path.join(extensionRoot, "README.md");
   fs.mkdirSync(extensionRoot, { recursive: true });
   fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
-  fs.writeFileSync(configPath, `${JSON.stringify({ authToken: "old-token", remnicDaemonUrl: "http://old" }, null, 2)}\n`);
+  fs.writeFileSync(
+    configPath,
+    `${JSON.stringify({ authToken: "old-token", remnicDaemonUrl: "http://old" }, null, 2)}\n`
+  );
   fs.writeFileSync(wrapperPath, "old wrapper\n");
   fs.writeFileSync(readmePath, "old readme\n");
 
@@ -53,12 +95,9 @@ test("Pi publisher restores prior extension files and token-store entry when pub
   process.env.USERPROFILE = home;
   process.env.PI_AGENT_HOME = piAgentHome;
   t.after(() => {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
-    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = previousUserProfile;
-    if (previousPiAgentHome === undefined) delete process.env.PI_AGENT_HOME;
-    else process.env.PI_AGENT_HOME = previousPiAgentHome;
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -68,24 +107,118 @@ test("Pi publisher restores prior extension files and token-store entry when pub
 
   const publisher = new FailingPiPublisher();
   await assert.rejects(
-    () => publisher.publish({
-      config: { memoryDir: path.join(root, "memory") },
-      skillsRoot: path.join(root, "memory", "skills"),
-      rollbackTokenEntry: {
-        connector: "pi",
-        token: "old-token",
-        createdAt: "2026-05-09T00:00:00.000Z",
-      },
-      log: { info: () => undefined, warn: () => undefined, error: () => undefined },
-    }),
-    /readme write failed/,
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        rollbackTokenEntry: {
+          connector: "pi",
+          token: "old-token",
+          createdAt: "2026-05-09T00:00:00.000Z",
+        },
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /readme write failed/
   );
 
-  assert.equal(fs.readFileSync(configPath, "utf8"), `${JSON.stringify({ authToken: "old-token", remnicDaemonUrl: "http://old" }, null, 2)}\n`);
+  assert.equal(
+    fs.readFileSync(configPath, "utf8"),
+    `${JSON.stringify({ authToken: "old-token", remnicDaemonUrl: "http://old" }, null, 2)}\n`
+  );
   assert.equal(fs.readFileSync(wrapperPath, "utf8"), "old wrapper\n");
   assert.equal(fs.readFileSync(readmePath, "utf8"), "old readme\n");
   const piToken = loadTokenStore().tokens.find((entry) => entry.connector === "pi");
   assert.equal(piToken?.token, "old-token");
+});
+
+test("Pi publisher rollback preserves unrelated files in a newly created extension root", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-publisher-rollback-root-test-"));
+  const home = path.join(root, "home");
+  const piAgentHome = path.join(root, "pi-agent");
+  const extensionRoot = path.join(piAgentHome, "extensions", "remnic");
+  const unrelatedPath = path.join(extensionRoot, "user-note.txt");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousPiAgentHome = process.env.PI_AGENT_HOME;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.PI_AGENT_HOME = piAgentHome;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "pi", token: "new-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const publisher = new InterferedFailingPiPublisher(unrelatedPath);
+  await assert.rejects(
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        rollbackTokenEntry: null,
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /readme write failed/
+  );
+
+  assert.equal(fs.readFileSync(unrelatedPath, "utf8"), "user-managed content\n");
+  assert.equal(fs.existsSync(path.join(extensionRoot, "remnic.config.json")), false);
+  assert.equal(fs.existsSync(path.join(extensionRoot, "index.ts")), false);
+  assert.equal(fs.existsSync(path.join(extensionRoot, "README.md")), false);
+});
+
+test("Pi publisher rollback refuses child cleanup when a new extension root becomes a symlink", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-publisher-rollback-symlink-test-"));
+  const home = path.join(root, "home");
+  const piAgentHome = path.join(root, "pi-agent");
+  const extensionRoot = path.join(piAgentHome, "extensions", "remnic");
+  const symlinkTarget = path.join(root, "external-remnic");
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousPiAgentHome = process.env.PI_AGENT_HOME;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.PI_AGENT_HOME = piAgentHome;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  saveTokenStore({
+    tokens: [{ connector: "pi", token: "new-token", createdAt: "2026-05-10T00:00:00.000Z" }],
+  });
+
+  const warnings: string[] = [];
+  const publisher = new ReplacedRootFailingPiPublisher(extensionRoot, symlinkTarget);
+  await assert.rejects(
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        rollbackTokenEntry: null,
+        log: {
+          info: () => undefined,
+          warn: (message) => warnings.push(message),
+          error: () => undefined,
+        },
+      }),
+    /readme write failed/
+  );
+
+  assert.match(warnings.join("\n"), /must not be a symlink/);
+  assert.equal(fs.readFileSync(path.join(symlinkTarget, "remnic.config.json"), "utf8"), "external config\n");
+  assert.equal(fs.readFileSync(path.join(symlinkTarget, "index.ts"), "utf8"), "external wrapper\n");
 });
 
 test("Pi publisher preserves user-managed extension settings on reinstall", async (t) => {
@@ -96,21 +229,28 @@ test("Pi publisher preserves user-managed extension settings on reinstall", asyn
   const configPath = path.join(extensionRoot, "remnic.config.json");
   fs.mkdirSync(extensionRoot, { recursive: true });
   fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
-  fs.writeFileSync(configPath, `${JSON.stringify({
-    remnicDaemonUrl: "http://old-daemon",
-    authToken: "old-token",
-    namespace: "old-namespace",
-    recallMode: "minimal",
-    recallTopK: 3,
-    recallBudgetChars: 2048,
-    recallEnabled: false,
-    observeEnabled: false,
-    observeSkipExtraction: true,
-    compactionEnabled: false,
-    mcpToolsEnabled: false,
-    statusEnabled: false,
-    requestTimeoutMs: 1234,
-  }, null, 2)}\n`);
+  fs.writeFileSync(
+    configPath,
+    `${JSON.stringify(
+      {
+        remnicDaemonUrl: "http://old-daemon",
+        authToken: "old-token",
+        namespace: "old-namespace",
+        recallMode: "minimal",
+        recallTopK: 3,
+        recallBudgetChars: 2048,
+        recallEnabled: false,
+        observeEnabled: false,
+        observeSkipExtraction: true,
+        compactionEnabled: false,
+        mcpToolsEnabled: false,
+        statusEnabled: false,
+        requestTimeoutMs: 1234,
+      },
+      null,
+      2
+    )}\n`
+  );
 
   const previousHome = process.env.HOME;
   const previousUserProfile = process.env.USERPROFILE;
@@ -119,12 +259,9 @@ test("Pi publisher preserves user-managed extension settings on reinstall", asyn
   process.env.USERPROFILE = home;
   process.env.PI_AGENT_HOME = piAgentHome;
   t.after(() => {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
-    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = previousUserProfile;
-    if (previousPiAgentHome === undefined) delete process.env.PI_AGENT_HOME;
-    else process.env.PI_AGENT_HOME = previousPiAgentHome;
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -167,11 +304,18 @@ test("Pi publisher preserves existing namespace when reinstall omits namespace",
   const configPath = path.join(extensionRoot, "remnic.config.json");
   fs.mkdirSync(extensionRoot, { recursive: true });
   fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
-  fs.writeFileSync(configPath, `${JSON.stringify({
-    remnicDaemonUrl: "http://old-daemon",
-    authToken: "old-token",
-    namespace: "manual-namespace",
-  }, null, 2)}\n`);
+  fs.writeFileSync(
+    configPath,
+    `${JSON.stringify(
+      {
+        remnicDaemonUrl: "http://old-daemon",
+        authToken: "old-token",
+        namespace: "manual-namespace",
+      },
+      null,
+      2
+    )}\n`
+  );
 
   const previousHome = process.env.HOME;
   const previousUserProfile = process.env.USERPROFILE;
@@ -180,12 +324,9 @@ test("Pi publisher preserves existing namespace when reinstall omits namespace",
   process.env.USERPROFILE = home;
   process.env.PI_AGENT_HOME = piAgentHome;
   t.after(() => {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
-    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = previousUserProfile;
-    if (previousPiAgentHome === undefined) delete process.env.PI_AGENT_HOME;
-    else process.env.PI_AGENT_HOME = previousPiAgentHome;
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -226,12 +367,9 @@ test("Pi publisher fails closed when existing config cannot be parsed", async (t
   process.env.USERPROFILE = home;
   process.env.PI_AGENT_HOME = piAgentHome;
   t.after(() => {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
-    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = previousUserProfile;
-    if (previousPiAgentHome === undefined) delete process.env.PI_AGENT_HOME;
-    else process.env.PI_AGENT_HOME = previousPiAgentHome;
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -241,17 +379,18 @@ test("Pi publisher fails closed when existing config cannot be parsed", async (t
 
   const publisher = new PiMemoryExtensionPublisher();
   await assert.rejects(
-    () => publisher.publish({
-      config: { memoryDir: path.join(root, "memory") },
-      skillsRoot: path.join(root, "memory", "skills"),
-      rollbackTokenEntry: {
-        connector: "pi",
-        token: "old-token",
-        createdAt: "2026-05-09T00:00:00.000Z",
-      },
-      log: { info: () => undefined, warn: () => undefined, error: () => undefined },
-    }),
-    /Failed to load existing Remnic Pi config/,
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        rollbackTokenEntry: {
+          connector: "pi",
+          token: "old-token",
+          createdAt: "2026-05-09T00:00:00.000Z",
+        },
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /Failed to load existing Remnic Pi config/
   );
 
   assert.equal(fs.readFileSync(configPath, "utf8"), "{bad-json");
@@ -285,12 +424,9 @@ test("Pi publisher refuses a symlinked extension root", async (t) => {
   process.env.USERPROFILE = home;
   process.env.PI_AGENT_HOME = piAgentHome;
   t.after(() => {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
-    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = previousUserProfile;
-    if (previousPiAgentHome === undefined) delete process.env.PI_AGENT_HOME;
-    else process.env.PI_AGENT_HOME = previousPiAgentHome;
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
     fs.rmSync(root, { recursive: true, force: true });
   });
 
@@ -300,12 +436,13 @@ test("Pi publisher refuses a symlinked extension root", async (t) => {
 
   const publisher = new PiMemoryExtensionPublisher();
   await assert.rejects(
-    () => publisher.publish({
-      config: { memoryDir: path.join(root, "memory") },
-      skillsRoot: path.join(root, "memory", "skills"),
-      log: { info: () => undefined, warn: () => undefined, error: () => undefined },
-    }),
-    /must not be a symlink/,
+    () =>
+      publisher.publish({
+        config: { memoryDir: path.join(root, "memory") },
+        skillsRoot: path.join(root, "memory", "skills"),
+        log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+      }),
+    /must not be a symlink/
   );
 
   assert.equal(fs.existsSync(path.join(targetDir, "remnic.config.json")), false);

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -3,14 +3,14 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
-  getConnectorToken,
-  loadTokenStore,
-  saveTokenStore,
   type MemoryExtensionPublisher,
   type PublishContext,
   type PublishResult,
   type PublisherCapabilities,
   type TokenEntry,
+  getConnectorToken,
+  loadTokenStore,
+  saveTokenStore,
 } from "@remnic/core";
 
 import { resolvePiAgentHome, resolvePiExtensionRoot } from "./paths.js";
@@ -56,7 +56,7 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
       "## Installed Capabilities",
       "",
       "- Recall relevant Remnic context in Pi's `context` hook before agent turns.",
-      "- Observe Pi user, assistant, and tool messages with `sourceFormat: \"pi\"`.",
+      '- Observe Pi user, assistant, and tool messages with `sourceFormat: "pi"`.',
       "- Coordinate Pi `session_before_compact` with Remnic LCM flush and checkpoint recording.",
       "- Register Remnic MCP tools as Pi tools when daemon authentication is configured.",
       "- Persist lightweight dedupe state in Pi custom entries via `appendEntry`.",
@@ -129,12 +129,16 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
       try {
         restorePublishSnapshot(extensionRoot, rootExisted, snapshots);
       } catch (restoreErr) {
-        ctx.log.warn(`Pi extension rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`);
+        ctx.log.warn(
+          `Pi extension rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`
+        );
       }
       try {
         restorePiTokenEntry(priorTokenEntry);
       } catch (tokenErr) {
-        ctx.log.warn(`Pi connector token rollback failed: ${tokenErr instanceof Error ? tokenErr.message : String(tokenErr)}`);
+        ctx.log.warn(
+          `Pi connector token rollback failed: ${tokenErr instanceof Error ? tokenErr.message : String(tokenErr)}`
+        );
       }
       throw err;
     }
@@ -229,11 +233,7 @@ function snapshotFiles(paths: string[]): FileSnapshot[] {
 }
 
 function restorePublishSnapshot(extensionRoot: string, rootExisted: boolean, snapshots: FileSnapshot[]): void {
-  if (!rootExisted) {
-    assertSafeExistingPath(extensionRoot);
-    fs.rmSync(extensionRoot, { recursive: true, force: true });
-    return;
-  }
+  if (!rootExisted && !canCleanNewExtensionRoot(extensionRoot)) return;
 
   for (const snapshot of snapshots) {
     if (!snapshot.existed) {
@@ -251,6 +251,40 @@ function restorePublishSnapshot(extensionRoot: string, rootExisted: boolean, sna
       }
     }
   }
+
+  if (!rootExisted) {
+    removeEmptyDirectory(extensionRoot);
+  }
+}
+
+function canCleanNewExtensionRoot(extensionRoot: string): boolean {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(extensionRoot);
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") return false;
+    throw err;
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Pi extension path must not be a symlink: ${extensionRoot}`);
+  }
+  return stat.isDirectory();
+}
+
+function removeEmptyDirectory(dirPath: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(dirPath);
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") return;
+    throw err;
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Pi extension path must not be a symlink: ${dirPath}`);
+  }
+  if (!stat.isDirectory()) return;
+  if (fs.readdirSync(dirPath).length > 0) return;
+  fs.rmdirSync(dirPath);
 }
 
 function mkdirPiExtensionRoot(extensionRoot: string, env: NodeJS.ProcessEnv): void {


### PR DESCRIPTION
## Summary
- constrain Pi publish rollback to Remnic-owned files instead of deleting a newly created extension root recursively
- remove the extension root only when it is empty and not a symlink
- add a regression test where an unrelated file appears during a failed publish and must survive rollback

## ClawPatch
- Fixes high finding `fnd_sig-feat-library-8d0e467c83-2768_da54087529`: Publish rollback can delete unrelated files when the extension root did not previously exist
- Targeted review run `20260602T034519-9ca031` no longer reports that high finding; current run produced only lower-severity follow-ups (`cc1d` medium, `3537` low)

## Validation
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/plugin-pi/src/publisher.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/plugin-pi check-types`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/plugin-pi/src/publisher.ts packages/plugin-pi/src/publisher.test.ts && git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm_config_ignore_scripts=false pnpm rebuild better-sqlite3`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem rollback semantics on failed Pi installs; incorrect edge-case handling could still leave partial state or skip cleanup, but the fix reduces data-loss risk versus recursive deletion.
> 
> **Overview**
> Fixes Pi extension **publish rollback** so a failed install no longer recursively deletes a newly created extension directory (which could wipe unrelated user files).
> 
> Rollback now restores only the snapshotted Remnic-owned paths (`remnic.config.json`, `index.ts`, `README.md`), then removes the extension root **only if it is empty** and **not a symlink**; symlinked or non-directory roots during cleanup raise or skip destructive removal. Regression tests cover unrelated files surviving rollback and symlink replacement during a failed publish. Root `package.json` changes are formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 988d965ce7d602f416230763f15d8cbf3a11b77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->