### PR TITLE
fix(cli): validate lossless source before destination setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.test.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
 
 import { parseImportLosslessClawArgs } from "./import-lossless-claw-args.js";
+import {
+  cmdImportLosslessClaw,
+  type ImportLosslessClawModule,
+} from "./import-lossless-claw-cmd.js";
 
 describe("parseImportLosslessClawArgs", () => {
   it("accepts --src and a relative path", () => {
@@ -95,5 +102,70 @@ describe("parseImportLosslessClawArgs", () => {
         ]),
       /Unknown argument/,
     );
+  });
+});
+
+describe("cmdImportLosslessClaw", () => {
+  it("does not create destination state when opening the source database fails", async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "remnic-lossless-source-first-"),
+    );
+    try {
+      const sourcePath = path.join(tempDir, "corrupt-source.sqlite");
+      const memoryDir = path.join(tempDir, "memory");
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      let sourceClosed = false;
+      let destinationOpened = false;
+      fs.writeFileSync(sourcePath, "not a sqlite database");
+      const sourceDb = {
+        close: () => {
+          sourceClosed = true;
+        },
+      };
+      const destinationDb = {
+        close: () => undefined,
+      };
+      const fakeModule: ImportLosslessClawModule = {
+        openSourceDatabase: () => sourceDb as never,
+        assertLosslessClawSchema: () => {
+          throw new Error(
+            "Source database is missing lossless-claw tables: conversations.",
+          );
+        },
+        openInMemoryDestinationDatabase: () => {
+          destinationOpened = true;
+          return destinationDb as never;
+        },
+        openExistingLcmDatabaseReadOnly: () => {
+          destinationOpened = true;
+          return destinationDb as never;
+        },
+        importLosslessClaw: () => {
+          throw new Error("import should not run");
+        },
+      };
+
+      const exitCode = await cmdImportLosslessClaw(
+        ["--src", sourcePath, "--memory-dir", memoryDir],
+        {
+          resolveMemoryDir: () => memoryDir,
+          stdout: (line) => stdout.push(line),
+          stderr: (line) => stderr.push(line),
+        },
+        {
+          loadImportLosslessClawModule: async () => fakeModule,
+        },
+      );
+
+      assert.equal(exitCode, 1);
+      assert.deepEqual(stdout, []);
+      assert.match(stderr.join("\n"), /lossless-claw/i);
+      assert.equal(sourceClosed, true);
+      assert.equal(destinationOpened, false);
+      assert.equal(fs.existsSync(memoryDir), false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/remnic-cli/src/import-lossless-claw-cmd.ts
+++ b/packages/remnic-cli/src/import-lossless-claw-cmd.ts
@@ -24,6 +24,7 @@ import { expandTilde } from "./path-utils.js";
 export { IMPORT_LOSSLESS_CLAW_USAGE };
 export { parseImportLosslessClawArgs };
 export type { ImportLosslessClawCmdArgs };
+export type { ImportLosslessClawModule } from "./optional-import-lossless-claw.js";
 
 /**
  * Reject file paths used as directory args (CLAUDE.md gotcha #24), but
@@ -52,9 +53,14 @@ export interface CmdImportLosslessClawIO {
   stderr: (line: string) => void;
 }
 
+export interface CmdImportLosslessClawDeps {
+  loadImportLosslessClawModule?: typeof loadImportLosslessClawModule;
+}
+
 export async function cmdImportLosslessClaw(
   argv: readonly string[],
   io: CmdImportLosslessClawIO,
+  deps: CmdImportLosslessClawDeps = {},
 ): Promise<number> {
   if (argv.includes("--help") || argv.includes("-h") || argv.length === 0) {
     io.stdout(IMPORT_LOSSLESS_CLAW_USAGE);
@@ -79,7 +85,17 @@ export async function cmdImportLosslessClaw(
     const memoryDir = parsed.memoryDir ?? expandTilde(io.resolveMemoryDir());
     assertDirectoryOrAbsent(memoryDir, "--memory-dir");
 
-    const mod = await loadImportLosslessClawModule();
+    const mod = await (
+      deps.loadImportLosslessClawModule ?? loadImportLosslessClawModule
+    )();
+
+    const sourceDb = mod.openSourceDatabase(parsed.src);
+    try {
+      mod.assertLosslessClawSchema(sourceDb);
+    } catch (err) {
+      sourceDb.close();
+      throw err;
+    }
 
     // Dry-run must not mutate destination storage (Codex P2). The dest
     // resolution rules are:
@@ -97,28 +113,21 @@ export async function cmdImportLosslessClaw(
     // Real runs always go through ensureLcmStateDir + openLcmDatabase
     // (which creates the dir + file + schema as needed).
     let destDb: ReturnType<typeof openLcmDatabase>;
-    if (parsed.dryRun) {
-      const lcmPath = path.join(memoryDir, "state", "lcm.sqlite");
-      if (fs.existsSync(lcmPath)) {
-        destDb = mod.openExistingLcmDatabaseReadOnly(lcmPath);
-      } else {
-        destDb = mod.openInMemoryDestinationDatabase();
-        applyLcmSchema(destDb);
-      }
-    } else {
-      await ensureLcmStateDir(memoryDir);
-      destDb = openLcmDatabase(memoryDir);
-    }
-
-    // Open the source DB inside its own try so a failed open (corrupt
-    // SQLite header, permission error, etc.) doesn't leak destDb (Cursor
-    // Bugbot review on PR #797 — `assertFile` catches existence but not
-    // every I/O failure mode).
-    let sourceDb: ReturnType<typeof mod.openSourceDatabase>;
     try {
-      sourceDb = mod.openSourceDatabase(parsed.src);
+      if (parsed.dryRun) {
+        const lcmPath = path.join(memoryDir, "state", "lcm.sqlite");
+        if (fs.existsSync(lcmPath)) {
+          destDb = mod.openExistingLcmDatabaseReadOnly(lcmPath);
+        } else {
+          destDb = mod.openInMemoryDestinationDatabase();
+          applyLcmSchema(destDb);
+        }
+      } else {
+        await ensureLcmStateDir(memoryDir);
+        destDb = openLcmDatabase(memoryDir);
+      }
     } catch (err) {
-      destDb.close();
+      sourceDb.close();
       throw err;
     }
 

--- a/packages/remnic-cli/src/optional-import-lossless-claw.ts
+++ b/packages/remnic-cli/src/optional-import-lossless-claw.ts
@@ -18,6 +18,7 @@ type BetterSqlite3DatabaseLike = ReturnType<typeof openLcmDatabase>;
 
 export interface ImportLosslessClawModule {
   openSourceDatabase(filePath: string): BetterSqlite3DatabaseLike;
+  assertLosslessClawSchema(db: BetterSqlite3DatabaseLike): void;
   openInMemoryDestinationDatabase(): BetterSqlite3DatabaseLike;
   openExistingLcmDatabaseReadOnly(filePath: string): BetterSqlite3DatabaseLike;
   importLosslessClaw(options: {


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-cli-command-b8c70044ce-_a8ea5fdb33` (`Failed lossless-claw imports can create destination state before the source DB is opened`).

Changes:
- Opens and validates the lossless-claw source database before creating or opening destination state.
- Keeps source and destination handles closed on destination setup and import failures.
- Adds a regression test proving a corrupt source does not create a fresh memory directory.

Validation:
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm run lint`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec tsx --test packages/remnic-cli/src/import-lossless-claw-cmd.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/cli run check-types`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI ordering and cleanup for import-lossless-claw; no auth or broad API changes beyond safer failure handling.
> 
> **Overview**
> The **`import-lossless-claw`** command now **opens and validates the source database before any destination LCM state** is created or opened. Invalid or non-lossless sources fail without calling `ensureLcmStateDir`, opening `lcm.sqlite`, or creating the memory directory. **Destination setup errors** close the source handle; **schema validation failures** close the source before rethrowing.
> 
> The optional module contract gains **`assertLosslessClawSchema`**, and **`cmdImportLosslessClaw`** accepts injectable **`loadImportLosslessClawModule`** for tests. A regression test asserts that a bad source yields exit code 1, closes the source, never opens destination helpers, and leaves the memory dir absent.
> 
> Root **`package.json`** changes are formatting-only (single-line arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9f6bcd36c39672bc03ef06507a8c67362aa904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->