### PR TITLE
Drain ingestion work before entity recall scoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -912,12 +910,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -940,9 +933,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -995,12 +986,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/bench/src/adapters/timeout-guard.test.ts
+++ b/packages/bench/src/adapters/timeout-guard.test.ts
@@ -509,3 +509,58 @@ test("timeout guard wraps ingestion adapter calls", async () => {
   );
   assert.equal(destroyed, true);
 });
+
+test("timeout guard preserves ingestion adapter drain hook", async () => {
+  let drained = false;
+  const guarded = createTimeoutGuardedIngestionAdapter(
+    {
+      async ingest() {
+        return { commandsIssued: [], promptsShown: [], errors: [], durationMs: 0 };
+      },
+      async getMemoryGraph() {
+        return { entities: [], links: [], pages: [] };
+      },
+      async reset() {},
+      async drain() {
+        drained = true;
+      },
+      async destroy() {},
+    },
+    {
+      benchmarkId: "timeout-test",
+      timeoutMs: 100,
+    },
+  );
+
+  assert.equal(typeof guarded.drain, "function");
+  await guarded.drain?.();
+  assert.equal(drained, true);
+});
+
+test("timeout guard uses separate ingestion drain timeout", async () => {
+  const guarded = createTimeoutGuardedIngestionAdapter(
+    {
+      async ingest() {
+        return { commandsIssued: [], promptsShown: [], errors: [], durationMs: 0 };
+      },
+      async getMemoryGraph() {
+        return { entities: [], links: [], pages: [] };
+      },
+      async reset() {},
+      async drain() {
+        return new Promise<void>(() => {});
+      },
+      async destroy() {},
+    },
+    {
+      benchmarkId: "timeout-test",
+      timeoutMs: 100,
+      drainTimeoutMs: 5,
+    },
+  );
+
+  await assert.rejects(
+    () => guarded.drain!(),
+    /benchmark phase timed out after 5ms: timeout-test:ingestion.drain/,
+  );
+});

--- a/packages/bench/src/adapters/timeout-guard.ts
+++ b/packages/bench/src/adapters/timeout-guard.ts
@@ -254,12 +254,17 @@ export function createTimeoutGuardedIngestionAdapter(
   options: TimeoutGuardOptions & { timeoutMs: number },
 ): IngestionBenchAdapter {
   assertPositiveTimeout(options.timeoutMs, "benchmark phase timeout");
+  if (options.drainTimeoutMs !== undefined) {
+    assertPositiveTimeout(options.drainTimeoutMs, "benchmark drain timeout");
+  }
+  const drainTimeoutMs = options.drainTimeoutMs ?? options.timeoutMs;
 
   const run = async <T>(
     phase: string,
     fn: (signal: AbortSignal) => Promise<T>,
+    timeoutMs = options.timeoutMs,
   ): Promise<T> =>
-    runWithBenchmarkPhaseTimeout(`${options.benchmarkId}:${phase}`, options.timeoutMs, fn, options);
+    runWithBenchmarkPhaseTimeout(`${options.benchmarkId}:${phase}`, timeoutMs, fn, options);
 
   return {
     ingest(inputDir: string): Promise<IngestionLog> {
@@ -271,6 +276,17 @@ export function createTimeoutGuardedIngestionAdapter(
     reset(): Promise<void> {
       return run("ingestion.reset", () => adapter.reset());
     },
+    ...(adapter.drain
+      ? {
+          drain(): Promise<void> {
+            return run(
+              "ingestion.drain",
+              () => adapter.drain?.() ?? Promise.resolve(),
+              drainTimeoutMs,
+            );
+          },
+        }
+      : {}),
     destroy(): Promise<void> {
       return adapter.destroy();
     },

--- a/packages/bench/src/benchmarks/remnic/ingestion-entity-recall/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-entity-recall/runner.test.ts
@@ -5,6 +5,7 @@ import {
   ingestionEntityRecallDefinition,
   runIngestionEntityRecallBenchmark,
 } from "./runner.ts";
+import { EMAIL_GOLD_GRAPH } from "../../../fixtures/inbox/email-gold.ts";
 
 test("entity recall fails the task when ingestion reports errors", async () => {
   let getMemoryGraphCalls = 0;
@@ -57,4 +58,112 @@ test("entity recall fails the task when ingestion reports errors", async () => {
   assert.match(task.actual, /ingestion error: store unavailable/);
   assert.deepEqual(task.details?.ingestionErrors, ["store unavailable"]);
   assert.equal(getMemoryGraphCalls, 0);
+});
+
+test("entity recall drains asynchronous ingestion work before scoring graph", async () => {
+  let drained = false;
+  let getMemoryGraphCalls = 0;
+
+  const result = await runIngestionEntityRecallBenchmark({
+    benchmark: ingestionEntityRecallDefinition,
+    mode: "quick",
+    system: {
+      async reset() {},
+      async store() {},
+      async recall() {
+        return "";
+      },
+      async search() {
+        return [];
+      },
+      async destroy() {},
+      async getStats() {
+        return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+    },
+    ingestionAdapter: {
+      async reset() {
+        drained = false;
+      },
+      async destroy() {},
+      async ingest() {
+        return {
+          commandsIssued: [],
+          promptsShown: [],
+          errors: [],
+          durationMs: 1,
+        };
+      },
+      async drain() {
+        drained = true;
+      },
+      async getMemoryGraph() {
+        getMemoryGraphCalls += 1;
+        return {
+          entities: drained
+            ? EMAIL_GOLD_GRAPH.entities.map((entity) => ({
+                name: entity.name,
+                type: entity.type,
+                sourceFile: "fixture.mbox",
+              }))
+            : [],
+          links: [],
+          pages: [],
+        };
+      },
+    },
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(getMemoryGraphCalls, 1);
+  assert.equal(task.scores.entity_recall, 1);
+  assert.equal(task.details?.extractedEntityCount, EMAIL_GOLD_GRAPH.entities.length);
+});
+
+test("entity recall reports drain failures before reading graph", async () => {
+  let getMemoryGraphCalls = 0;
+
+  const result = await runIngestionEntityRecallBenchmark({
+    benchmark: ingestionEntityRecallDefinition,
+    mode: "quick",
+    system: {
+      async reset() {},
+      async store() {},
+      async recall() {
+        return "";
+      },
+      async search() {
+        return [];
+      },
+      async destroy() {},
+      async getStats() {
+        return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+      },
+    },
+    ingestionAdapter: {
+      async reset() {},
+      async destroy() {},
+      async ingest() {
+        return {
+          commandsIssued: ["ingest"],
+          promptsShown: [],
+          errors: [],
+          durationMs: 1,
+        };
+      },
+      async drain() {
+        throw new Error("flush timed out");
+      },
+      async getMemoryGraph() {
+        getMemoryGraphCalls += 1;
+        return { entities: [], links: [], pages: [] };
+      },
+    },
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(getMemoryGraphCalls, 0);
+  assert.equal(task.scores.entity_recall, -1);
+  assert.match(task.actual, /ingestion drain error: flush timed out/);
+  assert.equal(task.details?.drainError, "flush timed out");
 });

--- a/packages/bench/src/benchmarks/remnic/ingestion-entity-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-entity-recall/runner.ts
@@ -79,6 +79,35 @@ export async function runIngestionEntityRecallBenchmark(
       return buildResult(options, tasks, durationMs);
     }
 
+    try {
+      await options.ingestionAdapter.drain?.();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const tasks: TaskResult[] = [
+        {
+          taskId: `entity-recall-${fixture.id}`,
+          question: `Extract entities from ${fixture.id} fixture`,
+          expected: `${fixture.goldGraph.entities.length} entities`,
+          actual: `(ingestion drain error: ${message})`,
+          scores: {
+            entity_recall: -1,
+          },
+          latencyMs: durationMs,
+          tokens: { input: 0, output: 0 },
+          details: {
+            fixtureId: fixture.id,
+            goldEntityCount: fixture.goldGraph.entities.length,
+            ingestionErrors: ingestionLog.errors,
+            drainError: message,
+            commandsIssued: ingestionLog.commandsIssued,
+            promptsShown: ingestionLog.promptsShown,
+          },
+        },
+      ];
+
+      return buildResult(options, tasks, durationMs);
+    }
+
     const graph = await options.ingestionAdapter.getMemoryGraph();
     const { overall, byType } = entityRecall(graph.entities, fixture.goldGraph.entities);
 

--- a/packages/bench/src/ingestion-types.ts
+++ b/packages/bench/src/ingestion-types.ts
@@ -71,6 +71,8 @@ export interface IngestionLog {
 
 export interface IngestionBenchAdapter {
   ingest(inputDir: string): Promise<IngestionLog>;
+  /** Flush asynchronous ingestion work before graph scoring. */
+  drain?(): Promise<void>;
   getMemoryGraph(): Promise<MemoryGraph>;
   reset(): Promise<void>;
   destroy(): Promise<void>;


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-8ee8e98e2c-21f4_031c80bc07`.

## Changes
- Add an optional `drain()` hook to the ingestion benchmark adapter contract.
- Call `ingestionAdapter.drain?.()` after successful ingest and before reading the memory graph for entity recall scoring.
- Report drain failures as a failed benchmark task and skip graph scoring.
- Add focused runner tests for async drain completion and drain failure.
- Format root `package.json` for the current release baseline so the quick preflight lint gate passes.

## Verification
- `pnpm exec tsx --test packages/bench/src/benchmarks/remnic/ingestion-entity-recall/runner.test.ts`
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark harness and test-only contract changes; no production auth or data paths, with behavior gated on optional `drain()`.
> 
> **Overview**
> Entity recall ingestion benchmarks now **flush async work** before scoring: an optional **`drain()`** on **`IngestionBenchAdapter`**, invoked after a successful **`ingest`** and before **`getMemoryGraph`**. Drain failures produce a failed task (`entity_recall: -1`) with **`drainError`** in details and **no graph read**.
> 
> The timeout-guarded ingestion wrapper **forwards `drain`** when present and can apply a **separate `drainTimeoutMs`** (defaulting to the phase timeout). Runner and timeout-guard tests cover drain-before-score and drain failure paths. Root **`package.json`** is reformatted only (arrays on one line) for lint/preflight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 685638ae918520f51eca62e3f8594794fb75a17a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->