### PR TITLE
Avoid offline sync mtime churn

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -2571,6 +2571,59 @@ test("offline snapshot apply defers volatile remote paths without changing local
   }
 });
 
+test("offline snapshot apply does not churn metadata for equivalent mtimes", async () => {
+  const root = await tempDir("remnic-offline-equivalent-mtime");
+  try {
+    const relPath = "facts/unchanged.md";
+    const content = Buffer.from("same content");
+    await write(root, relPath, content);
+    const filePath = path.join(root, relPath);
+    const baseTime = new Date("2026-05-31T00:00:00.000Z");
+    await utimes(filePath, baseTime, baseTime);
+    const before = await stat(filePath);
+    const sha256 = createHash("sha256").update(content).digest("hex");
+    const incomingMtimeMs = before.mtimeMs + 500;
+
+    const pull = await applyOfflineSyncSnapshot({
+      root,
+      currentFiles: [{
+        path: relPath,
+        sha256,
+        bytes: content.byteLength,
+        mtimeMs: before.mtimeMs,
+      }],
+      snapshot: {
+        format: "remnic.offline-sync.snapshot.v1",
+        schemaVersion: 1,
+        createdAt: new Date().toISOString(),
+        sourceId: "remote",
+        includeTranscripts: true,
+        files: [{
+          path: relPath,
+          sha256,
+          bytes: content.byteLength,
+          mtimeMs: incomingMtimeMs,
+        }],
+      },
+      baseFiles: [],
+    });
+
+    const after = await stat(filePath);
+    assert.equal(pull.upserted, 0);
+    assert.equal(pull.deleted, 0);
+    assert.equal(pull.skipped, 1);
+    assert.deepEqual(pull.nextBaseFiles, [{
+      path: relPath,
+      sha256,
+      bytes: content.byteLength,
+      mtimeMs: incomingMtimeMs,
+    }]);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("offline changeset validation reports client input errors with an offline sync prefix", async () => {
   const root = await tempDir("remnic-offline-invalid-changeset");
   try {

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -1517,7 +1517,11 @@ async function setSafeFileMtime(
   if (targetStat.isSymbolicLink()) {
     throw new Error(`offline sync target is a symlink: ${relPath}`);
   }
-  const mtime = new Date(assertOfflineSyncMtimeMs(mtimeMs, "mtimeMs"));
+  const targetMtimeMs = assertOfflineSyncMtimeMs(mtimeMs, "mtimeMs");
+  if (Math.abs(targetStat.mtimeMs - targetMtimeMs) <= OFFLINE_SYNC_FAST_BASE_MTIME_TOLERANCE_MS) {
+    return true;
+  }
+  const mtime = new Date(targetMtimeMs);
   await utimes(target, mtime, mtime);
   return true;
 }


### PR DESCRIPTION
## Summary
- avoid calling `utimes` during offline snapshot apply when the local file mtime is already within the sync tolerance
- add regression coverage proving equivalent mtimes do not churn file metadata
- format root `package.json` so the required quick preflight passes locally

## Why
An interrupted offline pull can bump ctime across the whole local base without updating `lastSyncedAt`. That poisons the fast-base check and forces the next status/watch cycle to rehash the entire offline cache even when content is unchanged.

## Verification
- `node --import tsx --test packages/remnic-core/src/offline-sync.test.ts`
- `npm run preflight:quick`
- live laptop status after runtime patch: pending.total=0, baseFileCount=155653, baseBytes=1742705986
- live watcher log: `[2026-06-02T17:53:33.489Z] sync ok: pushed=0, pulled=0, conflicts=0, deferred=0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted offline sync metadata optimization with regression coverage; no auth, data model, or API surface changes beyond sync bookkeeping behavior.
> 
> **Overview**
> **Offline snapshot apply** no longer calls `utimes` when the on-disk file’s mtime is already within the existing **1s fast-base tolerance** of the incoming metadata, so unchanged content is not forced through a metadata touch that bumps **ctime** and poisons later fast-base scans.
> 
> A regression test asserts that equivalent content with only small incoming **mtime** drift is skipped without changing local **mtime**, while **`nextBaseFiles`** still records the remote **mtime** for sync bookkeeping.
> 
> Root **`package.json`** is reformatted (single-line arrays) so quick preflight passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29401227b5b2d198c6b080d1b80697ad3e3a538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->