### PR TITLE
fix(ci): scope Hermes PyPI OIDC permission

### DIFF
--- a/.github/workflows/hermes-python.yml
+++ b/.github/workflows/hermes-python.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:
@@ -48,6 +47,9 @@ jobs:
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/p/remnic-hermes

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }


### PR DESCRIPTION
## Summary\n- remove workflow-wide id-token: write from Hermes Python CI\n- grant id-token: write only to the gated publish job\n\n## ClawPatch\n- fixes fnd_sig-feat-config-018970bb9d-04b79_8dde49118b\n- revalidated fixed with ClawPatch run 20260603T101411-b93e03\n\n## Validation\n- ruby YAML policy check for scoped id-token permission\n- git diff --check\n- npm run preflight:quick\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI permission hardening with no runtime or application logic changes; package.json edits are formatting-only.
> 
> **Overview**
> Tightens **Hermes Python CI** permissions so OIDC is only available where PyPI publish needs it.
> 
> Workflow-level **`id-token: write`** is removed; the default stays **`contents: read`**. The gated **`publish`** job now declares **`contents: read`** and **`id-token: write`** locally, so **`test`** no longer runs with token-minting rights.
> 
> **`package.json`** only reformats a few array fields to single-line style—no behavioral change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054ea9a9d53e216da16f2afd6dc6c5743b9033ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->