### PR TITLE
Export root secure-store shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,18 @@
     "./access-cli.js": {
       "import": "./dist/access-cli.js"
     },
+    "./secure-store": {
+      "import": "./dist/secure-store/index.js"
+    },
+    "./secure-store.js": {
+      "import": "./dist/secure-store/index.js"
+    },
+    "./secure-store/index": {
+      "import": "./dist/secure-store/index.js"
+    },
+    "./secure-store/index.js": {
+      "import": "./dist/secure-store/index.js"
+    },
     "./adapters": {
       "import": "./dist/adapters/index.js"
     },

--- a/tests/connectors-root-exports.test.ts
+++ b/tests/connectors-root-exports.test.ts
@@ -7,11 +7,20 @@ import {
   materializeForNamespace,
   runCodexMaterialize as runFromIndexShim,
 } from "../src/connectors/index.js";
+import * as secureStore from "../src/secure-store/index.js";
 
 test("root connector shims expose Codex materialize exports", () => {
   assert.equal(typeof runFromRunnerShim, "function");
   assert.equal(typeof runFromIndexShim, "function");
   assert.equal(typeof materializeForNamespace, "function");
+});
+
+test("root secure-store shim exposes the core secure-store surface", () => {
+  assert.equal(typeof secureStore.seal, "function");
+  assert.equal(typeof secureStore.open, "function");
+  assert.equal(typeof secureStore.keyring, "object");
+  assert.equal(typeof secureStore.keyring.unlock, "function");
+  assert.equal(typeof secureStore.keyring.size, "function");
 });
 
 test("root package export map exposes LCM shims", async () => {
@@ -55,6 +64,8 @@ test("root package export map exposes compat and source shims", async () => {
     ["consolidation-provenance-check", "./dist/consolidation-provenance-check.js"],
     ["entity-retrieval", "./dist/entity-retrieval.js"],
     ["extraction", "./dist/extraction.js"],
+    ["secure-store", "./dist/secure-store/index.js"],
+    ["secure-store/index", "./dist/secure-store/index.js"],
   ] as const) {
     assert.deepEqual(exportsMap[`./${subpath}`], { import: expectedTarget }, subpath);
     assert.deepEqual(exportsMap[`./${subpath}.js`], { import: expectedTarget }, `${subpath}.js`);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
     "src/search/orama-backend.ts",
     "src/search/port.ts",
     "src/search/remote-backend.ts",
+    "src/secure-store/index.ts",
     "src/schemas.ts",
     "src/sdk-compat.ts",
     "src/session-observer-bands.ts",


### PR DESCRIPTION
## Summary
- expose root secure-store subpaths in the package exports map
- include src/secure-store/index.ts in the root tsup build entries
- add package-surface coverage for the secure-store shim and subpath exports

## Verification
- pnpm exec tsx --test tests/connectors-root-exports.test.ts
- npm run build
- node scripts/check-release-artifacts.mjs
- node -e "const m = await import('remnic-workspace/secure-store'); if (typeof m.seal !== 'function' || typeof m.open !== 'function' || typeof m.keyring?.unlock !== 'function') throw new Error('secure-store export surface incomplete'); console.log('secure-store package self-import ok')"
- node -e "const m = await import('remnic-workspace/secure-store/index'); if (typeof m.seal !== 'function' || typeof m.open !== 'function' || typeof m.keyring?.unlock !== 'function') throw new Error('secure-store/index export surface incomplete'); console.log('secure-store/index package self-import ok')"
- git diff --check
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and test-only changes; no changes to encryption or keyring implementation, only build/export wiring for an existing re-export shim.
> 
> **Overview**
> This PR wires the existing **`secure-store`** root shim into the published package so consumers can import `remnic-workspace/secure-store` (and the `.js` / `index` variants) like other root subpaths.
> 
> **`package.json`** adds four export entries pointing at `./dist/secure-store/index.js`. **`tsup.config.ts`** includes `src/secure-store/index.ts` in the build so that artifact is emitted. **`tests/connectors-root-exports.test.ts`** asserts the export map targets and that the shim exposes **`seal`**, **`open`**, and **`keyring`** (`unlock`, `size`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a33afc4afcc287fc20caffcab11258a05a0a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->