### PR TITLE
fix(cli): reject unverified daemon pids

### DIFF
--- a/packages/remnic-cli/src/daemon-service.test.ts
+++ b/packages/remnic-cli/src/daemon-service.test.ts
@@ -271,7 +271,7 @@ test("readVerifiedDaemonPid accepts a live remnic-server command", () => {
   assert.deepEqual(removed, []);
 });
 
-test("readVerifiedDaemonPid keeps a live pid when command lookup is inconclusive", () => {
+test("readVerifiedDaemonPid rejects a live pid when command lookup is inconclusive", () => {
   const removed: string[] = [];
   const pid = readVerifiedDaemonPid({
     pidFiles: ["/tmp/remnic.pid"],
@@ -290,8 +290,59 @@ test("readVerifiedDaemonPid keeps a live pid when command lookup is inconclusive
     },
   });
 
-  assert.equal(pid, 34567);
+  assert.equal(pid, undefined);
+  assert.deepEqual(removed, ["/tmp/remnic.pid"]);
+});
+
+test("readVerifiedDaemonPid accepts a Windows daemon pid via PowerShell command lookup", () => {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const removed: string[] = [];
+  const pid = readVerifiedDaemonPid({
+    pidFiles: ["C:\\Temp\\remnic.pid"],
+    expectedServerBin: "C:\\repo\\packages\\remnic-server\\bin\\remnic-server.js",
+    platform: "win32",
+    readFileSync: () => "45678\n",
+    processKill: () => true,
+    execFileSync: (command, args) => {
+      calls.push({ command, args: [...args] });
+      assert.equal(command, "powershell.exe");
+      assert.ok(args.includes("-Command"));
+      return "node C:\\repo\\packages\\remnic-server\\bin\\remnic-server.js\n";
+    },
+    unlinkSync: (file) => {
+      removed.push(file);
+    },
+  });
+
+  assert.equal(pid, 45678);
   assert.deepEqual(removed, []);
+  assert.equal(calls[0]?.command, "powershell.exe");
+});
+
+test("readVerifiedDaemonPid falls back to WMIC when PowerShell lookup is unavailable", () => {
+  const calls: string[] = [];
+  const removed: string[] = [];
+  const pid = readVerifiedDaemonPid({
+    pidFiles: ["C:\\Temp\\remnic.pid"],
+    expectedServerBin: "C:\\repo\\packages\\remnic-server\\bin\\remnic-server.js",
+    platform: "win32",
+    readFileSync: () => "56789\n",
+    processKill: () => true,
+    execFileSync: (command) => {
+      calls.push(command);
+      if (command !== "wmic") {
+        throw new Error([command, "unavailable"].join(" "));
+      }
+      return "CommandLine=node C:\\repo\\packages\\remnic-server\\bin\\remnic-server.js\r\n";
+    },
+    unlinkSync: (file) => {
+      removed.push(file);
+    },
+  });
+
+  assert.equal(pid, 56789);
+  assert.deepEqual(removed, []);
+  assert.deepEqual(calls, ["powershell.exe", "powershell", "pwsh", "wmic"]);
 });
 
 test("doesProcessCommandLookLikeRemnicDaemon recognizes package and workspace server paths", () => {

--- a/packages/remnic-cli/src/daemon-service.ts
+++ b/packages/remnic-cli/src/daemon-service.ts
@@ -55,6 +55,7 @@ export interface LaunchctlProcess {
 export interface ReadVerifiedDaemonPidOptions {
   pidFiles: readonly string[];
   expectedServerBin: string;
+  platform?: NodeJS.Platform;
   readFileSync?: (file: string, encoding: BufferEncoding) => string;
   unlinkSync?: (file: string) => void;
   processKill?: (pid: number, signal?: NodeJS.Signals | 0) => boolean;
@@ -162,6 +163,7 @@ export function readVerifiedDaemonPid(
   const readFileSync = options.readFileSync ?? fs.readFileSync;
   const unlinkSync = options.unlinkSync ?? fs.unlinkSync;
   const processKill = options.processKill ?? process.kill;
+  const platform = options.platform ?? process.platform;
   const execFileSync =
     options.execFileSync ??
     ((command, args, execOptions) =>
@@ -185,9 +187,10 @@ export function readVerifiedDaemonPid(
       continue;
     }
 
-    const command = readProcessCommand(pid, execFileSync);
+    const command = readProcessCommand(pid, execFileSync, platform);
     if (command === undefined) {
-      return pid;
+      removePidFileBestEffort(file, unlinkSync);
+      continue;
     }
     if (
       doesProcessCommandLookLikeRemnicDaemon(command, options.expectedServerBin)
@@ -223,12 +226,64 @@ function parseDaemonPid(raw: string): number | undefined {
 function readProcessCommand(
   pid: number,
   execFileSync: NonNullable<ReadVerifiedDaemonPidOptions["execFileSync"]>,
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (platform === "win32") {
+    return readWindowsProcessCommand(pid, execFileSync);
+  }
+  return readPosixProcessCommand(pid, execFileSync);
+}
+
+function readPosixProcessCommand(
+  pid: number,
+  execFileSync: NonNullable<ReadVerifiedDaemonPidOptions["execFileSync"]>,
 ): string | undefined {
   try {
     return execFileSync("ps", ["-p", String(pid), "-o", "command="], {
       encoding: "utf8",
       stdio: "pipe",
     });
+  } catch {
+    return undefined;
+  }
+}
+
+function readWindowsProcessCommand(
+  pid: number,
+  execFileSync: NonNullable<ReadVerifiedDaemonPidOptions["execFileSync"]>,
+): string | undefined {
+  const powerShellCommand =
+    `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; ` +
+    "if ($null -ne $process) { $process.CommandLine }";
+  for (const command of ["powershell.exe", "powershell", "pwsh"]) {
+    try {
+      const output = execFileSync(
+        command,
+        ["-NoProfile", "-NonInteractive", "-Command", powerShellCommand],
+        {
+          encoding: "utf8",
+          stdio: "pipe",
+        },
+      );
+      if (output.trim() !== "") {
+        return output;
+      }
+    } catch {
+      // Try the next Windows command-inspection mechanism.
+    }
+  }
+
+  try {
+    const output = execFileSync(
+      "wmic",
+      ["process", "where", ["processid", String(pid)].join("="), "get", "CommandLine", "/value"],
+      {
+        encoding: "utf8",
+        stdio: "pipe",
+      },
+    );
+    const match = /^CommandLine=(.*)$/m.exec(output);
+    return match?.[1];
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- treat failed process-command inspection as an unverified daemon PID
- remove the stale pidfile instead of accepting any live process with that PID
- update daemon-service coverage for inconclusive command lookup

## ClawPatch
- Fixes finding `fnd_sig-feat-cli-command-3e758c6d14-_07a791afa3` (`PID verification accepts any live process when ps inspection fails`)

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm run lint`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec tsx --test packages/remnic-cli/src/daemon-service.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/cli run check-types`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon identity checks and stale-pid cleanup; incorrect behavior could affect daemon start/stop on Windows or when process inspection fails, but it closes accepting arbitrary live PIDs when verification fails.
> 
> **Overview**
> Tightens **daemon PID verification** so a live process is only trusted when its command line can be read and matches Remnic. If `ps` (POSIX) or Windows inspection fails, the pidfile is removed instead of treating any process with that PID as the daemon.
> 
> Adds **Windows command-line lookup** via PowerShell (`Get-CimInstance Win32_Process`), with fallbacks through `powershell` / `pwsh` and then **WMIC**, plus optional `platform` injection for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c40765d5cd955371ed15193ff55e3d84105b2561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->