### PR TITLE
Deduplicate ranked page_id markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -732,12 +730,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -760,9 +753,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -815,12 +806,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-page-ids.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-page-ids.test.ts
@@ -23,106 +23,93 @@ function page(id: string): SchemaTierPage {
 }
 
 test("extractRankedPageIds preserves dotted and slash-delimited IDs", () => {
-  const pages = [
-    page("project.alpha/task-1"),
-    page("project.alpha/task-2"),
-  ];
+  const pages = [page("project.alpha/task-1"), page("project.alpha/task-2")];
 
   assert.deepEqual(
-    extractRankedPageIds(
-      "recall hit\npage_id: project.alpha/task-2\npage_id: project.alpha/task-1",
-      pages,
-    ),
-    ["project.alpha/task-2", "project.alpha/task-1"],
+    extractRankedPageIds("recall hit\npage_id: project.alpha/task-2\npage_id: project.alpha/task-1", pages),
+    ["project.alpha/task-2", "project.alpha/task-1"]
   );
 });
 
 test("extractRankedPageIds ignores trailing punctuation on known IDs", () => {
-  const pages = [
-    page("task-1"),
-    page("project.alpha/task-2"),
-  ];
+  const pages = [page("task-1"), page("project.alpha/task-2")];
 
-  assert.deepEqual(
-    extractRankedPageIds(
-      "recall hit\npage_id: task-1,\npage_id: project.alpha/task-2)",
-      pages,
-    ),
-    ["task-1", "project.alpha/task-2"],
-  );
+  assert.deepEqual(extractRankedPageIds("recall hit\npage_id: task-1,\npage_id: project.alpha/task-2)", pages), [
+    "task-1",
+    "project.alpha/task-2",
+  ]);
 });
 
 test("extractRankedPageIds ignores leading wrappers on known IDs", () => {
-  const pages = [
-    page("task-1"),
-    page("project.alpha/task-2"),
-  ];
+  const pages = [page("task-1"), page("project.alpha/task-2")];
 
-  assert.deepEqual(
-    extractRankedPageIds(
-      'recall hit\npage_id: "task-1"\npage_id: (project.alpha/task-2)',
-      pages,
-    ),
-    ["task-1", "project.alpha/task-2"],
-  );
+  assert.deepEqual(extractRankedPageIds('recall hit\npage_id: "task-1"\npage_id: (project.alpha/task-2)', pages), [
+    "task-1",
+    "project.alpha/task-2",
+  ]);
 });
 
 test("extractRankedPageIds resolves known IDs case-insensitively", () => {
   const pages = [page("Project.Alpha/Task-1")];
 
-  assert.deepEqual(
-    extractRankedPageIds("page_id: PROJECT.ALPHA/TASK-1", pages),
-    ["Project.Alpha/Task-1"],
-  );
+  assert.deepEqual(extractRankedPageIds("page_id: PROJECT.ALPHA/TASK-1", pages), ["Project.Alpha/Task-1"]);
 });
 
 test("extractRankedPageIds ignores page_id substrings inside larger keys", () => {
   const pages = [page("task-1"), page("task-2")];
 
-  assert.deepEqual(
-    extractRankedPageIds(
-      "homepage_id: task-1\nprevious_page_id: task-2\npage_id: task-2",
-      pages,
-    ),
-    ["task-2"],
-  );
+  assert.deepEqual(extractRankedPageIds("homepage_id: task-1\nprevious_page_id: task-2\npage_id: task-2", pages), [
+    "task-2",
+  ]);
 });
 
 test("extractRankedPageIds keeps unknown IDs in recall order", () => {
   const pages = [page("known")];
 
+  assert.deepEqual(extractRankedPageIds("page_id: unknown.value,\npage_id: known", pages), ["unknown.value", "known"]);
+});
+
+test("extractRankedPageIds deduplicates canonical IDs in first-seen order", () => {
+  const pages = [page("Expected"), page("next")];
+
   assert.deepEqual(
-    extractRankedPageIds("page_id: unknown.value,\npage_id: known", pages),
-    ["unknown.value", "known"],
+    extractRankedPageIds('page_id: expected,\npage_id: "EXPECTED"\npage_id: next\npage_id: (expected)', pages),
+    ["Expected", "next"]
   );
 });
 
-test("extractRankedPageIds keeps duplicate hits as occupied ranking slots", () => {
-  const pages = [page("expected")];
+test("extractRankedPageIds can preserve repeated known IDs as occupied miss slots", () => {
+  const pages = [page("Expected"), page("next")];
 
   assert.deepEqual(
-    extractRankedPageIds(
-      "page_id: wrong\npage_id: wrong\npage_id: expected",
-      pages,
-    ),
-    ["wrong", "wrong", "expected"],
+    extractRankedPageIds('page_id: expected,\npage_id: "EXPECTED"\npage_id: next\npage_id: (expected)', pages, {
+      preserveDuplicateRankSlots: true,
+    }),
+    ["Expected", "__duplicate_page_id_slot__:2:Expected", "next", "__duplicate_page_id_slot__:3:Expected"]
   );
+});
+
+test("extractRankedPageIds preserves repeated unknown IDs as occupied ranking slots", () => {
+  const pages = [page("expected")];
+
+  assert.deepEqual(extractRankedPageIds("page_id: bogus\npage_id: bogus\npage_id: expected", pages), [
+    "bogus",
+    "bogus",
+    "expected",
+  ]);
 });
 
 test("extractRankedPageIds does not rescan markers inside extracted values", () => {
   const pages = [page("known")];
 
-  assert.deepEqual(
-    extractRankedPageIds("page_id: some-page_id:-thing\npage_id: known", pages),
-    ["some-page_id:-thing", "known"],
-  );
+  assert.deepEqual(extractRankedPageIds("page_id: some-page_id:-thing\npage_id: known", pages), [
+    "some-page_id:-thing",
+    "known",
+  ]);
 });
 
 test("extractRankedPageIds does not let a blank marker consume the next marker", () => {
   const pages = [page("expected")];
 
-  assert.deepEqual(
-    extractRankedPageIds("page_id:\npage_id: expected", pages),
-    ["expected"],
-  );
+  assert.deepEqual(extractRankedPageIds("page_id:\npage_id: expected", pages), ["expected"]);
 });

--- a/packages/bench/src/benchmarks/remnic/retrieval-page-ids.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-page-ids.ts
@@ -1,26 +1,49 @@
 import type { SchemaTierPage } from "../../fixtures/schema-tiers/index.js";
 
-export function extractRankedPageIds(recallText: string, pages: SchemaTierPage[]): string[] {
-  const pageIdByLowercase = new Map(
-    pages.map((page) => [page.id.toLowerCase(), page.id]),
-  );
-
-  return collectPageIdMarkers(recallText).sort((left, right) => {
-    if (left.index !== right.index) {
-      return left.index - right.index;
-    }
-    return left.id.localeCompare(right.id);
-  }).map((match) => resolvePageId(match.id, pageIdByLowercase));
+export interface ExtractRankedPageIdsOptions {
+  preserveDuplicateRankSlots?: boolean;
 }
 
-function resolvePageId(
-  markerId: string,
-  pageIdByLowercase: Map<string, string>,
-): string {
+export function extractRankedPageIds(
+  recallText: string,
+  pages: SchemaTierPage[],
+  options: ExtractRankedPageIdsOptions = {}
+): string[] {
+  const pageIdByLowercase = new Map(pages.map((page) => [page.id.toLowerCase(), page.id]));
+
+  const rankedPageIds = collectPageIdMarkers(recallText)
+    .sort((left, right) => {
+      if (left.index !== right.index) {
+        return left.index - right.index;
+      }
+      return left.id.localeCompare(right.id);
+    })
+    .map((match) => resolvePageId(match.id, pageIdByLowercase));
+
+  const seenKnown = new Map<string, number>();
+  const out: string[] = [];
+  for (const pageId of rankedPageIds) {
+    if (!pageId.known) {
+      out.push(pageId.id);
+      continue;
+    }
+
+    const seenCount = seenKnown.get(pageId.id) ?? 0;
+    seenKnown.set(pageId.id, seenCount + 1);
+    if (seenCount === 0) {
+      out.push(pageId.id);
+    } else if (options.preserveDuplicateRankSlots) {
+      out.push(formatDuplicatePageIdSlot(pageId.id, seenCount + 1));
+    }
+  }
+  return out;
+}
+
+function resolvePageId(markerId: string, pageIdByLowercase: Map<string, string>): { id: string; known: boolean } {
   const normalizedMarkerId = stripLeadingFormattingDelimiters(markerId).toLowerCase();
   const exact = pageIdByLowercase.get(normalizedMarkerId);
   if (exact !== undefined) {
-    return exact;
+    return { id: exact, known: true };
   }
 
   let candidate = normalizedMarkerId;
@@ -31,11 +54,15 @@ function resolvePageId(
     candidate = candidate.slice(0, -1);
     const known = pageIdByLowercase.get(candidate);
     if (known !== undefined) {
-      return known;
+      return { id: known, known: true };
     }
   }
 
-  return stripTrailingFormattingDelimiters(normalizedMarkerId);
+  return { id: stripTrailingFormattingDelimiters(normalizedMarkerId), known: false };
+}
+
+function formatDuplicatePageIdSlot(pageId: string, ordinal: number): string {
+  return `__duplicate_page_id_slot__:${ordinal}:${pageId}`;
 }
 
 function collectPageIdMarkers(recallText: string): Array<{ id: string; index: number }> {
@@ -53,18 +80,12 @@ function collectPageIdMarkers(recallText: string): Array<{ id: string; index: nu
     }
 
     let valueStart = markerIndex + marker.length;
-    while (
-      valueStart < lowerRecallText.length &&
-      isAsciiHorizontalWhitespace(lowerRecallText.charCodeAt(valueStart))
-    ) {
+    while (valueStart < lowerRecallText.length && isAsciiHorizontalWhitespace(lowerRecallText.charCodeAt(valueStart))) {
       valueStart += 1;
     }
 
     let valueEnd = valueStart;
-    while (
-      valueEnd < lowerRecallText.length &&
-      !isAsciiWhitespace(lowerRecallText.charCodeAt(valueEnd))
-    ) {
+    while (valueEnd < lowerRecallText.length && !isAsciiWhitespace(lowerRecallText.charCodeAt(valueEnd))) {
       valueEnd += 1;
     }
 
@@ -94,20 +115,12 @@ function isAsciiHorizontalWhitespace(code: number): boolean {
 }
 
 function isAsciiIdentifier(code: number): boolean {
-  return (
-    (code >= 48 && code <= 57) ||
-    (code >= 65 && code <= 90) ||
-    code === 95 ||
-    (code >= 97 && code <= 122)
-  );
+  return (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || code === 95 || (code >= 97 && code <= 122);
 }
 
 function stripTrailingFormattingDelimiters(value: string): string {
   let end = value.length;
-  while (
-    end > 0 &&
-    isTrailingFormattingDelimiter(value.charCodeAt(end - 1), { includePeriod: false })
-  ) {
+  while (end > 0 && isTrailingFormattingDelimiter(value.charCodeAt(end - 1), { includePeriod: false })) {
     end -= 1;
   }
   return value.slice(0, end);
@@ -115,29 +128,17 @@ function stripTrailingFormattingDelimiters(value: string): string {
 
 function stripLeadingFormattingDelimiters(value: string): string {
   let start = 0;
-  while (
-    start < value.length &&
-    isLeadingFormattingDelimiter(value.charCodeAt(start))
-  ) {
+  while (start < value.length && isLeadingFormattingDelimiter(value.charCodeAt(start))) {
     start += 1;
   }
   return value.slice(start);
 }
 
 function isLeadingFormattingDelimiter(code: number): boolean {
-  return (
-    code === 34 ||
-    code === 39 ||
-    code === 40 ||
-    code === 91 ||
-    code === 123
-  );
+  return code === 34 || code === 39 || code === 40 || code === 91 || code === 123;
 }
 
-function isTrailingFormattingDelimiter(
-  code: number,
-  options: { includePeriod: boolean },
-): boolean {
+function isTrailingFormattingDelimiter(code: number, options: { includePeriod: boolean }): boolean {
   if (options.includePeriod && code === 46) {
     return true;
   }

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -3,23 +3,13 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type {
-  BenchmarkDefinition,
-  BenchmarkResult,
-  ResolvedRunBenchmarkOptions,
-  TaskResult,
-} from "../../../types.js";
-import { precisionAtK } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
-import {
-  buildTieredAggregates,
-} from "../retrieval-shared.js";
+import { precisionAtK } from "../../../scorer.js";
+import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../../types.js";
 import { extractRankedPageIds } from "../retrieval-page-ids.js";
 import { buildSchemaTierMessages } from "../retrieval-schema-messages.js";
-import {
-  selectRetrievalPersonalizationCases,
-  type RetrievalPersonalizationCase,
-} from "./fixture.js";
+import { buildTieredAggregates } from "../retrieval-shared.js";
+import { type RetrievalPersonalizationCase, selectRetrievalPersonalizationCases } from "./fixture.js";
 
 export const retrievalPersonalizationDefinition: BenchmarkDefinition = {
   id: "retrieval-personalization",
@@ -30,15 +20,14 @@ export const retrievalPersonalizationDefinition: BenchmarkDefinition = {
   meta: {
     name: "retrieval-personalization",
     version: "1.0.0",
-    description:
-      "Deterministic clean-vs-dirty retrieval benchmark for personal-scope ranking precision.",
+    description: "Deterministic clean-vs-dirty retrieval benchmark for personal-scope ranking precision.",
     category: "retrieval",
     citation: "Remnic internal synthetic benchmark for issue #448",
   },
 };
 
 export async function runRetrievalPersonalizationBenchmark(
-  options: ResolvedRunBenchmarkOptions,
+  options: ResolvedRunBenchmarkOptions
 ): Promise<BenchmarkResult> {
   const cases = loadCases(options.mode, options.limit);
   const tasks: TaskResult[] = [];
@@ -51,7 +40,9 @@ export async function runRetrievalPersonalizationBenchmark(
     await options.system.drain?.();
     const recallText = await options.system.recall(sessionId, sample.query, 12_000);
     const latencyMs = Math.round(performance.now() - startedAt);
-    const rankedPageIds = extractRankedPageIds(recallText, sample.pages);
+    const rankedPageIds = extractRankedPageIds(recallText, sample.pages, {
+      preserveDuplicateRankSlots: true,
+    });
     const topRetrievedPageIds = rankedPageIds.slice(0, 5);
     const expectedJson = JSON.stringify(sample.expectedPageIds);
     const actualJson = JSON.stringify(topRetrievedPageIds);
@@ -122,10 +113,7 @@ export async function runRetrievalPersonalizationBenchmark(
   };
 }
 
-function loadCases(
-  mode: "quick" | "full",
-  limit?: number,
-): RetrievalPersonalizationCase[] {
+function loadCases(mode: "quick" | "full", limit?: number): RetrievalPersonalizationCase[] {
   if (limit !== undefined && (!Number.isInteger(limit) || limit <= 0)) {
     throw new Error("retrieval-personalization limit must be a positive integer");
   }

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -3,24 +3,13 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type {
-  BenchmarkDefinition,
-  BenchmarkResult,
-  ResolvedRunBenchmarkOptions,
-  TaskResult,
-} from "../../../types.js";
-import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
-import {
-  buildTieredAggregates,
-} from "../retrieval-shared.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../../types.js";
 import { extractRankedPageIds } from "../retrieval-page-ids.js";
 import { buildSchemaTierMessages } from "../retrieval-schema-messages.js";
-import {
-  RETRIEVAL_TEMPORAL_FIXTURE,
-  RETRIEVAL_TEMPORAL_SMOKE_FIXTURE,
-  type RetrievalTemporalCase,
-} from "./fixture.js";
+import { buildTieredAggregates } from "../retrieval-shared.js";
+import { RETRIEVAL_TEMPORAL_FIXTURE, RETRIEVAL_TEMPORAL_SMOKE_FIXTURE, type RetrievalTemporalCase } from "./fixture.js";
 
 export const retrievalTemporalDefinition: BenchmarkDefinition = {
   id: "retrieval-temporal",
@@ -31,16 +20,13 @@ export const retrievalTemporalDefinition: BenchmarkDefinition = {
   meta: {
     name: "retrieval-temporal",
     version: "1.0.0",
-    description:
-      "Deterministic clean-vs-dirty retrieval benchmark for temporal qrels under half-open windows.",
+    description: "Deterministic clean-vs-dirty retrieval benchmark for temporal qrels under half-open windows.",
     category: "retrieval",
     citation: "Remnic internal synthetic benchmark for issue #448",
   },
 };
 
-export async function runRetrievalTemporalBenchmark(
-  options: ResolvedRunBenchmarkOptions,
-): Promise<BenchmarkResult> {
+export async function runRetrievalTemporalBenchmark(options: ResolvedRunBenchmarkOptions): Promise<BenchmarkResult> {
   const cases = loadCases(options.mode, options.limit);
   const tasks: TaskResult[] = [];
 
@@ -52,14 +38,11 @@ export async function runRetrievalTemporalBenchmark(
     await options.system.reset(sessionId);
     await options.system.store(sessionId, buildSchemaTierMessages(sample.pages));
     await options.system.drain?.();
-    const recallText = await options.system.recall(
-      sessionId,
-      sample.query,
-      12_000,
-      { asOf: sample.window.end },
-    );
+    const recallText = await options.system.recall(sessionId, sample.query, 12_000, { asOf: sample.window.end });
     const latencyMs = Math.round(performance.now() - startedAt);
-    const retrievedPageIds = extractRankedPageIds(recallText, sample.pages);
+    const retrievedPageIds = extractRankedPageIds(recallText, sample.pages, {
+      preserveDuplicateRankSlots: true,
+    });
     const topRetrievedPageIds = retrievedPageIds.slice(0, 5);
     const matchedPageIds = matchingPageIds(retrievedPageIds, sample);
     const expectedJson = JSON.stringify({
@@ -136,13 +119,8 @@ export async function runRetrievalTemporalBenchmark(
   };
 }
 
-function loadCases(
-  mode: "quick" | "full",
-  limit?: number,
-): RetrievalTemporalCase[] {
-  const baseCases = mode === "quick"
-    ? RETRIEVAL_TEMPORAL_SMOKE_FIXTURE
-    : RETRIEVAL_TEMPORAL_FIXTURE;
+function loadCases(mode: "quick" | "full", limit?: number): RetrievalTemporalCase[] {
+  const baseCases = mode === "quick" ? RETRIEVAL_TEMPORAL_SMOKE_FIXTURE : RETRIEVAL_TEMPORAL_FIXTURE;
 
   if (limit === undefined) {
     return baseCases;
@@ -159,17 +137,15 @@ function loadCases(
   return limited;
 }
 
-function temporalQrelAtK(
-  rankedPageIds: string[],
-  sample: RetrievalTemporalCase,
-  k: number,
-): number {
+function temporalQrelAtK(rankedPageIds: string[], sample: RetrievalTemporalCase, k: number): number {
   const pageById = new Map(sample.pages.map((page) => [page.id, page]));
   const topK = rankedPageIds.slice(0, k);
   return topK.some((pageId) => {
     const page = pageById.get(pageId);
     return page ? pageQualifies(page, sample) : false;
-  }) ? 1 : 0;
+  })
+    ? 1
+    : 0;
 }
 
 function pageQualifies(page: SchemaTierPage, sample: RetrievalTemporalCase): boolean {
@@ -177,21 +153,14 @@ function pageQualifies(page: SchemaTierPage, sample: RetrievalTemporalCase): boo
   return pageHasTemporalEvidenceInWindow(page, sample.window.start, sample.window.end);
 }
 
-function pageHasTemporalEvidenceInWindow(
-  page: SchemaTierPage,
-  startIso: string,
-  endIso: string,
-): boolean {
+function pageHasTemporalEvidenceInWindow(page: SchemaTierPage, startIso: string, endIso: string): boolean {
   const { startMs, endMs } = validateHalfOpenWindow(startIso, endIso);
 
   const evidenceTimestamps = collectEvidenceTimestamps(page);
   return evidenceTimestamps.some((timestamp) => timestamp >= startMs && timestamp < endMs);
 }
 
-function validateHalfOpenWindow(
-  startIso: string,
-  endIso: string,
-): { startMs: number; endMs: number } {
+function validateHalfOpenWindow(startIso: string, endIso: string): { startMs: number; endMs: number } {
   const startMs = parseStrictIsoTimestamp(startIso);
   const endMs = parseStrictIsoTimestamp(endIso);
 
@@ -208,7 +177,7 @@ function validateExpectedPageIds(sample: RetrievalTemporalCase): void {
 
   if (missingPageIds.length > 0) {
     throw new Error(
-      `retrieval-temporal expectedPageIds must reference pages present in the fixture: ${sample.id} -> ${missingPageIds.join(", ")}`,
+      `retrieval-temporal expectedPageIds must reference pages present in the fixture: ${sample.id} -> ${missingPageIds.join(", ")}`
     );
   }
 }
@@ -244,11 +213,7 @@ function parseTimelineEntry(entry: string): number | null {
   const day = Number(match[3]);
   const date = new Date(Date.UTC(year, month - 1, day));
 
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() !== month - 1 ||
-    date.getUTCDate() !== day
-  ) {
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
     return null;
   }
 
@@ -268,10 +233,7 @@ function parseStrictIsoTimestamp(value: string): number | null {
   return date.toISOString() === value ? date.getTime() : null;
 }
 
-function matchingPageIds(
-  rankedPageIds: string[],
-  sample: RetrievalTemporalCase,
-): string[] {
+function matchingPageIds(rankedPageIds: string[], sample: RetrievalTemporalCase): string[] {
   const pageById = new Map(sample.pages.map((page) => [page.id, page]));
   return rankedPageIds.filter((pageId) => {
     const page = pageById.get(pageId);


### PR DESCRIPTION
## Summary
- deduplicate resolved page_id markers while preserving first-seen ranking order
- add regression coverage for canonical duplicate markers with case and punctuation variants
- format root package.json so the current lint gate passes

## Verification
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin pnpm exec tsx --test packages/bench/src/benchmarks/remnic/retrieval-page-ids.test.ts
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin git diff --check
- PATH=/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin OLLAMA_API_KEY=local-test-key npm run preflight:quick

ClawPatch finding: fnd_sig-feat-library-48975fc5f4-fcfa_922d924de0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default deduplication changes ranked ID lists for any caller of extractRankedPageIds without the new flag; benchmark runners were updated to preserve prior duplicate-slot semantics.
> 
> **Overview**
> **`extractRankedPageIds`** now collapses repeated **known** `page_id` markers to a single canonical ID (first occurrence wins), including variants that differ only by case or surrounding punctuation. Repeated **unknown** IDs are still emitted for each marker so ranking slots stay aligned with the recall text.
> 
> An optional **`preserveDuplicateRankSlots`** flag keeps duplicate known hits as synthetic placeholder entries (`__duplicate_page_id_slot__:*`) so benchmarks can treat them as occupied ranks without double-counting the same page. **Retrieval personalization** and **retrieval temporal** runners enable that flag when parsing recall output.
> 
> Tests cover canonical deduplication and the opt-in duplicate-slot behavior. Root **`package.json`** changes are formatting-only for the lint gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 861e4bd48a8ae849f45fa108383fb1632dc79ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->