### PR TITLE
Fallback on malformed semantic embeddings

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -924,12 +922,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -952,9 +945,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1007,12 +998,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/semantic-chunking.ts
+++ b/packages/remnic-core/src/semantic-chunking.ts
@@ -241,6 +241,20 @@ async function batchEmbed(
   return allEmbeddings;
 }
 
+function findEmbeddingDimensionMismatch(
+  embeddings: number[][],
+): { expected: number; actual: number; index: number } | null {
+  if (embeddings.length <= 1) return null;
+  const expected = embeddings[0].length;
+  for (let i = 1; i < embeddings.length; i++) {
+    const actual = embeddings[i].length;
+    if (actual !== expected) {
+      return { expected, actual, index: i };
+    }
+  }
+  return null;
+}
+
 /**
  * Build segments from boundary indices.
  * boundaries are sentence indices at which splits occur (i.e., the split
@@ -420,6 +434,17 @@ export async function semanticChunkContent(
     }
     throw new Error(
       `Semantic chunking failed: expected ${sentences.length} embeddings but received ${embeddings.length}`,
+    );
+  }
+
+  const dimensionMismatch = findEmbeddingDimensionMismatch(embeddings);
+  if (dimensionMismatch) {
+    if (cfg.fallbackToRecursive) {
+      return buildRecursiveFallback(content, cfg);
+    }
+    throw new Error(
+      `Semantic chunking failed: embedding vectors have mismatched dimensions ` +
+        `(${dimensionMismatch.expected} vs ${dimensionMismatch.actual} at index ${dimensionMismatch.index})`,
     );
   }
 

--- a/tests/semantic-chunking.test.ts
+++ b/tests/semantic-chunking.test.ts
@@ -564,6 +564,44 @@ test("semanticChunkContent: recursive fallback path caps targetTokens to maxToke
   }
 });
 
+test("semanticChunkContent: mismatched embedding dimensions fall back when enabled", async () => {
+  const text = [
+    "Alpha planning details span enough words to require semantic processing.",
+    "Alpha implementation notes continue the same topic for comparison.",
+    "Beta release details switch topics after the malformed embedding.",
+  ].join(" ");
+  const mismatchedEmbedFn: EmbedFn = async () => [[1, 0], [1], [0, 1]];
+
+  const result = await semanticChunkContent(text, mismatchedEmbedFn, {
+    fallbackToRecursive: true,
+    minTokens: 1,
+    targetTokens: 20,
+    maxTokens: 40,
+  });
+
+  assert.equal(result.method, "recursive-fallback");
+});
+
+test("semanticChunkContent: mismatched embedding dimensions reject when fallback is disabled", async () => {
+  const text = [
+    "Alpha planning details span enough words to require semantic processing.",
+    "Alpha implementation notes continue the same topic for comparison.",
+    "Beta release details switch topics after the malformed embedding.",
+  ].join(" ");
+  const mismatchedEmbedFn: EmbedFn = async () => [[1, 0], [1], [0, 1]];
+
+  await assert.rejects(
+    () =>
+      semanticChunkContent(text, mismatchedEmbedFn, {
+        fallbackToRecursive: false,
+        minTokens: 1,
+        targetTokens: 20,
+        maxTokens: 40,
+      }),
+    /embedding vectors have mismatched dimensions \(2 vs 1 at index 1\)/,
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Finding 4 (PR #420): even window sizes are rounded up to odd
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- validate semantic embedding vector dimensions before cosine similarity
- route malformed embedding dimensions through recursive fallback when enabled
- add fallback-enabled and fallback-disabled regression coverage
- normalize root package.json formatting required by current main preflight

## Verification
- pnpm exec tsx --test tests/semantic-chunking.test.ts
- git diff --check
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:entity-hardening

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted guard in semantic chunking with existing fallback semantics and tests; no auth or data-store changes.
> 
> **Overview**
> **Semantic chunking** now checks that every sentence embedding has the same vector length **before** pairwise cosine similarity runs. Malformed embedder output (mixed dimensions) no longer risks opaque `cosineSimilarity` throws mid-pipeline.
> 
> When `fallbackToRecursive` is **enabled**, dimension mismatches follow the same **recursive-fallback** path as count mismatches and embedding failures. When it is **disabled**, the flow fails fast with an explicit error naming expected vs actual dimension and the offending index.
> 
> Tests cover both behaviors with a deliberately mismatched mock `EmbedFn`. Root **`package.json`** array fields are collapsed to single-line form for current preflight formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500a665d02d3fa5c59a386edf85a42068161f410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->