### PR TITLE
Export QMD recall cache shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,6 +393,12 @@
     "./qmd.js": {
       "import": "./dist/qmd.js"
     },
+    "./qmd-recall-cache": {
+      "import": "./dist/qmd-recall-cache.js"
+    },
+    "./qmd-recall-cache.js": {
+      "import": "./dist/qmd-recall-cache.js"
+    },
     "./reconstruct": {
       "import": "./dist/reconstruct.js"
     },

--- a/scripts/check-release-artifacts.mjs
+++ b/scripts/check-release-artifacts.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { access, readdir, readFile } from "node:fs/promises";
+import { access, readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -40,9 +40,7 @@ for (const target of Object.values(rootPackageJson.exports ?? {})) {
 }
 requiredFiles.push(...[...exportedDistFiles].sort());
 
-const transferShims = (
-  await readdir(path.join(repoRoot, "src", "transfer"), { withFileTypes: true })
-)
+const transferShims = (await readdir(path.join(repoRoot, "src", "transfer"), { withFileTypes: true }))
   .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
   .map((entry) => entry.name.replace(/\.ts$/, ""))
   .sort();
@@ -58,6 +56,10 @@ await Promise.all(
     "remnic-workspace/migrate/from-engram",
     "remnic-workspace/lcm",
     "remnic-workspace/lcm/engine",
+    "remnic-workspace/qmd",
+    "remnic-workspace/qmd.js",
+    "remnic-workspace/qmd-recall-cache",
+    "remnic-workspace/qmd-recall-cache.js",
     "remnic-workspace/transfer/export-md",
     "remnic-workspace/transfer/capsule-export",
     "remnic-workspace/transfer/import-json",
@@ -66,20 +68,17 @@ await Promise.all(
       throw new Error(`root package subpath import failed for ${specifier}`, {
         cause: err,
       });
-    }),
-  ),
+    })
+  )
 );
 
 const [rootManifest, packageManifest] = await Promise.all([
   readFile(path.join(repoRoot, "openclaw.plugin.json"), "utf8"),
-  readFile(
-    path.join(repoRoot, "packages", "plugin-openclaw", "openclaw.plugin.json"),
-    "utf8",
-  ),
+  readFile(path.join(repoRoot, "packages", "plugin-openclaw", "openclaw.plugin.json"), "utf8"),
 ]);
 
 assert.equal(
   normalizeJson(rootManifest),
   normalizeJson(packageManifest),
-  "root openclaw.plugin.json must stay synced with packages/plugin-openclaw/openclaw.plugin.json",
+  "root openclaw.plugin.json must stay synced with packages/plugin-openclaw/openclaw.plugin.json"
 );

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
     "src/namespaces/storage.ts",
     "src/orchestrator.ts",
     "src/qmd.ts",
+    "src/qmd-recall-cache.ts",
     "src/reconstruct.ts",
     "src/replay/normalizers/chatgpt.ts",
     "src/replay/normalizers/claude.ts",


### PR DESCRIPTION
## Summary
- add root package exports for qmd-recall-cache and qmd-recall-cache.js
- include src/qmd-recall-cache.ts in the root build entrypoints
- extend release artifact smoke imports for qmd, qmd.js, qmd-recall-cache, and qmd-recall-cache.js

## ClawPatch
- Fixes fnd_sig-feat-library-ad89e9280f-5f09_7aab701fb9

## Validation
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec biome check --write package.json scripts/check-release-artifacts.mjs tsup.config.ts
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm run build
- PATH=/opt/homebrew/opt/node@22/bin:$PATH node scripts/check-release-artifacts.mjs
- PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm rebuild better-sqlite3
- OLLAMA_API_KEY=test PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and release-validation only; no runtime logic changes beyond publishing an existing re-export shim.
> 
> **Overview**
> Exposes **`qmd-recall-cache`** on the root **`remnic-workspace`** package so consumers can import the QMD recall cache API the same way as other library shims (with and without the `.js` suffix).
> 
> **`src/qmd-recall-cache.ts`** is added to the **tsup** build entries so **`dist/qmd-recall-cache.js`** is produced at release. **`scripts/check-release-artifacts.mjs`** now smoke-imports **`qmd`**, **`qmd.js`**, **`qmd-recall-cache`**, and **`qmd-recall-cache.js`** so missing exports fail the release check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5890ee73efc49bd69aa86a3d920753f25c603fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->