### PR TITLE
Avoid mixed metric score deltas

### DIFF
--- a/packages/bench-ui/src/bench-data.test.ts
+++ b/packages/bench-ui/src/bench-data.test.ts
@@ -5,6 +5,7 @@ import {
   buildCompareModel,
   buildProviderRows,
   deltaPolarityClass,
+  getBenchmarkCards,
   getRecentRuns,
   pickDefaultCompareIds,
   type BenchResultSummary,
@@ -135,6 +136,30 @@ test("getRecentRuns returns globally newest runs instead of one latest run per b
   assert.equal(recent[0]?.delta, 1);
   assert.equal(recent[1]?.delta, 1);
   assert.equal(recent[2]?.delta, null);
+});
+
+test("benchmark cards and recent runs do not compute deltas across primary metrics", () => {
+  const runs = [
+    summary({
+      id: "latest",
+      timestamp: "2026-05-21T10:00:00.000Z",
+      primaryMetric: "accuracy",
+      primaryScore: 0.8,
+    }),
+    summary({
+      id: "previous",
+      timestamp: "2026-05-21T09:00:00.000Z",
+      primaryMetric: "commands_count",
+      primaryScore: 2,
+    }),
+  ];
+  const payload = { resultsDir: "/tmp/results", summaries: runs };
+
+  const cards = getBenchmarkCards(payload);
+  const recent = getRecentRuns(payload);
+
+  assert.equal(cards[0]?.delta, null);
+  assert.equal(recent[0]?.delta, null);
 });
 
 test("pickDefaultCompareIds chooses newest comparable benchmark pair", () => {

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -186,6 +186,23 @@ export interface ProviderRow {
   benchmarkScores: Record<string, number | null>;
 }
 
+function comparablePrimaryScoreDelta(
+  latest: BenchResultSummary,
+  previous: BenchResultSummary | null,
+): number | null {
+  if (
+    latest.primaryMetric === null ||
+    latest.primaryScore === null ||
+    previous === null ||
+    previous.primaryMetric !== latest.primaryMetric ||
+    previous.primaryScore === null
+  ) {
+    return null;
+  }
+
+  return latest.primaryScore - previous.primaryScore;
+}
+
 function withinRange(timestamp: string, range: TrendRange, anchor: number): boolean {
   const value = Date.parse(timestamp);
   if (Number.isNaN(value) || value > anchor) {
@@ -326,12 +343,7 @@ export function getBenchmarkCards(payload: BenchResultSummaryPayload): Benchmark
       benchmark,
       latest,
       previous,
-      delta:
-        latest.primaryScore !== null &&
-        previous !== null &&
-        previous.primaryScore !== null
-          ? latest.primaryScore - previous.primaryScore
-          : null,
+      delta: comparablePrimaryScoreDelta(latest, previous),
     });
   }
 
@@ -350,12 +362,7 @@ export function getRecentRuns(payload: BenchResultSummaryPayload, limit = 6): Re
     for (let index = 0; index < runs.length; index += 1) {
       const run = runs[index]!;
       const previous = runs[index + 1] ?? null;
-      deltaByRunId.set(
-        run.id,
-        run.primaryScore !== null && previous !== null && previous.primaryScore !== null
-          ? run.primaryScore - previous.primaryScore
-          : null,
-      );
+      deltaByRunId.set(run.id, comparablePrimaryScoreDelta(run, previous));
     }
   }
 


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-ui-flow-171e9a4872-a750_3e88136264`.

## Changes
- Only compute primary-score deltas when latest and previous runs have the same non-null primary metric.
- Apply the same comparable-delta logic to benchmark cards and recent runs.
- Add bench-data regression coverage for mismatched primary metrics.

## Verification
- `pnpm exec tsx --test packages/bench-ui/src/bench-data.test.ts`
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-layer fix in bench-data with a focused unit test; no auth, persistence, or API behavior changes.
> 
> **Overview**
> Benchmark UI **primary-score deltas** no longer subtract scores when the latest and previous runs use **different** `primaryMetric` values (e.g. accuracy vs `commands_count`). A shared `comparablePrimaryScoreDelta` helper gates deltas on matching non-null metrics and scores; **benchmark cards** and **recent runs** both use it instead of raw score subtraction.
> 
> Regression test asserts cards and recent runs show **no delta** when consecutive runs disagree on metric type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164fe58d789b4fc39df63c8e6d25017909a3584a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->