### PR TITLE
Encode session toggle key separators safely

### DIFF
--- a/packages/remnic-core/src/session-toggles.test.ts
+++ b/packages/remnic-core/src/session-toggles.test.ts
@@ -24,6 +24,26 @@ test("createFileToggleStore round-trips disabled state for encoded session keys"
   assert.equal(Object.keys(raw.entries).length, 1);
 });
 
+test("createFileToggleStore lists and clears keys containing the separator", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-toggle-store-separator-"));
+  const filePath = path.join(root, "session-toggles.json");
+  const store = createFileToggleStore(filePath);
+
+  await store.setDisabled("pi::session", "agent::one", true);
+
+  assert.equal(await store.isDisabled("pi::session", "agent::one"), true);
+  const listed = await store.list();
+  assert.equal(listed.length, 1);
+  assert.equal(listed[0]?.sessionKey, "pi::session");
+  assert.equal(listed[0]?.agentId, "agent::one");
+  assert.equal(listed[0]?.disabled, true);
+
+  await store.clear("pi::session", "agent::one");
+
+  assert.equal(await store.isDisabled("pi::session", "agent::one"), false);
+  assert.deepEqual(await store.list(), []);
+});
+
 test("createFileToggleStore recovers from malformed primary store contents", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-toggle-store-bad-"));
   const filePath = path.join(root, "session-toggles.json");

--- a/packages/remnic-core/src/session-toggles.ts
+++ b/packages/remnic-core/src/session-toggles.ts
@@ -27,17 +27,39 @@ interface FileToggleStoreOptions {
   secondaryReadOnlyPath?: string;
 }
 
+const TOGGLE_KEY_SEPARATOR = "::";
+
+function encodeToggleComponent(value: string): string {
+  return encodeURIComponent(value).replaceAll(":", "%3A");
+}
+
 function encodeToggleKey(sessionKey: string, agentId: string): string {
-  return `${encodeURIComponent(sessionKey)}::${encodeURIComponent(agentId)}`;
+  return `${encodeToggleComponent(sessionKey)}${TOGGLE_KEY_SEPARATOR}${encodeToggleComponent(agentId)}`;
+}
+
+function encodeLegacyToggleKey(sessionKey: string, agentId: string): string {
+  return `${encodeURIComponent(sessionKey)}${TOGGLE_KEY_SEPARATOR}${encodeURIComponent(agentId)}`;
+}
+
+function toggleKeyCandidates(sessionKey: string, agentId: string): string[] {
+  const key = encodeToggleKey(sessionKey, agentId);
+  const legacyKey = encodeLegacyToggleKey(sessionKey, agentId);
+  return key === legacyKey ? [key] : [key, legacyKey];
 }
 
 function decodeToggleKey(key: string): { sessionKey: string; agentId: string } | null {
-  const [encodedSessionKey, encodedAgentId] = key.split("::");
+  const parts = key.split(TOGGLE_KEY_SEPARATOR);
+  if (parts.length !== 2) return null;
+  const [encodedSessionKey, encodedAgentId] = parts;
   if (!encodedSessionKey || !encodedAgentId) return null;
-  return {
-    sessionKey: decodeURIComponent(encodedSessionKey),
-    agentId: decodeURIComponent(encodedAgentId),
-  };
+  try {
+    return {
+      sessionKey: decodeURIComponent(encodedSessionKey),
+      agentId: decodeURIComponent(encodedAgentId),
+    };
+  } catch {
+    return null;
+  }
 }
 
 async function safeReadToggleFile(filePath: string): Promise<ToggleFile> {
@@ -97,21 +119,23 @@ export function createFileToggleStore(
     },
 
     async resolve(sessionKey: string, agentId: string) {
-      const key = encodeToggleKey(sessionKey, agentId);
+      const keys = toggleKeyCandidates(sessionKey, agentId);
       const primary = await readPrimary();
-      if (primary.entries[key]) {
+      const primaryKey = keys.find((key) => primary.entries[key]);
+      if (primaryKey) {
         return {
-          disabled: primary.entries[key].disabled,
+          disabled: primary.entries[primaryKey].disabled,
           source: "primary" as const,
-          updatedAt: primary.entries[key].updatedAt,
+          updatedAt: primary.entries[primaryKey].updatedAt,
         };
       }
       const secondary = await readSecondary();
-      if (secondary.entries[key]) {
+      const secondaryKey = keys.find((key) => secondary.entries[key]);
+      if (secondaryKey) {
         return {
-          disabled: secondary.entries[key].disabled,
+          disabled: secondary.entries[secondaryKey].disabled,
           source: "secondary" as const,
-          updatedAt: secondary.entries[key].updatedAt,
+          updatedAt: secondary.entries[secondaryKey].updatedAt,
         };
       }
       return { disabled: false, source: "none" as const };
@@ -130,10 +154,12 @@ export function createFileToggleStore(
     },
 
     async clear(sessionKey: string, agentId: string): Promise<void> {
-      const key = encodeToggleKey(sessionKey, agentId);
+      const keys = toggleKeyCandidates(sessionKey, agentId);
       await queueWrite(async () => {
         const current = await readPrimary();
-        delete current.entries[key];
+        for (const key of keys) {
+          delete current.entries[key];
+        }
         await writeToggleFile(current);
       });
     },


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-acabf0c104-f673_a6f0060e67`.

## Changes
- Encode literal `:` characters in session-toggle key components so `::` cannot collide with the stored key separator.
- Decode only exactly two separator-delimited components and ignore malformed keys in list output.
- Preserve legacy lookup and clear candidates so previously stored non-canonical keys can still be resolved or removed by exact session/agent values.
- Add a regression covering set/list/clear for `sessionKey="pi::session"` and `agentId="agent::one"`.

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/session-toggles.test.ts`
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:entity-hardening`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized persistence-key encoding in remnic-core session toggles with backward-compatible reads; no auth or network surface.
> 
> **Overview**
> Hardens how **session toggle** entries are keyed in the file store so `sessionKey` / `agentId` values that contain `::` cannot corrupt lookup, listing, or clear behavior.
> 
> **Canonical keys** now URI-encode each component and escape literal `:` as `%3A` before joining with `::`. **Decode** only accepts keys split into exactly two segments and ignores malformed entries in `list()`. **Resolve** and **clear** try both the new encoding and the previous `encodeURIComponent`-only form so existing on-disk entries still match.
> 
> Adds a regression test for `pi::session` / `agent::one` set, list, and clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e435b0a43e0f38af7038486626b2d58f107ab305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->