### PR TITLE
fix(core): guard peer migration create-if-absent

### DIFF
--- a/packages/remnic-core/src/peers/index.ts
+++ b/packages/remnic-core/src/peers/index.ts
@@ -26,6 +26,7 @@ export {
   assertValidPeerId,
   readPeer,
   writePeer,
+  writePeerIfAbsent,
   deletePeer,
   forgetPeer,
   listPeers,

--- a/packages/remnic-core/src/peers/migrate-from-identity-anchor.test.ts
+++ b/packages/remnic-core/src/peers/migrate-from-identity-anchor.test.ts
@@ -289,3 +289,36 @@ test("symlinked identity parent directory is silently skipped (P1 codex fix)", a
   assert.equal(result.written, true, "migration should still succeed with no notes");
   assert.equal(result.peer.notes, undefined, "no notes from symlinked parent source");
 });
+
+test("migration rejects symlinked peers root without writing outside memoryDir", async () => {
+  const dir = await makeTempDir();
+  const outside = await makeTempDir();
+  await fs.symlink(outside, path.join(dir, "peers"));
+
+  await assert.rejects(
+    () => migrateFromIdentityAnchor({ memoryDir: dir }),
+    /peers root .*symlink/,
+  );
+
+  await assert.rejects(
+    () => fs.stat(path.join(outside, "self", "identity.md")),
+    /ENOENT/,
+  );
+});
+
+test("migration rejects symlinked peer directory without writing outside memoryDir", async () => {
+  const dir = await makeTempDir();
+  const outside = await makeTempDir();
+  await fs.mkdir(path.join(dir, "peers"), { recursive: true });
+  await fs.symlink(outside, path.join(dir, "peers", "self"));
+
+  await assert.rejects(
+    () => migrateFromIdentityAnchor({ memoryDir: dir }),
+    /peer directory "self" is a symlink/,
+  );
+
+  await assert.rejects(
+    () => fs.stat(path.join(outside, "identity.md")),
+    /ENOENT/,
+  );
+});

--- a/packages/remnic-core/src/peers/migrate-from-identity-anchor.ts
+++ b/packages/remnic-core/src/peers/migrate-from-identity-anchor.ts
@@ -47,13 +47,13 @@
  * All file reads use `path.join` relative to the caller-supplied
  * `memoryDir`. The migration never follows symlinks for the source files
  * (uses `lstat` to detect + skip them). Writes go through the standard
- * `writePeer` helper which enforces all path-traversal and symlink guards.
+ * peer storage helpers which enforce path-traversal and symlink guards.
  */
 
 import { promises as fs, constants as fsConstants } from "node:fs";
 import path from "node:path";
 
-import { readPeer, writePeer, PEERS_DIR_NAME } from "./storage.js";
+import { readPeer, writePeerIfAbsent } from "./storage.js";
 import type { Peer } from "./types.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -288,55 +288,22 @@ export async function migrateFromIdentityAnchor(
     ...(notes !== undefined ? { notes } : {}),
   };
 
-  // 4. Write (unless dry-run).
-  //
-  // P2 (codex): the previous readPeer-then-writePeer pattern had a
-  // check-then-act TOCTOU race: two concurrent `remnic peer migrate`
-  // processes could both observe "missing" and the later write would
-  // overwrite the file, violating the non-destructive / idempotent
-  // guarantee.
-  //
-  // Mitigation: before calling writePeer we attempt to exclusively create
-  // (O_CREAT | O_EXCL | O_NOFOLLOW) the identity file path. If the open
-  // succeeds we are the sole creator; close the handle immediately and let
-  // writePeer fill in the real content (it mkdirs + rewrites atomically).
-  // If O_EXCL fails with EEXIST, another process won the race — re-read the
-  // file and return `skipped`. The window between our exclusive open and the
-  // writePeer overwrite is deliberate: we've already locked out concurrent
-  // migrate calls via EEXIST, and `peer set self` targeting the same file
-  // path will succeed (it is a legitimate overwrite, not a migrate race).
+  // 4. Write (unless dry-run). Use the peer storage create-if-absent helper so
+  // migration gets the same root, peer-directory, parent-inode, and O_NOFOLLOW
+  // guards as writePeer while preserving the non-overwrite migration contract.
   if (!dryRun) {
-    const selfPeerDir = path.join(memoryDir, PEERS_DIR_NAME, "self");
-    await fs.mkdir(selfPeerDir, { recursive: true });
-    const identityFilePath = path.join(selfPeerDir, "identity.md");
-    let exclusiveFh: import("node:fs/promises").FileHandle | null = null;
-    try {
-      exclusiveFh = await fs.open(
-        identityFilePath,
-        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
-      );
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "EEXIST") {
-        // Another process created the file between our readPeer check and
-        // now. Re-read and return skipped.
-        const raceWinner = await readPeer(memoryDir, "self");
-        return {
-          peer: raceWinner ?? peer,
-          written: false,
-          skipped: true,
-          dryRun,
-          identityAnchorSource: null,
-          identityMdSource: null,
-        };
-      }
-      throw err;
-    } finally {
-      if (exclusiveFh !== null) await exclusiveFh.close();
+    const created = await writePeerIfAbsent(memoryDir, peer);
+    if (!created) {
+      const raceWinner = await readPeer(memoryDir, "self");
+      return {
+        peer: raceWinner ?? peer,
+        written: false,
+        skipped: true,
+        dryRun,
+        identityAnchorSource: null,
+        identityMdSource: null,
+      };
     }
-    // We hold the exclusive-create claim. Now writePeer fills in the
-    // real content (it calls mkdirPeerDirAtomic + writeFileNoFollow).
-    await writePeer(memoryDir, peer);
   }
 
   return {

--- a/packages/remnic-core/src/peers/peers.test.ts
+++ b/packages/remnic-core/src/peers/peers.test.ts
@@ -22,6 +22,7 @@ import {
   readPeer,
   readPeerProfile,
   writePeer,
+  writePeerIfAbsent,
   writePeerProfile,
   type Peer,
   type PeerInteractionLogEntry,
@@ -64,6 +65,52 @@ test("writePeer + readPeer round-trips identity", async () => {
   assert.equal(loaded.createdAt, peer.createdAt);
   assert.equal(loaded.updatedAt, peer.updatedAt);
   assert.equal(loaded.notes, "Initial identity kernel.");
+});
+
+test("writePeerIfAbsent creates once without overwriting existing identity", async () => {
+  const dir = await makeTempDir();
+  const first = samplePeer({ id: "self", displayName: "First" });
+  const second = samplePeer({ id: "self", displayName: "Second" });
+
+  assert.equal(await writePeerIfAbsent(dir, first), true);
+  assert.equal(await writePeerIfAbsent(dir, second), false);
+
+  const loaded = await readPeer(dir, "self");
+  assert.ok(loaded);
+  assert.equal(loaded.displayName, "First");
+});
+
+test("writePeerIfAbsent rejects symlinked peers root without writing outside memoryDir", async () => {
+  const dir = await makeTempDir();
+  const outside = await makeTempDir();
+  await fs.symlink(outside, path.join(dir, "peers"));
+
+  await assert.rejects(
+    () => writePeerIfAbsent(dir, samplePeer({ id: "self" })),
+    /peers root .*symlink/,
+  );
+
+  await assert.rejects(
+    () => fs.stat(path.join(outside, "self", "identity.md")),
+    /ENOENT/,
+  );
+});
+
+test("writePeerIfAbsent rejects symlinked peer directories", async () => {
+  const dir = await makeTempDir();
+  const outside = await makeTempDir();
+  await fs.mkdir(path.join(dir, "peers"), { recursive: true });
+  await fs.symlink(outside, path.join(dir, "peers", "self"));
+
+  await assert.rejects(
+    () => writePeerIfAbsent(dir, samplePeer({ id: "self" })),
+    /peer directory "self" is a symlink/,
+  );
+
+  await assert.rejects(
+    () => fs.stat(path.join(outside, "identity.md")),
+    /ENOENT/,
+  );
 });
 
 test("readPeer round-trips peers with quote/backslash characters in displayName", async () => {

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -96,6 +96,39 @@ async function writeFileNoFollow(file: string, data: string): Promise<void> {
   }
 }
 
+/**
+ * Create a file only when absent, refusing symlinks and non-regular existing
+ * targets. Returns false only for an existing regular file.
+ */
+async function writeFileNoFollowIfAbsent(file: string, data: string): Promise<boolean> {
+  await assertParentDirInodeStable(file);
+  let fh: import("node:fs/promises").FileHandle;
+  try {
+    fh = await openNoFollow(
+      file,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw err;
+    }
+    const existing = await fs.lstat(file);
+    if (existing.isSymbolicLink()) {
+      throw new Error(`refusing to create "${file}": target is a symlink`);
+    }
+    if (!existing.isFile()) {
+      throw new Error(`refusing to create "${file}": target is not a regular file`);
+    }
+    return false;
+  }
+  try {
+    await fh.writeFile(data, "utf8");
+  } finally {
+    await fh.close();
+  }
+  return true;
+}
+
 /** Append to a file, refusing to follow symlinks AND verifying parent
  * inode stability (codex P1 round 9). */
 async function appendFileNoFollow(file: string, data: string): Promise<void> {
@@ -470,6 +503,28 @@ function emitPeerIdentity(peer: Peer): string {
   return out + "\n";
 }
 
+function assertWritablePeer(peer: Peer): void {
+  assertValidPeerId(peer.id);
+  assertValidKind(peer.kind);
+  if (typeof peer.displayName !== "string") {
+    throw new Error("peer.displayName must be a string");
+  }
+  if (typeof peer.createdAt !== "string" || peer.createdAt === "") {
+    throw new Error("peer.createdAt must be a non-empty ISO-8601 string");
+  }
+  if (typeof peer.updatedAt !== "string" || peer.updatedAt === "") {
+    throw new Error("peer.updatedAt must be a non-empty ISO-8601 string");
+  }
+  // Codex P2 round 8: reject non-string `peer.notes`. Without this,
+  // an untyped JS caller passing an object/number would silently
+  // coerce to "[object Object]"/"42" via lines.push(notes ?? "")
+  // and corrupt user-authored identity content. Notes are optional;
+  // omit by passing undefined (NOT null).
+  if (peer.notes !== undefined && typeof peer.notes !== "string") {
+    throw new Error("peer.notes must be a string when provided");
+  }
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Public storage API
 // ──────────────────────────────────────────────────────────────────────
@@ -555,25 +610,7 @@ export async function readPeer(
  * later PRs — for the schema slice we simply write the file.
  */
 export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
-  assertValidPeerId(peer.id);
-  assertValidKind(peer.kind);
-  if (typeof peer.displayName !== "string") {
-    throw new Error("peer.displayName must be a string");
-  }
-  if (typeof peer.createdAt !== "string" || peer.createdAt === "") {
-    throw new Error("peer.createdAt must be a non-empty ISO-8601 string");
-  }
-  if (typeof peer.updatedAt !== "string" || peer.updatedAt === "") {
-    throw new Error("peer.updatedAt must be a non-empty ISO-8601 string");
-  }
-  // Codex P2 round 8: reject non-string `peer.notes`. Without this,
-  // an untyped JS caller passing an object/number would silently
-  // coerce to "[object Object]"/"42" via lines.push(notes ?? "")
-  // and corrupt user-authored identity content. Notes are optional;
-  // omit by passing undefined (NOT null).
-  if (peer.notes !== undefined && typeof peer.notes !== "string") {
-    throw new Error("peer.notes must be a string when provided");
-  }
+  assertWritablePeer(peer);
   // Codex P1 round 13: atomic root validation. Open the peers root
   // (or its parent if peers doesn't exist yet) with O_DIRECTORY|
   // O_NOFOLLOW BEFORE the mkdir. This holds a kernel handle on the
@@ -587,6 +624,25 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
   // Codex P1 #2: reject if identity.md exists as a symlink so we
   // don't follow it on overwrite.
   await writeFileNoFollow(file, emitPeerIdentity(peer));
+}
+
+/**
+ * Create a peer identity only if it is absent, applying the same root,
+ * peer-directory, parent-inode, and O_NOFOLLOW guards as writePeer.
+ *
+ * Returns true when this call created the identity file and false when a
+ * regular identity file already existed. Symlinked roots, peer directories,
+ * identity paths, and non-regular identity paths are rejected.
+ */
+export async function writePeerIfAbsent(
+  memoryDir: string,
+  peer: Peer,
+): Promise<boolean> {
+  assertWritablePeer(peer);
+  await mkdirPeerDirAtomic(memoryDir, peer.id);
+  await assertPeerDirNotEscaped(memoryDir, peer.id);
+  const file = identityPath(memoryDir, peer.id);
+  return await writeFileNoFollowIfAbsent(file, emitPeerIdentity(peer));
 }
 
 /**


### PR DESCRIPTION
## Summary\n- add a guarded writePeerIfAbsent storage primitive that shares peer root, peer directory, parent-inode, and O_NOFOLLOW protections with writePeer\n- route identity-anchor migration through the safe create-if-absent primitive instead of constructing peer identity paths directly\n- add regression coverage for symlinked peers roots and peer directories\n\nClawPatch finding: fnd_sig-feat-library-a34ea8f8a9-6655_a6e1aefb53\n\n## Verification\n- pnpm exec tsx --test packages/remnic-core/src/peers/peers.test.ts packages/remnic-core/src/peers/migrate-from-identity-anchor.test.ts\n- npm run test:entity-hardening\n- npm run preflight:quick\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem security boundaries for peer identity and migration; changes are defensive with regression tests for symlink escape paths.
> 
> **Overview**
> Adds **`writePeerIfAbsent`** to peer storage: create-only writes with the same guards as **`writePeer`** (peers root, peer dir, parent-inode stability, **`O_NOFOLLOW`**), plus a low-level **`writeFileNoFollowIfAbsent`** helper. Peer validation is centralized in **`assertWritablePeer`** and reused by **`writePeer`** and **`writePeerIfAbsent`**.
> 
> **`migrateFromIdentityAnchor`** no longer hand-rolls exclusive **`O_EXCL`** opens under **`peers/self`**; it calls **`writePeerIfAbsent`** so migration stays idempotent and race-safe while using the full storage hardening path.
> 
> New tests cover create-if-absent semantics, symlinked **`peers`** root / peer directories (no writes outside **`memoryDir`**), and the same rejection behavior for migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69de07575dfdede7d20b19b0fbbd76076ecf05a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->