### PR TITLE
fix(maintenance): archive observations atomically

### DIFF
--- a/packages/remnic-core/src/maintenance/archive-observations.ts
+++ b/packages/remnic-core/src/maintenance/archive-observations.ts
@@ -1,13 +1,17 @@
 import path from "node:path";
-import { lstat, mkdir, readdir, readFile, realpath, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readdir, readFile, realpath, unlink } from "node:fs/promises";
+import { writeFileAtomically } from "./atomic-file.js";
 
 const DATE_FILE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})\.(jsonl|md)$/;
+
+type ArchiveFileWriter = (archivePath: string, content: Uint8Array) => Promise<void>;
 
 export interface ArchiveObservationsOptions {
   memoryDir: string;
   retentionDays?: number;
   dryRun?: boolean;
   now?: Date;
+  archiveFileWriter?: ArchiveFileWriter;
 }
 
 export interface ArchiveObservationsResult {
@@ -41,6 +45,10 @@ function extractDateFromFilename(name: string): Date | null {
 
 function startOfUtcDay(value: Date): number {
   return Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate());
+}
+
+async function writeArchiveFileAtomically(archivePath: string, content: Uint8Array): Promise<void> {
+  await writeFileAtomically(archivePath, content);
 }
 
 async function listFilesRecursive(root: string, relPrefix = ""): Promise<string[]> {
@@ -125,6 +133,7 @@ export async function archiveObservations(
   );
   const stamp = now.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
   const archiveRoot = path.join(options.memoryDir, "archive", "observations", stamp);
+  const archiveFileWriter = options.archiveFileWriter ?? writeArchiveFileAtomically;
   const candidates =
     retentionDays === 0
       ? []
@@ -146,7 +155,11 @@ export async function archiveObservations(
       const candidateInfo = await lstat(candidate.absolutePath).catch(() => null);
       if (!candidateInfo?.isFile() || candidateInfo.isSymbolicLink()) continue;
       const raw = await readFile(candidate.absolutePath);
-      await writeFile(archivePath, raw);
+      await archiveFileWriter(archivePath, raw);
+      const archivedRaw = await readFile(archivePath);
+      if (!archivedRaw.equals(raw)) {
+        throw new Error(`Archive copy verification failed for ${candidate.relativePath}`);
+      }
       await unlink(candidate.absolutePath);
       archivedFiles += 1;
       archivedBytes += raw.byteLength;

--- a/packages/remnic-core/src/maintenance/atomic-file.ts
+++ b/packages/remnic-core/src/maintenance/atomic-file.ts
@@ -36,7 +36,7 @@ export async function copyExistingFileToBackup(
 
 export async function writeFileAtomically(
   outputPath: string,
-  content: string,
+  content: string | Uint8Array,
   backupPath?: string,
 ): Promise<string | undefined> {
   const dir = path.dirname(outputPath);
@@ -46,7 +46,11 @@ export async function writeFileAtomically(
   let resolvedBackupPath: string | undefined;
   try {
     handle = await open(tempPath, "w");
-    await handle.writeFile(content, "utf-8");
+    if (typeof content === "string") {
+      await handle.writeFile(content, "utf-8");
+    } else {
+      await handle.writeFile(content);
+    }
     await handle.sync();
     await handle.close();
     handle = undefined;

--- a/tests/archive-observations.test.ts
+++ b/tests/archive-observations.test.ts
@@ -61,6 +61,30 @@ test("archiveObservations copies then removes old observation artifacts", async 
   }
 });
 
+test("archiveObservations preserves source when archived copy verification fails", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-archive-observations-partial-"));
+  const oldTranscript = "transcripts/main/default/2026-01-01.jsonl";
+  await createFile(memoryDir, oldTranscript, "{\"role\":\"user\",\"content\":\"keep me\"}\n");
+
+  await assert.rejects(
+    () =>
+      archiveObservations({
+        memoryDir,
+        now: new Date("2026-02-26T00:00:00.000Z"),
+        retentionDays: 14,
+        dryRun: false,
+        archiveFileWriter: async (archivePath, content) => {
+          await mkdir(path.dirname(archivePath), { recursive: true });
+          await writeFile(archivePath, content.subarray(0, 8));
+        },
+      }),
+    /Archive copy verification failed/,
+  );
+
+  const source = await readFile(path.join(memoryDir, oldTranscript), "utf-8");
+  assert.equal(source, "{\"role\":\"user\",\"content\":\"keep me\"}\n");
+});
+
 test("archiveObservations skips symlinked roots outside memoryDir", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-archive-observations-symlink-memory-"));
   const outsideDir = await mkdtemp(path.join(os.tmpdir(), "engram-archive-observations-symlink-outside-"));


### PR DESCRIPTION
## Summary
- copy archived observation files through the atomic file writer before deleting sources
- verify archived bytes match the source before unlinking the source file
- add a regression test that simulates a partial archive copy and asserts the source remains

## ClawPatch
- Fixes fnd_sig-feat-library-f24be41b7a-7a69_bc5b32ad21

## Verification
- pnpm exec tsx --test tests/archive-observations.test.ts
- pnpm --filter @remnic/core run check-types
- pnpm run lint
- git diff --check
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 212159c370e0bc92909a9f8bd2db30ac92a2a40b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->