### PR TITLE
test(cli): cover legacy engram wrapper env

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/tests/remnic-cli-bin-wrapper.test.ts
+++ b/tests/remnic-cli-bin-wrapper.test.ts
@@ -173,6 +173,62 @@ test("package bin wrappers do not inject FORCE_COLOR", async () => {
   }
 });
 
+test("package bin wrappers identify legacy engram invocation on built entrypoint", async () => {
+  const tempRoot = await mkdtemp(join(tmpdir(), "remnic-cli-bin-wrapper-"));
+  try {
+    const tempBinDir = join(tempRoot, "bin");
+    const tempDistDir = join(tempRoot, "dist");
+    await mkdir(tempBinDir, { recursive: true });
+    await mkdir(tempDistDir, { recursive: true });
+
+    const tempRemnicBin = join(tempBinDir, "remnic.cjs");
+    const tempEngramBin = join(tempBinDir, "engram.cjs");
+    await copyFile(remnicBin, tempRemnicBin);
+    await copyFile(engramBin, tempEngramBin);
+    await chmod(tempRemnicBin, 0o755);
+    await chmod(tempEngramBin, 0o755);
+    await writeFile(
+      join(tempDistDir, "index.js"),
+      [
+        "process.stdout.write(JSON.stringify({",
+        '  remnic: process.env.REMNIC_CLI_BIN === "1",',
+        '  engram: process.env.ENGRAM_CLI_BIN === "1",',
+        "  argv: process.argv.slice(2),",
+        "}));",
+        "",
+      ].join("\n"),
+    );
+
+    const env = { ...process.env };
+    delete env.REMNIC_CLI_BIN;
+    delete env.ENGRAM_CLI_BIN;
+
+    const remnicResult = spawnSync(process.execPath, [tempRemnicBin, "status"], {
+      encoding: "utf8",
+      env,
+    });
+    const engramResult = spawnSync(process.execPath, [tempEngramBin, "status"], {
+      encoding: "utf8",
+      env,
+    });
+
+    assert.equal(remnicResult.status, 0);
+    assert.equal(engramResult.status, 0);
+    assert.deepEqual(JSON.parse(remnicResult.stdout), {
+      remnic: true,
+      engram: false,
+      argv: ["status"],
+    });
+    assert.deepEqual(JSON.parse(engramResult.stdout), {
+      remnic: true,
+      engram: true,
+      argv: ["status"],
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("package bin wrappers keep a failing exit code when a self-signal is ignored", async () => {
   if (process.platform === "win32") {
     return;


### PR DESCRIPTION
## Summary
- add a built-entry wrapper regression test proving `engram.cjs` passes both `REMNIC_CLI_BIN` and `ENGRAM_CLI_BIN`
- assert the canonical `remnic.cjs` wrapper does not set the legacy marker
- carry Biome formatting for the root package manifest required by the lint gate

## ClawPatch
- Fixes `fnd_sig-feat-cli-command-fdb2abc43c-_191d4ad9ea`

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec tsx --test tests/remnic-cli-bin-wrapper.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @remnic/cli run check-types`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm run lint`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm rebuild better-sqlite3`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run test:openclaw-scenarios`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage plus manifest formatting; no runtime or dependency behavior changes.
> 
> **Overview**
> Adds a **built-entrypoint** regression test in `tests/remnic-cli-bin-wrapper.test.ts` that stubs `dist/index.js` and asserts env markers passed by the bin wrappers: **`remnic.cjs`** sets `REMNIC_CLI_BIN` only, while legacy **`engram.cjs`** sets both `REMNIC_CLI_BIN` and `ENGRAM_CLI_BIN`, with argv forwarded (e.g. `status`).
> 
> Root **`package.json`** is reformatted only (Biome): multi-line arrays collapsed to single-line for `workspaces`, `files`, `openclaw.extensions`, and `pnpm.onlyBuiltDependencies`—no dependency or script changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0218e021a4f3ad347f182d2a1486247ad22a1a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->