### PR TITLE
fix(openclaw): declare typebox schema dependency

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -9,24 +9,15 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist",
-    "openclaw.plugin.json",
-    "scripts/faiss_index.py",
-    "scripts/faiss_requirements.txt"
-  ],
+  "files": ["dist", "openclaw.plugin.json", "scripts/faiss_index.py", "scripts/faiss_requirements.txt"],
   "publishConfig": {
     "access": "public",
     "provenance": true
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ],
-    "runtimeExtensions": [
-      "./dist/index.js"
-    ],
+    "extensions": ["./dist/index.js"],
+    "runtimeExtensions": ["./dist/index.js"],
     "compat": {
       "pluginApi": ">=2026.4.1 || 2026.4.7-1 || 2026.4.9-beta.1 || 2026.4.11-beta.1 || 2026.4.12-beta.1 || 2026.4.14-beta.1 || 2026.4.15-beta.1 || 2026.4.15-beta.2 || 2026.4.19-beta.1 || 2026.4.19-beta.2 || 2026.4.20-beta.1 || 2026.4.20-beta.2 || 2026.4.22-beta.1 || 2026.4.23-beta.1 || 2026.4.23-beta.2 || 2026.4.23-beta.3 || 2026.4.23-beta.4 || 2026.4.23-beta.5 || 2026.4.23-beta.6 || 2026.4.24-beta.1 || 2026.4.24-beta.2 || 2026.4.24-beta.3 || 2026.4.24-beta.4 || 2026.4.24-beta.5 || 2026.4.24-beta.6 || 2026.4.25-beta.1 || 2026.4.25-beta.2 || 2026.4.25-beta.3 || 2026.4.25-beta.4 || 2026.4.25-beta.5 || 2026.4.25-beta.6 || 2026.4.25-beta.7 || 2026.4.25-beta.8 || 2026.4.25-beta.9 || 2026.4.25-beta.10 || 2026.4.25-beta.11 || 2026.4.26-beta.1 || 2026.4.27-beta.1 || 2026.4.29-beta.1 || 2026.4.29-beta.2 || 2026.4.29-beta.3 || 2026.4.29-beta.4 || 2026.4.30-beta.1 || 2026.5.2-beta.1 || 2026.5.2-beta.2 || 2026.5.2-beta.3 || 2026.5.3-1 || 2026.5.3-beta.1 || 2026.5.3-beta.2 || 2026.5.3-beta.3 || 2026.5.3-beta.4 || 2026.5.4-beta.1 || 2026.5.4-beta.2 || 2026.5.4-beta.3 || 2026.5.5-beta.1 || 2026.5.5-beta.2 || 2026.5.6-beta.1 || 2026.5.7-beta.1 || 2026.5.9-beta.1 || 2026.5.10-beta.1 || 2026.5.10-beta.2 || 2026.5.10-beta.3 || 2026.5.10-beta.4 || 2026.5.10-beta.5 || 2026.5.10-beta.6 || 2026.5.12-beta.1 || 2026.5.12-beta.2 || 2026.5.12-beta.3 || 2026.5.12-beta.4 || 2026.5.12-beta.5 || 2026.5.12-beta.6 || 2026.5.12-beta.7 || 2026.5.12-beta.8 || 2026.5.14-beta.1 || 2026.5.14-beta.2 || 2026.5.16-beta.1 || 2026.5.16-beta.2 || 2026.5.16-beta.3 || 2026.5.16-beta.4 || 2026.5.16-beta.5 || 2026.5.16-beta.6 || 2026.5.16-beta.7 || 2026.5.18-beta.1 || 2026.5.19-alpha.1 || 2026.5.19-beta.1 || 2026.5.19-beta.2 || 2026.5.20-beta.1 || 2026.5.20-beta.2 || 2026.5.21-alpha.1 || 2026.5.21-beta.1 || 2026.5.22-beta.1 || 2026.5.23-alpha.1 || 2026.5.24-alpha.1 || 2026.5.24-beta.1 || 2026.5.24-beta.2 || 2026.5.25-alpha.1 || 2026.5.25-alpha.2 || 2026.5.25-beta.1 || 2026.5.26-beta.1 || 2026.5.26-beta.2 || 2026.5.27-alpha.1 || 2026.5.27-beta.1 || 2026.5.28-alpha.1 || 2026.5.28-beta.1 || 2026.5.28-beta.2 || 2026.5.28-beta.3 || 2026.5.28-beta.4 || 2026.5.29-alpha.1 || 2026.5.30-beta.1 || 2026.5.30-beta.2 || 2026.5.31-alpha.1 || 2026.5.31-beta.1 || 2026.5.31-beta.2 || 2026.5.31-beta.3 || 2026.5.31-beta.4 || 2026.6.1-alpha.1 || 2026.6.1-alpha.2 || 2026.6.1-alpha.3 || 2026.6.1-beta.1 || 2026.6.1-beta.2 || 2026.6.2-alpha.1"
     },
@@ -41,18 +32,9 @@
       "minHostVersion": ">=2026.4.1"
     },
     "environment": {
-      "externalServices": [
-        "openclaw-gateway-models",
-        "configured-llm-providers"
-      ],
-      "optionalEnv": [
-        "OPENAI_API_KEY",
-        "<PROVIDER>_API_KEY",
-        "<PROVIDER>_TOKEN"
-      ],
-      "configPaths": [
-        "~/.openclaw/agents/main/agent/models.json"
-      ],
+      "externalServices": ["openclaw-gateway-models", "configured-llm-providers"],
+      "optionalEnv": ["OPENAI_API_KEY", "<PROVIDER>_API_KEY", "<PROVIDER>_TOKEN"],
+      "configPaths": ["~/.openclaw/agents/main/agent/models.json"],
       "credentialSources": [
         "OpenClaw runtime auth resolver",
         "OpenClaw materialized provider model config",
@@ -78,6 +60,7 @@
   },
   "dependencies": {
     "@remnic/core": "workspace:^",
+    "@sinclair/typebox": "^0.34.0",
     "openai": "^6.0.0"
   },
   "peerDependencies": {
@@ -96,11 +79,5 @@
     "url": "https://github.com/joshuaswarren/remnic.git",
     "directory": "packages/plugin-openclaw"
   },
-  "keywords": [
-    "remnic",
-    "memory",
-    "openclaw",
-    "adapter",
-    "plugin"
-  ]
+  "keywords": ["remnic", "memory", "openclaw", "adapter", "plugin"]
 }

--- a/packages/plugin-openclaw/src/package-boundary.test.ts
+++ b/packages/plugin-openclaw/src/package-boundary.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readdir, readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 
@@ -9,9 +9,7 @@ const sourceRoot = path.join(packageRoot, "src");
 test("OpenClaw plugin imports Remnic core through package exports", async () => {
   const violations: string[] = [];
   const forbiddenCoreSourcePattern = new RegExp(
-    String.raw`(?:^|['"])` +
-      String.raw`(?:\.\./)+` +
-      String.raw`(?:packages/)?remnic-core/src(?:/|\.|['"])`,
+    String.raw`(?:^|['"])` + String.raw`(?:\.\./)+` + String.raw`(?:packages/)?remnic-core/src(?:/|\.|['"])`
   );
 
   for (const filePath of await listTypeScriptFiles(sourceRoot)) {
@@ -25,44 +23,44 @@ test("OpenClaw plugin imports Remnic core through package exports", async () => 
 });
 
 test("OpenClaw plugin type-check config resolves @remnic/core to one source surface", async () => {
-  const tsconfig = await readFile(
-    path.join(packageRoot, "tsconfig.check.json"),
-    "utf8",
-  );
+  const tsconfig = await readFile(path.join(packageRoot, "tsconfig.check.json"), "utf8");
   const config = JSON.parse(tsconfig) as {
     compilerOptions?: { paths?: Record<string, unknown> };
   };
   const paths = config.compilerOptions?.paths ?? {};
-  assert.deepEqual(paths["@remnic/core"], [
-    "packages/remnic-core/src/index.ts",
-  ]);
-  assert.deepEqual(paths["@remnic/core/*"], [
-    "packages/remnic-core/src/*",
-  ]);
+  assert.deepEqual(paths["@remnic/core"], ["packages/remnic-core/src/index.ts"]);
+  assert.deepEqual(paths["@remnic/core/*"], ["packages/remnic-core/src/*"]);
 
   for (const [key, value] of Object.entries(paths)) {
     if (key === "@remnic/core" || key.startsWith("@remnic/core/")) {
       assert.ok(
         Array.isArray(value) &&
-          value.every((entry) =>
-            typeof entry === "string" &&
-            entry.startsWith("packages/remnic-core/src/"),
-          ),
+          value.every((entry) => typeof entry === "string" && entry.startsWith("packages/remnic-core/src/"))
       );
     }
   }
 });
 
 test("OpenClaw plugin source manifest keeps @remnic/core workspace-linked", async () => {
-  const manifest = JSON.parse(
-    await readFile(path.join(packageRoot, "package.json"), "utf8"),
-  ) as {
+  const manifest = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8")) as {
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
   };
 
   assert.equal(manifest.dependencies?.["@remnic/core"], "workspace:^");
   assert.equal(manifest.devDependencies?.["@remnic/core"], "workspace:^");
+});
+
+test("OpenClaw plugin declares runtime schema dependencies", async () => {
+  const manifest = JSON.parse(await readFile(path.join(packageRoot, "package.json"), "utf8")) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  const shapesSource = await readFile(path.join(sourceRoot, "openclaw-tools", "shapes.ts"), "utf8");
+
+  assert.match(shapesSource, /from "@sinclair\/typebox"/);
+  assert.equal(manifest.dependencies?.["@sinclair/typebox"], "^0.34.0");
+  assert.equal(manifest.devDependencies?.["@sinclair/typebox"], undefined);
 });
 
 async function listTypeScriptFiles(directory: string): Promise<string[]> {
@@ -77,7 +75,7 @@ async function listTypeScriptFiles(directory: string): Promise<string[]> {
         return [entryPath];
       }
       return [];
-    }),
+    })
   );
   return files.flat().sort();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
+      '@sinclair/typebox':
+        specifier: ^0.34.0
+        version: 0.34.49
       openai:
         specifier: ^6.0.0
         version: 6.33.0(zod@4.0.0)


### PR DESCRIPTION
## Summary
- declare @sinclair/typebox as a runtime dependency of @remnic/plugin-openclaw
- add a package-boundary regression test that ties the schema runtime import to the package manifest

## ClawPatch
- fixes fnd_sig-feat-library-f2433b77e7-b50e_af0dff6147: Runtime schema dependency is not declared by the package

## Verification
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin pnpm exec tsx --test packages/plugin-openclaw/src/package-boundary.test.ts
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin pnpm --filter @remnic/plugin-openclaw run check-types
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/plugin-openclaw/package.json packages/plugin-openclaw/src/package-boundary.test.ts pnpm-lock.yaml biome.json eslint.config.js package.json
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin npm run preflight:quick

Note: this fresh worktree required PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin pnpm rebuild better-sqlite3 before the final preflight rerun; before rebuild, test:openclaw-scenarios failed 7/7 with missing better-sqlite3 native bindings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and test-only changes; no auth, data, or tool behavior logic modified.
> 
> **Overview**
> **@remnic/plugin-openclaw** now lists **`@sinclair/typebox`** (`^0.34.0`) as a **runtime** dependency in `package.json`, with **`pnpm-lock.yaml`** updated so installs resolve TypeBox when the plugin is published or installed outside the monorepo. That matches the existing import in **`openclaw-tools/shapes.ts`**, which was using TypeBox without declaring it on the package.
> 
> A new **`package-boundary`** test asserts that `shapes.ts` imports `@sinclair/typebox`, that the version appears only under **`dependencies`** (not **`devDependencies`**), preventing the same “undeclared runtime schema lib” issue from regressing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e46d1c71c33a1b50b68d593ab67cfd8a9141450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->