### PR TITLE
fix(build): invoke preflight scripts with pnpm run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ lint:
 	pnpm check-types
 
 preflight:
-	pnpm preflight
+	pnpm run preflight
 
 preflight-quick:
-	pnpm preflight:quick
+	pnpm run preflight:quick
 
 clean:
 	node scripts/clean-dist.mjs

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/tests/makefile-pnpm-run.test.mjs
+++ b/tests/makefile-pnpm-run.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function recipeForTarget(makefile, target) {
+  const pattern = new RegExp(`^${target}:\\n((?:\\t.*\\n)+)`, "m");
+  const match = makefile.match(pattern);
+  assert.ok(match, `expected ${target} target in Makefile`);
+  return match[1];
+}
+
+test("Makefile package-script quality gates use pnpm run", () => {
+  const makefile = readFileSync(new URL("../Makefile", import.meta.url), "utf8");
+
+  assert.match(recipeForTarget(makefile, "preflight"), /\tpnpm run preflight\n/);
+  assert.match(recipeForTarget(makefile, "preflight-quick"), /\tpnpm run preflight:quick\n/);
+});


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-config-0902ad7be8-b6b06_82a16cb56d`.

Changes:
- Update `make preflight` and `make preflight-quick` to call package scripts via `pnpm run`.
- Add a focused Makefile regression test for package-script quality gates.

Validation:
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH node --test tests/makefile-pnpm-run.test.mjs`
- `make -n preflight`
- `make -n preflight-quick`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick` (after rebuilding local `better-sqlite3` binding)
- ClawPatch revalidation run `20260603T112432-47c539`: fixed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI wiring and a small test only; no runtime, auth, or application logic changes.
> 
> **Overview**
> **Makefile preflight gates** now invoke root package scripts with `pnpm run` (`preflight` and `preflight-quick`) instead of bare `pnpm preflight`, aligning with how those scripts are defined in `package.json` and satisfying the ClawPatch package-script finding.
> 
> A new **`tests/makefile-pnpm-run.test.mjs`** regression test parses the Makefile and asserts both targets use `pnpm run`.
> 
> **`package.json`** only has cosmetic array formatting (single-line `workspaces`, `files`, `extensions`, `onlyBuiltDependencies`); no behavioral dependency or script changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9084fd19bbf75ed624938d9b65745da07bab2ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->