### PR TITLE
fix(bench): shell-escape dataset fetch paths

### DIFF
--- a/scripts/bench/fetch-datasets.sh
+++ b/scripts/bench/fetch-datasets.sh
@@ -41,6 +41,10 @@ set -euo pipefail
 
 TARGET_DIR="./bench-datasets"
 
+shell_quote() {
+  printf '%q' "$1"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --target)
@@ -71,9 +75,19 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -z "${TARGET_DIR}" ]]; then
+  echo "error: --target requires a non-empty directory path" >&2
+  exit 2
+fi
+
 LONG_MEM_EVAL_DIR="${TARGET_DIR}/longmemeval"
 LOCOMO_DIR="${TARGET_DIR}/locomo"
 BEAM_DIR="${TARGET_DIR}/beam"
+
+LONG_MEM_EVAL_DIR_Q="$(shell_quote "${LONG_MEM_EVAL_DIR}")"
+LOCOMO_DIR_Q="$(shell_quote "${LOCOMO_DIR}")"
+BEAM_DIR_Q="$(shell_quote "${BEAM_DIR}")"
+BEAM_DATA_DIR_Q="$(shell_quote "${BEAM_DIR}/data")"
 
 cat <<EOF
 # Remnic published-benchmark datasets — download instructions
@@ -83,37 +97,37 @@ cat <<EOF
 # because it handles auth + resumable downloads; wget is shown as a fallback.
 
 # 1. Create the target directories
-mkdir -p "${LONG_MEM_EVAL_DIR}"
-mkdir -p "${LOCOMO_DIR}"
-mkdir -p "${BEAM_DIR}"
+mkdir -p -- ${LONG_MEM_EVAL_DIR_Q}
+mkdir -p -- ${LOCOMO_DIR_Q}
+mkdir -p -- ${BEAM_DIR_Q}
 
 # 2. LongMemEval-S  (https://huggingface.co/datasets/xiaowu0162/LongMemEval)
 #    Prefer the huggingface-cli path. Install via:  pipx install "huggingface_hub[cli]"
 huggingface-cli download xiaowu0162/LongMemEval \\
   --repo-type dataset \\
-  --local-dir "${LONG_MEM_EVAL_DIR}" \\
+  --local-dir ${LONG_MEM_EVAL_DIR_Q} \\
   --include "longmemeval_oracle.json" \\
            "longmemeval_s_cleaned.json" \\
            "longmemeval_s.json"
 
 # Fallback: direct file download (update commit hash if the upstream moves)
-# wget -P "${LONG_MEM_EVAL_DIR}" \\
+# wget -P ${LONG_MEM_EVAL_DIR_Q} \\
 #   "https://huggingface.co/datasets/xiaowu0162/LongMemEval/resolve/main/longmemeval_oracle.json"
 
 # 3. LoCoMo-10  (https://huggingface.co/datasets/snap-research/locomo10)
 huggingface-cli download snap-research/locomo10 \\
   --repo-type dataset \\
-  --local-dir "${LOCOMO_DIR}" \\
+  --local-dir ${LOCOMO_DIR_Q} \\
   --include "locomo10.json" "locomo.json"
 
 # Fallback direct download
-# wget -P "${LOCOMO_DIR}" \\
+# wget -P ${LOCOMO_DIR_Q} \\
 #   "https://huggingface.co/datasets/snap-research/locomo10/resolve/main/locomo10.json"
 
 # 4. BEAM 100K/500K/1M  (https://huggingface.co/datasets/Mohammadta/BEAM)
 huggingface-cli download Mohammadta/BEAM \\
   --repo-type dataset \\
-  --local-dir "${BEAM_DIR}" \\
+  --local-dir ${BEAM_DIR_Q} \\
   --include "data/100K-00000-of-00001.parquet" \\
             "data/500K-00000-of-00001.parquet" \\
             "data/1M-00000-of-00001.parquet"
@@ -121,14 +135,14 @@ huggingface-cli download Mohammadta/BEAM \\
 # BEAM 10M  (https://huggingface.co/datasets/Mohammadta/BEAM-10M)
 huggingface-cli download Mohammadta/BEAM-10M \\
   --repo-type dataset \\
-  --local-dir "${BEAM_DIR}" \\
+  --local-dir ${BEAM_DIR_Q} \\
   --include "data/10M-00000-of-00002.parquet" \\
             "data/10M-00001-of-00002.parquet"
 
 # 5. Smoke-check that the runner sees your files (quick-mode, no model calls):
-#    pnpm exec remnic bench run --quick longmemeval --dataset-dir "${LONG_MEM_EVAL_DIR}"
-#    pnpm exec remnic bench run --quick locomo      --dataset-dir "${LOCOMO_DIR}"
-#    pnpm exec remnic bench published --name beam --dataset "${BEAM_DIR}/data" --model gpt-5.5 --dry-run --limit 1
+#    pnpm exec remnic bench run --quick longmemeval --dataset-dir ${LONG_MEM_EVAL_DIR_Q}
+#    pnpm exec remnic bench run --quick locomo      --dataset-dir ${LOCOMO_DIR_Q}
+#    pnpm exec remnic bench published --name beam --dataset ${BEAM_DATA_DIR_Q} --model gpt-5.5 --dry-run --limit 1
 #
 # The 'bench published --dry-run' command validates dataset loading without model calls.
 

--- a/tests/fetch-datasets-script.test.mjs
+++ b/tests/fetch-datasets-script.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const scriptPath = "scripts/bench/fetch-datasets.sh";
+
+test("fetch-datasets prints target-derived paths as escaped shell literals", () => {
+  const target = "tmp/$(touch SHOULD_NOT_RUN)";
+  const result = spawnSync("bash", [scriptPath, "--target", target], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /tmp\/\$\(touch SHOULD_NOT_RUN\)\/longmemeval/);
+  assert.match(result.stdout, /mkdir -p -- tmp\/\\\$\\\(touch\\ SHOULD_NOT_RUN\\\)\/longmemeval/);
+  assert.match(result.stdout, /--local-dir tmp\/\\\$\\\(touch\\ SHOULD_NOT_RUN\\\)\/locomo/);
+  assert.match(result.stdout, /--dataset tmp\/\\\$\\\(touch\\ SHOULD_NOT_RUN\\\)\/beam\/data/);
+});
+
+test("fetch-datasets rejects an empty target path", () => {
+  const result = spawnSync("bash", [scriptPath, "--target="], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /non-empty directory path/);
+});


### PR DESCRIPTION
## Summary
- reject empty `--target` values in `scripts/bench/fetch-datasets.sh`
- render all target-derived printed paths with Bash `printf %q`
- add a regression test for hostile `$(touch ...)` target text and empty target rejection

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:$PATH node --test tests/fetch-datasets-script.test.mjs
- git diff --check
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick
- ClawPatch revalidate fnd_sig-feat-config-18f3cfb2fe-0f224_4df5a4d4e7: fixed (run 20260603T125715-cf3404)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bench documentation/helper script and tests only; no runtime auth, data, or production paths.
> 
> **Overview**
> Hardens **`scripts/bench/fetch-datasets.sh`** so copy-pasted download commands are safe when **`--target`** contains shell metacharacters.
> 
> The script now **rejects empty `--target`** values, adds a **`shell_quote`** helper (`printf %q`), and emits **pre-quoted path literals** for `mkdir`, `huggingface-cli`, `wget`, and the smoke-check examples instead of interpolating raw paths. A new **`tests/fetch-datasets-script.test.mjs`** regression test covers hostile `$(…)` target text and empty-target rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e3cc33b6d8810260a706f98f8f3277cab97603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->