### PR TITLE
chore: format root package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }


### PR DESCRIPTION
Fixes root `package.json` formatting drift introduced by the `v9.3.561` release commit so PR quality checks can run against a clean main merge base.

Validation:
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm run lint`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only JSON formatting in the root manifest; no runtime, dependency, or script behavior changes.
> 
> **Overview**
> Reformats the root **`package.json`** so several multi-line JSON arrays are collapsed onto single lines, with no dependency, script, or version changes.
> 
> Affected keys include **`workspaces`**, **`files`**, **`openclaw.extensions`**, and **`pnpm.onlyBuiltDependencies`**. The intent is to clear formatting drift from a recent release commit so lint and PR checks can run against a clean merge base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d299d78a931e3059915abec5aefbaa814cb0b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->