### PR TITLE
Add belief ledger package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 dist/
+packages/belief-ledger/dist/
 *.map
 __pycache__/
 *.pyc

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -732,12 +730,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -760,9 +753,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -815,12 +806,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/belief-ledger/README.md
+++ b/packages/belief-ledger/README.md
@@ -1,0 +1,70 @@
+# @remnic/belief-ledger
+
+A Remnic library for a personal belief and prediction ledger. It stores claims,
+predictions, and opinions as structured Remnic facts, retrieves prior claims that
+may conflict, asks a host LLM to classify the relationship, and tracks prediction
+calibration over time.
+
+This package is intentionally host-neutral:
+
+- It depends on `@remnic/core` public APIs.
+- It does not import OpenClaw, Hermes, or direct OpenAI clients.
+- Host adapters provide LLM access through `LedgerLlmAdapter`, or wrap Remnic's
+  existing `FallbackLlmClient` with `createFallbackLlmLedgerAdapter`.
+
+## Basic Usage
+
+```ts
+import { StorageManager } from "@remnic/core";
+import {
+  BeliefLedger,
+  RemnicLedgerStore,
+  createFallbackLlmLedgerAdapter,
+} from "@remnic/belief-ledger";
+
+const storage = new StorageManager("/path/to/remnic-memory");
+const store = new RemnicLedgerStore(storage);
+const llm = createFallbackLlmLedgerAdapter(fallbackLlmClient);
+
+const ledger = new BeliefLedger({ store, llm });
+
+const result = await ledger.capture({
+  text: "I think local-first memory tools will beat cloud-only memory tools by 2027.",
+});
+
+if (result.challenge) {
+  console.log(result.challenge.question);
+}
+```
+
+## What Gets Stored
+
+Claims are written as Remnic `fact` memories with:
+
+- `tags`: `belief-ledger`, claim kind, status, and optional domain.
+- `entityRef`: the first extracted entity when one exists.
+- `structuredAttributes`: stance, confidence, domain, entities, deadline,
+  evidence links, status, prediction outcome, and Brier score.
+
+That confirms issue #869's upstream requirements through the public core
+surface: custom metadata, entity-scoped retrieval inputs, and supersession via
+`StorageManager.supersedeMemory`.
+
+## Host LLM Access
+
+The package asks for a `LedgerLlmAdapter` rather than an API key. OpenClaw,
+Hermes, CLI, or app adapters can route the calls through their normal Remnic LLM
+path. For OpenClaw-backed Remnic runtimes, pass the existing gateway-backed
+`FallbackLlmClient` to `createFallbackLlmLedgerAdapter`.
+
+## Core Flows
+
+- `capture`: extract a structured claim, persist it, retrieve prior claims,
+  judge contradictions, and draft a Socratic challenge when needed.
+- `crossExamine`: run retrieval and LLM judging against an existing claim.
+- `supersede`, `split`, `resolve`, `snooze`, `ignore`: typed ledger actions
+  suitable for host tool/function surfaces.
+- `scoreDuePredictions`: find predictions past deadline, grade them from a
+  verdict source or return a user-verdict prompt.
+- `reflect`: compute calibration summaries, Brier score, flipped claims, and
+  dormant topics.

--- a/packages/belief-ledger/package.json
+++ b/packages/belief-ledger/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@remnic/belief-ledger",
+  "version": "9.3.579",
+  "description": "Belief and prediction ledger library built on Remnic memory primitives",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "check-types": "tsc --noEmit",
+    "pretest": "node ../../scripts/ensure-bench-build-deps.mjs",
+    "test": "tsx --test src/*.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.3.579"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/belief-ledger"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "beliefs",
+    "prediction",
+    "calibration",
+    "ledger"
+  ]
+}

--- a/packages/belief-ledger/src/index.ts
+++ b/packages/belief-ledger/src/index.ts
@@ -1,0 +1,74 @@
+export {
+  BeliefLedger,
+  type BeliefLedgerFromStorageOptions,
+  type BeliefLedgerOptions,
+  type ResolveClaimInput,
+} from "./ledger.js";
+export {
+  createFallbackLlmLedgerAdapter,
+  type FallbackLlmLedgerAdapterOptions,
+} from "./llm.js";
+export {
+  RemnicLedgerStore,
+  type RemnicLedgerStoreOptions,
+} from "./remnic-store.js";
+export {
+  retrievePriorClaims,
+} from "./retrieval.js";
+export {
+  buildReflectionReport,
+} from "./reflection.js";
+export {
+  LEDGER_SCHEMA_VERSION,
+  LEDGER_TAG,
+  claimFromMemory,
+  claimTags,
+  claimToStructuredAttributes,
+  computeBrierScore,
+  createResolution,
+  memoryFrontmatterPatchForClaim,
+  normalizeClaimDraft,
+  normalizeChallenge,
+  normalizeIsoTimestamp,
+  normalizeJudgeResult,
+  normalizePredictionGrade,
+  remnicMemoryStatusForClaim,
+  roundMetric,
+  serializeClaimBody,
+} from "./schema.js";
+export type {
+  LedgerCalibrationBin,
+  LedgerCaptureInput,
+  LedgerCaptureResult,
+  LedgerChallenge,
+  LedgerChallengeRequest,
+  LedgerClaim,
+  LedgerClaimDraft,
+  LedgerClaimKind,
+  LedgerClaimScope,
+  LedgerClaimStatus,
+  LedgerCrossExaminationResult,
+  LedgerCrossExaminationStats,
+  LedgerDomainCalibration,
+  LedgerDormantTopic,
+  LedgerFlippedClaim,
+  LedgerJudgeClassification,
+  LedgerJudgeRequest,
+  LedgerJudgeResult,
+  LedgerLlmAdapter,
+  LedgerPredictionGrade,
+  LedgerPredictionGradeRequest,
+  LedgerPredictionScoreResult,
+  LedgerPredictionVerdict,
+  LedgerReflectionOptions,
+  LedgerReflectionReport,
+  LedgerResolution,
+  LedgerRetrievalCandidate,
+  LedgerRetrievalOptions,
+  LedgerRerankerAdapter,
+  LedgerScoreDuePredictionsOptions,
+  LedgerSemanticRetrievalAdapter,
+  LedgerStance,
+  LedgerStore,
+  LedgerTimeWindow,
+} from "./types.js";

--- a/packages/belief-ledger/src/ledger.test.ts
+++ b/packages/belief-ledger/src/ledger.test.ts
@@ -1,0 +1,831 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { BeliefLedger } from "./ledger.js";
+import { buildReflectionReport } from "./reflection.js";
+import { retrievePriorClaims } from "./retrieval.js";
+import type {
+  LedgerChallenge,
+  LedgerClaim,
+  LedgerClaimDraft,
+  LedgerJudgeResult,
+  LedgerLlmAdapter,
+  LedgerPredictionGrade,
+  LedgerPredictionGradeRequest,
+  LedgerStore,
+} from "./types.js";
+
+class MemoryStore implements LedgerStore {
+  claims = new Map<string, any>();
+  next = 1;
+
+  async createClaim(input: any): Promise<any> {
+    const id = `claim-${this.next}`;
+    this.next += 1;
+    const claim = { ...input, id, memoryId: id };
+    this.claims.set(id, claim);
+    return claim;
+  }
+
+  async getClaim(id: string): Promise<any | null> {
+    return this.claims.get(id) ?? null;
+  }
+
+  async listClaims(filter: any = {}): Promise<any[]> {
+    const statuses = filter.statuses ? new Set(filter.statuses) : null;
+    const kinds = filter.kinds ? new Set(filter.kinds) : null;
+    return [...this.claims.values()]
+      .filter((claim) => !statuses || statuses.has(claim.status))
+      .filter((claim) => !kinds || kinds.has(claim.kind));
+  }
+
+  async updateClaim(id: string, patch: any): Promise<any> {
+    const claim = this.claims.get(id);
+    if (!claim) throw new Error("missing claim");
+    const updated = { ...claim, ...patch };
+    this.claims.set(id, updated);
+    return updated;
+  }
+
+  async supersedeClaim(priorId: string, newId: string): Promise<boolean> {
+    const prior = this.claims.get(priorId);
+    const next = this.claims.get(newId);
+    if (!prior || !next) return false;
+    this.claims.set(priorId, { ...prior, status: "superseded", supersededBy: newId });
+    this.claims.set(newId, {
+      ...next,
+      supersedes: priorId,
+      parentIds: [...new Set([...(next.parentIds ?? []), priorId])],
+    });
+    return true;
+  }
+}
+
+class FakeLlm implements LedgerLlmAdapter {
+  async extractClaim(request: any): Promise<LedgerClaimDraft> {
+    if (request.text.includes("Cloud-only")) {
+      return {
+        statement: "Cloud-only memory tools will beat local-first memory tools by 2027.",
+        kind: "prediction",
+        stance: "for",
+        confidence: 0.7,
+        scope: { entities: ["Memory Tools"], domain: "ai memory" },
+        deadline: "2027-01-01T00:00:00Z",
+      };
+    }
+    if (request.text.includes("demo")) {
+      return {
+        statement: "The demo shipped by June 2026.",
+        kind: "prediction",
+        stance: "for",
+        confidence: 0.75,
+        scope: { entities: ["Demo"], domain: "shipping" },
+        deadline: "2026-06-01T00:00:00Z",
+      };
+    }
+    return {
+      statement: "Local-first memory tools will beat cloud-only memory tools by 2027.",
+      kind: "prediction",
+      stance: "for",
+      confidence: 0.8,
+      scope: { entities: ["Memory Tools"], domain: "ai memory" },
+      deadline: "2027-01-01T00:00:00Z",
+    };
+  }
+
+  async judgeClaimPair(request: any): Promise<LedgerJudgeResult> {
+    const pair = `${request.current.statement}\n${request.prior.statement}`;
+    const classification = pair.includes("Cloud-only") && pair.includes("Local-first") ? "contradiction" : "unrelated";
+    return {
+      priorClaimId: request.prior.id,
+      classification,
+      confidence: 0.9,
+      rationale:
+        classification === "contradiction" ? "The winner is reversed under the same scope." : "Different topic.",
+    };
+  }
+
+  async draftSocraticChallenge(request: any): Promise<LedgerChallenge> {
+    return {
+      question: `You previously said "${request.contradictions[0].claim.statement}". Which claim should stand?`,
+      priorClaimIds: request.contradictions.map((item: any) => item.claim.id),
+      suggestedActions: ["supersede", "split", "ignore"],
+    };
+  }
+
+  async gradePrediction(_request: LedgerPredictionGradeRequest): Promise<LedgerPredictionGrade> {
+    return {
+      verdict: "false",
+      actualConfidence: 0,
+      rationale: "The supplied source says it did not ship.",
+      source: "test verdict",
+    };
+  }
+}
+
+describe("BeliefLedger", () => {
+  it("captures claims and asks a Socratic challenge for contradictions", async () => {
+    const store = new MemoryStore();
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    const first = await ledger.capture({ text: "Cloud-only will win." });
+    assert.equal(first.challenge, undefined);
+
+    const second = await ledger.capture({ text: "Local-first will win." });
+    assert.equal(second.stats.contradictions, 1);
+    assert.match(second.challenge?.question ?? "", /previously said/);
+
+    assert.equal(await ledger.supersede(first.claim.id, second.claim.id, "changed my mind"), true);
+    assert.equal((await store.getClaim(first.claim.id))?.status, "superseded");
+  });
+
+  it("uses capture now for immediate cross-examination", async () => {
+    const store = new MemoryStore();
+    await store.createClaim(
+      makeClaim({
+        id: "prior",
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-20T00:00:00Z",
+      })
+    );
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    const result = await ledger.capture({
+      text: "Local-first will win.",
+      now: "2020-01-01T00:00:00Z",
+    });
+
+    assert.equal(result.candidates.length, 1);
+    assert.equal(
+      result.candidates[0]?.reasons.some((reason) => reason.startsWith("recency:")),
+      false
+    );
+  });
+
+  it("persists extracted claims when cross-examination fails", async () => {
+    const store = new MemoryStore();
+    await store.createClaim({
+      ...makeClaim({
+        id: "prior",
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-20T00:00:00Z",
+      }),
+      statement: "Cloud-only memory tools will beat local-first memory tools by 2027.",
+    });
+    const llm = new FakeLlm();
+    llm.draftSocraticChallenge = async () => {
+      throw new Error("challenge failed");
+    };
+    const ledger = new BeliefLedger({
+      store,
+      llm,
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    await assert.rejects(() => ledger.capture({ text: "Local-first will win." }), /challenge failed/);
+
+    assert.equal(store.claims.size, 2);
+    assert.ok(
+      [...store.claims.values()].some(
+        (claim) => claim.statement === "Local-first memory tools will beat cloud-only memory tools by 2027."
+      )
+    );
+  });
+
+  it("throws when split cannot supersede the prior claim", async () => {
+    const store = new MemoryStore();
+    const prior = await store.createClaim(
+      makeClaim({
+        id: "prior",
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-20T00:00:00Z",
+      })
+    );
+    store.supersedeClaim = async () => false;
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    await assert.rejects(
+      () =>
+        ledger.split(prior.id, [
+          {
+            statement: "Narrower memory claim.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+        ]),
+      /could not supersede/
+    );
+
+    const replacements = [...store.claims.values()].filter((claim) => claim.parentIds?.includes(prior.id));
+    assert.equal((await store.getClaim(prior.id))?.status, "active");
+    assert.equal(replacements.length, 1);
+    assert.equal(replacements[0]?.status, "ignored");
+  });
+
+  it("returns the linked first replacement when split succeeds", async () => {
+    const store = new MemoryStore();
+    const prior = await store.createClaim(
+      makeClaim({
+        id: "prior",
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-20T00:00:00Z",
+      })
+    );
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    const replacements = await ledger.split(prior.id, [
+      {
+        statement: "Narrower memory claim.",
+        stance: "for",
+        confidence: 0.7,
+        scope: { entities: ["Memory Tools"], domain: "ai memory" },
+      },
+    ]);
+
+    assert.equal(replacements[0]?.supersedes, prior.id);
+    assert.equal(replacements[0]?.parentIds.includes(prior.id), true);
+  });
+
+  it("keeps the prior active when later split part creation fails", async () => {
+    const store = new MemoryStore();
+    const prior = await store.createClaim(
+      makeClaim({
+        id: "prior",
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-20T00:00:00Z",
+      })
+    );
+    const createClaim = store.createClaim.bind(store);
+    let replacementCreates = 0;
+    store.createClaim = async (input: any) => {
+      if (input.parentIds?.includes(prior.id)) {
+        replacementCreates += 1;
+        if (replacementCreates > 1) {
+          throw new Error("second part failed");
+        }
+      }
+      return createClaim(input);
+    };
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    await assert.rejects(
+      () =>
+        ledger.split(prior.id, [
+          {
+            statement: "First narrower memory claim.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+          {
+            statement: "Second narrower memory claim.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+        ]),
+      /second part failed/
+    );
+
+    assert.equal((await store.getClaim(prior.id))?.status, "active");
+    const replacements = [...store.claims.values()].filter((claim) => claim.parentIds?.includes(prior.id));
+    assert.equal(replacements.length, 1);
+    assert.equal(replacements[0]?.status, "ignored");
+  });
+
+  it("validates all split parts before creating replacements", async () => {
+    const store = new MemoryStore();
+    const prior = await store.createClaim(
+      makeClaim({
+        id: "prior",
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-20T00:00:00Z",
+      })
+    );
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    await assert.rejects(
+      () =>
+        ledger.split(prior.id, [
+          {
+            statement: "First narrower memory claim.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+          {
+            statement: "Invalid split part.",
+            stance: "for",
+            confidence: 1.7,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+        ]),
+      /confidence must be in \[0, 1\]/
+    );
+
+    assert.equal(store.claims.size, 1);
+    assert.equal((await store.getClaim(prior.id))?.status, "active");
+  });
+
+  it("rolls back split replacements when supersession throws", async () => {
+    const store = new MemoryStore();
+    const prior = await store.createClaim(
+      makeClaim({
+        id: "prior",
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-20T00:00:00Z",
+      })
+    );
+    store.supersedeClaim = async () => {
+      throw new Error("supersession failed");
+    };
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    await assert.rejects(
+      () =>
+        ledger.split(prior.id, [
+          {
+            statement: "First narrower memory claim.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+          {
+            statement: "Second narrower memory claim.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+        ]),
+      /supersession failed/
+    );
+
+    const replacements = [...store.claims.values()].filter((claim) => claim.parentIds?.includes(prior.id));
+    assert.equal((await store.getClaim(prior.id))?.status, "active");
+    assert.equal(replacements.length, 2);
+    assert.deepEqual(
+      replacements.map((claim) => claim.status),
+      ["ignored", "ignored"]
+    );
+  });
+
+  it("scores due predictions and reflects calibration", async () => {
+    const store = new MemoryStore();
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    const captured = await ledger.capture({ text: "The demo shipped." });
+    const scored = await ledger.scoreDuePredictions({
+      now: "2026-06-03T12:00:00Z",
+      verdictSources: { [captured.claim.id]: "The release notes say no demo shipped." },
+    });
+
+    assert.equal(scored.length, 1);
+    assert.equal(scored[0]?.status, "resolved");
+    assert.equal(scored[0]?.resolution?.brierScore, 0.5625);
+
+    const report = await ledger.reflect({ now: "2026-06-03T12:00:00Z" });
+    assert.equal(report.resolvedPredictions, 1);
+    assert.equal(report.brierScore, 0.5625);
+    assert.equal(report.domains[0]?.domain, "shipping");
+  });
+
+  it("scores the most overdue predictions before recently updated due predictions", async () => {
+    const store = new MemoryStore();
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+    await store.createClaim({
+      ...makeClaim({
+        id: "recent-deadline",
+        createdAt: "2026-06-01T00:00:00Z",
+        updatedAt: "2026-06-03T00:00:00Z",
+      }),
+      deadline: "2026-06-02T00:00:00Z",
+    });
+    const oldest = await store.createClaim({
+      ...makeClaim({
+        id: "oldest-deadline",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-06-01T00:00:00Z",
+      }),
+      deadline: "2026-01-15T00:00:00Z",
+    });
+
+    const results = await ledger.scoreDuePredictions({
+      now: "2026-06-03T12:00:00Z",
+      limit: 1,
+    });
+
+    assert.equal(results[0]?.claim.id, oldest.id);
+  });
+
+  it("continues scoring predictions when one grader call fails", async () => {
+    const store = new MemoryStore();
+    const failed = await store.createClaim({
+      ...makeClaim({
+        id: "failed",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-02T00:00:00Z",
+      }),
+      deadline: "2026-01-15T00:00:00Z",
+      statement: "The January launch will ship.",
+    });
+    const resolved = await store.createClaim({
+      ...makeClaim({
+        id: "resolved",
+        createdAt: "2026-02-01T00:00:00Z",
+        updatedAt: "2026-02-02T00:00:00Z",
+      }),
+      deadline: "2026-02-15T00:00:00Z",
+      statement: "The February launch will ship.",
+    });
+    const llm = new FakeLlm();
+    llm.gradePrediction = async (request) => {
+      if (request.claim.id === failed.id) {
+        throw new Error("grader unavailable");
+      }
+      return {
+        verdict: "true",
+        actualConfidence: 1,
+        rationale: "The supplied source confirms shipment.",
+        source: "test verdict",
+      };
+    };
+    const ledger = new BeliefLedger({
+      store,
+      llm,
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    const results = await ledger.scoreDuePredictions({
+      now: "2026-06-03T12:00:00Z",
+      verdictSources: {
+        [failed.id]: "The January launch source is unavailable.",
+        [resolved.id]: "The February launch shipped.",
+      },
+    });
+    const byId = new Map(results.map((result) => [result.claim.id, result]));
+
+    assert.equal(results.length, 2);
+    assert.equal(byId.get(failed.id)?.status, "skipped");
+    assert.match(byId.get(failed.id)?.reason ?? "", /grader unavailable/);
+    assert.equal(byId.get(resolved.id)?.status, "resolved");
+    assert.equal((await store.getClaim(failed.id))?.status, "active");
+    assert.equal((await store.getClaim(resolved.id))?.status, "resolved");
+  });
+
+  it("continues scoring predictions when one resolution write fails", async () => {
+    const store = new MemoryStore();
+    const failed = await store.createClaim({
+      ...makeClaim({
+        id: "failed-write",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-02T00:00:00Z",
+      }),
+      deadline: "2026-01-15T00:00:00Z",
+      statement: "The January release will finish.",
+    });
+    const resolved = await store.createClaim({
+      ...makeClaim({
+        id: "resolved-write",
+        createdAt: "2026-02-01T00:00:00Z",
+        updatedAt: "2026-02-02T00:00:00Z",
+      }),
+      deadline: "2026-02-15T00:00:00Z",
+      statement: "The February release will finish.",
+    });
+    const updateClaim = store.updateClaim.bind(store);
+    store.updateClaim = async (id: string, patch: any): Promise<any> => {
+      if (id === failed.id) {
+        throw new Error("write failed");
+      }
+      return updateClaim(id, patch);
+    };
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    const results = await ledger.scoreDuePredictions({
+      now: "2026-06-03T12:00:00Z",
+      verdictSources: {
+        [failed.id]: "The January release verdict is available.",
+        [resolved.id]: "The February release verdict is available.",
+      },
+    });
+    const byId = new Map(results.map((result) => [result.claim.id, result]));
+
+    assert.equal(results.length, 2);
+    assert.equal(byId.get(failed.id)?.status, "skipped");
+    assert.match(byId.get(failed.id)?.reason ?? "", /write failed/);
+    assert.equal(byId.get(resolved.id)?.status, "resolved");
+    assert.equal((await store.getClaim(failed.id))?.status, "active");
+    assert.equal((await store.getClaim(resolved.id))?.status, "resolved");
+  });
+
+  it("builds reflection reports with flipped claims", () => {
+    const report = buildReflectionReport(
+      [
+        {
+          id: "a",
+          memoryId: "a",
+          statement: "Remote work improves output.",
+          kind: "opinion",
+          stance: "for",
+          confidence: 0.6,
+          scope: { entities: ["Remote Work"], domain: "work" },
+          evidenceLinks: [],
+          status: "superseded",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+          parentIds: [],
+          supersededBy: "b",
+        },
+        {
+          id: "b",
+          memoryId: "b",
+          statement: "Remote work hurts output for this team.",
+          kind: "opinion",
+          stance: "against",
+          confidence: 0.7,
+          scope: { entities: ["Remote Work"], domain: "work" },
+          evidenceLinks: [],
+          status: "active",
+          createdAt: "2026-02-01T00:00:00Z",
+          updatedAt: "2026-02-01T00:00:00Z",
+          parentIds: ["a"],
+          supersedes: "a",
+        },
+      ],
+      { now: "2026-06-03T00:00:00Z", dormantAfterDays: 30 }
+    );
+
+    assert.equal(report.flippedClaims.length, 1);
+    assert.equal(report.flippedClaims[0]?.flipCount, 1);
+    assert.ok(report.dormantTopics.some((topic) => topic.topic === "Remote Work"));
+  });
+
+  it("normalizes reflection report timestamps before parsing", () => {
+    assert.throws(
+      () => buildReflectionReport([], { now: "2026-04-31T00:00:00Z" }),
+      /reflection.now must be a valid ISO timestamp/
+    );
+    assert.throws(
+      () => buildReflectionReport([], { now: "2026-06-01T09:00:00" }),
+      /reflection.now must be a valid ISO timestamp/
+    );
+  });
+
+  it("uses claim updates when detecting dormant topics", () => {
+    const report = buildReflectionReport(
+      [
+        {
+          id: "updated",
+          memoryId: "updated",
+          statement: "Remote work improves output.",
+          kind: "opinion",
+          stance: "for",
+          confidence: 0.6,
+          scope: { entities: ["Remote Work"], domain: "work" },
+          evidenceLinks: [],
+          status: "active",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-06-01T00:00:00Z",
+          parentIds: [],
+        },
+      ],
+      { now: "2026-06-03T00:00:00Z", dormantAfterDays: 30 }
+    );
+
+    assert.equal(
+      report.dormantTopics.some((topic) => topic.topic === "Remote Work"),
+      false
+    );
+  });
+
+  it("counts a claim only once when domain and entity topics match", () => {
+    const report = buildReflectionReport(
+      [
+        {
+          id: "duplicate-topic",
+          memoryId: "duplicate-topic",
+          statement: "Remote work needs better meeting defaults.",
+          kind: "opinion",
+          stance: "for",
+          confidence: 0.6,
+          scope: { entities: ["Remote Work"], domain: "remote work" },
+          evidenceLinks: [],
+          status: "active",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+          parentIds: [],
+        },
+      ],
+      { now: "2026-06-03T00:00:00Z", dormantAfterDays: 30 }
+    );
+
+    assert.equal(report.dormantTopics.length, 1);
+    assert.equal(report.dormantTopics[0]?.claimCount, 1);
+  });
+
+  it("scores retrieval recency against the ledger reference time", async () => {
+    const store = new MemoryStore();
+    const historical = await store.createClaim(
+      makeClaim({
+        id: "historical",
+        createdAt: "2020-01-01T00:00:00Z",
+        updatedAt: "2020-01-01T00:00:00Z",
+      })
+    );
+    const future = await store.createClaim(
+      makeClaim({
+        id: "future",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      })
+    );
+    const query: LedgerClaim = {
+      ...makeClaim({
+        id: "query",
+        createdAt: "2020-01-01T00:00:00Z",
+        updatedAt: "2020-01-01T00:00:00Z",
+      }),
+      memoryId: "query",
+    };
+
+    const results = await retrievePriorClaims(query, store, {
+      now: "2020-01-01T00:00:00Z",
+      limit: 2,
+    });
+
+    assert.equal(results[0]?.claim.id, historical.id);
+    assert.equal(results[1]?.claim.id, future.id);
+  });
+
+  it("requires topical evidence before retaining retrieval candidates", async () => {
+    const store = new MemoryStore();
+    const related = await store.createClaim(
+      makeClaim({
+        id: "related",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      })
+    );
+    const unrelated = await store.createClaim({
+      ...makeClaim({
+        id: "unrelated",
+        createdAt: "2026-06-01T00:00:00Z",
+        updatedAt: "2026-06-02T00:00:00Z",
+      }),
+      statement: "Coffee shops should switch to ceramic mugs.",
+      stance: "against",
+      scope: { entities: ["Coffee"], domain: "hospitality" },
+    });
+    const query: LedgerClaim = {
+      ...makeClaim({
+        id: "query",
+        createdAt: "2026-06-03T00:00:00Z",
+        updatedAt: "2026-06-03T00:00:00Z",
+      }),
+      memoryId: "query",
+    };
+
+    const results = await retrievePriorClaims(query, store, {
+      now: "2026-06-03T00:00:00Z",
+      limit: 8,
+    });
+
+    assert.ok(results.some((candidate) => candidate.claim.id === related.id));
+    assert.equal(
+      results.some((candidate) => candidate.claim.id === unrelated.id),
+      false
+    );
+  });
+
+  it("does not retrieve snoozed claims before their snooze window expires", async () => {
+    const store = new MemoryStore();
+    const expiredSnooze = await store.createClaim({
+      ...makeClaim({
+        id: "expired-snooze",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-06-01T00:00:00Z",
+      }),
+      status: "snoozed",
+      snoozedUntil: "2026-06-02T00:00:00Z",
+    });
+    const activeSnooze = await store.createClaim({
+      ...makeClaim({
+        id: "active-snooze",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-06-01T00:00:00Z",
+      }),
+      status: "snoozed",
+      snoozedUntil: "2026-06-04T00:00:00Z",
+    });
+    const query: LedgerClaim = {
+      ...makeClaim({
+        id: "query",
+        createdAt: "2026-06-03T00:00:00Z",
+        updatedAt: "2026-06-03T00:00:00Z",
+      }),
+      memoryId: "query",
+    };
+
+    const results = await retrievePriorClaims(query, store, {
+      now: "2026-06-03T00:00:00Z",
+      limit: 8,
+    });
+
+    assert.ok(results.some((candidate) => candidate.claim.id === expiredSnooze.id));
+    assert.equal(
+      results.some((candidate) => candidate.claim.id === activeSnooze.id),
+      false
+    );
+  });
+
+  it("uses the ledger clock when re-cross-examining claims", async () => {
+    const store = new MemoryStore();
+    const prior = await store.createClaim(
+      makeClaim({
+        id: "prior",
+        createdAt: "2026-05-01T00:00:00Z",
+        updatedAt: "2026-05-20T00:00:00Z",
+      })
+    );
+    const query: LedgerClaim = {
+      ...makeClaim({
+        id: "query",
+        createdAt: "2020-01-01T00:00:00Z",
+        updatedAt: "2020-01-01T00:00:00Z",
+      }),
+      memoryId: "query",
+    };
+    const ledger = new BeliefLedger({
+      store,
+      llm: new FakeLlm(),
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+
+    const result = await ledger.crossExamine(query);
+
+    assert.equal(result.candidates[0]?.claim.id, prior.id);
+    assert.ok(result.candidates[0]?.reasons.some((reason) => reason.startsWith("recency:")));
+  });
+});
+
+function makeClaim(input: {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+}): Omit<LedgerClaim, "memoryId"> {
+  return {
+    id: input.id,
+    statement: "Local-first memory tools will win.",
+    kind: "prediction",
+    stance: "for",
+    confidence: 0.7,
+    scope: { entities: ["Memory Tools"], domain: "ai memory" },
+    deadline: "2027-01-01T00:00:00Z",
+    evidenceLinks: [],
+    status: "active",
+    createdAt: input.createdAt,
+    updatedAt: input.updatedAt,
+    parentIds: [],
+  };
+}

--- a/packages/belief-ledger/src/ledger.ts
+++ b/packages/belief-ledger/src/ledger.ts
@@ -1,0 +1,359 @@
+import type { StorageManager } from "@remnic/core";
+import { buildReflectionReport } from "./reflection.js";
+import { RemnicLedgerStore, type RemnicLedgerStoreOptions } from "./remnic-store.js";
+import { retrievePriorClaims } from "./retrieval.js";
+import { createResolution, normalizeClaimDraft, normalizeIsoTimestamp } from "./schema.js";
+import type {
+  LedgerCaptureInput,
+  LedgerCaptureResult,
+  LedgerChallenge,
+  LedgerClaim,
+  LedgerClaimDraft,
+  LedgerCrossExaminationResult,
+  LedgerCrossExaminationStats,
+  LedgerJudgeResult,
+  LedgerLlmAdapter,
+  LedgerPredictionScoreResult,
+  LedgerReflectionOptions,
+  LedgerReflectionReport,
+  LedgerRetrievalOptions,
+  LedgerScoreDuePredictionsOptions,
+  LedgerStore,
+} from "./types.js";
+
+export interface BeliefLedgerOptions {
+  store: LedgerStore;
+  llm: LedgerLlmAdapter;
+  retrieval?: LedgerRetrievalOptions;
+  now?: () => Date;
+}
+
+export interface BeliefLedgerFromStorageOptions extends RemnicLedgerStoreOptions {
+  llm: LedgerLlmAdapter;
+  retrieval?: LedgerRetrievalOptions;
+}
+
+export interface ResolveClaimInput {
+  verdict: "true" | "false" | "mixed" | "unknown";
+  actualConfidence: number;
+  source?: string;
+  notes?: string;
+  resolvedAt?: string;
+}
+
+export class BeliefLedger {
+  private readonly store: LedgerStore;
+  private readonly llm: LedgerLlmAdapter;
+  private readonly retrieval: LedgerRetrievalOptions;
+  private readonly now: () => Date;
+
+  constructor(options: BeliefLedgerOptions) {
+    this.store = options.store;
+    this.llm = options.llm;
+    this.retrieval = options.retrieval ?? {};
+    this.now = options.now ?? (() => new Date());
+  }
+
+  static fromStorage(storage: StorageManager, options: BeliefLedgerFromStorageOptions): BeliefLedger {
+    return new BeliefLedger({
+      store: new RemnicLedgerStore(storage, options),
+      llm: options.llm,
+      retrieval: options.retrieval,
+      now: options.now,
+    });
+  }
+
+  async capture(input: LedgerCaptureInput): Promise<LedgerCaptureResult> {
+    const now = normalizeIsoTimestamp("now", input.now ?? this.now().toISOString());
+    const draft = await this.llm.extractClaim({ ...input, now });
+    const normalized = normalizeClaimDraft(draft, { now, sourceText: input.text });
+    const claim = await this.store.createClaim(normalized);
+    const examination = await this.crossExamine(claim, { now });
+    return { ...examination, claim };
+  }
+
+  async crossExamine(
+    claimOrId: LedgerClaim | string,
+    options: LedgerRetrievalOptions = {}
+  ): Promise<LedgerCrossExaminationResult> {
+    const claim = typeof claimOrId === "string" ? await this.requireClaim(claimOrId) : claimOrId;
+    const retrievalOptions: LedgerRetrievalOptions = {
+      ...this.retrieval,
+      ...options,
+      now: options.now ?? this.retrieval.now ?? this.now().toISOString(),
+    };
+    const candidates = await retrievePriorClaims(claim, this.store, retrievalOptions);
+    const judgments: LedgerJudgeResult[] = [];
+    for (const candidate of candidates) {
+      const judgment = await this.llm.judgeClaimPair({
+        current: claim,
+        prior: candidate.claim,
+      });
+      judgments.push({
+        ...judgment,
+        priorClaimId: candidate.claim.id,
+      });
+    }
+
+    const contradictions = judgments
+      .map((judgment) => ({
+        judgment,
+        claim: candidates.find((candidate) => candidate.claim.id === judgment.priorClaimId)?.claim,
+      }))
+      .filter(
+        (item): item is { judgment: LedgerJudgeResult; claim: LedgerClaim } =>
+          item.claim !== undefined && item.judgment.classification === "contradiction"
+      );
+
+    const challenge: LedgerChallenge | undefined =
+      contradictions.length > 0
+        ? await this.llm.draftSocraticChallenge({
+            current: claim,
+            contradictions,
+          })
+        : undefined;
+
+    return {
+      claim,
+      candidates,
+      judgments,
+      ...(challenge ? { challenge } : {}),
+      stats: buildCrossExaminationStats(judgments),
+    };
+  }
+
+  async supersede(priorId: string, newId: string, reason: string): Promise<boolean> {
+    return this.store.supersedeClaim(priorId, newId, reason);
+  }
+
+  async split(
+    priorId: string,
+    parts: LedgerClaimDraft[],
+    reason: string = "split into narrower claims"
+  ): Promise<LedgerClaim[]> {
+    if (parts.length === 0) {
+      throw new Error("split requires at least one part");
+    }
+    const prior = await this.requireClaim(priorId);
+    const now = this.now().toISOString();
+    const normalizedParts = parts.map((part) => ({
+      ...normalizeClaimDraft(part, {
+        now,
+        sourceText: prior.sourceText ?? prior.statement,
+      }),
+      parentIds: [priorId],
+    }));
+    const created: LedgerClaim[] = [];
+    try {
+      for (const part of normalizedParts) {
+        created.push(await this.store.createClaim(part));
+      }
+    } catch (error) {
+      await rollbackCreatedSplitClaims(this.store, created, now, `split creation failed for ${priorId}`);
+      throw error;
+    }
+
+    const firstReplacement = created[0]!;
+    let didSupersede = false;
+    try {
+      didSupersede = await this.store.supersedeClaim(priorId, firstReplacement.id, reason);
+    } catch (error) {
+      await rollbackCreatedSplitClaims(this.store, created, now, `split supersession failed for ${priorId}`);
+      throw error;
+    }
+    if (!didSupersede) {
+      await rollbackCreatedSplitClaims(this.store, created, now, `split supersession failed for ${priorId}`);
+      throw new Error(`split could not supersede prior claim ${priorId} with ${firstReplacement.id}`);
+    }
+    const linkedFirst = await this.store.getClaim(firstReplacement.id);
+    if (!linkedFirst) {
+      throw new Error(`split replacement claim ${firstReplacement.id} disappeared after supersession`);
+    }
+    created[0] = linkedFirst;
+    return created;
+  }
+
+  async resolve(claimId: string, input: ResolveClaimInput): Promise<LedgerClaim> {
+    const claim = await this.requireClaim(claimId);
+    const resolvedAt = normalizeIsoTimestamp("resolvedAt", input.resolvedAt ?? this.now().toISOString());
+    const resolution = createResolution({
+      verdict: input.verdict,
+      actualConfidence: input.actualConfidence,
+      resolvedAt,
+      source: input.source,
+      notes: input.notes,
+      predictedConfidence: claim.confidence,
+    });
+    return this.store.updateClaim(claimId, {
+      status: "resolved",
+      resolution,
+      updatedAt: resolvedAt,
+    });
+  }
+
+  async snooze(claimId: string, until: string): Promise<LedgerClaim> {
+    const snoozedUntil = normalizeIsoTimestamp("snoozedUntil", until);
+    return this.store.updateClaim(claimId, {
+      status: "snoozed",
+      snoozedUntil,
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  async ignore(claimId: string, reason?: string): Promise<LedgerClaim> {
+    const ignoredAt = this.now().toISOString();
+    return this.store.updateClaim(claimId, {
+      status: "ignored",
+      ignoredAt,
+      ...(reason?.trim() ? { ignoredReason: reason.trim() } : {}),
+      updatedAt: ignoredAt,
+    });
+  }
+
+  async scoreDuePredictions(options: LedgerScoreDuePredictionsOptions = {}): Promise<LedgerPredictionScoreResult[]> {
+    const now = normalizeIsoTimestamp("now", options.now ?? this.now().toISOString());
+    const limit = normalizeLimit(options.limit);
+    const verdictSources = options.verdictSources ?? {};
+    const due = (await this.store.listClaims({ kinds: ["prediction"], statuses: ["active", "snoozed"] }))
+      .filter((claim) => isDueForScoring(claim, now))
+      .sort(compareDuePredictions)
+      .slice(0, limit);
+
+    const results: LedgerPredictionScoreResult[] = [];
+    for (const claim of due) {
+      const verdictSource = verdictSources[claim.id];
+      if (!verdictSource?.trim()) {
+        results.push({
+          claim,
+          status: "needs_user_verdict",
+          prompt: `Prediction deadline passed: "${claim.statement}". What actually happened?`,
+        });
+        continue;
+      }
+      if (!this.llm.gradePrediction) {
+        results.push({
+          claim,
+          status: "needs_user_verdict",
+          prompt: `Prediction deadline passed: "${claim.statement}". Provide a verdict because no grader is configured.`,
+        });
+        continue;
+      }
+      try {
+        const grade = await this.llm.gradePrediction({ claim, verdictSource, now });
+        if (!grade) {
+          results.push({
+            claim,
+            status: "needs_user_verdict",
+            prompt: `Prediction deadline passed: "${claim.statement}". The verdict source was not enough to grade it.`,
+          });
+          continue;
+        }
+        const resolution = createResolution({
+          verdict: grade.verdict,
+          actualConfidence: grade.actualConfidence,
+          resolvedAt: now,
+          source: grade.source ?? verdictSource,
+          notes: grade.rationale,
+          predictedConfidence: claim.confidence,
+        });
+        const updated = await this.store.updateClaim(claim.id, {
+          status: "resolved",
+          resolution,
+          updatedAt: now,
+        });
+        results.push({
+          claim: updated,
+          status: "resolved",
+          resolution,
+        });
+      } catch (error) {
+        results.push({
+          claim,
+          status: "skipped",
+          reason: `prediction scoring failed: ${errorMessage(error)}`,
+        });
+      }
+    }
+    return results;
+  }
+
+  async reflect(options: LedgerReflectionOptions = {}): Promise<LedgerReflectionReport> {
+    const claims = await this.store.listClaims();
+    return buildReflectionReport(claims, {
+      ...options,
+      now: options.now ?? this.now().toISOString(),
+    });
+  }
+
+  private async requireClaim(id: string): Promise<LedgerClaim> {
+    const claim = await this.store.getClaim(id);
+    if (!claim) {
+      throw new Error(`claim ${id} not found`);
+    }
+    return claim;
+  }
+}
+
+function buildCrossExaminationStats(judgments: Array<{ classification: string }>): LedgerCrossExaminationStats {
+  const judged = judgments.length;
+  const contradictions = judgments.filter((judgment) => judgment.classification === "contradiction").length;
+  const unrelated = judgments.filter((judgment) => judgment.classification === "unrelated").length;
+  return {
+    candidatesConsidered: judged,
+    judged,
+    contradictions,
+    unrelated,
+    observableFalsePositiveRate: judged === 0 ? 0 : unrelated / judged,
+  };
+}
+
+async function rollbackCreatedSplitClaims(
+  store: LedgerStore,
+  claims: LedgerClaim[],
+  now: string,
+  ignoredReason: string
+): Promise<void> {
+  for (const claim of claims) {
+    try {
+      await store.updateClaim(claim.id, {
+        status: "ignored",
+        ignoredAt: now,
+        ignoredReason,
+        updatedAt: now,
+      });
+    } catch {
+      // Rollback is best-effort; preserve the original split failure.
+    }
+  }
+}
+
+function isDueForScoring(claim: LedgerClaim, nowIso: string): boolean {
+  if (!claim.deadline) return false;
+  if (claim.resolution) return false;
+  if (claim.status === "snoozed" && claim.snoozedUntil && Date.parse(claim.snoozedUntil) > Date.parse(nowIso)) {
+    return false;
+  }
+  return Date.parse(claim.deadline) <= Date.parse(nowIso);
+}
+
+function compareDuePredictions(a: LedgerClaim, b: LedgerClaim): number {
+  const aDeadline = a.deadline ? Date.parse(a.deadline) : Number.POSITIVE_INFINITY;
+  const bDeadline = b.deadline ? Date.parse(b.deadline) : Number.POSITIVE_INFINITY;
+  const deadlineOrder = aDeadline - bDeadline;
+  if (deadlineOrder !== 0) return deadlineOrder;
+  const updatedOrder = Date.parse(a.updatedAt) - Date.parse(b.updatedAt);
+  if (updatedOrder !== 0) return updatedOrder;
+  return a.id.localeCompare(b.id);
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined) return 100;
+  if (!Number.isInteger(value) || value < 1 || value > 1_000) {
+    throw new Error(`limit must be an integer in [1, 1000], got ${String(value)}`);
+  }
+  return value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/belief-ledger/src/llm.test.ts
+++ b/packages/belief-ledger/src/llm.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { FallbackLlmClient } from "@remnic/core";
+
+import { createFallbackLlmLedgerAdapter } from "./llm.js";
+import type { LedgerClaim } from "./types.js";
+
+describe("Fallback LLM ledger adapter", () => {
+  it("includes claim time windows in judge prompts", async () => {
+    let userPrompt = "";
+    const client = {
+      async parseWithSchema(messages: unknown, schema: { parse(data: unknown): unknown }): Promise<unknown> {
+        const sentMessages = messages as Array<{ role: string; content: string }>;
+        userPrompt = sentMessages.find((message) => message.role === "user")?.content ?? "";
+        return schema.parse({
+          classification: "unrelated",
+          confidence: 0.8,
+          rationale: "The claims are scoped to different periods.",
+        });
+      },
+    } as unknown as FallbackLlmClient;
+    const adapter = createFallbackLlmLedgerAdapter(client);
+
+    await adapter.judgeClaimPair({
+      current: makePromptClaim("current", {
+        start: "2026-01-01T00:00:00.000Z",
+        end: "2026-03-31T23:59:59.000Z",
+      }),
+      prior: makePromptClaim("prior", {
+        start: "2025-01-01T00:00:00.000Z",
+        end: "2025-12-31T23:59:59.000Z",
+      }),
+    });
+
+    assert.match(userPrompt, /timeWindow\.start: 2026-01-01T00:00:00\.000Z/);
+    assert.match(userPrompt, /timeWindow\.end: 2026-03-31T23:59:59\.000Z/);
+    assert.match(userPrompt, /timeWindow\.start: 2025-01-01T00:00:00\.000Z/);
+    assert.match(userPrompt, /timeWindow\.end: 2025-12-31T23:59:59\.000Z/);
+  });
+});
+
+function makePromptClaim(id: string, timeWindow: NonNullable<LedgerClaim["scope"]["timeWindow"]>): LedgerClaim {
+  return {
+    id,
+    memoryId: id,
+    statement: "Remote work improved output.",
+    kind: "claim",
+    stance: "for",
+    confidence: 0.7,
+    scope: { entities: ["Remote Work"], domain: "work", timeWindow },
+    evidenceLinks: [],
+    status: "active",
+    createdAt: "2026-06-03T00:00:00.000Z",
+    updatedAt: "2026-06-03T00:00:00.000Z",
+    parentIds: [],
+  };
+}

--- a/packages/belief-ledger/src/llm.ts
+++ b/packages/belief-ledger/src/llm.ts
@@ -1,0 +1,263 @@
+import type { FallbackLlmClient, FallbackLlmOptions } from "@remnic/core";
+import { normalizeChallenge, normalizeClaimDraft, normalizeJudgeResult, normalizePredictionGrade } from "./schema.js";
+import type {
+  LedgerChallenge,
+  LedgerClaim,
+  LedgerClaimDraft,
+  LedgerJudgeResult,
+  LedgerLlmAdapter,
+  LedgerPredictionGrade,
+} from "./types.js";
+
+export interface FallbackLlmLedgerAdapterOptions extends FallbackLlmOptions {
+  agentId?: string;
+}
+
+export function createFallbackLlmLedgerAdapter(
+  client: FallbackLlmClient,
+  options: FallbackLlmLedgerAdapterOptions = {}
+): LedgerLlmAdapter {
+  const baseOptions = { ...options };
+  return {
+    async extractClaim(request): Promise<LedgerClaimDraft> {
+      const parsed = await client.parseWithSchema(
+        [
+          { role: "system", content: EXTRACT_PROMPT },
+          {
+            role: "user",
+            content: [
+              `Current time: ${request.now}`,
+              request.sessionKey ? `Session: ${request.sessionKey}` : "",
+              "User text:",
+              request.text,
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          },
+        ],
+        {
+          parse: (data: unknown) => normalizeExtractedDraft(data, request.now, request.text),
+        },
+        { ...baseOptions, temperature: baseOptions.temperature ?? 0.1, maxTokens: baseOptions.maxTokens ?? 1_200 }
+      );
+      if (!parsed) {
+        throw new Error("belief-ledger extraction LLM did not return a valid claim");
+      }
+      return parsed;
+    },
+
+    async judgeClaimPair(request): Promise<LedgerJudgeResult> {
+      const parsed = await client.parseWithSchema(
+        [
+          { role: "system", content: JUDGE_PROMPT },
+          { role: "user", content: formatJudgeInput(request.current, request.prior) },
+        ],
+        {
+          parse: (data: unknown) => normalizeJudgeResult(data, request.prior.id),
+        },
+        { ...baseOptions, temperature: baseOptions.temperature ?? 0.1, maxTokens: baseOptions.maxTokens ?? 800 }
+      );
+      if (!parsed) {
+        throw new Error("belief-ledger judge LLM did not return a valid verdict");
+      }
+      return parsed;
+    },
+
+    async draftSocraticChallenge(request): Promise<LedgerChallenge> {
+      const priorClaimIds = request.contradictions.map((item) => item.claim.id);
+      const parsed = await client.parseWithSchema(
+        [
+          { role: "system", content: CHALLENGE_PROMPT },
+          {
+            role: "user",
+            content: [
+              "Current claim:",
+              formatClaim(request.current),
+              "",
+              "Contradicting prior claims:",
+              ...request.contradictions.map(
+                (item) => `${formatClaim(item.claim)}\nJudge rationale: ${item.judgment.rationale}`
+              ),
+            ].join("\n"),
+          },
+        ],
+        {
+          parse: (data: unknown) => normalizeChallenge(data, priorClaimIds),
+        },
+        { ...baseOptions, temperature: baseOptions.temperature ?? 0.2, maxTokens: baseOptions.maxTokens ?? 800 }
+      );
+      if (!parsed) {
+        throw new Error("belief-ledger challenge LLM did not return a valid prompt");
+      }
+      return parsed;
+    },
+
+    async gradePrediction(request): Promise<LedgerPredictionGrade | null> {
+      if (!request.verdictSource?.trim()) return null;
+      const parsed = await client.parseWithSchema(
+        [
+          { role: "system", content: GRADE_PROMPT },
+          {
+            role: "user",
+            content: [
+              `Current time: ${request.now}`,
+              "Prediction:",
+              formatClaim(request.claim),
+              "",
+              "Verdict source:",
+              request.verdictSource,
+            ].join("\n"),
+          },
+        ],
+        {
+          parse: (data: unknown) => normalizePredictionGrade(data),
+        },
+        { ...baseOptions, temperature: baseOptions.temperature ?? 0.1, maxTokens: baseOptions.maxTokens ?? 800 }
+      );
+      return parsed;
+    },
+  };
+}
+
+const EXTRACT_PROMPT = `Extract one belief-ledger claim from the user's text.
+
+Return JSON only:
+{
+  "statement": "single clear claim or prediction",
+  "kind": "claim" | "prediction" | "opinion",
+  "stance": "for" | "against" | "uncertain" | "neutral",
+  "confidence": 0.0,
+  "scope": {
+    "entities": ["entity names"],
+    "domain": "optional topic",
+    "timeWindow": { "start": "optional ISO", "end": "optional ISO" }
+  },
+  "deadline": "optional ISO timestamp for predictions",
+  "evidenceLinks": ["optional source URLs or identifiers"]
+}
+
+Use the user's stated confidence when present. If no confidence is stated, estimate conservatively.`;
+
+const JUDGE_PROMPT = `Classify how the current claim relates to the prior claim.
+
+Return JSON only:
+{
+  "classification": "contradiction" | "evolution" | "refinement" | "unrelated",
+  "confidence": 0.0,
+  "rationale": "brief reason"
+}
+
+Use "contradiction" only when both claims cannot comfortably be true at the same time under their stated scope.`;
+
+const CHALLENGE_PROMPT = `Draft one concise Socratic challenge for the user.
+
+Return JSON only:
+{
+  "question": "one question asking the user to reconcile the conflict",
+  "priorClaimIds": ["ids involved"],
+  "suggestedActions": ["supersede", "split", "resolve", "ignore"]
+}
+
+Do not agree with the user by default. Ask for a reconciliation decision.`;
+
+const GRADE_PROMPT = `Grade whether the prediction came true from the supplied verdict source.
+
+Return JSON only:
+{
+  "verdict": "true" | "false" | "mixed" | "unknown",
+  "actualConfidence": 0.0,
+  "rationale": "brief reason",
+  "source": "short source label"
+}
+
+Use actualConfidence 1 for true, 0 for false, a fractional value for mixed, and 0.5 for unknown.`;
+
+function normalizeExtractedDraft(data: unknown, now: string, sourceText: string): LedgerClaimDraft {
+  if (!isRecord(data)) {
+    throw new Error("claim extraction result must be an object");
+  }
+  const scope = isRecord(data.scope) ? data.scope : {};
+  const rawTimeWindow = isRecord(scope.timeWindow)
+    ? scope.timeWindow
+    : isRecord(scope.time_window)
+      ? scope.time_window
+      : undefined;
+  const draft: LedgerClaimDraft = {
+    statement: asString(data.statement),
+    kind: optionalString(data.kind) as LedgerClaimDraft["kind"],
+    stance: asString(data.stance) as LedgerClaimDraft["stance"],
+    confidence: asNumber(data.confidence),
+    scope: {
+      entities: Array.isArray(scope.entities)
+        ? scope.entities.filter((value): value is string => typeof value === "string")
+        : [],
+      ...(typeof scope.domain === "string" ? { domain: scope.domain } : {}),
+      ...(rawTimeWindow
+        ? {
+            timeWindow: {
+              ...(typeof rawTimeWindow.start === "string" ? { start: rawTimeWindow.start } : {}),
+              ...(typeof rawTimeWindow.end === "string" ? { end: rawTimeWindow.end } : {}),
+            },
+          }
+        : {}),
+    },
+    ...(typeof data.deadline === "string" && data.deadline.trim() ? { deadline: data.deadline } : {}),
+    evidenceLinks: Array.isArray(data.evidenceLinks)
+      ? data.evidenceLinks.filter((value): value is string => typeof value === "string")
+      : Array.isArray(data.evidence_links)
+        ? data.evidence_links.filter((value): value is string => typeof value === "string")
+        : [],
+  };
+  const normalized = normalizeClaimDraft(draft, { now, sourceText });
+  return {
+    statement: normalized.statement,
+    kind: normalized.kind,
+    stance: normalized.stance,
+    confidence: normalized.confidence,
+    scope: normalized.scope,
+    ...(normalized.deadline ? { deadline: normalized.deadline } : {}),
+    evidenceLinks: normalized.evidenceLinks,
+  };
+}
+
+function formatJudgeInput(current: LedgerClaim, prior: LedgerClaim): string {
+  return ["Current claim:", formatClaim(current), "", "Prior claim:", formatClaim(prior)].join("\n");
+}
+
+function formatClaim(claim: LedgerClaim): string {
+  return [
+    `id: ${claim.id}`,
+    `created: ${claim.createdAt}`,
+    `statement: ${claim.statement}`,
+    `kind: ${claim.kind}`,
+    `stance: ${claim.stance}`,
+    `confidence: ${claim.confidence}`,
+    `domain: ${claim.scope.domain ?? ""}`,
+    `entities: ${claim.scope.entities.join(", ")}`,
+    `timeWindow.start: ${claim.scope.timeWindow?.start ?? ""}`,
+    `timeWindow.end: ${claim.scope.timeWindow?.end ?? ""}`,
+    `deadline: ${claim.deadline ?? ""}`,
+    `status: ${claim.status}`,
+  ].join("\n");
+}
+
+function asString(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error("expected string");
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function asNumber(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && value.trim()) return Number(value);
+  throw new Error("expected number");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/belief-ledger/src/reflection.ts
+++ b/packages/belief-ledger/src/reflection.ts
@@ -1,0 +1,211 @@
+import { normalizeIsoTimestamp, roundMetric } from "./schema.js";
+import type {
+  LedgerCalibrationBin,
+  LedgerClaim,
+  LedgerDomainCalibration,
+  LedgerDormantTopic,
+  LedgerFlippedClaim,
+  LedgerReflectionOptions,
+  LedgerReflectionReport,
+} from "./types.js";
+
+const DEFAULT_DORMANT_AFTER_DAYS = 60;
+
+export function buildReflectionReport(
+  claims: LedgerClaim[],
+  options: LedgerReflectionOptions = {}
+): LedgerReflectionReport {
+  const nowIso = normalizeIsoTimestamp("reflection.now", options.now ?? new Date().toISOString());
+  const now = Date.parse(nowIso);
+  if (!Number.isFinite(now)) {
+    throw new Error(`reflection now must be a valid ISO timestamp, got ${String(options.now)}`);
+  }
+  const resolvedPredictions = claims.filter(
+    (claim) => claim.kind === "prediction" && claim.resolution?.brierScore !== undefined
+  );
+  const brierScore =
+    resolvedPredictions.length > 0
+      ? roundMetric(mean(resolvedPredictions.map((claim) => claim.resolution?.brierScore ?? 0)))
+      : undefined;
+
+  return {
+    generatedAt: new Date(now).toISOString(),
+    totalClaims: claims.length,
+    activeClaims: claims.filter((claim) => claim.status === "active").length,
+    resolvedPredictions: resolvedPredictions.length,
+    ...(brierScore !== undefined ? { brierScore } : {}),
+    calibrationBins: buildCalibrationBins(resolvedPredictions),
+    domains: buildDomainCalibration(resolvedPredictions),
+    flippedClaims: buildFlippedClaims(claims),
+    dormantTopics: buildDormantTopics(claims, now, options.dormantAfterDays ?? DEFAULT_DORMANT_AFTER_DAYS),
+  };
+}
+
+function buildCalibrationBins(claims: LedgerClaim[]): LedgerCalibrationBin[] {
+  const bins = [
+    { minConfidence: 0, maxConfidence: 0.2 },
+    { minConfidence: 0.2, maxConfidence: 0.4 },
+    { minConfidence: 0.4, maxConfidence: 0.6 },
+    { minConfidence: 0.6, maxConfidence: 0.8 },
+    { minConfidence: 0.8, maxConfidence: 1.000001 },
+  ];
+  return bins
+    .map((bin) => {
+      const members = claims.filter(
+        (claim) => claim.confidence >= bin.minConfidence && claim.confidence < bin.maxConfidence
+      );
+      if (members.length === 0) return null;
+      const predicted = mean(members.map((claim) => claim.confidence));
+      const actual = mean(members.map((claim) => claim.resolution?.actualConfidence ?? 0.5));
+      return {
+        minConfidence: bin.minConfidence,
+        maxConfidence: bin.maxConfidence > 1 ? 1 : bin.maxConfidence,
+        count: members.length,
+        meanPredictedConfidence: roundMetric(predicted),
+        meanActualConfidence: roundMetric(actual),
+        calibrationError: roundMetric(predicted - actual),
+      };
+    })
+    .filter((bin): bin is LedgerCalibrationBin => bin !== null);
+}
+
+function buildDomainCalibration(claims: LedgerClaim[]): LedgerDomainCalibration[] {
+  const grouped = new Map<string, LedgerClaim[]>();
+  for (const claim of claims) {
+    const domain = claim.scope.domain?.trim() || "uncategorized";
+    grouped.set(domain, [...(grouped.get(domain) ?? []), claim]);
+  }
+
+  return [...grouped.entries()]
+    .map(([domain, members]) => {
+      const predicted = mean(members.map((claim) => claim.confidence));
+      const actual = mean(members.map((claim) => claim.resolution?.actualConfidence ?? 0.5));
+      const error = predicted - actual;
+      const tendency: LedgerDomainCalibration["tendency"] =
+        Math.abs(error) <= 0.1 ? "well_calibrated" : error > 0 ? "overconfident" : "underconfident";
+      return {
+        domain,
+        count: members.length,
+        brierScore: roundMetric(mean(members.map((claim) => claim.resolution?.brierScore ?? 0))),
+        meanPredictedConfidence: roundMetric(predicted),
+        meanActualConfidence: roundMetric(actual),
+        tendency,
+      };
+    })
+    .sort((a, b) => {
+      const countOrder = b.count - a.count;
+      if (countOrder !== 0) return countOrder;
+      return a.domain.localeCompare(b.domain);
+    });
+}
+
+function buildFlippedClaims(claims: LedgerClaim[]): LedgerFlippedClaim[] {
+  const byId = new Map(claims.map((claim) => [claim.id, claim]));
+  const groups = new Map<string, LedgerClaim[]>();
+  for (const claim of claims) {
+    const root = findRootClaimId(claim, byId);
+    groups.set(root, [...(groups.get(root) ?? []), claim]);
+  }
+
+  return [...groups.entries()]
+    .map(([rootClaimId, members]) => {
+      const sorted = [...members].sort((a, b) => {
+        const createdOrder = Date.parse(a.createdAt) - Date.parse(b.createdAt);
+        if (createdOrder !== 0) return createdOrder;
+        return a.id.localeCompare(b.id);
+      });
+      let flipCount = 0;
+      for (let i = 1; i < sorted.length; i += 1) {
+        if (sorted[i - 1]?.stance !== sorted[i]?.stance) flipCount += 1;
+      }
+      if (flipCount === 0) return null;
+      return {
+        rootClaimId,
+        claimIds: sorted.map((claim) => claim.id),
+        statements: sorted.map((claim) => claim.statement),
+        flipCount,
+      };
+    })
+    .filter((item): item is LedgerFlippedClaim => item !== null)
+    .sort((a, b) => {
+      const flipOrder = b.flipCount - a.flipCount;
+      if (flipOrder !== 0) return flipOrder;
+      return a.rootClaimId.localeCompare(b.rootClaimId);
+    });
+}
+
+function findRootClaimId(claim: LedgerClaim, byId: Map<string, LedgerClaim>): string {
+  const seen = new Set<string>();
+  let cursor: LedgerClaim | undefined = claim;
+  while (cursor) {
+    if (seen.has(cursor.id)) return cursor.id;
+    seen.add(cursor.id);
+    const parentId = cursor.supersedes ?? cursor.parentIds[0];
+    if (!parentId) return cursor.id;
+    const parent = byId.get(parentId);
+    if (!parent) return parentId;
+    cursor = parent;
+  }
+  return claim.id;
+}
+
+function buildDormantTopics(claims: LedgerClaim[], nowMs: number, dormantAfterDays: number): LedgerDormantTopic[] {
+  if (!Number.isFinite(dormantAfterDays) || dormantAfterDays < 0) {
+    throw new Error(`dormantAfterDays must be a non-negative number, got ${String(dormantAfterDays)}`);
+  }
+  const topics = new Map<string, { lastClaimAt: string; claimCount: number }>();
+  for (const claim of claims) {
+    const activityAt = claimActivityAt(claim);
+    for (const topic of claimTopics(claim)) {
+      const existing = topics.get(topic);
+      if (!existing || Date.parse(activityAt) > Date.parse(existing.lastClaimAt)) {
+        topics.set(topic, {
+          lastClaimAt: activityAt,
+          claimCount: (existing?.claimCount ?? 0) + 1,
+        });
+      } else {
+        existing.claimCount += 1;
+      }
+    }
+  }
+
+  return [...topics.entries()]
+    .map(([topic, entry]) => {
+      const ageDays = (nowMs - Date.parse(entry.lastClaimAt)) / (24 * 60 * 60 * 1_000);
+      return {
+        topic,
+        lastClaimAt: entry.lastClaimAt,
+        daysSilent: Math.max(0, Math.floor(ageDays)),
+        claimCount: entry.claimCount,
+      };
+    })
+    .filter((topic) => topic.daysSilent >= dormantAfterDays)
+    .sort((a, b) => {
+      const daysOrder = b.daysSilent - a.daysSilent;
+      if (daysOrder !== 0) return daysOrder;
+      return a.topic.localeCompare(b.topic);
+    });
+}
+
+function claimActivityAt(claim: LedgerClaim): string {
+  return Date.parse(claim.updatedAt) >= Date.parse(claim.createdAt) ? claim.updatedAt : claim.createdAt;
+}
+
+function claimTopics(claim: LedgerClaim): string[] {
+  const seen = new Set<string>();
+  const topics: string[] = [];
+  for (const topic of [...(claim.scope.domain ? [claim.scope.domain] : []), ...claim.scope.entities]) {
+    const trimmed = topic.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    topics.push(trimmed);
+  }
+  return topics;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}

--- a/packages/belief-ledger/src/remnic-store.test.ts
+++ b/packages/belief-ledger/src/remnic-store.test.ts
@@ -1,0 +1,496 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { StorageManager } from "@remnic/core";
+import { createVersion, listVersions } from "@remnic/core/page-versioning";
+
+import { RemnicLedgerStore } from "./remnic-store.js";
+import { normalizeClaimDraft } from "./schema.js";
+
+async function withStore<T>(fn: (store: RemnicLedgerStore, storage: StorageManager) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-belief-ledger-"));
+  try {
+    const storage = new StorageManager(dir);
+    const store = new RemnicLedgerStore(storage, {
+      now: () => new Date("2026-06-03T12:00:00Z"),
+    });
+    return await fn(store, storage);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("RemnicLedgerStore", () => {
+  it("persists claims as Remnic memories with custom metadata and entity links", async () => {
+    await withStore(async (store, storage) => {
+      const input = normalizeClaimDraft(
+        {
+          statement: "Local-first memory tools will beat cloud-only memory tools.",
+          stance: "for",
+          confidence: 0.8,
+          scope: {
+            entities: ["Memory Tools"],
+            domain: "ai memory",
+          },
+        },
+        { now: "2026-06-03T12:00:00Z" }
+      );
+
+      const claim = await store.createClaim(input);
+      const reread = await store.getClaim(claim.id);
+      assert.ok(reread);
+      assert.equal(reread.statement, input.statement);
+      assert.equal(reread.scope.domain, "ai memory");
+      assert.equal(reread.sourceMemory?.frontmatter.structuredAttributes?.["ledger.kind"], "claim");
+      assert.equal(reread.sourceMemory?.frontmatter.structuredAttributes?.["ledger.confidence"], "0.8");
+
+      const entities = await storage.readAllEntityFiles();
+      const entity = entities.find((candidate) => candidate.name === "Memory Tools");
+      assert.ok(entity);
+      assert.equal(entity.timeline.length, 0);
+      const beliefSection = entity.structuredSections?.find((section) => section.key === "belief_ledger");
+      assert.ok(beliefSection?.facts.some((fact) => fact.includes("status=active") && fact.includes(input.statement)));
+    });
+  });
+
+  it("preserves multiline claim statements when reading through Remnic storage", async () => {
+    await withStore(async (store) => {
+      const input = normalizeClaimDraft(
+        {
+          statement: "Local-first memory tools will win.\nCloud-only tools will remain useful for teams.",
+          stance: "for",
+          confidence: 0.8,
+          scope: {
+            entities: ["Memory Tools"],
+            domain: "ai memory",
+          },
+        },
+        { now: "2026-06-03T12:00:00Z" }
+      );
+
+      const claim = await store.createClaim(input);
+
+      assert.equal(claim.statement, input.statement);
+    });
+  });
+
+  it("keeps created claims successful when entity link writes fail", async () => {
+    await withStore(async (store, storage) => {
+      storage.writeEntity = async () => {
+        throw new Error("entity index unavailable");
+      };
+      const input = normalizeClaimDraft(
+        {
+          statement: "Entity link failures should not orphan caller-visible claims.",
+          stance: "for",
+          confidence: 0.8,
+          scope: {
+            entities: ["Entity Index"],
+            domain: "storage",
+          },
+        },
+        { now: "2026-06-03T12:00:00Z" }
+      );
+
+      const claim = await store.createClaim(input);
+
+      assert.equal(claim.statement, input.statement);
+      assert.equal((await store.getClaim(claim.id))?.statement, input.statement);
+    });
+  });
+
+  it("preserves historical ledger timestamps when reading claims back", async () => {
+    await withStore(async (store) => {
+      const input = normalizeClaimDraft(
+        {
+          statement: "Backfilled predictions should keep their original claim time.",
+          kind: "prediction",
+          stance: "for",
+          confidence: 0.65,
+          deadline: "2020-02-01T00:00:00Z",
+          scope: { entities: ["Backfill"], domain: "timeline" },
+        },
+        { now: "2020-01-01T00:00:00Z" }
+      );
+
+      const claim = await store.createClaim(input);
+      const reread = await store.getClaim(claim.id);
+
+      assert.equal(claim.createdAt, "2020-01-01T00:00:00.000Z");
+      assert.equal(claim.updatedAt, "2020-01-01T00:00:00.000Z");
+      assert.equal(reread?.createdAt, "2020-01-01T00:00:00.000Z");
+      assert.equal(reread?.updatedAt, "2020-01-01T00:00:00.000Z");
+    });
+  });
+
+  it("skips corrupt ledger memories when listing claims", async () => {
+    await withStore(async (store, storage) => {
+      const valid = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "Valid claims should still be listed.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Valid"], domain: "quality" },
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        )
+      );
+
+      await storage.writeMemory("fact", "# Belief Ledger Claim\n\nBroken claim.\n\nKind: claim\nStatus: active\n", {
+        actor: "belief-ledger-test",
+        source: "belief-ledger",
+        confidence: 0.5,
+        tags: ["belief-ledger"],
+        structuredAttributes: {
+          "ledger.schemaVersion": "1",
+          "ledger.kind": "claim",
+          "ledger.stance": "neutral",
+          "ledger.confidence": "2",
+          "ledger.entities": "[]",
+          "ledger.status": "active",
+          "ledger.createdAt": "not-a-date",
+          "ledger.updatedAt": "2026-06-03T12:00:00.000Z",
+          "ledger.parentIds": "[]",
+        },
+      });
+
+      const claims = await store.listClaims();
+
+      assert.deepEqual(
+        claims.map((claim) => claim.id),
+        [valid.id]
+      );
+    });
+  });
+
+  it("lists active ledger claims after Remnic migrates them to cold storage", async () => {
+    await withStore(async (store, storage) => {
+      const claim = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "Cold-tier beliefs should remain available to the ledger.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Cold Tier"], domain: "storage" },
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        )
+      );
+      const memory = await storage.getMemoryById(claim.id);
+      assert.ok(memory);
+
+      await storage.migrateMemoryToTier(memory, "cold");
+
+      const claims = await store.listClaims({ statuses: ["active"] });
+
+      assert.ok(claims.some((listed) => listed.id === claim.id));
+    });
+  });
+
+  it("reads and updates individual ledger claims after Remnic migrates them to cold storage", async () => {
+    await withStore(async (store, storage) => {
+      const claim = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "Cold-tier predictions should remain editable.",
+            kind: "prediction",
+            stance: "for",
+            confidence: 0.7,
+            deadline: "2026-06-01T00:00:00Z",
+            scope: { entities: ["Cold Tier"], domain: "storage" },
+          },
+          { now: "2026-05-01T12:00:00Z" }
+        )
+      );
+      const memory = await storage.getMemoryById(claim.id);
+      assert.ok(memory);
+
+      await storage.migrateMemoryToTier(memory, "cold");
+
+      assert.equal((await store.getClaim(claim.id))?.statement, claim.statement);
+      const resolved = await store.updateClaim(claim.id, {
+        status: "resolved",
+        resolution: {
+          verdict: "true",
+          actualConfidence: 1,
+          resolvedAt: "2026-06-03T12:00:00.000Z",
+          brierScore: 0.09,
+        },
+      });
+
+      assert.equal(resolved.status, "resolved");
+      assert.equal((await store.getClaim(claim.id))?.resolution?.verdict, "true");
+      const cold = (await storage.readAllColdMemories()).find((candidate) => candidate.frontmatter.id === claim.id);
+      assert.equal(cold?.frontmatter.status, "archived");
+      assert.equal(cold?.frontmatter.structuredAttributes?.["ledger.status"], "resolved");
+    });
+  });
+
+  it("persists edited claim bodies when updating claims", async () => {
+    await withStore(async (store, storage) => {
+      const claim = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "Original belief body.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Body"], domain: "storage" },
+          },
+          { now: "2026-06-01T12:00:00Z" }
+        )
+      );
+
+      const beforeMemory = await storage.getMemoryById(claim.id);
+      assert.ok(beforeMemory);
+      assert.equal(await storage.hasFactContentHash(beforeMemory.content), true);
+
+      const updated = await store.updateClaim(claim.id, {
+        statement: "Edited belief body.",
+      });
+
+      assert.equal(updated.statement, "Edited belief body.");
+      assert.equal((await store.getClaim(claim.id))?.statement, "Edited belief body.");
+      const memory = await storage.getMemoryById(claim.id);
+      assert.match(memory?.content ?? "", /Edited belief body/);
+      assert.doesNotMatch(memory?.content ?? "", /Original belief body/);
+      assert.notEqual(memory?.frontmatter.contentHash, beforeMemory.frontmatter.contentHash);
+      assert.equal(await storage.hasFactContentHash(beforeMemory.content), false);
+      assert.equal(await storage.hasFactContentHash(memory?.content ?? ""), true);
+    });
+  });
+
+  it("keeps Remnic frontmatter and ledger metadata in sync during supersession", async () => {
+    await withStore(async (store) => {
+      const first = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "Cloud-only memory tools will win.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+          { now: "2026-06-01T12:00:00Z" }
+        )
+      );
+      const second = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "Local-first memory tools will win.",
+            stance: "for",
+            confidence: 0.8,
+            scope: { entities: ["Memory Tools"], domain: "ai memory" },
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        )
+      );
+
+      assert.equal(await store.supersedeClaim(first.id, second.id, "newer belief"), true);
+
+      const prior = await store.getClaim(first.id);
+      const current = await store.getClaim(second.id);
+      assert.equal(prior?.status, "superseded");
+      assert.equal(prior?.supersededBy, second.id);
+      assert.equal(current?.supersedes, first.id);
+      assert.ok(current?.parentIds.includes(first.id));
+    });
+  });
+
+  it("does not mutate a prior claim when the replacement claim is missing", async () => {
+    await withStore(async (store, storage) => {
+      const prior = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "A replacement should exist before supersession.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Supersession"], domain: "quality" },
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        )
+      );
+
+      assert.equal(await store.supersedeClaim(prior.id, "missing-claim", "replacement missing"), false);
+
+      const reread = await store.getClaim(prior.id);
+      const memory = await storage.getMemoryById(prior.id);
+      assert.equal(reread?.status, "active");
+      assert.equal(reread?.supersededBy, undefined);
+      assert.equal(memory?.frontmatter.status, "active");
+    });
+  });
+
+  it("rolls back replacement lineage when prior supersession update fails", async () => {
+    await withStore(async (store, storage) => {
+      const first = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "The first supersession write can fail.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Supersession"], domain: "quality" },
+          },
+          { now: "2026-06-01T12:00:00Z" }
+        )
+      );
+      const second = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "The replacement should be rolled back on failure.",
+            stance: "for",
+            confidence: 0.8,
+            scope: { entities: ["Supersession"], domain: "quality" },
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        )
+      );
+      const writeMemoryFrontmatter = storage.writeMemoryFrontmatter.bind(storage);
+      storage.writeMemoryFrontmatter = async (memory, patch, lifecycle) => {
+        if (patch.supersededBy === second.id) {
+          throw new Error("prior write failed");
+        }
+        return writeMemoryFrontmatter(memory, patch, lifecycle);
+      };
+
+      await assert.rejects(() => store.supersedeClaim(first.id, second.id, "newer belief"), /prior write failed/);
+
+      const prior = await store.getClaim(first.id);
+      const replacement = await store.getClaim(second.id);
+      assert.equal(prior?.status, "active");
+      assert.equal(prior?.supersededBy, undefined);
+      assert.equal(replacement?.supersedes, undefined);
+      assert.equal(replacement?.parentIds.includes(first.id), false);
+    });
+  });
+
+  it("surfaces rollback failure when replacement restore cannot be persisted", async () => {
+    await withStore(async (store, storage) => {
+      const first = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "The prior supersession write can fail.",
+            stance: "for",
+            confidence: 0.7,
+            scope: { entities: ["Supersession"], domain: "quality" },
+          },
+          { now: "2026-06-01T12:00:00Z" }
+        )
+      );
+      const second = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "The replacement restore can fail too.",
+            stance: "for",
+            confidence: 0.8,
+            scope: { entities: ["Supersession"], domain: "quality" },
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        )
+      );
+      const writeMemoryFrontmatter = storage.writeMemoryFrontmatter.bind(storage);
+      let restoreAttempted = false;
+      storage.writeMemoryFrontmatter = async (memory, patch, lifecycle) => {
+        if (patch.supersededBy === second.id) {
+          throw new Error("prior write failed");
+        }
+        if (memory.frontmatter.id === second.id && patch.supersedes === undefined) {
+          restoreAttempted = true;
+          return false;
+        }
+        return writeMemoryFrontmatter(memory, patch, lifecycle);
+      };
+
+      await assert.rejects(
+        () => store.supersedeClaim(first.id, second.id, "newer belief"),
+        /rollback failed.*prior write failed/
+      );
+
+      assert.equal(restoreAttempted, true);
+      const replacement = await store.getClaim(second.id);
+      assert.equal(replacement?.supersedes, first.id);
+    });
+  });
+
+  it("archives resolved and ignored claims in Remnic frontmatter", async () => {
+    await withStore(async (store, storage) => {
+      const first = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "The preview will ship by June.",
+            kind: "prediction",
+            stance: "for",
+            confidence: 0.7,
+            deadline: "2026-06-01T00:00:00Z",
+            scope: { entities: ["Preview"], domain: "shipping" },
+          },
+          { now: "2026-05-01T12:00:00Z" }
+        )
+      );
+      const second = await store.createClaim(
+        normalizeClaimDraft(
+          {
+            statement: "The beta release is blocked.",
+            stance: "for",
+            confidence: 0.6,
+            scope: { entities: ["Beta"], domain: "shipping" },
+          },
+          { now: "2026-05-01T12:00:00Z" }
+        )
+      );
+
+      await store.updateClaim(first.id, {
+        status: "resolved",
+        resolution: {
+          verdict: "false",
+          actualConfidence: 0,
+          resolvedAt: "2026-06-03T12:00:00.000Z",
+          brierScore: 0.49,
+        },
+      });
+      await store.updateClaim(second.id, {
+        status: "ignored",
+        ignoredAt: "2026-06-03T12:00:00.000Z",
+      });
+
+      const resolved = await storage.getMemoryById(first.id);
+      const ignored = await storage.getMemoryById(second.id);
+      assert.equal(resolved?.frontmatter.status, "archived");
+      assert.equal(ignored?.frontmatter.status, "archived");
+      assert.equal((await store.getClaim(first.id))?.status, "resolved");
+      assert.equal((await store.getClaim(second.id))?.status, "ignored");
+    });
+  });
+
+  it("can reach public core page-versioning from an external package", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-belief-ledger-versioning-"));
+    try {
+      const pagePath = path.join(dir, "facts", "belief-ledger.md");
+      await mkdir(path.dirname(pagePath), { recursive: true });
+      await writeFile(pagePath, "first version\n", "utf-8");
+
+      const version = await createVersion(
+        pagePath,
+        "first version\n",
+        "manual",
+        { enabled: true, maxVersionsPerPage: 5, sidecarDir: ".versions" },
+        undefined,
+        "belief ledger external consumer smoke test",
+        dir
+      );
+      const versions = await listVersions(
+        pagePath,
+        { enabled: true, maxVersionsPerPage: 5, sidecarDir: ".versions" },
+        dir
+      );
+
+      assert.equal(version.versionId, "1");
+      assert.equal(versions.versions.length, 1);
+      assert.equal(versions.versions[0]?.trigger, "manual");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/belief-ledger/src/remnic-store.ts
+++ b/packages/belief-ledger/src/remnic-store.ts
@@ -1,0 +1,270 @@
+import type { MemoryFile, StorageManager } from "@remnic/core";
+import { sanitizeMemoryContent } from "@remnic/core/sanitize";
+import { ContentHashIndex, normalizeAttributePairs } from "@remnic/core/storage";
+import {
+  claimFromMemory,
+  claimTags,
+  claimToStructuredAttributes,
+  memoryFrontmatterPatchForClaim,
+  mergeClaimPatch,
+  normalizeIsoTimestamp,
+  remnicMemoryStatusForClaim,
+  serializeClaimBody,
+} from "./schema.js";
+import type { LedgerClaim, LedgerClaimKind, LedgerClaimStatus, LedgerStore } from "./types.js";
+
+function serializeClaimMemoryContent(claim: LedgerClaim): string {
+  const attributes = normalizeAttributePairs(claimToStructuredAttributes(claim));
+  return `${serializeClaimBody(claim)}\n[Attributes: ${attributes}]`;
+}
+
+export interface RemnicLedgerStoreOptions {
+  now?: () => Date;
+  source?: string;
+  writeEntityLinks?: boolean;
+}
+
+export class RemnicLedgerStore implements LedgerStore {
+  private readonly storage: StorageManager;
+  private readonly now: () => Date;
+  private readonly source: string;
+  private readonly shouldWriteEntityLinks: boolean;
+
+  constructor(storage: StorageManager, options: RemnicLedgerStoreOptions = {}) {
+    this.storage = storage;
+    this.now = options.now ?? (() => new Date());
+    this.source = options.source ?? "belief-ledger";
+    this.shouldWriteEntityLinks = options.writeEntityLinks ?? true;
+  }
+
+  async createClaim(input: Omit<LedgerClaim, "id" | "memoryId" | "sourceMemory">): Promise<LedgerClaim> {
+    const pending: LedgerClaim = {
+      ...input,
+      id: "pending",
+      memoryId: "pending",
+    };
+    const memoryId = await this.storage.writeMemory("fact", serializeClaimBody(pending), {
+      actor: this.source,
+      confidence: pending.confidence,
+      tags: claimTags(pending),
+      entityRef: pending.scope.entities[0],
+      source: this.source,
+      supersedes: pending.supersedes,
+      lineage: pending.parentIds.length > 0 ? pending.parentIds : undefined,
+      memoryKind: "note",
+      validAt: pending.createdAt,
+      structuredAttributes: claimToStructuredAttributes(pending),
+      status: remnicMemoryStatusForClaim(pending),
+    });
+
+    const claim = await this.getClaim(memoryId);
+    if (!claim) {
+      throw new Error(`created claim ${memoryId} could not be read back`);
+    }
+    await this.writeEntityLinksBestEffort(claim);
+    return claim;
+  }
+
+  async getClaim(id: string): Promise<LedgerClaim | null> {
+    const memory = await this.getLedgerMemoryById(id);
+    return memory ? this.claimFromMemorySafely(memory) : null;
+  }
+
+  async listClaims(
+    filter: {
+      statuses?: LedgerClaimStatus[];
+      kinds?: LedgerClaimKind[];
+    } = {}
+  ): Promise<LedgerClaim[]> {
+    const memories = await this.readAllLedgerCandidateMemories();
+    const statuses = filter.statuses ? new Set(filter.statuses) : null;
+    const kinds = filter.kinds ? new Set(filter.kinds) : null;
+    return memories
+      .map((memory) => this.claimFromMemorySafely(memory))
+      .filter((claim): claim is LedgerClaim => claim !== null)
+      .filter((claim) => !statuses || statuses.has(claim.status))
+      .filter((claim) => !kinds || kinds.has(claim.kind))
+      .sort((a, b) => {
+        const updatedOrder = Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+        if (updatedOrder !== 0) return updatedOrder;
+        return a.id.localeCompare(b.id);
+      });
+  }
+
+  async updateClaim(id: string, patch: Partial<LedgerClaim>): Promise<LedgerClaim> {
+    const memory = await this.getLedgerMemoryById(id);
+    const existing = this.claimFromMemorySafely(memory);
+    if (!existing) {
+      throw new Error(`claim ${id} not found`);
+    }
+    const updated = mergeClaimPatch(existing, patch, this.now().toISOString());
+
+    const contentUpdated = await this.writeClaimMemory(memory, updated, { actor: this.source });
+    if (!contentUpdated) {
+      throw new Error(`claim ${id} content update failed`);
+    }
+
+    const reread = await this.getClaim(id);
+    if (!reread) {
+      throw new Error(`claim ${id} could not be read after update`);
+    }
+    await this.writeEntityLinksBestEffort(reread);
+    return reread;
+  }
+
+  async supersedeClaim(priorId: string, newId: string, reason: string): Promise<boolean> {
+    const cleanReason = reason.trim();
+    if (!cleanReason) {
+      throw new Error("supersede reason must not be empty");
+    }
+    const prior = await this.getClaim(priorId);
+    const next = await this.getClaim(newId);
+    if (!prior || !next) return false;
+
+    const parentIds = [...new Set([...next.parentIds, priorId])];
+    await this.updateClaim(newId, {
+      supersedes: priorId,
+      parentIds,
+      updatedAt: this.now().toISOString(),
+    });
+
+    try {
+      await this.updateClaim(priorId, {
+        status: "superseded",
+        supersededBy: newId,
+        updatedAt: this.now().toISOString(),
+      });
+    } catch (error) {
+      const restored = await this.restoreClaimBestEffort(next);
+      if (!restored) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`claim ${newId} rollback failed after prior supersession update failed: ${message}`);
+      }
+      throw error;
+    }
+
+    await this.writeSupersessionCorrectionBestEffort(prior, next, cleanReason);
+    return true;
+  }
+
+  private async getLedgerMemoryById(id: string): Promise<MemoryFile | null> {
+    const memories = await this.readAllLedgerCandidateMemories();
+    return memories.find((memory) => memory.frontmatter.id === id) ?? null;
+  }
+
+  private async readAllLedgerCandidateMemories(): Promise<MemoryFile[]> {
+    const [hot, cold, archived] = await Promise.all([
+      this.storage.readAllMemories(),
+      this.storage.readAllColdMemories(),
+      this.storage.readArchivedMemories(),
+    ]);
+    const byId = new Map<string, MemoryFile>();
+    for (const memory of [...hot, ...cold, ...archived]) {
+      if (!byId.has(memory.frontmatter.id)) {
+        byId.set(memory.frontmatter.id, memory);
+      }
+    }
+    return [...byId.values()];
+  }
+
+  private async writeClaimMemory(
+    memory: MemoryFile | null,
+    claim: LedgerClaim,
+    options: { actor: string }
+  ): Promise<boolean> {
+    if (!memory) return false;
+    const sanitized = sanitizeMemoryContent(serializeClaimMemoryContent(claim));
+    const relatedMemoryIds = [
+      ...(claim.supersedes ? [claim.supersedes] : []),
+      ...(claim.supersededBy ? [claim.supersededBy] : []),
+      ...claim.parentIds,
+    ];
+    return this.storage.writeMemoryFrontmatter(
+      { ...memory, content: sanitized.text },
+      {
+        ...memoryFrontmatterPatchForClaim(claim),
+        contentHash: ContentHashIndex.computeHash(sanitized.text),
+      },
+      {
+        actor: options.actor,
+        reasonCode: "belief-ledger-update",
+        relatedMemoryIds,
+      }
+    );
+  }
+
+  private async restoreClaimBestEffort(claim: LedgerClaim): Promise<boolean> {
+    try {
+      return await this.writeClaimMemory(claim.sourceMemory ?? (await this.getLedgerMemoryById(claim.id)), claim, {
+        actor: this.source,
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  private async writeSupersessionCorrectionBestEffort(
+    prior: LedgerClaim,
+    next: LedgerClaim,
+    reason: string
+  ): Promise<void> {
+    try {
+      await this.storage.writeMemory(
+        "correction",
+        `Superseded: ${prior.statement}\n\nReplacement: ${next.statement}\n\nReason: ${reason}`,
+        {
+          actor: this.source,
+          confidence: 1,
+          tags: ["belief-ledger:audit", "supersession", "auto-resolved"],
+          source: this.source,
+          lineage: [prior.id, next.id],
+        }
+      );
+    } catch {
+      // The ledger link is already durable; correction memory is an audit side effect.
+    }
+  }
+
+  private claimFromMemorySafely(memory: MemoryFile | null): LedgerClaim | null {
+    if (!memory) return null;
+    try {
+      return claimFromMemory(memory);
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeEntityLinksBestEffort(claim: LedgerClaim): Promise<void> {
+    if (!this.shouldWriteEntityLinks) return;
+    try {
+      await this.writeEntityLinks(claim);
+    } catch {
+      // Entity links are an index side effect; the claim itself is already durable.
+    }
+  }
+
+  private async writeEntityLinks(claim: LedgerClaim): Promise<void> {
+    const timestamp = normalizeIsoTimestamp("createdAt", claim.createdAt);
+    for (const entity of claim.scope.entities) {
+      await this.storage.writeEntity(entity, "topic", [], {
+        timestamp,
+        source: this.source,
+        structuredSections: [
+          {
+            key: "belief-ledger",
+            title: "Belief Ledger",
+            facts: beliefLedgerEntityFacts(claim),
+          },
+        ],
+      });
+    }
+  }
+}
+
+function beliefLedgerEntityFacts(claim: LedgerClaim): string[] {
+  const prefix = `claim=${claim.id}; status=${claim.status}; updatedAt=${claim.updatedAt}`;
+  return [
+    `${prefix}; ${claim.kind}: ${claim.statement}`,
+    `${prefix}; stance=${claim.stance}; confidence=${claim.confidence}`,
+  ];
+}

--- a/packages/belief-ledger/src/retrieval.ts
+++ b/packages/belief-ledger/src/retrieval.ts
@@ -1,0 +1,203 @@
+import type { LedgerClaim, LedgerRetrievalCandidate, LedgerRetrievalOptions, LedgerStore } from "./types.js";
+import { normalizeIsoTimestamp } from "./schema.js";
+
+const DEFAULT_LIMIT = 8;
+const STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "has",
+  "have",
+  "i",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "this",
+  "to",
+  "was",
+  "were",
+  "will",
+  "with",
+]);
+
+export async function retrievePriorClaims(
+  query: LedgerClaim,
+  store: LedgerStore,
+  options: LedgerRetrievalOptions = {}
+): Promise<LedgerRetrievalCandidate[]> {
+  const limit = normalizeLimit(options.limit);
+  const referenceTimeMs = Date.parse(normalizeIsoTimestamp("retrieval.now", options.now ?? query.createdAt));
+  const includeStatuses = options.includeStatuses ?? ["active", "snoozed"];
+  const claims = (await store.listClaims({ statuses: includeStatuses }))
+    .filter((claim) => claim.id !== query.id)
+    .filter((claim) => isRetrievableAt(claim, referenceTimeMs));
+
+  const semanticScores = options.semantic
+    ? await collectSemanticScores(query, claims, limit, options)
+    : new Map<string, number>();
+
+  const candidates = claims
+    .map((claim) => scoreCandidate(query, claim, semanticScores.get(claim.id), referenceTimeMs))
+    .filter((candidate) => candidate.score > 0)
+    .sort(compareCandidates);
+
+  const sliced = candidates.slice(0, limit);
+  if (!options.reranker) return sliced;
+
+  const reranked = await options.reranker.rerank({ query, candidates: sliced, limit });
+  return reranked.slice(0, limit);
+}
+
+function isRetrievableAt(claim: LedgerClaim, referenceTimeMs: number): boolean {
+  if (claim.status !== "snoozed" || !claim.snoozedUntil) return true;
+  return Date.parse(claim.snoozedUntil) <= referenceTimeMs;
+}
+
+function scoreCandidate(
+  query: LedgerClaim,
+  claim: LedgerClaim,
+  semanticScore: number | undefined,
+  referenceTimeMs: number
+): LedgerRetrievalCandidate {
+  let score = 0;
+  let hasTopicalMatch = false;
+  const reasons: string[] = [];
+
+  const lexical = jaccard(tokenize(query.statement), tokenize(claim.statement));
+  if (lexical > 0) {
+    hasTopicalMatch = true;
+    const lexicalScore = lexical * 4;
+    score += lexicalScore;
+    reasons.push(`lexical:${round(lexicalScore)}`);
+  }
+
+  const entityOverlap = overlap(query.scope.entities.map(normalizeText), claim.scope.entities.map(normalizeText));
+  if (entityOverlap > 0) {
+    hasTopicalMatch = true;
+    const entityScore = entityOverlap * 3;
+    score += entityScore;
+    reasons.push(`entity:${entityOverlap}`);
+  }
+
+  if (
+    query.scope.domain &&
+    claim.scope.domain &&
+    normalizeText(query.scope.domain) === normalizeText(claim.scope.domain)
+  ) {
+    hasTopicalMatch = true;
+    score += 2;
+    reasons.push("domain");
+  }
+
+  if (query.stance !== claim.stance && query.stance !== "uncertain" && claim.stance !== "uncertain") {
+    score += 1;
+    reasons.push("stance-diff");
+  }
+
+  const recency = recencyScore(claim.updatedAt, referenceTimeMs);
+  if (recency > 0) {
+    score += recency;
+    reasons.push(`recency:${round(recency)}`);
+  }
+
+  if (semanticScore !== undefined) {
+    const semantic = Math.max(0, Math.min(1, semanticScore)) * 5;
+    if (semantic > 0) hasTopicalMatch = true;
+    score += semantic;
+    reasons.push(`semantic:${round(semantic)}`);
+  }
+
+  return { claim, score: hasTopicalMatch ? round(score) : 0, reasons };
+}
+
+function compareCandidates(a: LedgerRetrievalCandidate, b: LedgerRetrievalCandidate): number {
+  const scoreOrder = b.score - a.score;
+  if (scoreOrder !== 0) return scoreOrder;
+  const updatedOrder = Date.parse(b.claim.updatedAt) - Date.parse(a.claim.updatedAt);
+  if (updatedOrder !== 0) return updatedOrder;
+  return a.claim.id.localeCompare(b.claim.id);
+}
+
+async function collectSemanticScores(
+  query: LedgerClaim,
+  candidates: LedgerClaim[],
+  limit: number,
+  options: LedgerRetrievalOptions
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  if (!options.semantic || candidates.length === 0) return result;
+  const scored = await options.semantic.scoreClaims({ query, candidates, limit });
+  for (const item of scored) {
+    if (!item.claimId.trim()) continue;
+    if (!Number.isFinite(item.score)) continue;
+    result.set(item.claimId, Math.max(0, Math.min(1, item.score)));
+  }
+  return result;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_LIMIT;
+  if (!Number.isInteger(value) || value < 1 || value > 100) {
+    throw new Error(`retrieval limit must be an integer in [1, 100], got ${String(value)}`);
+  }
+  return value;
+}
+
+function tokenize(value: string): string[] {
+  return normalizeText(value)
+    .split(/\s+/)
+    .filter((token) => token.length >= 2)
+    .filter((token) => !STOPWORDS.has(token));
+}
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function jaccard(left: string[], right: string[]): number {
+  if (left.length === 0 || right.length === 0) return 0;
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  let intersection = 0;
+  for (const token of leftSet) {
+    if (rightSet.has(token)) intersection += 1;
+  }
+  const union = new Set([...leftSet, ...rightSet]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function overlap(left: string[], right: string[]): number {
+  const rightSet = new Set(right.filter(Boolean));
+  let count = 0;
+  for (const item of new Set(left.filter(Boolean))) {
+    if (rightSet.has(item)) count += 1;
+  }
+  return count;
+}
+
+function recencyScore(updatedAt: string, referenceTimeMs: number): number {
+  const ageMs = referenceTimeMs - Date.parse(updatedAt);
+  if (!Number.isFinite(ageMs) || ageMs < 0) return 0;
+  const ageDays = ageMs / (24 * 60 * 60 * 1_000);
+  if (ageDays > 365) return 0;
+  return (365 - ageDays) / 365;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1_000) / 1_000;
+}

--- a/packages/belief-ledger/src/schema.test.ts
+++ b/packages/belief-ledger/src/schema.test.ts
@@ -1,0 +1,464 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { MemoryFile } from "@remnic/core";
+
+import {
+  computeBrierScore,
+  claimFromMemory,
+  claimTags,
+  mergeClaimPatch,
+  normalizeChallenge,
+  normalizeClaimDraft,
+  normalizePredictionGrade,
+} from "./schema.js";
+
+describe("belief ledger schema validation", () => {
+  it("normalizes a valid claim draft", () => {
+    const claim = normalizeClaimDraft(
+      {
+        statement: "Local-first memory tools will beat cloud-only tools.",
+        kind: "prediction",
+        stance: "for",
+        confidence: 0.75,
+        scope: {
+          entities: ["Local-first memory", "Cloud memory"],
+          domain: "ai memory",
+        },
+        deadline: "2027-01-01",
+        evidenceLinks: ["https://example.test/source"],
+      },
+      { now: "2026-06-03T12:00:00Z" }
+    );
+
+    assert.equal(claim.kind, "prediction");
+    assert.equal(claim.deadline, "2027-01-01T00:00:00.000Z");
+    assert.deepEqual(claim.scope.entities, ["Local-first memory", "Cloud memory"]);
+  });
+
+  it("rejects invalid confidence instead of silently clamping", () => {
+    assert.throws(
+      () =>
+        normalizeClaimDraft(
+          {
+            statement: "This should fail.",
+            stance: "for",
+            confidence: 1.2,
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        ),
+      /confidence must be in \[0, 1\]/
+    );
+  });
+
+  it("rejects invalid timestamps", () => {
+    assert.throws(
+      () =>
+        normalizeClaimDraft(
+          {
+            statement: "This should fail.",
+            stance: "for",
+            confidence: 0.5,
+            deadline: "not-a-date",
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        ),
+      /deadline must be a valid ISO timestamp/
+    );
+  });
+
+  it("rejects calendar-overflow timestamps", () => {
+    assert.throws(
+      () =>
+        normalizeClaimDraft(
+          {
+            statement: "Impossible calendar dates should fail.",
+            stance: "for",
+            confidence: 0.5,
+            deadline: "2026-04-31T00:00:00Z",
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        ),
+      /deadline must be a valid ISO timestamp/
+    );
+    assert.throws(
+      () =>
+        normalizeClaimDraft(
+          {
+            statement: "Impossible date-only timestamps should fail.",
+            stance: "for",
+            confidence: 0.5,
+            deadline: "2026-02-31",
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        ),
+      /deadline must be a valid ISO timestamp/
+    );
+  });
+
+  it("rejects date-time timestamps without an explicit offset", () => {
+    assert.throws(
+      () =>
+        normalizeClaimDraft(
+          {
+            statement: "Local date-times should not depend on process timezone.",
+            stance: "for",
+            confidence: 0.5,
+            deadline: "2026-06-01T09:00:00",
+          },
+          { now: "2026-06-03T12:00:00Z" }
+        ),
+      /deadline must be a valid ISO timestamp/
+    );
+  });
+
+  it("computes Brier score from predicted and actual confidence", () => {
+    assert.equal(computeBrierScore(0.75, 0), 0.5625);
+    assert.equal(computeBrierScore(0.8, 1), 0.04);
+  });
+
+  it("normalizes resolution patches before persistence", () => {
+    const claim = {
+      ...normalizeClaimDraft(
+        {
+          statement: "The belief ledger test release will pass.",
+          kind: "prediction",
+          stance: "for",
+          confidence: 0.75,
+        },
+        { now: "2026-06-03T12:00:00Z" }
+      ),
+      id: "claim-1",
+      memoryId: "claim-1",
+    };
+
+    const updated = mergeClaimPatch(
+      claim,
+      {
+        status: "resolved",
+        resolution: {
+          verdict: "mixed",
+          actualConfidence: "0.25" as unknown as number,
+          resolvedAt: "2026-06-04T12:00:00-05:00",
+          source: "test source",
+        },
+      },
+      "2026-06-04T12:00:00.000Z"
+    );
+
+    assert.equal(updated.resolution?.actualConfidence, 0.25);
+    assert.equal(updated.resolution?.resolvedAt, "2026-06-04T17:00:00.000Z");
+    assert.equal(updated.resolution?.brierScore, 0.25);
+  });
+
+  it("rejects invalid resolution patches before persistence", () => {
+    const claim = {
+      ...normalizeClaimDraft(
+        {
+          statement: "The belief ledger bad resolution patch should fail.",
+          kind: "prediction",
+          stance: "for",
+          confidence: 0.75,
+        },
+        { now: "2026-06-03T12:00:00Z" }
+      ),
+      id: "claim-1",
+      memoryId: "claim-1",
+    };
+
+    assert.throws(
+      () =>
+        mergeClaimPatch(
+          claim,
+          {
+            resolution: {
+              verdict: "true",
+              actualConfidence: 2,
+              resolvedAt: "2026-06-04T12:00:00.000Z",
+            },
+          },
+          "2026-06-04T12:00:00.000Z"
+        ),
+      /actualConfidence must be in \[0, 1\]/
+    );
+    assert.throws(
+      () =>
+        mergeClaimPatch(
+          claim,
+          {
+            resolution: {
+              verdict: "false",
+              actualConfidence: 0,
+              resolvedAt: "2026-06-04T12:00:00",
+            },
+          },
+          "2026-06-04T12:00:00.000Z"
+        ),
+      /resolvedAt must be a valid ISO timestamp/
+    );
+  });
+
+  it("normalizes createdAt patches before persistence", () => {
+    const claim = {
+      ...normalizeClaimDraft(
+        {
+          statement: "The belief ledger createdAt patch should normalize.",
+          kind: "claim",
+          stance: "for",
+          confidence: 0.75,
+        },
+        { now: "2026-06-03T12:00:00Z" }
+      ),
+      id: "claim-1",
+      memoryId: "claim-1",
+    };
+
+    const updated = mergeClaimPatch(
+      claim,
+      { createdAt: "2026-06-03T07:00:00-05:00" },
+      "2026-06-04T12:00:00.000Z"
+    );
+
+    assert.equal(updated.createdAt, "2026-06-03T12:00:00.000Z");
+  });
+
+  it("rejects invalid createdAt patches before persistence", () => {
+    const claim = {
+      ...normalizeClaimDraft(
+        {
+          statement: "The belief ledger bad createdAt patch should fail.",
+          kind: "claim",
+          stance: "for",
+          confidence: 0.75,
+        },
+        { now: "2026-06-03T12:00:00Z" }
+      ),
+      id: "claim-1",
+      memoryId: "claim-1",
+    };
+
+    assert.throws(
+      () =>
+        mergeClaimPatch(
+          claim,
+          { createdAt: "2026-06-03T12:00:00" },
+          "2026-06-04T12:00:00.000Z"
+        ),
+      /createdAt must be a valid ISO timestamp/
+    );
+  });
+
+  it("validates prediction grades from host LLMs", () => {
+    const grade = normalizePredictionGrade({
+      verdict: "mixed",
+      actualConfidence: "0.25",
+      rationale: "Partially happened.",
+    });
+
+    assert.equal(grade.verdict, "mixed");
+    assert.equal(grade.actualConfidence, 0.25);
+  });
+
+  it("drops hallucinated challenge claim IDs from host LLMs", () => {
+    const challenge = normalizeChallenge(
+      {
+        question: "Which version should stand?",
+        priorClaimIds: ["claim-2", "hallucinated", "claim-3"],
+        suggestedActions: ["supersede"],
+      },
+      ["claim-1", "claim-2"]
+    );
+    const fallback = normalizeChallenge(
+      {
+        question: "Which version should stand?",
+        priorClaimIds: ["hallucinated"],
+        suggestedActions: ["supersede"],
+      },
+      ["claim-1", "claim-2"]
+    );
+
+    assert.deepEqual(challenge.priorClaimIds, ["claim-2"]);
+    assert.deepEqual(fallback.priorClaimIds, ["claim-1", "claim-2"]);
+  });
+
+  it("builds safe domain tags for hyphen-heavy domains", () => {
+    const claim = normalizeClaimDraft(
+      {
+        statement: "Hyphen-only domains should not trigger slow regex paths.",
+        stance: "neutral",
+        confidence: 0.5,
+        scope: {
+          domain: "-----AI---Memory-----",
+        },
+      },
+      { now: "2026-06-03T12:00:00Z" }
+    );
+
+    assert.ok(claimTags({ ...claim, id: "claim-1", memoryId: "claim-1" }).includes("belief-ledger:domain:ai-memory"));
+  });
+
+  it("falls back to Remnic valid_at for legacy claim timestamps", () => {
+    const memory: MemoryFile = {
+      path: "/tmp/claim.md",
+      content: "# Belief Ledger Claim\n\nBackfilled belief.\n\nKind: claim\nStatus: active\n",
+      frontmatter: {
+        id: "claim-1",
+        category: "fact",
+        created: "2026-06-03T12:00:00.000Z",
+        updated: "2026-06-04T12:00:00.000Z",
+        source: "belief-ledger",
+        confidence: 0.5,
+        confidenceTier: "explicit",
+        tags: ["belief-ledger"],
+        valid_at: "2020-01-01T00:00:00.000Z",
+        structuredAttributes: {
+          "ledger.schemaVersion": "1",
+          "ledger.kind": "claim",
+          "ledger.stance": "neutral",
+          "ledger.confidence": "0.5",
+          "ledger.entities": "[]",
+          "ledger.status": "active",
+          "ledger.parentIds": "[]",
+        },
+      },
+    };
+
+    const claim = claimFromMemory(memory);
+
+    assert.equal(claim?.createdAt, "2020-01-01T00:00:00.000Z");
+    assert.equal(claim?.updatedAt, "2026-06-04T12:00:00.000Z");
+  });
+
+  it("rejects corrupt stored ledger array attributes instead of dropping them", () => {
+    const baseMemory: MemoryFile = {
+      path: "/tmp/claim.md",
+      content: "# Belief Ledger Claim\n\nStored belief.\n\nKind: claim\nStatus: active\n",
+      frontmatter: {
+        id: "claim-1",
+        category: "fact",
+        created: "2026-06-03T12:00:00.000Z",
+        updated: "2026-06-04T12:00:00.000Z",
+        source: "belief-ledger",
+        confidence: 0.5,
+        confidenceTier: "explicit",
+        tags: ["belief-ledger"],
+        structuredAttributes: {
+          "ledger.schemaVersion": "1",
+          "ledger.kind": "claim",
+          "ledger.stance": "neutral",
+          "ledger.confidence": "0.5",
+          "ledger.entities": "[]",
+          "ledger.status": "active",
+          "ledger.parentIds": "[]",
+          "ledger.evidenceLinks": "[]",
+        },
+      },
+    };
+
+    for (const [field, value] of [
+      ["ledger.entities", "null"],
+      ["ledger.parentIds", '"claim-0"'],
+      ["ledger.evidenceLinks", "[123]"],
+    ] as const) {
+      const memory: MemoryFile = {
+        ...baseMemory,
+        frontmatter: {
+          ...baseMemory.frontmatter,
+          id: `claim-${field}`,
+          structuredAttributes: {
+            ...baseMemory.frontmatter.structuredAttributes,
+            [field]: value,
+          },
+        },
+      };
+
+      assert.throws(
+        () => claimFromMemory(memory),
+        (error) => error instanceof Error && error.message.includes(field) && error.message.includes("must")
+      );
+    }
+  });
+
+  it("does not read hidden Remnic memory statuses as ledger claims", () => {
+    const baseMemory: MemoryFile = {
+      path: "/tmp/claim.md",
+      content: "# Belief Ledger Claim\n\nForgotten belief.\n\nKind: claim\nStatus: active\n",
+      frontmatter: {
+        id: "claim-1",
+        category: "fact",
+        created: "2026-06-03T12:00:00.000Z",
+        updated: "2026-06-04T12:00:00.000Z",
+        source: "belief-ledger",
+        confidence: 0.5,
+        confidenceTier: "explicit",
+        tags: ["belief-ledger"],
+        structuredAttributes: {
+          "ledger.schemaVersion": "1",
+          "ledger.kind": "claim",
+          "ledger.stance": "neutral",
+          "ledger.confidence": "0.5",
+          "ledger.entities": "[]",
+          "ledger.status": "active",
+          "ledger.parentIds": "[]",
+        },
+      },
+    };
+
+    for (const status of ["forgotten", "pending_review", "quarantined", "rejected"] as const) {
+      assert.equal(
+        claimFromMemory({
+          ...baseMemory,
+          frontmatter: {
+            ...baseMemory.frontmatter,
+            status,
+          },
+        }),
+        null
+      );
+    }
+  });
+
+  it("does not read Remnic-archived active claims but preserves ledger-owned archived statuses", () => {
+    const baseMemory: MemoryFile = {
+      path: "/tmp/claim.md",
+      content: "# Belief Ledger Claim\n\nArchived belief.\n\nKind: claim\nStatus: active\n",
+      frontmatter: {
+        id: "claim-1",
+        category: "fact",
+        created: "2026-06-03T12:00:00.000Z",
+        updated: "2026-06-04T12:00:00.000Z",
+        source: "belief-ledger",
+        confidence: 0.5,
+        confidenceTier: "explicit",
+        tags: ["belief-ledger"],
+        status: "archived",
+        structuredAttributes: {
+          "ledger.schemaVersion": "1",
+          "ledger.kind": "claim",
+          "ledger.stance": "neutral",
+          "ledger.confidence": "0.5",
+          "ledger.entities": "[]",
+          "ledger.status": "active",
+          "ledger.parentIds": "[]",
+        },
+      },
+    };
+
+    assert.equal(claimFromMemory(baseMemory), null);
+
+    for (const status of ["ignored", "resolved", "snoozed"] as const) {
+      const claim = claimFromMemory({
+        ...baseMemory,
+        frontmatter: {
+          ...baseMemory.frontmatter,
+          structuredAttributes: {
+            ...baseMemory.frontmatter.structuredAttributes,
+            "ledger.status": status,
+          },
+        },
+      });
+
+      assert.equal(claim?.status, status);
+    }
+  });
+});

--- a/packages/belief-ledger/src/schema.ts
+++ b/packages/belief-ledger/src/schema.ts
@@ -1,0 +1,749 @@
+import type { MemoryFile, MemoryFrontmatter } from "@remnic/core";
+import type {
+  LedgerClaim,
+  LedgerClaimDraft,
+  LedgerClaimKind,
+  LedgerClaimScope,
+  LedgerClaimStatus,
+  LedgerPredictionGrade,
+  LedgerPredictionVerdict,
+  LedgerResolution,
+  LedgerStance,
+  LedgerJudgeClassification,
+  LedgerJudgeResult,
+  LedgerChallenge,
+} from "./types.js";
+
+export const LEDGER_TAG = "belief-ledger";
+export const LEDGER_SCHEMA_VERSION = "1";
+
+const KIND_VALUES = new Set<LedgerClaimKind>(["claim", "prediction", "opinion"]);
+const STANCE_VALUES = new Set<LedgerStance>(["for", "against", "uncertain", "neutral"]);
+const STATUS_VALUES = new Set<LedgerClaimStatus>(["active", "superseded", "resolved", "snoozed", "ignored"]);
+const JUDGE_VALUES = new Set<LedgerJudgeClassification>(["contradiction", "evolution", "refinement", "unrelated"]);
+const VERDICT_VALUES = new Set<LedgerPredictionVerdict>(["true", "false", "mixed", "unknown"]);
+const HIDDEN_REMNIC_STATUSES = new Set<NonNullable<MemoryFrontmatter["status"]>>([
+  "forgotten",
+  "pending_review",
+  "quarantined",
+  "rejected",
+]);
+
+type StringRecord = Record<string, string>;
+
+export function normalizeClaimDraft(
+  draft: LedgerClaimDraft,
+  options: { now: string; sourceText?: string }
+): Omit<LedgerClaim, "id" | "memoryId" | "sourceMemory"> {
+  const now = normalizeIsoTimestamp("now", options.now);
+  const statement = cleanRequiredString("statement", draft.statement, 5_000);
+  const deadline = draft.deadline === undefined ? undefined : normalizeIsoTimestamp("deadline", draft.deadline);
+  const kind = normalizeKind(draft.kind ?? (deadline ? "prediction" : "claim"));
+  const stance = normalizeStance(draft.stance);
+  const confidence = normalizeUnitInterval("confidence", draft.confidence);
+  const scope = normalizeScope(draft.scope);
+
+  return {
+    statement,
+    kind,
+    stance,
+    confidence,
+    scope,
+    deadline,
+    evidenceLinks: normalizeStringList("evidenceLinks", draft.evidenceLinks ?? [], 100, 2_048),
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+    parentIds: [],
+    ...(options.sourceText ? { sourceText: options.sourceText } : {}),
+  };
+}
+
+export function normalizeJudgeResult(raw: unknown, priorClaimId: string): LedgerJudgeResult {
+  if (!isRecord(raw)) {
+    throw new Error("judge result must be an object");
+  }
+  const classification = normalizeJudgeClassification(raw.classification);
+  return {
+    priorClaimId,
+    classification,
+    confidence: normalizeUnitInterval("judge confidence", raw.confidence ?? 0.5),
+    rationale: cleanRequiredString("judge rationale", raw.rationale ?? "", 2_000),
+  };
+}
+
+export function normalizeChallenge(raw: unknown, priorClaimIds: string[]): LedgerChallenge {
+  if (!isRecord(raw)) {
+    throw new Error("challenge must be an object");
+  }
+  const question = cleanRequiredString("challenge question", raw.question, 2_000);
+  const parsedPriorIds = normalizeStringList(
+    "challenge priorClaimIds",
+    Array.isArray(raw.priorClaimIds) ? raw.priorClaimIds : priorClaimIds,
+    50,
+    256
+  );
+  const allowedPriorIds = new Set(priorClaimIds);
+  const safePriorIds = parsedPriorIds.filter((id) => allowedPriorIds.has(id));
+  const suggestedActions = Array.isArray(raw.suggestedActions)
+    ? raw.suggestedActions.filter(
+        (value): value is LedgerChallenge["suggestedActions"][number] =>
+          value === "supersede" || value === "split" || value === "resolve" || value === "ignore"
+      )
+    : [];
+  return {
+    question,
+    priorClaimIds: safePriorIds.length > 0 ? safePriorIds : priorClaimIds,
+    suggestedActions: suggestedActions.length > 0 ? [...new Set(suggestedActions)] : ["supersede", "split", "ignore"],
+  };
+}
+
+export function normalizePredictionGrade(raw: unknown): LedgerPredictionGrade {
+  if (!isRecord(raw)) {
+    throw new Error("prediction grade must be an object");
+  }
+  return {
+    verdict: normalizePredictionVerdict(raw.verdict),
+    actualConfidence: normalizeUnitInterval("actualConfidence", raw.actualConfidence),
+    rationale: cleanRequiredString("grade rationale", raw.rationale ?? "", 2_000),
+    ...(typeof raw.source === "string" && raw.source.trim() ? { source: raw.source.trim().slice(0, 2_048) } : {}),
+  };
+}
+
+export function createResolution(input: {
+  verdict: LedgerPredictionVerdict;
+  actualConfidence: number;
+  resolvedAt: string;
+  source?: string;
+  notes?: string;
+  predictedConfidence: number;
+}): LedgerResolution {
+  const actualConfidence = normalizeUnitInterval("actualConfidence", input.actualConfidence);
+  const predictedConfidence = normalizeUnitInterval("predictedConfidence", input.predictedConfidence);
+  const resolvedAt = normalizeIsoTimestamp("resolvedAt", input.resolvedAt);
+  return {
+    verdict: normalizePredictionVerdict(input.verdict),
+    actualConfidence,
+    resolvedAt,
+    ...(input.source ? { source: cleanRequiredString("source", input.source, 2_048) } : {}),
+    ...(input.notes ? { notes: cleanRequiredString("notes", input.notes, 5_000) } : {}),
+    brierScore: computeBrierScore(predictedConfidence, actualConfidence),
+  };
+}
+
+export function computeBrierScore(predictedConfidence: number, actualConfidence: number): number {
+  const predicted = normalizeUnitInterval("predictedConfidence", predictedConfidence);
+  const actual = normalizeUnitInterval("actualConfidence", actualConfidence);
+  return roundMetric((predicted - actual) ** 2);
+}
+
+export function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new Error(`metric must be finite, got ${String(value)}`);
+  }
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+export function claimToStructuredAttributes(claim: LedgerClaim): StringRecord {
+  const attrs: StringRecord = {
+    "ledger.schemaVersion": LEDGER_SCHEMA_VERSION,
+    "ledger.kind": claim.kind,
+    "ledger.stance": claim.stance,
+    "ledger.confidence": String(claim.confidence),
+    "ledger.entities": JSON.stringify(claim.scope.entities),
+    "ledger.status": claim.status,
+    "ledger.createdAt": claim.createdAt,
+    "ledger.updatedAt": claim.updatedAt,
+    "ledger.parentIds": JSON.stringify(claim.parentIds),
+  };
+  if (claim.scope.domain) attrs["ledger.domain"] = claim.scope.domain;
+  if (claim.scope.timeWindow?.start) attrs["ledger.timeWindowStart"] = claim.scope.timeWindow.start;
+  if (claim.scope.timeWindow?.end) attrs["ledger.timeWindowEnd"] = claim.scope.timeWindow.end;
+  if (claim.deadline) attrs["ledger.deadline"] = claim.deadline;
+  if (claim.evidenceLinks.length > 0) attrs["ledger.evidenceLinks"] = JSON.stringify(claim.evidenceLinks);
+  if (claim.supersedes) attrs["ledger.supersedes"] = claim.supersedes;
+  if (claim.supersededBy) attrs["ledger.supersededBy"] = claim.supersededBy;
+  if (claim.snoozedUntil) attrs["ledger.snoozedUntil"] = claim.snoozedUntil;
+  if (claim.ignoredAt) attrs["ledger.ignoredAt"] = claim.ignoredAt;
+  if (claim.ignoredReason) attrs["ledger.ignoredReason"] = claim.ignoredReason;
+  if (claim.sourceText) attrs["ledger.sourceText"] = claim.sourceText.slice(0, 5_000);
+  if (claim.resolution) {
+    attrs["ledger.verdict"] = claim.resolution.verdict;
+    attrs["ledger.actualConfidence"] = String(claim.resolution.actualConfidence);
+    attrs["ledger.resolvedAt"] = claim.resolution.resolvedAt;
+    if (claim.resolution.source) attrs["ledger.resolutionSource"] = claim.resolution.source;
+    if (claim.resolution.notes) attrs["ledger.resolutionNotes"] = claim.resolution.notes;
+    if (claim.resolution.brierScore !== undefined) attrs["ledger.brierScore"] = String(claim.resolution.brierScore);
+  }
+  return attrs;
+}
+
+export function claimTags(claim: LedgerClaim): string[] {
+  const tags = [LEDGER_TAG, `${LEDGER_TAG}:${claim.kind}`, `${LEDGER_TAG}:status:${claim.status}`];
+  if (claim.scope.domain) {
+    tags.push(`${LEDGER_TAG}:domain:${slugTagValue(claim.scope.domain)}`);
+  }
+  if (claim.deadline) tags.push(`${LEDGER_TAG}:deadline`);
+  return [...new Set(tags)];
+}
+
+export function serializeClaimBody(
+  claim: Pick<
+    LedgerClaim,
+    "statement" | "kind" | "stance" | "confidence" | "scope" | "deadline" | "evidenceLinks" | "status" | "resolution"
+  >
+): string {
+  const lines = [
+    "# Belief Ledger Claim",
+    "",
+    claim.statement,
+    "",
+    `Kind: ${claim.kind}`,
+    `Stance: ${claim.stance}`,
+    `Confidence: ${claim.confidence}`,
+    `Status: ${claim.status}`,
+  ];
+  if (claim.scope.domain) lines.push(`Domain: ${claim.scope.domain}`);
+  if (claim.scope.entities.length > 0) lines.push(`Entities: ${claim.scope.entities.join(", ")}`);
+  if (claim.deadline) lines.push(`Deadline: ${claim.deadline}`);
+  if (claim.resolution) {
+    lines.push(`Verdict: ${claim.resolution.verdict}`);
+    lines.push(`Actual confidence: ${claim.resolution.actualConfidence}`);
+    if (claim.resolution.brierScore !== undefined) {
+      lines.push(`Brier score: ${claim.resolution.brierScore}`);
+    }
+  }
+  if (claim.evidenceLinks.length > 0) {
+    lines.push("", "Evidence:");
+    for (const link of claim.evidenceLinks) {
+      lines.push(`- ${link}`);
+    }
+  }
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function claimFromMemory(memory: MemoryFile): LedgerClaim | null {
+  const attrs = normalizeStructuredAttributes(memory.frontmatter.structuredAttributes);
+  const tags = memory.frontmatter.tags ?? [];
+  if (!tags.includes(LEDGER_TAG) && attrs["ledger.schemaVersion"] !== LEDGER_SCHEMA_VERSION) {
+    return null;
+  }
+  if (isHiddenRemnicStatus(memory.frontmatter.status)) {
+    return null;
+  }
+
+  const storedStatus = normalizeStatus(attrs["ledger.status"] ?? "active");
+  if (memory.frontmatter.status === "archived" && storedStatus === "active") {
+    return null;
+  }
+
+  const statement = extractStatement(memory.content);
+  if (!statement) return null;
+
+  const entities = parseStringArrayAttribute("ledger.entities", attrs["ledger.entities"]);
+  const entityRef = memory.frontmatter.entityRef?.trim();
+  if (entityRef && !entities.includes(entityRef)) {
+    entities.unshift(entityRef);
+  }
+
+  const resolution = parseResolution(attrs);
+  const status = memory.frontmatter.status === "superseded" ? "superseded" : storedStatus;
+  const claim: LedgerClaim = {
+    id: memory.frontmatter.id,
+    memoryId: memory.frontmatter.id,
+    statement,
+    kind: normalizeKind(attrs["ledger.kind"] ?? "claim"),
+    stance: normalizeStance(attrs["ledger.stance"] ?? "uncertain"),
+    confidence: normalizeUnitInterval("confidence", attrs["ledger.confidence"] ?? memory.frontmatter.confidence),
+    scope: {
+      entities,
+      ...(attrs["ledger.domain"] ? { domain: attrs["ledger.domain"] } : {}),
+      ...parseTimeWindow(attrs),
+    },
+    ...(attrs["ledger.deadline"] ? { deadline: normalizeIsoTimestamp("deadline", attrs["ledger.deadline"]) } : {}),
+    evidenceLinks: parseStringArrayAttribute("ledger.evidenceLinks", attrs["ledger.evidenceLinks"]),
+    status,
+    createdAt: normalizeIsoTimestamp(
+      "createdAt",
+      attrs["ledger.createdAt"] ?? memory.frontmatter.valid_at ?? memory.frontmatter.created
+    ),
+    updatedAt: normalizeIsoTimestamp("updatedAt", attrs["ledger.updatedAt"] ?? memory.frontmatter.updated),
+    ...(memory.frontmatter.supersedes || attrs["ledger.supersedes"]
+      ? { supersedes: attrs["ledger.supersedes"] ?? memory.frontmatter.supersedes }
+      : {}),
+    ...(memory.frontmatter.supersededBy || attrs["ledger.supersededBy"]
+      ? { supersededBy: attrs["ledger.supersededBy"] ?? memory.frontmatter.supersededBy }
+      : {}),
+    parentIds: parseStringArrayAttribute("ledger.parentIds", attrs["ledger.parentIds"]).concat(
+      memory.frontmatter.lineage ?? []
+    ),
+    ...(attrs["ledger.snoozedUntil"]
+      ? { snoozedUntil: normalizeIsoTimestamp("snoozedUntil", attrs["ledger.snoozedUntil"]) }
+      : {}),
+    ...(attrs["ledger.ignoredAt"] ? { ignoredAt: normalizeIsoTimestamp("ignoredAt", attrs["ledger.ignoredAt"]) } : {}),
+    ...(attrs["ledger.ignoredReason"] ? { ignoredReason: attrs["ledger.ignoredReason"] } : {}),
+    ...(resolution ? { resolution } : {}),
+    ...(attrs["ledger.sourceText"] ? { sourceText: attrs["ledger.sourceText"] } : {}),
+    sourceMemory: memory,
+  };
+
+  claim.parentIds = [...new Set(claim.parentIds.filter((value) => value !== claim.id))];
+  return claim;
+}
+
+function isHiddenRemnicStatus(status: MemoryFrontmatter["status"] | undefined): boolean {
+  return status !== undefined && HIDDEN_REMNIC_STATUSES.has(status);
+}
+
+export function mergeClaimPatch(claim: LedgerClaim, patch: Partial<LedgerClaim>, now: string): LedgerClaim {
+  const updated: LedgerClaim = {
+    ...claim,
+    ...patch,
+    scope: patch.scope ? normalizeScope(patch.scope) : claim.scope,
+    evidenceLinks: patch.evidenceLinks
+      ? normalizeStringList("evidenceLinks", patch.evidenceLinks, 100, 2_048)
+      : claim.evidenceLinks,
+    parentIds: patch.parentIds ? normalizeStringList("parentIds", patch.parentIds, 100, 256) : claim.parentIds,
+    createdAt: normalizeIsoTimestamp("createdAt", patch.createdAt ?? claim.createdAt),
+    updatedAt: normalizeIsoTimestamp("updatedAt", patch.updatedAt ?? now),
+  };
+  updated.statement = cleanRequiredString("statement", updated.statement, 5_000);
+  updated.kind = normalizeKind(updated.kind);
+  updated.stance = normalizeStance(updated.stance);
+  updated.confidence = normalizeUnitInterval("confidence", updated.confidence);
+  updated.status = normalizeStatus(updated.status);
+  if (updated.resolution) updated.resolution = normalizeResolutionPatch(updated.resolution, updated.confidence);
+  if (updated.deadline) updated.deadline = normalizeIsoTimestamp("deadline", updated.deadline);
+  if (updated.snoozedUntil) updated.snoozedUntil = normalizeIsoTimestamp("snoozedUntil", updated.snoozedUntil);
+  if (updated.ignoredAt) updated.ignoredAt = normalizeIsoTimestamp("ignoredAt", updated.ignoredAt);
+  return updated;
+}
+
+function normalizeResolutionPatch(value: unknown, predictedConfidence: number): LedgerResolution {
+  if (!isRecord(value)) {
+    throw new Error("resolution must be an object");
+  }
+  if (value.source !== undefined && typeof value.source !== "string") {
+    throw new Error("resolution source must be a string");
+  }
+  if (value.notes !== undefined && typeof value.notes !== "string") {
+    throw new Error("resolution notes must be a string");
+  }
+  return createResolution({
+    verdict: value.verdict as LedgerPredictionVerdict,
+    actualConfidence: value.actualConfidence as number,
+    resolvedAt: value.resolvedAt as string,
+    source: value.source,
+    notes: value.notes,
+    predictedConfidence,
+  });
+}
+
+export function memoryFrontmatterPatchForClaim(claim: LedgerClaim): Partial<MemoryFrontmatter> {
+  return {
+    updated: claim.updatedAt,
+    confidence: claim.confidence,
+    tags: claimTags(claim),
+    entityRef: claim.scope.entities[0],
+    supersedes: claim.supersedes,
+    lineage: claim.parentIds.length > 0 ? claim.parentIds : undefined,
+    status: remnicMemoryStatusForClaim(claim),
+    supersededBy: claim.supersededBy,
+    supersededAt: claim.status === "superseded" ? claim.updatedAt : undefined,
+    structuredAttributes: claimToStructuredAttributes(claim),
+  };
+}
+
+export function remnicMemoryStatusForClaim(
+  claim: Pick<LedgerClaim, "status">
+): NonNullable<MemoryFrontmatter["status"]> {
+  switch (claim.status) {
+    case "active":
+      return "active";
+    case "superseded":
+      return "superseded";
+    case "ignored":
+    case "resolved":
+    case "snoozed":
+      return "archived";
+  }
+}
+
+export function normalizeIsoTimestamp(field: string, value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} must be a non-empty ISO timestamp string`);
+  }
+  const trimmed = value.trim();
+  validateIsoTimestampComponents(field, trimmed);
+  const time = Date.parse(trimmed);
+  if (!Number.isFinite(time)) {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(value)}`);
+  }
+  const date = new Date(time);
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error(`${field} must be within JavaScript Date bounds`);
+  }
+  return date.toISOString();
+}
+
+function validateIsoTimestampComponents(field: string, value: string): void {
+  if (value.length < 10 || value[4] !== "-" || value[7] !== "-") {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(value)}`);
+  }
+  const year = readFixedDigits(value, 0, 4);
+  const month = readFixedDigits(value, 5, 2);
+  const day = readFixedDigits(value, 8, 2);
+  if (year === undefined || month === undefined || day === undefined) {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(value)}`);
+  }
+
+  if (value.length === 10) {
+    assertValidCalendarParts(field, value, year, month, day, 0, 0, 0, 0);
+    return;
+  }
+
+  const separator = value[10];
+  if (separator !== "T" && separator !== "t" && separator !== " ") {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(value)}`);
+  }
+
+  const timeText = stripAndValidateTimeZone(field, value, value.slice(11));
+  const timeParts = parseIsoTimeParts(field, value, timeText);
+  assertValidCalendarParts(
+    field,
+    value,
+    year,
+    month,
+    day,
+    timeParts.hour,
+    timeParts.minute,
+    timeParts.second,
+    timeParts.millisecond
+  );
+}
+
+function stripAndValidateTimeZone(field: string, original: string, rawTime: string): string {
+  if (!rawTime) {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+  }
+  const lastChar = rawTime[rawTime.length - 1];
+  if (lastChar === "Z" || lastChar === "z") {
+    return rawTime.slice(0, -1);
+  }
+
+  const offsetStart = rawTime.length - 6;
+  const sign = offsetStart > 0 ? rawTime[offsetStart] : undefined;
+  if ((sign === "+" || sign === "-") && rawTime[offsetStart + 3] === ":") {
+    const offsetHour = readFixedDigits(rawTime, offsetStart + 1, 2);
+    const offsetMinute = readFixedDigits(rawTime, offsetStart + 4, 2);
+    if (offsetHour === undefined || offsetMinute === undefined || offsetHour > 23 || offsetMinute > 59) {
+      throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+    }
+    return rawTime.slice(0, offsetStart);
+  }
+
+  throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+}
+
+function parseIsoTimeParts(
+  field: string,
+  original: string,
+  value: string
+): { hour: number; minute: number; second: number; millisecond: number } {
+  if (value.length < 5 || value[2] !== ":") {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+  }
+  const hour = readFixedDigits(value, 0, 2);
+  const minute = readFixedDigits(value, 3, 2);
+  if (hour === undefined || minute === undefined || hour > 23 || minute > 59) {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+  }
+  if (value.length === 5) {
+    return { hour, minute, second: 0, millisecond: 0 };
+  }
+  if (value[5] !== ":") {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+  }
+  const second = readFixedDigits(value, 6, 2);
+  if (second === undefined || second > 59) {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+  }
+  if (value.length === 8) {
+    return { hour, minute, second, millisecond: 0 };
+  }
+  if (value[8] !== ".") {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+  }
+  const fraction = value.slice(9);
+  if (fraction.length === 0 || fraction.length > 3 || !isAllDigits(fraction)) {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+  }
+  return {
+    hour,
+    minute,
+    second,
+    millisecond: Number(fraction.padEnd(3, "0")),
+  };
+}
+
+function assertValidCalendarParts(
+  field: string,
+  original: string,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number
+): void {
+  const time = Date.UTC(year, month - 1, day, hour, minute, second, millisecond);
+  const date = new Date(time);
+  if (
+    !Number.isFinite(time) ||
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day ||
+    date.getUTCHours() !== hour ||
+    date.getUTCMinutes() !== minute ||
+    date.getUTCSeconds() !== second ||
+    date.getUTCMilliseconds() !== millisecond
+  ) {
+    throw new Error(`${field} must be a valid ISO timestamp, got ${JSON.stringify(original)}`);
+  }
+}
+
+function readFixedDigits(value: string, start: number, length: number): number | undefined {
+  const end = start + length;
+  if (end > value.length) return undefined;
+  const slice = value.slice(start, end);
+  return isAllDigits(slice) ? Number(slice) : undefined;
+}
+
+function isAllDigits(value: string): boolean {
+  if (!value) return false;
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code < 48 || code > 57) return false;
+  }
+  return true;
+}
+
+export function normalizeUnitInterval(field: string, value: unknown): number {
+  const num =
+    typeof value === "number" ? value : typeof value === "string" && value.trim() !== "" ? Number(value) : NaN;
+  if (!Number.isFinite(num)) {
+    throw new Error(`${field} must be a finite number in [0, 1], got ${String(value)}`);
+  }
+  if (num < 0 || num > 1) {
+    throw new Error(`${field} must be in [0, 1], got ${num}`);
+  }
+  return num;
+}
+
+function normalizeScope(value: Partial<LedgerClaimScope> | undefined): LedgerClaimScope {
+  const scope = value ?? {};
+  const entities = normalizeStringList("entities", scope.entities ?? [], 50, 256);
+  const domain =
+    typeof scope.domain === "string" && scope.domain.trim().length > 0 ? scope.domain.trim().slice(0, 256) : undefined;
+  const timeWindow = scope.timeWindow ? normalizeTimeWindow(scope.timeWindow) : undefined;
+  return {
+    entities,
+    ...(domain ? { domain } : {}),
+    ...(timeWindow ? { timeWindow } : {}),
+  };
+}
+
+function normalizeTimeWindow(value: { start?: unknown; end?: unknown }): { start?: string; end?: string } | undefined {
+  const start = value.start === undefined ? undefined : normalizeIsoTimestamp("timeWindow.start", value.start);
+  const end = value.end === undefined ? undefined : normalizeIsoTimestamp("timeWindow.end", value.end);
+  if (start && end && Date.parse(start) >= Date.parse(end)) {
+    throw new Error("timeWindow.start must be before timeWindow.end");
+  }
+  return start || end ? { ...(start ? { start } : {}), ...(end ? { end } : {}) } : undefined;
+}
+
+function parseTimeWindow(attrs: StringRecord): { timeWindow?: { start?: string; end?: string } } {
+  const start = attrs["ledger.timeWindowStart"];
+  const end = attrs["ledger.timeWindowEnd"];
+  const timeWindow = normalizeTimeWindow({ start, end });
+  return timeWindow ? { timeWindow } : {};
+}
+
+function normalizeKind(value: unknown): LedgerClaimKind {
+  if (typeof value !== "string" || !KIND_VALUES.has(value as LedgerClaimKind)) {
+    throw new Error(`kind must be one of ${[...KIND_VALUES].join(", ")}`);
+  }
+  return value as LedgerClaimKind;
+}
+
+function normalizeStance(value: unknown): LedgerStance {
+  if (typeof value !== "string" || !STANCE_VALUES.has(value as LedgerStance)) {
+    throw new Error(`stance must be one of ${[...STANCE_VALUES].join(", ")}`);
+  }
+  return value as LedgerStance;
+}
+
+function normalizeStatus(value: unknown): LedgerClaimStatus {
+  if (typeof value !== "string" || !STATUS_VALUES.has(value as LedgerClaimStatus)) {
+    throw new Error(`status must be one of ${[...STATUS_VALUES].join(", ")}`);
+  }
+  return value as LedgerClaimStatus;
+}
+
+function normalizeJudgeClassification(value: unknown): LedgerJudgeClassification {
+  if (typeof value !== "string" || !JUDGE_VALUES.has(value as LedgerJudgeClassification)) {
+    throw new Error(`classification must be one of ${[...JUDGE_VALUES].join(", ")}`);
+  }
+  return value as LedgerJudgeClassification;
+}
+
+function normalizePredictionVerdict(value: unknown): LedgerPredictionVerdict {
+  if (typeof value !== "string" || !VERDICT_VALUES.has(value as LedgerPredictionVerdict)) {
+    throw new Error(`verdict must be one of ${[...VERDICT_VALUES].join(", ")}`);
+  }
+  return value as LedgerPredictionVerdict;
+}
+
+function parseResolution(attrs: StringRecord): LedgerResolution | undefined {
+  if (!attrs["ledger.verdict"]) return undefined;
+  const actualConfidence = normalizeUnitInterval("actualConfidence", attrs["ledger.actualConfidence"]);
+  const verdict = normalizePredictionVerdict(attrs["ledger.verdict"]);
+  const resolvedAt = normalizeIsoTimestamp("resolvedAt", attrs["ledger.resolvedAt"]);
+  return {
+    verdict,
+    actualConfidence,
+    resolvedAt,
+    ...(attrs["ledger.resolutionSource"] ? { source: attrs["ledger.resolutionSource"] } : {}),
+    ...(attrs["ledger.resolutionNotes"] ? { notes: attrs["ledger.resolutionNotes"] } : {}),
+    ...(attrs["ledger.brierScore"] !== undefined
+      ? { brierScore: roundMetric(Number(attrs["ledger.brierScore"])) }
+      : {}),
+  };
+}
+
+function normalizeStructuredAttributes(value: unknown): StringRecord {
+  if (!isRecord(value)) return {};
+  const result: StringRecord = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string") {
+      result[key] = raw;
+    } else if (typeof raw === "number" || typeof raw === "boolean") {
+      result[key] = String(raw);
+    }
+  }
+  return result;
+}
+
+function parseStringArrayAttribute(field: string, value: string | undefined): string[] {
+  if (value === undefined || value.trim() === "") return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`${field} must be a JSON array`);
+  }
+  return normalizeStringList(field, parsed, 100, 2_048);
+}
+
+function normalizeStringList(field: string, value: unknown, maxItems: number, maxLength: number): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${field} must be an array`);
+  }
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== "string") {
+      throw new Error(`${field} entries must be strings`);
+    }
+    const trimmed = item.trim();
+    if (!trimmed) continue;
+    const clipped = trimmed.slice(0, maxLength);
+    if (seen.has(clipped)) continue;
+    seen.add(clipped);
+    result.push(clipped);
+    if (result.length > maxItems) {
+      throw new Error(`${field} must contain at most ${maxItems} entries`);
+    }
+  }
+  return result;
+}
+
+function cleanRequiredString(field: string, value: unknown, maxLength: number): string {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field} must not be empty`);
+  }
+  if (trimmed.length > maxLength) {
+    throw new Error(`${field} must be at most ${maxLength} characters`);
+  }
+  return trimmed;
+}
+
+function extractStatement(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n").trim();
+  const lines = normalized.split("\n");
+  const titleIndex = lines.findIndex((line) => line.trim() === "# Belief Ledger Claim");
+  if (titleIndex >= 0) {
+    const statementLines: string[] = [];
+    let started = false;
+    for (let i = titleIndex + 1; i < lines.length; i += 1) {
+      const line = lines[i] ?? "";
+      const trimmed = line.trim();
+      if (!started && !trimmed) continue;
+      if (isClaimMetadataLine(trimmed)) {
+        break;
+      }
+      started = true;
+      statementLines.push(line.trimEnd());
+    }
+    const statement = statementLines.join("\n").trim();
+    if (statement) {
+      return statement;
+    }
+  }
+  const first = lines.find((line) => line.trim() && !line.trim().startsWith("#"));
+  return first?.trim() ?? "";
+}
+
+function isClaimMetadataLine(line: string): boolean {
+  return CLAIM_METADATA_PREFIXES.some((prefix) => line.startsWith(prefix));
+}
+
+const CLAIM_METADATA_PREFIXES = [
+  "Kind:",
+  "Stance:",
+  "Confidence:",
+  "Status:",
+  "Domain:",
+  "Entities:",
+  "Deadline:",
+  "Verdict:",
+  "Actual confidence:",
+  "Brier score:",
+];
+
+function slugTagValue(value: string): string {
+  let slug = "";
+  let pendingDash = false;
+  for (const char of value.toLowerCase()) {
+    const code = char.charCodeAt(0);
+    const isAsciiLetter = code >= 97 && code <= 122;
+    const isDigit = code >= 48 && code <= 57;
+    if (isAsciiLetter || isDigit) {
+      if (pendingDash && slug) slug += "-";
+      slug += char;
+      pendingDash = false;
+    } else if (slug) {
+      pendingDash = true;
+    }
+  }
+  return slug || "unknown";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/belief-ledger/src/types.ts
+++ b/packages/belief-ledger/src/types.ts
@@ -1,0 +1,248 @@
+import type { MemoryFile } from "@remnic/core";
+
+export type LedgerClaimKind = "claim" | "prediction" | "opinion";
+export type LedgerStance = "for" | "against" | "uncertain" | "neutral";
+export type LedgerClaimStatus =
+  | "active"
+  | "superseded"
+  | "resolved"
+  | "snoozed"
+  | "ignored";
+export type LedgerJudgeClassification =
+  | "contradiction"
+  | "evolution"
+  | "refinement"
+  | "unrelated";
+export type LedgerPredictionVerdict = "true" | "false" | "mixed" | "unknown";
+
+export interface LedgerTimeWindow {
+  start?: string;
+  end?: string;
+}
+
+export interface LedgerClaimScope {
+  entities: string[];
+  domain?: string;
+  timeWindow?: LedgerTimeWindow;
+}
+
+export interface LedgerResolution {
+  verdict: LedgerPredictionVerdict;
+  actualConfidence: number;
+  resolvedAt: string;
+  source?: string;
+  notes?: string;
+  brierScore?: number;
+}
+
+export interface LedgerClaim {
+  id: string;
+  memoryId: string;
+  statement: string;
+  kind: LedgerClaimKind;
+  stance: LedgerStance;
+  confidence: number;
+  scope: LedgerClaimScope;
+  deadline?: string;
+  evidenceLinks: string[];
+  status: LedgerClaimStatus;
+  createdAt: string;
+  updatedAt: string;
+  supersedes?: string;
+  supersededBy?: string;
+  parentIds: string[];
+  snoozedUntil?: string;
+  ignoredAt?: string;
+  ignoredReason?: string;
+  resolution?: LedgerResolution;
+  sourceText?: string;
+  sourceMemory?: MemoryFile;
+}
+
+export interface LedgerClaimDraft {
+  statement: string;
+  kind?: LedgerClaimKind;
+  stance: LedgerStance;
+  confidence: number;
+  scope?: Partial<LedgerClaimScope>;
+  deadline?: string;
+  evidenceLinks?: string[];
+}
+
+export interface LedgerCaptureInput {
+  text: string;
+  now?: string;
+  source?: string;
+  sessionKey?: string;
+}
+
+export interface LedgerExtractionRequest extends LedgerCaptureInput {
+  now: string;
+}
+
+export interface LedgerJudgeRequest {
+  current: LedgerClaim;
+  prior: LedgerClaim;
+}
+
+export interface LedgerJudgeResult {
+  priorClaimId: string;
+  classification: LedgerJudgeClassification;
+  confidence: number;
+  rationale: string;
+}
+
+export interface LedgerChallengeRequest {
+  current: LedgerClaim;
+  contradictions: Array<{
+    claim: LedgerClaim;
+    judgment: LedgerJudgeResult;
+  }>;
+}
+
+export interface LedgerChallenge {
+  question: string;
+  priorClaimIds: string[];
+  suggestedActions: Array<"supersede" | "split" | "resolve" | "ignore">;
+}
+
+export interface LedgerPredictionGradeRequest {
+  claim: LedgerClaim;
+  verdictSource?: string;
+  now: string;
+}
+
+export interface LedgerPredictionGrade {
+  verdict: LedgerPredictionVerdict;
+  actualConfidence: number;
+  rationale: string;
+  source?: string;
+}
+
+export interface LedgerLlmAdapter {
+  extractClaim(request: LedgerExtractionRequest): Promise<LedgerClaimDraft>;
+  judgeClaimPair(request: LedgerJudgeRequest): Promise<LedgerJudgeResult>;
+  draftSocraticChallenge(request: LedgerChallengeRequest): Promise<LedgerChallenge>;
+  gradePrediction?(request: LedgerPredictionGradeRequest): Promise<LedgerPredictionGrade | null>;
+}
+
+export interface LedgerRetrievalCandidate {
+  claim: LedgerClaim;
+  score: number;
+  reasons: string[];
+}
+
+export interface LedgerSemanticRetrievalAdapter {
+  scoreClaims(request: {
+    query: LedgerClaim;
+    candidates: LedgerClaim[];
+    limit: number;
+  }): Promise<Array<{ claimId: string; score: number }>>;
+}
+
+export interface LedgerRerankerAdapter {
+  rerank(request: {
+    query: LedgerClaim;
+    candidates: LedgerRetrievalCandidate[];
+    limit: number;
+  }): Promise<LedgerRetrievalCandidate[]>;
+}
+
+export interface LedgerRetrievalOptions {
+  limit?: number;
+  includeStatuses?: LedgerClaimStatus[];
+  now?: string;
+  semantic?: LedgerSemanticRetrievalAdapter;
+  reranker?: LedgerRerankerAdapter;
+}
+
+export interface LedgerCrossExaminationStats {
+  candidatesConsidered: number;
+  judged: number;
+  contradictions: number;
+  unrelated: number;
+  observableFalsePositiveRate: number;
+}
+
+export interface LedgerCrossExaminationResult {
+  claim: LedgerClaim;
+  candidates: LedgerRetrievalCandidate[];
+  judgments: LedgerJudgeResult[];
+  challenge?: LedgerChallenge;
+  stats: LedgerCrossExaminationStats;
+}
+
+export interface LedgerCaptureResult extends LedgerCrossExaminationResult {
+  claim: LedgerClaim;
+}
+
+export interface LedgerStore {
+  createClaim(input: Omit<LedgerClaim, "id" | "memoryId" | "sourceMemory">): Promise<LedgerClaim>;
+  getClaim(id: string): Promise<LedgerClaim | null>;
+  listClaims(filter?: { statuses?: LedgerClaimStatus[]; kinds?: LedgerClaimKind[] }): Promise<LedgerClaim[]>;
+  updateClaim(id: string, patch: Partial<LedgerClaim>): Promise<LedgerClaim>;
+  supersedeClaim(priorId: string, newId: string, reason: string): Promise<boolean>;
+}
+
+export interface LedgerScoreDuePredictionsOptions {
+  now?: string;
+  verdictSources?: Record<string, string>;
+  limit?: number;
+}
+
+export interface LedgerPredictionScoreResult {
+  claim: LedgerClaim;
+  status: "resolved" | "needs_user_verdict" | "skipped";
+  resolution?: LedgerResolution;
+  prompt?: string;
+  reason?: string;
+}
+
+export interface LedgerReflectionOptions {
+  now?: string;
+  dormantAfterDays?: number;
+}
+
+export interface LedgerCalibrationBin {
+  minConfidence: number;
+  maxConfidence: number;
+  count: number;
+  meanPredictedConfidence: number;
+  meanActualConfidence: number;
+  calibrationError: number;
+}
+
+export interface LedgerDomainCalibration {
+  domain: string;
+  count: number;
+  brierScore: number;
+  meanPredictedConfidence: number;
+  meanActualConfidence: number;
+  tendency: "overconfident" | "underconfident" | "well_calibrated";
+}
+
+export interface LedgerFlippedClaim {
+  rootClaimId: string;
+  claimIds: string[];
+  statements: string[];
+  flipCount: number;
+}
+
+export interface LedgerDormantTopic {
+  topic: string;
+  lastClaimAt: string;
+  daysSilent: number;
+  claimCount: number;
+}
+
+export interface LedgerReflectionReport {
+  generatedAt: string;
+  totalClaims: number;
+  activeClaims: number;
+  resolvedPredictions: number;
+  brierScore?: number;
+  calibrationBins: LedgerCalibrationBin[];
+  domains: LedgerDomainCalibration[];
+  flippedClaims: LedgerFlippedClaim[];
+  dormantTopics: LedgerDormantTopic[];
+}

--- a/packages/belief-ledger/tsconfig.json
+++ b/packages/belief-ledger/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-core/src/entity-retrieval.ts
+++ b/packages/remnic-core/src/entity-retrieval.ts
@@ -12,6 +12,8 @@ const RECENT_TRANSCRIPT_LOOKBACK_HOURS = 24;
 const INSTRUCTION_LIKE_RE = /\b(always|never|must|should|remember to|do not|don't|process|workflow|template|checklist|instruction)\b/i;
 const METADATA_WRAPPER_RE = /^(source|context|metadata|notes?):/i;
 const ENTITY_PRONOUN_RE = /\b(he|him|his|she|her|they|them|their|it|its)\b/i;
+const BELIEF_LEDGER_SECTION_KEY = "belief_ledger";
+const BELIEF_LEDGER_FACT_RE = /^claim=([^;]+);\s*status=([^;]+);\s*updatedAt=([^;]+);\s*(.+)$/;
 
 type EntityQueryMode = "direct" | "timeline" | "follow_up";
 
@@ -106,6 +108,59 @@ function dedupeHintSnippetsByText(snippets: EntityHintSnippet[]): EntityHintSnip
     if (seen.has(key)) continue;
     seen.add(key);
     result.push(snippet);
+  }
+  return result;
+}
+
+function isBeliefLedgerSection(section: Pick<EntityStructuredSection, "key">): boolean {
+  return normalizeEntityText(section.key).replace(/\s+/g, "_") === BELIEF_LEDGER_SECTION_KEY;
+}
+
+function beliefLedgerFactKeys(sections: EntityStructuredSection[]): Set<string> {
+  const keys = new Set<string>();
+  for (const section of sections) {
+    if (!isBeliefLedgerSection(section)) continue;
+    for (const fact of section.facts) {
+      keys.add(normalizeEntityText(fact));
+    }
+  }
+  return keys;
+}
+
+function recallFactsForStructuredSection(section: EntityStructuredSection): string[] {
+  if (!isBeliefLedgerSection(section)) return section.facts;
+  return currentActiveBeliefLedgerFactTexts(section.facts);
+}
+
+function currentActiveBeliefLedgerFactTexts(facts: string[]): string[] {
+  const byClaim = new Map<string, { status: string; updatedAtMs: number; texts: string[] }>();
+  for (const fact of facts) {
+    const match = BELIEF_LEDGER_FACT_RE.exec(fact.trim());
+    if (!match) continue;
+    const [, claimId, status, updatedAt, text] = match;
+    const updatedAtMs = Date.parse(updatedAt);
+    if (!claimId?.trim() || !status?.trim() || !Number.isFinite(updatedAtMs) || !text?.trim()) continue;
+    const normalizedStatus = status.trim().toLowerCase();
+    const normalizedClaimId = claimId.trim();
+    const current = byClaim.get(normalizedClaimId);
+    const inactiveTieWins =
+      current &&
+      updatedAtMs === current.updatedAtMs &&
+      current.status === "active" &&
+      normalizedStatus !== "active";
+    if (!current || updatedAtMs > current.updatedAtMs || inactiveTieWins) {
+      byClaim.set(normalizedClaimId, { status: normalizedStatus, updatedAtMs, texts: [text.trim()] });
+      continue;
+    }
+    if (updatedAtMs === current.updatedAtMs && current.status === normalizedStatus) {
+      current.texts.push(text.trim());
+    }
+  }
+  const result: string[] = [];
+  for (const current of byClaim.values()) {
+    if (current.status === "active") {
+      result.push(...current.texts);
+    }
   }
   return result;
 }
@@ -408,7 +463,13 @@ async function buildEntityMentionIndex(
   const entities = new Map<string, EntityMentionIndexEntry>();
   for (const entity of entityFiles) {
     const canonicalId = normalizeEntityName(entity.name, entity.type);
-    const sanitizedFacts = entity.facts.map((fact) => sanitizeEntityFact(fact)).filter(Boolean).map((fact) => compactLine(fact, 180));
+    const rawStructuredSections = entity.structuredSections ?? [];
+    const rawBeliefLedgerFactKeys = beliefLedgerFactKeys(rawStructuredSections);
+    const sanitizedFacts = entity.facts
+      .map((fact) => sanitizeEntityFact(fact))
+      .filter(Boolean)
+      .filter((fact) => !rawBeliefLedgerFactKeys.has(normalizeEntityText(fact)))
+      .map((fact) => compactLine(fact, 180));
     const sanitizedTimelineFacts = entity.timeline
       .map((entry) => sanitizeEntityFact(entry.text))
       .filter(Boolean)
@@ -421,10 +482,10 @@ async function buildEntityMentionIndex(
       summary: entity.synthesis?.trim() || entity.summary?.trim() || undefined,
       facts: sanitizedFacts,
       timelineFacts: uniqueStrings(sanitizedTimelineFacts),
-      structuredSections: (entity.structuredSections ?? []).map((section) => ({
+      structuredSections: rawStructuredSections.map((section) => ({
         key: section.key,
         title: section.title,
-        facts: section.facts
+        facts: recallFactsForStructuredSection(section)
           .map((fact) => sanitizeEntityFact(fact))
           .filter(Boolean)
           .map((fact) => compactLine(fact, 180)),

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3226,6 +3226,35 @@ export class StorageManager {
     return ContentHashIndex.computeHash(sanitizeMemoryContent(hashSource).text);
   }
 
+  private async addActiveFactContentHash(memory: MemoryFile): Promise<void> {
+    if (memory.frontmatter.category !== "fact") return;
+    if (inferMemoryStatus(memory.frontmatter, memory.path) !== "active") return;
+    const hash = this.factContentHashForRemoval(memory);
+    if (!hash) return;
+
+    await this.ensureFactHashIndexAuthoritative();
+    const factHashIndex = await this.getFactHashIndex();
+    factHashIndex.addByHash(hash);
+    await factHashIndex.save();
+  }
+
+  private async syncFactHashIndexAfterRewrite(before: MemoryFile, after: MemoryFile): Promise<void> {
+    if (before.frontmatter.category !== "fact" && after.frontmatter.category !== "fact") return;
+
+    const beforeHash = this.factContentHashForRemoval(before);
+    const afterHash = this.factContentHashForRemoval(after);
+    const beforeStatus = inferMemoryStatus(before.frontmatter, before.path);
+    const afterStatus = inferMemoryStatus(after.frontmatter, after.path);
+    if (beforeHash === afterHash && beforeStatus === afterStatus) return;
+
+    if (beforeStatus === "active" && beforeHash && (beforeHash !== afterHash || afterStatus !== "active")) {
+      await this.removeFactContentHashesForMemories([before]);
+    }
+    if (afterStatus === "active" && afterHash && (beforeHash !== afterHash || beforeStatus !== "active")) {
+      await this.addActiveFactContentHash(after);
+    }
+  }
+
   async removeFactContentHashesForMemories(memories: MemoryFile[]): Promise<void> {
     await this.ensureFactHashIndexAuthoritative();
     const factHashIndex = await this.getFactHashIndex();
@@ -4491,6 +4520,17 @@ export class StorageManager {
     // call (Finding UvUy fix).
     if (memory.path.includes(`${path.sep}cold${path.sep}`)) {
       this.invalidateColdMemoriesCache();
+    }
+    try {
+      await this.syncFactHashIndexAfterRewrite(
+        memory,
+        {
+          ...memory,
+          frontmatter: updated,
+        },
+      );
+    } catch (err) {
+      log.warn(`storage.writeMemoryFrontmatter completed but failed to update fact hash index: ${err}`);
     }
     await this.appendGeneratedMemoryLifecycleEventFailOpen(
       "storage.writeMemoryFrontmatter",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,21 @@ importers:
         specifier: ^0.26.2
         version: 0.26.2
 
+  packages/belief-ledger:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/bench:
     dependencies:
       '@remnic/core':

--- a/tests/entity-retrieval.test.ts
+++ b/tests/entity-retrieval.test.ts
@@ -839,6 +839,34 @@ test("entity retrieval can surface relevant structured section facts for mixed e
   assert.match(section!, /Alice Example prefers small teams owning whole systems\./);
 });
 
+test("entity retrieval suppresses inactive belief-ledger facts by latest claim status", async () => {
+  const { config, storage } = await buildHarness("engram-entity-belief-ledger-status-filter");
+  await storage.writeEntity("Memory Tools", "topic", [], {
+    structuredSections: [
+      {
+        key: "belief-ledger",
+        title: "Belief Ledger",
+        facts: [
+          "claim=claim-1; status=active; updatedAt=2026-06-01T00:00:00.000Z; claim: Memory Tools will ship the local ledger.",
+          "claim=claim-1; status=ignored; updatedAt=2026-06-02T00:00:00.000Z; claim: Memory Tools will ship the local ledger.",
+          "claim=claim-2; status=active; updatedAt=2026-06-03T00:00:00.000Z; claim: Memory Tools preserve current beliefs.",
+          "claim=claim-3; status=ignored; updatedAt=2026-06-03T00:00:00.000Z; claim: Memory Tools use stale conflict notes.",
+          "claim=claim-3; status=active; updatedAt=2026-06-03T00:00:00.000Z; claim: Memory Tools use stale conflict notes.",
+        ],
+      },
+    ],
+  });
+
+  const section = await buildSection(config, storage, "What do we know about Memory Tools?");
+
+  assert.ok(section);
+  assert.match(section!, /Memory Tools preserve current beliefs\./);
+  assert.doesNotMatch(section!, /local ledger/);
+  assert.doesNotMatch(section!, /stale conflict notes/);
+  assert.doesNotMatch(section!, /claim=claim-2/);
+  assert.doesNotMatch(section!, /status=active/);
+});
+
 test("entity retrieval does not prefer fallback structured section facts over timeline evidence when a summary exists", async () => {
   const { config, storage } = await buildHarness("engram-entity-direct-structured-fallback-summary");
   await storage.writeEntity("Alice Example", "person", [], {

--- a/tests/post-tool-observe-state.test.mjs
+++ b/tests/post-tool-observe-state.test.mjs
@@ -37,6 +37,10 @@ async function makeFixture() {
   return { root, home, stateHome, transcript };
 }
 
+async function removeFixture(fixture) {
+  await rm(fixture.root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
 function runHook(hookCase, fixture, sessionId) {
   return spawnSync("bash", [hookCase.scriptPath], {
     cwd: process.cwd(),
@@ -94,7 +98,7 @@ for (const hookCase of hookCases) {
       assert.equal(existsSync(path.join(os.tmpdir(), `remnic-cursor-${sessionId}`)), false);
       assert.equal(existsSync(path.join(os.tmpdir(), `engram-cursor-${sessionId}`)), false);
     } finally {
-      await rm(fixture.root, { recursive: true, force: true });
+      await removeFixture(fixture);
       await rm(path.join(os.tmpdir(), `remnic-cursor-${sessionId}`), { force: true });
       await rm(path.join(os.tmpdir(), `engram-cursor-${sessionId}`), { force: true });
     }
@@ -124,7 +128,7 @@ for (const hookCase of hookCases) {
 
       assert.equal(await readFile(symlinkTarget, "utf8"), "unchanged\n");
     } finally {
-      await rm(fixture.root, { recursive: true, force: true });
+      await removeFixture(fixture);
     }
   });
 
@@ -152,7 +156,7 @@ for (const hookCase of hookCases) {
 
       assert.equal(existsSync(remnicCursorPath), false);
     } finally {
-      await rm(fixture.root, { recursive: true, force: true });
+      await removeFixture(fixture);
     }
   });
 
@@ -183,7 +187,7 @@ for (const hookCase of hookCases) {
       assert.equal(await readFile(cursorPath, "utf8"), "1\n");
       assert.equal(existsSync(tmpCursorPath), false);
     } finally {
-      await rm(fixture.root, { recursive: true, force: true });
+      await removeFixture(fixture);
       await rm(tmpCursorPath, { force: true });
     }
   });
@@ -219,7 +223,7 @@ for (const hookCase of hookCases) {
       assert.equal(existsSync(remnicTmpCursorPath), false);
       assert.equal(existsSync(engramTmpCursorPath), false);
     } finally {
-      await rm(fixture.root, { recursive: true, force: true });
+      await removeFixture(fixture);
       await rm(remnicTmpCursorPath, { force: true });
       await rm(engramTmpCursorPath, { force: true });
     }
@@ -245,7 +249,7 @@ for (const hookCase of hookCases) {
 
       assert.equal(await readFile(cursorPath, "utf8"), "0\n");
     } finally {
-      await rm(fixture.root, { recursive: true, force: true });
+      await removeFixture(fixture);
     }
   });
 }
@@ -282,7 +286,7 @@ test("codex package session-end skips final flush when cursor is unsafe", async 
     assert.doesNotMatch(logContent, /final flush for /);
     assert.equal(await readFile(symlinkTarget, "utf8"), "unchanged\n");
   } finally {
-    await rm(fixture.root, { recursive: true, force: true });
+    await removeFixture(fixture);
   }
 });
 
@@ -312,7 +316,7 @@ test("codex package session-end migrates tmp cursor before final flush", async (
       assert.doesNotMatch(await readFile(logPath, "utf8"), /final flush for /);
     }
   } finally {
-    await rm(fixture.root, { recursive: true, force: true });
+    await removeFixture(fixture);
     await rm(remnicTmpCursorPath, { force: true });
     await rm(engramTmpCursorPath, { force: true });
   }

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -21,6 +21,7 @@ const expectedPublishDirs = [
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/hermes-provider",
+  "packages/belief-ledger",
   "packages/remnic-server",
   "packages/plugin-pi",
   "packages/remnic-cli",
@@ -29,7 +30,6 @@ const expectedPublishDirs = [
   "packages/plugin-codex",
   "packages/shim-openclaw-engram",
 ] as const;
-
 test("release workflow publish order matches the supported npm install surfaces", async () => {
   const workflow = await readFile(".github/workflows/release-and-publish.yml", "utf8");
   const order = spawnSync(process.execPath, ["scripts/publish-order.mjs", "--json"], {

--- a/tests/storage-fact-hash-index.test.ts
+++ b/tests/storage-fact-hash-index.test.ts
@@ -76,6 +76,37 @@ test("hasFactContentHash normalizes unsafe input to the persisted sanitized body
   }
 });
 
+test("writeMemoryFrontmatter fail-opens when fact hash index sync fails after rewriting", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-fact-hash-frontmatter-failopen-"));
+  const originalSave = ContentHashIndex.prototype.save;
+  try {
+    const storage = new StorageManager(dir);
+    const id = await storage.writeMemory("fact", "Fact hash rewrite failure should not abort persistence.", {
+      source: "test",
+    });
+    const memory = await storage.getMemoryById(id);
+    assert.ok(memory, "expected written fact memory");
+
+    ContentHashIndex.prototype.save = async function failSave() {
+      throw new Error("hash index unavailable");
+    };
+
+    const updated = await storage.writeMemoryFrontmatter(memory, {
+      status: "superseded",
+      supersededBy: "replacement-id",
+      supersededAt: "2026-06-03T12:00:00.000Z",
+    });
+
+    const persisted = await readFile(memory.path, "utf-8");
+    assert.equal(updated, true);
+    assert.match(persisted, /^status: superseded$/m);
+    assert.match(persisted, /^supersededBy: replacement-id$/m);
+  } finally {
+    ContentHashIndex.prototype.save = originalSave;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Rebuild-from-frontmatter tests (issue #369 round 10 — Uhol fix)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add @remnic/belief-ledger as an in-monorepo library for issue #869
- implement claim/prediction capture, contradiction cross-examination, Socratic challenge generation, prediction grading, and calibration reflection
- store ledger claims through public Remnic storage primitives and expose host-neutral LLM adapters over Remnic FallbackLlmClient instead of direct OpenAI API usage

Closes #869

## Verification
- pnpm --filter @remnic/belief-ledger check-types
- pnpm --filter @remnic/belief-ledger test
- pnpm --filter @remnic/belief-ledger build
- npm run preflight:quick

Note: the OpenClaw SDK surface check skipped because the openclaw peer package is not installed locally; its skip-path test passed inside preflight.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New persistence and LLM-judgment flows touch memory storage and dedup indexes, though scoped to a new package with extensive tests and fail-open hash sync.
> 
> **Overview**
> Introduces **`@remnic/belief-ledger`**, a host-neutral library for capturing beliefs/predictions as Remnic facts, cross-examining them against prior claims via an injectable **`LedgerLlmAdapter`**, and supporting lifecycle actions (supersede, split, resolve, snooze, ignore) plus due-prediction scoring and calibration **`reflect`** reports. Persistence goes through **`RemnicLedgerStore`** on public **`StorageManager`** APIs (structured attributes, tags, entity links, cold-tier reads, supersession rollback).
> 
> **`@remnic/core`** gains entity-recall filtering so only **active** belief-ledger entity facts surface, and **`writeMemoryFrontmatter`** now keeps the **fact content-hash index** in sync on rewrites (fail-open on index errors). Release wiring adds the package to publish order; minor test/hygiene tweaks elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e1ee4b4a3e306e6e829a0391dcddd5c3ffefb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->