### PR TITLE
chore: restore root package formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }


### PR DESCRIPTION
Restores the Biome-required compact root package.json array formatting that was reintroduced on main after the prior formatting PR.\n\nVerification:\n- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin pnpm run lint\n- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin pnpm run check-types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic JSON formatting only; no dependency, script, or runtime behavior changes.
> 
> **Overview**
> Reformats several root `package.json` array fields (`workspaces`, `files`, `openclaw.extensions`, and `pnpm.onlyBuiltDependencies`) from multi-line lists to **Biome’s compact single-line** style. Values are unchanged—this only restores lint-compliant formatting that had drifted on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61e8ee892a077b0530b9aad743f5e562e3b6660a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->