### PR TITLE
fix(ci): keep dismissed AI review blockers fresh

### DIFF
--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -47,7 +47,7 @@ jobs:
               'timed_out',
             ]);
             const POSITIVE_CHECK_CONCLUSIONS = new Set(['success', 'neutral']);
-            const NEGATIVE_REVIEW_STATES = new Set(['CHANGES_REQUESTED']);
+            const NEGATIVE_REVIEW_STATES = new Set(['CHANGES_REQUESTED', 'DISMISSED']);
             const NEGATIVE_VERDICT_PATTERN =
               /\b(?:changes\s+requested|do\s+not\s+merge|(?:not|no|never|cannot|can['’]?t|isn['’]?t)\s+(?:a\s+)?(?:pass|approved|lgtm))\b/i;
             const POSITIVE_VERDICT_PATTERN = /\b(?:PASS|APPROVED|LGTM)\b/i;
@@ -194,7 +194,7 @@ jobs:
               }
 
               const positiveByAlias = new Map();
-              const positiveCheckRunAliases = new Set();
+              const positiveCheckRunTimesByAlias = new Map();
               const blockers = [];
               const configuredAliases = new Set(groups.flat());
 
@@ -215,7 +215,7 @@ jobs:
                   continue;
                 }
                 if (NEGATIVE_REVIEW_STATES.has(review.state)) {
-                  blockers.push({ alias: login, kind: 'review', state: review.state });
+                  blockers.push({ alias: login, kind: 'review', state: review.state, time: activityTime(review) });
                 }
               }
 
@@ -245,10 +245,14 @@ jobs:
               for (const checkRun of latestCheckRuns.values()) {
                 const conclusion = normalizeLogin(checkRun.conclusion);
                 const alias = checkRun.alias;
+                const checkTime = checkRunTime(checkRun);
                 if (BAD_CHECK_CONCLUSIONS.has(conclusion)) {
                   blockers.push({ alias, kind: 'check_run', state: conclusion || 'unknown' });
                 } else if (POSITIVE_CHECK_CONCLUSIONS.has(conclusion)) {
-                  positiveCheckRunAliases.add(alias);
+                  const previousPositiveTime = positiveCheckRunTimesByAlias.get(alias);
+                  if (previousPositiveTime === undefined || checkTime > previousPositiveTime) {
+                    positiveCheckRunTimesByAlias.set(alias, checkTime);
+                  }
                   positiveByAlias.set(alias, { alias, kind: 'check_run', state: conclusion });
                 }
               }
@@ -264,9 +268,12 @@ jobs:
                 }
               }
 
-              const effectiveBlockers = blockers.filter(
-                (blocker) => blocker.kind !== 'review' || !positiveCheckRunAliases.has(blocker.alias),
-              );
+              const effectiveBlockers = blockers.filter((blocker) => {
+                if (blocker.kind !== 'review') return true;
+                if (blocker.state === 'DISMISSED') return true;
+                const positiveCheckRunTime = positiveCheckRunTimesByAlias.get(blocker.alias);
+                return positiveCheckRunTime === undefined || positiveCheckRunTime < (blocker.time ?? 0);
+              });
 
               if (effectiveBlockers.length > 0) {
                 return {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/scripts/ai-review-gate.mjs
+++ b/scripts/ai-review-gate.mjs
@@ -8,7 +8,7 @@ const BAD_CHECK_CONCLUSIONS = new Set([
   "timed_out",
 ]);
 const POSITIVE_CHECK_CONCLUSIONS = new Set(["success", "neutral"]);
-const NEGATIVE_REVIEW_STATES = new Set(["CHANGES_REQUESTED"]);
+const NEGATIVE_REVIEW_STATES = new Set(["CHANGES_REQUESTED", "DISMISSED"]);
 const NEGATIVE_VERDICT_PATTERN =
   /\b(?:changes\s+requested|do\s+not\s+merge|(?:not|no|never|cannot|can['’]?t|isn['’]?t)\s+(?:a\s+)?(?:pass|approved|lgtm))\b/i;
 const POSITIVE_VERDICT_PATTERN = /\b(?:PASS|APPROVED|LGTM)\b/i;
@@ -154,7 +154,7 @@ export function evaluateAiReviewGate({
   }
 
   const positiveByAlias = new Map();
-  const positiveCheckRunAliases = new Set();
+  const positiveCheckRunTimesByAlias = new Map();
   const blockers = [];
   const configuredAliases = new Set(groups.flat());
 
@@ -175,7 +175,7 @@ export function evaluateAiReviewGate({
       continue;
     }
     if (NEGATIVE_REVIEW_STATES.has(review.state)) {
-      blockers.push({ alias: login, kind: "review", state: review.state });
+      blockers.push({ alias: login, kind: "review", state: review.state, time: activityTime(review) });
     }
   }
 
@@ -205,10 +205,14 @@ export function evaluateAiReviewGate({
   for (const checkRun of latestCheckRuns.values()) {
     const conclusion = normalizeLogin(checkRun.conclusion);
     const alias = checkRun.alias;
+    const checkTime = checkRunTime(checkRun);
     if (BAD_CHECK_CONCLUSIONS.has(conclusion)) {
       blockers.push({ alias, kind: "check_run", state: conclusion || "unknown" });
     } else if (POSITIVE_CHECK_CONCLUSIONS.has(conclusion)) {
-      positiveCheckRunAliases.add(alias);
+      const previousPositiveTime = positiveCheckRunTimesByAlias.get(alias);
+      if (previousPositiveTime === undefined || checkTime > previousPositiveTime) {
+        positiveCheckRunTimesByAlias.set(alias, checkTime);
+      }
       positiveByAlias.set(alias, { alias, kind: "check_run", state: conclusion });
     }
   }
@@ -224,9 +228,12 @@ export function evaluateAiReviewGate({
     }
   }
 
-  const effectiveBlockers = blockers.filter(
-    (blocker) => blocker.kind !== "review" || !positiveCheckRunAliases.has(blocker.alias),
-  );
+  const effectiveBlockers = blockers.filter((blocker) => {
+    if (blocker.kind !== "review") return true;
+    if (blocker.state === "DISMISSED") return true;
+    const positiveCheckRunTime = positiveCheckRunTimesByAlias.get(blocker.alias);
+    return positiveCheckRunTime === undefined || positiveCheckRunTime < (blocker.time ?? 0);
+  });
 
   if (effectiveBlockers.length > 0) {
     return {

--- a/tests/ai-review-gate.test.mjs
+++ b/tests/ai-review-gate.test.mjs
@@ -157,6 +157,32 @@ test("AI review gate uses the latest current-head review state per alias", () =>
   assert.equal(result.blockers[0]?.state, "CHANGES_REQUESTED");
 });
 
+test("AI review gate blocks dismissed current-head review changes", () => {
+  const result = evaluateAiReviewGate({
+    groups: parseReviewerGroups("codex"),
+    headSha,
+    headCommittedAt,
+    reviews: [
+      {
+        user: { login: "codex" },
+        state: "CHANGES_REQUESTED",
+        commit_id: headSha,
+        submitted_at: "2026-05-21T12:00:01.000Z",
+      },
+      {
+        user: { login: "codex" },
+        state: "DISMISSED",
+        commit_id: headSha,
+        submitted_at: "2026-05-21T12:00:02.000Z",
+      },
+    ],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.blockers[0]?.alias, "codex");
+  assert.equal(result.blockers[0]?.state, "DISMISSED");
+});
+
 test("AI review gate accepts a later current-head approval after changes requested", () => {
   const result = evaluateAiReviewGate({
     groups: parseReviewerGroups("codex"),
@@ -209,6 +235,34 @@ test("AI review gate lets current-head positive check runs clear review blockers
   assert.equal(result.ok, true);
   assert.deepEqual(result.blockers, []);
   assert.equal(result.present[0]?.kind, "check_run");
+});
+
+test("AI review gate does not clear dismissed review blockers with check runs", () => {
+  const result = evaluateAiReviewGate({
+    groups: parseReviewerGroups("cursor"),
+    headSha,
+    headCommittedAt,
+    reviews: [
+      {
+        user: { login: "cursor" },
+        state: "DISMISSED",
+        commit_id: headSha,
+        submitted_at: "2026-05-21T12:00:03.000Z",
+      },
+    ],
+    checkRuns: [
+      {
+        app: { slug: "cursor" },
+        conclusion: "success",
+        head_sha: headSha,
+        completed_at: "2026-05-21T12:00:04.000Z",
+      },
+    ],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.blockers[0]?.alias, "cursor");
+  assert.equal(result.blockers[0]?.state, "DISMISSED");
 });
 
 test("AI review gate ignores failed check runs from non-reviewer apps", () => {


### PR DESCRIPTION
## Summary
- treat DISMISSED AI reviews as negative review states in the AI review gate
- only let positive check runs clear review blockers when the check run is at least as fresh as the review
- add dismissed-review regression tests, including the older-check-run ordering case

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:$PATH node --test tests/ai-review-gate.test.mjs
- git diff --check
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick
- ClawPatch revalidate fnd_sig-feat-config-14b04d8835-9ece1_ade2e3684d: fixed (run 20260603T122042-efd645)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-gating CI logic for AI reviewers; incorrect timing rules could block or unblock PRs incorrectly, but scope is limited to review gate evaluation with added tests.
> 
> **Overview**
> Tightens the **AI review gate** so merge blocking stays accurate when reviews are dismissed or when check runs and reviews disagree on timing.
> 
> **DISMISSED** is now treated like **CHANGES_REQUESTED** as a negative review state. A later positive check run no longer clears a **DISMISSED** blocker (only **CHANGES_REQUESTED** can be cleared that way, and only when the check is at least as fresh as the review).
> 
> Review blockers from **CHANGES_REQUESTED** are only overridden by a positive check run if that check’s completion time is **≥** the review’s `submitted_at`; stale successful checks after an older review no longer unblock the gate.
> 
> The same logic is mirrored in `.github/workflows/ai-review-gate.yml` and `scripts/ai-review-gate.mjs`, with new regression tests in `tests/ai-review-gate.test.mjs`. `package.json` changes are formatting-only (array literals on one line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 813d7a9769b435b4b07b9d8f34e77c04c370a1b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->