### PR TITLE
fix(pi): export manifest extension entry

### DIFF
--- a/packages/plugin-pi/package.json
+++ b/packages/plugin-pi/package.json
@@ -10,28 +10,20 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./dist/index.js": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
     "./publisher": {
       "import": "./dist/publisher.js",
       "types": "./dist/publisher.d.ts"
     }
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "pi": {
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
-  "keywords": [
-    "remnic",
-    "pi-package",
-    "pi",
-    "memory",
-    "ai-agent",
-    "coding-agent"
-  ],
+  "keywords": ["remnic", "pi-package", "pi", "memory", "ai-agent", "coding-agent"],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/plugin-pi/scripts/check-packed-imports.mjs
+++ b/packages/plugin-pi/scripts/check-packed-imports.mjs
@@ -15,6 +15,7 @@ try {
   const tarballPath = packPackage();
   packedFiles = new Set(listPackedFiles(tarballPath));
   assertPublishableDependencyRanges(tarballPath);
+  assertPiExtensionEntriesResolveFromPackedPackage(tarballPath);
 } finally {
   fs.rmSync(packRoot, { recursive: true, force: true });
 }
@@ -84,6 +85,69 @@ function assertPublishableDependencyRanges(tarballPath) {
         throw new Error(`Packed @remnic/plugin-pi ${section}.${name} uses non-publishable range ${range}`);
       }
     }
+  }
+}
+
+function assertPiExtensionEntriesResolveFromPackedPackage(tarballPath) {
+  const packageJson = JSON.parse(
+    execFileSync("tar", ["-xOf", tarballPath, "package/package.json"], { encoding: "utf8" })
+  );
+  const extensions = packageJson?.pi?.extensions;
+  if (!Array.isArray(extensions)) return;
+
+  const tempProject = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-plugin-pi-resolve-"));
+  try {
+    const installRoot = path.join(tempProject, "node_modules", ...packageJson.name.split("/"));
+    fs.mkdirSync(installRoot, { recursive: true });
+    execFileSync("tar", ["-xzf", tarballPath, "-C", installRoot, "--strip-components=1"]);
+
+    for (const extensionPath of extensions) {
+      const specifier = piManifestPathToPackageSpecifier(packageJson.name, extensionPath);
+      assertPackageSpecifierResolves(tempProject, specifier);
+    }
+  } finally {
+    fs.rmSync(tempProject, { recursive: true, force: true });
+  }
+}
+
+function piManifestPathToPackageSpecifier(packageName, manifestPath) {
+  if (typeof manifestPath !== "string" || manifestPath.length === 0) {
+    throw new Error(`Packed @remnic/plugin-pi pi.extensions entry must be a non-empty string: ${manifestPath}`);
+  }
+  if (manifestPath === ".") return packageName;
+  if (manifestPath.startsWith("!") || hasGlobPattern(manifestPath)) {
+    throw new Error(`Packed @remnic/plugin-pi pi.extensions entry must be an exact package path: ${manifestPath}`);
+  }
+  if (path.isAbsolute(manifestPath) || manifestPath.startsWith("..")) {
+    throw new Error(`Packed @remnic/plugin-pi pi.extensions entry must stay inside the package: ${manifestPath}`);
+  }
+
+  const packagePath = manifestPath.startsWith("./") ? manifestPath.slice(2) : manifestPath;
+  if (!packagePath || packagePath.startsWith("../") || packagePath.includes("/../")) {
+    throw new Error(`Packed @remnic/plugin-pi pi.extensions entry must stay inside the package: ${manifestPath}`);
+  }
+  return `${packageName}/${packagePath}`;
+}
+
+function hasGlobPattern(value) {
+  return /[*?[\]{}]/.test(value);
+}
+
+function assertPackageSpecifierResolves(cwd, specifier) {
+  try {
+    execFileSync(
+      process.execPath,
+      ["--input-type=module", "-e", "console.log(import.meta.resolve(process.env.SPECIFIER))"],
+      {
+        cwd,
+        env: { ...process.env, SPECIFIER: specifier },
+        encoding: "utf8",
+      }
+    );
+  } catch (err) {
+    throw new Error(`Packed @remnic/plugin-pi pi.extensions entry is not exported by package.json: ${specifier}`, {
+      cause: err,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- export the Pi manifest extension entry `./dist/index.js` through `@remnic/plugin-pi` package exports
- extend `check-packed-imports` so packed `pi.extensions` entries resolve through Node package export rules from an unpacked tarball

## ClawPatch
- Fixes `fnd_sig-feat-library-8d0e467c83-47a3_9c33212914` (Pi extension manifest points at a non-existent package entry)

## Verification
- `pnpm --filter @remnic/plugin-pi run check-packed-imports`
- `pnpm --filter @remnic/plugin-pi run check-types`
- `pnpm --filter @remnic/plugin-pi test` (63/63, exit 0)
- `pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/plugin-pi/package.json packages/plugin-pi/scripts/check-packed-imports.mjs`
- `git diff --check`
- `pnpm rebuild better-sqlite3`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and release-time validation only; no runtime auth, data, or agent logic changes.
> 
> **Overview**
> Fixes Pi failing to load the Remnic extension because the manifest points at `./dist/index.js`, which was not a valid **package export** subpath.
> 
> **`@remnic/plugin-pi`** now exposes `./dist/index.js` in `exports` (same entry as `.`), so Node’s resolver can load the path declared in `pi.extensions`. **`check-packed-imports`** unpacks the packed tarball into a temp install, maps each `pi.extensions` path to a package specifier, and asserts `import.meta.resolve` succeeds—catching missing exports before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b25ef6628896f12db2dcf57439fc41d7060915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->