### PR TITLE
Ignore malformed semantic dedup hits

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -924,12 +922,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -952,9 +945,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1007,12 +998,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/dedup/semantic.test.ts
+++ b/packages/remnic-core/src/dedup/semantic.test.ts
@@ -134,6 +134,38 @@ test("semantic dedup: ignores non-finite scores", async () => {
   }
 });
 
+test("semantic dedup: ignores malformed hits without a usable memory id", async () => {
+  const decision = await decideSemanticDedup(
+    "content",
+    makeLookup([
+      { id: "", score: 0.99 },
+      { id: "   ", score: 0.98 },
+      { id: 42, score: 0.97 } as unknown as SemanticDedupHit,
+      { id: "valid-hit", score: 0.93 },
+    ]),
+    DEFAULT_OPTS,
+  );
+
+  assert.equal(decision.action, "skip");
+  if (decision.action === "skip") {
+    assert.equal(decision.reason, "near_duplicate");
+    assert.equal(decision.topId, "valid-hit");
+    assert.equal(decision.topScore, 0.93);
+  }
+
+  const allMalformed = await decideSemanticDedup(
+    "content",
+    makeLookup([
+      { id: "", score: 0.99 },
+      { id: 42, score: 0.98 } as unknown as SemanticDedupHit,
+    ]),
+    DEFAULT_OPTS,
+  );
+
+  assert.equal(allMalformed.action, "keep");
+  assert.equal(allMalformed.reason, "no_near_duplicate");
+});
+
 test("semantic dedup: treats lookup throw as fail-open keep", async () => {
   const decision = await decideSemanticDedup(
     "content",
@@ -553,6 +585,7 @@ test("embedding fallback ignores persisted indexes from a different provider or 
       localLlmUrl: "http://127.0.0.1:1234",
       localLlmModel: "local-embed",
       embeddingFallbackModel: "local-embed",
+      openaiApiKey: false,
     });
     const fallback = new EmbeddingFallback(config);
 

--- a/packages/remnic-core/src/dedup/semantic.ts
+++ b/packages/remnic-core/src/dedup/semantic.ts
@@ -138,7 +138,13 @@ export async function decideSemanticDedup(
   // Defensive: callers ought to return sorted, but don't trust it.
   let top: SemanticDedupHit | undefined;
   for (const hit of hits) {
-    if (!hit || typeof hit.score !== "number" || !Number.isFinite(hit.score)) {
+    if (
+      !hit ||
+      typeof hit.id !== "string" ||
+      hit.id.trim().length === 0 ||
+      typeof hit.score !== "number" ||
+      !Number.isFinite(hit.score)
+    ) {
       continue;
     }
     if (!top || hit.score > top.score) {


### PR DESCRIPTION
## Summary
- ignore semantic dedup lookup hits whose memory id is missing, empty, or non-string before selecting the top hit
- add regression coverage for malformed high-score hits and all-malformed hit lists
- make the existing provider-mismatch fallback test independent of a local OPENAI_API_KEY environment value

## Verification
- `pnpm exec tsx --test packages/remnic-core/src/dedup/semantic.test.ts`
- `git diff --check`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:entity-hardening`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change to write-time dedup selection; may allow writes that previously skipped on bogus top hits, with fail-open keep when all hits are invalid.
> 
> **Overview**
> **Semantic dedup** now skips lookup hits whose memory `id` is missing, whitespace-only, or not a string when picking the top neighbor, so bad high-score rows cannot drive a **near_duplicate** skip or block valid duplicates from being considered.
> 
> Regression tests cover mixed malformed plus valid hits (skip uses the valid id) and all-malformed lists (**keep** / **no_near_duplicate**). An embedding fallback test sets **`openaiApiKey: false`** so provider-mismatch behavior does not depend on a local API key. Root **`package.json`** changes are formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11bf13f724a93576ba983a4d8afc7fb183678c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->