### PR TITLE
fix(core): separate live connector persisted config

### DIFF
--- a/packages/remnic-core/src/connectors/live/framework.ts
+++ b/packages/remnic-core/src/connectors/live/framework.ts
@@ -20,14 +20,60 @@
 
 /**
  * Free-form connector configuration. Validated by each connector's
- * `validateConfig` implementation. Stored alongside the cursor in the state
- * store. MUST be JSON-serializable: no functions, no class instances, no
+ * `validateConfig` implementation and passed to `syncIncremental` for runtime
+ * use. MUST be JSON-serializable: no functions, no class instances, no
  * circular references.
  *
- * Connectors MUST NOT persist secrets here — credentials belong in OS keychain
- * / OAuth token storage (PR 2 design).
+ * Runtime configs may contain hydrated credentials. Do not persist a runtime
+ * config directly. Any code that needs to store connector settings must call
+ * `persistableConnectorConfig()` so credentials are stripped or replaced by
+ * connector-owned references.
  */
 export type ConnectorConfig = Record<string, unknown>;
+
+const DEFAULT_SECRET_KEY_PARTS = [
+  "token",
+  "secret",
+  "password",
+  "credential",
+  "apikey",
+  "accesskey",
+  "privatekey",
+  "authorization",
+  "authheader",
+  "cookie",
+] as const;
+
+/**
+ * Redact secret-looking keys from a JSON-serializable connector config.
+ * Built-in connectors provide explicit projections, but this default keeps
+ * third-party connectors from accidentally persisting obvious credentials.
+ */
+export function redactConnectorConfigSecrets(config: ConnectorConfig): ConnectorConfig {
+  return redactConnectorConfigValue(config) as ConnectorConfig;
+}
+
+function redactConnectorConfigValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactConnectorConfigValue(item));
+  }
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    if (isConnectorSecretConfigKey(key)) {
+      continue;
+    }
+    out[key] = redactConnectorConfigValue(nested);
+  }
+  return out;
+}
+
+function isConnectorSecretConfigKey(key: string): boolean {
+  const normalized = key.replace(/[^a-z0-9]/giu, "").toLowerCase();
+  return DEFAULT_SECRET_KEY_PARTS.some((part) => normalized.includes(part));
+}
 
 /**
  * Opaque cursor describing "where the last sync left off". Each connector
@@ -135,16 +181,35 @@ export interface LiveConnector {
 
   /**
    * Validate raw user-supplied config. MUST throw on malformed input — never
-   * silently default. The returned object is what gets persisted and passed
-   * back to `syncIncremental`. Connectors SHOULD strip unknown fields.
+   * silently default. The returned object is the runtime config passed back to
+   * `syncIncremental`; it may contain hydrated credentials and MUST NOT be
+   * persisted directly. Connectors SHOULD strip unknown fields.
    */
   validateConfig(raw: unknown): ConnectorConfig;
+
+  /**
+   * Return the subset of validated config that may be written to disk. Use this
+   * for state/config persistence instead of `validateConfig()`. Connectors that
+   * need credentials should omit the raw values here and store only non-secret
+   * scope/schedule fields plus any connector-owned secret references.
+   */
+  persistConfig?(validated: ConnectorConfig): ConnectorConfig;
 
   /**
    * Run one incremental sync pass. See `SyncIncrementalArgs` /
    * `SyncIncrementalResult` for the contract.
    */
   syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult>;
+}
+
+export function persistableConnectorConfig(
+  connector: Pick<LiveConnector, "persistConfig">,
+  validated: ConnectorConfig,
+): ConnectorConfig {
+  if (typeof connector.persistConfig === "function") {
+    return connector.persistConfig(validated);
+  }
+  return redactConnectorConfigSecrets(validated);
 }
 
 /**

--- a/packages/remnic-core/src/connectors/live/github.ts
+++ b/packages/remnic-core/src/connectors/live/github.ts
@@ -514,6 +514,16 @@ export function createGitHubConnector(
       return validateGitHubConfig(raw) as unknown as ConnectorConfig;
     },
 
+    persistConfig(validated: ConnectorConfig): ConnectorConfig {
+      const config = validateGitHubConfig(validated);
+      return Object.freeze({
+        userLogin: config.userLogin,
+        repos: config.repos,
+        pollIntervalMs: config.pollIntervalMs,
+        includeDiscussions: config.includeDiscussions,
+      });
+    },
+
     async syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult> {
       const config = validateGitHubConfig(args.config);
       throwIfAborted(args.abortSignal);

--- a/packages/remnic-core/src/connectors/live/gmail.ts
+++ b/packages/remnic-core/src/connectors/live/gmail.ts
@@ -848,6 +848,16 @@ export function createGmailConnector(
       return validateGmailConfig(raw) as unknown as ConnectorConfig;
     },
 
+    persistConfig(validated: ConnectorConfig): ConnectorConfig {
+      const config = validateGmailConfig(validated);
+      return Object.freeze({
+        clientId: config.clientId,
+        userId: config.userId,
+        query: config.query,
+        pollIntervalMs: config.pollIntervalMs,
+      });
+    },
+
     async syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult> {
       const config = validateGmailConfig(args.config);
       throwIfAborted(args.abortSignal);

--- a/packages/remnic-core/src/connectors/live/google-drive.ts
+++ b/packages/remnic-core/src/connectors/live/google-drive.ts
@@ -397,14 +397,22 @@ export function createGoogleDriveConnector(
 
     validateConfig(raw: unknown): ConnectorConfig {
       // Cast to ConnectorConfig (Record<string, unknown>) per framework
-      // contract. The frozen object survives JSON round-trips through the
-      // state store.
+      // contract. Persist only `persistConfig()` output; this runtime object
+      // carries hydrated credentials.
       return validateGoogleDriveConfig(raw) as unknown as ConnectorConfig;
     },
 
+    persistConfig(validated: ConnectorConfig): ConnectorConfig {
+      const config = validateGoogleDriveConfig(validated);
+      return Object.freeze({
+        clientId: config.clientId,
+        pollIntervalMs: config.pollIntervalMs,
+        folderIds: config.folderIds,
+      });
+    },
+
     async syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult> {
-      // Re-validate on every pass: the framework persists raw config, and
-      // a JS caller could mutate it between passes.
+      // Re-validate on every pass: a JS caller could mutate it between passes.
       const config = validateGoogleDriveConfig(args.config);
       throwIfAborted(args.abortSignal);
 

--- a/packages/remnic-core/src/connectors/live/index.ts
+++ b/packages/remnic-core/src/connectors/live/index.ts
@@ -13,6 +13,8 @@
 export {
   CONNECTOR_ID_PATTERN,
   isValidConnectorId,
+  persistableConnectorConfig,
+  redactConnectorConfigSecrets,
   type ConnectorConfig,
   type ConnectorCursor,
   type ConnectorDocument,

--- a/packages/remnic-core/src/connectors/live/live-connectors.test.ts
+++ b/packages/remnic-core/src/connectors/live/live-connectors.test.ts
@@ -6,6 +6,10 @@ import test from "node:test";
 
 import {
   CONNECTOR_ID_PATTERN,
+  createGitHubConnector,
+  createGmailConnector,
+  createGoogleDriveConnector,
+  createNotionConnector,
   type ConnectorConfig,
   type ConnectorCursor,
   type ConnectorDocument,
@@ -13,6 +17,8 @@ import {
   type LiveConnector,
   LiveConnectorRegistry,
   LiveConnectorRegistryError,
+  persistableConnectorConfig,
+  redactConnectorConfigSecrets,
   type SyncIncrementalArgs,
   type SyncIncrementalResult,
   isValidConnectorId,
@@ -21,6 +27,10 @@ import {
   withConnectorStateLock,
   writeConnectorState,
 } from "./index.js";
+import {
+  persistableConnectorConfig as persistableConnectorConfigFromRoot,
+  redactConnectorConfigSecrets as redactConnectorConfigSecretsFromRoot,
+} from "../../index.js";
 import {
   _connectorStatePathForTest,
   _refreshConnectorLockForTest,
@@ -120,6 +130,137 @@ test("isValidConnectorId rejects malformed ids", () => {
 test("CONNECTOR_ID_PATTERN matches isValidConnectorId", () => {
   assert.ok(CONNECTOR_ID_PATTERN.test("drive"));
   assert.ok(!CONNECTOR_ID_PATTERN.test("Drive"));
+});
+
+test("redactConnectorConfigSecrets removes nested secret-shaped keys", () => {
+  assert.deepEqual(
+    redactConnectorConfigSecrets({
+      endpoint: "https://example.invalid",
+      authorization: "Bearer synthetic-token",
+      authHeader: "Basic synthetic-credentials",
+      authorName: "kept",
+      nested: {
+        accessToken: "synthetic-token",
+        cookieHeader: "sid=synthetic-session",
+        publicLabel: "kept",
+      },
+      list: [
+        { clientSecret: "synthetic-secret", sessionCookie: "synthetic-cookie", label: "kept" },
+      ],
+    }),
+    {
+      endpoint: "https://example.invalid",
+      authorName: "kept",
+      nested: {
+        publicLabel: "kept",
+      },
+      list: [{ label: "kept" }],
+    }
+  );
+});
+
+test("persisted-config helpers are exported from the package root", () => {
+  assert.equal(persistableConnectorConfigFromRoot, persistableConnectorConfig);
+  assert.equal(redactConnectorConfigSecretsFromRoot, redactConnectorConfigSecrets);
+});
+
+test("built-in live connectors expose persistable config without credential material", () => {
+  const cases: Array<{
+    connector: LiveConnector;
+    raw: ConnectorConfig;
+    secretKeys: readonly string[];
+    secretValues: readonly string[];
+    expected: ConnectorConfig;
+  }> = [
+    {
+      connector: createGitHubConnector(),
+      raw: {
+        token: "synthetic-github-token",
+        userLogin: "octocat",
+        repos: ["owner/repo"],
+        pollIntervalMs: 300_000,
+        includeDiscussions: true,
+      },
+      secretKeys: ["token"],
+      secretValues: ["synthetic-github-token"],
+      expected: {
+        userLogin: "octocat",
+        repos: ["owner/repo"],
+        pollIntervalMs: 300_000,
+        includeDiscussions: true,
+      },
+    },
+    {
+      connector: createGmailConnector(),
+      raw: {
+        clientId: "synthetic-gmail-client-id",
+        clientSecret: "synthetic-gmail-client-secret",
+        refreshToken: "synthetic-gmail-refresh-token",
+        userId: "me",
+        query: "in:inbox",
+        pollIntervalMs: 300_000,
+      },
+      secretKeys: ["clientSecret", "refreshToken"],
+      secretValues: ["synthetic-gmail-client-secret", "synthetic-gmail-refresh-token"],
+      expected: {
+        clientId: "synthetic-gmail-client-id",
+        userId: "me",
+        query: "in:inbox",
+        pollIntervalMs: 300_000,
+      },
+    },
+    {
+      connector: createGoogleDriveConnector(),
+      raw: {
+        clientId: "synthetic-drive-client-id",
+        clientSecret: "synthetic-drive-client-secret",
+        refreshToken: "synthetic-drive-refresh-token",
+        folderIds: ["folder_12345678"],
+        pollIntervalMs: 300_000,
+      },
+      secretKeys: ["clientSecret", "refreshToken"],
+      secretValues: ["synthetic-drive-client-secret", "synthetic-drive-refresh-token"],
+      expected: {
+        clientId: "synthetic-drive-client-id",
+        folderIds: ["folder_12345678"],
+        pollIntervalMs: 300_000,
+      },
+    },
+    {
+      connector: createNotionConnector(),
+      raw: {
+        token: "secret_synthetic-notion-token",
+        databaseIds: ["0123456789abcdef0123456789abcdef"],
+        pollIntervalMs: 300_000,
+      },
+      secretKeys: ["token"],
+      secretValues: ["secret_synthetic-notion-token"],
+      expected: {
+        databaseIds: ["0123456789abcdef0123456789abcdef"],
+        pollIntervalMs: 300_000,
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    const runtimeConfig = testCase.connector.validateConfig(testCase.raw);
+    for (const key of testCase.secretKeys) {
+      assert.ok(key in runtimeConfig, `${testCase.connector.id} runtime config should keep ${key}`);
+    }
+
+    const persisted = persistableConnectorConfig(testCase.connector, runtimeConfig);
+    assert.deepEqual(persisted, testCase.expected);
+    const persistedJson = JSON.stringify(persisted);
+    for (const key of testCase.secretKeys) {
+      assert.ok(!(key in persisted), `${testCase.connector.id} persisted config should omit ${key}`);
+    }
+    for (const value of testCase.secretValues) {
+      assert.ok(
+        !persistedJson.includes(value),
+        `${testCase.connector.id} persisted config leaked ${value}`,
+      );
+    }
+  }
 });
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/connectors/live/notion.ts
+++ b/packages/remnic-core/src/connectors/live/notion.ts
@@ -643,6 +643,14 @@ export function createNotionConnector(
       return validateNotionConfig(raw) as unknown as ConnectorConfig;
     },
 
+    persistConfig(validated: ConnectorConfig): ConnectorConfig {
+      const config = validateNotionConfig(validated);
+      return Object.freeze({
+        databaseIds: config.databaseIds,
+        pollIntervalMs: config.pollIntervalMs,
+      });
+    },
+
     async syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult> {
       const config = validateNotionConfig(args.config);
       throwIfAborted(args.abortSignal);

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -794,6 +794,8 @@ export { coerceInstallExtension } from "./connectors/coerce.js";
 export {
   CONNECTOR_ID_PATTERN,
   isValidConnectorId,
+  persistableConnectorConfig,
+  redactConnectorConfigSecrets,
   LiveConnectorRegistry,
   LiveConnectorRegistryError,
   listConnectorStates,


### PR DESCRIPTION
## Summary
- Fixes ClawPatch high finding `fnd_sig-feat-library-ed6f735bab-e179_a71ebd3302` (live connector configs persisted raw credentials despite the no-secret contract).
- Adds a persistable connector config projection hook plus a default nested secret redactor.
- Projects built-in GitHub/Gmail/Google Drive/Notion live connector configs down to non-secret persisted fields while preserving runtime credential hydration.

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/connectors/live/live-connectors.test.ts`
- `npm run test:entity-hardening`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how connector settings are stored on disk and what sync receives at runtime; mis-wiring callers that still persist `validateConfig()` output would reintroduce credential leakage.
> 
> **Overview**
> **Separates runtime live-connector config from what may be written to disk**, addressing persistence of raw credentials despite the no-secret contract.
> 
> The live framework now treats `validateConfig()` output as **runtime-only** (may include hydrated secrets) and adds optional `persistConfig()` plus `persistableConnectorConfig()` / `redactConnectorConfigSecrets()` for safe persistence. Third-party connectors without `persistConfig` get a **nested key redactor** that drops secret-shaped field names (token, secret, password, etc.).
> 
> **GitHub, Gmail, Google Drive, and Notion** each implement `persistConfig()` to persist only non-secret scope/schedule fields (e.g. repos, `clientId`, folder/database ids, poll interval) while sync still uses full validated config at runtime.
> 
> Helpers are re-exported from `connectors/live` and `@remnic/core` root; tests cover redaction, package exports, and that built-in connectors’ persisted JSON omits secret keys and values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b343f4c7e2919b4cdb02e4692a90b621e912b968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->