### PR TITLE
fix(ci): recognize CodeQL bot review threads

### DIFF
--- a/.github/workflows/review-thread-guard.yml
+++ b/.github/workflows/review-thread-guard.yml
@@ -86,7 +86,12 @@ jobs:
               // Exclude github-advanced-security (CodeQL) threads — these cannot be resolved
               // via the GitHub API and must be addressed through CodeQL configuration.
               const author = t.comments?.nodes?.[0]?.author?.login;
-              if (author === "github-advanced-security") return false;
+              const codeqlAuthorLogins = new Set([
+                "github-advanced-security",
+                "github-advanced-security[bot]",
+                "github-code-scanning[bot]",
+              ]);
+              if (author && codeqlAuthorLogins.has(author)) return false;
               return true;
             });
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/tests/review-thread-guard-workflow.test.mjs
+++ b/tests/review-thread-guard-workflow.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("review-thread guard excludes CodeQL bot review-thread authors", () => {
+  const workflow = readFileSync(".github/workflows/review-thread-guard.yml", "utf8");
+
+  assert.match(workflow, /const codeqlAuthorLogins = new Set/);
+  assert.match(workflow, /github-advanced-security/);
+  assert.match(workflow, /github-advanced-security\[bot\]/);
+  assert.match(workflow, /github-code-scanning\[bot\]/);
+  assert.match(workflow, /codeqlAuthorLogins\.has\(author\)/);
+});


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-config-07dfb7d470-e2606_7034256355`.

Changes:
- Treat `github-advanced-security[bot]` and `github-code-scanning[bot]` as CodeQL review-thread authors in `review-thread-guard.yml`.
- Add a focused workflow regression test for CodeQL bot author matching.

Validation:
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH node --test tests/review-thread-guard-workflow.test.mjs`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick` (after rebuilding local `better-sqlite3` binding)
- ClawPatch revalidation run `20260603T105135-f60df7`: fixed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CI gate change plus a string-matching test; no runtime product or security logic.
> 
> **Overview**
> Expands the **Review Thread Guard** CI filter so unresolved threads from **CodeQL / GitHub Advanced Security bots** are ignored, not only the legacy `github-advanced-security` login. Author matching now uses a `codeqlAuthorLogins` set including `github-advanced-security[bot]` and `github-code-scanning[bot]`, which should stop false merge failures when those bots leave threads that cannot be resolved via the API.
> 
> Adds `tests/review-thread-guard-workflow.test.mjs` to assert the workflow still defines that set and uses `codeqlAuthorLogins.has(author)`. Root `package.json` changes are formatting-only (single-line arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ef93102c765d6b1c70f19185973867555e2dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->