### PR TITLE
fix(hooks): harden session cursor state paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/plugin-claude-code/hooks/bin/post-tool-observe.sh
+++ b/packages/plugin-claude-code/hooks/bin/post-tool-observe.sh
@@ -61,31 +61,147 @@ CWD="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.cwd|
 TOOL_NAME="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.tool_name||'')" "$INPUT" 2>/dev/null || echo "")"
 PROJECT_NAME="$(basename "$CWD" 2>/dev/null || echo "unknown")"
 
-[ -z "$SESSION_ID" ] && exit 0
+case "$SESSION_ID" in
+  ""|*[!A-Za-z0-9._-]*)
+    log "invalid session id: $SESSION_ID"
+    exit 0
+    ;;
+esac
 { [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; } && exit 0
 
-LEGACY_CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
-CURSOR_FILE="/tmp/remnic-cursor-${SESSION_ID}"
-LEGACY_LOCK_DIR="/tmp/engram-lock-${SESSION_ID}.d"
-LOCK_DIR="/tmp/remnic-lock-${SESSION_ID}.d"
+STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+STATE_DIR="${STATE_HOME}/remnic/hooks"
+
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+if ! node - "$STATE_DIR" <<'NODE'
+const fs = require('fs');
+const stateDir = process.argv[2];
+try {
+  const info = fs.lstatSync(stateDir);
+  if (info.isSymbolicLink() || !info.isDirectory()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+  if ((info.mode & 0o077) !== 0) fs.chmodSync(stateDir, 0o700);
+} catch {
+  process.exit(1);
+}
+NODE
+then
+  log "unsafe state directory $STATE_DIR"
+  exit 0
+fi
+
+CURSOR_FILE="${STATE_DIR}/remnic-cursor-${SESSION_ID}"
+LOCK_DIR="${STATE_DIR}/remnic-lock-${SESSION_ID}.d"
+LEGACY_CURSOR_FILE="${STATE_DIR}/engram-cursor-${SESSION_ID}"
+LEGACY_LOCK_DIR="${STATE_DIR}/engram-lock-${SESSION_ID}.d"
 
 if [ ! -f "$CURSOR_FILE" ] && { [ -f "$LEGACY_CURSOR_FILE" ] || [ -d "$LEGACY_LOCK_DIR" ]; }; then
   CURSOR_FILE="$LEGACY_CURSOR_FILE"
   LOCK_DIR="$LEGACY_LOCK_DIR"
 fi
 
+validate_cursor_file() {
+  node - "$CURSOR_FILE" <<'NODE'
+const fs = require('fs');
+const cursorFile = process.argv[2];
+try {
+  const info = fs.lstatSync(cursorFile);
+  if (info.isSymbolicLink() || !info.isFile()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+} catch (error) {
+  if (error && error.code === 'ENOENT') process.exit(0);
+  process.exit(1);
+}
+NODE
+}
+
+read_cursor_file() {
+  validate_cursor_file || {
+    log "unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  [ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo 0
+}
+
+write_cursor_file() {
+  NEW_CURSOR_VALUE="$1"
+  validate_cursor_file || {
+    log "refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  TEMP_CURSOR="$(mktemp "${CURSOR_FILE}.tmp.XXXXXX" 2>/dev/null)" || return 1
+  if ! printf '%s\n' "$NEW_CURSOR_VALUE" > "$TEMP_CURSOR"; then
+    rm -f "$TEMP_CURSOR"
+    return 1
+  fi
+  chmod 600 "$TEMP_CURSOR" 2>/dev/null || true
+  mv -f "$TEMP_CURSOR" "$CURSOR_FILE"
+}
+
+migrate_tmp_cursor_file() {
+  for TMP_CURSOR_FILE in "/tmp/remnic-cursor-${SESSION_ID}" "/tmp/engram-cursor-${SESSION_ID}"; do
+    [ ! -e "$TMP_CURSOR_FILE" ] && continue
+    TMP_CURSOR_VALUE="$(node - "$TMP_CURSOR_FILE" <<'NODE'
+const fs = require('fs');
+const cursorFile = process.argv[2];
+try {
+  const info = fs.lstatSync(cursorFile);
+  if (info.isSymbolicLink() || !info.isFile()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+  const value = fs.readFileSync(cursorFile, 'utf8').trim();
+  if (!/^\d+$/.test(value)) process.exit(1);
+  process.stdout.write(value);
+} catch {
+  process.exit(1);
+}
+NODE
+    )" || continue
+    CURRENT_CURSOR_VALUE=""
+    if validate_cursor_file; then
+      CURRENT_CURSOR_VALUE="$([ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo "")"
+    fi
+    case "$CURRENT_CURSOR_VALUE" in
+      ""|*[!0-9]*) CURRENT_CURSOR_VALUE="-1" ;;
+    esac
+    if [ "$TMP_CURSOR_VALUE" -gt "$CURRENT_CURSOR_VALUE" ]; then
+      write_cursor_file "$TMP_CURSOR_VALUE" || continue
+    fi
+    rm -f "$TMP_CURSOR_FILE" 2>/dev/null
+  done
+}
+
+remove_stale_lock_dir() {
+  node - "$LOCK_DIR" <<'NODE'
+const fs = require('fs');
+const lockDir = process.argv[2];
+try {
+  const info = fs.lstatSync(lockDir);
+  if (info.isSymbolicLink() || !info.isDirectory()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+  if (Date.now() - info.mtimeMs < 10 * 60 * 1000) process.exit(0);
+  fs.rmSync(lockDir, { recursive: true, force: true });
+} catch (error) {
+  if (error && error.code === 'ENOENT') process.exit(0);
+  process.exit(1);
+}
+NODE
+}
+
 (
   # Acquire exclusive lock
   ACQUIRED=0
   for _i in $(seq 1 50); do
     if mkdir "$LOCK_DIR" 2>/dev/null; then ACQUIRED=1; break; fi
+    [ "$_i" -eq 1 ] && remove_stale_lock_dir >/dev/null 2>&1
     sleep 0.1
   done
   trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT INT TERM
   [ "$ACQUIRED" -eq 0 ] && exit 0
 
+  migrate_tmp_cursor_file
+
   LAST_COUNT=0
-  [ -f "$CURSOR_FILE" ] && LAST_COUNT="$(cat "$CURSOR_FILE" 2>/dev/null || echo 0)"
+  LAST_COUNT="$(read_cursor_file)" || exit 0
 
   PAYLOAD="$(node -e "
     const fs = require('fs');
@@ -130,7 +246,7 @@ fi
   [ -z "$PAYLOAD" ] && { log "parse failed for $SESSION_ID"; exit 0; }
 
   if echo "$PAYLOAD" | grep -q "^CURSOR:"; then
-    echo "${PAYLOAD#CURSOR:}" > "$CURSOR_FILE"
+    write_cursor_file "${PAYLOAD#CURSOR:}" || log "cursor write failed for $SESSION_ID"
     exit 0
   fi
 
@@ -153,7 +269,7 @@ fi
 
   if [ $CURL_EXIT -eq 0 ] && [[ "$HTTP_STATUS" =~ ^2 ]]; then
     log "observe OK for $SESSION_ID"
-    echo "$TOTAL" > "$CURSOR_FILE"
+    write_cursor_file "$TOTAL" || log "cursor write failed for $SESSION_ID"
   else
     log "observe failed (curl=$CURL_EXIT http=$HTTP_STATUS) — cursor not advanced"
   fi

--- a/packages/plugin-claude-code/hooks/bin/session-end.sh
+++ b/packages/plugin-claude-code/hooks/bin/session-end.sh
@@ -1,21 +1,38 @@
 #!/usr/bin/env bash
 # Remnic session cleanup for Claude Code.
-# Removes cursor and lock files for the session.
+# Removes private cursor and lock files for the session.
 #
 # NOTE: Claude Code does not support a Stop/SessionEnd hook event.
 # This script is provided for manual cleanup or future hook support.
-# Temp files in /tmp/ are cleaned by the OS on reboot.
+# Private state files live under ${XDG_STATE_HOME:-$HOME/.local/state}/remnic/hooks.
 
 INPUT="$(cat)"
 SESSION_ID="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.session_id||'')" "$INPUT" 2>/dev/null || echo "")"
 
 echo '{"continue":true}'
 
-[ -z "$SESSION_ID" ] && exit 0
+case "$SESSION_ID" in
+  ""|*[!A-Za-z0-9._-]*)
+    exit 0
+    ;;
+esac
 
-rm -f "/tmp/remnic-cursor-${SESSION_ID}" 2>/dev/null
-rmdir "/tmp/remnic-lock-${SESSION_ID}.d" 2>/dev/null
-rm -f "/tmp/engram-cursor-${SESSION_ID}" 2>/dev/null
-rmdir "/tmp/engram-lock-${SESSION_ID}.d" 2>/dev/null
+STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+STATE_DIR="${STATE_HOME}/remnic/hooks"
+CURSOR_FILE="${STATE_DIR}/remnic-cursor-${SESSION_ID}"
+LOCK_DIR="${STATE_DIR}/remnic-lock-${SESSION_ID}.d"
+LEGACY_CURSOR_FILE="${STATE_DIR}/engram-cursor-${SESSION_ID}"
+LEGACY_LOCK_DIR="${STATE_DIR}/engram-lock-${SESSION_ID}.d"
+
+if [ -d "$STATE_DIR" ] && [ ! -L "$STATE_DIR" ]; then
+  if [ -e "$CURSOR_FILE" ] && [ ! -L "$CURSOR_FILE" ]; then
+    rm -f "$CURSOR_FILE" 2>/dev/null
+  fi
+  rmdir "$LOCK_DIR" 2>/dev/null
+  if [ -e "$LEGACY_CURSOR_FILE" ] && [ ! -L "$LEGACY_CURSOR_FILE" ]; then
+    rm -f "$LEGACY_CURSOR_FILE" 2>/dev/null
+  fi
+  rmdir "$LEGACY_LOCK_DIR" 2>/dev/null
+fi
 
 exit 0

--- a/packages/plugin-codex/hooks/bin/post-tool-observe.sh
+++ b/packages/plugin-codex/hooks/bin/post-tool-observe.sh
@@ -62,31 +62,147 @@ CWD="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.cwd|
 TOOL_NAME="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.tool_name||'')" "$INPUT" 2>/dev/null || echo "")"
 PROJECT_NAME="$(basename "$CWD" 2>/dev/null || echo "unknown")"
 
-[ -z "$SESSION_ID" ] && exit 0
+case "$SESSION_ID" in
+  ""|*[!A-Za-z0-9._-]*)
+    log "invalid session id: $SESSION_ID"
+    exit 0
+    ;;
+esac
 { [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; } && exit 0
 
-LEGACY_CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
-CURSOR_FILE="/tmp/remnic-cursor-${SESSION_ID}"
-LEGACY_LOCK_DIR="/tmp/engram-lock-${SESSION_ID}.d"
-LOCK_DIR="/tmp/remnic-lock-${SESSION_ID}.d"
+STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+STATE_DIR="${STATE_HOME}/remnic/hooks"
+
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+if ! node - "$STATE_DIR" <<'NODE'
+const fs = require('fs');
+const stateDir = process.argv[2];
+try {
+  const info = fs.lstatSync(stateDir);
+  if (info.isSymbolicLink() || !info.isDirectory()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+  if ((info.mode & 0o077) !== 0) fs.chmodSync(stateDir, 0o700);
+} catch {
+  process.exit(1);
+}
+NODE
+then
+  log "unsafe state directory $STATE_DIR"
+  exit 0
+fi
+
+CURSOR_FILE="${STATE_DIR}/remnic-cursor-${SESSION_ID}"
+LOCK_DIR="${STATE_DIR}/remnic-lock-${SESSION_ID}.d"
+LEGACY_CURSOR_FILE="${STATE_DIR}/engram-cursor-${SESSION_ID}"
+LEGACY_LOCK_DIR="${STATE_DIR}/engram-lock-${SESSION_ID}.d"
 
 if [ ! -f "$CURSOR_FILE" ] && { [ -f "$LEGACY_CURSOR_FILE" ] || [ -d "$LEGACY_LOCK_DIR" ]; }; then
   CURSOR_FILE="$LEGACY_CURSOR_FILE"
   LOCK_DIR="$LEGACY_LOCK_DIR"
 fi
 
+validate_cursor_file() {
+  node - "$CURSOR_FILE" <<'NODE'
+const fs = require('fs');
+const cursorFile = process.argv[2];
+try {
+  const info = fs.lstatSync(cursorFile);
+  if (info.isSymbolicLink() || !info.isFile()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+} catch (error) {
+  if (error && error.code === 'ENOENT') process.exit(0);
+  process.exit(1);
+}
+NODE
+}
+
+read_cursor_file() {
+  validate_cursor_file || {
+    log "unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  [ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo 0
+}
+
+write_cursor_file() {
+  NEW_CURSOR_VALUE="$1"
+  validate_cursor_file || {
+    log "refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  TEMP_CURSOR="$(mktemp "${CURSOR_FILE}.tmp.XXXXXX" 2>/dev/null)" || return 1
+  if ! printf '%s\n' "$NEW_CURSOR_VALUE" > "$TEMP_CURSOR"; then
+    rm -f "$TEMP_CURSOR"
+    return 1
+  fi
+  chmod 600 "$TEMP_CURSOR" 2>/dev/null || true
+  mv -f "$TEMP_CURSOR" "$CURSOR_FILE"
+}
+
+migrate_tmp_cursor_file() {
+  for TMP_CURSOR_FILE in "/tmp/remnic-cursor-${SESSION_ID}" "/tmp/engram-cursor-${SESSION_ID}"; do
+    [ ! -e "$TMP_CURSOR_FILE" ] && continue
+    TMP_CURSOR_VALUE="$(node - "$TMP_CURSOR_FILE" <<'NODE'
+const fs = require('fs');
+const cursorFile = process.argv[2];
+try {
+  const info = fs.lstatSync(cursorFile);
+  if (info.isSymbolicLink() || !info.isFile()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+  const value = fs.readFileSync(cursorFile, 'utf8').trim();
+  if (!/^\d+$/.test(value)) process.exit(1);
+  process.stdout.write(value);
+} catch {
+  process.exit(1);
+}
+NODE
+    )" || continue
+    CURRENT_CURSOR_VALUE=""
+    if validate_cursor_file; then
+      CURRENT_CURSOR_VALUE="$([ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo "")"
+    fi
+    case "$CURRENT_CURSOR_VALUE" in
+      ""|*[!0-9]*) CURRENT_CURSOR_VALUE="-1" ;;
+    esac
+    if [ "$TMP_CURSOR_VALUE" -gt "$CURRENT_CURSOR_VALUE" ]; then
+      write_cursor_file "$TMP_CURSOR_VALUE" || continue
+    fi
+    rm -f "$TMP_CURSOR_FILE" 2>/dev/null
+  done
+}
+
+remove_stale_lock_dir() {
+  node - "$LOCK_DIR" <<'NODE'
+const fs = require('fs');
+const lockDir = process.argv[2];
+try {
+  const info = fs.lstatSync(lockDir);
+  if (info.isSymbolicLink() || !info.isDirectory()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+  if (Date.now() - info.mtimeMs < 10 * 60 * 1000) process.exit(0);
+  fs.rmSync(lockDir, { recursive: true, force: true });
+} catch (error) {
+  if (error && error.code === 'ENOENT') process.exit(0);
+  process.exit(1);
+}
+NODE
+}
+
 (
   # Acquire exclusive lock
   ACQUIRED=0
   for _i in $(seq 1 50); do
     if mkdir "$LOCK_DIR" 2>/dev/null; then ACQUIRED=1; break; fi
+    [ "$_i" -eq 1 ] && remove_stale_lock_dir >/dev/null 2>&1
     sleep 0.1
   done
   trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT INT TERM
   [ "$ACQUIRED" -eq 0 ] && exit 0
 
+  migrate_tmp_cursor_file
+
   LAST_COUNT=0
-  [ -f "$CURSOR_FILE" ] && LAST_COUNT="$(cat "$CURSOR_FILE" 2>/dev/null || echo 0)"
+  LAST_COUNT="$(read_cursor_file)" || exit 0
 
   PAYLOAD="$(node -e "
     const fs = require('fs');
@@ -131,7 +247,7 @@ fi
   [ -z "$PAYLOAD" ] && { log "parse failed for $SESSION_ID"; exit 0; }
 
   if echo "$PAYLOAD" | grep -q "^CURSOR:"; then
-    echo "${PAYLOAD#CURSOR:}" > "$CURSOR_FILE"
+    write_cursor_file "${PAYLOAD#CURSOR:}" || log "cursor write failed for $SESSION_ID"
     exit 0
   fi
 
@@ -154,7 +270,7 @@ fi
 
   if [ $CURL_EXIT -eq 0 ] && [[ "$HTTP_STATUS" =~ ^2 ]]; then
     log "observe OK for $SESSION_ID"
-    echo "$TOTAL" > "$CURSOR_FILE"
+    write_cursor_file "$TOTAL" || log "cursor write failed for $SESSION_ID"
   else
     log "observe failed (curl=$CURL_EXIT http=$HTTP_STATUS) — cursor not advanced"
   fi

--- a/packages/plugin-codex/hooks/bin/session-end.sh
+++ b/packages/plugin-codex/hooks/bin/session-end.sh
@@ -53,55 +53,172 @@ TRANSCRIPT_PATH="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.
 
 echo '{"continue":true}'
 
-# Final observe flush if we have transcript
-if [ -n "$REMNIC_TOKEN" ] && [ -n "$SESSION_ID" ] && [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
-  LEGACY_CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
-  CURSOR_FILE="/tmp/remnic-cursor-${SESSION_ID}"
-  if [ ! -f "$CURSOR_FILE" ] && [ -f "$LEGACY_CURSOR_FILE" ]; then
-    CURSOR_FILE="$LEGACY_CURSOR_FILE"
+SESSION_ID_SAFE=0
+if [[ "$SESSION_ID" != "" && ! "$SESSION_ID" =~ [^A-Za-z0-9._-] ]]; then
+  SESSION_ID_SAFE=1
+  STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+  STATE_DIR="${STATE_HOME}/remnic/hooks"
+  CURSOR_FILE="${STATE_DIR}/remnic-cursor-${SESSION_ID}"
+  LOCK_DIR="${STATE_DIR}/remnic-lock-${SESSION_ID}.d"
+  LEGACY_CURSOR_FILE="${STATE_DIR}/engram-cursor-${SESSION_ID}"
+  LEGACY_LOCK_DIR="${STATE_DIR}/engram-lock-${SESSION_ID}.d"
+
+  mkdir -p "$STATE_DIR" 2>/dev/null || SESSION_ID_SAFE=0
+  if [ "$SESSION_ID_SAFE" -eq 1 ]; then
+    if ! node - "$STATE_DIR" <<'NODE'
+const fs = require('fs');
+const stateDir = process.argv[2];
+try {
+  const info = fs.lstatSync(stateDir);
+  if (info.isSymbolicLink() || !info.isDirectory()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+  if ((info.mode & 0o077) !== 0) fs.chmodSync(stateDir, 0o700);
+} catch {
+  process.exit(1);
+}
+NODE
+    then
+      log "unsafe state directory $STATE_DIR"
+      SESSION_ID_SAFE=0
+    fi
   fi
+  if [ "$SESSION_ID_SAFE" -eq 1 ] && [ ! -f "$CURSOR_FILE" ] && { [ -f "$LEGACY_CURSOR_FILE" ] || [ -d "$LEGACY_LOCK_DIR" ]; }; then
+    CURSOR_FILE="$LEGACY_CURSOR_FILE"
+    LOCK_DIR="$LEGACY_LOCK_DIR"
+  fi
+fi
+
+validate_cursor_file() {
+  node - "$CURSOR_FILE" <<'NODE'
+const fs = require('fs');
+const cursorFile = process.argv[2];
+try {
+  const info = fs.lstatSync(cursorFile);
+  if (info.isSymbolicLink() || !info.isFile()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+} catch (error) {
+  if (error && error.code === 'ENOENT') process.exit(0);
+  process.exit(1);
+}
+NODE
+}
+
+read_cursor_file() {
+  validate_cursor_file || {
+    log "unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  [ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo 0
+}
+
+write_cursor_file() {
+  NEW_CURSOR_VALUE="$1"
+  validate_cursor_file || {
+    log "refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  TEMP_CURSOR="$(mktemp "${CURSOR_FILE}.tmp.XXXXXX" 2>/dev/null)" || return 1
+  if ! printf '%s\n' "$NEW_CURSOR_VALUE" > "$TEMP_CURSOR"; then
+    rm -f "$TEMP_CURSOR"
+    return 1
+  fi
+  chmod 600 "$TEMP_CURSOR" 2>/dev/null || true
+  mv -f "$TEMP_CURSOR" "$CURSOR_FILE"
+}
+
+migrate_tmp_cursor_file() {
+  for TMP_CURSOR_FILE in "/tmp/remnic-cursor-${SESSION_ID}" "/tmp/engram-cursor-${SESSION_ID}"; do
+    [ ! -e "$TMP_CURSOR_FILE" ] && continue
+    TMP_CURSOR_VALUE="$(node - "$TMP_CURSOR_FILE" <<'NODE'
+const fs = require('fs');
+const cursorFile = process.argv[2];
+try {
+  const info = fs.lstatSync(cursorFile);
+  if (info.isSymbolicLink() || !info.isFile()) process.exit(1);
+  if (typeof process.getuid === 'function' && info.uid !== process.getuid()) process.exit(1);
+  const value = fs.readFileSync(cursorFile, 'utf8').trim();
+  if (!/^\d+$/.test(value)) process.exit(1);
+  process.stdout.write(value);
+} catch {
+  process.exit(1);
+}
+NODE
+    )" || continue
+    CURRENT_CURSOR_VALUE=""
+    if validate_cursor_file; then
+      CURRENT_CURSOR_VALUE="$([ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo "")"
+    fi
+    case "$CURRENT_CURSOR_VALUE" in
+      ""|*[!0-9]*) CURRENT_CURSOR_VALUE="-1" ;;
+    esac
+    if [ "$TMP_CURSOR_VALUE" -gt "$CURRENT_CURSOR_VALUE" ]; then
+      write_cursor_file "$TMP_CURSOR_VALUE" || continue
+    fi
+    rm -f "$TMP_CURSOR_FILE" 2>/dev/null
+  done
+}
+
+remove_cursor_file() {
+  validate_cursor_file || {
+    log "refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  rm -f "$CURSOR_FILE"
+}
+
+# Final observe flush if we have transcript
+if [ -n "$REMNIC_TOKEN" ] && [ "$SESSION_ID_SAFE" -eq 1 ] && [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   LAST_COUNT=0
-  [ -f "$CURSOR_FILE" ] && LAST_COUNT="$(cat "$CURSOR_FILE" 2>/dev/null || echo 0)"
+  migrate_tmp_cursor_file
+  if LAST_COUNT="$(read_cursor_file)"; then
+    PAYLOAD="$(node -e "
+      const fs = require('fs');
+      const lines = fs.readFileSync(process.argv[1], 'utf8').split('\n').filter(Boolean);
+      const messages = [];
+      for (const line of lines) {
+        try {
+          const entry = JSON.parse(line);
+          if (entry.type !== 'user' && entry.type !== 'assistant') continue;
+          const msg = entry.message;
+          if (!msg || typeof msg !== 'object') continue;
+          const role = msg.role;
+          if (role !== 'user' && role !== 'assistant') continue;
+          let text = typeof msg.content === 'string' ? msg.content.trim() :
+            Array.isArray(msg.content) ? msg.content.filter(b => b.type === 'text' && b.text).map(b => b.text.trim()).join('\n').trim() : '';
+          if (text) messages.push({ role, content: text });
+        } catch {}
+      }
+      const newMessages = messages.slice(parseInt(process.argv[3], 10) || 0);
+      if (newMessages.length) {
+        process.stdout.write(JSON.stringify({ sessionKey: process.argv[2], messages: newMessages }));
+      }
+    " "$TRANSCRIPT_PATH" "$SESSION_ID" "$LAST_COUNT" 2>/dev/null)"
 
-  PAYLOAD="$(node -e "
-    const fs = require('fs');
-    const lines = fs.readFileSync(process.argv[1], 'utf8').split('\n').filter(Boolean);
-    const messages = [];
-    for (const line of lines) {
-      try {
-        const entry = JSON.parse(line);
-        if (entry.type !== 'user' && entry.type !== 'assistant') continue;
-        const msg = entry.message;
-        if (!msg || typeof msg !== 'object') continue;
-        const role = msg.role;
-        if (role !== 'user' && role !== 'assistant') continue;
-        let text = typeof msg.content === 'string' ? msg.content.trim() :
-          Array.isArray(msg.content) ? msg.content.filter(b => b.type === 'text' && b.text).map(b => b.text.trim()).join('\n').trim() : '';
-        if (text) messages.push({ role, content: text });
-      } catch {}
-    }
-    const newMessages = messages.slice(parseInt(process.argv[3], 10) || 0);
-    if (newMessages.length) {
-      process.stdout.write(JSON.stringify({ sessionKey: process.argv[2], messages: newMessages }));
-    }
-  " "$TRANSCRIPT_PATH" "$SESSION_ID" "$LAST_COUNT" 2>/dev/null)"
-
-  if [ -n "$PAYLOAD" ]; then
-    log "final flush for $SESSION_ID"
-    curl -s --max-time 30 \
-      -X POST "$REMNIC_URL" \
-      -H "Authorization: Bearer ${REMNIC_TOKEN}" \
-      -H "Content-Type: application/json" \
-      -H "X-Engram-Client-Id: codex" \
-      -d "$PAYLOAD" >/dev/null 2>&1 || log "final flush failed"
+    if [ -n "$PAYLOAD" ]; then
+      log "final flush for $SESSION_ID"
+      curl -s --max-time 30 \
+        -X POST "$REMNIC_URL" \
+        -H "Authorization: Bearer ${REMNIC_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -H "X-Engram-Client-Id: codex" \
+        -d "$PAYLOAD" >/dev/null 2>&1 || log "final flush failed"
+    fi
+  else
+    log "final flush skipped for $SESSION_ID due to unsafe cursor"
   fi
 fi
 
 # Cleanup
-rm -f "/tmp/remnic-cursor-${SESSION_ID}" 2>/dev/null
-rmdir "/tmp/remnic-lock-${SESSION_ID}.d" 2>/dev/null
-rm -f "/tmp/engram-cursor-${SESSION_ID}" 2>/dev/null
-rmdir "/tmp/engram-lock-${SESSION_ID}.d" 2>/dev/null
+if [ "$SESSION_ID_SAFE" -eq 1 ]; then
+  remove_cursor_file || true
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+  if [ "$CURSOR_FILE" != "$LEGACY_CURSOR_FILE" ] && [ -e "$LEGACY_CURSOR_FILE" ] && [ ! -L "$LEGACY_CURSOR_FILE" ]; then
+    rm -f "$LEGACY_CURSOR_FILE" 2>/dev/null || true
+  fi
+  if [ "$LOCK_DIR" != "$LEGACY_LOCK_DIR" ]; then
+    rmdir "$LEGACY_LOCK_DIR" 2>/dev/null || true
+  fi
+fi
 
 # Codex-native memory materialization (#378). The script honors the
 # `codexMaterializeMemories` config flag and the `.remnic-managed` sentinel,

--- a/scripts/hooks/claude-code/engram-session-end.sh
+++ b/scripts/hooks/claude-code/engram-session-end.sh
@@ -2,7 +2,7 @@
 # Claude Code SessionEnd hook: final flush of remaining transcript messages into Engram.
 #
 # Fires when the session actually exits. Sends any messages not yet observed
-# (since the last Stop cursor), then cleans up the cursor file.
+# (since the last Stop cursor), then cleans up the private cursor file.
 #
 # Required env vars:
 #   OPENCLAW_ENGRAM_ACCESS_TOKEN  — bearer token for the Engram REST API
@@ -30,26 +30,173 @@ PROJECT_NAME="$(basename "$CWD" 2>/dev/null || echo "unknown")"
 echo '{}'
 
 [ -z "$ENGRAM_TOKEN" ] && exit 0
-[ -z "$SESSION_ID" ] && exit 0
+case "$SESSION_ID" in
+  ""|*[!A-Za-z0-9._-]*)
+    log "session-end[$SESSION_ID]: invalid session id"
+    exit 0
+    ;;
+esac
 [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ] && exit 0
 
-CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
-LOCK_FILE="/tmp/engram-lock-${SESSION_ID}"
+STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+STATE_DIR="${STATE_HOME}/remnic/hooks"
+
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+if ! python3 - "$STATE_DIR" <<'PYEOF'
+import os
+import stat
+import sys
+
+state_dir = sys.argv[1]
+try:
+    info = os.lstat(state_dir)
+except OSError:
+    sys.exit(1)
+
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+if info.st_mode & 0o077:
+    os.chmod(state_dir, 0o700)
+PYEOF
+then
+  log "session-end[$SESSION_ID]: unsafe state directory $STATE_DIR"
+  exit 0
+fi
+
+CURSOR_FILE="${STATE_DIR}/engram-cursor-${SESSION_ID}"
+LOCK_DIR="${STATE_DIR}/engram-lock-${SESSION_ID}.d"
+
+validate_cursor_file() {
+  python3 - "$CURSOR_FILE" <<'PYEOF'
+import os
+import stat
+import sys
+
+cursor_file = sys.argv[1]
+try:
+    info = os.lstat(cursor_file)
+except FileNotFoundError:
+    sys.exit(0)
+except OSError:
+    sys.exit(1)
+
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+PYEOF
+}
+
+read_cursor_file() {
+  validate_cursor_file || {
+    log "session-end[$SESSION_ID]: unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  [ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo 0
+}
+
+write_cursor_file() {
+  NEW_CURSOR_VALUE="$1"
+  validate_cursor_file || {
+    log "session-end[$SESSION_ID]: refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  TEMP_CURSOR="$(mktemp "${CURSOR_FILE}.tmp.XXXXXX" 2>/dev/null)" || return 1
+  if ! printf '%s\n' "$NEW_CURSOR_VALUE" > "$TEMP_CURSOR"; then
+    rm -f "$TEMP_CURSOR"
+    return 1
+  fi
+  chmod 600 "$TEMP_CURSOR" 2>/dev/null || true
+  mv -f "$TEMP_CURSOR" "$CURSOR_FILE"
+}
+
+migrate_tmp_cursor_file() {
+  TMP_CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
+  [ ! -e "$TMP_CURSOR_FILE" ] && return 0
+  TMP_CURSOR_VALUE="$(python3 - "$TMP_CURSOR_FILE" <<'PYEOF'
+import os
+import stat
+import sys
+
+cursor_file = sys.argv[1]
+try:
+    info = os.lstat(cursor_file)
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        sys.exit(1)
+    if info.st_uid != os.getuid():
+        sys.exit(1)
+    value = open(cursor_file, "r", encoding="utf-8").read().strip()
+    if not value.isdigit():
+        sys.exit(1)
+    print(value, end="")
+except OSError:
+    sys.exit(1)
+PYEOF
+  )" || return 0
+  CURRENT_CURSOR_VALUE=""
+  if validate_cursor_file; then
+    CURRENT_CURSOR_VALUE="$([ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo "")"
+  fi
+  case "$CURRENT_CURSOR_VALUE" in
+    ""|*[!0-9]*) CURRENT_CURSOR_VALUE="-1" ;;
+  esac
+  if [ "$TMP_CURSOR_VALUE" -gt "$CURRENT_CURSOR_VALUE" ]; then
+    write_cursor_file "$TMP_CURSOR_VALUE" || return 0
+  fi
+  rm -f "$TMP_CURSOR_FILE" 2>/dev/null
+}
+
+remove_stale_lock_dir() {
+  python3 - "$LOCK_DIR" <<'PYEOF'
+import os
+import shutil
+import stat
+import sys
+import time
+
+lock_dir = sys.argv[1]
+try:
+    info = os.lstat(lock_dir)
+except FileNotFoundError:
+    sys.exit(0)
+except OSError:
+    sys.exit(1)
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+if time.time() - info.st_mtime < 10 * 60:
+    sys.exit(0)
+shutil.rmtree(lock_dir)
+PYEOF
+}
+
+remove_cursor_file() {
+  validate_cursor_file || {
+    log "session-end[$SESSION_ID]: refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  rm -f "$CURSOR_FILE"
+}
 
 (
   # Acquire exclusive lock to prevent races with any in-flight Stop observe job.
   # Uses mkdir atomicity (POSIX-portable; flock(1) is Linux-only).
-  LOCK_DIR="${LOCK_FILE}.d"
   ACQUIRED=0
   for _i in $(seq 1 100); do
     if mkdir "$LOCK_DIR" 2>/dev/null; then ACQUIRED=1; break; fi
+    [ "$_i" -eq 1 ] && remove_stale_lock_dir >/dev/null 2>&1
     sleep 0.1
   done
   trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT INT TERM
   [ "$ACQUIRED" -eq 0 ] && exit 0
 
+  migrate_tmp_cursor_file
+
   LAST_COUNT=0
-  [ -f "$CURSOR_FILE" ] && LAST_COUNT="$(cat "$CURSOR_FILE" 2>/dev/null || echo 0)"
+  LAST_COUNT="$(read_cursor_file)" || exit 0
 
   PAYLOAD="$(python3 - "$TRANSCRIPT_PATH" "$SESSION_ID" "$LAST_COUNT" <<'PYEOF'
 import sys, json
@@ -115,7 +262,7 @@ PYEOF
 
   if echo "$PAYLOAD" | grep -q "^CURSOR:"; then
     log "session-end[$SESSION_ID]: no new messages at exit"
-    rm -f "$CURSOR_FILE"
+    remove_cursor_file
     exit 0
   fi
 
@@ -148,7 +295,7 @@ import json, sys
 d = json.load(sys.stdin)
 print(f\"accepted={d.get('accepted','?')} lcm={d.get('lcmArchived','?')} extraction={d.get('extractionQueued','?')}\")" 2>/dev/null || echo "$RESPONSE" | head -c 80)"
     log "session-end[$SESSION_ID]: flush OK — $RESULT"
-    rm -f "$CURSOR_FILE"
+    remove_cursor_file
   else
     log "session-end[$SESSION_ID]: flush failed (curl=$CURL_EXIT http=$HTTP_STATUS)"
   fi

--- a/scripts/hooks/claude-code/engram-session-store.sh
+++ b/scripts/hooks/claude-code/engram-session-store.sh
@@ -2,7 +2,7 @@
 # Claude Code Stop hook: incrementally feed new transcript messages into Engram.
 #
 # Fires after every assistant turn. Tracks a cursor per session in
-# /tmp/engram-cursor-<session_id> so only NEW messages are sent each call.
+# a private per-user state directory so only NEW messages are sent each call.
 # Runs observe in the background — never blocks the stop.
 #
 # Required env vars:
@@ -31,27 +31,166 @@ PROJECT_NAME="$(basename "$CWD" 2>/dev/null || echo "unknown")"
 echo '{}'
 
 [ -z "$ENGRAM_TOKEN" ] && exit 0
-[ -z "$SESSION_ID" ] && exit 0
+case "$SESSION_ID" in
+  ""|*[!A-Za-z0-9._-]*)
+    log "stop[$SESSION_ID]: invalid session id"
+    exit 0
+    ;;
+esac
 [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ] && exit 0
 
-CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
-LOCK_FILE="/tmp/engram-lock-${SESSION_ID}"
+STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+STATE_DIR="${STATE_HOME}/remnic/hooks"
+
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+if ! python3 - "$STATE_DIR" <<'PYEOF'
+import os
+import stat
+import sys
+
+state_dir = sys.argv[1]
+try:
+    info = os.lstat(state_dir)
+except OSError:
+    sys.exit(1)
+
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+if info.st_mode & 0o077:
+    os.chmod(state_dir, 0o700)
+PYEOF
+then
+  log "stop[$SESSION_ID]: unsafe state directory $STATE_DIR"
+  exit 0
+fi
+
+CURSOR_FILE="${STATE_DIR}/engram-cursor-${SESSION_ID}"
+LOCK_DIR="${STATE_DIR}/engram-lock-${SESSION_ID}.d"
+
+validate_cursor_file() {
+  python3 - "$CURSOR_FILE" <<'PYEOF'
+import os
+import stat
+import sys
+
+cursor_file = sys.argv[1]
+try:
+    info = os.lstat(cursor_file)
+except FileNotFoundError:
+    sys.exit(0)
+except OSError:
+    sys.exit(1)
+
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+PYEOF
+}
+
+read_cursor_file() {
+  validate_cursor_file || {
+    log "stop[$SESSION_ID]: unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  [ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo 0
+}
+
+write_cursor_file() {
+  NEW_CURSOR_VALUE="$1"
+  validate_cursor_file || {
+    log "stop[$SESSION_ID]: refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  TEMP_CURSOR="$(mktemp "${CURSOR_FILE}.tmp.XXXXXX" 2>/dev/null)" || return 1
+  if ! printf '%s\n' "$NEW_CURSOR_VALUE" > "$TEMP_CURSOR"; then
+    rm -f "$TEMP_CURSOR"
+    return 1
+  fi
+  chmod 600 "$TEMP_CURSOR" 2>/dev/null || true
+  mv -f "$TEMP_CURSOR" "$CURSOR_FILE"
+}
+
+migrate_tmp_cursor_file() {
+  TMP_CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
+  [ ! -e "$TMP_CURSOR_FILE" ] && return 0
+  TMP_CURSOR_VALUE="$(python3 - "$TMP_CURSOR_FILE" <<'PYEOF'
+import os
+import stat
+import sys
+
+cursor_file = sys.argv[1]
+try:
+    info = os.lstat(cursor_file)
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        sys.exit(1)
+    if info.st_uid != os.getuid():
+        sys.exit(1)
+    value = open(cursor_file, "r", encoding="utf-8").read().strip()
+    if not value.isdigit():
+        sys.exit(1)
+    print(value, end="")
+except OSError:
+    sys.exit(1)
+PYEOF
+  )" || return 0
+  CURRENT_CURSOR_VALUE=""
+  if validate_cursor_file; then
+    CURRENT_CURSOR_VALUE="$([ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo "")"
+  fi
+  case "$CURRENT_CURSOR_VALUE" in
+    ""|*[!0-9]*) CURRENT_CURSOR_VALUE="-1" ;;
+  esac
+  if [ "$TMP_CURSOR_VALUE" -gt "$CURRENT_CURSOR_VALUE" ]; then
+    write_cursor_file "$TMP_CURSOR_VALUE" || return 0
+  fi
+  rm -f "$TMP_CURSOR_FILE" 2>/dev/null
+}
+
+remove_stale_lock_dir() {
+  python3 - "$LOCK_DIR" <<'PYEOF'
+import os
+import shutil
+import stat
+import sys
+import time
+
+lock_dir = sys.argv[1]
+try:
+    info = os.lstat(lock_dir)
+except FileNotFoundError:
+    sys.exit(0)
+except OSError:
+    sys.exit(1)
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+if time.time() - info.st_mtime < 10 * 60:
+    sys.exit(0)
+shutil.rmtree(lock_dir)
+PYEOF
+}
 
 (
   # Acquire exclusive lock to prevent overlapping observe jobs from replaying
   # the same transcript tail when Stop fires in rapid succession.
   # Uses mkdir atomicity (POSIX-portable; flock(1) is Linux-only).
-  LOCK_DIR="${LOCK_FILE}.d"
   ACQUIRED=0
   for _i in $(seq 1 100); do
     if mkdir "$LOCK_DIR" 2>/dev/null; then ACQUIRED=1; break; fi
+    [ "$_i" -eq 1 ] && remove_stale_lock_dir >/dev/null 2>&1
     sleep 0.1
   done
   trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT INT TERM
   [ "$ACQUIRED" -eq 0 ] && exit 0
 
+  migrate_tmp_cursor_file
+
   LAST_COUNT=0
-  [ -f "$CURSOR_FILE" ] && LAST_COUNT="$(cat "$CURSOR_FILE" 2>/dev/null || echo 0)"
+  LAST_COUNT="$(read_cursor_file)" || exit 0
 
   PAYLOAD="$(python3 - "$TRANSCRIPT_PATH" "$SESSION_ID" "$LAST_COUNT" <<'PYEOF'
 import sys, json
@@ -117,7 +256,7 @@ PYEOF
 
   if echo "$PAYLOAD" | grep -q "^CURSOR:"; then
     NEW_CURSOR="$(echo "$PAYLOAD" | sed 's/CURSOR://')"
-    echo "$NEW_CURSOR" > "$CURSOR_FILE"
+    write_cursor_file "$NEW_CURSOR" || log "stop[$SESSION_ID]: cursor write failed"
     exit 0
   fi
 
@@ -152,7 +291,7 @@ import json, sys
 d = json.load(sys.stdin)
 print(f\"accepted={d.get('accepted','?')} lcm={d.get('lcmArchived','?')} extraction={d.get('extractionQueued','?')}\")" 2>/dev/null || echo "$RESPONSE" | head -c 80)"
     log "stop[$SESSION_ID]: observe OK — $RESULT"
-    echo "$NEW_COUNT" > "$CURSOR_FILE"
+    write_cursor_file "$NEW_COUNT" || log "stop[$SESSION_ID]: cursor write failed"
   else
     log "stop[$SESSION_ID]: observe failed (curl=$CURL_EXIT http=$HTTP_STATUS) — cursor not advanced"
   fi

--- a/scripts/hooks/codex/engram-session-store.sh
+++ b/scripts/hooks/codex/engram-session-store.sh
@@ -2,7 +2,7 @@
 # Codex Stop hook: incrementally feed new transcript messages into Engram.
 #
 # Fires after every agent turn (Stop) and also on final exit (stop_hook_active=false).
-# Tracks a cursor per session in /tmp/engram-cursor-<session_id> so only NEW
+# Tracks a cursor per session in a private per-user state directory so only NEW
 # messages are sent each call. When stop_hook_active is false (final stop),
 # the cursor file is also cleaned up.
 # Runs observe in the background — never blocks the stop.
@@ -36,27 +36,174 @@ IS_FINAL_STOP=$( [ "$STOP_HOOK_ACTIVE" = "False" ] && echo "true" || echo "false
 echo '{}'
 
 [ -z "$ENGRAM_TOKEN" ] && exit 0
-[ -z "$SESSION_ID" ] && exit 0
+case "$SESSION_ID" in
+  ""|*[!A-Za-z0-9._-]*)
+    log "stop[$SESSION_ID]: invalid session id"
+    exit 0
+    ;;
+esac
 [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ] && exit 0
 
-CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
-LOCK_FILE="/tmp/engram-lock-${SESSION_ID}"
+STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+STATE_DIR="${STATE_HOME}/remnic/hooks"
+
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+if ! python3 - "$STATE_DIR" <<'PYEOF'
+import os
+import stat
+import sys
+
+state_dir = sys.argv[1]
+try:
+    info = os.lstat(state_dir)
+except OSError:
+    sys.exit(1)
+
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+if info.st_mode & 0o077:
+    os.chmod(state_dir, 0o700)
+PYEOF
+then
+  log "stop[$SESSION_ID]: unsafe state directory $STATE_DIR"
+  exit 0
+fi
+
+CURSOR_FILE="${STATE_DIR}/engram-cursor-${SESSION_ID}"
+LOCK_DIR="${STATE_DIR}/engram-lock-${SESSION_ID}.d"
+
+validate_cursor_file() {
+  python3 - "$CURSOR_FILE" <<'PYEOF'
+import os
+import stat
+import sys
+
+cursor_file = sys.argv[1]
+try:
+    info = os.lstat(cursor_file)
+except FileNotFoundError:
+    sys.exit(0)
+except OSError:
+    sys.exit(1)
+
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+PYEOF
+}
+
+read_cursor_file() {
+  validate_cursor_file || {
+    log "stop[$SESSION_ID]: unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  [ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo 0
+}
+
+write_cursor_file() {
+  NEW_CURSOR_VALUE="$1"
+  validate_cursor_file || {
+    log "stop[$SESSION_ID]: refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  TEMP_CURSOR="$(mktemp "${CURSOR_FILE}.tmp.XXXXXX" 2>/dev/null)" || return 1
+  if ! printf '%s\n' "$NEW_CURSOR_VALUE" > "$TEMP_CURSOR"; then
+    rm -f "$TEMP_CURSOR"
+    return 1
+  fi
+  chmod 600 "$TEMP_CURSOR" 2>/dev/null || true
+  mv -f "$TEMP_CURSOR" "$CURSOR_FILE"
+}
+
+migrate_tmp_cursor_file() {
+  TMP_CURSOR_FILE="/tmp/engram-cursor-${SESSION_ID}"
+  [ ! -e "$TMP_CURSOR_FILE" ] && return 0
+  TMP_CURSOR_VALUE="$(python3 - "$TMP_CURSOR_FILE" <<'PYEOF'
+import os
+import stat
+import sys
+
+cursor_file = sys.argv[1]
+try:
+    info = os.lstat(cursor_file)
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        sys.exit(1)
+    if info.st_uid != os.getuid():
+        sys.exit(1)
+    value = open(cursor_file, "r", encoding="utf-8").read().strip()
+    if not value.isdigit():
+        sys.exit(1)
+    print(value, end="")
+except OSError:
+    sys.exit(1)
+PYEOF
+  )" || return 0
+  CURRENT_CURSOR_VALUE=""
+  if validate_cursor_file; then
+    CURRENT_CURSOR_VALUE="$([ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo "")"
+  fi
+  case "$CURRENT_CURSOR_VALUE" in
+    ""|*[!0-9]*) CURRENT_CURSOR_VALUE="-1" ;;
+  esac
+  if [ "$TMP_CURSOR_VALUE" -gt "$CURRENT_CURSOR_VALUE" ]; then
+    write_cursor_file "$TMP_CURSOR_VALUE" || return 0
+  fi
+  rm -f "$TMP_CURSOR_FILE" 2>/dev/null
+}
+
+remove_stale_lock_dir() {
+  python3 - "$LOCK_DIR" <<'PYEOF'
+import os
+import shutil
+import stat
+import sys
+import time
+
+lock_dir = sys.argv[1]
+try:
+    info = os.lstat(lock_dir)
+except FileNotFoundError:
+    sys.exit(0)
+except OSError:
+    sys.exit(1)
+if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+    sys.exit(1)
+if info.st_uid != os.getuid():
+    sys.exit(1)
+if time.time() - info.st_mtime < 10 * 60:
+    sys.exit(0)
+shutil.rmtree(lock_dir)
+PYEOF
+}
+
+remove_cursor_file() {
+  validate_cursor_file || {
+    log "stop[$SESSION_ID]: refusing unsafe cursor file $CURSOR_FILE"
+    return 1
+  }
+  rm -f "$CURSOR_FILE"
+}
 
 (
   # Acquire exclusive lock to prevent overlapping observe jobs from replaying
   # the same transcript tail when Stop fires in rapid succession.
   # Uses mkdir atomicity (POSIX-portable; flock(1) is Linux-only).
-  LOCK_DIR="${LOCK_FILE}.d"
   ACQUIRED=0
   for _i in $(seq 1 100); do
     if mkdir "$LOCK_DIR" 2>/dev/null; then ACQUIRED=1; break; fi
+    [ "$_i" -eq 1 ] && remove_stale_lock_dir >/dev/null 2>&1
     sleep 0.1
   done
   trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT INT TERM
   [ "$ACQUIRED" -eq 0 ] && exit 0
 
+  migrate_tmp_cursor_file
+
   LAST_COUNT=0
-  [ -f "$CURSOR_FILE" ] && LAST_COUNT="$(cat "$CURSOR_FILE" 2>/dev/null || echo 0)"
+  LAST_COUNT="$(read_cursor_file)" || exit 0
 
   PAYLOAD="$(python3 - "$TRANSCRIPT_PATH" "$SESSION_ID" "$LAST_COUNT" <<'PYEOF'
 import sys, json
@@ -117,14 +264,14 @@ PYEOF
 
   if [ -z "$PAYLOAD" ]; then
     log "stop[$SESSION_ID]: parse failed"
-    [ "$IS_FINAL_STOP" = "true" ] && rm -f "$CURSOR_FILE"
+    [ "$IS_FINAL_STOP" = "true" ] && remove_cursor_file
     exit 0
   fi
 
   if echo "$PAYLOAD" | grep -q "^CURSOR:"; then
     NEW_CURSOR="$(echo "$PAYLOAD" | sed 's/CURSOR://')"
-    echo "$NEW_CURSOR" > "$CURSOR_FILE"
-    [ "$IS_FINAL_STOP" = "true" ] && rm -f "$CURSOR_FILE" && log "stop[$SESSION_ID]: final stop, no new messages, cursor cleaned up"
+    write_cursor_file "$NEW_CURSOR" || log "stop[$SESSION_ID]: cursor write failed"
+    [ "$IS_FINAL_STOP" = "true" ] && remove_cursor_file && log "stop[$SESSION_ID]: final stop, no new messages, cursor cleaned up"
     exit 0
   fi
 
@@ -159,11 +306,11 @@ import json, sys
 d = json.load(sys.stdin)
 print(f\"accepted={d.get('accepted','?')} lcm={d.get('lcmArchived','?')} extraction={d.get('extractionQueued','?')}\")" 2>/dev/null || echo "$RESPONSE" | head -c 80)"
     log "$LABEL[$SESSION_ID]: observe OK — $RESULT"
-    echo "$NEW_COUNT" > "$CURSOR_FILE"
-    [ "$IS_FINAL_STOP" = "true" ] && rm -f "$CURSOR_FILE"
+    write_cursor_file "$NEW_COUNT" || log "$LABEL[$SESSION_ID]: cursor write failed"
+    [ "$IS_FINAL_STOP" = "true" ] && remove_cursor_file
   else
     log "$LABEL[$SESSION_ID]: observe failed (curl=$CURL_EXIT http=$HTTP_STATUS) — cursor not advanced"
-    [ "$IS_FINAL_STOP" = "true" ] && rm -f "$CURSOR_FILE"
+    [ "$IS_FINAL_STOP" = "true" ] && remove_cursor_file
   fi
 ) >> "$LOG" 2>&1 &
 

--- a/tests/codex-session-end-hook.test.ts
+++ b/tests/codex-session-end-hook.test.ts
@@ -1,22 +1,29 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import test from "node:test";
 
 const sessionEndHook = "packages/plugin-codex/hooks/bin/session-end.sh";
 
-test("Codex session-end hook falls back to legacy engram cursor files", async () => {
+test("Codex session-end hook falls back to private legacy engram cursor files", async () => {
   const content = await readFile(sessionEndHook, "utf8");
 
-  assert.match(content, /LEGACY_CURSOR_FILE="\/tmp\/engram-cursor-\$\{SESSION_ID\}"/);
-  assert.match(content, /CURSOR_FILE="\/tmp\/remnic-cursor-\$\{SESSION_ID\}"/);
-  assert.match(content, /if \[ ! -f "\$CURSOR_FILE" \] && \[ -f "\$LEGACY_CURSOR_FILE" \]; then/);
+  assert.match(content, /LEGACY_CURSOR_FILE="\$\{STATE_DIR\}\/engram-cursor-\$\{SESSION_ID\}"/);
+  assert.match(content, /CURSOR_FILE="\$\{STATE_DIR\}\/remnic-cursor-\$\{SESSION_ID\}"/);
+  assert.match(content, /if \[ "\$SESSION_ID_SAFE" -eq 1 \] && \[ ! -f "\$CURSOR_FILE" \]/);
   assert.match(content, /CURSOR_FILE="\$LEGACY_CURSOR_FILE"/);
+  assert.match(
+    content,
+    /for TMP_CURSOR_FILE in "\/tmp\/remnic-cursor-\$\{SESSION_ID\}" "\/tmp\/engram-cursor-\$\{SESSION_ID\}"; do/
+  );
 });
 
 test("Codex session-end hook retries legacy engram tokens when remnic token parsing fails", async () => {
   const content = await readFile(sessionEndHook, "utf8");
 
-  assert.match(content, /for TOKEN_FILE in "\$\{HOME\}\/\.remnic\/tokens\.json" "\$\{HOME\}\/\.engram\/tokens\.json"; do/);
+  assert.match(
+    content,
+    /for TOKEN_FILE in "\$\{HOME\}\/\.remnic\/tokens\.json" "\$\{HOME\}\/\.engram\/tokens\.json"; do/
+  );
   assert.match(content, /\[ ! -f "\$TOKEN_FILE" \] && continue/);
   assert.match(content, /JSON\.parse\(fs\.readFileSync\(tokenFile, 'utf8'\)\)/);
   assert.match(content, /\[ -n "\$REMNIC_TOKEN" \] && break/);

--- a/tests/engram-session-store-hook.test.mjs
+++ b/tests/engram-session-store-hook.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const hookCases = [
+  {
+    name: "claude-code",
+    scriptPath: "scripts/hooks/claude-code/engram-session-store.sh",
+    logPath: [".claude", "logs", "engram-session-store.log"],
+  },
+  {
+    name: "codex",
+    scriptPath: "scripts/hooks/codex/engram-session-store.sh",
+    logPath: [".codex", "logs", "engram-session-store.log"],
+  },
+];
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.fail(message);
+}
+
+async function makeFixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-session-store-"));
+  const home = path.join(root, "home");
+  const stateHome = path.join(root, "state");
+  const transcript = path.join(root, "transcript.jsonl");
+  await mkdir(home, { recursive: true });
+  await mkdir(stateHome, { recursive: true });
+  await writeFile(transcript, "", "utf8");
+  return { root, home, stateHome, transcript };
+}
+
+function runHook(hookCase, fixture, sessionId) {
+  return spawnSync("bash", [hookCase.scriptPath], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: fixture.home,
+      XDG_STATE_HOME: fixture.stateHome,
+      OPENCLAW_ENGRAM_ACCESS_TOKEN: "test-token",
+    },
+    input: JSON.stringify({
+      session_id: sessionId,
+      transcript_path: fixture.transcript,
+      cwd: process.cwd(),
+    }),
+  });
+}
+
+for (const hookCase of hookCases) {
+  test(`${hookCase.name} session store writes cursor state inside a private state directory`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `safe-session-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const cursorPath = path.join(stateDir, `engram-cursor-${sessionId}`);
+
+    try {
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, "{}\n");
+
+      await waitFor(async () => existsSync(cursorPath), "cursor was not written");
+
+      assert.equal(await readFile(cursorPath, "utf8"), "0\n");
+      assert.equal((await stat(stateDir)).mode & 0o777, 0o700);
+      assert.equal(existsSync(path.join(os.tmpdir(), `engram-cursor-${sessionId}`)), false);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+      await rm(path.join(os.tmpdir(), `engram-cursor-${sessionId}`), { force: true });
+    }
+  });
+
+  test(`${hookCase.name} session store refuses to write through a symlinked cursor`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `symlink-session-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const cursorPath = path.join(stateDir, `engram-cursor-${sessionId}`);
+    const symlinkTarget = path.join(fixture.root, "target.txt");
+
+    try {
+      await mkdir(stateDir, { recursive: true, mode: 0o700 });
+      await writeFile(symlinkTarget, "unchanged\n", "utf8");
+      await symlink(symlinkTarget, cursorPath);
+
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, "{}\n");
+
+      const logPath = path.join(fixture.home, ...hookCase.logPath);
+      await waitFor(async () => {
+        if (!existsSync(logPath)) return false;
+        return (await readFile(logPath, "utf8")).includes("unsafe cursor file");
+      }, "unsafe cursor was not rejected");
+
+      assert.equal(await readFile(symlinkTarget, "utf8"), "unchanged\n");
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  test(`${hookCase.name} session store migrates an owned non-symlink tmp cursor once`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `tmp-session-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const cursorPath = path.join(stateDir, `engram-cursor-${sessionId}`);
+    const tmpCursorPath = `/tmp/engram-cursor-${sessionId}`;
+
+    try {
+      await writeFile(tmpCursorPath, "1\n", "utf8");
+      await writeFile(
+        fixture.transcript,
+        `${JSON.stringify({ type: "user", message: { role: "user", content: "hello" } })}\n`,
+        "utf8",
+      );
+
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, "{}\n");
+
+      await waitFor(async () => {
+        if (!existsSync(cursorPath) || existsSync(tmpCursorPath)) return false;
+        return (await readFile(cursorPath, "utf8")) === "1\n";
+      }, "tmp cursor was not migrated");
+
+      assert.equal(await readFile(cursorPath, "utf8"), "1\n");
+      assert.equal(existsSync(tmpCursorPath), false);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+      await rm(tmpCursorPath, { force: true });
+    }
+  });
+
+  test(`${hookCase.name} session store recovers stale private lock directories`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `stale-lock-session-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const lockDir = path.join(stateDir, `engram-lock-${sessionId}.d`);
+    const cursorPath = path.join(stateDir, `engram-cursor-${sessionId}`);
+    const oldTime = new Date(Date.now() - 20 * 60 * 1000);
+
+    try {
+      await mkdir(lockDir, { recursive: true, mode: 0o700 });
+      await utimes(lockDir, oldTime, oldTime);
+
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, "{}\n");
+
+      await waitFor(async () => existsSync(cursorPath), "stale lock was not recovered");
+
+      assert.equal(await readFile(cursorPath, "utf8"), "0\n");
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+}

--- a/tests/post-tool-observe-hook.test.ts
+++ b/tests/post-tool-observe-hook.test.ts
@@ -8,16 +8,23 @@ const hookFiles = [
 ];
 
 for (const hookFile of hookFiles) {
-  test(`${hookFile} falls back to legacy engram cursor and lock files`, async () => {
+  test(`${hookFile} stores cursor and lock files in private state`, async () => {
     const content = await readFile(hookFile, "utf8");
 
-    assert.match(content, /LEGACY_CURSOR_FILE="\/tmp\/engram-cursor-\$\{SESSION_ID\}"/);
-    assert.match(content, /CURSOR_FILE="\/tmp\/remnic-cursor-\$\{SESSION_ID\}"/);
-    assert.match(content, /LEGACY_LOCK_DIR="\/tmp\/engram-lock-\$\{SESSION_ID\}\.d"/);
-    assert.match(content, /LOCK_DIR="\/tmp\/remnic-lock-\$\{SESSION_ID\}\.d"/);
-    assert.match(content, /if \[ ! -f "\$CURSOR_FILE" \] && \{ \[ -f "\$LEGACY_CURSOR_FILE" \] \|\| \[ -d "\$LEGACY_LOCK_DIR" \]; \}; then/);
+    assert.match(content, /STATE_HOME="\$\{XDG_STATE_HOME:-\$\{HOME\}\/\.local\/state\}"/);
+    assert.match(content, /STATE_DIR="\$\{STATE_HOME\}\/remnic\/hooks"/);
+    assert.match(content, /CURSOR_FILE="\$\{STATE_DIR\}\/remnic-cursor-\$\{SESSION_ID\}"/);
+    assert.match(content, /LOCK_DIR="\$\{STATE_DIR\}\/remnic-lock-\$\{SESSION_ID\}\.d"/);
+    assert.match(content, /LEGACY_CURSOR_FILE="\$\{STATE_DIR\}\/engram-cursor-\$\{SESSION_ID\}"/);
+    assert.match(content, /LEGACY_LOCK_DIR="\$\{STATE_DIR\}\/engram-lock-\$\{SESSION_ID\}\.d"/);
     assert.match(content, /CURSOR_FILE="\$LEGACY_CURSOR_FILE"/);
     assert.match(content, /LOCK_DIR="\$LEGACY_LOCK_DIR"/);
+    assert.match(content, /validate_cursor_file\(\)/);
+    assert.match(content, /write_cursor_file\(\)/);
+    assert.match(content, /migrate_tmp_cursor_file\(\)/);
+    assert.doesNotMatch(content, /> "\$CURSOR_FILE"/);
+    assert.doesNotMatch(content, /CURSOR_FILE="\/tmp/);
+    assert.doesNotMatch(content, /LOCK_DIR="\/tmp/);
   });
 
   test(`${hookFile} retries legacy engram tokens when remnic token parsing fails`, async () => {

--- a/tests/post-tool-observe-state.test.mjs
+++ b/tests/post-tool-observe-state.test.mjs
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const hookCases = [
+  {
+    name: "claude-code-package",
+    scriptPath: "packages/plugin-claude-code/hooks/bin/post-tool-observe.sh",
+  },
+  {
+    name: "codex-package",
+    scriptPath: "packages/plugin-codex/hooks/bin/post-tool-observe.sh",
+  },
+];
+
+async function waitFor(predicate, message) {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.fail(message);
+}
+
+async function makeFixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-post-tool-state-"));
+  const home = path.join(root, "home");
+  const stateHome = path.join(root, "state");
+  const transcript = path.join(root, "transcript.jsonl");
+  await mkdir(home, { recursive: true });
+  await mkdir(stateHome, { recursive: true });
+  await writeFile(transcript, "", "utf8");
+  return { root, home, stateHome, transcript };
+}
+
+function runHook(hookCase, fixture, sessionId) {
+  return spawnSync("bash", [hookCase.scriptPath], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: fixture.home,
+      XDG_STATE_HOME: fixture.stateHome,
+      OPENCLAW_REMNIC_ACCESS_TOKEN: "test-token",
+    },
+    input: JSON.stringify({
+      session_id: sessionId,
+      transcript_path: fixture.transcript,
+      cwd: process.cwd(),
+      tool_name: "Bash",
+    }),
+  });
+
+}
+
+function runCodexSessionEnd(fixture, sessionId) {
+  return spawnSync("bash", ["packages/plugin-codex/hooks/bin/session-end.sh"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: fixture.home,
+      XDG_STATE_HOME: fixture.stateHome,
+      OPENCLAW_REMNIC_ACCESS_TOKEN: "test-token",
+      REMNIC_CODEX_MATERIALIZE: "0",
+    },
+    input: JSON.stringify({
+      session_id: sessionId,
+      transcript_path: fixture.transcript,
+    }),
+  });
+}
+
+for (const hookCase of hookCases) {
+  test(`${hookCase.name} writes cursor state inside a private state directory`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `post-tool-safe-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const cursorPath = path.join(stateDir, `remnic-cursor-${sessionId}`);
+
+    try {
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, '{"continue":true}\n');
+
+      await waitFor(async () => existsSync(cursorPath), "cursor was not written");
+
+      assert.equal(await readFile(cursorPath, "utf8"), "0\n");
+      assert.equal((await stat(stateDir)).mode & 0o777, 0o700);
+      assert.equal(existsSync(path.join(os.tmpdir(), `remnic-cursor-${sessionId}`)), false);
+      assert.equal(existsSync(path.join(os.tmpdir(), `engram-cursor-${sessionId}`)), false);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+      await rm(path.join(os.tmpdir(), `remnic-cursor-${sessionId}`), { force: true });
+      await rm(path.join(os.tmpdir(), `engram-cursor-${sessionId}`), { force: true });
+    }
+  });
+
+  test(`${hookCase.name} refuses to write through a symlinked cursor`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `post-tool-symlink-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const cursorPath = path.join(stateDir, `remnic-cursor-${sessionId}`);
+    const symlinkTarget = path.join(fixture.root, "target.txt");
+
+    try {
+      await mkdir(stateDir, { recursive: true, mode: 0o700 });
+      await writeFile(symlinkTarget, "unchanged\n", "utf8");
+      await symlink(symlinkTarget, cursorPath);
+
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, '{"continue":true}\n');
+
+      const logPath = path.join(fixture.home, ".remnic", "logs", "remnic-post-tool-observe.log");
+      await waitFor(async () => {
+        if (!existsSync(logPath)) return false;
+        return (await readFile(logPath, "utf8")).includes("unsafe cursor file");
+      }, "unsafe cursor was not rejected");
+
+      assert.equal(await readFile(symlinkTarget, "utf8"), "unchanged\n");
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  test(`${hookCase.name} reuses a private engram cursor when remnic cursor is absent`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `post-tool-engram-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const engramCursorPath = path.join(stateDir, `engram-cursor-${sessionId}`);
+    const remnicCursorPath = path.join(stateDir, `remnic-cursor-${sessionId}`);
+
+    try {
+      await mkdir(stateDir, { recursive: true, mode: 0o700 });
+      await writeFile(engramCursorPath, "1\n", "utf8");
+      await writeFile(
+        fixture.transcript,
+        `${JSON.stringify({ type: "user", message: { role: "user", content: "hello" } })}\n`,
+        "utf8",
+      );
+
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, '{"continue":true}\n');
+
+      await waitFor(async () => (await readFile(engramCursorPath, "utf8")) === "1\n", "engram cursor changed unexpectedly");
+
+      assert.equal(existsSync(remnicCursorPath), false);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  test(`${hookCase.name} migrates an owned non-symlink tmp cursor once`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `post-tool-tmp-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const cursorPath = path.join(stateDir, `remnic-cursor-${sessionId}`);
+    const tmpCursorPath = `/tmp/remnic-cursor-${sessionId}`;
+
+    try {
+      await writeFile(tmpCursorPath, "1\n", "utf8");
+      await writeFile(
+        fixture.transcript,
+        `${JSON.stringify({ type: "user", message: { role: "user", content: "hello" } })}\n`,
+        "utf8",
+      );
+
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, '{"continue":true}\n');
+
+      await waitFor(async () => {
+        if (!existsSync(cursorPath) || existsSync(tmpCursorPath)) return false;
+        return (await readFile(cursorPath, "utf8")) === "1\n";
+      }, "tmp cursor was not migrated");
+
+      assert.equal(await readFile(cursorPath, "utf8"), "1\n");
+      assert.equal(existsSync(tmpCursorPath), false);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+      await rm(tmpCursorPath, { force: true });
+    }
+  });
+
+  test(`${hookCase.name} prefers a newer tmp cursor over older private engram state`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `post-tool-newer-tmp-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const engramCursorPath = path.join(stateDir, `engram-cursor-${sessionId}`);
+    const remnicTmpCursorPath = `/tmp/remnic-cursor-${sessionId}`;
+    const engramTmpCursorPath = `/tmp/engram-cursor-${sessionId}`;
+
+    try {
+      await mkdir(stateDir, { recursive: true, mode: 0o700 });
+      await writeFile(engramCursorPath, "1\n", "utf8");
+      await writeFile(remnicTmpCursorPath, "2\n", "utf8");
+      await writeFile(engramTmpCursorPath, "3\n", "utf8");
+      await writeFile(
+        fixture.transcript,
+        `${JSON.stringify({ type: "user", message: { role: "user", content: "hello" } })}\n${JSON.stringify({ type: "assistant", message: { role: "assistant", content: "world" } })}\n${JSON.stringify({ type: "user", message: { role: "user", content: "again" } })}\n`,
+        "utf8",
+      );
+
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, '{"continue":true}\n');
+
+      await waitFor(async () => {
+        if (existsSync(remnicTmpCursorPath) || existsSync(engramTmpCursorPath)) return false;
+        return (await readFile(engramCursorPath, "utf8")) === "3\n";
+      }, "newer tmp cursor was not preserved");
+
+      assert.equal(existsSync(remnicTmpCursorPath), false);
+      assert.equal(existsSync(engramTmpCursorPath), false);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+      await rm(remnicTmpCursorPath, { force: true });
+      await rm(engramTmpCursorPath, { force: true });
+    }
+  });
+
+  test(`${hookCase.name} recovers stale private lock directories`, async () => {
+    const fixture = await makeFixture();
+    const sessionId = `post-tool-stale-lock-${hookCase.name}-${process.pid}`;
+    const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+    const lockDir = path.join(stateDir, `remnic-lock-${sessionId}.d`);
+    const cursorPath = path.join(stateDir, `remnic-cursor-${sessionId}`);
+    const oldTime = new Date(Date.now() - 20 * 60 * 1000);
+
+    try {
+      await mkdir(lockDir, { recursive: true, mode: 0o700 });
+      await utimes(lockDir, oldTime, oldTime);
+
+      const result = runHook(hookCase, fixture, sessionId);
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, '{"continue":true}\n');
+
+      await waitFor(async () => existsSync(cursorPath), "stale lock was not recovered");
+
+      assert.equal(await readFile(cursorPath, "utf8"), "0\n");
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+}
+
+test("codex package session-end skips final flush when cursor is unsafe", async () => {
+  const fixture = await makeFixture();
+  const sessionId = `codex-end-symlink-${process.pid}`;
+  const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+  const cursorPath = path.join(stateDir, `remnic-cursor-${sessionId}`);
+  const symlinkTarget = path.join(fixture.root, "target.txt");
+  const logPath = path.join(fixture.home, ".remnic", "logs", "remnic-codex-session-end.log");
+
+  try {
+    await mkdir(stateDir, { recursive: true, mode: 0o700 });
+    await writeFile(symlinkTarget, "unchanged\n", "utf8");
+    await symlink(symlinkTarget, cursorPath);
+    await writeFile(
+      fixture.transcript,
+      `${JSON.stringify({ type: "user", message: { role: "user", content: "hello" } })}\n`,
+      "utf8",
+    );
+
+    const result = runCodexSessionEnd(fixture, sessionId);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, '{"continue":true}\n');
+
+    await waitFor(async () => {
+      if (!existsSync(logPath)) return false;
+      return (await readFile(logPath, "utf8")).includes("final flush skipped");
+    }, "unsafe cursor did not skip final flush");
+
+    const logContent = await readFile(logPath, "utf8");
+    assert.match(logContent, /unsafe cursor file/);
+    assert.doesNotMatch(logContent, /final flush for /);
+    assert.equal(await readFile(symlinkTarget, "utf8"), "unchanged\n");
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("codex package session-end migrates tmp cursor before final flush", async () => {
+  const fixture = await makeFixture();
+  const sessionId = `codex-end-tmp-${process.pid}`;
+  const remnicTmpCursorPath = `/tmp/remnic-cursor-${sessionId}`;
+  const engramTmpCursorPath = `/tmp/engram-cursor-${sessionId}`;
+  const logPath = path.join(fixture.home, ".remnic", "logs", "remnic-codex-session-end.log");
+
+  try {
+    await writeFile(remnicTmpCursorPath, "1\n", "utf8");
+    await writeFile(engramTmpCursorPath, "2\n", "utf8");
+    await writeFile(
+      fixture.transcript,
+      `${JSON.stringify({ type: "user", message: { role: "user", content: "hello" } })}\n${JSON.stringify({ type: "assistant", message: { role: "assistant", content: "world" } })}\n`,
+      "utf8",
+    );
+
+    const result = runCodexSessionEnd(fixture, sessionId);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, '{"continue":true}\n');
+
+    assert.equal(existsSync(remnicTmpCursorPath), false);
+    assert.equal(existsSync(engramTmpCursorPath), false);
+    if (existsSync(logPath)) {
+      assert.doesNotMatch(await readFile(logPath, "utf8"), /final flush for /);
+    }
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+    await rm(remnicTmpCursorPath, { force: true });
+    await rm(engramTmpCursorPath, { force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- move root Claude/Codex session cursor and lock state out of predictable /tmp paths into private XDG state
- apply the same private-state cursor handling to packaged Claude/Codex post-tool hooks and session cleanup
- add execution regressions for private state directory creation and symlinked cursor refusal

## ClawPatch
- Finding: fnd_sig-feat-config-3358d2ffb7-65ecb_5502212973
- Initial revalidation confirmed the root Claude hook was fixed but found the duplicate Codex/package hook issue.
- After broadening the fix, ClawPatch provider revalidation timed out/failed repeatedly, so the finding was marked fixed with local evidence in the scan worktree.

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin node --test tests/engram-session-store-hook.test.mjs tests/post-tool-observe-state.test.mjs
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin npx tsx --test tests/post-tool-observe-hook.test.ts
- rg -n '/tmp/(remnic|engram)-(cursor|lock)|CURSOR_FILE="/tmp|LOCK_(FILE|DIR)="/tmp|> "\"' packages scripts tests -g '*.sh' -g '*.mjs' -g '*.ts' (no matches)
- git diff --check
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local filesystem security for transcript observe cursors across many hook entrypoints; behavior is defensive but a bug could skip observes or mishandle migration.
> 
> **Overview**
> Moves Claude/Codex and packaged hook **session cursor and lock state** from predictable `/tmp` paths into **`${XDG_STATE_HOME:-$HOME/.local/state}/remnic/hooks`**, with **mode `0700`**, **session ID validation**, and **checks** that block symlinks and foreign-owned paths.
> 
> Hooks now use **validated read/write** (atomic temp files, `chmod 600`), **one-time migration** from legacy `/tmp` and private `engram-*` files, and **stale lock recovery** (~10 minutes). Codex **session-end** skips final observe when the cursor is unsafe instead of writing through it.
> 
> **Regression tests** cover private state layout, symlink refusal, tmp migration, and stale locks across root scripts and package hooks. `package.json` changes are formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3821b46a3317a5d2f460c52fa41454684a0c8b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->