### PR TITLE
fix(scripts): ignore build staleness symlinks

### DIFF
--- a/scripts/build-staleness.mjs
+++ b/scripts/build-staleness.mjs
@@ -43,7 +43,10 @@ function newestMtime(paths) {
     if (!fs.existsSync(entryPath)) {
       return;
     }
-    const stat = fs.statSync(entryPath);
+    const stat = fs.lstatSync(entryPath);
+    if (stat.isSymbolicLink()) {
+      return;
+    }
     if (stat.isDirectory()) {
       for (const child of fs.readdirSync(entryPath)) {
         visit(path.join(entryPath, child));

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -71,6 +71,7 @@ if [[ "$MODE" == "quick" ]]; then
   run pnpm exec tsx --test tests/register-multi-registry.test.ts
   run pnpm exec tsx --test tests/intent.test.ts
   run pnpm exec tsx --test tests/runtime-input-guards.test.ts
+  run pnpm exec tsx --test tests/build-staleness.test.mjs
   run pnpm exec tsx --test tests/artifact-recall-limit.test.ts
   run pnpm exec tsx --test tests/artifact-status-snapshot.test.ts
   run pnpm exec tsx --test tests/recall-no-recall-short-circuit.test.ts

--- a/tests/build-staleness.test.mjs
+++ b/tests/build-staleness.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { isAnySourceNewerThan } from "../scripts/build-staleness.mjs";
+
+test("build staleness scan does not follow source symlinks outside the package", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-build-staleness-"));
+  try {
+    const srcDir = path.join(root, "pkg", "src");
+    const distDir = path.join(root, "pkg", "dist");
+    const outsideDir = path.join(root, "outside");
+    await mkdir(srcDir, { recursive: true });
+    await mkdir(distDir, { recursive: true });
+    await mkdir(outsideDir, { recursive: true });
+
+    const distFile = path.join(distDir, "index.js");
+    const localFile = path.join(srcDir, "local.ts");
+    const outsideFile = path.join(outsideDir, "newer.ts");
+    await writeFile(distFile, "dist\n");
+    await writeFile(localFile, "local\n");
+    await writeFile(outsideFile, "outside\n");
+
+    const oldTime = new Date("2026-01-01T00:00:00Z");
+    const distTime = new Date("2026-01-02T00:00:00Z");
+    const newerOutsideTime = new Date("2026-01-03T00:00:00Z");
+    await utimes(localFile, oldTime, oldTime);
+    await utimes(distFile, distTime, distTime);
+    await utimes(outsideFile, newerOutsideTime, newerOutsideTime);
+
+    await symlink(outsideDir, path.join(srcDir, "outside-link"), "dir");
+
+    assert.equal(isAnySourceNewerThan([srcDir], distFile), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Make the shared build-staleness walker use `lstatSync` and skip symlinks before recursing.
- Add a regression test proving a newer external directory reached through a source symlink does not mark package builds stale.

## ClawPatch
- Follow-up for `fnd_sig-feat-cli-command-50823c78d7-_0689187a5c`; #1311 fixed the CLI-local walker, and this fixes the shared script path ClawPatch revalidation still found.

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH node --test scripts/build-staleness.test.mjs`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec tsx --test packages/remnic-cli/src/bench-build-freshness.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm run lint`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-cache staleness logic only; no runtime auth, data, or product behavior changes.
> 
> **Overview**
> The shared **`build-staleness`** source walker no longer treats symlink targets as package sources when deciding if a build is stale: it uses **`lstatSync`** and **skips symlinks** instead of following them into outside directories with newer mtimes.
> 
> A **regression test** covers a newer file reached only via a source symlink, and **`pr-preflight` quick** now runs that test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb03cebe88bc0422c49337d6606dba1f97a32c0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->