### PR TITLE
Treat QMD recall state as remote-authoritative offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/offline-sync.test.ts
+++ b/packages/remnic-core/src/offline-sync.test.ts
@@ -213,6 +213,7 @@ test("offline sync includes live LCM sqlite artifacts for full-fidelity offline 
     ]);
     assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/lcm.sqlite-shm"), true);
     assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/lcm.sqlite-wal"), true);
+    assert.equal(shouldPreferIncomingOfflineRuntimeFile("state/last_qmd_recall.json"), true);
     const focused = await buildOfflineSyncSnapshotForPaths({
       root,
       sourceId: "remote",

--- a/packages/remnic-core/src/offline-sync.ts
+++ b/packages/remnic-core/src/offline-sync.ts
@@ -488,6 +488,7 @@ const REMOTE_AUTHORITATIVE_RUNTIME_STATE_FILES = new Set([
   "embeddings.json",
   "index_time.json",
   "last_intent.json",
+  "last_qmd_recall.json",
   "last_recall.json",
   "lcm.sqlite-shm",
   "lcm.sqlite-wal",


### PR DESCRIPTION
## Summary
- Classify QMD recall state snapshots as remote-authoritative runtime state during offline sync.
- Prevent volatile recall metadata from producing persistent conflicts between any offline Remnic client and its upstream Remnic server.
- Keep the rebased root package manifest formatted so the merged head passes the quality gate.
- Add regression coverage for the QMD recall state path.

## Verification
- `node --import tsx --test packages/remnic-core/src/offline-sync.test.ts`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted addition to an existing runtime-state allowlist with a unit test; no auth or data-model changes.
> 
> **Overview**
> Treats **`state/last_qmd_recall.json`** like other **remote-authoritative** offline runtime state (alongside `last_intent.json`, `last_recall.json`, `buffer.json`, etc.).
> 
> On **pull**, the server snapshot wins over divergent local QMD recall metadata; on **push**, local changes to that file are not sent. That aligns QMD recall debug state with the existing offline sync model and avoids spurious **both_modified** conflicts when clients and the upstream server each update recall metadata independently.
> 
> Adds a regression check that `shouldPreferIncomingOfflineRuntimeFile("state/last_qmd_recall.json")` is true. Root **`package.json`** changes are formatting-only (single-line array literals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccd844d69f36ed06532181c5b8e0b5b9399b7c1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->