### PR TITLE
Render dynamic run mode options

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -912,12 +910,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -940,9 +933,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -995,12 +986,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -79,7 +79,7 @@ export interface BenchResultSummary {
   benchmark: string;
   benchmarkTier: string;
   timestamp: string;
-  mode: "quick" | "full";
+  mode: string;
   totalLatencyMs: number | null;
   meanQueryLatencyMs: number | null;
   taskCount: number;

--- a/packages/bench-ui/src/pages/Runs.test.tsx
+++ b/packages/bench-ui/src/pages/Runs.test.tsx
@@ -1,9 +1,11 @@
 import * as React from "react";
 import assert from "node:assert/strict";
 import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
 
 import type { BenchResultSummary, BenchResultSummaryPayload, RunFilters } from "../bench-data";
-import { reconcileRunFilters } from "./Runs";
+import { reconcileRunFilters, Runs } from "./Runs";
 
 function summary(overrides: Partial<BenchResultSummary>): BenchResultSummary {
   return {
@@ -76,4 +78,32 @@ test("reconcileRunFilters resets dynamic filter values missing after payload ref
       range: "30d",
     },
   );
+});
+
+test("Runs renders payload modes and reconcileRunFilters preserves them", () => {
+  const data = payload([
+    summary({ id: "quick-run", mode: "quick" }),
+    summary({ id: "eval-run", mode: "eval" }),
+  ]);
+
+  assert.equal(
+    reconcileRunFilters(data, {
+      benchmark: "all",
+      systemProvider: "all",
+      judgeProvider: "all",
+      mode: "eval",
+      range: "all",
+    }).mode,
+    "eval",
+  );
+
+  const markup = renderToStaticMarkup(
+    <MemoryRouter>
+      <Runs payload={data} />
+    </MemoryRouter>,
+  );
+
+  assert.match(markup, /<option[^>]*value="all"[^>]*>All modes<\/option>/);
+  assert.match(markup, /<option[^>]*value="eval"[^>]*>eval<\/option>/);
+  assert.match(markup, /<option[^>]*value="quick"[^>]*>quick<\/option>/);
 });

--- a/packages/bench-ui/src/pages/Runs.tsx
+++ b/packages/bench-ui/src/pages/Runs.tsx
@@ -3,8 +3,13 @@ import { useEffect, useState } from "react";
 import type { BenchResultSummaryPayload, RunFilters, TrendRange } from "../bench-data";
 import { filterRuns, listBenchmarks, listProviders } from "../bench-data";
 import { RunTable } from "../components/RunTable";
+import { compareStrings } from "../sort-utils";
 
 const ranges: TrendRange[] = ["7d", "30d", "90d", "all"];
+
+function listModes(payload: BenchResultSummaryPayload): string[] {
+  return Array.from(new Set(payload.summaries.map((summary) => summary.mode))).sort(compareStrings);
+}
 
 export function reconcileRunFilters(
   payload: BenchResultSummaryPayload,
@@ -61,6 +66,7 @@ export function Runs({ payload }: { payload: BenchResultSummaryPayload }) {
   const benchmarks = listBenchmarks(payload);
   const systemProviders = listProviders(payload, "systemProvider");
   const judgeProviders = listProviders(payload, "judgeProvider");
+  const modes = listModes(payload);
   const filtered = filterRuns(payload, reconciledFilters);
 
   return (
@@ -127,8 +133,11 @@ export function Runs({ payload }: { payload: BenchResultSummaryPayload }) {
             onChange={(event) => setFilters((current) => ({ ...current, mode: event.target.value }))}
           >
             <option value="all">All modes</option>
-            <option value="quick">quick</option>
-            <option value="full">full</option>
+            {modes.map((mode) => (
+              <option key={mode} value={mode}>
+                {mode}
+              </option>
+            ))}
           </select>
         </label>
         <label>

--- a/packages/bench-ui/src/results.test.ts
+++ b/packages/bench-ui/src/results.test.ts
@@ -37,3 +37,30 @@ test("loadBenchResultSummaries reports malformed result files as skipped warning
     await rm(resultsDir, { recursive: true, force: true });
   }
 });
+
+test("loadBenchResultSummaries preserves non-standard result modes", async () => {
+  const resultsDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-results-"));
+  const resultPath = path.join(resultsDir, "eval.json");
+
+  try {
+    await writeFile(
+      resultPath,
+      JSON.stringify({
+        meta: {
+          id: "run-eval",
+          benchmark: "locomo",
+          timestamp: "2026-05-21T00:00:00.000Z",
+          mode: "eval",
+        },
+        results: { aggregates: {} },
+      }),
+      "utf8",
+    );
+
+    const payload = await loadBenchResultSummaries(resultsDir);
+
+    assert.equal(payload.summaries[0]?.mode, "eval");
+  } finally {
+    await rm(resultsDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench-ui/src/results.ts
+++ b/packages/bench-ui/src/results.ts
@@ -271,7 +271,7 @@ export function summarizeBenchmarkResult(
     benchmarkTier:
       typeof meta.benchmarkTier === "string" ? meta.benchmarkTier : "custom",
     timestamp: meta.timestamp,
-    mode: meta.mode === "full" ? "full" : "quick",
+    mode: typeof meta.mode === "string" ? meta.mode : "quick",
     totalLatencyMs: toFiniteNumber(cost.totalLatencyMs),
     meanQueryLatencyMs: toFiniteNumber(cost.meanQueryLatencyMs),
     taskCount: tasks.length,


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-2e9426128f-1787_63900a21f3`.

## Changes
- Derive the Runs page mode select options from `payload.summaries`, matching `reconcileRunFilters`.
- Keep the `all` option first while rendering every valid payload mode.
- Add a render regression test for a non-quick/full mode and assert reconciliation preserves it.

## Verification
- `pnpm exec tsx --test packages/bench-ui/src/pages/Runs.test.ts packages/bench-ui/src/pages/Runs.test.tsx`
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local bench UI display and filter behavior only; no auth, data, or production runtime paths.
> 
> **Overview**
> The bench UI **Runs** page no longer hardcodes **quick** and **full** in the mode filter. Mode options are built from distinct `mode` values in loaded run summaries (with **All modes** first), aligned with how `reconcileRunFilters` already validates the selected mode.
> 
> Result loading and typing were loosened so `meta.mode` is kept as any string (defaulting to **quick** when missing) instead of collapsing non-**full** values to **quick**. `BenchResultSummary.mode` is now a plain `string`.
> 
> Regression tests cover preserving modes like **eval** when loading JSON and rendering them in the mode `<select>`. Root `package.json` changes are formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418433c5e19d730ad5ce849cec17caefada8ff36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->