### PR TITLE
fix(ci): pin release drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/tests/release-drafter-workflow.test.mjs
+++ b/tests/release-drafter-workflow.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("release-drafter action is pinned to a full commit SHA", () => {
+  const workflow = readFileSync(new URL("../.github/workflows/release-drafter.yml", import.meta.url), "utf8");
+  const match = workflow.match(/uses:\s+release-drafter\/release-drafter@([^\s#]+)/);
+
+  assert.ok(match, "release-drafter action use was not found");
+  assert.match(match[1], /^[0-9a-f]{40}$/);
+});


### PR DESCRIPTION
## Summary
- pin `release-drafter/release-drafter` to full commit SHA `6a93d829887aa2e0748befe2e808c66c0ec6e4c7`
- add a focused workflow regression test requiring the release-drafter action ref to be a 40-character SHA

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:$PATH node --test tests/release-drafter-workflow.test.mjs
- git diff --check
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick
- ClawPatch revalidate fnd_sig-feat-config-1f1436b9c5-f560e_1b417ae0c5: fixed (run 20260603T133206-c5fa46)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow supply-chain hardening and a small test; no application runtime, auth, or data paths change.
> 
> **Overview**
> Pins the **Release Drafter** GitHub Action from a floating `@v6` tag to commit **`6a93d829887aa2e0748befe2e808c66c0ec6e4c7`**, so CI always runs a fixed revision instead of whatever the tag currently points at.
> 
> Adds **`tests/release-drafter-workflow.test.mjs`**, which reads `.github/workflows/release-drafter.yml` and fails if the `release-drafter/release-drafter@` ref is not a 40-character hex SHA.
> 
> **`package.json`** only reformats a few array fields onto single lines; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eeaa09e26cf9872f18f55f551a3b7af56e09bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->