### PR TITLE
fix(bench): normalize artifact timestamps

### DIFF
--- a/packages/bench/src/published-artifact.test.ts
+++ b/packages/bench/src/published-artifact.test.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import type { BenchmarkResult } from "./types.ts";
 import {
   BENCHMARK_ARTIFACT_SCHEMA_VERSION,
   PUBLISHED_BENCHMARK_ARTIFACT_IDS,
@@ -16,6 +15,7 @@ import {
   serializeBenchmarkArtifact,
   writeBenchmarkArtifact,
 } from "./published-artifact.ts";
+import type { BenchmarkResult } from "./types.ts";
 
 function sampleResult(overrides: Partial<BenchmarkResult> = {}): BenchmarkResult {
   return {
@@ -142,8 +142,7 @@ test("buildBenchmarkArtifact attaches category via categoryFor", () => {
     startedAt: "2026-04-20T12:00:00.000Z",
     finishedAt: "2026-04-20T12:01:00.000Z",
     result: sampleResult(),
-    categoryFor: (task) =>
-      (task.details?.category as string | undefined) ?? undefined,
+    categoryFor: (task) => (task.details?.category as string | undefined) ?? undefined,
   });
 
   assert.equal(artifact.perTaskScores[0]?.category, "multi_hop");
@@ -161,6 +160,23 @@ test("buildBenchmarkArtifact durationMs clamps to 0 for identical timestamps", (
     result: sampleResult(),
   });
   assert.equal(artifact.durationMs, 0);
+});
+
+test("buildBenchmarkArtifact normalizes timestamps before filename generation", () => {
+  const artifact = buildBenchmarkArtifact({
+    benchmarkId: "longmemeval",
+    datasetVersion: "v1",
+    model: "gpt-4o-mini",
+    seed: 1,
+    startedAt: "2026-06-02 00:00:00Z",
+    finishedAt: "2026-06-02T00:05:00+00:00",
+    result: sampleResult(),
+  });
+
+  assert.equal(artifact.startedAt, "2026-06-02T00:00:00.000Z");
+  assert.equal(artifact.finishedAt, "2026-06-02T00:05:00.000Z");
+  assert.equal(artifact.durationMs, 5 * 60 * 1000);
+  assert.equal(buildBenchmarkArtifactFilename(artifact), "2026-06-02-longmemeval-gpt-4o-mini-abc1234.json");
 });
 
 test("buildBenchmarkArtifact drops arch when hardware absent", () => {
@@ -295,10 +311,7 @@ test("parseBenchmarkArtifact rejects unknown schemaVersion", () => {
     durationMs: 0,
     env: { node: "v22", os: "linux" },
   });
-  assert.throws(
-    () => parseBenchmarkArtifact(raw),
-    /schemaVersion 999 is not supported/,
-  );
+  assert.throws(() => parseBenchmarkArtifact(raw), /schemaVersion 999 is not supported/);
 });
 
 test("parseBenchmarkArtifact rejects invalid benchmarkId", () => {
@@ -316,10 +329,7 @@ test("parseBenchmarkArtifact rejects invalid benchmarkId", () => {
     durationMs: 0,
     env: { node: "v22", os: "linux" },
   });
-  assert.throws(
-    () => parseBenchmarkArtifact(raw),
-    /benchmarkId must be one of/,
-  );
+  assert.throws(() => parseBenchmarkArtifact(raw), /benchmarkId must be one of/);
 });
 
 test("parseBenchmarkArtifact rejects non-number metric value", () => {
@@ -379,10 +389,7 @@ test("parseBenchmarkArtifact rejects non-ISO startedAt", () => {
     durationMs: 0,
     env: { node: "v22", os: "linux" },
   });
-  assert.throws(
-    () => parseBenchmarkArtifact(raw),
-    /"startedAt" "not-a-date" is not a parseable ISO-8601/,
-  );
+  assert.throws(() => parseBenchmarkArtifact(raw), /"startedAt" "not-a-date" is not a parseable ISO-8601/);
 });
 
 test("parseBenchmarkArtifact rejects non-ISO finishedAt", () => {
@@ -400,10 +407,7 @@ test("parseBenchmarkArtifact rejects non-ISO finishedAt", () => {
     durationMs: 0,
     env: { node: "v22", os: "linux" },
   });
-  assert.throws(
-    () => parseBenchmarkArtifact(raw),
-    /"finishedAt" "nope" is not a parseable ISO-8601/,
-  );
+  assert.throws(() => parseBenchmarkArtifact(raw), /"finishedAt" "nope" is not a parseable ISO-8601/);
 });
 
 test("parseBenchmarkArtifact rejects non-finite metric value", () => {
@@ -424,10 +428,7 @@ test("parseBenchmarkArtifact rejects non-finite metric value", () => {
     env: { node: "v22", os: "linux" },
   });
   const raw = rawBase.replace('"metrics":{}', '"metrics":{"f1":1e309}');
-  assert.throws(
-    () => parseBenchmarkArtifact(raw),
-    /metrics\.f1 must be a finite number/,
-  );
+  assert.throws(() => parseBenchmarkArtifact(raw), /metrics\.f1 must be a finite number/);
 });
 
 test("parseBenchmarkArtifact rejects non-finite per-task score", () => {
@@ -446,10 +447,7 @@ test("parseBenchmarkArtifact rejects non-finite per-task score", () => {
     env: { node: "v22", os: "linux" },
   });
   const raw = rawBase.replace('"f1":1', '"f1":1e309');
-  assert.throws(
-    () => parseBenchmarkArtifact(raw),
-    /perTaskScores\[0\]\.scores\.f1 must be a finite number/,
-  );
+  assert.throws(() => parseBenchmarkArtifact(raw), /perTaskScores\[0\]\.scores\.f1 must be a finite number/);
 });
 
 test("parseBenchmarkArtifact rejects malformed optional string fields", () => {
@@ -457,21 +455,21 @@ test("parseBenchmarkArtifact rejects malformed optional string fields", () => {
   (withBadArch.env as Record<string, unknown>).arch = {};
   assert.throws(
     () => parseBenchmarkArtifact(JSON.stringify(withBadArch)),
-    /field "env\.arch" must be a string when provided/,
+    /field "env\.arch" must be a string when provided/
   );
 
   const withBadNote = sampleArtifactPayload();
   withBadNote.note = 42;
   assert.throws(
     () => parseBenchmarkArtifact(JSON.stringify(withBadNote)),
-    /field "note" must be a string when provided/,
+    /field "note" must be a string when provided/
   );
 
   const withBadCategory = sampleArtifactPayload();
-  ((withBadCategory.perTaskScores as Array<Record<string, unknown>>)[0]!).category = 42;
+  (withBadCategory.perTaskScores as Array<Record<string, unknown>>)[0]!.category = 42;
   assert.throws(
     () => parseBenchmarkArtifact(JSON.stringify(withBadCategory)),
-    /field "perTaskScores\[0\]\.category" must be a string when provided/,
+    /field "perTaskScores\[0\]\.category" must be a string when provided/
   );
 });
 
@@ -547,7 +545,7 @@ test("buildBenchmarkArtifact rejects non-finite per-task scores", () => {
           },
         }),
       }),
-    /perTaskScores\[0\] "t1" scores\.f1 must be a finite number/,
+    /perTaskScores\[0\] "t1" scores\.f1 must be a finite number/
   );
 });
 
@@ -563,7 +561,7 @@ test("buildBenchmarkArtifact rejects invalid startedAt/finishedAt timestamps", (
         finishedAt: "2026-04-20T12:00:00.000Z",
         result: sampleResult(),
       }),
-    /startedAt "not-a-date" is not a valid ISO-8601 timestamp/,
+    /startedAt "not-a-date" is not a valid ISO-8601 timestamp/
   );
   assert.throws(
     () =>
@@ -576,7 +574,7 @@ test("buildBenchmarkArtifact rejects invalid startedAt/finishedAt timestamps", (
         finishedAt: "garbage",
         result: sampleResult(),
       }),
-    /finishedAt "garbage" is not a valid ISO-8601 timestamp/,
+    /finishedAt "garbage" is not a valid ISO-8601 timestamp/
   );
 });
 

--- a/packages/bench/src/published-artifact.ts
+++ b/packages/bench/src/published-artifact.ts
@@ -46,8 +46,7 @@ export const PUBLISHED_BENCHMARK_ARTIFACT_IDS = Object.freeze([
 ] as const);
 
 /** Identifier of a published-benchmark runner. */
-export type PublishedBenchmarkId =
-  (typeof PUBLISHED_BENCHMARK_ARTIFACT_IDS)[number];
+export type PublishedBenchmarkId = (typeof PUBLISHED_BENCHMARK_ARTIFACT_IDS)[number];
 
 export interface BenchmarkArtifactSystem {
   /** Short product name, e.g. "remnic". */
@@ -128,9 +127,7 @@ export interface BuildBenchmarkArtifactInput {
  * per-task scores verbatim. The result is sort-stable: metric keys are
  * emitted in sorted order and perTaskScores preserves runner order.
  */
-export function buildBenchmarkArtifact(
-  input: BuildBenchmarkArtifactInput,
-): BenchmarkArtifact {
+export function buildBenchmarkArtifact(input: BuildBenchmarkArtifactInput): BenchmarkArtifact {
   const { result } = input;
   const metrics: Record<string, number> = {};
   // Only finite means are exported — a non-finite mean is almost
@@ -146,49 +143,46 @@ export function buildBenchmarkArtifact(
     }
   }
 
-  const perTaskScores: BenchmarkArtifactPerTaskScore[] =
-    result.results.tasks.map((task, index) => {
-      const category = input.categoryFor?.(task);
-      // Validate up-front so a non-finite score (e.g. NaN from a
-      // rejected extraction, Infinity from a broken divisor) fails
-      // at build time with a clear per-task pointer — instead of
-      // silently serializing to JSON `null` (which
-      // `parseBenchmarkArtifact()` would then reject) or flowing
-      // into leaderboard aggregates downstream.
-      const cleanedScores: Record<string, number> = {};
-      for (const [key, value] of Object.entries(task.scores)) {
-        if (typeof value !== "number" || !Number.isFinite(value)) {
-          throw new Error(
-            `BuildBenchmarkArtifact: perTaskScores[${index}] "${task.taskId}" scores.${key} must be a finite number; got ${String(value)}.`,
-          );
-        }
-        cleanedScores[key] = value;
+  const perTaskScores: BenchmarkArtifactPerTaskScore[] = result.results.tasks.map((task, index) => {
+    const category = input.categoryFor?.(task);
+    // Validate up-front so a non-finite score (e.g. NaN from a
+    // rejected extraction, Infinity from a broken divisor) fails
+    // at build time with a clear per-task pointer — instead of
+    // silently serializing to JSON `null` (which
+    // `parseBenchmarkArtifact()` would then reject) or flowing
+    // into leaderboard aggregates downstream.
+    const cleanedScores: Record<string, number> = {};
+    for (const [key, value] of Object.entries(task.scores)) {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        throw new Error(
+          `BuildBenchmarkArtifact: perTaskScores[${index}] "${task.taskId}" scores.${key} must be a finite number; got ${String(value)}.`
+        );
       }
-      const entry: BenchmarkArtifactPerTaskScore = {
-        taskId: task.taskId,
-        // In-memory scores preserve whatever order the runner emitted;
-        // `serializeBenchmarkArtifact()` sorts keys at write time via
-        // the shared `canonicalJsonStringify` helper.
-        scores: cleanedScores,
-      };
-      if (category !== undefined) {
-        entry.category = category;
-      }
-      return entry;
-    });
+      cleanedScores[key] = value;
+    }
+    const entry: BenchmarkArtifactPerTaskScore = {
+      taskId: task.taskId,
+      // In-memory scores preserve whatever order the runner emitted;
+      // `serializeBenchmarkArtifact()` sorts keys at write time via
+      // the shared `canonicalJsonStringify` helper.
+      scores: cleanedScores,
+    };
+    if (category !== undefined) {
+      entry.category = category;
+    }
+    return entry;
+  });
 
   const startedMs = Date.parse(input.startedAt);
   const finishedMs = Date.parse(input.finishedAt);
   if (!Number.isFinite(startedMs)) {
-    throw new Error(
-      `BuildBenchmarkArtifact: startedAt "${input.startedAt}" is not a valid ISO-8601 timestamp.`,
-    );
+    throw new Error(`BuildBenchmarkArtifact: startedAt "${input.startedAt}" is not a valid ISO-8601 timestamp.`);
   }
   if (!Number.isFinite(finishedMs)) {
-    throw new Error(
-      `BuildBenchmarkArtifact: finishedAt "${input.finishedAt}" is not a valid ISO-8601 timestamp.`,
-    );
+    throw new Error(`BuildBenchmarkArtifact: finishedAt "${input.finishedAt}" is not a valid ISO-8601 timestamp.`);
   }
+  const startedAt = new Date(startedMs).toISOString();
+  const finishedAt = new Date(finishedMs).toISOString();
   const durationMs = Math.max(0, finishedMs - startedMs);
 
   return {
@@ -204,15 +198,13 @@ export function buildBenchmarkArtifact(
     seed: input.seed,
     metrics,
     perTaskScores,
-    startedAt: input.startedAt,
-    finishedAt: input.finishedAt,
+    startedAt,
+    finishedAt,
     durationMs,
     env: {
       node: result.environment.nodeVersion,
       os: result.environment.os,
-      ...(result.environment.hardware
-        ? { arch: result.environment.hardware }
-        : {}),
+      ...(result.environment.hardware ? { arch: result.environment.hardware } : {}),
     },
     ...(input.note !== undefined ? { note: input.note } : {}),
   };
@@ -229,34 +221,26 @@ export function buildBenchmarkArtifact(
  * path-separator characters — preventing a malicious artifact input
  * from directing `writeBenchmarkArtifact()` outside of `outputDir`.
  */
-export function buildBenchmarkArtifactFilename(
-  artifact: BenchmarkArtifact,
-): string {
+export function buildBenchmarkArtifactFilename(artifact: BenchmarkArtifact): string {
   const date = sanitizeSegment(artifact.startedAt.slice(0, 10));
-  const sha = sanitizeSegment(
-    (artifact.system.gitSha || "unknown").slice(0, 7),
-  );
+  const sha = sanitizeSegment((artifact.system.gitSha || "unknown").slice(0, 7));
   const model = sanitizeSegment(artifact.model);
   const benchmark = sanitizeSegment(artifact.benchmarkId);
   return `${date}-${benchmark}-${model}-${sha}.json`;
 }
 
 /** Serialize an artifact to deterministic JSON (sorted keys, indented). */
-export function serializeBenchmarkArtifact(
-  artifact: BenchmarkArtifact,
-): string {
+export function serializeBenchmarkArtifact(artifact: BenchmarkArtifact): string {
   // Reuse the package's shared canonical-JSON helper (CLAUDE.md rule 22:
   // single source of truth for canonicalization) with pretty-print
   // indentation so the SHA-256 stays reproducible regardless of key
   // insertion order.
-  return canonicalJsonStringify(artifact, 2) + "\n";
+  return `${canonicalJsonStringify(artifact, 2)}\n`;
 }
 
 /** Compute SHA-256 of the canonical JSON serialization of the artifact. */
 export function hashBenchmarkArtifact(artifact: BenchmarkArtifact): string {
-  return createHash("sha256")
-    .update(serializeBenchmarkArtifact(artifact))
-    .digest("hex");
+  return createHash("sha256").update(serializeBenchmarkArtifact(artifact)).digest("hex");
 }
 
 export interface WriteBenchmarkArtifactResult {
@@ -278,7 +262,7 @@ export interface WriteBenchmarkArtifactResult {
  */
 export async function writeBenchmarkArtifact(
   artifact: BenchmarkArtifact,
-  outputDir: string,
+  outputDir: string
 ): Promise<WriteBenchmarkArtifactResult> {
   await mkdir(outputDir, { recursive: true });
   const filename = buildBenchmarkArtifactFilename(artifact);
@@ -288,14 +272,9 @@ export async function writeBenchmarkArtifact(
   // `abs` must be a direct child of `resolvedDir`. Reject anything that
   // resolves to a parent directory, sibling, or any other location.
   const relative = path.relative(resolvedDir, abs);
-  if (
-    relative.length === 0 ||
-    relative.startsWith("..") ||
-    path.isAbsolute(relative) ||
-    relative.includes(path.sep)
-  ) {
+  if (relative.length === 0 || relative.startsWith("..") || path.isAbsolute(relative) || relative.includes(path.sep)) {
     throw new Error(
-      `writeBenchmarkArtifact: refusing to write outside outputDir (filename="${filename}", resolved="${abs}").`,
+      `writeBenchmarkArtifact: refusing to write outside outputDir (filename="${filename}", resolved="${abs}").`
     );
   }
   await writeFile(abs, body);
@@ -322,12 +301,12 @@ export function parseBenchmarkArtifact(raw: string): BenchmarkArtifact {
   if (record.schemaVersion !== BENCHMARK_ARTIFACT_SCHEMA_VERSION) {
     throw new Error(
       `BenchmarkArtifact schemaVersion ${String(record.schemaVersion)} is not supported. ` +
-        `This build expects schemaVersion ${BENCHMARK_ARTIFACT_SCHEMA_VERSION}.`,
+        `This build expects schemaVersion ${BENCHMARK_ARTIFACT_SCHEMA_VERSION}.`
     );
   }
   if (!isPublishedBenchmarkArtifactId(record.benchmarkId)) {
     throw new Error(
-      `BenchmarkArtifact benchmarkId must be one of ${PUBLISHED_BENCHMARK_ARTIFACT_IDS.map((id) => `"${id}"`).join(", ")}; got ${String(record.benchmarkId)}.`,
+      `BenchmarkArtifact benchmarkId must be one of ${PUBLISHED_BENCHMARK_ARTIFACT_IDS.map((id) => `"${id}"`).join(", ")}; got ${String(record.benchmarkId)}.`
     );
   }
   requireString(record, "datasetVersion");
@@ -348,9 +327,7 @@ export function parseBenchmarkArtifact(raw: string): BenchmarkArtifact {
   const metrics = requireObject(record, "metrics");
   for (const [key, value] of Object.entries(metrics)) {
     if (typeof value !== "number" || !Number.isFinite(value)) {
-      throw new Error(
-        `BenchmarkArtifact metrics.${key} must be a finite number; got ${String(value)}.`,
-      );
+      throw new Error(`BenchmarkArtifact metrics.${key} must be a finite number; got ${String(value)}.`);
     }
   }
   const tasks = record.perTaskScores;
@@ -365,22 +342,12 @@ export function parseBenchmarkArtifact(raw: string): BenchmarkArtifact {
     requireString(task as Record<string, unknown>, "taskId");
     requireOptionalString(task as Record<string, unknown>, "category", `perTaskScores[${index}].category`);
     const scoreRecord = (task as Record<string, unknown>).scores;
-    if (
-      !scoreRecord ||
-      typeof scoreRecord !== "object" ||
-      Array.isArray(scoreRecord)
-    ) {
-      throw new Error(
-        `BenchmarkArtifact perTaskScores[${index}].scores must be an object.`,
-      );
+    if (!scoreRecord || typeof scoreRecord !== "object" || Array.isArray(scoreRecord)) {
+      throw new Error(`BenchmarkArtifact perTaskScores[${index}].scores must be an object.`);
     }
-    for (const [scoreKey, scoreValue] of Object.entries(
-      scoreRecord as Record<string, unknown>,
-    )) {
+    for (const [scoreKey, scoreValue] of Object.entries(scoreRecord as Record<string, unknown>)) {
       if (typeof scoreValue !== "number" || !Number.isFinite(scoreValue)) {
-        throw new Error(
-          `BenchmarkArtifact perTaskScores[${index}].scores.${scoreKey} must be a finite number.`,
-        );
+        throw new Error(`BenchmarkArtifact perTaskScores[${index}].scores.${scoreKey} must be a finite number.`);
       }
     }
   }
@@ -390,7 +357,7 @@ export function parseBenchmarkArtifact(raw: string): BenchmarkArtifact {
 
 /** Read + parse + re-hash an artifact file. Handy for `verify-artifact` CLI. */
 export async function loadBenchmarkArtifact(
-  filePath: string,
+  filePath: string
 ): Promise<{ artifact: BenchmarkArtifact; sha256: string; bytes: number }> {
   const raw = await readFile(filePath, "utf8");
   const artifact = parseBenchmarkArtifact(raw);
@@ -461,41 +428,26 @@ function sanitizeSegment(value: string): string {
   return cleaned.length > 0 ? cleaned : "unknown";
 }
 
-function requireString(
-  record: Record<string, unknown>,
-  field: string,
-): void {
+function requireString(record: Record<string, unknown>, field: string): void {
   if (typeof record[field] !== "string") {
     throw new Error(`BenchmarkArtifact field "${field}" must be a string.`);
   }
 }
 
-function requireOptionalString(
-  record: Record<string, unknown>,
-  field: string,
-  label: string,
-): void {
+function requireOptionalString(record: Record<string, unknown>, field: string, label: string): void {
   if (record[field] !== undefined && typeof record[field] !== "string") {
     throw new Error(`BenchmarkArtifact field "${label}" must be a string when provided.`);
   }
 }
 
-function requireNumber(
-  record: Record<string, unknown>,
-  field: string,
-): void {
+function requireNumber(record: Record<string, unknown>, field: string): void {
   const value = record[field];
   if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new Error(
-      `BenchmarkArtifact field "${field}" must be a finite number.`,
-    );
+    throw new Error(`BenchmarkArtifact field "${field}" must be a finite number.`);
   }
 }
 
-function requireObject(
-  record: Record<string, unknown>,
-  field: string,
-): Record<string, unknown> {
+function requireObject(record: Record<string, unknown>, field: string): Record<string, unknown> {
   const value = record[field];
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`BenchmarkArtifact field "${field}" must be an object.`);
@@ -509,28 +461,16 @@ function requireObject(
  * (so `"not-a-date"` fails here instead of quietly flowing into
  * downstream duration math or leaderboard ordering).
  */
-function requireIsoTimestamp(
-  record: Record<string, unknown>,
-  field: string,
-): void {
+function requireIsoTimestamp(record: Record<string, unknown>, field: string): void {
   const value = record[field];
   if (typeof value !== "string") {
-    throw new Error(
-      `BenchmarkArtifact field "${field}" must be an ISO-8601 timestamp string.`,
-    );
+    throw new Error(`BenchmarkArtifact field "${field}" must be an ISO-8601 timestamp string.`);
   }
   if (!Number.isFinite(Date.parse(value))) {
-    throw new Error(
-      `BenchmarkArtifact field "${field}" "${value}" is not a parseable ISO-8601 timestamp.`,
-    );
+    throw new Error(`BenchmarkArtifact field "${field}" "${value}" is not a parseable ISO-8601 timestamp.`);
   }
 }
 
-function isPublishedBenchmarkArtifactId(
-  value: unknown,
-): value is PublishedBenchmarkId {
-  return (
-    typeof value === "string" &&
-    (PUBLISHED_BENCHMARK_ARTIFACT_IDS as readonly string[]).includes(value)
-  );
+function isPublishedBenchmarkArtifactId(value: unknown): value is PublishedBenchmarkId {
+  return typeof value === "string" && (PUBLISHED_BENCHMARK_ARTIFACT_IDS as readonly string[]).includes(value);
 }


### PR DESCRIPTION
## Summary
- normalize published benchmark artifact timestamps to canonical ISO strings at build time
- add regression coverage for parseable non-canonical timestamp spellings and filename generation

## Verification
- PATH=/opt/homebrew/opt/node@22/bin:$PATH NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/bench/src/published-artifact.test.ts
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/bench check-types
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/bench/src/published-artifact.ts packages/bench/src/published-artifact.test.ts && git diff --check

ClawPatch finding: fnd_sig-feat-library-91c7aa4429-491a_deb1e8689a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bench artifact serialization change with new tests; no auth, security, or broad API surface impact beyond consistent timestamp strings and filenames.
> 
> **Overview**
> **`buildBenchmarkArtifact`** now converts parseable `startedAt` / `finishedAt` inputs to canonical UTC ISO strings (`*.000Z`) via `Date.parse` + `toISOString()`, instead of echoing the runner’s original spelling. **`durationMs`** still uses the parsed millisecond values; only the stored string fields and anything derived from them (e.g. the date prefix in **`buildBenchmarkArtifactFilename`**) change when inputs used alternate ISO forms (spaces vs `T`, `+00:00` vs `Z`).
> 
> A regression test covers non-canonical timestamp spellings and expects a stable on-disk filename. Remaining edits in **`published-artifact.ts`** / tests are mostly formatting (import order, compact `assert.throws`, template literals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 926dffbf72e62c0e54d1060427789def6e18cb6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->