### PR TITLE
Preserve Pi extension user files on uninstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -726,12 +724,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -754,9 +747,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -807,12 +798,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -448,3 +448,79 @@ test("Pi publisher refuses a symlinked extension root", async (t) => {
   assert.equal(fs.existsSync(path.join(targetDir, "remnic.config.json")), false);
   assert.equal(fs.existsSync(path.join(targetDir, "index.ts")), false);
 });
+
+test("Pi publisher unpublish removes only Remnic-owned files", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-publisher-unpublish-preserve-"));
+  const home = path.join(root, "home");
+  const piAgentHome = path.join(root, "pi-agent");
+  const extensionRoot = path.join(piAgentHome, "extensions", "remnic");
+  const unrelatedPath = path.join(extensionRoot, "user-note.txt");
+  const tempPath = path.join(extensionRoot, "remnic.config.json.tmp-123-456");
+  const unrelatedTempPath = path.join(extensionRoot, "remnic.config.json.tmp-user-note");
+  fs.mkdirSync(extensionRoot, { recursive: true });
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+  fs.writeFileSync(path.join(extensionRoot, "remnic.config.json"), "{}\n");
+  fs.writeFileSync(path.join(extensionRoot, "index.ts"), "export default {};\n");
+  fs.writeFileSync(path.join(extensionRoot, "README.md"), "# Remnic\n");
+  fs.writeFileSync(unrelatedPath, "user-managed content\n");
+  fs.writeFileSync(tempPath, "temporary token-bearing config\n");
+  fs.writeFileSync(unrelatedTempPath, "user-managed temp note\n");
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousPiAgentHome = process.env.PI_AGENT_HOME;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.PI_AGENT_HOME = piAgentHome;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const publisher = new PiMemoryExtensionPublisher();
+  await publisher.unpublish();
+
+  assert.equal(fs.existsSync(path.join(extensionRoot, "remnic.config.json")), false);
+  assert.equal(fs.existsSync(path.join(extensionRoot, "index.ts")), false);
+  assert.equal(fs.existsSync(path.join(extensionRoot, "README.md")), false);
+  assert.equal(fs.existsSync(tempPath), false);
+  assert.equal(fs.readFileSync(unrelatedPath, "utf8"), "user-managed content\n");
+  assert.equal(fs.readFileSync(unrelatedTempPath, "utf8"), "user-managed temp note\n");
+});
+
+test("Pi publisher unpublish refuses owned file symlinks", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-pi-publisher-unpublish-symlink-"));
+  const home = path.join(root, "home");
+  const piAgentHome = path.join(root, "pi-agent");
+  const extensionRoot = path.join(piAgentHome, "extensions", "remnic");
+  const targetDir = path.join(root, "symlink-target");
+  fs.mkdirSync(extensionRoot, { recursive: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.mkdirSync(path.join(home, ".remnic"), { recursive: true });
+  fs.writeFileSync(path.join(targetDir, "external-wrapper.ts"), "external wrapper\n");
+  fs.writeFileSync(path.join(extensionRoot, "remnic.config.json"), "{}\n");
+  fs.symlinkSync(path.join(targetDir, "external-wrapper.ts"), path.join(extensionRoot, "index.ts"));
+  fs.writeFileSync(path.join(extensionRoot, "README.md"), "# Remnic\n");
+
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousPiAgentHome = process.env.PI_AGENT_HOME;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  process.env.PI_AGENT_HOME = piAgentHome;
+  t.after(() => {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("USERPROFILE", previousUserProfile);
+    restoreEnv("PI_AGENT_HOME", previousPiAgentHome);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const publisher = new PiMemoryExtensionPublisher();
+  await assert.rejects(() => publisher.unpublish(), /must not be a symlink/);
+
+  assert.equal(fs.readFileSync(path.join(targetDir, "external-wrapper.ts"), "utf8"), "external wrapper\n");
+  assert.equal(fs.readFileSync(path.join(extensionRoot, "remnic.config.json"), "utf8"), "{}\n");
+  assert.equal(fs.readFileSync(path.join(extensionRoot, "README.md"), "utf8"), "# Remnic\n");
+});

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -16,6 +16,8 @@ import {
 import { resolvePiAgentHome, resolvePiExtensionRoot } from "./paths.js";
 
 const DEFAULT_DAEMON_PORT = 4318;
+const PI_EXTENSION_OWNED_FILES = ["remnic.config.json", "index.ts", "README.md"] as const;
+const PI_EXTENSION_OWNED_TEMP_FILE_PATTERN = /^(?:remnic\.config\.json|index\.ts|README\.md)\.tmp-\d+-\d+$/u;
 
 type FileSnapshot = {
   path: string;
@@ -79,9 +81,7 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
 
     ctx.log.info(`Publishing Pi memory extension to ${extensionRoot}`);
 
-    const configPath = path.join(extensionRoot, "remnic.config.json");
-    const wrapperPath = path.join(extensionRoot, "index.ts");
-    const readmePath = path.join(extensionRoot, "README.md");
+    const [configPath, wrapperPath, readmePath] = piExtensionOwnedPaths(extensionRoot);
     const rootExisted = fs.existsSync(extensionRoot);
     const snapshots = snapshotFiles([configPath, wrapperPath, readmePath]);
     const priorTokenEntry =
@@ -154,10 +154,30 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
   async unpublish(): Promise<void> {
     const extensionRoot = await this.resolveExtensionRoot();
     assertSafePiExtensionRoot(extensionRoot, process.env);
-    if (fs.existsSync(extensionRoot)) {
-      fs.rmSync(extensionRoot, { recursive: true, force: true });
+    if (!fs.existsSync(extensionRoot)) {
+      return;
+    }
+
+    const removableFiles = removableOwnedExtensionFiles(piExtensionOwnedUnpublishPaths(extensionRoot));
+    for (const filePath of removableFiles) {
+      fs.rmSync(filePath, { force: true });
+    }
+    removeEmptyDirectory(extensionRoot);
+  }
+}
+
+function piExtensionOwnedPaths(extensionRoot: string): string[] {
+  return PI_EXTENSION_OWNED_FILES.map((fileName) => path.join(extensionRoot, fileName));
+}
+
+function piExtensionOwnedUnpublishPaths(extensionRoot: string): string[] {
+  const ownedPaths = piExtensionOwnedPaths(extensionRoot);
+  for (const fileName of fs.readdirSync(extensionRoot)) {
+    if (PI_EXTENSION_OWNED_TEMP_FILE_PATTERN.test(fileName)) {
+      ownedPaths.push(path.join(extensionRoot, fileName));
     }
   }
+  return ownedPaths;
 }
 
 function resolveDaemonUrl(ctx: PublishContext): string {
@@ -285,6 +305,30 @@ function removeEmptyDirectory(dirPath: string): void {
   if (!stat.isDirectory()) return;
   if (fs.readdirSync(dirPath).length > 0) return;
   fs.rmdirSync(dirPath);
+}
+
+function removableOwnedExtensionFiles(filePaths: string[]): string[] {
+  const removableFiles: string[] = [];
+  for (const filePath of filePaths) {
+    const stat = statOwnedExtensionPath(filePath);
+    if (stat === null) continue;
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Pi extension path must not be a symlink: ${filePath}`);
+    }
+    if (stat.isFile()) removableFiles.push(filePath);
+  }
+  return removableFiles;
+}
+
+function statOwnedExtensionPath(filePath: string): fs.Stats | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(filePath);
+  } catch (err) {
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") return null;
+    throw err;
+  }
+  return stat;
 }
 
 function mkdirPiExtensionRoot(extensionRoot: string, env: NodeJS.ProcessEnv): void {


### PR DESCRIPTION
## Summary
- change Pi extension unpublish to remove only Remnic-owned files
- preserve unrelated user-managed files under the extension root
- fail closed on symlinked owned paths and remove the root only when empty

## ClawPatch
- Fixes fnd_sig-feat-library-8d0e467c83-a128_e554909f66

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec biome check --write packages/plugin-pi/src/publisher.ts packages/plugin-pi/src/publisher.test.ts
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec tsx --test packages/plugin-pi/src/publisher.test.ts
- OLLAMA_API_KEY=test PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick

Note: the first preflight attempt failed because this new worktree was missing better-sqlite3 native bindings. After PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm rebuild better-sqlite3, preflight:quick passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uninstall touches the user’s Pi extension directory on disk; behavior change could leave stale Remnic files if logic is wrong, but scope is narrowed and symlink guards reduce traversal risk.
> 
> **Overview**
> **Pi connector uninstall** no longer deletes the whole `extensions/remnic` directory. **Unpublish** now removes only Remnic-owned artifacts (`remnic.config.json`, `index.ts`, `README.md`, and matching `*.tmp-<pid>-<time>` publish temps), leaves other files in that folder untouched, and removes the extension directory only when it is empty afterward.
> 
> Owned paths that are **symlinks** cause unpublish to **fail closed** (same safety model as publish/rollback). Publish continues to use a shared owned-file list for the three main paths.
> 
> **Tests** cover selective removal, preserving user files and non-matching temp names, and symlink refusal on unpublish. Root **`package.json`** changes are formatting-only (single-line arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faee93e2177103b60685ee8681f25996328fd2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->