### PR TITLE
Constrain OpenClaw runtime discovery to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -912,12 +910,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -940,9 +933,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -995,12 +986,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/src/resolve-provider-secret.ts
+++ b/src/resolve-provider-secret.ts
@@ -53,7 +53,7 @@ export async function findGatewayRuntimeModules(filePrefix: string): Promise<str
     for (const f of files) {
       if (f.startsWith(filePrefix) && f.endsWith(".js")) {
         const candidate = realpathSync(path.join(distDir, f));
-        if (isWithinRoot(packageRoot, candidate)) {
+        if (isWithinRoot(packageRoot, candidate) && isWithinRoot(distDir, candidate)) {
           candidates.push(candidate);
         }
       }

--- a/tests/resolve-provider-secret-openclaw.test.ts
+++ b/tests/resolve-provider-secret-openclaw.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -67,6 +67,64 @@ test("OpenClaw runtime discovery resolves exported entrypoint when package.json 
     assert.deepEqual(
       (result.modules as string[]).map((entry) => path.basename(entry)),
       ["provider-auth-runtime-fixture.js"],
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("OpenClaw runtime discovery rejects dist symlinks that resolve outside dist", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "remnic-openclaw-runtime-discovery-"));
+  try {
+    const nodePath = path.join(tempDir, "node-path");
+    const packageRoot = path.join(nodePath, "openclaw");
+    const distDir = path.join(packageRoot, "dist");
+    await mkdir(distDir, { recursive: true });
+    await writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        type: "module",
+        exports: {
+          ".": "./dist/index.js",
+        },
+      }),
+      "utf8",
+    );
+    await writeFile(path.join(distDir, "index.js"), "export const marker = true;\n", "utf8");
+    await writeFile(path.join(distDir, "provider-auth-runtime-valid.js"), "export {};\n", "utf8");
+    await writeFile(path.join(packageRoot, "provider-auth-runtime-escape.js"), "export {};\n", "utf8");
+    await symlink(
+      path.join(packageRoot, "provider-auth-runtime-escape.js"),
+      path.join(distDir, "provider-auth-runtime-escape.js"),
+    );
+
+    const moduleUrl = pathToFileURL(path.join(process.cwd(), "src/resolve-provider-secret.ts")).href;
+    const script = `
+      import { findGatewayRuntimeModules } from ${JSON.stringify(moduleUrl)};
+
+      const modules = await findGatewayRuntimeModules("provider-auth-runtime-");
+      console.log(JSON.stringify({ modules }));
+    `;
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [...process.execArgv, "--input-type=module", "--eval", script],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          NODE_PATH: nodePath,
+        },
+      },
+    );
+    const result = JSON.parse(stdout) as {
+      modules?: unknown;
+    };
+
+    assert.deepEqual(
+      (result.modules as string[]).map((entry) => path.basename(entry)),
+      ["provider-auth-runtime-valid.js"],
     );
   } finally {
     await rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-7afb309848-2dfa_fd3a63818a`.

## Changes
- Require discovered OpenClaw runtime candidates to resolve within the real `dist` directory, not just the package root.
- Keep the package-root containment check while enforcing the runtime module discovery boundary at `dist`.
- Add a symlink regression test for a matching dist entry that resolves outside `dist`.
- Format root `package.json` for the current release baseline so the quick preflight lint gate passes.

## Verification
- `pnpm exec tsx --test tests/resolve-provider-secret-openclaw.test.ts`
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:entity-hardening`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows which dynamically imported OpenClaw auth/runtime modules can load (security-sensitive), but the change is a small containment check plus tests with no behavior change for legitimate in-dist modules.
> 
> **Overview**
> Tightens **OpenClaw runtime module discovery** so only files whose real paths stay inside the package’s `dist` directory are eligible—closing a case where a `dist` symlink could still point outside `dist` while passing the package-root check.
> 
> `findGatewayRuntimeModules` now applies `isWithinRoot(distDir, candidate)` after `realpathSync`, alongside the existing package-root guard. A new integration test builds a malicious `dist` symlink and asserts the escape module is excluded.
> 
> Root **`package.json`** changes are formatting-only (single-line arrays) to satisfy the quick preflight lint gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f98d1833762d5bbac5b2a1009c8c7c5e31b94a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->