### PR TITLE
Prevent duplicate semantic rule promotions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/semantic-rule-promotion.ts
+++ b/packages/remnic-core/src/semantic-rule-promotion.ts
@@ -1,3 +1,7 @@
+import { createHash, randomUUID } from "node:crypto";
+import { link, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import { StorageManager } from "./storage.js";
 import type { MemoryFile, MemoryLink } from "./types.js";
 
@@ -28,6 +32,465 @@ export interface SemanticRulePromotionReport {
   dryRun: boolean;
   promoted: SemanticRulePromotionCandidate[];
   skipped: SemanticRulePromotionSkip[];
+}
+
+const PROMOTION_LOCK_TIMEOUT_MS = 10 * 60 * 1000;
+const PROMOTION_LOCK_RETRY_MS = 25;
+const PROMOTION_LOCK_STALE_MS = 5 * 60 * 1000;
+const PROMOTION_LOCK_OWNERLESS_GRACE_MS = 1000;
+const PROMOTION_LOCK_HEARTBEAT_MS = 30 * 1000;
+
+type SemanticRulePromotionTestHooks = {
+  beforeLockOwnerWrite?: (lockDir: string, ownerToken: string) => Promise<void> | void;
+  beforeLockRelease?: (lockDir: string, ownerToken: string) => Promise<void> | void;
+  beforePromotedRuleWrite?: (lockDir: string, ownerToken: string) => Promise<void> | void;
+  lockTimeoutMs?: number;
+  lockRetryMs?: number;
+  staleLockMs?: number;
+  ownerlessGraceMs?: number;
+  heartbeatMs?: number;
+};
+
+let testHooks: SemanticRulePromotionTestHooks | null = null;
+
+export function setSemanticRulePromotionTestHooks(hooks: SemanticRulePromotionTestHooks | null): void {
+  testHooks = hooks;
+}
+
+function promotionLockTimeoutMs(): number {
+  return testHooks?.lockTimeoutMs ?? PROMOTION_LOCK_TIMEOUT_MS;
+}
+
+function promotionLockRetryMs(): number {
+  return testHooks?.lockRetryMs ?? PROMOTION_LOCK_RETRY_MS;
+}
+
+function promotionLockStaleMs(): number {
+  return testHooks?.staleLockMs ?? PROMOTION_LOCK_STALE_MS;
+}
+
+function promotionLockOwnerlessGraceMs(): number {
+  return testHooks?.ownerlessGraceMs ?? PROMOTION_LOCK_OWNERLESS_GRACE_MS;
+}
+
+function promotionLockHeartbeatMs(): number {
+  return testHooks?.heartbeatMs ?? PROMOTION_LOCK_HEARTBEAT_MS;
+}
+
+function isErrnoCode(err: unknown, code: string): boolean {
+  return typeof err === "object" && err !== null && "code" in err && (err as { code?: unknown }).code === code;
+}
+
+function promotionLockDir(memoryDir: string, ruleKey: string): string {
+  const digest = createHash("sha256").update(ruleKey).digest("hex");
+  return path.join(path.resolve(memoryDir), "state", "semantic-rule-promotion-locks", `${digest}.lock`);
+}
+
+function promotionHeartbeatPath(lockDir: string, token: string): string {
+  return path.join(lockDir, `heartbeat.${token}.json`);
+}
+
+function promotionReapDir(lockDir: string): string {
+  return `${lockDir}.reap`;
+}
+
+function promotionReleaseDir(lockDir: string): string {
+  return `${lockDir}.release`;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch (err) {
+    if (isErrnoCode(err, "ENOENT")) return false;
+    throw err;
+  }
+}
+
+async function readPromotionLockOwner(lockDir: string): Promise<{
+  acquiredAtMs: number | null;
+  heartbeatAtMs: number | null;
+  token: string | null;
+}> {
+  try {
+    const owner = JSON.parse(await readFile(path.join(lockDir, "owner.json"), "utf8")) as {
+      acquiredAt?: unknown;
+      heartbeatAt?: unknown;
+      token?: unknown;
+    };
+    const acquiredAtMs = typeof owner.acquiredAt === "string" ? Date.parse(owner.acquiredAt) : Number.NaN;
+    const heartbeatAtMs = typeof owner.heartbeatAt === "string" ? Date.parse(owner.heartbeatAt) : Number.NaN;
+    return {
+      acquiredAtMs: Number.isFinite(acquiredAtMs) ? acquiredAtMs : null,
+      heartbeatAtMs: Number.isFinite(heartbeatAtMs) ? heartbeatAtMs : null,
+      token: typeof owner.token === "string" ? owner.token : null,
+    };
+  } catch {
+    return {
+      acquiredAtMs: null,
+      heartbeatAtMs: null,
+      token: null,
+    };
+  }
+}
+
+async function tryWritePromotionLockOwner(
+  lockDir: string,
+  owner: { token: string; acquiredAt: string }
+): Promise<boolean> {
+  const ownerPath = path.join(lockDir, "owner.json");
+  const tempPath = path.join(lockDir, `owner.${process.pid}.${randomUUID()}.tmp`);
+  await testHooks?.beforeLockOwnerWrite?.(lockDir, owner.token);
+  try {
+    await writeFile(
+      tempPath,
+      `${JSON.stringify(
+        {
+          pid: process.pid,
+          token: owner.token,
+          acquiredAt: owner.acquiredAt,
+        },
+        null,
+        2
+      )}\n`
+    );
+    await link(tempPath, ownerPath);
+    return true;
+  } catch (err) {
+    if (isErrnoCode(err, "EEXIST") || isErrnoCode(err, "ENOENT")) {
+      return false;
+    }
+    throw err;
+  } finally {
+    await rm(tempPath, { force: true });
+  }
+}
+
+async function writePromotionLockHeartbeat(lockDir: string, token: string): Promise<void> {
+  const heartbeatPath = promotionHeartbeatPath(lockDir, token);
+  const tempPath = path.join(lockDir, `heartbeat.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(
+      tempPath,
+      `${JSON.stringify(
+        {
+          pid: process.pid,
+          token,
+          heartbeatAt: new Date().toISOString(),
+        },
+        null,
+        2
+      )}\n`
+    );
+    await rename(tempPath, heartbeatPath);
+  } catch (err) {
+    await rm(tempPath, { force: true });
+    throw err;
+  }
+}
+
+async function refreshPromotionLockHeartbeat(lockDir: string, token: string): Promise<boolean> {
+  const owner = await readPromotionLockOwner(lockDir);
+  if (owner.token !== token) {
+    return pathExists(promotionReapDir(lockDir));
+  }
+  await writePromotionLockHeartbeat(lockDir, token);
+  return true;
+}
+
+async function readPromotionLockHeartbeatMs(lockDir: string, token: string | null): Promise<number | null> {
+  if (!token) return null;
+  try {
+    return (await stat(promotionHeartbeatPath(lockDir, token))).mtimeMs;
+  } catch (err) {
+    if (isErrnoCode(err, "ENOENT")) return null;
+    throw err;
+  }
+}
+
+async function reapAbandonedPromotionGuard(guardDir: string): Promise<boolean> {
+  let reapStat: { mtimeMs: number };
+  try {
+    reapStat = await stat(guardDir);
+  } catch (err) {
+    if (isErrnoCode(err, "ENOENT")) return false;
+    throw err;
+  }
+  if (Date.now() - reapStat.mtimeMs < promotionLockStaleMs()) {
+    return false;
+  }
+
+  const staleReapDir = `${guardDir}.stale-${process.pid}-${randomUUID()}`;
+  try {
+    await rename(guardDir, staleReapDir);
+  } catch (err) {
+    if (isErrnoCode(err, "ENOENT")) return false;
+    throw err;
+  }
+  await rm(staleReapDir, { recursive: true, force: true });
+  return true;
+}
+
+async function reapAbandonedPromotionGuards(lockDir: string): Promise<boolean> {
+  const reapedReapGuard = await reapAbandonedPromotionGuard(promotionReapDir(lockDir));
+  const reapedReleaseGuard = await reapAbandonedPromotionGuard(promotionReleaseDir(lockDir));
+  return reapedReapGuard || reapedReleaseGuard;
+}
+
+async function hasPromotionGuard(lockDir: string): Promise<boolean> {
+  return (await pathExists(promotionReapDir(lockDir))) || (await pathExists(promotionReleaseDir(lockDir)));
+}
+
+async function reapStalePromotionLock(lockDir: string): Promise<boolean> {
+  if (await hasPromotionGuard(lockDir)) {
+    await reapAbandonedPromotionGuards(lockDir);
+    return false;
+  }
+
+  const reapDir = promotionReapDir(lockDir);
+  try {
+    await mkdir(reapDir);
+  } catch (err) {
+    if (isErrnoCode(err, "EEXIST")) return false;
+    throw err;
+  }
+
+  let staleDir: string | null = null;
+  try {
+    return await reapStalePromotionLockWithGuard(lockDir, (value) => {
+      staleDir = value;
+    });
+  } finally {
+    if (staleDir) {
+      await rm(staleDir, { recursive: true, force: true });
+    }
+    await rm(reapDir, { recursive: true, force: true });
+  }
+}
+
+async function reapStalePromotionLockWithGuard(
+  lockDir: string,
+  setStaleDir: (staleDir: string) => void
+): Promise<boolean> {
+  let lockStat: { mtimeMs: number };
+  try {
+    lockStat = await stat(lockDir);
+  } catch (err) {
+    if (isErrnoCode(err, "ENOENT")) return false;
+    throw err;
+  }
+
+  const owner = await readPromotionLockOwner(lockDir);
+  const heartbeatMs = await readPromotionLockHeartbeatMs(lockDir, owner.token);
+  const lockedAtMs = heartbeatMs ?? owner.heartbeatAtMs ?? owner.acquiredAtMs ?? lockStat.mtimeMs;
+  const ownerlessLock = owner.token === null && owner.heartbeatAtMs === null && owner.acquiredAtMs === null;
+  const staleAfterMs = ownerlessLock ? promotionLockOwnerlessGraceMs() : promotionLockStaleMs();
+  if (Date.now() - lockedAtMs < staleAfterMs) {
+    return false;
+  }
+
+  const staleDir = `${lockDir}.stale-${process.pid}-${randomUUID()}`;
+  try {
+    await rename(lockDir, staleDir);
+    setStaleDir(staleDir);
+  } catch (err) {
+    if (isErrnoCode(err, "ENOENT")) return false;
+    throw err;
+  }
+
+  const staleOwner = await readPromotionLockOwner(staleDir);
+  const staleHeartbeatMs = await readPromotionLockHeartbeatMs(staleDir, staleOwner.token);
+  const staleLockedAtMs = staleHeartbeatMs ?? staleOwner.heartbeatAtMs ?? staleOwner.acquiredAtMs ?? lockStat.mtimeMs;
+  const staleOwnerlessLock =
+    staleOwner.token === null && staleOwner.heartbeatAtMs === null && staleOwner.acquiredAtMs === null;
+  const staleAfterRecheckMs = staleOwnerlessLock ? promotionLockOwnerlessGraceMs() : promotionLockStaleMs();
+  if (Date.now() - staleLockedAtMs < staleAfterRecheckMs) {
+    await rename(staleDir, lockDir);
+    setStaleDir("");
+    return false;
+  }
+
+  await rm(staleDir, { recursive: true, force: true });
+  setStaleDir("");
+  return true;
+}
+
+async function releasePromotionLock(lockDir: string, token: string): Promise<void> {
+  const releaseDir = promotionReleaseDir(lockDir);
+  const deadline = Date.now() + promotionLockTimeoutMs();
+  await testHooks?.beforeLockRelease?.(lockDir, token);
+  for (;;) {
+    try {
+      await mkdir(releaseDir);
+      break;
+    } catch (err) {
+      if (!isErrnoCode(err, "EEXIST")) {
+        throw err;
+      }
+      const owner = await readPromotionLockOwner(lockDir);
+      if (owner.token !== token) {
+        return;
+      }
+      await reapAbandonedPromotionGuard(releaseDir);
+      if (Date.now() >= deadline) {
+        throw new Error("Timed out releasing semantic rule promotion lock");
+      }
+      await sleep(promotionLockRetryMs());
+    }
+  }
+
+  try {
+    const owner = await readPromotionLockOwner(lockDir);
+    if (owner.token !== token) {
+      return;
+    }
+    await rm(lockDir, { recursive: true, force: true });
+  } finally {
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+}
+
+type PromotionLockLease = {
+  assertHeld: () => Promise<void>;
+  beforePromotedRuleWrite: () => Promise<void>;
+};
+
+async function withPromotionLock<T>(
+  memoryDir: string,
+  ruleKey: string,
+  fn: (lease: PromotionLockLease) => Promise<T>
+): Promise<T> {
+  const lockDir = promotionLockDir(memoryDir, ruleKey);
+  const lockRoot = path.dirname(lockDir);
+  const deadline = Date.now() + promotionLockTimeoutMs();
+  let lockToken: string | null = null;
+  let heartbeat: NodeJS.Timeout | null = null;
+
+  await mkdir(lockRoot, { recursive: true });
+  for (;;) {
+    try {
+      if (await hasPromotionGuard(lockDir)) {
+        await reapAbandonedPromotionGuards(lockDir);
+        if (Date.now() >= deadline) {
+          throw new Error("Timed out acquiring semantic rule promotion lock");
+        }
+        await sleep(promotionLockRetryMs());
+        continue;
+      }
+      await mkdir(lockDir);
+      if (await hasPromotionGuard(lockDir)) {
+        await reapAbandonedPromotionGuards(lockDir);
+        if (Date.now() >= deadline) {
+          throw new Error("Timed out acquiring semantic rule promotion lock");
+        }
+        await sleep(promotionLockRetryMs());
+        continue;
+      }
+      try {
+        lockToken = randomUUID();
+        const lockOwner = {
+          token: lockToken,
+          acquiredAt: new Date().toISOString(),
+        };
+        const wroteOwner = await tryWritePromotionLockOwner(lockDir, lockOwner);
+        if (!wroteOwner) {
+          lockToken = null;
+          if (Date.now() >= deadline) {
+            throw new Error("Timed out acquiring semantic rule promotion lock");
+          }
+          await sleep(promotionLockRetryMs());
+          continue;
+        }
+        await writePromotionLockHeartbeat(lockDir, lockToken);
+        const heartbeatToken = lockToken;
+        const heartbeatMs = promotionLockHeartbeatMs();
+        if (heartbeatMs > 0) {
+          heartbeat = setInterval(() => {
+            void refreshPromotionLockHeartbeat(lockDir, heartbeatToken)
+              .then((ownsLock) => {
+                if (!ownsLock && heartbeat) {
+                  clearInterval(heartbeat);
+                  heartbeat = null;
+                }
+              })
+              .catch(() => undefined);
+          }, heartbeatMs);
+        }
+      } catch (err) {
+        lockToken = null;
+        if (heartbeat) {
+          clearInterval(heartbeat);
+          heartbeat = null;
+        }
+        await rm(lockDir, { recursive: true, force: true });
+        throw err;
+      }
+      break;
+    } catch (err) {
+      if (!isErrnoCode(err, "EEXIST")) {
+        throw err;
+      }
+      if (await reapStalePromotionLock(lockDir)) {
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error("Timed out acquiring semantic rule promotion lock");
+      }
+      await sleep(promotionLockRetryMs());
+    }
+  }
+
+  const assertHeld = async () => {
+    if (!lockToken) {
+      throw new Error("Semantic rule promotion lock is no longer held");
+    }
+    const ownsLock = await refreshPromotionLockHeartbeat(lockDir, lockToken);
+    if (!ownsLock) {
+      throw new Error("Semantic rule promotion lock is no longer held");
+    }
+  };
+
+  let hasResult = false;
+  let result: T | undefined;
+  let callbackError: unknown;
+  let releaseError: unknown;
+  try {
+    await assertHeld();
+    result = await fn({
+      assertHeld,
+      beforePromotedRuleWrite: async () => {
+        if (!lockToken) {
+          throw new Error("Semantic rule promotion lock is no longer held");
+        }
+        await testHooks?.beforePromotedRuleWrite?.(lockDir, lockToken);
+        await assertHeld();
+      },
+    });
+    hasResult = true;
+  } catch (err) {
+    callbackError = err;
+  } finally {
+    if (heartbeat) {
+      clearInterval(heartbeat);
+    }
+    if (lockToken) {
+      try {
+        await releasePromotionLock(lockDir, lockToken);
+      } catch (err) {
+        if (!hasResult && !callbackError) {
+          releaseError = err;
+        }
+      }
+    }
+  }
+  if (releaseError) {
+    throw releaseError;
+  }
+  if (callbackError) {
+    throw callbackError;
+  }
+  return result as T;
 }
 
 function normalizeRuleWhitespace(value: string): string {
@@ -111,10 +574,7 @@ export async function promoteSemanticRuleFromMemory(options: {
     });
     return report;
   }
-  if (
-    sourceMemory.frontmatter.status === "archived" ||
-    sourceMemory.frontmatter.memoryKind !== "episode"
-  ) {
+  if (sourceMemory.frontmatter.status === "archived" || sourceMemory.frontmatter.memoryKind !== "episode") {
     report.skipped.push({
       sourceMemoryId: options.sourceMemoryId,
       reason: "source-memory-not-episode",
@@ -132,22 +592,6 @@ export async function promoteSemanticRuleFromMemory(options: {
   }
 
   const ruleKey = canonicalizeRuleKey(content);
-  const existingRule = (await storage.readAllMemories()).find(
-    (memory) =>
-      memory.frontmatter.category === "rule" &&
-      memory.frontmatter.status !== "archived" &&
-      memory.frontmatter.status !== "forgotten" &&
-      canonicalizeRuleKey(memory.content) === ruleKey,
-  );
-  if (existingRule) {
-    report.skipped.push({
-      sourceMemoryId: options.sourceMemoryId,
-      reason: "duplicate-rule",
-      existingRuleId: existingRule.frontmatter.id,
-    });
-    return report;
-  }
-
   const confidence = promotionConfidence(sourceMemory);
   const candidateBase = {
     sourceMemoryId: options.sourceMemoryId,
@@ -158,26 +602,47 @@ export async function promoteSemanticRuleFromMemory(options: {
     lineage: [options.sourceMemoryId],
   };
 
-  if (options.dryRun === true) {
+  return withPromotionLock(options.memoryDir, ruleKey, async (lock) => {
+    storage.invalidateAllMemoriesCacheForDir();
+    const existingRule = (await storage.readAllMemories()).find(
+      (memory) =>
+        memory.frontmatter.category === "rule" &&
+        memory.frontmatter.status !== "archived" &&
+        memory.frontmatter.status !== "forgotten" &&
+        canonicalizeRuleKey(memory.content) === ruleKey
+    );
+    if (existingRule) {
+      report.skipped.push({
+        sourceMemoryId: options.sourceMemoryId,
+        reason: "duplicate-rule",
+        existingRuleId: existingRule.frontmatter.id,
+      });
+      return report;
+    }
+
+    if (options.dryRun === true) {
+      await lock.assertHeld();
+      report.promoted.push({
+        id: `dry-run:${options.sourceMemoryId}`,
+        ...candidateBase,
+      });
+      return report;
+    }
+
+    await lock.beforePromotedRuleWrite();
+    const id = await storage.writeMemory("rule", content, {
+      confidence,
+      tags: candidateBase.tags,
+      source: "semantic-rule-promotion",
+      lineage: candidateBase.lineage,
+      sourceMemoryId: options.sourceMemoryId,
+      memoryKind: "note",
+      links: buildSupportLinks(options.sourceMemoryId, confidence),
+    });
     report.promoted.push({
-      id: `dry-run:${options.sourceMemoryId}`,
+      id,
       ...candidateBase,
     });
     return report;
-  }
-
-  const id = await storage.writeMemory("rule", content, {
-    confidence,
-    tags: candidateBase.tags,
-    source: "semantic-rule-promotion",
-    lineage: candidateBase.lineage,
-    sourceMemoryId: options.sourceMemoryId,
-    memoryKind: "note",
-    links: buildSupportLinks(options.sourceMemoryId, confidence),
   });
-  report.promoted.push({
-    id,
-    ...candidateBase,
-  });
-  return report;
 }

--- a/packages/remnic-core/src/semantic-rule-promotion.ts
+++ b/packages/remnic-core/src/semantic-rule-promotion.ts
@@ -193,7 +193,7 @@ async function writePromotionLockHeartbeat(lockDir: string, token: string): Prom
 async function refreshPromotionLockHeartbeat(lockDir: string, token: string): Promise<boolean> {
   const owner = await readPromotionLockOwner(lockDir);
   if (owner.token !== token) {
-    return pathExists(promotionReapDir(lockDir));
+    return false;
   }
   await writePromotionLockHeartbeat(lockDir, token);
   return true;

--- a/tests/semantic-rule-verifier.test.ts
+++ b/tests/semantic-rule-verifier.test.ts
@@ -1,18 +1,20 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp } from "node:fs/promises";
+import test from "node:test";
+import { setTimeout as sleep } from "node:timers/promises";
+import { runSemanticRuleVerifyCliCommand } from "../src/cli.js";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
+import {
+  type SemanticRulePromotionReport,
+  promoteSemanticRuleFromMemory,
+  setSemanticRulePromotionTestHooks,
+} from "../src/semantic-rule-promotion.js";
+import { searchVerifiedSemanticRules } from "../src/semantic-rule-verifier.js";
 import { StorageManager } from "../src/storage.js";
-import { promoteSemanticRuleFromMemory } from "../src/semantic-rule-promotion.js";
-import {
-  runSemanticRuleVerifyCliCommand,
-} from "../src/cli.js";
-import {
-  searchVerifiedSemanticRules,
-} from "../src/semantic-rule-verifier.js";
 
 async function createSemanticRuleHarness() {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-semantic-rule-verify-"));
@@ -29,7 +31,7 @@ async function seedPromotedRule(memoryDir: string, storage: StorageManager) {
       tags: ["pr-loop", "cursor"],
       confidence: 0.92,
       memoryKind: "episode",
-    },
+    }
   );
 
   const promotion = await promoteSemanticRuleFromMemory({
@@ -60,6 +62,375 @@ test("searchVerifiedSemanticRules returns promoted rules whose source episode st
   assert.equal(results[0]?.sourceMemoryId, sourceMemoryId);
   assert.equal(results[0]?.verificationStatus, "verified");
   assert.equal((results[0]?.effectiveConfidence ?? 0) > 0.8, true);
+});
+
+test("concurrent semantic rule promotions are idempotent for one source memory", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF the reviewer check is still pending THEN wait for the current-head verdict before merging.",
+    {
+      source: "test",
+      tags: ["pr-loop", "reviewer"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+
+  const promotions = await Promise.all([
+    promoteSemanticRuleFromMemory({
+      memoryDir,
+      enabled: true,
+      sourceMemoryId,
+    }),
+    promoteSemanticRuleFromMemory({
+      memoryDir,
+      enabled: true,
+      sourceMemoryId,
+    }),
+  ]);
+
+  const promotedIds = promotions.flatMap((promotion) => promotion.promoted.map((candidate) => candidate.id));
+  const duplicateSkips = promotions.flatMap((promotion) =>
+    promotion.skipped.filter((skip) => skip.reason === "duplicate-rule")
+  );
+  const rules = (await storage.readAllMemories()).filter(
+    (memory) => memory.frontmatter.category === "rule" && memory.frontmatter.source === "semantic-rule-promotion"
+  );
+
+  assert.equal(promotedIds.length, 1);
+  assert.equal(duplicateSkips.length, 1);
+  assert.equal(duplicateSkips[0]?.existingRuleId, promotedIds[0]);
+  assert.equal(rules.length, 1);
+  assert.equal(rules[0]?.frontmatter.id, promotedIds[0]);
+});
+
+test("semantic rule promotion refreshes duplicate scan after acquiring the lock", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF the duplicate scan was already in flight THEN refresh it after acquiring the lock.",
+    {
+      source: "test",
+      tags: ["pr-loop", "stale-read"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+  const sourceMemory = await storage.getMemoryById(sourceMemoryId);
+  assert.ok(sourceMemory);
+  const existingRuleId = await storage.writeMemory(
+    "rule",
+    "IF the duplicate scan was already in flight THEN refresh it after acquiring the lock.",
+    {
+      source: "semantic-rule-promotion",
+      tags: ["semantic-rule", "promoted-rule"],
+      confidence: 0.91,
+      memoryKind: "note",
+      lineage: [sourceMemoryId],
+      sourceMemoryId,
+    }
+  );
+  (StorageManager as any).allMemoriesInFlight.set(path.resolve(memoryDir), Promise.resolve([sourceMemory]));
+
+  const promotion = await promoteSemanticRuleFromMemory({
+    memoryDir,
+    enabled: true,
+    sourceMemoryId,
+  });
+
+  assert.equal(promotion.promoted.length, 0);
+  assert.equal(promotion.skipped.length, 1);
+  assert.equal(promotion.skipped[0]?.reason, "duplicate-rule");
+  assert.equal(promotion.skipped[0]?.existingRuleId, existingRuleId);
+});
+
+test("semantic rule promotion recovers stale lock directories", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF a promotion lock is stale THEN recover it before writing the rule.",
+    {
+      source: "test",
+      tags: ["pr-loop", "stale-lock"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+  const ruleKey = "if a promotion lock is stale then recover it before writing the rule.";
+  const lockDigest = createHash("sha256").update(ruleKey).digest("hex");
+  const lockDir = path.join(memoryDir, "state", "semantic-rule-promotion-locks", `${lockDigest}.lock`);
+  await mkdir(lockDir, { recursive: true });
+  await writeFile(
+    path.join(lockDir, "owner.json"),
+    JSON.stringify({
+      pid: 0,
+      token: "stale-test-lock",
+      acquiredAt: "2026-01-01T00:00:00.000Z",
+    })
+  );
+
+  const promotion = await promoteSemanticRuleFromMemory({
+    memoryDir,
+    enabled: true,
+    sourceMemoryId,
+  });
+
+  assert.equal(promotion.promoted.length, 1);
+  assert.equal(promotion.skipped.length, 0);
+});
+
+test("semantic rule promotion recovers stale locks even when the recorded pid is live", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF a promotion lock owner pid was reused THEN recover the stale heartbeat before writing the rule.",
+    {
+      source: "test",
+      tags: ["pr-loop", "stale-lock", "pid-reuse"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+  const ruleKey = "if a promotion lock owner pid was reused then recover the stale heartbeat before writing the rule.";
+  const lockDigest = createHash("sha256").update(ruleKey).digest("hex");
+  const lockDir = path.join(memoryDir, "state", "semantic-rule-promotion-locks", `${lockDigest}.lock`);
+  await mkdir(lockDir, { recursive: true });
+  await writeFile(
+    path.join(lockDir, "owner.json"),
+    JSON.stringify({
+      pid: process.pid,
+      token: "stale-live-pid-test-lock",
+      acquiredAt: "2026-01-01T00:00:00.000Z",
+      heartbeatAt: "2026-01-01T00:00:00.000Z",
+    })
+  );
+
+  const promotion = await promoteSemanticRuleFromMemory({
+    memoryDir,
+    enabled: true,
+    sourceMemoryId,
+  });
+
+  assert.equal(promotion.promoted.length, 1);
+  assert.equal(promotion.skipped.length, 0);
+});
+
+test("semantic rule promotion recovers ownerless lock directories after a short creation grace", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF a promotion lock has no owner file THEN recover it after the creation grace.",
+    {
+      source: "test",
+      tags: ["pr-loop", "ownerless-lock"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+  const ruleKey = "if a promotion lock has no owner file then recover it after the creation grace.";
+  const lockDigest = createHash("sha256").update(ruleKey).digest("hex");
+  const lockDir = path.join(memoryDir, "state", "semantic-rule-promotion-locks", `${lockDigest}.lock`);
+  await mkdir(lockDir, { recursive: true });
+  const abandonedDate = new Date(Date.now() - 2000);
+  await utimes(lockDir, abandonedDate, abandonedDate);
+
+  const promotion = await promoteSemanticRuleFromMemory({
+    memoryDir,
+    enabled: true,
+    sourceMemoryId,
+  });
+
+  assert.equal(promotion.promoted.length, 1);
+  assert.equal(promotion.skipped.length, 0);
+});
+
+test("semantic rule promotion retries when a delayed owner write loses the lock", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF a delayed promotion owner loses the lock THEN retry before checking duplicates.",
+    {
+      source: "test",
+      tags: ["pr-loop", "late-owner"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+  let pauseFirstOwnerWrite = true;
+  let releaseFirstOwnerWrite!: () => void;
+  let firstOwnerWritePaused!: () => void;
+  const firstOwnerWriteBlocked = new Promise<void>((resolve) => {
+    firstOwnerWritePaused = resolve;
+  });
+  const firstOwnerWriteReleased = new Promise<void>((resolve) => {
+    releaseFirstOwnerWrite = resolve;
+  });
+
+  setSemanticRulePromotionTestHooks({
+    beforeLockOwnerWrite: async () => {
+      if (!pauseFirstOwnerWrite) return;
+      pauseFirstOwnerWrite = false;
+      firstOwnerWritePaused();
+      await firstOwnerWriteReleased;
+    },
+  });
+
+  try {
+    const delayedPromotion = promoteSemanticRuleFromMemory({
+      memoryDir,
+      enabled: true,
+      sourceMemoryId,
+    });
+    await firstOwnerWriteBlocked;
+    await sleep(1200);
+    const competingPromotion = promoteSemanticRuleFromMemory({
+      memoryDir,
+      enabled: true,
+      sourceMemoryId,
+    });
+
+    const competingReport = await competingPromotion;
+    releaseFirstOwnerWrite();
+    const delayedReport = await delayedPromotion;
+    const promotedIds = [...competingReport.promoted, ...delayedReport.promoted].map((candidate) => candidate.id);
+    const duplicateSkips = [...competingReport.skipped, ...delayedReport.skipped].filter(
+      (skip) => skip.reason === "duplicate-rule"
+    );
+    const rules = (await storage.readAllMemories()).filter(
+      (memory) => memory.frontmatter.category === "rule" && memory.frontmatter.source === "semantic-rule-promotion"
+    );
+
+    assert.equal(promotedIds.length, 1);
+    assert.equal(duplicateSkips.length, 1);
+    assert.equal(duplicateSkips[0]?.existingRuleId, promotedIds[0]);
+    assert.equal(rules.length, 1);
+    assert.equal(rules[0]?.frontmatter.id, promotedIds[0]);
+  } finally {
+    setSemanticRulePromotionTestHooks(null);
+  }
+});
+
+test("semantic rule promotion does not write after losing the promotion lock", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF a promotion lock is reaped before the write THEN do not write a duplicate rule.",
+    {
+      source: "test",
+      tags: ["pr-loop", "lost-lock"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+  let stealLockOnce = true;
+  let competingPromotion: SemanticRulePromotionReport | undefined;
+
+  setSemanticRulePromotionTestHooks({
+    beforePromotedRuleWrite: async (lockDir) => {
+      if (!stealLockOnce) return;
+      stealLockOnce = false;
+      await rm(lockDir, { recursive: true, force: true });
+      competingPromotion = await promoteSemanticRuleFromMemory({
+        memoryDir,
+        enabled: true,
+        sourceMemoryId,
+      });
+    },
+  });
+
+  try {
+    await assert.rejects(
+      promoteSemanticRuleFromMemory({
+        memoryDir,
+        enabled: true,
+        sourceMemoryId,
+      }),
+      /Semantic rule promotion lock is no longer held/
+    );
+    if (!competingPromotion) {
+      throw new Error("Expected competing promotion to complete");
+    }
+    const completedPromotion: SemanticRulePromotionReport = competingPromotion;
+    const rules = (await storage.readAllMemories()).filter(
+      (memory) => memory.frontmatter.category === "rule" && memory.frontmatter.source === "semantic-rule-promotion"
+    );
+
+    assert.equal(completedPromotion.promoted.length, 1);
+    assert.equal(rules.length, 1);
+    assert.equal(rules[0]?.frontmatter.id, completedPromotion.promoted[0]?.id);
+  } finally {
+    setSemanticRulePromotionTestHooks(null);
+  }
+});
+
+test("semantic rule promotion keeps a successful result when lock release times out", async () => {
+  const { memoryDir } = await createSemanticRuleHarness();
+  const storage = new StorageManager(memoryDir);
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF lock release stalls after promotion THEN report the already written rule.",
+    {
+      source: "test",
+      tags: ["pr-loop", "release-timeout"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+  let blockReleaseOnce = true;
+
+  setSemanticRulePromotionTestHooks({
+    lockTimeoutMs: 25,
+    lockRetryMs: 1,
+    beforeLockRelease: async (lockDir) => {
+      if (!blockReleaseOnce) return;
+      blockReleaseOnce = false;
+      await mkdir(`${lockDir}.release`, { recursive: true });
+    },
+  });
+
+  try {
+    const promotion = await promoteSemanticRuleFromMemory({
+      memoryDir,
+      enabled: true,
+      sourceMemoryId,
+    });
+
+    assert.equal(promotion.promoted.length, 1);
+    assert.equal(promotion.skipped.length, 0);
+  } finally {
+    setSemanticRulePromotionTestHooks(null);
+  }
+});
+
+test("semantic rule promotion recovers abandoned release guards", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF a promotion release guard is stale THEN recover it before writing the rule.",
+    {
+      source: "test",
+      tags: ["pr-loop", "release-guard"],
+      confidence: 0.91,
+      memoryKind: "episode",
+    }
+  );
+  const ruleKey = "if a promotion release guard is stale then recover it before writing the rule.";
+  const lockDigest = createHash("sha256").update(ruleKey).digest("hex");
+  const lockDir = path.join(memoryDir, "state", "semantic-rule-promotion-locks", `${lockDigest}.lock`);
+  const releaseDir = `${lockDir}.release`;
+  await mkdir(releaseDir, { recursive: true });
+  const oldDate = new Date("2026-01-01T00:00:00.000Z");
+  await utimes(releaseDir, oldDate, oldDate);
+
+  const promotion = await promoteSemanticRuleFromMemory({
+    memoryDir,
+    enabled: true,
+    sourceMemoryId,
+  });
+
+  assert.equal(promotion.promoted.length, 1);
+  assert.equal(promotion.skipped.length, 0);
 });
 
 test("searchVerifiedSemanticRules downgrades archived-source rules below the default recall threshold", async () => {
@@ -148,58 +519,62 @@ test("recall injects verified semantic rules only when the verifier flag and rec
   const { memoryDir, storage } = await createSemanticRuleHarness();
   await seedPromotedRule(memoryDir, storage);
 
-  const enabled = new Orchestrator(parseConfig({
-    openaiApiKey: "test-openai-key",
-    memoryDir,
-    qmdEnabled: false,
-    transcriptEnabled: false,
-    sharedContextEnabled: false,
-    conversationIndexEnabled: false,
-    hourlySummariesEnabled: false,
-    injectQuestions: false,
-    semanticRulePromotionEnabled: true,
-    semanticRuleVerificationEnabled: true,
-    recallPipeline: [
-      {
-        id: "verified-rules",
-        enabled: true,
-        maxResults: 3,
-        maxChars: 1800,
-      },
-    ],
-  }));
+  const enabled = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "test-openai-key",
+      memoryDir,
+      qmdEnabled: false,
+      transcriptEnabled: false,
+      sharedContextEnabled: false,
+      conversationIndexEnabled: false,
+      hourlySummariesEnabled: false,
+      injectQuestions: false,
+      semanticRulePromotionEnabled: true,
+      semanticRuleVerificationEnabled: true,
+      recallPipeline: [
+        {
+          id: "verified-rules",
+          enabled: true,
+          maxResults: 3,
+          maxChars: 1800,
+        },
+      ],
+    })
+  );
 
   const enabledContext = await (enabled as any).recallInternal(
     "What rule says to wait for Cursor before merging?",
-    "agent:main",
+    "agent:main"
   );
   assert.match(enabledContext, /## Verified Rules/);
   assert.match(enabledContext, /wait for the terminal result before merging/i);
 
-  const disabled = new Orchestrator(parseConfig({
-    openaiApiKey: "test-openai-key",
-    memoryDir,
-    qmdEnabled: false,
-    transcriptEnabled: false,
-    sharedContextEnabled: false,
-    conversationIndexEnabled: false,
-    hourlySummariesEnabled: false,
-    injectQuestions: false,
-    semanticRulePromotionEnabled: true,
-    semanticRuleVerificationEnabled: false,
-    recallPipeline: [
-      {
-        id: "verified-rules",
-        enabled: true,
-        maxResults: 3,
-        maxChars: 1800,
-      },
-    ],
-  }));
+  const disabled = new Orchestrator(
+    parseConfig({
+      openaiApiKey: "test-openai-key",
+      memoryDir,
+      qmdEnabled: false,
+      transcriptEnabled: false,
+      sharedContextEnabled: false,
+      conversationIndexEnabled: false,
+      hourlySummariesEnabled: false,
+      injectQuestions: false,
+      semanticRulePromotionEnabled: true,
+      semanticRuleVerificationEnabled: false,
+      recallPipeline: [
+        {
+          id: "verified-rules",
+          enabled: true,
+          maxResults: 3,
+          maxChars: 1800,
+        },
+      ],
+    })
+  );
 
   const disabledContext = await (disabled as any).recallInternal(
     "What rule says to wait for Cursor before merging?",
-    "agent:main",
+    "agent:main"
   );
   assert.equal(disabledContext.includes("## Verified Rules"), false);
 });

--- a/tests/semantic-rule-verifier.test.ts
+++ b/tests/semantic-rule-verifier.test.ts
@@ -245,7 +245,7 @@ test("semantic rule promotion recovers ownerless lock directories after a short 
   assert.equal(promotion.skipped.length, 0);
 });
 
-test("semantic rule promotion retries when a delayed owner write loses the lock", async () => {
+test("semantic rule promotion retries when a delayed owner write loses the lock", { concurrency: false }, async () => {
   const { memoryDir, storage } = await createSemanticRuleHarness();
   const sourceMemoryId = await storage.writeMemory(
     "fact",
@@ -311,7 +311,7 @@ test("semantic rule promotion retries when a delayed owner write loses the lock"
   }
 });
 
-test("semantic rule promotion does not write after losing the promotion lock", async () => {
+test("semantic rule promotion does not write after losing the promotion lock", { concurrency: false }, async () => {
   const { memoryDir, storage } = await createSemanticRuleHarness();
   const sourceMemoryId = await storage.writeMemory(
     "fact",
@@ -364,44 +364,98 @@ test("semantic rule promotion does not write after losing the promotion lock", a
   }
 });
 
-test("semantic rule promotion keeps a successful result when lock release times out", async () => {
-  const { memoryDir } = await createSemanticRuleHarness();
-  const storage = new StorageManager(memoryDir);
+test("semantic rule promotion does not treat a reap guard as proof of ownership", { concurrency: false }, async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
   const sourceMemoryId = await storage.writeMemory(
     "fact",
-    "IF lock release stalls after promotion THEN report the already written rule.",
+    "IF a promotion lock owner token changes during reap THEN do not write the rule.",
     {
       source: "test",
-      tags: ["pr-loop", "release-timeout"],
+      tags: ["pr-loop", "reap-token-mismatch"],
       confidence: 0.91,
       memoryKind: "episode",
     }
   );
-  let blockReleaseOnce = true;
+  let replaceOwnerOnce = true;
 
   setSemanticRulePromotionTestHooks({
-    lockTimeoutMs: 25,
-    lockRetryMs: 1,
-    beforeLockRelease: async (lockDir) => {
-      if (!blockReleaseOnce) return;
-      blockReleaseOnce = false;
-      await mkdir(`${lockDir}.release`, { recursive: true });
+    beforePromotedRuleWrite: async (lockDir) => {
+      if (!replaceOwnerOnce) return;
+      replaceOwnerOnce = false;
+      await mkdir(`${lockDir}.reap`, { recursive: true });
+      await rm(path.join(lockDir, "owner.json"), { force: true });
+      await writeFile(
+        path.join(lockDir, "owner.json"),
+        JSON.stringify({
+          pid: process.pid,
+          token: "different-owner-token",
+          acquiredAt: new Date().toISOString(),
+        })
+      );
     },
   });
 
   try {
-    const promotion = await promoteSemanticRuleFromMemory({
-      memoryDir,
-      enabled: true,
-      sourceMemoryId,
-    });
+    await assert.rejects(
+      promoteSemanticRuleFromMemory({
+        memoryDir,
+        enabled: true,
+        sourceMemoryId,
+      }),
+      /Semantic rule promotion lock is no longer held/
+    );
+    const rules = (await storage.readAllMemories()).filter(
+      (memory) => memory.frontmatter.category === "rule" && memory.frontmatter.source === "semantic-rule-promotion"
+    );
 
-    assert.equal(promotion.promoted.length, 1);
-    assert.equal(promotion.skipped.length, 0);
+    assert.equal(rules.length, 0);
   } finally {
     setSemanticRulePromotionTestHooks(null);
   }
 });
+
+test(
+  "semantic rule promotion keeps a successful result when lock release times out",
+  { concurrency: false },
+  async () => {
+    const { memoryDir } = await createSemanticRuleHarness();
+    const storage = new StorageManager(memoryDir);
+    const sourceMemoryId = await storage.writeMemory(
+      "fact",
+      "IF lock release stalls after promotion THEN report the already written rule.",
+      {
+        source: "test",
+        tags: ["pr-loop", "release-timeout"],
+        confidence: 0.91,
+        memoryKind: "episode",
+      }
+    );
+    let blockReleaseOnce = true;
+
+    setSemanticRulePromotionTestHooks({
+      lockTimeoutMs: 25,
+      lockRetryMs: 1,
+      beforeLockRelease: async (lockDir) => {
+        if (!blockReleaseOnce) return;
+        blockReleaseOnce = false;
+        await mkdir(`${lockDir}.release`, { recursive: true });
+      },
+    });
+
+    try {
+      const promotion = await promoteSemanticRuleFromMemory({
+        memoryDir,
+        enabled: true,
+        sourceMemoryId,
+      });
+
+      assert.equal(promotion.promoted.length, 1);
+      assert.equal(promotion.skipped.length, 0);
+    } finally {
+      setSemanticRulePromotionTestHooks(null);
+    }
+  }
+);
 
 test("semantic rule promotion recovers abandoned release guards", async () => {
   const { memoryDir, storage } = await createSemanticRuleHarness();


### PR DESCRIPTION
## Summary
- serialize semantic rule promotion by canonical rule key with an atomic per-memory-directory lock under `state/semantic-rule-promotion-locks`
- re-check existing rule content while holding the lock before writing the promoted rule
- add a concurrent promotion regression test for a single source memory

## Finding
- Fixes ClawPatch finding `fnd_sig-feat-library-c96b1c7b70-ea24_eea2d041df`

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npx tsx --test tests/semantic-rule-verifier.test.ts`
- `/Users/joshuawarren/src/remnic/.worktrees/clawpatch-session-store-tmp/node_modules/.bin/biome check --diagnostic-level=error --files-ignore-unknown=true packages/remnic-core/src/semantic-rule-promotion.ts tests/semantic-rule-verifier.test.ts`
- `git diff --check`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run test:entity-hardening`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm rebuild better-sqlite3`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent write behavior for promoted rules via new filesystem locking; mis-handling could block promotion or leave stale locks, though tests cover many failure modes.
> 
> **Overview**
> **Semantic rule promotion** is now serialized per memory directory and canonical rule key using filesystem locks under `state/semantic-rule-promotion-locks`, with owner tokens, heartbeats, stale/ownerless recovery, and guarded release so concurrent callers cannot create duplicate `rule` memories.
> 
> Duplicate detection and the actual write (or dry-run) run **inside** the lock after invalidating the in-memory memories cache, so a second promoter sees an existing rule and returns `duplicate-rule` instead of writing again.
> 
> `tests/semantic-rule-verifier.test.ts` adds broad regression coverage (concurrency, stale locks, lost ownership, release timeouts). Root `package.json` changes are formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d1c328cc0be2a4fcbcd7a37f52b0536d6f03b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->