### PR TITLE
fix(cli): ignore bench freshness symlinks

### DIFF
--- a/packages/remnic-cli/src/bench-build-freshness.test.ts
+++ b/packages/remnic-cli/src/bench-build-freshness.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -63,6 +63,44 @@ test("checkBenchBuildFreshness ignores published bench packages without source",
   await touch(path.join(benchDir, "package.json"), newTime);
 
   assert.equal(checkBenchBuildFreshness(benchDir).stale, false);
+});
+
+test("checkBenchBuildFreshness does not follow source symlinks outside bench", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-freshness-"));
+  try {
+    const benchDir = path.join(root, "bench");
+    const srcDir = path.join(benchDir, "src");
+    const distDir = path.join(benchDir, "dist");
+    const outsideDir = path.join(root, "outside");
+    await mkdir(srcDir, { recursive: true });
+    await mkdir(distDir, { recursive: true });
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(
+      path.join(benchDir, "package.json"),
+      JSON.stringify({ name: "@remnic/bench" }),
+    );
+    await writeFile(path.join(srcDir, "index.ts"), "export const value = 1;\n");
+    await writeFile(
+      path.join(outsideDir, "outside.ts"),
+      "export const value = 2;\n",
+    );
+    await writeFile(path.join(distDir, "index.js"), "export const value = 0;\n");
+    await symlink(outsideDir, path.join(srcDir, "outside-link"), "dir");
+
+    const oldTime = new Date("2026-01-01T00:00:00.000Z");
+    const distTime = new Date("2026-01-01T00:00:05.000Z");
+    const outsideTime = new Date("2026-01-01T00:00:10.000Z");
+    await touch(path.join(benchDir, "package.json"), oldTime);
+    await touch(path.join(srcDir, "index.ts"), oldTime);
+    await touch(path.join(distDir, "index.js"), distTime);
+    await touch(path.join(outsideDir, "outside.ts"), outsideTime);
+
+    const freshness = checkBenchBuildFreshness(benchDir);
+    assert.equal(freshness.stale, false);
+    assert.notEqual(freshness.sourcePath, path.join(outsideDir, "outside.ts"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 async function touch(filePath: string, date: Date): Promise<void> {

--- a/packages/remnic-cli/src/bench-build-freshness.ts
+++ b/packages/remnic-cli/src/bench-build-freshness.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  lstatSync,
   readdirSync,
   readFileSync,
   statSync,
@@ -122,7 +123,10 @@ function newestMtime(
     if (!existsSync(entryPath)) {
       return;
     }
-    const stat = statSync(entryPath);
+    const stat = lstatSync(entryPath);
+    if (stat.isSymbolicLink()) {
+      return;
+    }
     if (stat.isDirectory()) {
       for (const child of readdirSync(entryPath)) {
         visit(path.join(entryPath, child));


### PR DESCRIPTION
## Summary
- Use `lstatSync` in bench build freshness scans so symlinked source directories are not followed outside the bench package.
- Add a regression test with a newer external directory reachable only through a source symlink.

## ClawPatch
- Fixes `fnd_sig-feat-cli-command-50823c78d7-_0689187a5c` (`Freshness scan follows symlinked directories outside the bench package`).

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec tsx --test packages/remnic-cli/src/bench-build-freshness.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm run lint`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/cli run check-types`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

Note: preflight initially failed because this fresh worktree lacked the `better-sqlite3` native binding. After `pnpm rebuild better-sqlite3`, preflight passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to dev-time freshness heuristics in the CLI; reduces false positives from symlink traversal with no impact on production runtime paths.
> 
> **Overview**
> Fixes **bench build freshness** checks in the CLI so they no longer traverse symlinked paths under `bench/src`.
> 
> The scan that finds the newest source mtime now uses **`lstatSync`** and **skips symbolic links** instead of following them into directories outside `@remnic/bench`. That stops a newer file reachable only via a symlink from incorrectly marking the local dist as stale.
> 
> A **regression test** adds a symlink from `src` to an external directory with a newer file and asserts the build is still considered fresh and the outside path is not treated as the newest source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31558194c810d66bd9c9acced16890a3d6852617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->