### PR TITLE
Reject symlinked projection memory roots

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -780,12 +778,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -808,9 +801,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -863,12 +854,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/projection/index.test.ts
+++ b/packages/remnic-core/src/projection/index.test.ts
@@ -159,6 +159,34 @@ test("generateContextTree rejects symlinked memory category roots", async () => 
   }
 });
 
+test("generateContextTree rejects symlinked memoryDir roots", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-projection-root-symlink-"));
+  try {
+    const outsideMemoryDir = path.join(root, "outside-memory");
+    const memoryDir = path.join(root, "memory");
+    const outputDir = path.join(root, "context-tree");
+    await writeFact(outsideMemoryDir);
+    await symlink(outsideMemoryDir, memoryDir, "dir");
+
+    await assert.rejects(
+      generateContextTree({
+        memoryDir,
+        outputDir,
+        categories: ["fact"],
+        includeEntities: false,
+        includeQuestions: false,
+      }),
+      /memoryDir must not be a symlink/,
+    );
+    await assert.rejects(
+      readFile(path.join(outputDir, "fact", "fact-1.md"), "utf-8"),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("generateContextTree rejects symlinked output path components", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-projection-output-symlink-"));
   try {

--- a/packages/remnic-core/src/projection/index.ts
+++ b/packages/remnic-core/src/projection/index.ts
@@ -90,7 +90,7 @@ export async function generateContextTree(options: GenerateOptions): Promise<Gen
   const resolvedMemoryDir = path.resolve(memoryDir);
   const resolvedOutputDir = path.resolve(outputDir);
   const requestedCategories = validateProjectionCategories(filterCategories);
-  const realMemoryDir = fs.realpathSync(resolvedMemoryDir);
+  const realMemoryDir = assertSafeMemoryRoot(resolvedMemoryDir);
 
   // Ensure output directory exists
   assertNotSymlink(resolvedOutputDir, "context tree outputDir");
@@ -238,6 +238,17 @@ function assertNotSymlink(targetPath: string, label: string): void {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
     throw err;
   }
+}
+
+function assertSafeMemoryRoot(targetPath: string): string {
+  const stat = fs.lstatSync(targetPath);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`memoryDir must not be a symlink: ${targetPath}`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`memoryDir must be a directory: ${targetPath}`);
+  }
+  return fs.realpathSync(targetPath);
 }
 
 function assertSafeInputRoot(realMemoryDir: string, targetPath: string, label: string): void {


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-9cfc5791cf-192f_ad51e1f531`.

## Changes
- Reject symlinked or non-directory `memoryDir` roots before resolving projection containment.
- Add a regression test for symlinked root memory directories.
- Apply root `package.json` Biome formatting required by `preflight:quick` on current main.

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/projection/index.test.ts`
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:entity-hardening`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted filesystem hardening with tests; no auth or API surface changes beyond stricter input validation.
> 
> **Overview**
> **Context tree projection** now refuses a symlinked or non-directory `memoryDir` before resolving paths, via new `assertSafeMemoryRoot` in `packages/remnic-core/src/projection/index.ts`. That closes a gap where a symlinked memory root could bypass containment checks that already applied to category and output paths.
> 
> A regression test covers symlinked `memoryDir` roots and confirms no projected files are written. Root `package.json` only picks up **Biome** array formatting for `preflight:quick`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23aacd462646f2ad90a4cd530fecc878eeddc33a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->