### PR TITLE
docs: add real coding agent memory demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Remnic exposes memory and context through HTTP and MCP surfaces and includes int
 
 The long-term goal is to make memory inspectable, scoped, correctable, and measurable across agent workflows.
 
+Try the no-key [Coding Agent Memory Demo](examples/coding-agent-memory-demo/) for a five-minute walkthrough where real Remnic `memoryStore()` and `recallXray()` calls carry a scoped project decision/preference across two coding-agent session identities.
+
 ## Engram -> Remnic
  **Engram is now Remnic.** Canonical packages live under the `@remnic/*` scope:
  [`@remnic/core`](https://www.npmjs.com/package/@remnic/core),

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@
 - [User-Aware Agents](user-aware-agents.md) — User-model dimensions, context scopes, and boundary principles
 - [Agentic Commerce Demo](agentic-commerce-demo.md) — Buyer-aware recommendations, checkout boundaries, and commerce eval coverage
 - [Developer Workflow Demo](developer-workflow-demo.md) — Coding-agent memory for repo conventions, review behavior, checks, and ask-before rules
+- [Coding Agent Memory Demo](../examples/coding-agent-memory-demo/) — No-key cross-tool walkthrough for scoped coding-agent project memory
 - [Temporal Recall](temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and `as_of` recall filter (issue #680)
 - [Tags](tags.md) — Free-form tag filter on recall and propose; tags vs taxonomy (issue #689)
 - [Live Connectors](live-connectors.md) — Continuous-sync framework for external sources (issue #683)

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -45,6 +45,12 @@ remnic connectors install replit
 
 Each command generates a dedicated auth token and installs the native plugin for that platform.
 
+Want to see cross-tool memory before installing connectors? Run the no-key
+[Coding Agent Memory Demo](../../examples/coding-agent-memory-demo/) from a
+source checkout. It uses real Remnic storage and recall paths to carry scoped
+project context from one coding-agent session identity to another with
+retrieval reasons.
+
 ## Step 4: Verify
 
 ```bash

--- a/examples/coding-agent-memory-demo/.gitignore
+++ b/examples/coding-agent-memory-demo/.gitignore
@@ -1,0 +1,1 @@
+.demo-memory/

--- a/examples/coding-agent-memory-demo/README.md
+++ b/examples/coding-agent-memory-demo/README.md
@@ -69,7 +69,9 @@ The generated demo memory files live under
 that directory whenever you want a fresh run; the demo also resets only that
 built-in directory by default.
 
-Custom memory directories are preserved unless you explicitly pass `--reset`:
+Custom memory directories are preserved unless you explicitly pass `--reset`.
+For safety, reset only removes the built-in demo directory, an absent or empty
+custom directory, or a custom directory already marked by a previous demo run:
 
 ```bash
 pnpm run demo:coding-agent-memory -- --memory-dir /tmp/remnic-demo

--- a/examples/coding-agent-memory-demo/README.md
+++ b/examples/coding-agent-memory-demo/README.md
@@ -66,7 +66,15 @@ result: PASS - claude-code:session-b recalled checkout-service context written b
 
 The generated demo memory files live under
 `examples/coding-agent-memory-demo/.demo-memory/`, which is gitignored. Delete
-that directory whenever you want a fresh run; the demo also resets it by default.
+that directory whenever you want a fresh run; the demo also resets only that
+built-in directory by default.
+
+Custom memory directories are preserved unless you explicitly pass `--reset`:
+
+```bash
+pnpm run demo:coding-agent-memory -- --memory-dir /tmp/remnic-demo
+pnpm run demo:coding-agent-memory -- --memory-dir /tmp/remnic-demo --reset
+```
 
 ## Smoke test
 

--- a/examples/coding-agent-memory-demo/README.md
+++ b/examples/coding-agent-memory-demo/README.md
@@ -1,0 +1,106 @@
+# Coding Agent Memory Demo
+
+This repo-level demo shows Remnic carrying scoped project memory from one coding
+agent session to another. It uses no private API keys and makes no network
+calls: the script creates a real `@remnic/core` `Orchestrator`, stores memories
+through `EngramAccessService.memoryStore()`, then recalls them through
+`EngramAccessService.recallXray({ includeRecall: true })`.
+
+## Five-minute walkthrough
+
+From the repository root:
+
+```bash
+pnpm run demo:coding-agent-memory
+```
+
+What happens:
+
+1. `codex-cli:session-a` writes a checkout-service decision and preference into
+   the real Remnic namespace `project-checkout-service`.
+2. The same write path stores an unrelated marketing-site decision in the real
+   namespace `project-marketing-site`.
+3. `claude-code:session-b` recalls from `project-checkout-service` through real
+   Remnic recall/X-ray.
+4. The recall returns only checkout-service memories and explains why each
+   surfaced.
+5. The marketing-site memory does not surface because it is in a different
+   namespace.
+
+Expected terminal output:
+
+```text
+$ pnpm run demo:coding-agent-memory
+
+> remnic-workspace@9.3.567 demo:coding-agent-memory /path/to/remnic
+> NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" tsx examples/coding-agent-memory-demo/demo.mts
+
+Remnic coding-agent memory demo
+memoryDir: examples/coding-agent-memory-demo/.demo-memory
+engine: real @remnic/core Orchestrator + EngramAccessService
+apiKeys: none (OpenAI disabled, QMD disabled)
+
+1) codex-cli / session-a stores real Remnic memories via memoryStore()
+stored decision "checkout retry-policy decision" -> namespace=project-checkout-service status=stored
+stored preference "checkout change-note preference" -> namespace=project-checkout-service status=stored
+stored decision "marketing-site unrelated decision" -> namespace=project-marketing-site status=stored
+
+2) switch to claude-code / session-b and recall through recallXray(includeRecall=true)
+active namespace: project-checkout-service
+query: payment retry policy decision and change notes
+recalled 2 real Remnic memories
+- preference
+  content: Preference: for checkout-service, include the retry-policy file path in change notes before code edits.
+  why: scope=namespace:project-checkout-service; servedBy=recent-scan; served-by=recent-scan
+- decision
+  content: Decision: checkout-service payment retry policy lives in src/payments/retry-policy.ts and uses idempotency keys with a maximum of 3 attempts.
+  why: scope=namespace:project-checkout-service; servedBy=recent-scan; served-by=recent-scan
+
+3) scope check
+checkout namespace: project-checkout-service
+unrelated namespace: project-marketing-site
+xray filter: tag-filter admitted 2/2
+marketing memory surfaced: no
+result: PASS - claude-code:session-b recalled checkout-service context written by codex-cli:session-a using real Remnic storage and recall.
+```
+
+The generated demo memory files live under
+`examples/coding-agent-memory-demo/.demo-memory/`, which is gitignored. Delete
+that directory whenever you want a fresh run; the demo also resets it by default.
+
+## Smoke test
+
+Run the scriptable smoke test:
+
+```bash
+node examples/coding-agent-memory-demo/smoke-test.mjs
+```
+
+Or use the root package script:
+
+```bash
+pnpm run test:coding-agent-memory-demo
+```
+
+Expected output:
+
+```text
+PASS coding-agent-memory-demo smoke test
+```
+
+## Why this is real and offline
+
+Production Remnic integrations normally reach the same access-service through
+the daemon, HTTP, MCP, hooks, or host adapters. This demo runs that access
+service in-process so it can be checked from a source checkout without starting
+a daemon. The write and recall paths are real Remnic paths:
+
+- `EngramAccessService.memoryStore()` validates namespace ACLs and persists via
+  explicit capture into `StorageManager.writeMemory()`.
+- `EngramAccessService.recallXray()` delegates to `Orchestrator.recall()`,
+  captures X-ray provenance, and returns a recall response from the same
+  snapshot.
+- Namespace policies scope the checkout-service and marketing-site memories.
+
+OpenAI, QMD, local LLMs, embeddings, and direct-answer annotation are disabled
+so the demo is deterministic and requires no credentials.

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -175,10 +175,10 @@ async function runDemo() {
   }
 
   const orchestrator = new Orchestrator(createConfig(options.memoryDir));
-  await orchestrator.initialize();
-  const service = new EngramAccessService(orchestrator);
-
   try {
+    await orchestrator.initialize();
+    const service = new EngramAccessService(orchestrator);
+
     const writes = [];
     for (const memory of memoryWrites) {
       const response = await service.memoryStore({

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -16,8 +16,13 @@ class DemoError extends Error {
   constructor(public readonly safeDetail: string) {
     super("demo failed");
     this.name = "DemoError";
+    lastDemoError = this;
+    lastSafeDemoDetail = safeDetail;
   }
 }
+
+let lastDemoError: DemoError | undefined;
+let lastSafeDemoDetail: string | undefined;
 
 const memoryWrites = [
   {
@@ -57,7 +62,7 @@ function parseArgs(argv: string[]) {
       continue;
     } else if (arg === "--memory-dir") {
       const value = argv[index + 1];
-      if (!value) {
+      if (!value || value.startsWith("--")) {
         throw new DemoError("--memory-dir requires a path value");
       }
       memoryDir = value;
@@ -265,7 +270,7 @@ async function runDemo() {
 
 runDemo().catch((error) => {
   const script = path.relative(process.cwd(), fileURLToPath(import.meta.url));
-  const detail = error instanceof DemoError ? `: ${error.safeDetail}` : "";
-  console.error(`${script}: demo failed${detail}`);
+  const detail = error === lastDemoError && lastSafeDemoDetail ? `: ${lastSafeDemoDetail}` : "";
+  process.stderr.write(`${script}: demo failed${detail}\n`);
   process.exitCode = 1;
 });

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -256,7 +256,7 @@ async function runDemo() {
 
 runDemo().catch((error) => {
   const script = path.relative(process.cwd(), fileURLToPath(import.meta.url));
-  const failureKind = error instanceof Error ? error.name : "UnknownError";
-  console.error(`${script}: demo failed (${failureKind})`);
+  void error;
+  console.error(`${script}: demo failed`);
   process.exitCode = 1;
 });

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -88,7 +88,7 @@ function createConfig(memoryDir: string) {
   return parseConfig({
     memoryDir,
     workspaceDir: path.join(memoryDir, "workspace"),
-    openaiApiKey: "disabled",
+    openaiApiKey: false,
     qmdEnabled: false,
     queryAwareIndexingEnabled: false,
     embeddingFallbackEnabled: false,

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -1,9 +1,12 @@
-import { rm } from "node:fs/promises";
+import { lstat, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { EngramAccessService, Orchestrator, expandTildePath, parseConfig } from "@remnic/core";
 
 const DEFAULT_MEMORY_DIR = "examples/coding-agent-memory-demo/.demo-memory";
+const DEMO_MARKER_FILE = ".remnic-coding-agent-memory-demo";
+const DEMO_MARKER_CONTENT = "Remnic coding-agent memory demo directory\n";
 const CHECKOUT_NAMESPACE = "project-checkout-service";
 const MARKETING_NAMESPACE = "project-marketing-site";
 const WRITE_PRINCIPAL = "codex-cli";
@@ -84,6 +87,7 @@ function parseArgs(argv: string[]) {
     displayMemoryDir: memoryDir,
     memoryDir: path.resolve(process.cwd(), expandTildePath(memoryDir)),
     reset: reset ?? usesDefaultMemoryDir,
+    usesDefaultMemoryDir,
   };
 }
 
@@ -150,6 +154,72 @@ async function removeDirWithRetry(dir: string): Promise<void> {
   }
 }
 
+async function statPath(filePath: string) {
+  try {
+    return await lstat(filePath);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isProtectedResetTarget(memoryDir: string): boolean {
+  const resolved = path.resolve(memoryDir);
+  const protectedTargets = [path.parse(resolved).root, path.resolve(process.cwd()), path.resolve(os.homedir())];
+  return protectedTargets.some((protectedTarget) => resolved === protectedTarget);
+}
+
+async function hasDemoMarkerOrIsEmpty(memoryDir: string): Promise<boolean> {
+  const entries = await readdir(memoryDir);
+  return entries.length === 0 || entries.includes(DEMO_MARKER_FILE);
+}
+
+async function assertSafeResetTarget(options: ReturnType<typeof parseArgs>): Promise<void> {
+  if (isProtectedResetTarget(options.memoryDir)) {
+    throw new DemoError("refusing to reset protected memory directory");
+  }
+
+  const existing = await statPath(options.memoryDir);
+  if (!existing) {
+    return;
+  }
+  if (existing.isSymbolicLink()) {
+    throw new DemoError("refusing to reset symlinked memory directory");
+  }
+  if (!existing.isDirectory()) {
+    throw new DemoError("--memory-dir reset target must be a directory");
+  }
+  if (options.usesDefaultMemoryDir || (await hasDemoMarkerOrIsEmpty(options.memoryDir))) {
+    return;
+  }
+
+  throw new DemoError("refusing to reset custom memory directory without demo marker");
+}
+
+async function shouldWriteDemoMarker(options: ReturnType<typeof parseArgs>): Promise<boolean> {
+  if (options.usesDefaultMemoryDir) {
+    return true;
+  }
+  const existing = await statPath(options.memoryDir);
+  if (!existing) {
+    return true;
+  }
+  if (existing.isSymbolicLink() || !existing.isDirectory()) {
+    return false;
+  }
+  return hasDemoMarkerOrIsEmpty(options.memoryDir);
+}
+
+async function writeDemoMarker(options: ReturnType<typeof parseArgs>): Promise<void> {
+  if (!(await shouldWriteDemoMarker(options))) {
+    return;
+  }
+  await mkdir(options.memoryDir, { recursive: true });
+  await writeFile(path.join(options.memoryDir, DEMO_MARKER_FILE), DEMO_MARKER_CONTENT, "utf8");
+}
+
 function resultForMemoryId<T extends { memoryId?: string; id?: string }>(
   entries: T[] | undefined,
   memoryId: string,
@@ -176,8 +246,10 @@ function assertDemoInvariant(condition: unknown, message: string): asserts condi
 async function runDemo() {
   const options = parseArgs(process.argv.slice(2));
   if (options.reset) {
+    await assertSafeResetTarget(options);
     await removeDirWithRetry(options.memoryDir);
   }
+  await writeDemoMarker(options);
 
   const orchestrator = new Orchestrator(createConfig(options.memoryDir));
   try {

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -1,7 +1,7 @@
 import { rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { EngramAccessService, Orchestrator, parseConfig } from "@remnic/core";
+import { EngramAccessService, Orchestrator, expandTildePath, parseConfig } from "@remnic/core";
 
 const DEFAULT_MEMORY_DIR = "examples/coding-agent-memory-demo/.demo-memory";
 const CHECKOUT_NAMESPACE = "project-checkout-service";
@@ -68,7 +68,7 @@ function parseArgs(argv: string[]) {
 
   return {
     displayMemoryDir: memoryDir,
-    memoryDir: path.resolve(process.cwd(), memoryDir),
+    memoryDir: path.resolve(process.cwd(), expandTildePath(memoryDir)),
     reset: reset ?? usesDefaultMemoryDir,
   };
 }

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -12,6 +12,13 @@ const WRITE_SESSION = "codex-cli:session-a";
 const RECALL_SESSION = "claude-code:session-b";
 const QUERY = "payment retry policy decision and change notes";
 
+class DemoError extends Error {
+  constructor(public readonly safeDetail: string) {
+    super("demo failed");
+    this.name = "DemoError";
+  }
+}
+
 const memoryWrites = [
   {
     label: "checkout retry-policy decision",
@@ -46,10 +53,12 @@ function parseArgs(argv: string[]) {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === "--memory-dir") {
+    if (arg === "--") {
+      continue;
+    } else if (arg === "--memory-dir") {
       const value = argv[index + 1];
       if (!value) {
-        throw new Error("--memory-dir requires a path value");
+        throw new DemoError("--memory-dir requires a path value");
       }
       memoryDir = value;
       usesDefaultMemoryDir = false;
@@ -62,7 +71,7 @@ function parseArgs(argv: string[]) {
       printUsage();
       process.exit(0);
     } else {
-      throw new Error(`unknown argument: ${arg}`);
+      throw new DemoError("unknown argument; run with --help for usage");
     }
   }
 
@@ -155,7 +164,7 @@ function formatReason(result: {
 
 function assertDemoInvariant(condition: unknown, message: string): asserts condition {
   if (!condition) {
-    throw new Error(`demo invariant failed: ${message}`);
+    throw new DemoError(`demo invariant failed: ${message}`);
   }
 }
 
@@ -200,7 +209,7 @@ async function runDemo() {
 
     const recall = xray.recall;
     if (!xray.snapshotFound || !recall) {
-      throw new Error("expected recallXray(includeRecall=true) to produce a recall response");
+      throw new DemoError("expected recallXray(includeRecall=true) to produce a recall response");
     }
 
     const surfacedMarketing = recall.context.includes("marketing-site hero copy");
@@ -256,7 +265,7 @@ async function runDemo() {
 
 runDemo().catch((error) => {
   const script = path.relative(process.cwd(), fileURLToPath(import.meta.url));
-  void error;
-  console.error(`${script}: demo failed`);
+  const detail = error instanceof DemoError ? `: ${error.safeDetail}` : "";
+  console.error(`${script}: demo failed${detail}`);
   process.exitCode = 1;
 });

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -41,7 +41,8 @@ const memoryWrites = [
 
 function parseArgs(argv: string[]) {
   let memoryDir = process.env.REMNIC_DEMO_MEMORY_DIR ?? DEFAULT_MEMORY_DIR;
-  let reset = true;
+  let usesDefaultMemoryDir = !process.env.REMNIC_DEMO_MEMORY_DIR;
+  let reset: boolean | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -51,9 +52,12 @@ function parseArgs(argv: string[]) {
         throw new Error("--memory-dir requires a path value");
       }
       memoryDir = value;
+      usesDefaultMemoryDir = false;
       index += 1;
     } else if (arg === "--keep") {
       reset = false;
+    } else if (arg === "--reset") {
+      reset = true;
     } else if (arg === "--help" || arg === "-h") {
       printUsage();
       process.exit(0);
@@ -65,18 +69,19 @@ function parseArgs(argv: string[]) {
   return {
     displayMemoryDir: memoryDir,
     memoryDir: path.resolve(process.cwd(), memoryDir),
-    reset,
+    reset: reset ?? usesDefaultMemoryDir,
   };
 }
 
 function printUsage() {
-  console.log(`Usage: pnpm run demo:coding-agent-memory -- [--memory-dir <path>] [--keep]
+  console.log(`Usage: pnpm run demo:coding-agent-memory -- [--memory-dir <path>] [--keep] [--reset]
 
 Runs a local, no-key Remnic coding-agent memory demo.
 
 Options:
   --memory-dir <path>  Memory directory to seed and recall from
-  --keep               Do not reset the memory directory before seeding`);
+  --keep               Do not reset the built-in demo memory directory before seeding
+  --reset              Explicitly reset the selected memory directory before seeding`);
 }
 
 function createConfig(memoryDir: string) {
@@ -148,6 +153,12 @@ function formatReason(result: {
   return `scope=${scope}; servedBy=${servedBy}; ${retrievalReason}`;
 }
 
+function assertDemoInvariant(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`demo invariant failed: ${message}`);
+  }
+}
+
 async function runDemo() {
   const options = parseArgs(process.argv.slice(2));
   if (options.reset) {
@@ -194,6 +205,17 @@ async function runDemo() {
 
     const surfacedMarketing = recall.context.includes("marketing-site hero copy");
     const tagFilter = xray.snapshot?.filters.find((filter) => filter.name === "tag-filter");
+    const printableResults = recall.memoryIds.map((memoryId) => {
+      const summary = resultForMemoryId(recall.results, memoryId);
+      const result = resultForMemoryId(xray.snapshot?.results, memoryId);
+      assertDemoInvariant(summary, `missing recall summary for ${memoryId}`);
+      assertDemoInvariant(result, `missing X-ray result for ${memoryId}`);
+      return { memoryId, result, summary };
+    });
+
+    assertDemoInvariant(recall.count === 2, `expected 2 checkout memories, got ${recall.count}`);
+    assertDemoInvariant(printableResults.length === 2, `expected 2 printable memories, got ${printableResults.length}`);
+    assertDemoInvariant(!surfacedMarketing, "marketing namespace memory surfaced in checkout recall");
 
     console.log("Remnic coding-agent memory demo");
     console.log(`memoryDir: ${options.displayMemoryDir}`);
@@ -211,12 +233,7 @@ async function runDemo() {
     console.log(`active namespace: ${CHECKOUT_NAMESPACE}`);
     console.log(`query: ${QUERY}`);
     console.log(`recalled ${recall.count} real Remnic memories`);
-    for (const memoryId of recall.memoryIds) {
-      const summary = resultForMemoryId(recall.results, memoryId);
-      const result = resultForMemoryId(xray.snapshot?.results, memoryId);
-      if (!summary || !result) {
-        continue;
-      }
+    for (const { result, summary } of printableResults) {
       console.log(`- ${summary.category}`);
       console.log(`  content: ${summary.content ?? summary.preview}`);
       console.log(`  why: ${formatReason(result)}`);
@@ -239,6 +256,7 @@ async function runDemo() {
 
 runDemo().catch((error) => {
   const script = path.relative(process.cwd(), fileURLToPath(import.meta.url));
-  console.error(`${script}: ${error instanceof Error ? error.message : String(error)}`);
+  const failureKind = error instanceof Error ? error.name : "UnknownError";
+  console.error(`${script}: demo failed (${failureKind})`);
   process.exitCode = 1;
 });

--- a/examples/coding-agent-memory-demo/demo.mts
+++ b/examples/coding-agent-memory-demo/demo.mts
@@ -1,0 +1,244 @@
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { EngramAccessService, Orchestrator, parseConfig } from "@remnic/core";
+
+const DEFAULT_MEMORY_DIR = "examples/coding-agent-memory-demo/.demo-memory";
+const CHECKOUT_NAMESPACE = "project-checkout-service";
+const MARKETING_NAMESPACE = "project-marketing-site";
+const WRITE_PRINCIPAL = "codex-cli";
+const RECALL_PRINCIPAL = "claude-code";
+const WRITE_SESSION = "codex-cli:session-a";
+const RECALL_SESSION = "claude-code:session-b";
+const QUERY = "payment retry policy decision and change notes";
+
+const memoryWrites = [
+  {
+    label: "checkout retry-policy decision",
+    namespace: CHECKOUT_NAMESPACE,
+    category: "decision" as const,
+    content:
+      "Decision: checkout-service payment retry policy lives in src/payments/retry-policy.ts and uses " +
+      "idempotency keys with a maximum of 3 attempts.",
+    tags: ["agent-memory-demo", "payment", "retry-policy"],
+  },
+  {
+    label: "checkout change-note preference",
+    namespace: CHECKOUT_NAMESPACE,
+    category: "preference" as const,
+    content:
+      "Preference: for checkout-service, include the retry-policy file path in change notes before code edits.",
+    tags: ["agent-memory-demo", "change-notes", "retry-policy"],
+  },
+  {
+    label: "marketing-site unrelated decision",
+    namespace: MARKETING_NAMESPACE,
+    category: "decision" as const,
+    content: "Decision: marketing-site hero copy must avoid launch metrics until legal approval.",
+    tags: ["agent-memory-demo", "hero-copy"],
+  },
+];
+
+function parseArgs(argv: string[]) {
+  let memoryDir = process.env.REMNIC_DEMO_MEMORY_DIR ?? DEFAULT_MEMORY_DIR;
+  let reset = true;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--memory-dir") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("--memory-dir requires a path value");
+      }
+      memoryDir = value;
+      index += 1;
+    } else if (arg === "--keep") {
+      reset = false;
+    } else if (arg === "--help" || arg === "-h") {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return {
+    displayMemoryDir: memoryDir,
+    memoryDir: path.resolve(process.cwd(), memoryDir),
+    reset,
+  };
+}
+
+function printUsage() {
+  console.log(`Usage: pnpm run demo:coding-agent-memory -- [--memory-dir <path>] [--keep]
+
+Runs a local, no-key Remnic coding-agent memory demo.
+
+Options:
+  --memory-dir <path>  Memory directory to seed and recall from
+  --keep               Do not reset the memory directory before seeding`);
+}
+
+function createConfig(memoryDir: string) {
+  return parseConfig({
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    openaiApiKey: "disabled",
+    qmdEnabled: false,
+    queryAwareIndexingEnabled: false,
+    embeddingFallbackEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    knowledgeIndexEnabled: false,
+    compoundingInjectEnabled: false,
+    memoryBoxesEnabled: false,
+    temporalMemoryTreeEnabled: false,
+    injectQuestions: false,
+    localLlmEnabled: false,
+    recallDirectAnswerEnabled: false,
+    namespacesEnabled: true,
+    defaultNamespace: "global",
+    sharedNamespace: "shared",
+    defaultRecallNamespaces: ["self"],
+    principalFromSessionKeyMode: "none",
+    namespacePolicies: [
+      {
+        name: CHECKOUT_NAMESPACE,
+        readPrincipals: [WRITE_PRINCIPAL, RECALL_PRINCIPAL],
+        writePrincipals: [WRITE_PRINCIPAL],
+      },
+      {
+        name: MARKETING_NAMESPACE,
+        readPrincipals: [WRITE_PRINCIPAL, RECALL_PRINCIPAL],
+        writePrincipals: [WRITE_PRINCIPAL],
+      },
+    ],
+    recallOuterTimeoutMs: 10_000,
+  });
+}
+
+async function removeDirWithRetry(dir: string): Promise<void> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      await rm(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 4) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+    }
+  }
+}
+
+function resultForMemoryId<T extends { memoryId?: string; id?: string }>(
+  entries: T[] | undefined,
+  memoryId: string,
+): T | undefined {
+  return entries?.find((entry) => (entry.memoryId ?? entry.id) === memoryId);
+}
+
+function formatReason(result: {
+  servedBy?: string;
+  provenance?: { scope?: string; retrievalReason?: string };
+}): string {
+  const scope = result.provenance?.scope ?? "unknown-scope";
+  const servedBy = result.servedBy ?? "unknown";
+  const retrievalReason = result.provenance?.retrievalReason ?? `served-by=${servedBy}`;
+  return `scope=${scope}; servedBy=${servedBy}; ${retrievalReason}`;
+}
+
+async function runDemo() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.reset) {
+    await removeDirWithRetry(options.memoryDir);
+  }
+
+  const orchestrator = new Orchestrator(createConfig(options.memoryDir));
+  await orchestrator.initialize();
+  const service = new EngramAccessService(orchestrator);
+
+  try {
+    const writes = [];
+    for (const memory of memoryWrites) {
+      const response = await service.memoryStore({
+        schemaVersion: 1,
+        sessionKey: WRITE_SESSION,
+        authenticatedPrincipal: WRITE_PRINCIPAL,
+        namespace: memory.namespace,
+        content: memory.content,
+        category: memory.category,
+        confidence: 0.95,
+        tags: memory.tags,
+        sourceReason: `coding-agent-memory-demo:${memory.label}`,
+      });
+      writes.push({ memory, response });
+    }
+
+    const xray = await service.recallXray({
+      query: QUERY,
+      sessionKey: RECALL_SESSION,
+      authenticatedPrincipal: RECALL_PRINCIPAL,
+      namespace: CHECKOUT_NAMESPACE,
+      tags: ["agent-memory-demo"],
+      tagMatch: "all",
+      mode: "full",
+      disclosure: "section",
+      includeRecall: true,
+    });
+
+    const recall = xray.recall;
+    if (!xray.snapshotFound || !recall) {
+      throw new Error("expected recallXray(includeRecall=true) to produce a recall response");
+    }
+
+    const surfacedMarketing = recall.context.includes("marketing-site hero copy");
+    const tagFilter = xray.snapshot?.filters.find((filter) => filter.name === "tag-filter");
+
+    console.log("Remnic coding-agent memory demo");
+    console.log(`memoryDir: ${options.displayMemoryDir}`);
+    console.log("engine: real @remnic/core Orchestrator + EngramAccessService");
+    console.log("apiKeys: none (OpenAI disabled, QMD disabled)");
+    console.log("");
+    console.log("1) codex-cli / session-a stores real Remnic memories via memoryStore()");
+    for (const { memory, response } of writes) {
+      console.log(
+        `stored ${memory.category} "${memory.label}" -> namespace=${response.namespace} status=${response.status}`,
+      );
+    }
+    console.log("");
+    console.log("2) switch to claude-code / session-b and recall through recallXray(includeRecall=true)");
+    console.log(`active namespace: ${CHECKOUT_NAMESPACE}`);
+    console.log(`query: ${QUERY}`);
+    console.log(`recalled ${recall.count} real Remnic memories`);
+    for (const memoryId of recall.memoryIds) {
+      const summary = resultForMemoryId(recall.results, memoryId);
+      const result = resultForMemoryId(xray.snapshot?.results, memoryId);
+      if (!summary || !result) {
+        continue;
+      }
+      console.log(`- ${summary.category}`);
+      console.log(`  content: ${summary.content ?? summary.preview}`);
+      console.log(`  why: ${formatReason(result)}`);
+    }
+    console.log("");
+    console.log("3) scope check");
+    console.log(`checkout namespace: ${CHECKOUT_NAMESPACE}`);
+    console.log(`unrelated namespace: ${MARKETING_NAMESPACE}`);
+    if (tagFilter) {
+      console.log(`xray filter: ${tagFilter.name} admitted ${tagFilter.admitted}/${tagFilter.considered}`);
+    }
+    console.log(`marketing memory surfaced: ${surfacedMarketing ? "yes" : "no"}`);
+    console.log(
+      `result: PASS - ${RECALL_SESSION} recalled checkout-service context written by ${WRITE_SESSION} using real Remnic storage and recall.`,
+    );
+  } finally {
+    await orchestrator.destroy();
+  }
+}
+
+runDemo().catch((error) => {
+  const script = path.relative(process.cwd(), fileURLToPath(import.meta.url));
+  console.error(`${script}: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/examples/coding-agent-memory-demo/smoke-test.mjs
+++ b/examples/coding-agent-memory-demo/smoke-test.mjs
@@ -47,21 +47,23 @@ async function walkMarkdownFiles(root) {
   return files.sort();
 }
 
+function runDemo(memoryDir, envOverrides = {}) {
+  return spawnSync("pnpm", ["exec", "tsx", "examples/coding-agent-memory-demo/demo.mts", "--memory-dir", memoryDir], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...envOverrides,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ? `${process.env.NODE_OPTIONS} ` : ""}--conditions=remnic-source`,
+    },
+  });
+}
+
 async function main() {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-coding-agent-memory-demo-"));
+  const tempHome = await mkdtemp(path.join(os.tmpdir(), "remnic-coding-agent-memory-demo-home-"));
   try {
-    const result = spawnSync(
-      "pnpm",
-      ["exec", "tsx", "examples/coding-agent-memory-demo/demo.mts", "--memory-dir", memoryDir],
-      {
-        cwd: repoRoot,
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          NODE_OPTIONS: `${process.env.NODE_OPTIONS ? `${process.env.NODE_OPTIONS} ` : ""}--conditions=remnic-source`,
-        },
-      }
-    );
+    const result = runDemo(memoryDir);
 
     if (result.status !== 0) {
       throw new Error(`demo exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
@@ -89,9 +91,24 @@ async function main() {
     assertIncludes(persisted, "agent-memory-demo");
     assertIncludes(persisted, "idempotency keys with a maximum of 3 attempts");
 
+    const tildeResult = runDemo("~/remnic-demo-memory", { HOME: tempHome });
+    if (tildeResult.status !== 0) {
+      throw new Error(
+        `tilde demo exited ${tildeResult.status}\nstdout:\n${tildeResult.stdout}\nstderr:\n${tildeResult.stderr}`
+      );
+    }
+
+    const tildeMemoryDir = path.join(tempHome, "remnic-demo-memory");
+    const tildeMarkdownFiles = await walkMarkdownFiles(tildeMemoryDir);
+    const tildePersisted = (await Promise.all(tildeMarkdownFiles.map((filePath) => readFile(filePath, "utf8")))).join(
+      "\n"
+    );
+    assertIncludes(tildePersisted, "idempotency keys with a maximum of 3 attempts");
+
     console.log("PASS coding-agent-memory-demo smoke test");
   } finally {
     await removeDirWithRetry(memoryDir);
+    await removeDirWithRetry(tempHome);
   }
 }
 

--- a/examples/coding-agent-memory-demo/smoke-test.mjs
+++ b/examples/coding-agent-memory-demo/smoke-test.mjs
@@ -47,8 +47,8 @@ async function walkMarkdownFiles(root) {
   return files.sort();
 }
 
-function runDemo(memoryDir, envOverrides = {}) {
-  return spawnSync("pnpm", ["exec", "tsx", "examples/coding-agent-memory-demo/demo.mts", "--memory-dir", memoryDir], {
+function runDemoArgs(args, envOverrides = {}) {
+  return spawnSync("pnpm", ["exec", "tsx", "examples/coding-agent-memory-demo/demo.mts", ...args], {
     cwd: repoRoot,
     encoding: "utf8",
     env: {
@@ -57,6 +57,10 @@ function runDemo(memoryDir, envOverrides = {}) {
       NODE_OPTIONS: `${process.env.NODE_OPTIONS ? `${process.env.NODE_OPTIONS} ` : ""}--conditions=remnic-source`,
     },
   });
+}
+
+function runDemo(memoryDir, envOverrides = {}) {
+  return runDemoArgs(["--memory-dir", memoryDir], envOverrides);
 }
 
 async function main() {
@@ -91,7 +95,7 @@ async function main() {
     assertIncludes(persisted, "agent-memory-demo");
     assertIncludes(persisted, "idempotency keys with a maximum of 3 attempts");
 
-    const tildeResult = runDemo("~/remnic-demo-memory", { HOME: tempHome });
+    const tildeResult = runDemoArgs(["--", "--memory-dir", "~/remnic-demo-memory"], { HOME: tempHome });
     if (tildeResult.status !== 0) {
       throw new Error(
         `tilde demo exited ${tildeResult.status}\nstdout:\n${tildeResult.stdout}\nstderr:\n${tildeResult.stderr}`

--- a/examples/coding-agent-memory-demo/smoke-test.mjs
+++ b/examples/coding-agent-memory-demo/smoke-test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const demoDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(demoDir, "..", "..");
+const tsxCli = path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs");
 
 function assertIncludes(output, expected) {
   if (!output.includes(expected)) {
@@ -48,7 +49,7 @@ async function walkMarkdownFiles(root) {
 }
 
 function runDemoArgs(args, envOverrides = {}) {
-  return spawnSync("pnpm", ["exec", "tsx", "examples/coding-agent-memory-demo/demo.mts", ...args], {
+  return spawnSync(process.execPath, [tsxCli, "examples/coding-agent-memory-demo/demo.mts", ...args], {
     cwd: repoRoot,
     encoding: "utf8",
     env: {

--- a/examples/coding-agent-memory-demo/smoke-test.mjs
+++ b/examples/coding-agent-memory-demo/smoke-test.mjs
@@ -1,4 +1,4 @@
-import { access, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { access, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -131,6 +131,15 @@ async function main() {
     }
     assertIncludes(invalidFlagResult.stderr, "--memory-dir requires a path value");
     await assertPathMissing(invalidFlagPath);
+
+    const homeSentinel = path.join(tempHome, "sentinel");
+    await writeFile(homeSentinel, "keep\n", "utf8");
+    const unsafeResetResult = runDemoArgs(["--memory-dir", "~", "--reset"], { HOME: tempHome });
+    if (unsafeResetResult.status === 0) {
+      throw new Error(`unsafe home reset succeeded\nstdout:\n${unsafeResetResult.stdout}`);
+    }
+    assertIncludes(unsafeResetResult.stderr, "refusing to reset protected memory directory");
+    await access(homeSentinel);
 
     console.log("PASS coding-agent-memory-demo smoke test");
   } finally {

--- a/examples/coding-agent-memory-demo/smoke-test.mjs
+++ b/examples/coding-agent-memory-demo/smoke-test.mjs
@@ -1,0 +1,101 @@
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const demoDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(demoDir, "..", "..");
+
+function assertIncludes(output, expected) {
+  if (!output.includes(expected)) {
+    throw new Error(`expected output to include ${JSON.stringify(expected)}`);
+  }
+}
+
+function assertNotIncludes(output, unexpected) {
+  if (output.includes(unexpected)) {
+    throw new Error(`expected output not to include ${JSON.stringify(unexpected)}`);
+  }
+}
+
+async function removeDirWithRetry(dir) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      await rm(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 4) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+    }
+  }
+}
+
+async function walkMarkdownFiles(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkMarkdownFiles(entryPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(entryPath);
+    }
+  }
+  return files.sort();
+}
+
+async function main() {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-coding-agent-memory-demo-"));
+  try {
+    const result = spawnSync(
+      "pnpm",
+      ["exec", "tsx", "examples/coding-agent-memory-demo/demo.mts", "--memory-dir", memoryDir],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_OPTIONS: `${process.env.NODE_OPTIONS ? `${process.env.NODE_OPTIONS} ` : ""}--conditions=remnic-source`,
+        },
+      }
+    );
+
+    if (result.status !== 0) {
+      throw new Error(`demo exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    }
+
+    const output = result.stdout;
+    assertIncludes(output, "Remnic coding-agent memory demo");
+    assertIncludes(output, "engine: real @remnic/core Orchestrator + EngramAccessService");
+    assertIncludes(output, "apiKeys: none (OpenAI disabled, QMD disabled)");
+    assertIncludes(output, "codex-cli / session-a stores real Remnic memories via memoryStore()");
+    assertIncludes(output, "switch to claude-code / session-b and recall through recallXray(includeRecall=true)");
+    assertIncludes(output, "active namespace: project-checkout-service");
+    assertIncludes(output, "recalled 2 real Remnic memories");
+    assertIncludes(output, "content: Decision: checkout-service payment retry policy lives in");
+    assertIncludes(output, "content: Preference: for checkout-service, include the retry-policy file path");
+    assertIncludes(output, "why: scope=namespace:project-checkout-service; servedBy=recent-scan");
+    assertIncludes(output, "unrelated namespace: project-marketing-site");
+    assertIncludes(output, "marketing memory surfaced: no");
+    assertIncludes(output, "result: PASS");
+    assertNotIncludes(output, "content: Decision: marketing-site hero copy");
+
+    const markdownFiles = await walkMarkdownFiles(memoryDir);
+    const persisted = (await Promise.all(markdownFiles.map((filePath) => readFile(filePath, "utf8")))).join("\n");
+    assertIncludes(persisted, "source: explicit");
+    assertIncludes(persisted, "agent-memory-demo");
+    assertIncludes(persisted, "idempotency keys with a maximum of 3 attempts");
+
+    console.log("PASS coding-agent-memory-demo smoke test");
+  } finally {
+    await removeDirWithRetry(memoryDir);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/examples/coding-agent-memory-demo/smoke-test.mjs
+++ b/examples/coding-agent-memory-demo/smoke-test.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { access, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -32,6 +32,18 @@ async function removeDirWithRetry(dir) {
       await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
     }
   }
+}
+
+async function assertPathMissing(filePath) {
+  try {
+    await access(filePath);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  throw new Error(`expected path not to exist: ${filePath}`);
 }
 
 async function walkMarkdownFiles(root) {
@@ -109,6 +121,16 @@ async function main() {
       "\n"
     );
     assertIncludes(tildePersisted, "idempotency keys with a maximum of 3 attempts");
+
+    const invalidFlagDir = "--remnic-demo-invalid-memory-dir";
+    const invalidFlagPath = path.join(repoRoot, invalidFlagDir);
+    await removeDirWithRetry(invalidFlagPath);
+    const invalidFlagResult = runDemoArgs(["--memory-dir", invalidFlagDir]);
+    if (invalidFlagResult.status === 0) {
+      throw new Error(`invalid flag-like memory-dir succeeded\nstdout:\n${invalidFlagResult.stdout}`);
+    }
+    assertIncludes(invalidFlagResult.stderr, "--memory-dir requires a path value");
+    await assertPathMissing(invalidFlagPath);
 
     console.log("PASS coding-agent-memory-demo smoke test");
   } finally {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -772,6 +763,8 @@
     "test:openclaw-scenarios": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" pnpm exec tsx --test tests/openclaw-adapter-scenarios.test.ts",
     "test:openclaw-privacy": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" pnpm exec tsx --test tests/openclaw-hook-privacy.test.ts",
     "test:entity-hardening": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts tests/entity-contamination.test.ts",
+    "demo:coding-agent-memory": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx examples/coding-agent-memory-demo/demo.mts",
+    "test:coding-agent-memory-demo": "node examples/coding-agent-memory-demo/smoke-test.mjs",
     "test:release-smoke": "pnpm run build && node scripts/check-release-artifacts.mjs",
     "plugin:inspect": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect",
     "plugin:inspect:runtime": "pnpm --filter @remnic/plugin-openclaw run plugin:inspect:runtime",
@@ -807,12 +800,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }


### PR DESCRIPTION
## Summary

- add `examples/coding-agent-memory-demo`, a no-key local demo that uses real `@remnic/core` `Orchestrator` and `EngramAccessService.memoryStore()` / `recallXray()` paths
- document a five-minute walkthrough with copy-pastable terminal output plus a scriptable smoke test
- link the demo from the root README, docs index, and quickstart install docs

## Verification

- `pnpm run demo:coding-agent-memory`
- `pnpm run test:coding-agent-memory-demo`
- `npm run preflight:quick`

Note: `check:openclaw-sdk-surface` skipped its live peer-package scan because `openclaw` is not installed in this worktree; the bundled OpenClaw SDK surface tests passed inside `preflight:quick`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes; no production core behavior changes, with isolated demo storage and guarded reset logic.
> 
> **Overview**
> Adds **`examples/coding-agent-memory-demo`**, an offline, no-API-key walkthrough that runs a real in-process **`Orchestrator`** + **`EngramAccessService`**: **`codex-cli:session-a`** writes scoped memories via **`memoryStore()`**, then **`claude-code:session-b`** recalls checkout-only context via **`recallXray({ includeRecall: true })`** with X-ray reasons, proving namespace isolation from a separate marketing namespace.
> 
> The demo script disables OpenAI/QMD and related features for determinism, gitignores **`.demo-memory/`**, and includes **conservative reset guards** (protected paths, demo marker, symlink checks). A **`smoke-test.mjs`** asserts PASS output, persistence, tilde paths, and unsafe-reset failures.
> 
> **Docs and wiring:** links from the root **README**, **`docs/README.md`**, and **`docs/guides/quickstart.md`**; root **`pnpm`** scripts **`demo:coding-agent-memory`** and **`test:coding-agent-memory-demo`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091fc110e920ae460f4a4f7bc7da7421675f04fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->