### PR TITLE
Report ingestion setup task progress

### DIFF
--- a/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.test.ts
@@ -29,3 +29,53 @@ test("setup friction reports missing ingestion adapter clearly", async () => {
     /ingestionAdapter is required for ingestion benchmarks/,
   );
 });
+
+test("setup friction reports task completion progress", async () => {
+  const completed: { taskId: string; completedCount: number; totalCount: number | undefined }[] = [];
+
+  const result = await runIngestionSetupFrictionBenchmark({
+    benchmark: ingestionSetupFrictionDefinition,
+    mode: "quick",
+    system: {
+      async reset() {},
+      async store() {},
+      async recall() {
+        return "";
+      },
+      async search() {
+        return [];
+      },
+      async destroy() {},
+      async getStats() {
+        return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+    },
+    ingestionAdapter: {
+      async reset() {},
+      async ingest() {
+        return {
+          commandsIssued: ["remnic ingest inbox"],
+          promptsShown: ["Confirm source"],
+          errors: [],
+          durationMs: 12,
+        };
+      },
+      async getMemoryGraph() {
+        return { entities: [], links: [], pages: [] };
+      },
+      async destroy() {},
+    },
+    onTaskComplete(task, completedCount, totalCount) {
+      completed.push({ taskId: task.taskId, completedCount, totalCount });
+    },
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.deepEqual(completed, [
+    {
+      taskId: result.results.tasks[0]?.taskId,
+      completedCount: 1,
+      totalCount: 1,
+    },
+  ]);
+});

--- a/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts
@@ -90,6 +90,7 @@ export async function runIngestionSetupFrictionBenchmark(
         },
       },
     ];
+    options.onTaskComplete?.(tasks[0], 1, tasks.length);
 
     const remnicVersion = await getRemnicVersion();
     return {


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-bb43edb0c7-01e1_59faeb5591`.

## Changes
- Call `options.onTaskComplete` for the ingestion setup friction runner's single task.
- Pass completed count `1` and total count `1`, matching the shared runner progress contract.
- Add a focused runner test that uses a fake ingestion adapter and asserts the progress callback receives the task.

## Verification
- `pnpm exec tsx --test packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.test.ts`
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only progress callback and test; no production ingestion or runtime behavior changes.
> 
> **Overview**
> The ingestion setup friction benchmark now invokes **`onTaskComplete`** after its single task finishes, passing completed count **1** and total **1** so UIs and orchestration match other bench runners.
> 
> A new unit test runs the benchmark with a stub **`ingestionAdapter`** and asserts the callback receives the expected task id and counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b9819ced9c97fc3038007705b4b45c9fbcf404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->