### PR TITLE
fix(core): align secure-store migration aad root

### DIFF
--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -241,8 +241,7 @@ export async function readMaybeEncryptedFileBuffer(
         "Run `remnic secure-store unlock` to decrypt.",
     );
   }
-  const aad = filePathAad(filePath, memoryDir);
-  return decryptFileBody(buf, key, aad);
+  return decryptFileBodyForPath(buf, key, filePath, memoryDir);
 }
 
 export async function readMaybeEncryptedFile(
@@ -498,8 +497,7 @@ export async function decryptMemoryDirToPlaintext(
         continue;
       }
 
-      const aad = filePathAad(filePath, dir);
-      const plaintext = decryptFileBody(buf, key, aad);
+      const plaintext = decryptFileBodyForPath(buf, key, filePath, dir);
       const tempPath = uniqueAtomicTempPath(filePath, "dec-tmp");
       try {
         await writeFile(tempPath, plaintext, { mode: 0o600 });
@@ -530,6 +528,42 @@ export async function decryptMemoryDirToPlaintext(
 
 function uniqueAtomicTempPath(filePath: string, label: string): string {
   return `${filePath}.${label}-${process.pid}-${Date.now()}-${randomUUID()}`;
+}
+
+function decryptFileBodyForPath(
+  buf: Buffer,
+  key: Buffer,
+  filePath: string,
+  memoryDir?: string,
+): Buffer {
+  const aad = filePathAad(filePath, memoryDir);
+  try {
+    return decryptFileBody(buf, key, aad);
+  } catch (err) {
+    if (!(err instanceof SecureStoreDecryptError)) {
+      throw err;
+    }
+    const legacyRoot = legacyNamespaceAadRootForFile(filePath, memoryDir);
+    if (!legacyRoot) {
+      throw err;
+    }
+    try {
+      return decryptFileBody(buf, key, filePathAad(filePath, legacyRoot));
+    } catch {
+      throw err;
+    }
+  }
+}
+
+function legacyNamespaceAadRootForFile(filePath: string, memoryDir?: string): string | null {
+  if (!memoryDir || !path.isAbsolute(filePath)) return null;
+  const rel = path.relative(memoryDir, filePath);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  const parts = rel.split(path.sep);
+  if (parts[0] === "namespaces" && parts.length >= 3 && parts[1]) {
+    return path.join(memoryDir, "namespaces", parts[1]);
+  }
+  return null;
 }
 
 /**

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -544,15 +544,44 @@ function decryptFileBodyForPath(
       throw err;
     }
     const legacyRoot = legacyNamespaceAadRootForFile(filePath, memoryDir);
-    if (!legacyRoot) {
-      throw err;
+    if (legacyRoot) {
+      try {
+        return decryptFileBody(buf, key, filePathAad(filePath, legacyRoot));
+      } catch {
+        // Fall through to the namespace-reader fallback below.
+      }
     }
-    try {
-      return decryptFileBody(buf, key, filePathAad(filePath, legacyRoot));
-    } catch {
-      throw err;
+
+    const topLevelRoot = topLevelAadRootForNamespaceReader(filePath, memoryDir);
+    if (topLevelRoot) {
+      try {
+        return decryptFileBody(buf, key, filePathAad(filePath, topLevelRoot));
+      } catch {
+        // Preserve the caller-facing error from the canonical decrypt attempt.
+      }
     }
+
+    throw err;
   }
+}
+
+function topLevelAadRootForNamespaceReader(filePath: string, memoryDir?: string): string | null {
+  if (!memoryDir || !path.isAbsolute(filePath)) return null;
+  const resolvedMemoryDir = path.resolve(memoryDir);
+  const rel = path.relative(resolvedMemoryDir, filePath);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  const parts = resolvedMemoryDir.split(path.sep);
+  if (parts.length < 3 || parts.at(-2) !== "namespaces" || !parts.at(-1)) return null;
+  const topLevelRoot = parts.slice(0, -2).join(path.sep) || path.sep;
+  const topRel = path.relative(topLevelRoot, filePath);
+  if (topRel === "" || topRel.startsWith("..") || path.isAbsolute(topRel)) {
+    return null;
+  }
+  const topParts = topRel.split(path.sep);
+  if (topParts[0] !== "namespaces" || topParts[1] !== parts.at(-1)) {
+    return null;
+  }
+  return topLevelRoot;
 }
 
 function legacyNamespaceAadRootForFile(filePath: string, memoryDir?: string): string | null {

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -443,7 +443,7 @@ export async function migrateMemoryDirToEncrypted(
         }
       }
       const content = buf.toString("utf8");
-      const aad = filePathAad(filePath, storageAadRootForFile(filePath, dir));
+      const aad = filePathAad(filePath, dir);
       const encrypted = encryptFileBody(content, key, aad);
 
       // Atomic write: temp → rename (gotcha #54).
@@ -498,7 +498,7 @@ export async function decryptMemoryDirToPlaintext(
         continue;
       }
 
-      const aad = filePathAad(filePath, storageAadRootForFile(filePath, dir));
+      const aad = filePathAad(filePath, dir);
       const plaintext = decryptFileBody(buf, key, aad);
       const tempPath = uniqueAtomicTempPath(filePath, "dec-tmp");
       try {
@@ -609,16 +609,6 @@ function normalizeStorageRelativePath(rel: string): string {
     return parts.slice(2).join("/");
   }
   return normalized;
-}
-
-function storageAadRootForFile(filePath: string, rootDir: string): string {
-  const rel = path.relative(rootDir, filePath);
-  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return rootDir;
-  const parts = rel.split(path.sep);
-  if (parts[0] === "namespaces" && parts.length >= 3 && parts[1]) {
-    return path.join(rootDir, "namespaces", parts[1]);
-  }
-  return rootDir;
 }
 
 const ENCRYPTABLE_MARKDOWN_STORAGE_ROOTS = new Set([

--- a/packages/remnic-core/src/secure-store/secure-store.test.ts
+++ b/packages/remnic-core/src/secure-store/secure-store.test.ts
@@ -15,6 +15,9 @@
  */
 
 import { PassThrough } from "node:stream";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
 
@@ -42,6 +45,9 @@ import {
   MAGIC_BYTES,
   SecureStoreDecryptError,
   decryptFileBody,
+  decryptMemoryDirToPlaintext,
+  migrateMemoryDirToEncrypted,
+  readMaybeEncryptedFile,
 } from "./secure-fs.js";
 import {
   DEFAULT_ARGON2ID_PARAMS,
@@ -619,6 +625,32 @@ test("end-to-end: build metadata → derive key → seal → open round-trip", (
   const sealed = seal(key, recoveredSalt, Buffer.from("end-to-end"));
   const opened = open(key, sealed);
   assert.equal(opened.toString("utf8"), "end-to-end");
+});
+
+test("secure-store migration keeps namespaced file AAD readable through memory root", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-secure-store-aad-"));
+  try {
+    const filePath = path.join(memoryDir, "namespaces", "project-a", "facts", "note.md");
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, "namespaced fact", "utf8");
+
+    const key = deriveKeyScrypt("namespace-aad", Buffer.alloc(KDF_SALT_LENGTH, 0x44), FAST_SCRYPT);
+    const migrated = await migrateMemoryDirToEncrypted(memoryDir, key);
+
+    assert.equal(migrated.encrypted, 1);
+    assert.deepEqual(migrated.errors, []);
+    assert.equal(
+      await readMaybeEncryptedFile(filePath, key, memoryDir),
+      "namespaced fact",
+    );
+
+    const decrypted = await decryptMemoryDirToPlaintext(memoryDir, key);
+    assert.equal(decrypted.decrypted, 1);
+    assert.deepEqual(decrypted.errors, []);
+    assert.equal(await readFile(filePath, "utf8"), "namespaced fact");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });
 
 test("tampered envelope salt fails decryption (codex P1 — header AAD)", () => {

--- a/packages/remnic-core/src/secure-store/secure-store.test.ts
+++ b/packages/remnic-core/src/secure-store/secure-store.test.ts
@@ -46,6 +46,8 @@ import {
   SecureStoreDecryptError,
   decryptFileBody,
   decryptMemoryDirToPlaintext,
+  encryptFileBody,
+  filePathAad,
   migrateMemoryDirToEncrypted,
   readMaybeEncryptedFile,
 } from "./secure-fs.js";
@@ -648,6 +650,35 @@ test("secure-store migration keeps namespaced file AAD readable through memory r
     assert.equal(decrypted.decrypted, 1);
     assert.deepEqual(decrypted.errors, []);
     assert.equal(await readFile(filePath, "utf8"), "namespaced fact");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("secure-store can recover namespaced files encrypted with legacy namespace AAD", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-secure-store-legacy-aad-"));
+  try {
+    const namespaceRoot = path.join(memoryDir, "namespaces", "project-a");
+    const filePath = path.join(namespaceRoot, "facts", "note.md");
+    await mkdir(path.dirname(filePath), { recursive: true });
+
+    const key = deriveKeyScrypt("legacy-namespace-aad", Buffer.alloc(KDF_SALT_LENGTH, 0x55), FAST_SCRYPT);
+    const legacyEncrypted = encryptFileBody(
+      "legacy namespaced fact",
+      key,
+      filePathAad(filePath, namespaceRoot),
+    );
+    await writeFile(filePath, legacyEncrypted);
+
+    assert.equal(
+      await readMaybeEncryptedFile(filePath, key, memoryDir),
+      "legacy namespaced fact",
+    );
+
+    const decrypted = await decryptMemoryDirToPlaintext(memoryDir, key);
+    assert.equal(decrypted.decrypted, 1);
+    assert.deepEqual(decrypted.errors, []);
+    assert.equal(await readFile(filePath, "utf8"), "legacy namespaced fact");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- fix ClawPatch finding `fnd_sig-feat-service-e1b7f16da4-9c2c_427f01af3d`
- make secure-store migration/decryption use the same top-level memoryDir AAD root as documented reads/writes
- add a regression for migrated namespaced files remaining readable and decryptable

## Verification
- pnpm exec tsx --test packages/remnic-core/src/secure-store/secure-store.test.ts
- npm run test:entity-hardening
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes encryption binding and decrypt fallbacks for namespaced memory files; wrong AAD logic could lock data until fallbacks apply, but scope is limited to secure-store paths and is regression-tested.
> 
> **Overview**
> Aligns **secure-store** path-bound AAD so **bulk encrypt/decrypt** and normal reads use the same **top-level `memoryDir`** root, instead of a per-namespace AAD root that could break decrypt after migration.
> 
> **`migrateMemoryDirToEncrypted`** now seals namespaced files with `filePathAad(filePath, dir)` (full memory root). Reads and **`decryptMemoryDirToPlaintext`** go through **`decryptFileBodyForPath`**, which tries the canonical AAD first, then **legacy namespace-root** ciphertext and a **namespace-reader** top-level fallback when `memoryDir` sits under `namespaces/<id>`. **`storageAadRootForFile`** is removed.
> 
> Adds integration tests that migrated namespaced facts stay readable/decryptable and that files encrypted with the old namespace AAD still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e8e16828f9f8742aaf09409363e4a993adc4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->