### PR TITLE
fix(bench): harden repro manifest boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/bench/src/leaderboard-export.test.ts
+++ b/packages/bench/src/leaderboard-export.test.ts
@@ -4,12 +4,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import type { BenchmarkResult } from "./types.ts";
 import {
   buildAmaBenchLeaderboardRows,
   serializeJsonl,
   writeLeaderboardArtifactsForResult,
 } from "./leaderboard-export.ts";
+import type { BenchmarkResult } from "./types.ts";
 
 function amaResult(): BenchmarkResult {
   return {
@@ -93,12 +93,9 @@ test("buildAmaBenchLeaderboardRows groups answers by episode in task order", () 
 
 test("buildAmaBenchLeaderboardRows rejects missing episode ids instead of undercounting", () => {
   const result = amaResult();
-  delete result.results.tasks[0]!.details;
+  result.results.tasks[0]!.details = undefined;
 
-  assert.throws(
-    () => buildAmaBenchLeaderboardRows(result),
-    /requires details\.episodeId/,
-  );
+  assert.throws(() => buildAmaBenchLeaderboardRows(result), /requires details\.episodeId/);
 });
 
 test("serializeJsonl emits one valid JSON object per line", () => {
@@ -122,7 +119,7 @@ test("writeLeaderboardArtifactsForResult writes AMA-Bench answer-list JSONL", as
     assert.equal(writes[0]?.format, "ama-bench-answer-list-jsonl");
     assert.equal(writes[0]?.records, 2);
 
-    const raw = await readFile(writes[0]!.path, "utf8");
+    const raw = await readFile(writes[0]?.path, "utf8");
     assert.match(raw, /"episode_id":101/);
     assert.match(raw, /"answer_list":\["opened the app","changed settings"\]/);
   } finally {

--- a/packages/bench/src/leaderboard-export.ts
+++ b/packages/bench/src/leaderboard-export.ts
@@ -18,7 +18,7 @@ interface AmaBenchLeaderboardRow {
 
 export async function writeLeaderboardArtifactsForResult(
   result: BenchmarkResult,
-  outputDir: string,
+  outputDir: string
 ): Promise<LeaderboardArtifactWrite[]> {
   if (result.meta.benchmark !== "ama-bench") {
     return [];
@@ -33,10 +33,7 @@ export async function writeLeaderboardArtifactsForResult(
   const leaderboardDir = resolveContainedPath(outputRoot, "leaderboard");
   await mkdir(leaderboardDir, { recursive: true });
   const timestamp = sanitizeFilenameSegment(result.meta.timestamp.replace(/[:.]/g, "-"));
-  const filePath = resolveContainedPath(
-    leaderboardDir,
-    `ama-bench-${timestamp}-answers.jsonl`,
-  );
+  const filePath = resolveContainedPath(leaderboardDir, `ama-bench-${timestamp}-answers.jsonl`);
   await writeFile(filePath, serializeJsonl(rows), "utf8");
   return [
     {
@@ -48,19 +45,14 @@ export async function writeLeaderboardArtifactsForResult(
   ];
 }
 
-export function buildAmaBenchLeaderboardRows(
-  result: BenchmarkResult,
-): AmaBenchLeaderboardRow[] {
-  const rowsByEpisode = new Map<
-    number | string,
-    { firstTaskIndex: number; answers: string[] }
-  >();
+export function buildAmaBenchLeaderboardRows(result: BenchmarkResult): AmaBenchLeaderboardRow[] {
+  const rowsByEpisode = new Map<number | string, { firstTaskIndex: number; answers: string[] }>();
 
   result.results.tasks.forEach((task, taskIndex) => {
     const episodeId = amaBenchEpisodeIdForTask(task);
     if (episodeId === undefined) {
       throw new Error(
-        `AMA-Bench leaderboard export requires details.episodeId for every task; missing on ${task.taskId}.`,
+        `AMA-Bench leaderboard export requires details.episodeId for every task; missing on ${task.taskId}.`
       );
     }
 
@@ -85,7 +77,7 @@ export function buildAmaBenchLeaderboardRows(
 }
 
 export function serializeJsonl(rows: readonly AmaBenchLeaderboardRow[]): string {
-  return rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+  return `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`;
 }
 
 function amaBenchEpisodeIdForTask(task: TaskResult): number | string | undefined {

--- a/packages/bench/src/reporter.test.ts
+++ b/packages/bench/src/reporter.test.ts
@@ -5,11 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { writeLeaderboardArtifactsForResult } from "./leaderboard-export.ts";
-import {
-  redactBenchmarkResultSecrets,
-  sanitizeBenchmarkResultForJson,
-  writeBenchmarkResult,
-} from "./reporter.ts";
+import { redactBenchmarkResultSecrets, sanitizeBenchmarkResultForJson, writeBenchmarkResult } from "./reporter.ts";
 import type { BenchmarkResult } from "./types.js";
 
 function buildResult(): BenchmarkResult {
@@ -31,13 +27,13 @@ function buildResult(): BenchmarkResult {
       systemProvider: {
         provider: "ollama",
         model: "gemma4:31b-cloud",
-        baseUrl: "https://ollama.com/api",
+        baseUrl: "https://ollama.com/api?api_key=system-url-secret&model=keep",
         apiKey: "system-secret-key",
       },
       judgeProvider: {
         provider: "ollama",
         model: "gemma4:31b-cloud",
-        baseUrl: "https://ollama.com/api",
+        baseUrl: "https://ollama.com/api?access_token=judge-url-secret;mode=keep",
         apiKey: "judge-secret-key",
       },
       internalProvider: {
@@ -86,45 +82,19 @@ test("redactBenchmarkResultSecrets redacts provider and nested secret fields", (
   assert.equal(redacted.config.systemProvider?.apiKey, "[REDACTED]");
   assert.equal(redacted.config.judgeProvider?.apiKey, "[REDACTED]");
   assert.equal(redacted.config.internalProvider?.apiKey, "[REDACTED]");
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { authToken?: string }).authToken,
-    "[REDACTED]",
-  );
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { bearerToken?: string }).bearerToken,
-    "[REDACTED]",
-  );
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { privateKey?: string }).privateKey,
-    "[REDACTED]",
-  );
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { sessionToken?: string }).sessionToken,
-    "[REDACTED]",
-  );
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { authorization?: string }).authorization,
-    "[REDACTED]",
-  );
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { token?: string }).token,
-    "[REDACTED]",
-  );
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { secretary?: string }).secretary,
-    "office-role",
-  );
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { passwordless?: boolean }).passwordless,
-    true,
-  );
-  assert.equal(
-    (redacted.config.remnicConfig.nested as { credentialingOrg?: string })
-      .credentialingOrg,
-    "board",
-  );
+  assert.equal((redacted.config.remnicConfig.nested as { authToken?: string }).authToken, "[REDACTED]");
+  assert.equal((redacted.config.remnicConfig.nested as { bearerToken?: string }).bearerToken, "[REDACTED]");
+  assert.equal((redacted.config.remnicConfig.nested as { privateKey?: string }).privateKey, "[REDACTED]");
+  assert.equal((redacted.config.remnicConfig.nested as { sessionToken?: string }).sessionToken, "[REDACTED]");
+  assert.equal((redacted.config.remnicConfig.nested as { authorization?: string }).authorization, "[REDACTED]");
+  assert.equal((redacted.config.remnicConfig.nested as { token?: string }).token, "[REDACTED]");
+  assert.equal((redacted.config.remnicConfig.nested as { secretary?: string }).secretary, "office-role");
+  assert.equal((redacted.config.remnicConfig.nested as { passwordless?: boolean }).passwordless, true);
+  assert.equal((redacted.config.remnicConfig.nested as { credentialingOrg?: string }).credentialingOrg, "board");
   assert.equal(redacted.config.systemProvider?.provider, "ollama");
   assert.equal(redacted.config.systemProvider?.model, "gemma4:31b-cloud");
+  assert.equal(redacted.config.systemProvider?.baseUrl, "https://ollama.com/api?api_key=[REDACTED]&model=keep");
+  assert.equal(redacted.config.judgeProvider?.baseUrl, "https://ollama.com/api?access_token=[REDACTED];mode=keep");
 });
 
 test("writeBenchmarkResult does not persist secret values", async () => {
@@ -135,12 +105,116 @@ test("writeBenchmarkResult does not persist secret values", async () => {
 
     assert.doesNotMatch(
       raw,
-      /system-secret-key|judge-secret-key|internal-secret-key|nested-token|bearer-token|private-key|session-token|auth-header|plain-token/,
+      /system-secret-key|judge-secret-key|internal-secret-key|nested-token|bearer-token|private-key|session-token|auth-header|plain-token|system-url-secret|judge-url-secret/
     );
     assert.match(raw, /"apiKey": "\[REDACTED\]"/);
+    assert.match(raw, /api_key=\[REDACTED\]&model=keep/);
+    assert.match(raw, /access_token=\[REDACTED\];mode=keep/);
     assert.match(raw, /"provider": "ollama"/);
     assert.match(raw, /"secretary": "office-role"/);
     assert.match(raw, /"credentialingOrg": "board"/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeBenchmarkResult redacts AMA-Bench leaderboard sidecar answers", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-reporter-"));
+  try {
+    const result = buildResult();
+    result.results.tasks = [
+      {
+        taskId: "ama-q1",
+        question: "What happened?",
+        expected: "opened the app",
+        actual: "opened https://proxy.test/cb?api_key=leaderboard-answer-secret&mode=keep",
+        scores: { llm_judge: 1 },
+        latencyMs: 1,
+        tokens: { input: 0, output: 0 },
+        details: { episodeId: 1 },
+      },
+    ];
+
+    const filePath = await writeBenchmarkResult(result, dir);
+    const raw = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as BenchmarkResult;
+    const leaderboardArtifacts = parsed.config.benchmarkOptions?.leaderboardArtifacts as
+      | Array<{ path: string }>
+      | undefined;
+    const leaderboardRaw = await readFile(leaderboardArtifacts?.[0]?.path ?? "", "utf8");
+
+    assert.doesNotMatch(raw, /leaderboard-answer-secret/);
+    assert.doesNotMatch(leaderboardRaw, /leaderboard-answer-secret/);
+    assert.match(leaderboardRaw, /api_key=\[REDACTED\]&mode=keep/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeBenchmarkResult redacts free-form string secrets", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-reporter-"));
+  try {
+    const result = buildResult();
+    result.results.tasks = [
+      {
+        taskId: "ama-q1",
+        question: "api_key: freeform-api-key-secret",
+        expected: "opened the app",
+        actual: "Authorization: Bearer freeform-bearer-secret",
+        scores: { llm_judge: 1 },
+        latencyMs: 1,
+        tokens: { input: 0, output: 0 },
+        details: {
+          episodeId: 1,
+          recalledText: 'token="freeform-token-secret"',
+          jsonSnippet: '{"authorization":"Bearer json-string-secret","safe":"keep"}',
+          jsonCookieSnippet:
+            '{"headers":{"Cookie":"sid=json-cookie-secret","Set-Cookie":"sid=json-set-cookie-secret"},"safe":"keep"}',
+          jsonSafeSnippet: '{  "choice": "A", "reason": "keep spacing" }',
+          jsonUrlSnippet: '{"baseUrl":"https://proxy.test/v1?api_key=json-terminal-url-secret","safe":"keep"}',
+          cookieSnippet: "Cookie: sid=freeform-cookie-secret",
+          multiCookieSnippet: "Cookie: sid=freeform-cookie-secret; csrf=freeform-csrf-cookie-secret",
+          setCookieSnippet: "Set-Cookie: sid=freeform-set-cookie-secret; Path=/",
+          sourceSessionSnippet: "source_session: longmemeval-session-42",
+          sessionSnippet: "session: freeform-session-secret",
+          quotedKeySnippet: '"api_key" = "freeform-quoted-key-secret"',
+          urlSnippet:
+            "https://user:p@ss-freeform-url-userinfo-secret@example.test/v1?api_key=freeform-url-query-secret&model=keep",
+        },
+      },
+    ];
+
+    const filePath = await writeBenchmarkResult(result, dir);
+    const raw = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as BenchmarkResult;
+
+    assert.doesNotMatch(
+      raw,
+      /freeform-api-key-secret|freeform-bearer-secret|freeform-token-secret|json-string-secret|json-cookie-secret|json-set-cookie-secret|json-terminal-url-secret|freeform-cookie-secret|freeform-csrf-cookie-secret|freeform-set-cookie-secret|freeform-session-secret|freeform-quoted-key-secret|freeform-url-userinfo-secret|freeform-url-query-secret/
+    );
+    assert.equal(parsed.results.tasks[0]?.question, "api_key: [REDACTED]");
+    assert.equal(parsed.results.tasks[0]?.actual, "Authorization: Bearer [REDACTED]");
+    assert.equal(parsed.results.tasks[0]?.details?.recalledText, 'token="[REDACTED]"');
+    assert.equal(parsed.results.tasks[0]?.details?.jsonSnippet, '{"authorization":"[REDACTED]","safe":"keep"}');
+    assert.equal(
+      parsed.results.tasks[0]?.details?.jsonCookieSnippet,
+      '{"headers":{"Cookie":"[REDACTED]","Set-Cookie":"[REDACTED]"},"safe":"keep"}'
+    );
+    assert.equal(parsed.results.tasks[0]?.details?.jsonSafeSnippet, '{  "choice": "A", "reason": "keep spacing" }');
+    assert.equal(
+      parsed.results.tasks[0]?.details?.jsonUrlSnippet,
+      '{"baseUrl":"https://proxy.test/v1?api_key=[REDACTED]","safe":"keep"}'
+    );
+    assert.equal(parsed.results.tasks[0]?.details?.cookieSnippet, "Cookie: [REDACTED]");
+    assert.equal(parsed.results.tasks[0]?.details?.multiCookieSnippet, "Cookie: [REDACTED]");
+    assert.equal(parsed.results.tasks[0]?.details?.setCookieSnippet, "Set-Cookie: [REDACTED]; Path=/");
+    assert.equal(parsed.results.tasks[0]?.details?.sourceSessionSnippet, "source_session: longmemeval-session-42");
+    assert.equal(parsed.results.tasks[0]?.details?.sessionSnippet, "session: [REDACTED]");
+    assert.equal(parsed.results.tasks[0]?.details?.quotedKeySnippet, '"api_key" = "[REDACTED]"');
+    assert.equal(
+      parsed.results.tasks[0]?.details?.urlSnippet,
+      "https://[REDACTED]@example.test/v1?api_key=[REDACTED]&model=keep"
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -218,6 +292,33 @@ test("writeBenchmarkResult preserves main result when leaderboard sidecar write 
   }
 });
 
+test("writeBenchmarkResult redacts leaderboard sidecar error messages", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-reporter-"));
+  try {
+    const result = buildResult();
+    result.results.tasks = [
+      {
+        taskId: "api_key=leaderboard-error-secret",
+        question: "What happened?",
+        expected: "opened the app",
+        actual: "opened the app",
+        scores: { llm_judge: 1 },
+        latencyMs: 1,
+        tokens: { input: 0, output: 0 },
+      },
+    ];
+
+    const filePath = await writeBenchmarkResult(result, dir);
+    const raw = await readFile(filePath, "utf8");
+
+    assert.doesNotMatch(raw, /leaderboard-error-secret/);
+    assert.match(raw, /api_key=\[REDACTED\]/);
+    assert.match(raw, /"format": "leaderboard-artifact-error"/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("writeBenchmarkResult confines benchmark-derived filenames to output directory", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-reporter-"));
   try {
@@ -231,10 +332,7 @@ test("writeBenchmarkResult confines benchmark-derived filenames to output direct
     assert.equal(path.isAbsolute(relativePath), false);
     assert.equal(relativePath === "..", false);
     assert.equal(relativePath.startsWith(`..${path.sep}`), false);
-    assert.equal(
-      path.basename(filePath),
-      ".._outside_evil-v9.3.169---_2026_04_25T02-52-05-982Z.json",
-    );
+    assert.equal(path.basename(filePath), ".._outside_evil-v9.3.169---_2026_04_25T02-52-05-982Z.json");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -265,10 +363,7 @@ test("writeLeaderboardArtifactsForResult confines timestamp-derived filenames to
     assert.equal(path.isAbsolute(relativePath), false);
     assert.equal(relativePath === "..", false);
     assert.equal(relativePath.startsWith(`..${path.sep}`), false);
-    assert.equal(
-      path.basename(artifacts[0].path),
-      "ama-bench---_2026_04_25T02-52-05-982Z-answers.jsonl",
-    );
+    assert.equal(path.basename(artifacts[0].path), "ama-bench---_2026_04_25T02-52-05-982Z-answers.jsonl");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -9,6 +9,7 @@ import type { LegacyBenchmarkResult } from "./adapters/types.js";
 import { resolveContainedPath, sanitizeFilenameSegment } from "./filename-safety.js";
 import { writeLeaderboardArtifactsForResult } from "./leaderboard-export.js";
 import { isSecretKey } from "./security/secret-keys.js";
+import { redactUrlSecrets as redactUrlSecretMaterial } from "./security/url-secrets.js";
 import type { BenchmarkResult } from "./types.js";
 
 const REDACTED_SECRET = "[REDACTED]";
@@ -27,17 +28,199 @@ function redactSecrets(value: unknown): unknown {
     return value.map((item) => redactSecrets(item));
   }
 
+  if (typeof value === "string") {
+    return redactFreeformStringSecrets(value);
+  }
+
   if (!value || typeof value !== "object") {
     return value;
   }
 
   const redacted: Record<string, unknown> = {};
   for (const [key, nestedValue] of Object.entries(value)) {
-    redacted[key] = isSecretKey(key)
-      ? REDACTED_SECRET
-      : redactSecrets(nestedValue);
+    redacted[key] = isSensitiveResultKey(key) ? REDACTED_SECRET : redactSecrets(nestedValue);
   }
   return redacted;
+}
+
+function redactFreeformStringSecrets(value: string): string {
+  const structuredRedaction = redactStructuredStringSecrets(value);
+  if (structuredRedaction !== undefined) return structuredRedaction;
+  return redactSecretAssignments(redactAuthorizationSchemes(redactFreeformUrlSecrets(value)));
+}
+
+function redactStructuredStringSecrets(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return undefined;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== "object") return undefined;
+    const redacted = redactJsonValueSecrets(parsed);
+    if (!redacted.changed) return value;
+    return JSON.stringify(redacted.value);
+  } catch {
+    return undefined;
+  }
+}
+
+function redactJsonValueSecrets(value: unknown): { value: unknown; changed: boolean } {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const entries = value.map((item) => {
+      const redactedItem = redactJsonValueSecrets(item);
+      changed ||= redactedItem.changed;
+      return redactedItem.value;
+    });
+    return { value: entries, changed };
+  }
+
+  if (typeof value === "string") {
+    const redactedValue = redactSecretAssignments(redactAuthorizationSchemes(redactFreeformUrlSecrets(value)));
+    return { value: redactedValue, changed: redactedValue !== value };
+  }
+
+  if (!value || typeof value !== "object") {
+    return { value, changed: false };
+  }
+
+  const redacted: Record<string, unknown> = {};
+  let changed = false;
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (isSensitiveResultKey(key)) {
+      redacted[key] = REDACTED_SECRET;
+      changed = true;
+      continue;
+    }
+    const redactedNestedValue = redactJsonValueSecrets(nestedValue);
+    redacted[key] = redactedNestedValue.value;
+    changed ||= redactedNestedValue.changed;
+  }
+  return { value: redacted, changed };
+}
+
+function redactAuthorizationSchemes(value: string): string {
+  return value.replace(
+    /\b(authorization)\b(\s*[:=]\s*)(bearer|basic|digest)(\s+)("[^"]+"|'[^']+'|[^\s,;}]+)/gi,
+    (_match, key: string, separator: string, scheme: string, space: string, secret: string) =>
+      `${key}${separator}${scheme}${space}${redactSecretLiteral(secret)}`
+  );
+}
+
+function redactSecretAssignments(value: string): string {
+  let redacted = "";
+  let cursor = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const parsed = parseSecretAssignment(value, index);
+    if (!parsed) continue;
+    if (!isSensitiveResultKey(parsed.key) || isAuthorizationAssignmentScheme(parsed.rawValue)) continue;
+    const valueEnd = isCookieResultKey(parsed.key)
+      ? findCookieAssignmentValueEnd(value, parsed.valueStart, parsed.valueEnd)
+      : parsed.valueEnd;
+    const rawValue = value.slice(parsed.valueStart, valueEnd);
+
+    redacted += value.slice(cursor, parsed.valueStart);
+    redacted += redactSecretLiteral(rawValue);
+    cursor = valueEnd;
+    index = valueEnd - 1;
+  }
+
+  return cursor === 0 ? value : redacted + value.slice(cursor);
+}
+
+function parseSecretAssignment(
+  value: string,
+  startIndex: number
+): { key: string; valueStart: number; valueEnd: number; rawValue: string } | undefined {
+  if (startIndex > 0 && isAssignmentKeyChar(value[startIndex - 1])) return undefined;
+  let keyStart = startIndex;
+  let keyEnd: number;
+  const quote = value[startIndex];
+
+  if (quote === '"' || quote === "'") {
+    keyStart = startIndex + 1;
+    keyEnd = value.indexOf(quote, keyStart);
+    if (keyEnd === -1) return undefined;
+  } else {
+    if (!isAssignmentKeyChar(value[startIndex])) return undefined;
+    keyEnd = keyStart;
+    while (keyEnd < value.length && isAssignmentKeyChar(value[keyEnd]!) && keyEnd - keyStart <= 80) {
+      keyEnd += 1;
+    }
+  }
+
+  const key = value.slice(keyStart, keyEnd);
+  if (key.length < 3 || key.length > 80) return undefined;
+
+  let separatorIndex = quote === '"' || quote === "'" ? keyEnd + 1 : keyEnd;
+  while (separatorIndex < value.length && /\s/.test(value[separatorIndex]!)) separatorIndex += 1;
+  if (value[separatorIndex] !== ":" && value[separatorIndex] !== "=") return undefined;
+
+  let valueStart = separatorIndex + 1;
+  while (valueStart < value.length && /\s/.test(value[valueStart]!)) valueStart += 1;
+  if (valueStart >= value.length) return undefined;
+
+  let valueEnd: number;
+  const valueQuote = value[valueStart];
+  if (valueQuote === '"' || valueQuote === "'") {
+    const closingQuote = value.indexOf(valueQuote, valueStart + 1);
+    if (closingQuote === -1) return undefined;
+    valueEnd = closingQuote + 1;
+  } else {
+    valueEnd = valueStart;
+    while (valueEnd < value.length && !isAssignmentValueTerminator(value[valueEnd]!)) valueEnd += 1;
+  }
+
+  return { key, valueStart, valueEnd, rawValue: value.slice(valueStart, valueEnd) };
+}
+
+function findCookieAssignmentValueEnd(value: string, valueStart: number, parsedValueEnd: number): number {
+  const quote = value[valueStart];
+  if (quote === '"' || quote === "'") return parsedValueEnd;
+  let cursor = valueStart;
+  while (cursor < value.length && !isCookieAssignmentValueTerminator(value[cursor]!)) cursor += 1;
+  return cursor;
+}
+
+function isAssignmentKeyChar(char: string | undefined): boolean {
+  return typeof char === "string" && /[A-Za-z0-9_.[\]-]/.test(char);
+}
+
+function isAssignmentValueTerminator(char: string): boolean {
+  return /\s/.test(char) || char === "," || char === ";" || char === "}" || char === "&" || char === "#";
+}
+
+function isCookieAssignmentValueTerminator(char: string): boolean {
+  return char === "\n" || char === "\r" || char === "," || char === "}" || char === "&" || char === "#";
+}
+
+function isAuthorizationAssignmentScheme(value: string): boolean {
+  return /^(?:bearer|basic|digest)$/i.test(value.replace(/^["']|["']$/g, ""));
+}
+
+function redactSecretLiteral(value: string): string {
+  const quote = value.length >= 2 && (value.startsWith('"') || value.startsWith("'")) ? value[0] : undefined;
+  return quote && value.endsWith(quote) ? `${quote}${REDACTED_SECRET}${quote}` : REDACTED_SECRET;
+}
+
+function redactFreeformUrlSecrets(value: string): string {
+  return redactUrlSecretMaterial(value, REDACTED_SECRET, isSensitiveResultKey);
+}
+
+function isSensitiveResultKey(key: string): boolean {
+  const normalizedKey = normalizeSensitiveResultKey(key).toLowerCase();
+  if (normalizedKey === "source-session") return false;
+  return (
+    isSecretKey(key) || normalizedKey === "cookie" || normalizedKey === "set-cookie" || normalizedKey === "session"
+  );
+}
+
+function isCookieResultKey(key: string): boolean {
+  return normalizeSensitiveResultKey(key).toLowerCase() === "cookie";
+}
+
+function normalizeSensitiveResultKey(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, "$1-$2").replace(/[\[\]._:]+/g, "-");
 }
 
 function sanitizeForJson(value: unknown): unknown {
@@ -86,65 +269,50 @@ function replaceLoneSurrogates(value: string): string {
   return out;
 }
 
-export async function writeBenchmarkResult(
-  result: BenchmarkResult,
-  outputDir: string,
-): Promise<string> {
+export async function writeBenchmarkResult(result: BenchmarkResult, outputDir: string): Promise<string> {
   const outputRoot = path.resolve(outputDir);
   await mkdir(outputRoot, { recursive: true });
 
   const safeBenchmark = sanitizeFilenameSegment(result.meta.benchmark);
   const safeRemnicVersion = sanitizeFilenameSegment(result.meta.remnicVersion);
-  const timestamp = sanitizeFilenameSegment(
-    result.meta.timestamp.replace(/[:.]/g, "-"),
+  const timestamp = sanitizeFilenameSegment(result.meta.timestamp.replace(/[:.]/g, "-"));
+  const filePath = resolveContainedPath(outputRoot, `${safeBenchmark}-v${safeRemnicVersion}-${timestamp}.json`);
+  const publicBaseResult = sanitizeBenchmarkResultForJson(redactBenchmarkResultSecrets(result));
+  const leaderboardArtifacts = await writeLeaderboardArtifactsForResult(publicBaseResult, outputRoot).catch(
+    (error: unknown) => [
+      {
+        benchmark: publicBaseResult.meta.benchmark,
+        path: "",
+        format: "leaderboard-artifact-error",
+        records: 0,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    ]
   );
-  const filePath = resolveContainedPath(
-    outputRoot,
-    `${safeBenchmark}-v${safeRemnicVersion}-${timestamp}.json`,
-  );
-  const leaderboardArtifacts = await writeLeaderboardArtifactsForResult(
-    result,
-    outputRoot,
-  ).catch((error: unknown) => [
-    {
-      benchmark: result.meta.benchmark,
-      path: "",
-      format: "leaderboard-artifact-error",
-      records: 0,
-      error: error instanceof Error ? error.message : String(error),
-    },
-  ]);
 
   const resultWithArtifacts = {
-    ...result,
+    ...publicBaseResult,
     config: {
-      ...result.config,
+      ...publicBaseResult.config,
       benchmarkOptions: {
-        ...(result.config.benchmarkOptions ?? {}),
+        ...(publicBaseResult.config.benchmarkOptions ?? {}),
         leaderboardArtifacts,
       },
     },
   };
 
-  const publicResult = sanitizeBenchmarkResultForJson(
-    redactBenchmarkResultSecrets(resultWithArtifacts),
-  );
-  await writeFile(filePath, JSON.stringify(publicResult, null, 2) + "\n");
+  const publicResult = sanitizeBenchmarkResultForJson(redactBenchmarkResultSecrets(resultWithArtifacts));
+  await writeFile(filePath, `${JSON.stringify(publicResult, null, 2)}\n`);
   return filePath;
 }
 
 export async function getRemnicVersion(): Promise<string> {
   try {
     const packageJson = JSON.parse(
-      await readFile(
-        path.resolve(import.meta.dirname, "../../../package.json"),
-        "utf8",
-      ),
+      await readFile(path.resolve(import.meta.dirname, "../../../package.json"), "utf8")
     ) as { version?: string };
 
-    return typeof packageJson.version === "string"
-      ? packageJson.version
-      : "unknown";
+    return typeof packageJson.version === "string" ? packageJson.version : "unknown";
   } catch {
     return "unknown";
   }
@@ -155,10 +323,7 @@ export function getGitSha(): string {
 }
 
 function readGitSha(): string {
-  const explicitSha =
-    process.env.REMNIC_BENCH_GIT_SHA ??
-    process.env.GITHUB_SHA ??
-    process.env.CI_COMMIT_SHA;
+  const explicitSha = process.env.REMNIC_BENCH_GIT_SHA ?? process.env.GITHUB_SHA ?? process.env.CI_COMMIT_SHA;
   if (typeof explicitSha === "string" && explicitSha.trim().length > 0) {
     return explicitSha.trim().slice(0, 40);
   }

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -1,8 +1,9 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, realpath, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { mkdir, mkdtemp, readFile, realpath, symlink, writeFile } from "node:fs/promises";
+import test from "node:test";
 import {
   BENCHMARK_REPRO_MANIFEST_FILENAME,
   buildBenchmarkReproManifest,
@@ -92,11 +93,297 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
         "--system-api-key",
         "secret-value",
         "--judge-api-key=other-secret",
+        "--api-key",
+        "--limit",
+        "10",
         "--max-tokens",
         "2048",
         "--output-token-limit=128",
+        "--api-key",
+        "--config",
+        "profile=real",
+        "--api-key",
+        "--token",
+        "adjacent-token-secret",
+        "--api-key",
+        "-sk-live-dash-secret",
+        "--mode",
+        "quick",
+        "--api-key",
+        "-sk_live_123",
+        "--limit",
+        "21",
+        "--api-key",
+        "--sk-live-secret",
+        "--mode",
+        "boundary-mode",
+        "--api-key",
+        "--tokenlike-secret",
+        "--limit",
+        "24",
+        "--apiKey",
+        "camel-api-key-secret",
+        "--accessToken",
+        "camel-access-token-secret",
+        "--openai-api-key",
+        "provider-prefixed-openai-api-secret",
+        "--anthropic-api-key",
+        "provider-prefixed-anthropic-api-secret",
+        "--bearer-token",
+        "provider-prefixed-bearer-token-secret",
+        "--password",
+        "provider-password-alias-secret",
+        "--secret",
+        "provider-secret-alias-secret",
+        "--authorization",
+        "Bearer",
+        "split-authorization-token",
+        "--authorization=Bearer",
+        "assigned-authorization-secret",
+        "--mode",
+        "auth-mode",
+        "--auth-token",
+        "Bearer",
+        "split-auth-token-secret",
+        "--auth-token=Bearer",
+        "assigned-auth-token-secret",
+        "--mode",
+        "auth-token-mode",
         "--auth-token",
         "auth-secret",
+        "--token",
+        "-dash-secret",
+        "--auth-token",
+        "Bearer",
+        "-dash-auth-token-secret",
+        "--mode",
+        "dash-auth-mode",
+        "--auth-token",
+        "--opaque-token",
+        "--token",
+        "--provider-config",
+        "--mode",
+        "dash-mode",
+        "-t",
+        "short-token-secret",
+        "-k=short-key-secret",
+        "-p",
+        "-short-dash-secret",
+        "-pattached-secret",
+        "-tAttachedToken",
+        "-kAttachedKey",
+        "--api-keysk-live-attached-long-secret",
+        "--tokenabc-attached-long-secret",
+        "--auth-tokenBearerAttachedLongSecret",
+        "--auth-tokenBearer",
+        "attached-long-auth-continuation-secret",
+        "--api-key=attached-equals-api-secret",
+        "--token=attached-equals-token-secret",
+        "--secret-key",
+        "split-secret-key-value",
+        "--client-secret-key=client-secret-key-value",
+        "secretKey=direct-secret-key-value",
+        "provider.clientSecretKey=nested-client-secret-key-value",
+        "AWS_SECRET_ACCESS_KEY=aws-secret-access-key-value",
+        "--config",
+        "apiKey=sk-test",
+        "--config",
+        "accessKey",
+        "split-access-key-secret",
+        "--config=apiKey",
+        "split-assigned-secret",
+        "--config=callbackUrl=https://example.test/cb?api_key=url-query-secret&mode=test",
+        "--endpoint=https://user:p@ss-argv-url-userinfo-secret@example.test/v1?model=keep",
+        "--provider-config=apiKey",
+        "split-provider-assigned-secret",
+        "--provider-config=token",
+        "split-provider-token-secret",
+        "--provider-config",
+        "awsSecretAccessKey=provider-access-key-secret",
+        "--provider-config",
+        "baseUrl=https://host.test/path?access_token=url-access-secret;mode=keep",
+        "--provider-config",
+        "https://example.test/v1?api_key=separate-url-secret&model=x",
+        "--config",
+        "https://example.test/cb?password=url-password-secret&mode=keep",
+        "--config=api_key=sk-inline",
+        "--config=systemApiKey=system-camel-secret",
+        "--provider-config",
+        '{"apiKey":"sk-live-secret","systemApiKey":"json-camel-secret","baseUrl":"https://proxy.test/v1?api_key=json-url-secret&model=x","provider":"openai"}',
+        "--provider-config",
+        '{"headers":{"Cookie":"sid=json-cookie-secret","Authorization":"Bearer json-auth-secret"},"provider":"openai"}',
+        "--provider-config",
+        '{"privateKey":"json-private-key-secret","provider":"aws"}',
+        "--provider-config",
+        "{apiKey:loose-object-api-secret,provider:openai}",
+        "--config={authorization:loose-object-authorization-secret,model:gpt-test}",
+        "provider={credentials:{password:'loose-nested-password-secret'},name:openai}",
+        "provider=https://user:p@ss-provider-url-userinfo-secret@example.test/v1?api_key=provider-url-query-secret&model=keep",
+        '--config={"judge":{"token":"judge-secret"},"model":"gpt-test"}',
+        'provider={"credentials":{"password":"nested-secret","accessToken":"access-camel-secret"},"name":"openai"}',
+        "--config",
+        "token",
+        "split-secret",
+        "--config",
+        "authorization=Bearer",
+        "config-assigned-authorization-secret",
+        "--provider-config",
+        "authorization=Bearer",
+        "provider-assigned-authorization-secret",
+        "--config=authorization=Bearer",
+        "assigned-wrapper-authorization-secret",
+        "--config=auth_token",
+        "Bearer",
+        "assigned-config-auth-token-secret",
+        "--config",
+        "auth_token",
+        "Bearer",
+        "split-config-auth-token-secret",
+        "--config",
+        "auth_token:",
+        "Bearer",
+        "colon-config-auth-token-secret",
+        "--config",
+        "Authorization:",
+        "ApiKey",
+        "config-authorization-apikey-secret",
+        "--limit",
+        "25",
+        "--config",
+        "authorization:",
+        "Bearer",
+        "config-lower-authorization-bearer-secret",
+        "--provider-config",
+        "authorization:",
+        "Bearer",
+        "provider-lower-authorization-bearer-secret",
+        "--config",
+        "token",
+        "--token-value",
+        "--config",
+        "openai.apiKey",
+        "namespaced-secret",
+        "--config",
+        "openai.apiKey:colon-secret",
+        "--config=openai.apiKey:colon-inline-secret",
+        "--config",
+        "refreshToken",
+        "refresh-camel-secret",
+        "--config",
+        "--api-key",
+        "dashed-config-secret",
+        "--header",
+        "Authorization",
+        "Bearer header-secret",
+        "--header",
+        "Authorization",
+        "Bearer",
+        "split-auth-token",
+        "--header",
+        "Authorization",
+        "-dash-header-name-secret",
+        "--limit",
+        "16",
+        "--header",
+        "Authorization",
+        "--bearer-secret",
+        "--limit",
+        "17",
+        "--header",
+        "Authorization:",
+        "Bearer",
+        "split-header-secret",
+        "--header",
+        "Authorization:",
+        "-dash-header-secret",
+        "--limit",
+        "14",
+        "--config",
+        "apiKey:",
+        "split-colon-secret",
+        "--config",
+        "apiKey",
+        "-split-dash-config-secret",
+        "--limit",
+        "15",
+        "authorization:",
+        "-dash-bearer-secret",
+        "--limit",
+        "13",
+        "--header",
+        "Cookie: session=cookie-secret",
+        "--header",
+        "Cookie: session=cookie-multipart-secret",
+        "path=/",
+        "domain=example.test",
+        "--limit",
+        "11",
+        "--header",
+        "Authorization=Bearer auth-equals-secret",
+        "--header",
+        "Authorization=Bearer",
+        "split-equals-secret",
+        "--header=Authorization: Bearer assigned-colon-header-secret",
+        "--header=Authorization:",
+        "Bearer",
+        "split-assigned-colon-header-secret",
+        "--limit",
+        "18",
+        "--header=Authorization=Bearer",
+        "split-assigned-equals-secret",
+        "--header=Authorization=",
+        "Bearer",
+        "split-assigned-empty-equals-secret",
+        "--limit",
+        "19",
+        "--header=Authorization",
+        "Bearer",
+        "split-assigned-auth-secret",
+        "--header=Authorization",
+        "Bearer assigned-auth-secret",
+        "--header=Cookie=session=assigned-cookie-secret",
+        "--header=Cookie: session=assigned-cookie-multipart-secret",
+        "path=/",
+        "secure=true",
+        "--mode",
+        "smoke",
+        "--header",
+        "Cookie=session",
+        "cookie-continuation-secret",
+        "--limit",
+        "12",
+        "provider.header=Authorization: Bearer generic-header-secret",
+        "authorization=Bearer",
+        "bare-assigned-authorization-secret",
+        "token=Bearer",
+        "bare-assigned-token-secret",
+        "authorization",
+        "Bearer",
+        "bare-authorization-secret",
+        "--limit",
+        "22",
+        "token:",
+        "Bearer",
+        "bare-token-colon-secret",
+        "access_token:",
+        "Bearer",
+        "bare-access-token-colon-secret",
+        "Authorization:",
+        "Bearer",
+        "bare-authorization-colon-secret",
+        "--limit",
+        "23",
+        "--password:option-password-secret",
+        "--token:option-token-secret",
+        "--password:",
+        "option-password-continuation-secret",
+        "token",
+        "Bearer",
+        "bare-token-secret",
+        "password",
+        "bare-password-secret",
+        "provider.token=provider-secret",
+        "provider.name=openai",
         "next-positional",
       ],
       env: { OLLAMA_API_KEY: "secret-value", QMD_CONFIG_DIR: "/tmp/qmd" },
@@ -108,9 +395,7 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
   assert.equal(manifest.run.mode, "full");
   assert.match(manifest.run.id, /^20[0-9]{2}-/);
   assert.deepEqual(manifest.run.runtimeProfiles, ["real"]);
-  assert.deepEqual(manifest.run.selectedWorkItems, [
-    { benchmark: "longmemeval", runtimeProfile: "real" },
-  ]);
+  assert.deepEqual(manifest.run.selectedWorkItems, [{ benchmark: "longmemeval", runtimeProfile: "real" }]);
   assert.equal(manifest.run.seed, 42);
   assert.deepEqual(manifest.command.argv, [
     "bench",
@@ -119,11 +404,288 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
     "--system-api-key",
     "[redacted]",
     "--judge-api-key=[redacted]",
+    "--api-key",
+    "--limit",
+    "10",
     "--max-tokens",
     "2048",
     "--output-token-limit=128",
+    "--api-key",
+    "--config",
+    "profile=real",
+    "--api-key",
+    "--token",
+    "[redacted]",
+    "--api-key",
+    "[redacted]",
+    "--mode",
+    "quick",
+    "--api-key",
+    "[redacted]",
+    "--limit",
+    "21",
+    "--api-key",
+    "[redacted]",
+    "--mode",
+    "boundary-mode",
+    "--api-key",
+    "[redacted]",
+    "--limit",
+    "24",
+    "--apiKey",
+    "[redacted]",
+    "--accessToken",
+    "[redacted]",
+    "--openai-api-key",
+    "[redacted]",
+    "--anthropic-api-key",
+    "[redacted]",
+    "--bearer-token",
+    "[redacted]",
+    "--password",
+    "[redacted]",
+    "--secret",
+    "[redacted]",
+    "--authorization",
+    "[redacted]",
+    "[redacted]",
+    "--authorization=[redacted]",
+    "[redacted]",
+    "--mode",
+    "auth-mode",
     "--auth-token",
     "[redacted]",
+    "[redacted]",
+    "--auth-token=[redacted]",
+    "[redacted]",
+    "--mode",
+    "auth-token-mode",
+    "--auth-token",
+    "[redacted]",
+    "--token",
+    "[redacted]",
+    "--auth-token",
+    "[redacted]",
+    "[redacted]",
+    "--mode",
+    "dash-auth-mode",
+    "--auth-token",
+    "[redacted]",
+    "--token",
+    "--provider-config",
+    "--mode",
+    "dash-mode",
+    "-t",
+    "[redacted]",
+    "-k=[redacted]",
+    "-p",
+    "[redacted]",
+    "-p[redacted]",
+    "-t[redacted]",
+    "-k[redacted]",
+    "--api-key[redacted]",
+    "--token[redacted]",
+    "--auth-token[redacted]",
+    "--auth-token[redacted]",
+    "[redacted]",
+    "--api-key=[redacted]",
+    "--token=[redacted]",
+    "--secret-key",
+    "[redacted]",
+    "--client-secret-key=[redacted]",
+    "secretKey=[redacted]",
+    "provider.clientSecretKey=[redacted]",
+    "AWS_SECRET_ACCESS_KEY=[redacted]",
+    "--config",
+    "apiKey=[redacted]",
+    "--config",
+    "accessKey",
+    "[redacted]",
+    "--config=apiKey",
+    "[redacted]",
+    "--config=callbackUrl=https://example.test/cb?api_key=[redacted]&mode=test",
+    "--endpoint=https://[redacted]@example.test/v1?model=keep",
+    "--provider-config=apiKey",
+    "[redacted]",
+    "--provider-config=token",
+    "[redacted]",
+    "--provider-config",
+    "awsSecretAccessKey=[redacted]",
+    "--provider-config",
+    "baseUrl=https://host.test/path?access_token=[redacted];mode=keep",
+    "--provider-config",
+    "https://example.test/v1?api_key=[redacted]&model=x",
+    "--config",
+    "https://example.test/cb?password=[redacted]&mode=keep",
+    "--config=api_key=[redacted]",
+    "--config=systemApiKey=[redacted]",
+    "--provider-config",
+    '{"apiKey":"[redacted]","systemApiKey":"[redacted]","baseUrl":"https://proxy.test/v1?api_key=[redacted]&model=x","provider":"openai"}',
+    "--provider-config",
+    '{"headers":{"Cookie":"[redacted]","Authorization":"[redacted]"},"provider":"openai"}',
+    "--provider-config",
+    '{"privateKey":"[redacted]","provider":"aws"}',
+    "--provider-config",
+    "{apiKey:[redacted],provider:openai}",
+    "--config={authorization:[redacted],model:gpt-test}",
+    "provider={credentials:{password:[redacted]},name:openai}",
+    "provider=https://[redacted]@example.test/v1?api_key=[redacted]&model=keep",
+    '--config={"judge":{"token":"[redacted]"},"model":"gpt-test"}',
+    'provider={"credentials":{"password":"[redacted]","accessToken":"[redacted]"},"name":"openai"}',
+    "--config",
+    "token",
+    "[redacted]",
+    "--config",
+    "authorization=[redacted]",
+    "[redacted]",
+    "--provider-config",
+    "authorization=[redacted]",
+    "[redacted]",
+    "--config=authorization=[redacted]",
+    "[redacted]",
+    "--config=auth_token",
+    "[redacted]",
+    "[redacted]",
+    "--config",
+    "auth_token",
+    "[redacted]",
+    "[redacted]",
+    "--config",
+    "auth_token:[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--config",
+    "Authorization:[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--limit",
+    "25",
+    "--config",
+    "authorization:[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--provider-config",
+    "authorization:[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--config",
+    "token",
+    "[redacted]",
+    "--config",
+    "openai.apiKey",
+    "[redacted]",
+    "--config",
+    "openai.apiKey:[redacted]",
+    "--config=openai.apiKey:[redacted]",
+    "--config",
+    "refreshToken",
+    "[redacted]",
+    "--config",
+    "--api-key",
+    "[redacted]",
+    "--header",
+    "Authorization",
+    "[redacted]",
+    "--header",
+    "Authorization",
+    "[redacted]",
+    "[redacted]",
+    "--header",
+    "Authorization",
+    "[redacted]",
+    "--limit",
+    "16",
+    "--header",
+    "Authorization",
+    "[redacted]",
+    "--limit",
+    "17",
+    "--header",
+    "Authorization:[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--header",
+    "Authorization:[redacted]",
+    "[redacted]",
+    "--limit",
+    "14",
+    "--config",
+    "apiKey:[redacted]",
+    "--config",
+    "apiKey",
+    "[redacted]",
+    "--limit",
+    "15",
+    "authorization:[redacted]",
+    "--limit",
+    "13",
+    "--header",
+    "Cookie:[redacted]",
+    "--header",
+    "Cookie:[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--limit",
+    "11",
+    "--header",
+    "Authorization=[redacted]",
+    "--header",
+    "Authorization=[redacted]",
+    "[redacted]",
+    "--header=Authorization:[redacted]",
+    "--header=Authorization:[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--limit",
+    "18",
+    "--header=Authorization=[redacted]",
+    "[redacted]",
+    "--header=Authorization=[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--limit",
+    "19",
+    "--header=Authorization",
+    "[redacted]",
+    "[redacted]",
+    "--header=Authorization",
+    "[redacted]",
+    "--header=Cookie=[redacted]",
+    "--header=Cookie:[redacted]",
+    "[redacted]",
+    "[redacted]",
+    "--mode",
+    "smoke",
+    "--header",
+    "Cookie=[redacted]",
+    "[redacted]",
+    "--limit",
+    "12",
+    "provider.header=Authorization: [redacted]",
+    "authorization=[redacted]",
+    "[redacted]",
+    "token=[redacted]",
+    "[redacted]",
+    "authorization",
+    "[redacted]",
+    "[redacted]",
+    "--limit",
+    "22",
+    "token:[redacted]",
+    "access_token:[redacted]",
+    "Authorization:[redacted]",
+    "--limit",
+    "23",
+    "--password:[redacted]",
+    "--token:[redacted]",
+    "--password:[redacted]",
+    "token",
+    "[redacted]",
+    "[redacted]",
+    "password",
+    "[redacted]",
+    "provider.token=[redacted]",
+    "provider.name=openai",
     "next-positional",
   ]);
   assert.deepEqual(manifest.command.envKeys, ["OLLAMA_API_KEY", "QMD_CONFIG_DIR"]);
@@ -132,13 +694,12 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
   assert.ok(manifest.datasets[0]?.sha256);
   assert.equal(manifest.results[0]?.benchmark, "longmemeval");
   assert.equal(manifest.results[0]?.seeds.length, 5);
-  assert.deepEqual(manifest.qmd?.collections, [
-    "bench-cold",
-    "bench-conversations",
-    "bench-hot",
-  ]);
+  assert.deepEqual(manifest.qmd?.collections, ["bench-cold", "bench-conversations", "bench-hot"]);
   assert.ok(/^[0-9a-f]{64}$/.test(manifest.artifactHash));
-  assert.doesNotMatch(JSON.stringify(manifest), /secret-value|other-secret|auth-secret/);
+  assert.doesNotMatch(
+    JSON.stringify(manifest),
+    /secret-value|other-secret|auth-secret|dash-secret|adjacent-token-secret|sk-live-dash-secret|sk_live_123|tokenlike-secret|camel-api-key-secret|camel-access-token-secret|provider-prefixed-openai-api-secret|provider-prefixed-anthropic-api-secret|provider-prefixed-bearer-token-secret|provider-password-alias-secret|provider-secret-alias-secret|split-authorization-token|assigned-authorization-secret|split-auth-token-secret|assigned-auth-token-secret|short-token-secret|short-key-secret|short-dash-secret|attached-secret|AttachedToken|AttachedKey|sk-live-attached-long-secret|abc-attached-long-secret|BearerAttachedLongSecret|attached-long-auth-continuation-secret|attached-equals-api-secret|attached-equals-token-secret|split-secret-key-value|client-secret-key-value|direct-secret-key-value|nested-client-secret-key-value|aws-secret-access-key-value|sk-test|split-access-key-secret|split-assigned-secret|url-query-secret|argv-url-userinfo-secret|split-provider-assigned-secret|split-provider-token-secret|provider-access-key-secret|url-access-secret|separate-url-secret|url-password-secret|sk-inline|system-camel-secret|sk-live-secret|json-camel-secret|json-url-secret|json-cookie-secret|json-auth-secret|json-private-key-secret|json-private-key-secret|loose-object-api-secret|loose-object-authorization-secret|loose-nested-password-secret|provider-url-userinfo-secret|provider-url-query-secret|judge-secret|nested-secret|access-camel-secret|split-secret|config-assigned-authorization-secret|provider-assigned-authorization-secret|assigned-wrapper-authorization-secret|assigned-config-auth-token-secret|split-config-auth-token-secret|colon-config-auth-token-secret|config-authorization-apikey-secret|config-lower-authorization-bearer-secret|provider-lower-authorization-bearer-secret|namespaced-secret|colon-secret|colon-inline-secret|refresh-camel-secret|dashed-config-secret|header-secret|dash-header-secret|dash-header-name-secret|bearer-secret|Bearer|split-auth-token|dash-auth-token-secret|split-header-secret|dash-bearer-secret|split-colon-secret|split-dash-config-secret|token-value|option-password-secret|option-token-secret|option-password-continuation-secret|cookie-secret|cookie-multipart-secret|auth-equals-secret|split-equals-secret|assigned-colon-header-secret|split-assigned-colon-header-secret|split-assigned-equals-secret|split-assigned-empty-equals-secret|split-assigned-auth-secret|assigned-auth-secret|assigned-cookie-secret|assigned-cookie-multipart-secret|cookie-continuation-secret|generic-header-secret|bare-assigned-authorization-secret|bare-assigned-token-secret|bare-authorization-secret|bare-token-colon-secret|bare-access-token-colon-secret|bare-authorization-colon-secret|bare-token-secret|bare-password-secret|provider-secret/
+  );
 });
 
 test("writeBenchmarkReproManifest writes MANIFEST.json beside results", async () => {
@@ -158,6 +719,358 @@ test("writeBenchmarkReproManifest writes MANIFEST.json beside results", async ()
     results: Array<{ benchmark: string }>;
   };
   assert.equal(manifest.results[0]?.benchmark, "longmemeval");
+});
+
+test("buildBenchmarkReproManifest redacts terminal URL query secrets inside JSON argv", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-json-url-redaction-");
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    command: {
+      cwd: root,
+      argv: [
+        "--provider-config",
+        '{"baseUrl":"https://proxy.test/v1?api_key=json-terminal-url-secret","provider":"openai"}',
+      ],
+    },
+  });
+
+  assert.deepEqual(manifest.command.argv, [
+    "--provider-config",
+    '{"baseUrl":"https://proxy.test/v1?api_key=[redacted]","provider":"openai"}',
+  ]);
+  assert.doesNotMatch(JSON.stringify(manifest), /json-terminal-url-secret/);
+});
+
+test("buildBenchmarkReproManifest redacts separated URL-valued bench flags", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-separated-url-redaction-");
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    command: {
+      cwd: root,
+      argv: [
+        "--system-base-url",
+        "https://system.test/v1?api_key=system-url-secret&model=keep",
+        "--judge-base-url",
+        "https://judge.test/v1?access_token=judge-url-secret&model=keep",
+        "--internal-base-url",
+        "https://internal.test/v1?password=internal-url-secret&model=keep",
+        "--base-url",
+        "https://published.test/v1?token=published-url-secret&model=keep",
+        "--ama-bench-cross-judge-base-url",
+        "https://ama.test/v1?client_secret=ama-url-secret&model=keep",
+      ],
+    },
+  });
+
+  assert.deepEqual(manifest.command.argv, [
+    "--system-base-url",
+    "https://system.test/v1?api_key=[redacted]&model=keep",
+    "--judge-base-url",
+    "https://judge.test/v1?access_token=[redacted]&model=keep",
+    "--internal-base-url",
+    "https://internal.test/v1?password=[redacted]&model=keep",
+    "--base-url",
+    "https://published.test/v1?token=[redacted]&model=keep",
+    "--ama-bench-cross-judge-base-url",
+    "https://ama.test/v1?client_secret=[redacted]&model=keep",
+  ]);
+  assert.doesNotMatch(
+    JSON.stringify(manifest),
+    /system-url-secret|judge-url-secret|internal-url-secret|published-url-secret|ama-url-secret/
+  );
+});
+
+test("buildBenchmarkReproManifest preserves bench flags after multi-token secrets", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-secret-boundaries-");
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    command: {
+      cwd: root,
+      argv: [
+        "--header",
+        "Authorization",
+        "Bearer",
+        "header-boundary-secret",
+        "--system-model",
+        "gpt-5.4",
+        "--auth-token",
+        "Bearer",
+        "auth-token-boundary-secret",
+        "--judge-model",
+        "claude-opus-4.5",
+        "--authorization",
+        "Bearer",
+        "authorization-boundary-secret",
+        "--json",
+        "--token",
+        "Bearer",
+        "token-boundary-secret",
+        "--results-dir",
+        "results",
+        "--header",
+        "Cookie=session=cookie-boundary-secret",
+        "--out",
+        "published-artifacts",
+        "--provider",
+        "openai",
+      ],
+    },
+  });
+
+  assert.deepEqual(manifest.command.argv, [
+    "--header",
+    "Authorization",
+    "[redacted]",
+    "[redacted]",
+    "--system-model",
+    "gpt-5.4",
+    "--auth-token",
+    "[redacted]",
+    "[redacted]",
+    "--judge-model",
+    "claude-opus-4.5",
+    "--authorization",
+    "[redacted]",
+    "[redacted]",
+    "--json",
+    "--token",
+    "[redacted]",
+    "[redacted]",
+    "--results-dir",
+    "results",
+    "--header",
+    "Cookie=[redacted]",
+    "--out",
+    "published-artifacts",
+    "--provider",
+    "openai",
+  ]);
+  assert.doesNotMatch(
+    JSON.stringify(manifest),
+    /header-boundary-secret|auth-token-boundary-secret|authorization-boundary-secret|token-boundary-secret|cookie-boundary-secret/
+  );
+});
+
+test("buildBenchmarkReproManifest preserves suffixes after colon-delimited secret values", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-colon-suffixes-");
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    command: {
+      cwd: root,
+      argv: [
+        "--config=apiKey:sk-live-colon-secret,provider:openai",
+        "--provider-config",
+        "openai.apiKey:provider-colon-secret,model:gpt-test",
+      ],
+    },
+  });
+
+  assert.deepEqual(manifest.command.argv, [
+    "--config=apiKey:[redacted],provider:openai",
+    "--provider-config",
+    "openai.apiKey:[redacted],model:gpt-test",
+  ]);
+  assert.doesNotMatch(JSON.stringify(manifest), /sk-live-colon-secret|provider-colon-secret/);
+});
+
+test("buildBenchmarkReproManifest redacts every pair in Cookie argv headers", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-cookie-pairs-");
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    command: {
+      cwd: root,
+      argv: [
+        "--header",
+        "Cookie=sid=cookie-sid-secret; csrf=cookie-csrf-secret",
+        "--header=Cookie: sid=assigned-cookie-sid-secret; csrf=assigned-cookie-csrf-secret",
+      ],
+    },
+  });
+
+  assert.deepEqual(manifest.command.argv, ["--header", "Cookie=[redacted]", "--header=Cookie:[redacted]"]);
+  assert.doesNotMatch(
+    JSON.stringify(manifest),
+    /cookie-sid-secret|cookie-csrf-secret|assigned-cookie-sid-secret|assigned-cookie-csrf-secret/
+  );
+});
+
+test("buildBenchmarkReproManifest redacts secret-bearing config file hashes", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-config-redaction-");
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+  const secretConfigPath = path.join(root, "secret-config.json");
+  const malformedSecretConfigPath = path.join(root, "malformed-secret-config.json");
+  const jsonStringSecretConfigPath = path.join(root, "json-string-secret-config.json");
+  const tomlSecretConfigPath = path.join(root, "secret-config.toml");
+  const urlSecretConfigPath = path.join(root, "url-secret-config.toml");
+  const safeConfigPath = path.join(root, "safe-config.json");
+  const secretConfig = `${JSON.stringify({ model: "gpt-test", systemApiKey: "config-secret" })}\n`;
+  const malformedSecretConfig = '{"systemApiKey":"malformed-config-secret",}\n';
+  const jsonStringSecretConfig = `${JSON.stringify({
+    model: "gpt-test",
+    note: "api_key=json-string-config-secret",
+  })}\n`;
+  const tomlSecretConfig = '"api_key" = "toml-config-secret"\nmodel = "gpt-test"\n';
+  const urlSecretConfig = 'baseUrl = "https://proxy.test/v1?api_key=url-config-secret"\nmodel = "gpt-test"\n';
+  const safeConfig = `${JSON.stringify({ model: "gpt-test", temperature: 0 })}\n`;
+  await writeFile(secretConfigPath, secretConfig, "utf8");
+  await writeFile(malformedSecretConfigPath, malformedSecretConfig, "utf8");
+  await writeFile(jsonStringSecretConfigPath, jsonStringSecretConfig, "utf8");
+  await writeFile(tomlSecretConfigPath, tomlSecretConfig, "utf8");
+  await writeFile(urlSecretConfigPath, urlSecretConfig, "utf8");
+  await writeFile(safeConfigPath, safeConfig, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    configFiles: [
+      { label: "secret", path: secretConfigPath },
+      { label: "malformed-secret", path: malformedSecretConfigPath },
+      { label: "json-string-secret", path: jsonStringSecretConfigPath },
+      { label: "toml-secret", path: tomlSecretConfigPath },
+      { label: "url-secret", path: urlSecretConfigPath },
+      { label: "safe", path: safeConfigPath },
+    ],
+  });
+
+  const secretEntry = manifest.configFiles.find((entry) => entry.label === "secret");
+  const malformedSecretEntry = manifest.configFiles.find((entry) => entry.label === "malformed-secret");
+  const jsonStringSecretEntry = manifest.configFiles.find((entry) => entry.label === "json-string-secret");
+  const tomlSecretEntry = manifest.configFiles.find((entry) => entry.label === "toml-secret");
+  const urlSecretEntry = manifest.configFiles.find((entry) => entry.label === "url-secret");
+  const safeEntry = manifest.configFiles.find((entry) => entry.label === "safe");
+  const rawSecretHash = createHash("sha256").update(secretConfig).digest("hex");
+  const rawJsonStringSecretHash = createHash("sha256").update(jsonStringSecretConfig).digest("hex");
+  const rawUrlSecretHash = createHash("sha256").update(urlSecretConfig).digest("hex");
+  const rawSafeHash = createHash("sha256").update(safeConfig).digest("hex");
+  assert.equal(secretEntry?.redacted, true);
+  assert.ok(secretEntry?.sha256);
+  assert.notEqual(secretEntry?.sha256, rawSecretHash);
+  assert.equal(malformedSecretEntry?.redacted, true);
+  assert.equal(Object.hasOwn(malformedSecretEntry ?? {}, "sha256"), false);
+  assert.equal(jsonStringSecretEntry?.redacted, true);
+  assert.ok(jsonStringSecretEntry?.sha256);
+  assert.notEqual(jsonStringSecretEntry?.sha256, rawJsonStringSecretHash);
+  assert.equal(tomlSecretEntry?.redacted, true);
+  assert.equal(Object.hasOwn(tomlSecretEntry ?? {}, "sha256"), false);
+  assert.equal(urlSecretEntry?.redacted, true);
+  assert.equal(Object.hasOwn(urlSecretEntry ?? {}, "sha256"), false);
+  assert.equal(safeEntry?.redacted, undefined);
+  assert.equal(safeEntry?.sha256, rawSafeHash);
+  assert.doesNotMatch(
+    JSON.stringify(manifest),
+    new RegExp(
+      `config-secret|malformed-config-secret|json-string-config-secret|toml-config-secret|url-config-secret|${rawSecretHash}|${rawJsonStringSecretHash}|${rawUrlSecretHash}`
+    )
+  );
+});
+
+test("buildBenchmarkReproManifest rejects explicit result paths outside resultsDir", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-result-containment-");
+  const resultsDir = path.join(root, "results");
+  const outsideDir = path.join(root, "outside");
+  await mkdir(resultsDir, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+  const outsideResultPath = path.join(outsideDir, "longmemeval.json");
+  await writeFile(outsideResultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    () =>
+      buildBenchmarkReproManifest(resultsDir, {
+        resultPaths: [outsideResultPath],
+      }),
+    /result path must be inside/
+  );
+});
+
+test("buildBenchmarkReproManifest rejects outside result paths when resultsDir is relative", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-relative-result-containment-");
+  const resultsDir = path.join(root, "results");
+  const outsideDir = path.join(root, "outside");
+  await mkdir(resultsDir, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+  const outsideResultPath = path.join(outsideDir, "longmemeval.json");
+  await writeFile(outsideResultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const previousCwd = process.cwd();
+  try {
+    process.chdir(root);
+    await assert.rejects(
+      () =>
+        buildBenchmarkReproManifest("results", {
+          resultPaths: [outsideResultPath],
+        }),
+      /result path must be inside/
+    );
+  } finally {
+    process.chdir(previousCwd);
+  }
+});
+
+test("buildBenchmarkReproManifest rejects explicit result paths that are symlinks", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-result-link-containment-");
+  const resultsDir = path.join(root, "results");
+  const outsideDir = path.join(root, "outside");
+  await mkdir(resultsDir, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+  const outsideResultPath = path.join(outsideDir, "longmemeval.json");
+  const linkedResultPath = path.join(resultsDir, "linked.json");
+  await writeFile(outsideResultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+  await symlink(outsideResultPath, linkedResultPath);
+
+  await assert.rejects(
+    () =>
+      buildBenchmarkReproManifest(resultsDir, {
+        resultPaths: [linkedResultPath],
+      }),
+    /result path must be a regular file without symlink components/
+  );
+});
+
+test("buildBenchmarkReproManifest accepts contained result filenames starting with dots", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-result-dotfile-");
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "..valid.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+  });
+
+  assert.equal(manifest.results[0]?.path, "..valid.json");
 });
 
 test("artifact hash ignores volatile host metadata but binds run id", async () => {
@@ -247,15 +1160,35 @@ test("buildBenchmarkReproManifest rejects symlinked dataset ancestors", async ()
   assert.equal(manifest.datasets[0]?.sha256, undefined);
 });
 
+test("buildBenchmarkReproManifest rejects dataset symlinks outside the dataset root", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-dataset-external-link-");
+  const resultsDir = path.join(root, "results");
+  const datasetDir = path.join(root, "dataset");
+  const outsideDir = path.join(root, "outside");
+  await mkdir(resultsDir, { recursive: true });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+  await writeFile(path.join(outsideDir, "secret-notes.txt"), "outside dataset\n", "utf8");
+  await symlink(path.join(outsideDir, "secret-notes.txt"), path.join(datasetDir, "outside-link.txt"));
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    () =>
+      buildBenchmarkReproManifest(resultsDir, {
+        resultPaths: [resultPath],
+        selectedBenchmarks: ["longmemeval"],
+        datasetDirs: { longmemeval: datasetDir },
+      }),
+    /dataset symlink target must be inside/
+  );
+});
+
 test("buildBenchmarkReproManifest preserves explicitly empty result paths", async () => {
   const root = await createTempRoot("remnic-repro-manifest-empty-results-");
   const resultsDir = path.join(root, "results");
   await mkdir(resultsDir, { recursive: true });
-  await writeFile(
-    path.join(resultsDir, "longmemeval.json"),
-    `${JSON.stringify(buildResult(), null, 2)}\n`,
-    "utf8",
-  );
+  await writeFile(path.join(resultsDir, "longmemeval.json"), `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
 
   const manifest = await buildBenchmarkReproManifest(resultsDir, {
     resultPaths: [],

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -1,20 +1,13 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
-import {
-  lstat,
-  mkdir,
-  readdir,
-  readlink,
-  realpath,
-  stat,
-  writeFile,
-} from "node:fs/promises";
+import { lstat, mkdir, readFile, readdir, readlink, realpath, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { BenchmarkMode, BenchmarkResult } from "./types.js";
-import { loadBenchmarkResult, listBenchmarkResults } from "./results-store.js";
+import { listBenchmarkResults, loadBenchmarkResult } from "./results-store.js";
 import { resolveBenchmarkRunId } from "./run-identity.js";
+import { redactUrlSecrets as redactUrlSecretMaterial } from "./security/url-secrets.js";
+import type { BenchmarkMode, BenchmarkResult } from "./types.js";
 
 export const BENCHMARK_REPRO_MANIFEST_FILENAME = "MANIFEST.json";
 export const BENCHMARK_REPRO_MANIFEST_SCHEMA_VERSION = 1;
@@ -96,6 +89,7 @@ export interface BenchmarkReproManifest {
     sha256?: string;
     sizeBytes?: number;
     missing?: boolean;
+    redacted?: boolean;
   }>;
   datasets: BenchmarkReproManifestDataset[];
   results: BenchmarkReproManifestResult[];
@@ -135,11 +129,113 @@ const SECRET_ARG_FLAGS = new Set([
   "--judge-api-key",
   "--token",
   "--auth-token",
+  "-k",
+  "-p",
+  "-t",
 ]);
 
-const SECRET_KEY_PATTERN = /(^|[-_])(?:api[-_]?key|secret|password|authorization|credential|access[-_]?token|auth[-_]?token|refresh[-_]?token|id[-_]?token|token)$/i;
+const ATTACHED_LONG_SECRET_ARG_FLAGS = [
+  "--system-api-key",
+  "--judge-api-key",
+  "--auth-token",
+  "--api-key",
+  "--token",
+] as const;
+
+const NON_SECRET_ARG_FLAGS = new Set([
+  "--ama-bench-cross-judge-base-url",
+  "--base-url",
+  "--config",
+  "--dataset-dir",
+  "--header",
+  "--internal-base-url",
+  "--judge-base-url",
+  "--limit",
+  "--max-tokens",
+  "--mode",
+  "--output-token-limit",
+  "--provider-config",
+  "--system-base-url",
+]);
+
+const BENCH_OPTION_BOUNDARY_FLAGS = new Set([
+  "--all",
+  "--ama-bench-cross-judge-api-key",
+  "--ama-bench-cross-judge-base-url",
+  "--ama-bench-cross-judge-codex-reasoning-effort",
+  "--ama-bench-cross-judge-model",
+  "--ama-bench-cross-judge-provider",
+  "--ama-bench-judge-protocol",
+  "--base-url",
+  "--baselines-dir",
+  "--custom",
+  "--dataset",
+  "--dataset-dir",
+  "--detail",
+  "--disable-thinking",
+  "--drain-timeout",
+  "--dry-run",
+  "--explain",
+  "--fast-gateway-agent-id",
+  "--format",
+  "--gateway-agent-id",
+  "--help",
+  "--ingest-concurrency",
+  "--internal-api-key",
+  "--internal-base-url",
+  "--internal-codex-reasoning-effort",
+  "--internal-disable-thinking",
+  "--internal-model",
+  "--internal-provider",
+  "--json",
+  "--judge-api-key",
+  "--judge-base-url",
+  "--judge-codex-reasoning-effort",
+  "--judge-model",
+  "--judge-provider",
+  "--limit",
+  "--matrix",
+  "--max-429-wait",
+  "--model",
+  "--model-source",
+  "--name",
+  "--openclaw-config",
+  "--out",
+  "--output",
+  "--provider",
+  "--quick",
+  "--remnic-config",
+  "--request-timeout",
+  "--results-dir",
+  "--resume",
+  "--retry-failed",
+  "--runtime-profile",
+  "--seed",
+  "--system-api-key",
+  "--system-base-url",
+  "--system-codex-reasoning-effort",
+  "--system-model",
+  "--system-provider",
+  "--system-responder-context-budget-chars",
+  "--system-responder-prompt-budget-chars",
+  "--target",
+  "--task-filter",
+  "--threshold",
+  "--trial-concurrency",
+  "--trial-limit",
+  "-h",
+]);
+
+const SECRET_KEY_PATTERN =
+  /(^|[-_])(?:api[-_]?key|secret[-_]?access[-_]?key|secret[-_]?key|client[-_]?secret(?:[-_]?key)?|app[-_]?secret(?:[-_]?key)?|provider[-_]?secret(?:[-_]?key)?|access[-_]?key|private[-_]?key|secret|password|authorization|credential|access[-_]?token|auth[-_]?token|refresh[-_]?token|id[-_]?token|token)$/i;
+
+const REDACTED_ARG_VALUE = "[redacted]";
 
 function sha256String(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function sha256Buffer(value: Buffer): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
@@ -172,31 +268,583 @@ function sanitizeArgv(argv: string[]): string[] {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]!;
     const isOptionFlag = arg.startsWith("-");
-    const [flagName] = arg.split("=", 1);
-    if (
-      isOptionFlag &&
-      (SECRET_ARG_FLAGS.has(flagName) || SECRET_KEY_PATTERN.test(flagName))
-    ) {
-      if (arg.includes("=")) {
-        sanitized.push(`${flagName}=[redacted]`);
+    const assignmentIndex = arg.indexOf("=");
+    const flagName = assignmentIndex === -1 ? arg : arg.slice(0, assignmentIndex);
+    const attachedShortSecretFlag = getAttachedShortSecretFlag(arg);
+    const attachedLongSecret = getAttachedLongSecretArg(arg);
+    if (attachedLongSecret) {
+      sanitized.push(`${attachedLongSecret.flag}${attachedLongSecret.delimiter}${REDACTED_ARG_VALUE}`);
+      const attachedSecretValue = arg.slice(
+        attachedLongSecret.flag.length + (attachedLongSecret.delimiter === "=" ? 1 : 0)
+      );
+      if (shouldConsumeAuthSchemePair(attachedLongSecret.flag, attachedSecretValue)) {
+        const consumedValues = countAuthSchemeContinuationTokens(attachedLongSecret.flag, argv, index + 1);
+        sanitized.push(...redactedPlaceholders(consumedValues));
+        index += consumedValues;
+      }
+      continue;
+    }
+    if (attachedShortSecretFlag) {
+      sanitized.push(`${attachedShortSecretFlag}${REDACTED_ARG_VALUE}`);
+      continue;
+    }
+    const secretDelimiterIndex = assignmentIndex === -1 ? findSecretConfigDelimiterIndex(arg) : -1;
+    if (secretDelimiterIndex !== -1) {
+      sanitized.push(sanitizeSecretDelimitedArg(arg, secretDelimiterIndex, ":"));
+      if (arg.slice(secretDelimiterIndex + 1).trim().length === 0) {
+        index += countBareSecretValueTokens(arg.slice(0, secretDelimiterIndex), argv, index + 1);
+      }
+      continue;
+    }
+    if (isOptionFlag && (SECRET_ARG_FLAGS.has(flagName) || isSecretOptionFlagName(flagName))) {
+      if (assignmentIndex !== -1) {
+        const assignedSecretValue = arg.slice(assignmentIndex + 1);
+        sanitized.push(`${flagName}=${REDACTED_ARG_VALUE}`);
+        if (shouldConsumeAuthSchemePair(flagName, assignedSecretValue)) {
+          const consumedValues = countAuthSchemeContinuationTokens(flagName, argv, index + 1);
+          sanitized.push(...redactedPlaceholders(consumedValues));
+          index += consumedValues;
+        }
       } else {
         sanitized.push(arg);
-        if (index + 1 < argv.length) {
-          sanitized.push("[redacted]");
-          index += 1;
+        if (index + 1 < argv.length && shouldConsumeSeparatedSecretFlagValue(argv[index + 1]!)) {
+          const consumeAllValueTokens =
+            isAuthorizationConfigKey(flagName) ||
+            ((flagName === "--auth-token" || flagName === "--token") && isAuthSchemeToken(argv[index + 1]!));
+          let consumedValues = 1;
+          while (
+            consumeAllValueTokens &&
+            index + 1 + consumedValues < argv.length &&
+            !isOptionValueBoundaryFlag(argv[index + 1 + consumedValues]!)
+          ) {
+            consumedValues += 1;
+          }
+          sanitized.push(...redactedPlaceholders(consumedValues));
+          index += consumedValues;
         }
       }
       continue;
     }
-    sanitized.push(arg);
+    if (assignmentIndex === -1 && isKnownNonSecretOptionFlag(arg)) {
+      sanitized.push(arg);
+      if (index + 1 < argv.length && !argv[index + 1]!.startsWith("-")) {
+        const optionValue = sanitizeOptionValueSpan(arg, argv, index + 1);
+        sanitized.push(...optionValue.values);
+        index += optionValue.consumed;
+      }
+      continue;
+    }
+    if (assignmentIndex !== -1 && isOptionFlag && NON_SECRET_ARG_FLAGS.has(getOptionName(arg))) {
+      const assignedValue = arg.slice(assignmentIndex + 1);
+      const assignedOptionName = getOptionName(arg);
+      if (assignedOptionName === "--header") {
+        const headerDelimiterIndex = findSensitiveHeaderDelimiterIndex(assignedValue);
+        if (headerDelimiterIndex !== -1) {
+          let consumedValues = 0;
+          while (
+            index + 1 + consumedValues < argv.length &&
+            !isOptionValueBoundaryFlag(argv[index + 1 + consumedValues]!)
+          ) {
+            consumedValues += 1;
+          }
+          sanitized.push(
+            `${assignedOptionName}=${sanitizeSecretDelimitedArg(
+              assignedValue,
+              headerDelimiterIndex,
+              assignedValue[headerDelimiterIndex]!
+            )}`
+          );
+          sanitized.push(...redactedPlaceholders(consumedValues));
+          index += consumedValues;
+          continue;
+        }
+      }
+      const authSchemeAssignmentIndex = findAuthSchemeAssignmentIndex(assignedValue);
+      if (authSchemeAssignmentIndex !== -1) {
+        const authSchemeKey = assignedValue.slice(0, authSchemeAssignmentIndex);
+        const consumedValues = countAuthSchemeContinuationTokens(authSchemeKey, argv, index + 1);
+        if (consumedValues > 0) {
+          sanitized.push(
+            `${assignedOptionName}=${sanitizeAssignmentArg(assignedValue, authSchemeAssignmentIndex, false)}`
+          );
+          sanitized.push(...redactedPlaceholders(consumedValues));
+          index += consumedValues;
+          continue;
+        }
+      }
+      const assignedValueIsSensitive =
+        isSecretConfigKey(assignedValue) || (assignedOptionName === "--header" && isSensitiveHeaderKey(assignedValue));
+      if (assignedValueIsSensitive && index + 1 < argv.length && !isOptionValueBoundaryFlag(argv[index + 1]!)) {
+        let consumedValues = 1;
+        if (
+          shouldConsumeAuthSchemePair(assignedValue, argv[index + 1]!) &&
+          index + 2 < argv.length &&
+          !isOptionValueBoundaryFlag(argv[index + 2]!)
+        ) {
+          consumedValues = 2;
+        } else {
+          const consumeAllValueTokens = assignedOptionName === "--header" || isAuthorizationConfigKey(assignedValue);
+          while (
+            index + 1 + consumedValues < argv.length &&
+            !isOptionValueBoundaryFlag(argv[index + 1 + consumedValues]!) &&
+            consumeAllValueTokens
+          ) {
+            consumedValues += 1;
+          }
+        }
+        sanitized.push(arg);
+        sanitized.push(...redactedPlaceholders(consumedValues));
+        index += consumedValues;
+        continue;
+      }
+    }
+    if (assignmentIndex !== -1) {
+      const authSchemeAssignmentIndex = findAuthSchemeAssignmentIndex(arg);
+      if (authSchemeAssignmentIndex !== -1) {
+        const authSchemeKey = arg.slice(0, authSchemeAssignmentIndex);
+        const consumedValues = countAuthSchemeContinuationTokens(authSchemeKey, argv, index + 1);
+        sanitized.push(sanitizeAssignmentArg(arg, assignmentIndex, isOptionFlag));
+        sanitized.push(...redactedPlaceholders(consumedValues));
+        index += consumedValues;
+        continue;
+      }
+      sanitized.push(sanitizeAssignmentArg(arg, assignmentIndex, isOptionFlag));
+      continue;
+    }
+    if (!isOptionFlag && isSecretConfigKey(arg)) {
+      sanitized.push(arg);
+      const consumedValues = countBareSecretValueTokens(arg, argv, index + 1);
+      sanitized.push(...redactedPlaceholders(consumedValues));
+      index += consumedValues;
+      continue;
+    }
+    sanitized.push(sanitizeStructuredArg(arg));
   }
   return sanitized;
 }
 
-function sanitizeEnvKeys(
-  env: NodeJS.ProcessEnv | undefined,
-  explicitKeys: string[] | undefined,
-): string[] {
+function sanitizeOptionValueSpan(
+  optionArg: string,
+  argv: string[],
+  startIndex: number
+): { values: string[]; consumed: number } {
+  const value = argv[startIndex]!;
+  const optionName = getOptionName(optionArg);
+  if (optionName === "--header") {
+    const headerDelimiterIndex = findSensitiveHeaderDelimiterIndex(value);
+    if (headerDelimiterIndex !== -1) {
+      let consumed = 1;
+      while (startIndex + consumed < argv.length && !isOptionValueBoundaryFlag(argv[startIndex + consumed]!)) {
+        consumed += 1;
+      }
+      return {
+        values: [
+          sanitizeSecretDelimitedArg(value, headerDelimiterIndex, value[headerDelimiterIndex]!),
+          ...redactedPlaceholders(consumed - 1),
+        ],
+        consumed,
+      };
+    }
+    if (
+      isSensitiveHeaderKey(value) &&
+      startIndex + 1 < argv.length &&
+      !isOptionValueBoundaryFlag(argv[startIndex + 1]!)
+    ) {
+      let consumed = 2;
+      while (startIndex + consumed < argv.length && !isOptionValueBoundaryFlag(argv[startIndex + consumed]!)) {
+        consumed += 1;
+      }
+      return { values: [value, ...redactedPlaceholders(consumed - 1)], consumed };
+    }
+  }
+  const secretDelimiterIndex = findSecretConfigDelimiterIndex(value);
+  if (secretDelimiterIndex !== -1 && value.slice(secretDelimiterIndex + 1).trim().length === 0) {
+    const secretKey = value.slice(0, secretDelimiterIndex);
+    let consumed = 1;
+    if (isAuthorizationConfigKey(secretKey)) {
+      while (startIndex + consumed < argv.length && !isOptionValueBoundaryFlag(argv[startIndex + consumed]!)) {
+        consumed += 1;
+      }
+    } else if (
+      startIndex + 1 < argv.length &&
+      shouldConsumeAuthSchemePair(secretKey, argv[startIndex + 1]!) &&
+      startIndex + 2 < argv.length &&
+      !isOptionValueBoundaryFlag(argv[startIndex + 2]!)
+    ) {
+      consumed = 3;
+    } else if (startIndex + 1 < argv.length && !isOptionValueBoundaryFlag(argv[startIndex + 1]!)) {
+      consumed = 2;
+    }
+    const continuationValues =
+      consumed > 1 &&
+      (isAuthorizationConfigKey(secretKey) ||
+        (consumed > 2 && shouldConsumeAuthSchemePair(secretKey, argv[startIndex + 1]!)))
+        ? redactedPlaceholders(consumed - 1)
+        : [];
+    return { values: [sanitizeSecretDelimitedArg(value, secretDelimiterIndex, ":"), ...continuationValues], consumed };
+  }
+  if (isSecretConfigKey(value) && startIndex + 1 < argv.length && !isOptionValueBoundaryFlag(argv[startIndex + 1]!)) {
+    let consumed = 2;
+    if (
+      shouldConsumeAuthSchemePair(value, argv[startIndex + 1]!) &&
+      startIndex + 2 < argv.length &&
+      !isOptionValueBoundaryFlag(argv[startIndex + 2]!)
+    ) {
+      consumed = 3;
+    } else if (isAuthorizationConfigKey(value)) {
+      while (startIndex + consumed < argv.length && !isOptionValueBoundaryFlag(argv[startIndex + consumed]!)) {
+        consumed += 1;
+      }
+    }
+    return { values: [value, ...redactedPlaceholders(consumed - 1)], consumed };
+  }
+  const assignmentIndex = value.indexOf("=");
+  if (assignmentIndex !== -1 && findAuthSchemeAssignmentIndex(value) !== -1) {
+    const authSchemeKey = value.slice(0, assignmentIndex);
+    const consumedContinuations = countAuthSchemeContinuationTokens(authSchemeKey, argv, startIndex + 1);
+    if (consumedContinuations > 0) {
+      return {
+        values: [sanitizeAssignmentArg(value, assignmentIndex, false), ...redactedPlaceholders(consumedContinuations)],
+        consumed: 1 + consumedContinuations,
+      };
+    }
+  }
+  return { values: [sanitizeOptionValueArg(value)], consumed: 1 };
+}
+
+function sanitizeOptionValueArg(arg: string): string {
+  const sanitizedStructuredValue = sanitizeStructuredArg(arg);
+  if (sanitizedStructuredValue !== arg) return sanitizedStructuredValue;
+  const sanitizedUrlValue = sanitizeUrlSecrets(arg);
+  if (sanitizedUrlValue !== arg) return sanitizedUrlValue;
+  const assignmentIndex = arg.indexOf("=");
+  if (assignmentIndex !== -1) return sanitizeAssignmentArg(arg, assignmentIndex, false);
+  const secretDelimiterIndex = findSecretConfigDelimiterIndex(arg);
+  if (secretDelimiterIndex !== -1) return sanitizeSecretDelimitedArg(arg, secretDelimiterIndex, ":");
+  return arg;
+}
+
+function sanitizeAssignmentArg(arg: string, assignmentIndex: number, isOptionFlag: boolean): string {
+  const key = arg.slice(0, assignmentIndex);
+  const value = arg.slice(assignmentIndex + 1);
+  if (isSensitiveHeaderKey(key)) return `${key}=${REDACTED_ARG_VALUE}`;
+  const sanitizedStructuredValue = sanitizeStructuredArg(value);
+  if (sanitizedStructuredValue !== value) return `${key}=${sanitizedStructuredValue}`;
+  const sanitizedUrlValue = sanitizeUrlSecrets(value);
+  if (sanitizedUrlValue !== value) return `${key}=${sanitizedUrlValue}`;
+  const nestedHeaderDelimiterIndex = findSensitiveHeaderDelimiterIndex(value);
+  if (nestedHeaderDelimiterIndex !== -1) {
+    return `${key}=${sanitizeSecretDelimitedArg(value, nestedHeaderDelimiterIndex, value[nestedHeaderDelimiterIndex]!)}`;
+  }
+  const nestedSecretDelimiterIndex = findSecretConfigDelimiterIndex(value);
+  if (nestedSecretDelimiterIndex !== -1) {
+    const sanitizedValue = sanitizeSecretDelimitedArg(value, nestedSecretDelimiterIndex, ":");
+    return sanitizedValue === value ? arg : `${key}=${sanitizedValue}`;
+  }
+  if (!isOptionFlag) return arg;
+  const nestedAssignmentIndex = value.indexOf("=");
+  if (nestedAssignmentIndex === -1) return arg;
+  const sanitizedValue = sanitizeAssignmentArg(value, nestedAssignmentIndex, false);
+  return sanitizedValue === value ? arg : `${key}=${sanitizedValue}`;
+}
+
+function findSecretConfigDelimiterIndex(arg: string): number {
+  const trimmed = arg.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return -1;
+  const delimiterIndex = arg.indexOf(":");
+  if (delimiterIndex <= 0) return -1;
+  const key = arg.slice(0, delimiterIndex);
+  return isSensitiveHeaderKey(key) || isSensitiveHeaderKey(stripLeadingOptionPrefix(key)) ? delimiterIndex : -1;
+}
+
+function findSensitiveHeaderDelimiterIndex(arg: string): number {
+  const colonIndex = arg.indexOf(":");
+  const equalsIndex = arg.indexOf("=");
+  const delimiterIndex =
+    colonIndex === -1 ? equalsIndex : equalsIndex === -1 ? colonIndex : Math.min(colonIndex, equalsIndex);
+  if (delimiterIndex <= 0) return -1;
+  return isSensitiveHeaderKey(arg.slice(0, delimiterIndex)) ? delimiterIndex : -1;
+}
+
+function sanitizeSecretDelimitedArg(arg: string, delimiterIndex: number, delimiter: string): string {
+  const key = arg.slice(0, delimiterIndex);
+  const valueStart = skipLooseAssignmentWhitespace(arg, delimiterIndex + 1);
+  const valueEnd =
+    valueStart >= arg.length ? arg.length : findLooseAssignmentValueEnd(arg, valueStart, isRequestCookieHeaderKey(key));
+  return `${arg.slice(0, delimiterIndex)}${delimiter}${REDACTED_ARG_VALUE}${arg.slice(valueEnd)}`;
+}
+
+function redactedPlaceholders(count: number): string[] {
+  return Array.from({ length: Math.max(0, count) }, () => REDACTED_ARG_VALUE);
+}
+
+function sanitizeStructuredArg(arg: string): string {
+  const sanitizedUrlArg = sanitizeUrlSecrets(arg);
+  const trimmed = sanitizedUrlArg.trim();
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return sanitizeLooseSecretConfigText(sanitizedUrlArg);
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const redacted = redactStructuredSecrets(parsed);
+    if (!redacted.changed) return sanitizedUrlArg;
+    return JSON.stringify(redacted.value);
+  } catch {
+    return sanitizeLooseSecretConfigText(sanitizedUrlArg);
+  }
+}
+
+function sanitizeLooseSecretConfigText(value: string): string {
+  if (!value.includes(":") && !value.includes("=")) return value;
+  let redacted = "";
+  let cursor = 0;
+  let changed = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const delimiter = value[index];
+    if (delimiter !== ":" && delimiter !== "=") continue;
+    const keySpan = findLooseAssignmentKey(value, index);
+    if (!keySpan || !isSensitiveHeaderKey(keySpan.key)) continue;
+    const valueStart = skipLooseAssignmentWhitespace(value, index + 1);
+    if (valueStart >= value.length) continue;
+    const valueEnd = findLooseAssignmentValueEnd(value, valueStart, isRequestCookieHeaderKey(keySpan.key));
+    redacted += value.slice(cursor, valueStart);
+    redacted += REDACTED_ARG_VALUE;
+    cursor = valueEnd;
+    changed = true;
+    index = valueEnd - 1;
+  }
+
+  return changed ? redacted + value.slice(cursor) : value;
+}
+
+function findLooseAssignmentKey(value: string, delimiterIndex: number): { key: string } | undefined {
+  let keyEnd = delimiterIndex;
+  while (keyEnd > 0 && isWhitespace(value[keyEnd - 1])) keyEnd -= 1;
+  if (keyEnd <= 0) return undefined;
+
+  const quote = value[keyEnd - 1];
+  if (quote === '"' || quote === "'") {
+    const keyStart = value.lastIndexOf(quote, keyEnd - 2);
+    if (keyStart === -1) return undefined;
+    const key = value.slice(keyStart + 1, keyEnd - 1);
+    return key.length > 0 ? { key } : undefined;
+  }
+
+  let keyStart = keyEnd;
+  while (keyStart > 0 && isLooseAssignmentKeyChar(value[keyStart - 1]!)) keyStart -= 1;
+  const key = value.slice(keyStart, keyEnd);
+  return key.length > 0 ? { key } : undefined;
+}
+
+function skipLooseAssignmentWhitespace(value: string, index: number): number {
+  let cursor = index;
+  while (cursor < value.length && isWhitespace(value[cursor])) cursor += 1;
+  return cursor;
+}
+
+function findLooseAssignmentValueEnd(value: string, startIndex: number, consumeSemicolonPairs = false): number {
+  const quote = value[startIndex];
+  if (quote === '"' || quote === "'") {
+    let cursor = startIndex + 1;
+    let escaped = false;
+    while (cursor < value.length) {
+      const char = value[cursor];
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        return cursor + 1;
+      }
+      cursor += 1;
+    }
+    return value.length;
+  }
+
+  let cursor = startIndex;
+  while (cursor < value.length && !isLooseAssignmentValueTerminator(value[cursor]!, consumeSemicolonPairs)) cursor += 1;
+  return cursor;
+}
+
+function isLooseAssignmentKeyChar(char: string): boolean {
+  return isAsciiAlnum(char) || char === "_" || char === "-" || char === "." || char === "[" || char === "]";
+}
+
+function isLooseAssignmentValueTerminator(char: string, consumeSemicolonPairs: boolean): boolean {
+  return char === "," || char === "}" || char === "&" || (!consumeSemicolonPairs && char === ";");
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r";
+}
+
+function sanitizeUrlSecrets(value: string): string {
+  return redactUrlSecretMaterial(value, REDACTED_ARG_VALUE, isSecretConfigKey);
+}
+
+function redactStructuredSecrets(value: unknown): { value: unknown; changed: boolean } {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const entries = value.map((entry) => {
+      const redactedEntry = redactStructuredSecrets(entry);
+      changed ||= redactedEntry.changed;
+      return redactedEntry.value;
+    });
+    return { value: entries, changed };
+  }
+  if (value && typeof value === "object") {
+    let changed = false;
+    const entries: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (isSensitiveHeaderKey(key)) {
+        entries[key] = REDACTED_ARG_VALUE;
+        changed = true;
+        continue;
+      }
+      const redactedEntry = redactStructuredSecrets(entry);
+      entries[key] = redactedEntry.value;
+      changed ||= redactedEntry.changed;
+    }
+    return { value: entries, changed };
+  }
+  if (typeof value === "string") {
+    let redactedValue = sanitizeUrlSecrets(value);
+    const secretDelimiterIndex = findSecretConfigDelimiterIndex(redactedValue);
+    if (secretDelimiterIndex !== -1) {
+      redactedValue = sanitizeSecretDelimitedArg(redactedValue, secretDelimiterIndex, ":");
+    }
+    redactedValue = sanitizeLooseSecretConfigText(redactedValue);
+    return { value: redactedValue, changed: redactedValue !== value };
+  }
+  return { value, changed: false };
+}
+
+function isSecretConfigKey(key: string): boolean {
+  return SECRET_KEY_PATTERN.test(normalizeSecretKey(key));
+}
+
+function isSecretOptionFlagName(flagName: string): boolean {
+  return isSecretConfigKey(flagName) || isSecretConfigKey(stripLeadingOptionPrefix(flagName));
+}
+
+function isAuthorizationConfigKey(key: string): boolean {
+  return /(^|[-_])authorization$/i.test(normalizeSecretKey(key));
+}
+
+function isSensitiveHeaderKey(key: string): boolean {
+  const normalized = normalizeSecretKey(key);
+  return isSecretConfigKey(key) || /(^|[-_])(?:cookie|set[-_]?cookie|session)$/i.test(normalized);
+}
+
+function isRequestCookieHeaderKey(key: string): boolean {
+  const parts = normalizeSecretKey(key).toLowerCase().split(/[-_]+/).filter(Boolean);
+  const lastPart = parts.at(-1);
+  const previousPart = parts.at(-2);
+  return lastPart === "cookie" && previousPart !== "set";
+}
+
+function isAuthSchemeToken(value: string): boolean {
+  return /^(?:bearer|basic|digest)$/i.test(value);
+}
+
+function isTokenConfigKey(key: string): boolean {
+  return /(^|[-_])(?:auth[-_]?token|access[-_]?token|refresh[-_]?token|id[-_]?token|token)$/i.test(
+    normalizeSecretKey(key)
+  );
+}
+
+function shouldConsumeAuthSchemePair(key: string, firstValue: string): boolean {
+  return (isTokenConfigKey(key) || isAuthorizationConfigKey(key)) && isAuthSchemeToken(firstValue);
+}
+
+function findAuthSchemeAssignmentIndex(arg: string): number {
+  const assignmentIndex = arg.indexOf("=");
+  if (assignmentIndex === -1) return -1;
+  return shouldConsumeAuthSchemePair(arg.slice(0, assignmentIndex), arg.slice(assignmentIndex + 1))
+    ? assignmentIndex
+    : -1;
+}
+
+function countAuthSchemeContinuationTokens(key: string, argv: string[], startIndex: number): number {
+  if (startIndex >= argv.length || isAuthSchemeContinuationBoundary(argv[startIndex]!)) return 0;
+  let consumedValues = 1;
+  while (
+    isAuthorizationConfigKey(key) &&
+    startIndex + consumedValues < argv.length &&
+    !isAuthSchemeContinuationBoundary(argv[startIndex + consumedValues]!)
+  ) {
+    consumedValues += 1;
+  }
+  return consumedValues;
+}
+
+function isAuthSchemeContinuationBoundary(arg: string): boolean {
+  return isOptionValueBoundaryFlag(arg) || findAuthSchemeAssignmentIndex(arg) !== -1;
+}
+
+function countBareSecretValueTokens(key: string, argv: string[], startIndex: number): number {
+  if (startIndex >= argv.length || isOptionValueBoundaryFlag(argv[startIndex]!)) return 0;
+  const consumeAllValueTokens = isAuthorizationConfigKey(key);
+  let consumedValues = 1;
+  if (!consumeAllValueTokens && shouldConsumeAuthSchemePair(key, argv[startIndex]!)) {
+    return startIndex + 1 < argv.length && !isOptionValueBoundaryFlag(argv[startIndex + 1]!) ? 2 : 1;
+  }
+  while (
+    consumeAllValueTokens &&
+    startIndex + consumedValues < argv.length &&
+    !isOptionValueBoundaryFlag(argv[startIndex + consumedValues]!)
+  ) {
+    consumedValues += 1;
+  }
+  return consumedValues;
+}
+
+function normalizeSecretKey(key: string): string {
+  let normalized = "";
+  for (let index = 0; index < key.length; index += 1) {
+    const char = key[index]!;
+    if (char === "." || char === "[" || char === "]" || char === ":") {
+      normalized += "-";
+      continue;
+    }
+    if (isUppercaseAscii(char)) {
+      const previous = key[index - 1];
+      const next = key[index + 1];
+      if (
+        index > 0 &&
+        ((previous !== undefined && isLowercaseOrDigitAscii(previous)) ||
+          (previous !== undefined && isUppercaseAscii(previous) && next !== undefined && isLowercaseAscii(next)))
+      ) {
+        normalized += "-";
+      }
+    }
+    normalized += char;
+  }
+  return normalized;
+}
+
+function stripLeadingOptionPrefix(key: string): string {
+  let index = 0;
+  while (index < key.length && key[index] === "-") index += 1;
+  return key.slice(index);
+}
+
+function isUppercaseAscii(char: string): boolean {
+  return char >= "A" && char <= "Z";
+}
+
+function isLowercaseAscii(char: string): boolean {
+  return char >= "a" && char <= "z";
+}
+
+function isLowercaseOrDigitAscii(char: string): boolean {
+  return isLowercaseAscii(char) || (char >= "0" && char <= "9");
+}
+
+function isAsciiAlnum(char: string): boolean {
+  return isUppercaseAscii(char) || isLowercaseAscii(char) || (char >= "0" && char <= "9");
+}
+
+function sanitizeEnvKeys(env: NodeJS.ProcessEnv | undefined, explicitKeys: string[] | undefined): string[] {
   const sourceKeys = explicitKeys ?? Object.keys(env ?? {});
   return [...new Set(sourceKeys)]
     .filter((key) => typeof key === "string" && key.length > 0)
@@ -253,9 +901,7 @@ function buildArtifactHashIdentity(manifest: Omit<BenchmarkReproManifest, "artif
       platform: manifest.environment.platform,
       arch: manifest.environment.arch,
       nodeVersion: manifest.environment.nodeVersion,
-      ...(manifest.environment.packageManager
-        ? { packageManager: manifest.environment.packageManager }
-        : {}),
+      ...(manifest.environment.packageManager ? { packageManager: manifest.environment.packageManager } : {}),
     },
     ...(manifest.qmd ? { qmd: manifest.qmd } : {}),
     configFiles: manifest.configFiles,
@@ -277,12 +923,24 @@ async function scanDatasetFiles(root: string): Promise<BenchmarkReproManifestFil
       const relativePath = path.relative(root, entryPath).split(path.sep).join("/");
       if (entryStat.isSymbolicLink()) {
         const target = await readlink(entryPath);
+        const resolvedTarget = path.resolve(directory, target);
+        const realTarget = await realpath(resolvedTarget);
+        const targetRelativePath = path.relative(root, realTarget);
+        if (
+          targetRelativePath.length === 0 ||
+          targetRelativePath === ".." ||
+          targetRelativePath.startsWith(`..${path.sep}`) ||
+          path.isAbsolute(targetRelativePath)
+        ) {
+          throw new Error(`dataset symlink target must be inside ${root}: ${entryPath}`);
+        }
+        const manifestTarget = path.isAbsolute(target) ? targetRelativePath.split(path.sep).join("/") : target;
         files.push({
           path: relativePath,
           kind: "symlink",
-          sizeBytes: Buffer.byteLength(target, "utf8"),
-          sha256: sha256String(target),
-          target,
+          sizeBytes: Buffer.byteLength(manifestTarget, "utf8"),
+          sha256: sha256String(manifestTarget),
+          target: manifestTarget,
         });
         continue;
       }
@@ -306,7 +964,7 @@ async function scanDatasetFiles(root: string): Promise<BenchmarkReproManifestFil
 }
 
 async function lstatPathWithoutSymlinkComponents(
-  targetPath: string,
+  targetPath: string
 ): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
   const parsed = path.parse(targetPath);
   const relativePath = path.relative(parsed.root, targetPath);
@@ -334,7 +992,7 @@ async function lstatPathWithoutSymlinkComponents(
 
 async function buildDatasetManifest(
   benchmark: string,
-  datasetDir: string | undefined,
+  datasetDir: string | undefined
 ): Promise<BenchmarkReproManifestDataset> {
   if (!datasetDir) {
     return {
@@ -389,8 +1047,10 @@ async function buildDatasetManifest(
 async function buildResultManifest(
   resultsDir: string,
   resultPath: string,
-  result: BenchmarkResult,
+  result: BenchmarkResult
 ): Promise<BenchmarkReproManifestResult> {
+  assertPathInsideRoot(resultsDir, resultPath, "result path");
+  await assertRegularFileWithoutSymlinkComponents(resultPath, "result path");
   const fileStats = await stat(resultPath);
   return {
     path: path.relative(resultsDir, resultPath).split(path.sep).join("/"),
@@ -407,20 +1067,87 @@ async function buildResultManifest(
   };
 }
 
-async function resolveResultPaths(
-  resultsDir: string,
-  explicitPaths: string[] | undefined,
-): Promise<string[]> {
+async function resolveResultPaths(resultsDir: string, explicitPaths: string[] | undefined): Promise<string[]> {
   if (explicitPaths !== undefined) {
-    return [...new Set(explicitPaths.map((entry) => path.resolve(entry)))]
-      .sort((left, right) => left.localeCompare(right));
+    const resolvedPaths = await Promise.all(
+      explicitPaths.map(async (entry) => {
+        const resultPath = path.resolve(entry);
+        assertPathInsideRoot(resultsDir, resultPath, "result path");
+        await assertRegularFileWithoutSymlinkComponents(resultPath, "result path");
+        return resultPath;
+      })
+    );
+    return [...new Set(resolvedPaths)].sort((left, right) => left.localeCompare(right));
   }
   const summaries = await listBenchmarkResults(resultsDir);
   return summaries.map((summary) => path.resolve(summary.path));
 }
 
+function assertPathInsideRoot(root: string, targetPath: string, label: string): void {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTargetPath = path.resolve(targetPath);
+  const relativePath = path.relative(resolvedRoot, resolvedTargetPath);
+  if (
+    relativePath.length === 0 ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw new Error(`${label} must be inside ${resolvedRoot}: ${resolvedTargetPath}`);
+  }
+}
+
+async function assertRegularFileWithoutSymlinkComponents(targetPath: string, label: string): Promise<void> {
+  const targetStat = await lstatPathWithoutSymlinkComponents(path.resolve(targetPath));
+  if (!targetStat?.isFile()) {
+    throw new Error(`${label} must be a regular file without symlink components: ${path.resolve(targetPath)}`);
+  }
+}
+
+function isKnownNonSecretOptionFlag(arg: string): boolean {
+  if (!arg.startsWith("-")) return false;
+  return NON_SECRET_ARG_FLAGS.has(getOptionName(arg));
+}
+
+function isOptionValueBoundaryFlag(arg: string): boolean {
+  if (!arg.startsWith("-")) return false;
+  const optionName = getOptionName(arg);
+  return (
+    BENCH_OPTION_BOUNDARY_FLAGS.has(optionName) ||
+    NON_SECRET_ARG_FLAGS.has(optionName) ||
+    SECRET_ARG_FLAGS.has(optionName) ||
+    (arg.includes("=") && isSecretConfigKey(optionName))
+  );
+}
+
+function shouldConsumeSeparatedSecretFlagValue(arg: string): boolean {
+  return !isOptionValueBoundaryFlag(arg);
+}
+
+function getOptionName(arg: string): string {
+  return arg.includes("=") ? arg.slice(0, arg.indexOf("=")) : arg;
+}
+
+function getAttachedShortSecretFlag(arg: string): string | undefined {
+  if (arg.includes("=")) return undefined;
+  for (const flag of ["-k", "-p", "-t"]) {
+    if (arg.startsWith(flag) && arg.length > flag.length) return flag;
+  }
+  return undefined;
+}
+
+function getAttachedLongSecretArg(arg: string): { flag: string; delimiter: "" | "=" } | undefined {
+  for (const flag of ATTACHED_LONG_SECRET_ARG_FLAGS) {
+    if (arg.startsWith(`${flag}=`) && arg.length > flag.length + 1) {
+      return { flag, delimiter: "=" };
+    }
+    if (arg.startsWith(flag) && arg.length > flag.length && arg[flag.length] !== ":") return { flag, delimiter: "" };
+  }
+  return undefined;
+}
+
 async function buildConfigFileEntries(
-  configFiles: BuildBenchmarkReproManifestOptions["configFiles"] = [],
+  configFiles: BuildBenchmarkReproManifestOptions["configFiles"] = []
 ): Promise<BenchmarkReproManifest["configFiles"]> {
   const entries: BenchmarkReproManifest["configFiles"] = [];
   for (const configFile of configFiles) {
@@ -433,11 +1160,14 @@ async function buildConfigFileEntries(
         entries.push({ label: configFile.label, path: configFile.path, missing: true });
         continue;
       }
+      const content = await readFile(configFile.path);
+      const sanitizedConfig = sanitizeConfigFileContent(content);
       entries.push({
         label: configFile.label,
         path: configFile.path,
         sizeBytes: fileStats.size,
-        sha256: await sha256File(configFile.path),
+        ...(sanitizedConfig.sha256 !== undefined ? { sha256: sanitizedConfig.sha256 } : {}),
+        ...(sanitizedConfig.redacted ? { redacted: true } : {}),
       });
     } catch {
       entries.push({ label: configFile.label, path: configFile.path, missing: true });
@@ -446,18 +1176,41 @@ async function buildConfigFileEntries(
   return entries;
 }
 
-function collectQmdCollections(
-  explicitCollections: string[] | undefined,
-  results: BenchmarkResult[],
-): string[] {
+function sanitizeConfigFileContent(content: Buffer): { sha256?: string; redacted: boolean } {
+  const text = content.toString("utf8");
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      const redacted = redactStructuredSecrets(parsed);
+      if (redacted.changed) {
+        return { sha256: sha256String(stableStringify(redacted.value)), redacted: true };
+      }
+    } catch {
+      // Fall through to text-pattern detection for malformed config files.
+    }
+  }
+  if (containsSecretConfigText(text)) {
+    return { redacted: true };
+  }
+  return { sha256: sha256Buffer(content), redacted: false };
+}
+
+function containsSecretConfigText(text: string): boolean {
+  if (sanitizeUrlSecrets(text) !== text) return true;
+  const assignmentPattern = /["']?([A-Za-z0-9_.:[\]-]{3,80})["']?\s*[:=]\s*("[^"]+"|'[^']+'|[^\s,;}]+)/g;
+  for (const match of text.matchAll(assignmentPattern)) {
+    const key = match[1];
+    if (key && isSecretConfigKey(key)) return true;
+  }
+  return false;
+}
+
+function collectQmdCollections(explicitCollections: string[] | undefined, results: BenchmarkResult[]): string[] {
   const collections = new Set(explicitCollections ?? []);
   for (const result of results) {
     const config = result.config.remnicConfig ?? {};
-    for (const key of [
-      "qmdCollection",
-      "qmdColdCollection",
-      "conversationIndexQmdCollection",
-    ]) {
+    for (const key of ["qmdCollection", "qmdColdCollection", "conversationIndexQmdCollection"]) {
       const value = config[key];
       if (typeof value === "string" && value.trim().length > 0) {
         collections.add(value);
@@ -481,27 +1234,26 @@ function resolvePackageManager(cwd: string): string | undefined {
 
 export async function buildBenchmarkReproManifest(
   resultsDir: string,
-  options: BuildBenchmarkReproManifestOptions = {},
+  options: BuildBenchmarkReproManifestOptions = {}
 ): Promise<BenchmarkReproManifest> {
   const resolvedResultsDir = path.resolve(resultsDir);
   const cwd = options.command?.cwd ?? process.cwd();
   const resultPaths = await resolveResultPaths(resolvedResultsDir, options.resultPaths);
   const loadedResults = await Promise.all(resultPaths.map((resultPath) => loadBenchmarkResult(resultPath)));
   const resultEntries = await Promise.all(
-    resultPaths.map((resultPath, index) =>
-      buildResultManifest(resolvedResultsDir, resultPath, loadedResults[index]!),
-    ),
+    resultPaths.map((resultPath, index) => buildResultManifest(resolvedResultsDir, resultPath, loadedResults[index]!))
   );
-  const selectedBenchmarks = options.selectedBenchmarks ??
-    [...new Set(loadedResults.map((result) => result.meta.benchmark))].sort();
-  const selectedWorkItems = options.selectedWorkItems ??
+  const selectedBenchmarks =
+    options.selectedBenchmarks ?? [...new Set(loadedResults.map((result) => result.meta.benchmark))].sort();
+  const selectedWorkItems =
+    options.selectedWorkItems ??
     loadedResults.map((result) => ({
       benchmark: result.meta.benchmark,
       runtimeProfile: result.config.runtimeProfile ?? "unknown",
     }));
   const datasetDirs = options.datasetDirs ?? {};
   const datasets = await Promise.all(
-    selectedBenchmarks.map((benchmark) => buildDatasetManifest(benchmark, datasetDirs[benchmark])),
+    selectedBenchmarks.map((benchmark) => buildDatasetManifest(benchmark, datasetDirs[benchmark]))
   );
   const qmdCollections = collectQmdCollections(options.qmd?.collections, loadedResults);
   const pnpmVersion = resolvePackageManager(cwd);
@@ -552,7 +1304,7 @@ export async function buildBenchmarkReproManifest(
 
 export async function writeBenchmarkReproManifest(
   resultsDir: string,
-  options: BuildBenchmarkReproManifestOptions = {},
+  options: BuildBenchmarkReproManifestOptions = {}
 ): Promise<string> {
   await mkdir(resultsDir, { recursive: true });
   const manifest = await buildBenchmarkReproManifest(resultsDir, options);

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -1,23 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { createTimeoutGuardedAdapter } from "./adapters/timeout-guard.ts";
+import type { LlmProvider } from "./providers/types.ts";
 import {
+  compactResponderContext,
+  compactResponderQuestion,
   createGatewayResponder,
   createProviderBackedAmaBenchRecommendedJudge,
   createProviderBackedJudge,
   createProviderBackedResponder,
   createResponderFromProvider,
   createStructuredJudgeFromProvider,
-  compactResponderContext,
-  compactResponderQuestion,
 } from "./responders.ts";
-import { createTimeoutGuardedAdapter } from "./adapters/timeout-guard.ts";
-import type { LlmProvider } from "./providers/types.ts";
 
-function createFakeProvider(
-  resultText: string,
-  onPrompt?: (prompt: string) => void,
-): LlmProvider {
+function createFakeProvider(resultText: string, onPrompt?: (prompt: string) => void): LlmProvider {
   let inputTokens = 0;
   let outputTokens = 0;
 
@@ -76,44 +73,31 @@ test("responder wrappers adapt a provider instance into answer-generation and ju
 
   const cuedJudge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Score: 0.82\nmetadata id: 17"),
+    createFakeProvider("Score: 0.82\nmetadata id: 17")
   );
   assert.equal(await cuedJudge.score("q", "predicted", "expected"), 0.82);
 
   const cuedFractionJudge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Final score: 8/10\ncase: 99"),
+    createFakeProvider("Final score: 8/10\ncase: 99")
   );
   assert.equal(await cuedFractionJudge.score("q", "predicted", "expected"), 0.8);
 
-  const noJudge = createProviderBackedJudge(
-    { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("No."),
-  );
-  assert.equal(
-    (await noJudge.scoreBinaryPrompt?.("yes/no prompt"))?.score,
-    0,
-  );
+  const noJudge = createProviderBackedJudge({ provider: "openai", model: "gpt-5.4-mini" }, createFakeProvider("No."));
+  assert.equal((await noJudge.scoreBinaryPrompt?.("yes/no prompt"))?.score, 0);
 
-  const yesJudge = createProviderBackedJudge(
-    { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Yes."),
-  );
-  assert.equal(
-    (await yesJudge.scoreBinaryPrompt?.("yes/no prompt"))?.score,
-    1,
-  );
+  const yesJudge = createProviderBackedJudge({ provider: "openai", model: "gpt-5.4-mini" }, createFakeProvider("Yes."));
+  assert.equal((await yesJudge.scoreBinaryPrompt?.("yes/no prompt"))?.score, 1);
 
   const invalidBinaryJudge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("I cannot determine the answer from the prompt."),
+    createFakeProvider("I cannot determine the answer from the prompt.")
   );
-  assert.equal(
-    (await invalidBinaryJudge.scoreBinaryPrompt?.("yes/no prompt"))?.score,
-    -1,
-  );
+  assert.equal((await invalidBinaryJudge.scoreBinaryPrompt?.("yes/no prompt"))?.score, -1);
 
-  const structuredProvider = createFakeProvider("{\"identity_accuracy\":0.9,\"stance_coherence\":0.8,\"novelty\":0.7,\"calibration\":0.6,\"notes\":\"ok\"}");
+  const structuredProvider = createFakeProvider(
+    '{"identity_accuracy":0.9,"stance_coherence":0.8,"novelty":0.7,"calibration":0.6,"notes":"ok"}'
+  );
   const structuredJudge = createStructuredJudgeFromProvider(structuredProvider);
   const raw = await structuredJudge.evaluate({
     system: "judge-system",
@@ -138,17 +122,85 @@ test("responder context compaction preserves referenced trajectory evidence", as
     },
     createFakeProvider("answer", (prompt) => {
       capturedPrompt = prompt;
-    }),
+    })
   );
 
-  await responder.respond(
-    "What changed between Actions 41-42?",
-    recalledText,
-  );
+  await responder.respond("What changed between Actions 41-42?", recalledText);
 
   assert.equal(capturedPrompt.includes("state-42"), true);
   assert.equal(capturedPrompt.includes("move-2"), false);
   assert.equal(capturedPrompt.length < recalledText.length, true);
+});
+
+test("responder context compaction preserves trajectory history before boundary steps", () => {
+  const recalledText = [
+    "## Search evidence",
+    "[Action 20]: take brass key from drawer",
+    "[Observation 20]: Inventory now contains brass key.",
+    "[Action 24]: unlock pantry with brass key",
+    "[Observation 24]: Inventory no longer contains brass key.",
+    "[Action 79]: count supplies before entering final room",
+    "[Observation 79]: Inventory still excludes brass key.",
+    "[Action 80]: inspect final room",
+    "[Observation 80]: The final room is quiet.",
+    ...Array.from(
+      { length: 120 },
+      (_, index) =>
+        `[Action ${index + 81}]: unrelated late action ${index + 81} with filler text that should be dropped`
+    ),
+  ].join("\n");
+
+  const compacted = compactResponderContext(recalledText, "What inventory changes occurred before step 80?", 900);
+
+  assert.match(compacted, /Inventory now contains brass key/);
+  assert.match(compacted, /Inventory no longer contains brass key/);
+  assert.match(compacted, /Action 79/);
+  assert.doesNotMatch(compacted, /Action 80/);
+  assert.doesNotMatch(compacted, /Observation 80/);
+  assert.doesNotMatch(compacted, /unrelated late action 120/);
+  assert.equal(compacted.length <= 900, true);
+});
+
+test("responder context compaction preserves between-step trajectory ranges", () => {
+  const recalledText = [
+    "## Search evidence",
+    ...Array.from(
+      { length: 60 },
+      (_, index) =>
+        `[Action ${index + 1}]: range action ${index + 1}\n[Observation ${index + 1}]: range state ${index + 1}`
+    ),
+  ].join("\n");
+
+  const compacted = compactResponderContext(recalledText, "What actions happened between step 10 and step 20?", 900);
+
+  assert.match(compacted, /Action 10/);
+  assert.match(compacted, /Action 15/);
+  assert.match(compacted, /Action 20/);
+  assert.doesNotMatch(compacted, /\[Action 2\]:/);
+  assert.doesNotMatch(compacted, /\[Action 40\]:/);
+  assert.equal(compacted.length <= 900, true);
+});
+
+test("responder context compaction lower-bounds ranged trajectory lists", () => {
+  const recalledText = [
+    "## Search evidence",
+    ...Array.from(
+      { length: 60 },
+      (_, index) =>
+        `[Action ${index + 1}]: ranged list action ${index + 1}\n[Observation ${index + 1}]: ranged list state ${
+          index + 1
+        }`
+    ),
+  ].join("\n");
+
+  const compacted = compactResponderContext(recalledText, "List actions 10-20.", 900);
+
+  assert.match(compacted, /Action 10/);
+  assert.match(compacted, /Action 15/);
+  assert.match(compacted, /Action 20/);
+  assert.doesNotMatch(compacted, /\[Action 2\]:/);
+  assert.doesNotMatch(compacted, /\[Action 40\]:/);
+  assert.equal(compacted.length <= 900, true);
 });
 
 test("responder context compaction preserves trajectory analysis before raw transcript lines", () => {
@@ -168,16 +220,10 @@ test("responder context compaction preserves trajectory analysis before raw tran
     "Inferred cd 3 location at step 115: safe 1.",
     "",
     "## Search evidence",
-    ...Array.from({ length: 120 }, (_, index) =>
-      `[Action ${index}]: noisy old action ${index}`,
-    ),
+    ...Array.from({ length: 120 }, (_, index) => `[Action ${index}]: noisy old action ${index}`),
   ].join("\n");
 
-  const compacted = compactResponderContext(
-    recalledText,
-    "What is the location of cd 3, cd 2 at step 115?",
-    900,
-  );
+  const compacted = compactResponderContext(recalledText, "What is the location of cd 3, cd 2 at step 115?", 900);
 
   assert.match(compacted, /## Trajectory analysis/);
   assert.match(compacted, /Inferred cd 2 location at step 115: inventory/);
@@ -187,11 +233,7 @@ test("responder context compaction preserves trajectory analysis before raw tran
 });
 
 test("compactResponderContext falls back to deterministic head/tail context without trajectory references", () => {
-  const compacted = compactResponderContext(
-    "alpha ".repeat(200) + "omega",
-    "What is the summary?",
-    320,
-  );
+  const compacted = compactResponderContext(`${"alpha ".repeat(200)}omega`, "What is the summary?", 320);
 
   assert.equal(compacted.length <= 320, true);
   assert.match(compacted, /alpha/);
@@ -209,9 +251,7 @@ test("responder prompt compaction preserves the question and concise agentic pro
     "- Return the shortest complete answer that satisfies the question.",
     "",
     "Agentic trajectory protocol:",
-    ...Array.from({ length: 40 }, (_, index) =>
-      `- Detailed trajectory instruction ${index + 1}.`,
-    ),
+    ...Array.from({ length: 40 }, (_, index) => `- Detailed trajectory instruction ${index + 1}.`),
   ].join("\n");
   const responder = createProviderBackedResponder(
     {
@@ -221,7 +261,7 @@ test("responder prompt compaction preserves the question and concise agentic pro
     },
     createFakeProvider("answer", (prompt) => {
       capturedPrompt = prompt;
-    }),
+    })
   );
 
   await responder.respond(longProtocolQuestion, "[Action 42]: right");
@@ -234,21 +274,18 @@ test("responder prompt compaction preserves the question and concise agentic pro
 });
 
 test("compactResponderQuestion validates the prompt budget", () => {
-  assert.throws(
-    () => compactResponderQuestion("question", 0),
-    /responder prompt budget must be a positive integer/,
-  );
+  assert.throws(() => compactResponderQuestion("question", 0), /responder prompt budget must be a positive integer/);
 });
 
 test("provider-backed responder factories reject invalid configs and produce typed wrappers", () => {
   assert.throws(
     () => createProviderBackedResponder({ provider: "openai", model: "" } as never),
-    /provider-backed responder requires a non-empty model/i,
+    /provider-backed responder requires a non-empty model/i
   );
 
   assert.throws(
     () => createProviderBackedJudge({ provider: "openai", model: "" } as never),
-    /provider-backed judge requires a non-empty model/i,
+    /provider-backed judge requires a non-empty model/i
   );
 
   const responder = createProviderBackedResponder({
@@ -259,10 +296,7 @@ test("provider-backed responder factories reject invalid configs and produce typ
 });
 
 test("gateway responder requires gateway config", () => {
-  assert.throws(
-    () => createGatewayResponder({}),
-    /gateway responder requires gatewayConfig/i,
-  );
+  assert.throws(() => createGatewayResponder({}), /gateway responder requires gatewayConfig/i);
 });
 
 test("gateway responder forwards profile-scoped auth context to the fallback client", async () => {
@@ -342,7 +376,7 @@ test("gateway responder forwards benchmark abort signals to the fallback client"
                 observedAbort = true;
                 reject(options.signal!.reason);
               },
-              { once: true },
+              { once: true }
             );
           });
         },
@@ -369,12 +403,12 @@ test("gateway responder forwards benchmark abort signals to the fallback client"
     {
       benchmarkId: "gateway-responder-test",
       timeoutMs: 5,
-    },
+    }
   );
 
   await assert.rejects(
     () => adapter.responder!.respond("What changed?", "Context"),
-    /benchmark phase timed out after 5ms: gateway-responder-test:respond/,
+    /benchmark phase timed out after 5ms: gateway-responder-test:respond/
   );
   assert.equal(observedAbort, true);
 });
@@ -382,25 +416,25 @@ test("gateway responder forwards benchmark abort signals to the fallback client"
 test("provider-backed judge parses fraction and percent score formats", async () => {
   const fractionJudge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("8/10"),
+    createFakeProvider("8/10")
   );
   assert.equal(await fractionJudge.score("q", "predicted", "expected"), 0.8);
 
   const extendedFractionJudge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Score: 7/20"),
+    createFakeProvider("Score: 7/20")
   );
   assert.equal(await extendedFractionJudge.score("q", "predicted", "expected"), 0.35);
 
   const percentJudge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("75%"),
+    createFakeProvider("75%")
   );
   assert.equal(await percentJudge.score("q", "predicted", "expected"), 0.75);
 
   const outOfJudge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Score: 8 out of 10"),
+    createFakeProvider("Score: 8 out of 10")
   );
   assert.equal(await outOfJudge.score("q", "predicted", "expected"), 0.8);
 });
@@ -408,7 +442,7 @@ test("provider-backed judge parses fraction and percent score formats", async ()
 test("AMA-Bench recommended judge uses binary JSON scoring", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider('{"score":1,"reason":"same fact"}'),
+    createFakeProvider('{"score":1,"reason":"same fact"}')
   );
 
   const result = await judge.scoreWithMetrics?.("q", "predicted", "expected");
@@ -419,7 +453,7 @@ test("AMA-Bench recommended judge uses binary JSON scoring", async () => {
 test("AMA-Bench recommended judge parses incorrect before correct", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider("incorrect"),
+    createFakeProvider("incorrect")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0);
@@ -428,7 +462,7 @@ test("AMA-Bench recommended judge parses incorrect before correct", async () => 
 test("AMA-Bench recommended judge scans multiple JSON objects for score", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider('Reasoning object: {"note":"ignore"}\nFinal: {"score":1,"reason":"same fact"}'),
+    createFakeProvider('Reasoning object: {"note":"ignore"}\nFinal: {"score":1,"reason":"same fact"}')
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 1);
@@ -437,7 +471,7 @@ test("AMA-Bench recommended judge scans multiple JSON objects for score", async 
 test("AMA-Bench recommended judge prefers the last scored JSON object", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider('Draft: {"score":0,"reason":"scratch"}\nFinal: {"score":1,"reason":"same fact"}'),
+    createFakeProvider('Draft: {"score":0,"reason":"scratch"}\nFinal: {"score":1,"reason":"same fact"}')
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 1);
@@ -446,7 +480,7 @@ test("AMA-Bench recommended judge prefers the last scored JSON object", async ()
 test("AMA-Bench recommended judge parses nested JSON score objects", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider('{"analysis":{"note":"nested braces are valid"},"score":1}'),
+    createFakeProvider('{"analysis":{"note":"nested braces are valid"},"score":1}')
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 1);
@@ -455,7 +489,7 @@ test("AMA-Bench recommended judge parses nested JSON score objects", async () =>
 test("AMA-Bench recommended judge does not treat benign no-phrases as negative", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider("No issues found; the answer is correct."),
+    createFakeProvider("No issues found; the answer is correct.")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 1);
@@ -464,14 +498,14 @@ test("AMA-Bench recommended judge does not treat benign no-phrases as negative",
 test("AMA-Bench recommended judge treats negated negative labels as correct", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider("This is not incorrect."),
+    createFakeProvider("This is not incorrect.")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 1);
 
   const failJudge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider("It doesn't fail."),
+    createFakeProvider("It doesn't fail.")
   );
 
   assert.equal(await failJudge.score("q", "predicted", "expected"), 1);
@@ -480,21 +514,21 @@ test("AMA-Bench recommended judge treats negated negative labels as correct", as
 test("AMA-Bench recommended judge treats negated positive labels as incorrect", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider("The answer is not correct."),
+    createFakeProvider("The answer is not correct.")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0);
 
   const passJudge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider("This does not pass."),
+    createFakeProvider("This does not pass.")
   );
 
   assert.equal(await passJudge.score("q", "predicted", "expected"), 0);
 
   const adjectiveJudge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },
-    createFakeProvider("This is not a correct answer."),
+    createFakeProvider("This is not a correct answer.")
   );
 
   assert.equal(await adjectiveJudge.score("q", "predicted", "expected"), 0);
@@ -503,7 +537,7 @@ test("AMA-Bench recommended judge treats negated positive labels as incorrect", 
 test("provider-backed judge ignores date-like fractions and uses the trailing score", async () => {
   const judge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Reviewed on 2026/04/19. Final score: 0.4"),
+    createFakeProvider("Reviewed on 2026/04/19. Final score: 0.4")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
@@ -512,7 +546,7 @@ test("provider-backed judge ignores date-like fractions and uses the trailing sc
 test("provider-backed judge does not treat month/day text as a slash score", async () => {
   const judge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Reviewed on 4/20. Final score: 0.4"),
+    createFakeProvider("Reviewed on 4/20. Final score: 0.4")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
@@ -521,7 +555,7 @@ test("provider-backed judge does not treat month/day text as a slash score", asy
 test("provider-backed judge rejects date-like slash triplets before trailing scores", async () => {
   const judge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Reviewed on 4/5/2026. Final score: 0.4"),
+    createFakeProvider("Reviewed on 4/5/2026. Final score: 0.4")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
@@ -530,7 +564,7 @@ test("provider-backed judge rejects date-like slash triplets before trailing sco
 test("provider-backed judge does not treat month/day pairs as slash scores", async () => {
   const judge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Reviewed on 4/5. Final score: 0.4"),
+    createFakeProvider("Reviewed on 4/5. Final score: 0.4")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
@@ -539,7 +573,7 @@ test("provider-backed judge does not treat month/day pairs as slash scores", asy
 test("provider-backed judge ignores trailing large scalar metadata after a normalized score", async () => {
   const judge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Score is 0.5. Reviewed 2026"),
+    createFakeProvider("Score is 0.5. Reviewed 2026")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.5);
@@ -548,7 +582,7 @@ test("provider-backed judge ignores trailing large scalar metadata after a norma
 test("provider-backed judge keeps out-of parsing stable across repeated calls", async () => {
   const judge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
-    createFakeProvider("Score: 8 out of 10"),
+    createFakeProvider("Score: 8 out of 10")
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.8);

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -1,20 +1,8 @@
-import {
-  FallbackLlmClient,
-  type FallbackLlmRuntimeContext,
-  type GatewayConfig,
-} from "@remnic/core";
-import type {
-  BenchJudge,
-  BenchJudgeResult,
-  BenchResponder,
-  BenchResponse,
-} from "./adapters/types.js";
-import { createProvider } from "./providers/factory.js";
-import type {
-  LlmProvider,
-  ProviderFactoryConfig,
-} from "./providers/types.js";
+import { FallbackLlmClient, type FallbackLlmRuntimeContext, type GatewayConfig } from "@remnic/core";
+import type { BenchJudge, BenchJudgeResult, BenchResponder, BenchResponse } from "./adapters/types.js";
 import type { StructuredJudge } from "./judges/sealed-rubric.js";
+import { createProvider } from "./providers/factory.js";
+import type { LlmProvider, ProviderFactoryConfig } from "./providers/types.js";
 
 const DEFAULT_RESPONDER_SYSTEM_PROMPT = [
   "You answer benchmark questions using only the supplied Remnic memory context.",
@@ -44,12 +32,7 @@ const CONTEXT_COMPACTION_MARKER = "[...omitted unrelated recalled context...]";
 const COMPACTED_CONTEXT_PREFIX =
   "[Remnic memory context compacted for the responder prompt; full recalled text is preserved in the benchmark artifact.]";
 const TRAJECTORY_ANALYSIS_HEADING = "## Trajectory analysis";
-const TRAJECTORY_LABELS = Object.freeze([
-  "action",
-  "observation",
-  "step",
-  "turn",
-]);
+const TRAJECTORY_LABELS = Object.freeze(["action", "observation", "step", "turn"]);
 
 export interface GatewayResponderOptions {
   gatewayConfig?: GatewayConfig;
@@ -58,7 +41,7 @@ export interface GatewayResponderOptions {
   workspaceDir?: string;
   llmFactory?: (
     gatewayConfig: GatewayConfig,
-    runtimeContext: FallbackLlmRuntimeContext,
+    runtimeContext: FallbackLlmRuntimeContext
   ) => Pick<FallbackLlmClient, "chatCompletion">;
 }
 
@@ -69,32 +52,24 @@ export interface ProviderResponderOptions {
 
 export function createResponderFromProvider(
   provider: LlmProvider,
-  options: ProviderResponderOptions = {},
+  options: ProviderResponderOptions = {}
 ): BenchResponder {
   return {
-    async respond(
-      question: string,
-      recalledText: string,
-      control,
-    ): Promise<BenchResponse> {
-      const responderQuestion = options.promptBudgetChars === undefined
-        ? question
-        : compactResponderQuestion(question, options.promptBudgetChars);
-      const responderContext = options.contextBudgetChars === undefined
-        ? recalledText
-        : compactResponderContext(
-          recalledText,
-          question,
-          options.contextBudgetChars,
-        );
+    async respond(question: string, recalledText: string, control): Promise<BenchResponse> {
+      const responderQuestion =
+        options.promptBudgetChars === undefined
+          ? question
+          : compactResponderQuestion(question, options.promptBudgetChars);
+      const responderContext =
+        options.contextBudgetChars === undefined
+          ? recalledText
+          : compactResponderContext(recalledText, question, options.contextBudgetChars);
       const completion = await provider.complete(
         [
           `QUESTION: ${responderQuestion}`,
           "",
           "REMNIC_MEMORY_CONTEXT:",
-          responderContext.trim().length > 0
-            ? responderContext
-            : "(no memory context available)",
+          responderContext.trim().length > 0 ? responderContext : "(no memory context available)",
           "",
           "Answer the question using only the supplied memory context.",
         ].join("\n"),
@@ -103,7 +78,7 @@ export function createResponderFromProvider(
           temperature: 0,
           maxTokens: 256,
           signal: control?.signal,
-        },
+        }
       );
 
       return {
@@ -118,7 +93,7 @@ export function createResponderFromProvider(
 
 export function createProviderBackedResponder(
   config: ProviderFactoryConfig,
-  providerInstance?: LlmProvider,
+  providerInstance?: LlmProvider
 ): BenchResponder {
   validateProviderConfig(config, "responder");
   return createResponderFromProvider(providerInstance ?? createProvider(config), {
@@ -127,10 +102,7 @@ export function createProviderBackedResponder(
   });
 }
 
-export function compactResponderQuestion(
-  question: string,
-  maxChars: number,
-): string {
+export function compactResponderQuestion(question: string, maxChars: number): string {
   if (!Number.isInteger(maxChars) || maxChars <= 0) {
     throw new Error("responder prompt budget must be a positive integer");
   }
@@ -144,9 +116,7 @@ export function compactResponderQuestion(
     : question.includes("Benchmark answer protocol:")
       ? buildConciseStrictProtocol(question)
       : "";
-  const compacted = [baseQuestion, conciseProtocol]
-    .filter((part) => part.trim().length > 0)
-    .join("\n\n");
+  const compacted = [baseQuestion, conciseProtocol].filter((part) => part.trim().length > 0).join("\n\n");
   if (compacted.length <= maxChars) {
     return compacted;
   }
@@ -157,10 +127,7 @@ export function compactResponderQuestion(
 
   const separator = "\n\n";
   const protocolBudget = maxChars - baseQuestion.length - separator.length;
-  return `${baseQuestion}${separator}${headTailCompact(
-    conciseProtocol,
-    protocolBudget,
-  )}`;
+  return `${baseQuestion}${separator}${headTailCompact(conciseProtocol, protocolBudget)}`;
 }
 
 function extractBenchmarkQuestionText(question: string): string {
@@ -180,7 +147,7 @@ function buildConciseStrictProtocol(question: string): string {
     "Benchmark answer protocol:",
     "- Use only the supplied Remnic memory context.",
     "- Answer directly and briefly; do not add unsupported facts.",
-    "- Say \"unknown\" only when relevant evidence is absent, contradictory, or lacks the requested value.",
+    '- Say "unknown" only when relevant evidence is absent, contradictory, or lacks the requested value.',
     "- Preserve any requested output format.",
   ];
   appendFormatSpecificInstruction(question, instructions);
@@ -202,10 +169,7 @@ function buildConciseAgenticProtocol(question: string): string {
   return instructions.join("\n");
 }
 
-function appendFormatSpecificInstruction(
-  question: string,
-  instructions: string[],
-): void {
+function appendFormatSpecificInstruction(question: string, instructions: string[]): void {
   if (question.includes("- Return only the selected option letter")) {
     instructions.push("- Return only the selected option letter.");
   } else if (question.includes("- Return only the selected option number")) {
@@ -217,11 +181,7 @@ function appendFormatSpecificInstruction(
   }
 }
 
-export function compactResponderContext(
-  recalledText: string,
-  question: string,
-  maxChars: number,
-): string {
+export function compactResponderContext(recalledText: string, question: string, maxChars: number): string {
   if (!Number.isInteger(maxChars) || maxChars <= 0) {
     throw new Error("responder context budget must be a positive integer");
   }
@@ -232,20 +192,21 @@ export function compactResponderContext(
   }
 
   const stepRefs = extractReferencedTrajectoryNumbers(question);
-  const trajectoryAnalysis = extractContextSection(
-    normalized,
-    TRAJECTORY_ANALYSIS_HEADING,
-  );
-  const focusedTranscript = stepRefs.size > 0
-    ? buildTrajectoryFocusedContext(normalized, stepRefs)
-    : "";
-  const body = joinCompactedContextSections(
-    trajectoryAnalysis,
-    focusedTranscript,
-  );
-  const compactedBody = body.trim().length > 0
-    ? body.trim()
-    : headTailCompact(normalized, maxChars);
+  const trajectoryAnalysis = extractContextSection(normalized, TRAJECTORY_ANALYSIS_HEADING);
+  const preserveTrajectorySpan = shouldPreserveTrajectorySpan(question);
+  const includeTrajectoryBoundary = shouldIncludeTrajectorySpanBoundary(question);
+  const preserveTrajectoryInterval = shouldPreserveTrajectoryInterval(question);
+  const focusedTranscript =
+    stepRefs.size > 0
+      ? preserveTrajectorySpan
+        ? buildTrajectorySpanContext(normalized, stepRefs, {
+            includeBoundary: includeTrajectoryBoundary,
+            intervalOnly: preserveTrajectoryInterval,
+          })
+        : buildTrajectoryFocusedContext(normalized, stepRefs)
+      : "";
+  const body = joinCompactedContextSections(trajectoryAnalysis, focusedTranscript);
+  const compactedBody = body.trim().length > 0 ? body.trim() : headTailCompact(normalized, maxChars);
   const withPrefix = `${COMPACTED_CONTEXT_PREFIX}\n${compactedBody}`;
   if (withPrefix.length <= maxChars) {
     return withPrefix;
@@ -259,10 +220,7 @@ export function compactResponderContext(
   return `${COMPACTED_CONTEXT_PREFIX}\n${headTailCompact(compactedBody, bodyBudget)}`;
 }
 
-function extractContextSection(
-  text: string,
-  heading: string,
-): string {
+function extractContextSection(text: string, heading: string): string {
   const lines = text.split("\n");
   const start = lines.findIndex((line) => line.trim() === heading);
   if (start < 0) {
@@ -316,11 +274,7 @@ function extractReferencedTrajectoryNumbers(question: string): Set<number> {
   return refs;
 }
 
-function matchedTrajectoryLabelLength(
-  text: string,
-  index: number,
-  label: string,
-): number {
+function matchedTrajectoryLabelLength(text: string, index: number, label: string): number {
   if (!isWordBoundary(text[index - 1])) {
     return 0;
   }
@@ -336,7 +290,7 @@ function matchedTrajectoryLabelLength(
 
 function parseNumberRangeAfterLabel(
   text: string,
-  index: number,
+  index: number
 ): { start: number; end: number; nextIndex: number } | undefined {
   let cursor = skipNumberLeadIn(text, index);
   const first = parseUnsignedIntegerAt(text, cursor);
@@ -383,10 +337,7 @@ function skipWhitespace(text: string, index: number): number {
   return cursor;
 }
 
-function parseUnsignedIntegerAt(
-  text: string,
-  index: number,
-): { value: number; nextIndex: number } | undefined {
+function parseUnsignedIntegerAt(text: string, index: number): { value: number; nextIndex: number } | undefined {
   let cursor = index;
   let raw = "";
   while (cursor < text.length && isDigit(text[cursor])) {
@@ -411,10 +362,7 @@ function addBoundedRange(refs: Set<number>, start: number, end: number): void {
   }
 }
 
-function buildTrajectoryFocusedContext(
-  recalledText: string,
-  stepRefs: Set<number>,
-): string {
+function buildTrajectoryFocusedContext(recalledText: string, stepRefs: Set<number>): string {
   const lines = recalledText.split("\n");
   const include = new Set<number>();
   for (let index = 0; index < lines.length; index += 1) {
@@ -449,11 +397,7 @@ function buildTrajectoryFocusedContext(
     if (!include.has(index)) {
       continue;
     }
-    if (
-      lastIncluded >= 0 &&
-      index > lastIncluded + 1 &&
-      rendered.at(-1) !== CONTEXT_COMPACTION_MARKER
-    ) {
+    if (lastIncluded >= 0 && index > lastIncluded + 1 && rendered.at(-1) !== CONTEXT_COMPACTION_MARKER) {
       rendered.push(CONTEXT_COMPACTION_MARKER);
     }
     rendered.push(lines[index]);
@@ -462,21 +406,93 @@ function buildTrajectoryFocusedContext(
   return rendered.join("\n");
 }
 
+function buildTrajectorySpanContext(
+  recalledText: string,
+  stepRefs: Set<number>,
+  options: { includeBoundary: boolean; intervalOnly: boolean }
+): string {
+  const lines = recalledText.split("\n");
+  const include = new Set<number>();
+  const minStep = Math.min(...stepRefs);
+  const maxStep = Math.max(...stepRefs);
+  for (let index = 0; index < lines.length; index += 1) {
+    if (isContextHeading(lines[index])) {
+      include.add(index);
+      continue;
+    }
+
+    const trajectoryNumber = parseTrajectoryLineNumber(lines[index]);
+    if (trajectoryNumber !== undefined && isTrajectoryNumberInSpan(trajectoryNumber, minStep, maxStep, options)) {
+      include.add(index);
+    }
+  }
+
+  if (include.size === 0) {
+    return "";
+  }
+
+  const rendered: string[] = [];
+  let lastIncluded = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!include.has(index)) {
+      continue;
+    }
+    if (lastIncluded >= 0 && index > lastIncluded + 1 && rendered.at(-1) !== CONTEXT_COMPACTION_MARKER) {
+      rendered.push(CONTEXT_COMPACTION_MARKER);
+    }
+    rendered.push(lines[index]);
+    lastIncluded = index;
+  }
+  return rendered.join("\n");
+}
+
+function isTrajectoryNumberInSpan(
+  trajectoryNumber: number,
+  minStep: number,
+  maxStep: number,
+  options: { includeBoundary: boolean; intervalOnly: boolean }
+): boolean {
+  if (options.intervalOnly || minStep !== maxStep) {
+    return (
+      trajectoryNumber >= minStep &&
+      (options.includeBoundary ? trajectoryNumber <= maxStep : trajectoryNumber < maxStep)
+    );
+  }
+  return options.includeBoundary ? trajectoryNumber <= maxStep : trajectoryNumber < maxStep;
+}
+
+function shouldPreserveTrajectorySpan(question: string): boolean {
+  const baseQuestion = extractBenchmarkQuestionText(question).toLowerCase();
+  return /\b(?:before|until|through|thru|prior to|between|history|histories|range|count|counts|list|lists)\b|up to/.test(
+    baseQuestion
+  );
+}
+
+function shouldIncludeTrajectorySpanBoundary(question: string): boolean {
+  const baseQuestion = extractBenchmarkQuestionText(question).toLowerCase();
+  return !/\b(?:before|prior to)\b/.test(baseQuestion);
+}
+
+function shouldPreserveTrajectoryInterval(question: string): boolean {
+  const baseQuestion = extractBenchmarkQuestionText(question).toLowerCase();
+  return /\bbetween\b/.test(baseQuestion);
+}
+
 function isContextHeading(line: string): boolean {
   const trimmed = line.trim();
-  return trimmed.startsWith("#") ||
+  return (
+    trimmed.startsWith("#") ||
     trimmed === "REMNIC_MEMORY_CONTEXT:" ||
     trimmed.startsWith("Memory context") ||
-    trimmed.startsWith("Relevant");
+    trimmed.startsWith("Relevant")
+  );
 }
 
 function parseTrajectoryLineNumber(line: string): number | undefined {
   const trimmed = line.trimStart();
   const bracketStart = trimmed[0] === "[" ? 1 : 0;
   const bracketEnd = bracketStart === 1 ? trimmed.indexOf("]") : -1;
-  const candidate = bracketEnd > bracketStart
-    ? trimmed.slice(bracketStart, bracketEnd)
-    : trimmed.slice(0, 48);
+  const candidate = bracketEnd > bracketStart ? trimmed.slice(bracketStart, bracketEnd) : trimmed.slice(0, 48);
   const lower = candidate.toLowerCase();
   for (const label of TRAJECTORY_LABELS) {
     if (!lower.startsWith(label)) {
@@ -503,9 +519,7 @@ function headTailCompact(text: string, maxChars: number): string {
   const remaining = maxChars - marker.length;
   const headChars = Math.ceil(remaining * 0.6);
   const tailChars = remaining - headChars;
-  return `${text.slice(0, headChars).trimEnd()}${marker}${
-    text.slice(text.length - tailChars).trimStart()
-  }`;
+  return `${text.slice(0, headChars).trimEnd()}${marker}${text.slice(text.length - tailChars).trimStart()}`;
 }
 
 function isWordBoundary(char: string | undefined): boolean {
@@ -514,9 +528,7 @@ function isWordBoundary(char: string | undefined): boolean {
 
 function isAsciiAlnum(char: string): boolean {
   const code = char.charCodeAt(0);
-  return (code >= 48 && code <= 57) ||
-    (code >= 65 && code <= 90) ||
-    (code >= 97 && code <= 122);
+  return (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
 }
 
 function isDigit(char: string | undefined): boolean {
@@ -536,10 +548,7 @@ function isRangeDash(char: string | undefined): boolean {
 }
 
 function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
-  async function scoreBinaryPrompt(
-    prompt: string,
-    control?: { signal?: AbortSignal },
-  ): Promise<BenchJudgeResult> {
+  async function scoreBinaryPrompt(prompt: string, control?: { signal?: AbortSignal }): Promise<BenchJudgeResult> {
     const completion = await provider.complete(prompt, {
       systemPrompt: "Answer the benchmark judging question with yes or no only.",
       temperature: 0,
@@ -559,7 +568,7 @@ function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
     question: string,
     predicted: string,
     expected: string,
-    control?: { signal?: AbortSignal },
+    control?: { signal?: AbortSignal }
   ): Promise<BenchJudgeResult> {
     const completion = await provider.complete(
       [
@@ -576,7 +585,7 @@ function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
         temperature: 0,
         maxTokens: 16,
         signal: control?.signal,
-      },
+      }
     );
 
     return {
@@ -588,12 +597,7 @@ function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
   }
 
   return {
-    async score(
-      question: string,
-      predicted: string,
-      expected: string,
-      control,
-    ): Promise<number> {
+    async score(question: string, predicted: string, expected: string, control): Promise<number> {
       return (await scoreWithMetrics(question, predicted, expected, control)).score;
     },
     scoreWithMetrics,
@@ -601,10 +605,7 @@ function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
   };
 }
 
-export function createProviderBackedJudge(
-  config: ProviderFactoryConfig,
-  providerInstance?: LlmProvider,
-): BenchJudge {
+export function createProviderBackedJudge(config: ProviderFactoryConfig, providerInstance?: LlmProvider): BenchJudge {
   validateProviderConfig(config, "judge");
   return createJudgeFromProvider(providerInstance ?? createProvider(config));
 }
@@ -614,7 +615,7 @@ function createAmaBenchRecommendedJudgeFromProvider(provider: LlmProvider): Benc
     question: string,
     predicted: string,
     expected: string,
-    control?: { signal?: AbortSignal },
+    control?: { signal?: AbortSignal }
   ): Promise<BenchJudgeResult> {
     const completion = await provider.complete(
       [
@@ -631,7 +632,7 @@ function createAmaBenchRecommendedJudgeFromProvider(provider: LlmProvider): Benc
         temperature: 0,
         maxTokens: 128,
         signal: control?.signal,
-      },
+      }
     );
 
     return {
@@ -643,12 +644,7 @@ function createAmaBenchRecommendedJudgeFromProvider(provider: LlmProvider): Benc
   }
 
   return {
-    async score(
-      question: string,
-      predicted: string,
-      expected: string,
-      control,
-    ): Promise<number> {
+    async score(question: string, predicted: string, expected: string, control): Promise<number> {
       return (await scoreWithMetrics(question, predicted, expected, control)).score;
     },
     scoreWithMetrics,
@@ -657,17 +653,13 @@ function createAmaBenchRecommendedJudgeFromProvider(provider: LlmProvider): Benc
 
 export function createProviderBackedAmaBenchRecommendedJudge(
   config: ProviderFactoryConfig,
-  providerInstance?: LlmProvider,
+  providerInstance?: LlmProvider
 ): BenchJudge {
   validateProviderConfig(config, "AMA-Bench recommended judge");
-  return createAmaBenchRecommendedJudgeFromProvider(
-    providerInstance ?? createProvider(config),
-  );
+  return createAmaBenchRecommendedJudgeFromProvider(providerInstance ?? createProvider(config));
 }
 
-export function createStructuredJudgeFromProvider(
-  provider: LlmProvider,
-): StructuredJudge {
+export function createStructuredJudgeFromProvider(provider: LlmProvider): StructuredJudge {
   return {
     async evaluate(request) {
       const completion = await provider.complete(request.user, {
@@ -682,15 +674,13 @@ export function createStructuredJudgeFromProvider(
 
 export function createProviderBackedStructuredJudge(
   config: ProviderFactoryConfig,
-  providerInstance?: LlmProvider,
+  providerInstance?: LlmProvider
 ): StructuredJudge {
   validateProviderConfig(config, "judge");
   return createStructuredJudgeFromProvider(providerInstance ?? createProvider(config));
 }
 
-export function createGatewayResponder(
-  options: GatewayResponderOptions,
-): BenchResponder {
+export function createGatewayResponder(options: GatewayResponderOptions): BenchResponder {
   if (!options.gatewayConfig) {
     throw new Error("gateway responder requires gatewayConfig");
   }
@@ -699,15 +689,12 @@ export function createGatewayResponder(
     ...(options.agentDir ? { agentDir: options.agentDir } : {}),
     ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
   };
-  const llm = options.llmFactory?.(options.gatewayConfig, runtimeContext)
-    ?? new FallbackLlmClient(options.gatewayConfig, runtimeContext);
+  const llm =
+    options.llmFactory?.(options.gatewayConfig, runtimeContext) ??
+    new FallbackLlmClient(options.gatewayConfig, runtimeContext);
 
   return {
-    async respond(
-      question: string,
-      recalledText: string,
-      control,
-    ): Promise<BenchResponse> {
+    async respond(question: string, recalledText: string, control): Promise<BenchResponse> {
       const startedAt = performance.now();
       const response = await llm.chatCompletion(
         [
@@ -718,9 +705,7 @@ export function createGatewayResponder(
               `QUESTION: ${question}`,
               "",
               "REMNIC_MEMORY_CONTEXT:",
-              recalledText.trim().length > 0
-                ? recalledText
-                : "(no memory context available)",
+              recalledText.trim().length > 0 ? recalledText : "(no memory context available)",
               "",
               "Answer the question using only the supplied memory context.",
             ].join("\n"),
@@ -730,7 +715,7 @@ export function createGatewayResponder(
           temperature: 0,
           agentId: options.agentId,
           signal: control?.signal,
-        },
+        }
       );
 
       if (!response?.content) {
@@ -752,7 +737,7 @@ export function createGatewayResponder(
 
 function validateProviderConfig(
   config: ProviderFactoryConfig,
-  kind: "responder" | "judge" | "AMA-Bench recommended judge",
+  kind: "responder" | "judge" | "AMA-Bench recommended judge"
 ): void {
   if (typeof config.model !== "string" || config.model.trim().length === 0) {
     throw new Error(`provider-backed ${kind} requires a non-empty model`);
@@ -776,7 +761,7 @@ function parseScalarJudgeScore(raw: string): number {
 
   const scoreCueMatches = [
     ...trimmed.matchAll(
-      /\b(?:final\s+score|score|rating)\b\s*[:=]\s*(-?\d+(?:\.\d+)?)(?:\s*(%|\/\s*(-?\d+(?:\.\d+)?)))?/gi,
+      /\b(?:final\s+score|score|rating)\b\s*[:=]\s*(-?\d+(?:\.\d+)?)(?:\s*(%|\/\s*(-?\d+(?:\.\d+)?)))?/gi
     ),
   ];
   for (const match of scoreCueMatches.reverse()) {
@@ -801,9 +786,7 @@ function parseScalarJudgeScore(raw: string): number {
     }
   }
 
-  const fractionMatches = [
-    ...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s*\/\s*(-?\d+(?:\.\d+)?)/g),
-  ];
+  const fractionMatches = [...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s*\/\s*(-?\d+(?:\.\d+)?)/g)];
   for (const match of fractionMatches.reverse()) {
     const numerator = Number.parseFloat(match[1]);
     const denominator = Number.parseFloat(match[2]);
@@ -820,9 +803,7 @@ function parseScalarJudgeScore(raw: string): number {
     }
   }
 
-  const outOfMatches = [
-    ...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s+out\s+of\s+(-?\d+(?:\.\d+)?)/gi),
-  ];
+  const outOfMatches = [...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s+out\s+of\s+(-?\d+(?:\.\d+)?)/gi)];
   for (const match of outOfMatches.reverse()) {
     const numerator = Number.parseFloat(match[1]);
     const denominator = Number.parseFloat(match[2]);
@@ -890,7 +871,7 @@ function parseAmaBenchBinaryJudgeScore(raw: string): number {
   }
   if (
     /\b(?:not|never|isn'?t|wasn'?t|doesn'?t|didn'?t|cannot|can'?t)\b(?:\s+\w+){0,3}\s+(?:incorrect|false|fail(?:ed|s|ing)?)\b/i.test(
-      trimmed,
+      trimmed
     )
   ) {
     return 1;
@@ -900,7 +881,7 @@ function parseAmaBenchBinaryJudgeScore(raw: string): number {
   }
   if (
     /\b(?:not|never|isn'?t|wasn'?t|doesn'?t|didn'?t|cannot|can'?t)\b(?:\s+\w+){0,3}\s+(?:correct|true|pass(?:ed|es|ing)?|match(?:es|ed|ing)?|same)\b/i.test(
-      trimmed,
+      trimmed
     )
   ) {
     return 0;
@@ -935,13 +916,13 @@ function extractJsonObjects(raw: string): string[] {
         escaped = false;
       } else if (char === "\\") {
         escaped = true;
-      } else if (char === "\"") {
+      } else if (char === '"') {
         inString = false;
       }
       continue;
     }
 
-    if (char === "\"") {
+    if (char === '"') {
       inString = true;
     } else if (char === "{") {
       depth += 1;
@@ -957,10 +938,7 @@ function extractJsonObjects(raw: string): string[] {
   return objects;
 }
 
-function isPlausibleScoreFraction(
-  numerator: number,
-  denominator: number,
-): boolean {
+function isPlausibleScoreFraction(numerator: number, denominator: number): boolean {
   if (!Number.isFinite(numerator) || !Number.isFinite(denominator)) {
     return false;
   }
@@ -976,7 +954,7 @@ function isPlausibleSlashScoreFraction(
   raw: string,
   match: RegExpMatchArray,
   numerator: number,
-  denominator: number,
+  denominator: number
 ): boolean {
   if (!isPlausibleScoreFraction(numerator, denominator)) {
     return false;
@@ -1004,19 +982,12 @@ function isPlausibleSlashScoreFraction(
   return hasScoreCueBefore(raw, start);
 }
 
-function isStandaloneSlashScore(
-  raw: string,
-  start: number,
-  end: number,
-): boolean {
-  return raw.slice(0, start).trim().length === 0 &&
-    /^[\s.!?]*$/.test(raw.slice(end));
+function isStandaloneSlashScore(raw: string, start: number, end: number): boolean {
+  return raw.slice(0, start).trim().length === 0 && /^[\s.!?]*$/.test(raw.slice(end));
 }
 
 function hasScoreCueBefore(raw: string, start: number): boolean {
-  const beforeContext = raw
-    .slice(Math.max(0, start - 20), start)
-    .toLowerCase();
+  const beforeContext = raw.slice(Math.max(0, start - 20), start).toLowerCase();
 
   return SCORE_CUE_REGEX.test(beforeContext);
 }

--- a/packages/bench/src/security/url-secrets.ts
+++ b/packages/bench/src/security/url-secrets.ts
@@ -1,0 +1,121 @@
+export type SecretQueryKeyPredicate = (key: string) => boolean;
+
+export function redactUrlSecrets(
+  value: string,
+  redactedValue: string,
+  isSecretQueryKey: SecretQueryKeyPredicate
+): string {
+  return redactUrlQuerySecrets(redactUrlUserinfoSecrets(value, redactedValue), redactedValue, isSecretQueryKey);
+}
+
+function redactUrlUserinfoSecrets(value: string, redactedValue: string): string {
+  if (!value.includes("://")) return value;
+  let redacted = "";
+  let cursor = 0;
+  let changed = false;
+
+  for (let schemeEnd = value.indexOf("://"); schemeEnd !== -1; schemeEnd = value.indexOf("://", schemeEnd + 3)) {
+    const schemeStart = findUrlSchemeStart(value, schemeEnd);
+    if (schemeStart === -1) continue;
+    const authorityStart = schemeEnd + 3;
+    const authorityEnd = findUrlAuthorityEnd(value, authorityStart);
+    const atIndex = value.lastIndexOf("@", authorityEnd - 1);
+    if (atIndex < authorityStart) continue;
+    redacted += value.slice(cursor, authorityStart);
+    redacted += redactedValue;
+    cursor = atIndex;
+    changed = true;
+  }
+
+  return changed ? redacted + value.slice(cursor) : value;
+}
+
+function redactUrlQuerySecrets(
+  value: string,
+  redactedValue: string,
+  isSecretQueryKey: SecretQueryKeyPredicate
+): string {
+  if (!/[?&;]/.test(value)) return value;
+  let redacted = "";
+  let cursor = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== "?" && value[index] !== "&" && value[index] !== ";") continue;
+    const keyStart = index + 1;
+    const equalsIndex = value.indexOf("=", keyStart);
+    if (equalsIndex === -1) continue;
+    const valueEnd = findQueryValueEnd(value, equalsIndex + 1);
+    const key = value.slice(keyStart, equalsIndex);
+    if (isSecretUrlQueryKey(key, isSecretQueryKey)) {
+      if (redactedValue.length > 0 && value.startsWith(redactedValue, equalsIndex + 1)) continue;
+      redacted += value.slice(cursor, equalsIndex + 1);
+      redacted += redactedValue;
+      cursor = valueEnd;
+      index = valueEnd - 1;
+    }
+  }
+
+  return cursor === 0 ? value : redacted + value.slice(cursor);
+}
+
+function findQueryValueEnd(value: string, startIndex: number): number {
+  let index = startIndex;
+  while (index < value.length && !isQueryValueTerminator(value[index]!)) {
+    index += 1;
+  }
+  return index;
+}
+
+function isQueryValueTerminator(char: string): boolean {
+  return (
+    char === "&" ||
+    char === ";" ||
+    char === "#" ||
+    char === '"' ||
+    char === "'" ||
+    char === "}" ||
+    char === "]" ||
+    isWhitespace(char)
+  );
+}
+
+function isSecretUrlQueryKey(key: string, isSecretQueryKey: SecretQueryKeyPredicate): boolean {
+  try {
+    return isSecretQueryKey(decodeURIComponent(key.replace(/\+/g, " ")));
+  } catch {
+    return isSecretQueryKey(key);
+  }
+}
+
+function findUrlSchemeStart(value: string, schemeEnd: number): number {
+  let cursor = schemeEnd - 1;
+  while (cursor >= 0 && isUrlSchemeChar(value[cursor]!)) cursor -= 1;
+  const schemeStart = cursor + 1;
+  return schemeStart < schemeEnd && isAsciiLetter(value[schemeStart]!) ? schemeStart : -1;
+}
+
+function isUrlSchemeChar(char: string): boolean {
+  return isAsciiAlnum(char) || char === "+" || char === "-" || char === ".";
+}
+
+function findUrlAuthorityEnd(value: string, authorityStart: number): number {
+  let cursor = authorityStart;
+  while (cursor < value.length && !isUrlAuthorityTerminator(value[cursor]!)) cursor += 1;
+  return cursor;
+}
+
+function isUrlAuthorityTerminator(char: string): boolean {
+  return char === "/" || char === "?" || char === "#" || isWhitespace(char) || char === '"' || char === "'";
+}
+
+function isAsciiLetter(char: string): boolean {
+  return (char >= "A" && char <= "Z") || (char >= "a" && char <= "z");
+}
+
+function isAsciiAlnum(char: string): boolean {
+  return isAsciiLetter(char) || (char >= "0" && char <= "9");
+}
+
+function isWhitespace(char: string): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r";
+}

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -68,10 +68,10 @@ packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts(18
 packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts(206,60): TS2352
 packages/bench/src/providers/local-llm.test.ts(155,50): TS2304
 packages/bench/src/providers/ollama.test.ts(10,50): TS2304
-packages/bench/src/responders.test.ts(334,5): TS2322
-packages/bench/src/responders.test.ts(337,21): TS18048
-packages/bench/src/responders.test.ts(339,13): TS18048
-packages/bench/src/responders.test.ts(343,24): TS18048
+packages/bench/src/responders.test.ts(368,5): TS2322
+packages/bench/src/responders.test.ts(371,21): TS18048
+packages/bench/src/responders.test.ts(373,13): TS18048
+packages/bench/src/responders.test.ts(377,24): TS18048
 packages/bench/src/results-store.test.ts(31,18): TS2352
 packages/bench/src/runtime-profiles.test.ts(54,38): TS2345
 packages/bench/src/security/extraction-attack/baseline.test.ts(12,62): TS2559


### PR DESCRIPTION
## Summary

Fixes ClawPatch repro-manifest findings for `feat_library_91c7aa4429` by hardening the manifest boundary for shareable benchmark artifacts.

- redact secret argv values across direct flags, `key=value`, colon-delimited config tokens, nested assignments, split key/value tokens, camelCase secret keys, and structured JSON argv values
- mark secret-bearing config file entries as `redacted` and hash sanitized JSON content instead of raw secret-bearing file bytes
- constrain explicit result paths to the resolved results directory while allowing valid contained dot-prefixed filenames

ClawPatch targeted clean run:
- `20260602T050248-7b8ea2`: `reviewed=1 findings=0` for `feat_library_91c7aa4429`

## Validation

- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/bench/src/repro-manifest.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/bench/src/repro-manifest.ts packages/bench/src/repro-manifest.test.ts && git diff --check`
- `npm_config_ignore_scripts=false pnpm rebuild better-sqlite3 && npm run preflight:quick` (`[preflight] OK (quick)`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential redaction and filesystem containment for published benchmark artifacts; behavior is defensive with large test coverage, but mistakes could strip needed repro data or miss a leak vector.
> 
> **Overview**
> **Hardens shareable benchmark artifacts** so repro manifests and persisted results leak fewer credentials while staying reproducible.
> 
> `buildBenchmarkReproManifest` now runs a much broader **`sanitizeArgv`** pass: direct secret flags, attached tokens, colon/`key=value` config fragments, headers (including multi-part **Cookie**), structured JSON argv blobs, and URL query/userinfo secrets are replaced with **`[redacted]`**, with bench flags after multi-token secrets preserved. Secret-bearing **config file** entries are marked **`redacted`** and hashed from sanitized content instead of raw bytes. Explicit **result paths** must live under the resolved results directory (regular files only; contained dot-prefixed names still allowed), and **dataset symlinks** must resolve inside the dataset root.
> 
> **`redactBenchmarkResultSecrets`** in the reporter gains the same URL helper plus free-form string redaction (authorization schemes, cookie/session assignments, embedded JSON). Leaderboard sidecars and error metadata are redacted from already-sanitized results before write.
> 
> Smaller bench tweaks: trajectory **responder context** compaction keeps step ranges for “before/between/list” questions; root **`package.json`** is formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a9398838126b670e7146a0d1c49e3c4eb0d29e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->