### PR TITLE
Fix rerank cache key collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -732,12 +730,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -760,9 +753,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -815,12 +806,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/rerank.test.ts
+++ b/packages/remnic-core/src/rerank.test.ts
@@ -86,3 +86,55 @@ test("rerankLocalOrNoop cache is isolated from caller mutations", async () => {
   assert.deepEqual(second, ["a", "b"]);
   assert.equal(calls, 1);
 });
+
+test("rerankLocalOrNoop cache keys distinguish candidate IDs containing commas", async () => {
+  let calls = 0;
+  const cache = new RerankCache();
+  const commonOptions = {
+    query: "API rate limit issue",
+    local: {
+      async chatCompletion() {
+        calls += 1;
+        return {
+          content: JSON.stringify({
+            scores:
+              calls === 1
+                ? [
+                    { id: "c", score: 90 },
+                    { id: "a,b", score: 10 },
+                  ]
+                : [
+                    { id: "b,c", score: 90 },
+                    { id: "a", score: 10 },
+                  ],
+          }),
+        };
+      },
+    },
+    enabled: true,
+    timeoutMs: 1_500,
+    maxCandidates: 5,
+    cache,
+    cacheEnabled: true,
+    cacheTtlMs: 60_000,
+  };
+
+  const first = await rerankLocalOrNoop({
+    ...commonOptions,
+    candidates: [
+      { id: "a,b", snippet: "API rate limit is 1000 requests per minute." },
+      { id: "c", snippet: "Deployment note." },
+    ],
+  });
+  assert.deepEqual(first, ["c", "a,b"]);
+
+  const second = await rerankLocalOrNoop({
+    ...commonOptions,
+    candidates: [
+      { id: "a", snippet: "API rate limit is 1000 requests per minute." },
+      { id: "b,c", snippet: "Deployment note." },
+    ],
+  });
+  assert.deepEqual(second, ["b,c", "a"]);
+  assert.equal(calls, 2);
+});

--- a/packages/remnic-core/src/rerank.ts
+++ b/packages/remnic-core/src/rerank.ts
@@ -41,7 +41,7 @@ export class RerankCache {
  */
 export function parseRerankResponse(
   raw: string,
-  candidates: RerankCandidate[],
+  candidates: RerankCandidate[]
 ): Array<RerankCandidate & { score?: number }> {
   const byId = new Map<string, RerankCandidate>();
   for (const c of candidates) byId.set(c.id, c);
@@ -80,8 +80,8 @@ export function parseRerankResponse(
 }
 
 function stableKey(query: string, ids: string[]): string {
-  // Keep it simple and deterministic; this is not a security boundary.
-  return `${query.trim().toLowerCase()}|${ids.join(",")}`;
+  // Keep candidate boundaries explicit; candidate IDs are arbitrary strings.
+  return JSON.stringify([query.trim().toLowerCase(), ids]);
 }
 
 function clampSnippet(snippet: string, maxChars: number): string {
@@ -101,7 +101,7 @@ export async function rerankLocalOrNoop(opts: {
         timeoutMs?: number;
         operation?: string;
         priority?: "recall-critical" | "background";
-      },
+      }
     ) => Promise<{ content: string } | null>;
   };
   enabled: boolean;
@@ -127,8 +127,7 @@ export async function rerankLocalOrNoop(opts: {
     snippet: clampSnippet(c.snippet, 400),
   }));
 
-  const system =
-    "You are a ranking system. Return JSON only. No markdown, no commentary.";
+  const system = "You are a ranking system. Return JSON only. No markdown, no commentary.";
   const user = JSON.stringify(
     {
       task: "rerank",
@@ -144,7 +143,7 @@ export async function rerankLocalOrNoop(opts: {
       ],
     },
     null,
-    0,
+    0
   );
 
   const res = await opts.local.chatCompletion(
@@ -158,13 +157,13 @@ export async function rerankLocalOrNoop(opts: {
       timeoutMs: opts.timeoutMs,
       operation: "rerank",
       priority: "recall-critical",
-    },
+    }
   );
   if (!res?.content) return null;
 
   const parsed = parseRerankResponse(
     res.content,
-    ids.map((id, i) => ({ id, originalIndex: i })),
+    ids.map((id, i) => ({ id, originalIndex: i }))
   );
   const rankedIds = parsed.map((p) => p.id);
 


### PR DESCRIPTION
## Summary
- serialize rerank cache keys with explicit candidate boundaries instead of comma-joined IDs
- add regression coverage for candidate ID arrays that collide under comma-join serialization

## ClawPatch
- Fixes fnd_sig-feat-library-0dfe449a13-9c1c_3f1f145d96

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/rerank.test.ts`
- `pnpm exec biome check --write packages/remnic-core/src/rerank.ts packages/remnic-core/src/rerank.test.ts`
- `pnpm rebuild better-sqlite3`
- `npm run test:openclaw-scenarios`
- `OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect cache hits could skew recall-critical reranking; the change is small and covered by a new test, but it affects retrieval ordering behavior.
> 
> **Overview**
> Fixes **rerank cache key collisions** when candidate IDs are arbitrary strings that can include commas.
> 
> `stableKey` in `rerank.ts` no longer builds keys as `query|id1,id2,...`. It now uses `JSON.stringify([normalizedQuery, ids])` so each ID stays a distinct array element. Without that, different candidate sets could hash to the same key (e.g. one ID `"a,b"` vs two IDs `"a"` and `"b"`), returning **stale or wrong rankings** from cache on recall paths.
> 
> Adds a regression test in `rerank.test.ts` that two rerank calls with comma-bearing IDs hit the LLM twice and get correct orderings. Root `package.json` changes are **format-only** (Biome array layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9096fb34e573f92ffe6dbf41579ec018ee9ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->