### PR TITLE
Stabilize contradiction review pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -744,12 +742,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -772,9 +765,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -827,12 +818,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/contradiction/contradiction-review.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-review.ts
@@ -135,6 +135,30 @@ function isDeferralActive(pair: ContradictionPair): boolean {
   return deferredUntil !== null && Date.now() < deferredUntil;
 }
 
+function isReviewActionable(pair: ContradictionPair): boolean {
+  return !isTerminalResolution(pair.resolution)
+    && !isDeferralActive(pair)
+    && pair.resolution !== "both-valid"
+    && pair.verdict !== "independent";
+}
+
+function compareReviewPairs(a: ContradictionPair, b: ContradictionPair): number {
+  const aActionable = isReviewActionable(a);
+  const bActionable = isReviewActionable(b);
+  if (aActionable !== bActionable) return aActionable ? -1 : 1;
+
+  const aDetectedAt = parseIsoMillis(a.detectedAt) ?? Number.POSITIVE_INFINITY;
+  const bDetectedAt = parseIsoMillis(b.detectedAt) ?? Number.POSITIVE_INFINITY;
+  if (aDetectedAt !== bDetectedAt) return aDetectedAt < bDetectedAt ? -1 : 1;
+
+  const aPairId = typeof a.pairId === "string" ? a.pairId : "";
+  const bPairId = typeof b.pairId === "string" ? b.pairId : "";
+  const pairIdOrder = aPairId.localeCompare(bPairId);
+  if (pairIdOrder !== 0) return pairIdOrder;
+
+  return a.memoryIds.join("\0").localeCompare(b.memoryIds.join("\0"));
+}
+
 function reviewStateMillis(pair: ContradictionPair): number {
   return Math.max(
     parseIsoMillis(pair.deferredUntil) ?? Number.NEGATIVE_INFINITY,
@@ -390,7 +414,7 @@ export function listPairs(
   const startTime = Date.now();
   const dir = reviewDir(memoryDir);
   const { filter = "all", namespace, includeUnscopedForNamespace = false, limit = 50 } = options ?? {};
-  const pairs: ContradictionPair[] = [];
+  const matchingPairs: ContradictionPair[] = [];
   let total = 0;
 
   if (!fs.existsSync(dir)) {
@@ -423,10 +447,17 @@ export function listPairs(
       }
 
       total++;
-      if (pairs.length < limit) pairs.push(pair);
+      matchingPairs.push(pair);
     } catch {
       continue;
     }
+  }
+
+  matchingPairs.sort(compareReviewPairs);
+  const pairs: ContradictionPair[] = [];
+  for (const pair of matchingPairs) {
+    if (!(pairs.length < limit)) break;
+    pairs.push(pair);
   }
 
   return { pairs, total, durationMs: Date.now() - startTime };

--- a/packages/remnic-core/src/contradiction/contradiction.test.ts
+++ b/packages/remnic-core/src/contradiction/contradiction.test.ts
@@ -545,12 +545,37 @@ test("listPairs filters by verdict", async () => {
 test("listPairs respects limit", async () => {
   const { dir, cleanup } = await makeTempDir();
   try {
-    for (let i = 0; i < 5; i++) {
-      writePair(dir, makePair({ memoryIds: [`a-${i}`, `b-${i}`] }));
-    }
+    const expectedFirst = writePair(dir, makePair({
+      memoryIds: ["a-first", "b-first"],
+      detectedAt: "2026-01-01T00:00:00.000Z",
+    }));
+    const expectedSecond = writePair(dir, makePair({
+      memoryIds: ["a-second", "b-second"],
+      detectedAt: "2026-01-02T00:00:00.000Z",
+    }));
+    const terminal = writePair(dir, makePair({
+      memoryIds: ["a-terminal", "b-terminal"],
+      detectedAt: "2025-01-01T00:00:00.000Z",
+    }));
+    resolvePair(dir, terminal.pairId, "keep-a");
+    writePair(dir, makePair({
+      memoryIds: ["a-independent", "b-independent"],
+      detectedAt: "2025-01-02T00:00:00.000Z",
+      verdict: "independent",
+    }));
+    writePair(dir, makePair({
+      memoryIds: ["a-third", "b-third"],
+      detectedAt: "2026-01-03T00:00:00.000Z",
+    }));
+
     const result = listPairs(dir, { filter: "all", limit: 2 });
     assert.equal(result.pairs.length, 2);
     assert.equal(result.total, 5, "total should reflect all matching pairs, not just returned");
+    assert.deepEqual(
+      result.pairs.map((pair) => pair.pairId),
+      [expectedFirst.pairId, expectedSecond.pairId],
+      "limit should apply after deterministic review ordering, not raw directory order",
+    );
   } finally {
     await cleanup();
   }


### PR DESCRIPTION
## Summary
- collect all matching contradiction review pairs before limiting
- sort review queue results deterministically: actionable first, then detectedAt, then pairId
- add a regression test proving limit is applied after stable ordering

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3
- pnpm exec tsx --test packages/remnic-core/src/contradiction/contradiction.test.ts
- git diff --check
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for all paginated contradiction review UIs/APIs; large queues may read more JSON files per list call, though logic stays local to review storage.
> 
> **Overview**
> **Contradiction review listing** now gathers every pair that passes filters, sorts them with a fixed queue order, then applies `limit`—instead of stopping at `limit` while scanning the review directory (which depended on filesystem order).
> 
> The sort prioritizes **actionable** items (not terminal, not deferred, not `both-valid`, not `independent`), then **`detectedAt`**, then **`pairId`**, then **`memoryIds`**. **`total`** still counts all matches; only the returned page changes. HTTP/MCP/CLI review endpoints that call `listPairs` inherit this ordering.
> 
> A regression test asserts that `limit: 2` returns the two earliest actionable pairs by `detectedAt`, not arbitrary directory order. Root **`package.json`** changes are formatting-only (single-line arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44732a3510352c254dcba92288a5c530b75cda5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->