### PR TITLE
fix(migration): validate rollback manifest paths

### DIFF
--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -29,12 +29,19 @@ interface RollbackManifestEntry {
   targetPath: string;
   backupPath?: string;
   createdByMigration?: boolean;
+  contentHash?: string;
 }
 
 interface RollbackManifest {
   version: 1;
   createdAt: string;
   entries: RollbackManifestEntry[];
+}
+
+interface ValidatedRollbackManifestEntry extends RollbackManifestEntry {
+  targetPath: string;
+  backupPath?: string;
+  contentHash?: string;
 }
 
 export interface MigrationOptions {
@@ -134,6 +141,14 @@ function defaultRollbackCommand(): string {
   return "remnic migrate --rollback";
 }
 
+function resolveMigrationCwd(options?: MigrationOptions): string {
+  return path.resolve(options?.cwd ?? process.cwd());
+}
+
+function resolveConnectorConfigPath(candidate: string, cwd: string): string {
+  return path.isAbsolute(candidate) ? path.resolve(candidate) : path.resolve(cwd, candidate);
+}
+
 async function ensureParent(filePath: string): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
 }
@@ -145,6 +160,10 @@ async function secureTokenFilePermissions(filePath: string): Promise<void> {
 async function writeOwnerOnlyFile(filePath: string, content: string): Promise<void> {
   await writeFile(filePath, content, { encoding: "utf8", mode: TOKEN_STORE_MODE });
   await chmod(filePath, TOKEN_STORE_MODE);
+}
+
+async function fileContentHash(filePath: string): Promise<string> {
+  return createHash("sha256").update(await readFile(filePath)).digest("hex");
 }
 
 async function writeTokenStoreFile(filePath: string, content: string): Promise<void> {
@@ -271,6 +290,221 @@ function parseTokenEntries(raw: unknown): TokenEntry[] {
 
 function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseRollbackManifestEntry(raw: unknown, index: number): RollbackManifestEntry {
+  if (!isPlainJsonObject(raw)) {
+    throw new Error(`rollback manifest entry ${index} must be an object`);
+  }
+  if (typeof raw.targetPath !== "string" || raw.targetPath.length === 0 || !path.isAbsolute(raw.targetPath)) {
+    throw new Error(`rollback manifest entry ${index} has an invalid targetPath`);
+  }
+  if (raw.backupPath !== undefined && (typeof raw.backupPath !== "string" || raw.backupPath.length === 0 || !path.isAbsolute(raw.backupPath))) {
+    throw new Error(`rollback manifest entry ${index} has an invalid backupPath`);
+  }
+  if (raw.createdByMigration !== undefined && typeof raw.createdByMigration !== "boolean") {
+    throw new Error(`rollback manifest entry ${index} has an invalid createdByMigration flag`);
+  }
+  if (raw.contentHash !== undefined && (typeof raw.contentHash !== "string" || !/^[a-f0-9]{64}$/u.test(raw.contentHash))) {
+    throw new Error(`rollback manifest entry ${index} has an invalid contentHash`);
+  }
+  return {
+    targetPath: raw.targetPath,
+    ...(raw.backupPath === undefined ? {} : { backupPath: raw.backupPath }),
+    ...(raw.createdByMigration === undefined ? {} : { createdByMigration: raw.createdByMigration }),
+    ...(raw.contentHash === undefined ? {} : { contentHash: raw.contentHash }),
+  };
+}
+
+function parseRollbackManifest(raw: unknown, manifestPath: string): RollbackManifest {
+  if (!isPlainJsonObject(raw)) {
+    throw new Error(`rollback manifest must be an object: ${manifestPath}`);
+  }
+  if (raw.version !== 1) {
+    throw new Error(`rollback manifest has unsupported version: ${manifestPath}`);
+  }
+  if (typeof raw.createdAt !== "string") {
+    throw new Error(`rollback manifest has an invalid createdAt: ${manifestPath}`);
+  }
+  if (!Array.isArray(raw.entries)) {
+    throw new Error(`rollback manifest entries must be an array: ${manifestPath}`);
+  }
+  return {
+    version: 1,
+    createdAt: raw.createdAt,
+    entries: raw.entries.map(parseRollbackManifestEntry),
+  };
+}
+
+function isPathInside(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function isPathDescendant(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function hasConnectorConfigShape(targetPath: string, homeDir: string): boolean {
+  const relative = path.relative(path.resolve(homeDir), path.resolve(targetPath));
+  if (relative === ".claude.json" || relative === path.join(".claude", ".mcp.json")) {
+    return true;
+  }
+
+  return hasRepoConnectorConfigShape(relative);
+}
+
+function hasRepoConnectorConfigShape(relativePath: string): boolean {
+  const parts = relativePath.split(path.sep);
+  const last = parts.at(-1);
+  const packageName = parts.at(-2);
+  const packagesDir = parts.at(-3);
+  return last === ".mcp.json" &&
+    packagesDir === "packages" &&
+    (packageName === "plugin-claude-code" || packageName === "plugin-codex");
+}
+
+function connectorBackupPathForTarget(targetPath: string, homeDir: string): string {
+  const digest = createHash("sha256").update(targetPath).digest("hex").slice(0, 12);
+  return path.join(backupRoot(homeDir), "mcp", `${digest}.json`);
+}
+
+function isRollbackTargetAllowed(
+  entry: RollbackManifestEntry,
+  targetPath: string,
+  homeDir: string,
+  options?: MigrationOptions,
+): boolean {
+  const resolvedTarget = path.resolve(targetPath);
+  if (isPathDescendant(remnicRoot(homeDir), resolvedTarget)) {
+    if (entry.createdByMigration && !entry.backupPath) return true;
+    return Boolean(entry.backupPath) && isRemnicTokenStorePath(resolvedTarget, homeDir);
+  }
+  if (isPathDescendant(path.join(homeDir, ".config", "remnic"), resolvedTarget)) {
+    return entry.createdByMigration === true && !entry.backupPath;
+  }
+
+  const serviceTargets = new Set([
+    path.resolve(path.join(homeDir, "Library", "LaunchAgents", "ai.remnic.daemon.plist")),
+    path.resolve(path.join(homeDir, ".config", "systemd", "user", "remnic.service")),
+  ]);
+  if (serviceTargets.has(resolvedTarget)) return true;
+
+  const cwd = resolveMigrationCwd(options);
+  const allowedConnectorPaths = new Set(
+    [
+      ...defaultConnectorConfigPaths(homeDir, cwd),
+      ...(options?.connectorConfigPaths ?? []),
+    ].map((candidate) => resolveConnectorConfigPath(candidate, cwd)),
+  );
+  if (allowedConnectorPaths.has(resolvedTarget)) return true;
+
+  return isPathInside(homeDir, resolvedTarget) && hasConnectorConfigShape(resolvedTarget, homeDir);
+}
+
+function isRollbackBackupAllowed(backupPath: string, homeDir: string): boolean {
+  return isPathInside(backupRoot(homeDir), backupPath);
+}
+
+async function assertNoSymlinkPathSegments(filePath: string, trustedRoot: string, label: string): Promise<void> {
+  const resolvedPath = path.resolve(filePath);
+  const resolvedRoot = path.resolve(trustedRoot);
+  if (!isPathInside(resolvedRoot, resolvedPath)) {
+    throw new Error(`${label} is outside the trusted rollback root: ${filePath}`);
+  }
+  const segments = path.relative(resolvedRoot, resolvedPath).split(path.sep).filter(Boolean);
+  let current = resolvedRoot;
+
+  for (const [index, segment] of segments.entries()) {
+    current = path.join(current, segment);
+    try {
+      const currentStat = await lstat(current);
+      if (currentStat.isSymbolicLink()) {
+        throw new Error(`${label} must not contain symlink segments: ${filePath}`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT" && index === segments.length - 1) return;
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new Error(`${label} must not contain missing parent segments: ${filePath}`);
+      }
+      throw error;
+    }
+  }
+}
+
+function rollbackTargetSymlinkRoot(targetPath: string, homeDir: string, options?: MigrationOptions): string {
+  if (isPathInside(homeDir, targetPath)) return homeDir;
+
+  const cwd = resolveMigrationCwd(options);
+  if (isPathInside(cwd, targetPath)) return cwd;
+
+  return path.parse(targetPath).root;
+}
+
+async function validateRollbackManifestEntries(
+  manifest: RollbackManifest,
+  homeDir: string,
+  options?: MigrationOptions,
+): Promise<ValidatedRollbackManifestEntry[]> {
+  const validated: ValidatedRollbackManifestEntry[] = [];
+
+  for (const entry of manifest.entries) {
+    const targetPath = path.resolve(entry.targetPath);
+    if (!isRollbackTargetAllowed(entry, targetPath, homeDir, options)) {
+      throw new Error(`rollback manifest target is outside migration-owned paths: ${entry.targetPath}`);
+    }
+    if (entry.backupPath && entry.createdByMigration) {
+      throw new Error(`rollback manifest entry cannot restore and remove the same target: ${entry.targetPath}`);
+    }
+    const targetExists = await pathExistsNoFollow(targetPath);
+    if (!entry.createdByMigration || targetExists) {
+      const targetSymlinkRoot = rollbackTargetSymlinkRoot(targetPath, homeDir, options);
+      await assertNoSymlinkPathSegments(targetPath, targetSymlinkRoot, "rollback manifest target");
+    }
+    if (entry.createdByMigration && targetExists) {
+      await assertCreatedRollbackTargetMatchesRecord(entry, targetPath);
+    }
+
+    let backupPath: string | undefined;
+    if (entry.backupPath) {
+      backupPath = path.resolve(entry.backupPath);
+      if (!isRollbackBackupAllowed(backupPath, homeDir)) {
+        throw new Error(`rollback manifest backup is outside migration backup storage: ${entry.backupPath}`);
+      }
+      if (await pathExistsNoFollow(backupPath)) {
+        await assertNoSymlinkPathSegments(backupPath, homeDir, "rollback manifest backup");
+        await assertExistingRegularFileNoFollow(backupPath, "rollback manifest backup");
+      }
+      if (backupPath !== connectorBackupPathForTarget(targetPath, homeDir)) {
+        throw new Error(`rollback manifest backup does not match target: ${entry.targetPath}`);
+      }
+    }
+
+    validated.push({
+      targetPath,
+      ...(backupPath === undefined ? {} : { backupPath }),
+      ...(entry.createdByMigration === undefined ? {} : { createdByMigration: entry.createdByMigration }),
+      ...(entry.contentHash === undefined ? {} : { contentHash: entry.contentHash }),
+    });
+  }
+
+  return validated;
+}
+
+async function assertCreatedRollbackTargetMatchesRecord(
+  entry: RollbackManifestEntry,
+  targetPath: string,
+): Promise<boolean> {
+  const targetStat = await lstat(targetPath);
+  if (targetStat.isDirectory()) {
+    throw new Error(`rollback manifest created target must be a file path: ${entry.targetPath}`);
+  }
+  if (!targetStat.isFile() || !entry.contentHash) return false;
+  if (await fileContentHash(targetPath) !== entry.contentHash) {
+    throw new Error(`rollback manifest created target content does not match migration record: ${entry.targetPath}`);
+  }
+  return true;
 }
 
 async function rewriteTokensIfPresent(filePath: string): Promise<number> {
@@ -461,8 +695,7 @@ async function backupFile(
   if (manifest.entries.some((entry) => entry.targetPath === targetPath && entry.backupPath)) {
     return;
   }
-  const digest = createHash("sha256").update(targetPath).digest("hex").slice(0, 12);
-  const backupPath = path.join(backupRoot(homeDir), "mcp", `${digest}.json`);
+  const backupPath = connectorBackupPathForTarget(targetPath, homeDir);
   await ensureParent(backupPath);
   if (isRemnicTokenStorePath(targetPath, homeDir)) {
     await writeOwnerOnlyFile(backupPath, originalContent);
@@ -481,7 +714,24 @@ async function recordCreatedPath(
   persistManifest?: PersistRollbackManifest,
 ): Promise<void> {
   if (manifest.entries.some((entry) => entry.targetPath === filePath)) return;
-  manifest.entries.push({ targetPath: filePath, createdByMigration: true });
+  manifest.entries.push({
+    targetPath: filePath,
+    createdByMigration: true,
+    contentHash: await fileContentHash(filePath),
+  });
+  await persistManifest?.();
+}
+
+async function refreshCreatedPathHash(
+  filePath: string,
+  manifest: RollbackManifest,
+  persistManifest?: PersistRollbackManifest,
+): Promise<void> {
+  const entry = manifest.entries.find((candidate) =>
+    candidate.targetPath === filePath && candidate.createdByMigration
+  );
+  if (!entry) return;
+  entry.contentHash = await fileContentHash(filePath);
   await persistManifest?.();
 }
 
@@ -504,8 +754,9 @@ async function updateConnectorConfigs(
   const updated: string[] = [];
   const candidates = options?.connectorConfigPaths ?? defaultConnectorConfigPaths(homeDir, cwd);
   for (const targetPath of candidates) {
-    if (await rewriteJsonFile(targetPath, homeDir, manifest, persistManifest)) {
-      updated.push(targetPath);
+    const resolvedTarget = resolveConnectorConfigPath(targetPath, cwd);
+    if (await rewriteJsonFile(resolvedTarget, homeDir, manifest, persistManifest)) {
+      updated.push(resolvedTarget);
     }
   }
   return updated;
@@ -616,12 +867,26 @@ async function writeRollbackManifest(homeDir: string, manifest: RollbackManifest
 
 async function readRollbackManifest(homeDir: string): Promise<RollbackManifest | null> {
   const target = rollbackManifestPath(homeDir);
-  if (!existsSync(target)) return null;
+  let targetStat: Awaited<ReturnType<typeof lstat>>;
   try {
-    return JSON.parse(await readFile(target, "utf8")) as RollbackManifest;
+    targetStat = await lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  if (targetStat.isSymbolicLink()) {
+    throw new Error(`rollback manifest must not be a symlink: ${target}`);
+  }
+  if (!targetStat.isFile()) {
+    throw new Error(`rollback manifest must be a regular file: ${target}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(target, "utf8")) as unknown;
   } catch {
     return null;
   }
+  return parseRollbackManifest(parsed, target);
 }
 
 async function acquireLock(homeDir: string): Promise<() => Promise<void>> {
@@ -699,6 +964,7 @@ export async function rollbackFromEngramMigration(options?: MigrationOptions): P
   const removed: string[] = [];
 
   if (!manifest) return { restored, removed };
+  const entries = await validateRollbackManifestEntries(manifest, homeDir, options);
 
   if (platform === "darwin") {
     const remnicPlist = path.join(homeDir, "Library", "LaunchAgents", "ai.remnic.daemon.plist");
@@ -718,8 +984,10 @@ export async function rollbackFromEngramMigration(options?: MigrationOptions): P
     }
   }
 
-  for (const entry of [...manifest.entries].reverse()) {
-    if (entry.backupPath && existsSync(entry.backupPath)) {
+  for (const entry of [...entries].reverse()) {
+    if (entry.backupPath && await pathExistsNoFollow(entry.backupPath)) {
+      await assertNoSymlinkPathSegments(entry.backupPath, homeDir, "rollback manifest backup");
+      await assertExistingRegularFileNoFollow(entry.backupPath, "rollback manifest backup");
       await ensureParent(entry.targetPath);
       await copyFile(entry.backupPath, entry.targetPath);
       if (isRemnicTokenStorePath(entry.targetPath, homeDir)) {
@@ -729,6 +997,9 @@ export async function rollbackFromEngramMigration(options?: MigrationOptions): P
       continue;
     }
     if (entry.createdByMigration && existsSync(entry.targetPath)) {
+      const targetSymlinkRoot = rollbackTargetSymlinkRoot(entry.targetPath, homeDir, options);
+      await assertNoSymlinkPathSegments(entry.targetPath, targetSymlinkRoot, "rollback manifest target");
+      if (!await assertCreatedRollbackTargetMatchesRecord(entry, entry.targetPath)) continue;
       await rm(entry.targetPath, { recursive: true, force: true });
       removed.push(entry.targetPath);
     }
@@ -749,7 +1020,7 @@ export async function rollbackFromEngramMigration(options?: MigrationOptions): P
 
 export async function migrateFromEngram(options?: MigrationOptions): Promise<MigrationResult> {
   const homeDir = resolveMigrationHome(options);
-  const cwd = options?.cwd ?? process.cwd();
+  const cwd = resolveMigrationCwd(options);
   const logger = resolveLogger(options);
   const copied: string[] = [];
   let tokensRegenerated = 0;
@@ -806,6 +1077,7 @@ export async function migrateFromEngram(options?: MigrationOptions): Promise<Mig
     const remnicTokens = path.join(remnicRoot(homeDir), "tokens.json");
     if (copied.includes(remnicTokens)) {
       tokensRegenerated += await rewriteTokensIfPresent(remnicTokens);
+      await refreshCreatedPathHash(remnicTokens, manifest, persistManifest);
     } else {
       tokensRegenerated += await mergeLegacyTokens(
         legacyTokens,

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { chmod, mkdtemp, mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, symlinkSync } from "node:fs";
 import {
   migrateFromEngram,
   rollbackFromEngramMigration,
@@ -12,6 +13,11 @@ import {
 
 async function makeTempHome(prefix: string): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+function rollbackBackupPathForTarget(homeDir: string, targetPath: string): string {
+  const digest = createHash("sha256").update(targetPath).digest("hex").slice(0, 12);
+  return path.join(homeDir, ".remnic", ".backup", "mcp", `${digest}.json`);
 }
 
 async function makeExitedPid(): Promise<number> {
@@ -845,6 +851,63 @@ test("rollbackFromEngramMigration restores backed up connector configs and remov
   await assertFileMode(claudeConfig, 0o644);
 });
 
+test("rollbackFromEngramMigration restores repo connector configs from a different cwd", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-repo-rollback-home-");
+  const rollbackCwd = await makeTempHome("remnic-migrate-repo-rollback-other-cwd-");
+  const repoRoot = path.join(homeDir, "repo");
+  const migrationCwd = path.relative(process.cwd(), repoRoot);
+  const externalConfig = path.join(repoRoot, "packages", "plugin-codex", ".mcp.json");
+  const legacyRoot = path.join(homeDir, ".engram");
+
+  await mkdir(legacyRoot, { recursive: true });
+  await mkdir(path.dirname(externalConfig), { recursive: true });
+  await writeFile(path.join(legacyRoot, "tokens.json"), JSON.stringify({ tokens: [] }), "utf8");
+  await writeFile(
+    externalConfig,
+    JSON.stringify({
+      mcpServers: {
+        engram: {
+          headers: {
+            Authorization: "Bearer {{ENGRAM_TOKEN}}",
+          },
+        },
+      },
+    }),
+    "utf8",
+  );
+
+  await migrateFromEngram({
+    homeDir,
+    cwd: migrationCwd,
+    quiet: true,
+  });
+
+  const manifest = JSON.parse(await readFile(path.join(homeDir, ".remnic", ".rollback.json"), "utf8")) as {
+    entries: Array<{ targetPath: string; backupPath?: string }>;
+  };
+  const configEntry = manifest.entries.find((entry) => entry.targetPath === externalConfig);
+  assert.ok(configEntry?.backupPath, "expected connector config backup in rollback manifest");
+
+  const migratedConfig = JSON.parse(await readFile(externalConfig, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+  assert.ok(migratedConfig.mcpServers.remnic);
+  assert.equal(migratedConfig.mcpServers.engram, undefined);
+
+  const rollback = await rollbackFromEngramMigration({
+    homeDir,
+    cwd: rollbackCwd,
+    quiet: true,
+  });
+
+  assert.ok(rollback.restored.includes(externalConfig));
+  const restoredConfig = JSON.parse(await readFile(externalConfig, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+  assert.ok(restoredConfig.mcpServers.engram);
+  assert.equal(restoredConfig.mcpServers.remnic, undefined);
+});
+
 test("rollbackFromEngramMigration removes files created from first-run legacy copies", async () => {
   const homeDir = await makeTempHome("remnic-migrate-created-rollback-");
   const legacyRoot = path.join(homeDir, ".engram");
@@ -911,6 +974,418 @@ test("rollbackFromEngramMigration removes files created from first-run legacy co
   assert.equal(existsSync(remnicLogPath), false);
   assert.equal(existsSync(remnicConfig), false);
   assert.equal(existsSync(path.join(homeDir, ".remnic", ".migrated-from-engram")), false);
+});
+
+test("rollbackFromEngramMigration rejects forged targets outside migration-owned paths before side effects", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-forged-rollback-");
+  const outsideDir = await makeTempHome("remnic-migrate-forged-target-");
+  const outsideFile = path.join(outsideDir, "keep.txt");
+  const remnicPlist = path.join(homeDir, "Library", "LaunchAgents", "ai.remnic.daemon.plist");
+  const execCalls: Array<{ command: string; args: string[] }> = [];
+
+  await mkdir(path.join(homeDir, ".remnic"), { recursive: true });
+  await mkdir(path.dirname(remnicPlist), { recursive: true });
+  await writeFile(outsideFile, "keep\n", "utf8");
+  await writeFile(remnicPlist, "<plist>ai.remnic.daemon</plist>", "utf8");
+  await writeFile(
+    path.join(homeDir, ".remnic", ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: outsideFile, createdByMigration: true }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({
+      homeDir,
+      quiet: true,
+      platform: "darwin",
+      execCommand: (command, args) => execCalls.push({ command, args }),
+    }),
+    /rollback manifest target is outside migration-owned paths/,
+  );
+
+  assert.equal(await readFile(outsideFile, "utf8"), "keep\n");
+  assert.equal(existsSync(remnicPlist), true);
+  assert.deepEqual(execCalls, []);
+});
+
+test("rollbackFromEngramMigration rejects forged root directory removals before side effects", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-root-rollback-");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const remnicData = path.join(remnicRoot, "tokens.json");
+  const remnicPlist = path.join(homeDir, "Library", "LaunchAgents", "ai.remnic.daemon.plist");
+  const execCalls: Array<{ command: string; args: string[] }> = [];
+
+  await mkdir(remnicRoot, { recursive: true });
+  await mkdir(path.dirname(remnicPlist), { recursive: true });
+  await writeFile(remnicData, "keep\n", "utf8");
+  await writeFile(remnicPlist, "<plist>ai.remnic.daemon</plist>", "utf8");
+  await writeFile(
+    path.join(remnicRoot, ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: remnicRoot, createdByMigration: true }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({
+      homeDir,
+      quiet: true,
+      platform: "darwin",
+      execCommand: (command, args) => execCalls.push({ command, args }),
+    }),
+    /rollback manifest target is outside migration-owned paths/,
+  );
+
+  assert.equal(await readFile(remnicData, "utf8"), "keep\n");
+  assert.equal(existsSync(remnicPlist), true);
+  assert.deepEqual(execCalls, []);
+});
+
+test("rollbackFromEngramMigration skips unhashed created-file removals", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-forged-created-file-");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const remnicTokens = path.join(remnicRoot, "tokens.json");
+
+  await mkdir(remnicRoot, { recursive: true });
+  await writeFile(remnicTokens, "keep\n", "utf8");
+  await writeFile(
+    path.join(remnicRoot, ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: remnicTokens, createdByMigration: true }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const rollback = await rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true });
+
+  assert.equal(await readFile(remnicTokens, "utf8"), "keep\n");
+  assert.deepEqual(rollback.removed, []);
+});
+
+test("rollbackFromEngramMigration rejects created-file removals with mismatched hashes", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-created-hash-mismatch-");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const remnicTokens = path.join(remnicRoot, "tokens.json");
+
+  await mkdir(remnicRoot, { recursive: true });
+  await writeFile(remnicTokens, "keep\n", "utf8");
+  await writeFile(
+    path.join(remnicRoot, ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{
+        targetPath: remnicTokens,
+        createdByMigration: true,
+        contentHash: "0".repeat(64),
+      }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true }),
+    /rollback manifest created target content does not match migration record/,
+  );
+
+  assert.equal(await readFile(remnicTokens, "utf8"), "keep\n");
+});
+
+test("rollbackFromEngramMigration rejects entries that both restore and remove a target", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-restore-remove-rollback-");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const targetPath = path.join(remnicRoot, "tokens.json");
+  const backupPath = path.join(remnicRoot, ".backup", "mcp", "tokens.json");
+
+  await mkdir(path.dirname(backupPath), { recursive: true });
+  await writeFile(targetPath, "keep\n", "utf8");
+  await writeFile(backupPath, "backup\n", "utf8");
+  await writeFile(
+    path.join(remnicRoot, ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath, backupPath, createdByMigration: true }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true }),
+    /rollback manifest entry cannot restore and remove the same target/,
+  );
+
+  assert.equal(await readFile(targetPath, "utf8"), "keep\n");
+});
+
+test("rollbackFromEngramMigration rejects created directory rollback targets", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-created-dir-rollback-");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const remnicLogs = path.join(remnicRoot, "logs");
+  const remnicLog = path.join(remnicLogs, "daemon.log");
+
+  await mkdir(remnicLogs, { recursive: true });
+  await writeFile(remnicLog, "keep\n", "utf8");
+  await writeFile(
+    path.join(remnicRoot, ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: remnicLogs, createdByMigration: true }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true }),
+    /rollback manifest created target must be a file path/,
+  );
+
+  assert.equal(await readFile(remnicLog, "utf8"), "keep\n");
+});
+
+test("rollbackFromEngramMigration skips missing created rollback targets", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-missing-created-rollback-");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const missingLog = path.join(remnicRoot, "logs", "daemon.log");
+
+  await mkdir(remnicRoot, { recursive: true });
+  await writeFile(
+    path.join(remnicRoot, ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: missingLog, createdByMigration: true }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const rollback = await rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true });
+
+  assert.deepEqual(rollback.removed, []);
+  assert.equal(existsSync(path.join(remnicRoot, ".rollback.json")), false);
+});
+
+test("rollbackFromEngramMigration rejects symlinked rollback backup paths", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-backup-symlink-");
+  const targetConfig = path.join(homeDir, ".claude.json");
+  const outsideBackup = path.join(homeDir, "outside-backup.json");
+  const backupLink = rollbackBackupPathForTarget(homeDir, targetConfig);
+
+  await mkdir(path.dirname(backupLink), { recursive: true });
+  await writeFile(targetConfig, "current\n", "utf8");
+  await writeFile(outsideBackup, "forged\n", "utf8");
+  await symlink(outsideBackup, backupLink);
+  await writeFile(
+    path.join(homeDir, ".remnic", ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: targetConfig, backupPath: backupLink }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true }),
+    /rollback manifest backup must not contain symlink segments/,
+  );
+
+  assert.equal(await readFile(targetConfig, "utf8"), "current\n");
+});
+
+test("rollbackFromEngramMigration rejects rollback backups paired with the wrong target", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-backup-pairing-");
+  const targetConfig = path.join(homeDir, ".claude.json");
+  const otherConfig = path.join(homeDir, ".claude", ".mcp.json");
+  const mismatchedBackup = rollbackBackupPathForTarget(homeDir, otherConfig);
+
+  await mkdir(path.dirname(otherConfig), { recursive: true });
+  await mkdir(path.dirname(mismatchedBackup), { recursive: true });
+  await writeFile(targetConfig, "current\n", "utf8");
+  await writeFile(otherConfig, "other-current\n", "utf8");
+  await writeFile(mismatchedBackup, "other-backup\n", "utf8");
+  await writeFile(
+    path.join(homeDir, ".remnic", ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: targetConfig, backupPath: mismatchedBackup }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true }),
+    /rollback manifest backup does not match target/,
+  );
+
+  assert.equal(await readFile(targetConfig, "utf8"), "current\n");
+  assert.equal(await readFile(otherConfig, "utf8"), "other-current\n");
+});
+
+test("rollbackFromEngramMigration rejects forged Remnic-root restore targets", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-forged-remnic-restore-");
+  const remnicRoot = path.join(homeDir, ".remnic");
+  const targetPath = path.join(remnicRoot, "arbitrary.json");
+  const backupPath = rollbackBackupPathForTarget(homeDir, targetPath);
+
+  await mkdir(path.dirname(backupPath), { recursive: true });
+  await writeFile(targetPath, "current\n", "utf8");
+  await writeFile(backupPath, "forged\n", "utf8");
+  await writeFile(
+    path.join(remnicRoot, ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath, backupPath }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true }),
+    /rollback manifest target is outside migration-owned paths/,
+  );
+
+  assert.equal(await readFile(targetPath, "utf8"), "current\n");
+});
+
+test("rollbackFromEngramMigration rechecks backup paths before restoring", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-backup-race-");
+  const targetConfig = path.join(homeDir, ".claude.json");
+  const backupPath = rollbackBackupPathForTarget(homeDir, targetConfig);
+  const outsideBackup = path.join(homeDir, "outside-backup.json");
+  const remnicPlist = path.join(homeDir, "Library", "LaunchAgents", "ai.remnic.daemon.plist");
+
+  await mkdir(path.dirname(backupPath), { recursive: true });
+  await mkdir(path.dirname(remnicPlist), { recursive: true });
+  await writeFile(targetConfig, "current\n", "utf8");
+  await writeFile(outsideBackup, "forged\n", "utf8");
+  await writeFile(remnicPlist, "plist\n", "utf8");
+  await writeFile(
+    path.join(homeDir, ".remnic", ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: targetConfig, backupPath }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({
+      homeDir,
+      cwd: homeDir,
+      platform: "darwin",
+      quiet: true,
+      execCommand: () => {
+        if (!existsSync(backupPath)) {
+          symlinkSync(outsideBackup, backupPath);
+        }
+      },
+    }),
+    /rollback manifest backup must not contain symlink segments/,
+  );
+
+  assert.equal(await readFile(targetConfig, "utf8"), "current\n");
+});
+
+test("rollbackFromEngramMigration rejects rollback targets with missing parent segments", async () => {
+  const homeDir = await makeTempHome("remnic-migrate-target-missing-parent-");
+  const cwd = await makeTempHome("remnic-migrate-missing-parent-repo-");
+  const targetConfig = path.join(cwd, "packages", "plugin-codex", ".mcp.json");
+  const backupPath = rollbackBackupPathForTarget(homeDir, targetConfig);
+
+  await mkdir(path.dirname(backupPath), { recursive: true });
+  await writeFile(backupPath, "backup\n", "utf8");
+  await writeFile(
+    path.join(homeDir, ".remnic", ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: targetConfig, backupPath }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd, quiet: true }),
+    /rollback manifest target must not contain missing parent segments/,
+  );
+
+  assert.equal(existsSync(targetConfig), false);
+});
+
+test("rollbackFromEngramMigration rejects symlinked cwd connector target segments", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-target-segment-symlink-");
+  const cwd = await makeTempHome("remnic-migrate-repo-");
+  const attackerRoot = path.join(homeDir, "attacker-packages");
+  const attackerConfig = path.join(attackerRoot, "plugin-codex", ".mcp.json");
+  const targetConfig = path.join(cwd, "packages", "plugin-codex", ".mcp.json");
+  const backupPath = path.join(homeDir, ".remnic", ".backup", "mcp", "forged.json");
+
+  await mkdir(path.dirname(attackerConfig), { recursive: true });
+  await mkdir(path.dirname(backupPath), { recursive: true });
+  await writeFile(attackerConfig, "attacker-current\n", "utf8");
+  await writeFile(backupPath, "forged-backup\n", "utf8");
+  await symlink(attackerRoot, path.join(cwd, "packages"));
+  await writeFile(
+    path.join(homeDir, ".remnic", ".rollback.json"),
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [{ targetPath: targetConfig, backupPath }],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd, quiet: true }),
+    /rollback manifest target must not contain symlink segments/,
+  );
+
+  assert.equal(await readFile(attackerConfig, "utf8"), "attacker-current\n");
+});
+
+test("rollbackFromEngramMigration rejects symlinked rollback manifests", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-manifest-symlink-");
+  const externalManifest = path.join(homeDir, "external-rollback.json");
+  const rollbackManifest = path.join(homeDir, ".remnic", ".rollback.json");
+
+  await mkdir(path.dirname(rollbackManifest), { recursive: true });
+  await writeFile(
+    externalManifest,
+    `${JSON.stringify({
+      version: 1,
+      createdAt: new Date().toISOString(),
+      entries: [],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  await symlink(externalManifest, rollbackManifest);
+
+  await assert.rejects(
+    () => rollbackFromEngramMigration({ homeDir, cwd: homeDir, quiet: true }),
+    /rollback manifest must not be a symlink/,
+  );
 });
 
 test("migration retry preserves rollback entries created before a failed first run", async () => {


### PR DESCRIPTION
ClawPatch finding: fnd_sig-feat-library-10121b507d-7a11_f642444014

Fixes high finding `Rollback can overwrite arbitrary paths from a tampered manifest`.

Changes:
- validate rollback manifest shape and normalize entries before rollback side effects
- constrain rollback targets to Remnic-owned migration paths or explicit connector config paths
- reject symlinked manifest files and symlinked rollback backup/target path segments
- add rollback regression tests for forged targets and symlink paths

Verification:
- `pnpm exec tsx --test tests/remnic-migration.test.ts`
- `pnpm --filter @remnic/core run check-types`
- `git diff --check origin/main..HEAD`
- `npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes rollback file I/O and deletion guards for a security finding; incorrect allowlisting could block legitimate rollbacks or still leave edge cases, but behavior is heavily test-covered.
> 
> **Overview**
> Hardens Engram→Remnic **rollback** so a tampered `.rollback.json` cannot restore or delete arbitrary paths. Rollback now **parses and validates** manifest entries **before** launchctl/systemd or file operations run.
> 
> **Allowlists** targets to migration-owned paths: Remnic data (with stricter rules for restores vs created files), config under `~/.config/remnic`, known service units, and connector configs (home + repo `packages/*/plugin-*/.mcp.json`), with **cwd-aware** resolution so repo configs still roll back when `cwd` differs from migrate time.
> 
> **Symlink and integrity checks** reject symlinked manifests, symlink segments on targets/backups, backup/target path pairing mismatches, and invalid entry shapes (e.g. restore+remove same path, directory “created” targets). **Created-by-migration** removals require a recorded **SHA-256 `contentHash`** (recorded/updated during migrate); missing or mismatched hashes skip or fail instead of deleting user data.
> 
> Adds broad regression tests for forged manifests, symlink races, and cross-cwd connector rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1406afe8ea8cb446cf471361269ae75e6635c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->