### PR TITLE
Preserve Unicode recall tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -924,12 +922,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -952,9 +945,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1007,12 +998,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/causal-chain.ts
+++ b/packages/remnic-core/src/causal-chain.ts
@@ -6,20 +6,15 @@
  * another session. Persists edges in a graph index for later retrieval.
  */
 
-import path from "node:path";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
-import { listJsonFiles, readJsonFile } from "./json-store.js";
-import { resolveCausalTrajectoryStoreDir, type CausalTrajectoryRecord } from "./causal-trajectory.js";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { topicOverlapScore } from "./boxes.js";
-import { countRecallTokenOverlap, normalizeRecallTokens } from "./recall-tokenization.js";
-import {
-  assertIsoRecordedAt,
-  assertString,
-  isRecord,
-  recordStoreDay,
-} from "./store-contract.js";
+import { type CausalTrajectoryRecord, resolveCausalTrajectoryStoreDir } from "./causal-trajectory.js";
+import { listJsonFiles, readJsonFile } from "./json-store.js";
 import { log } from "./logger.js";
+import { normalizeRecallTokens } from "./recall-tokenization.js";
+import { assertIsoRecordedAt, assertString, isRecord, recordStoreDay } from "./store-contract.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -65,6 +60,59 @@ const STITCH_WEIGHTS = {
   temporalProximity: 1.0,
 } as const;
 
+function hasUnsegmentableRecallChar(token: string): boolean {
+  if (token.includes("ー") || token.includes("ｰ")) return true;
+  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(token);
+}
+
+function extractUnsegmentableStitchPhrases(value: string): string[] {
+  const phrases = new Set<string>();
+  let segment = "";
+
+  const flushSegment = () => {
+    if ([...segment].length >= 4) {
+      phrases.add(segment);
+    }
+    segment = "";
+  };
+
+  for (const ch of value.toLowerCase().normalize("NFC")) {
+    if (hasUnsegmentableRecallChar(ch)) {
+      segment += ch;
+      continue;
+    }
+    if (/\p{M}/u.test(ch) && segment.length > 0) {
+      segment += ch;
+      continue;
+    }
+    if (/\s/u.test(ch) && segment.length > 0) {
+      continue;
+    }
+    flushSegment();
+  }
+  flushSegment();
+
+  return [...phrases];
+}
+
+function normalizeStitchLexicalTokens(value: string, extraStopWords: string[] = []): string[] {
+  const tokens = new Set(
+    normalizeRecallTokens(value, extraStopWords).filter((token) => !hasUnsegmentableRecallChar(token))
+  );
+  for (const phrase of extractUnsegmentableStitchPhrases(value)) {
+    tokens.add(phrase);
+  }
+  return [...tokens];
+}
+
+function countTokenSetOverlap(queryTokens: Set<string>, valueTokens: Set<string>): number {
+  let matches = 0;
+  for (const token of queryTokens) {
+    if (valueTokens.has(token)) matches += 1;
+  }
+  return matches;
+}
+
 // ─── Validation ──────────────────────────────────────────────────────────────
 
 export function validateCausalEdge(raw: unknown): CausalEdge {
@@ -97,9 +145,7 @@ export function validateCausalEdge(raw: unknown): CausalEdge {
     createdAt: assertIsoRecordedAt(assertString(raw.createdAt, "createdAt")),
     metadata: isRecord(raw.metadata)
       ? Object.fromEntries(
-          Object.entries(raw.metadata).filter(
-            (entry): entry is [string, string] => typeof entry[1] === "string",
-          ),
+          Object.entries(raw.metadata).filter((entry): entry is [string, string] => typeof entry[1] === "string")
         )
       : undefined,
   };
@@ -108,10 +154,7 @@ export function validateCausalEdge(raw: unknown): CausalEdge {
 // ─── Stable Edge ID ──────────────────────────────────────────────────────────
 
 export function makeEdgeId(fromId: string, toId: string): string {
-  const digest = createHash("sha256")
-    .update(`${fromId}\0${toId}`)
-    .digest("hex")
-    .slice(0, 12);
+  const digest = createHash("sha256").update(`${fromId}\0${toId}`).digest("hex").slice(0, 12);
   return `edge-${digest}`;
 }
 
@@ -153,9 +196,9 @@ export async function readChainIndex(chainsDir: string): Promise<CausalChainInde
   try {
     const raw = JSON.parse(await readFile(chainIndexPath(chainsDir), "utf8"));
     return {
-      outgoing: isRecord(raw.outgoing) ? raw.outgoing as Record<string, string[]> : {},
-      incoming: isRecord(raw.incoming) ? raw.incoming as Record<string, string[]> : {},
-      edges: isRecord(raw.edges) ? raw.edges as Record<string, CausalEdge> : {},
+      outgoing: isRecord(raw.outgoing) ? (raw.outgoing as Record<string, string[]>) : {},
+      incoming: isRecord(raw.incoming) ? (raw.incoming as Record<string, string[]>) : {},
+      edges: isRecord(raw.edges) ? (raw.edges as Record<string, CausalEdge>) : {},
       updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : new Date().toISOString(),
     };
   } catch {
@@ -202,19 +245,18 @@ function addEdgeToIndex(index: CausalChainIndex, edge: CausalEdge): void {
  */
 export function scoreStitchCandidate(
   newTrajectory: CausalTrajectoryRecord,
-  candidate: CausalTrajectoryRecord,
+  candidate: CausalTrajectoryRecord
 ): StitchCandidate {
   let score = 0;
   let dominantMethod: CausalEdge["stitchMethod"] = "lexical";
   let maxComponent = 0;
 
   // 1. Follow-up → Goal match (token overlap)
-  const newFollowUpTokens = new Set(
-    normalizeRecallTokens(newTrajectory.followUpSummary ?? "", []),
-  );
-  const candidateGoalTokens = normalizeRecallTokens(candidate.goal, []);
+  const newFollowUpTokens = new Set(normalizeStitchLexicalTokens(newTrajectory.followUpSummary ?? "", []));
+  const candidateGoalTokens = normalizeStitchLexicalTokens(candidate.goal, []);
+  const candidateGoalTokenSet = new Set(candidateGoalTokens);
   if (newFollowUpTokens.size > 0 && candidateGoalTokens.length > 0) {
-    const overlap = countRecallTokenOverlap(newFollowUpTokens, candidate.goal, []);
+    const overlap = countTokenSetOverlap(newFollowUpTokens, candidateGoalTokenSet);
     const normalized = overlap / Math.max(newFollowUpTokens.size, candidateGoalTokens.length);
     const component = normalized * STITCH_WEIGHTS.followUpToGoal;
     score += component;
@@ -225,12 +267,11 @@ export function scoreStitchCandidate(
   }
 
   // 1b. Candidate follow-up → New goal match (reverse direction)
-  const candidateFollowUpTokens = new Set(
-    normalizeRecallTokens(candidate.followUpSummary ?? "", []),
-  );
-  const newGoalTokens = normalizeRecallTokens(newTrajectory.goal, []);
+  const candidateFollowUpTokens = new Set(normalizeStitchLexicalTokens(candidate.followUpSummary ?? "", []));
+  const newGoalTokens = normalizeStitchLexicalTokens(newTrajectory.goal, []);
+  const newGoalTokenSet = new Set(newGoalTokens);
   if (candidateFollowUpTokens.size > 0 && newGoalTokens.length > 0) {
-    const overlap = countRecallTokenOverlap(candidateFollowUpTokens, newTrajectory.goal, []);
+    const overlap = countTokenSetOverlap(candidateFollowUpTokens, newGoalTokenSet);
     const normalized = overlap / Math.max(candidateFollowUpTokens.size, newGoalTokens.length);
     const component = normalized * 3.0;
     score += component;
@@ -241,11 +282,9 @@ export function scoreStitchCandidate(
   }
 
   // 2. Outcome → Goal match
-  const newOutcomeTokens = new Set(
-    normalizeRecallTokens(newTrajectory.outcomeSummary, []),
-  );
+  const newOutcomeTokens = new Set(normalizeStitchLexicalTokens(newTrajectory.outcomeSummary, []));
   if (newOutcomeTokens.size > 0) {
-    const overlap = countRecallTokenOverlap(newOutcomeTokens, candidate.goal, []);
+    const overlap = countTokenSetOverlap(newOutcomeTokens, candidateGoalTokenSet);
     const normalized = overlap / Math.max(newOutcomeTokens.size, candidateGoalTokens.length || 1);
     const component = normalized * STITCH_WEIGHTS.outcomeToGoal;
     score += component;
@@ -297,9 +336,8 @@ export function scoreStitchCandidate(
 
   // Determine edge type by heuristic
   let edgeType: CausalEdge["edgeType"] = "continuation";
-  const goalTokens = new Set(normalizeRecallTokens(newTrajectory.goal, []));
-  const candidateGoalSet = new Set(candidateGoalTokens);
-  const goalOverlap = [...goalTokens].filter((t) => candidateGoalSet.has(t)).length;
+  const goalTokens = new Set(newGoalTokens);
+  const goalOverlap = countTokenSetOverlap(goalTokens, candidateGoalTokenSet);
   const goalSimilarity = goalTokens.size > 0 ? goalOverlap / goalTokens.size : 0;
 
   if (goalSimilarity > 0.7 && candidate.outcomeKind === "failure") {
@@ -307,7 +345,7 @@ export function scoreStitchCandidate(
   } else if (goalSimilarity > 0.7 && newTrajectory.outcomeKind !== candidate.outcomeKind) {
     edgeType = "correction";
   } else if (newFollowUpTokens.size > 0 && candidateGoalTokens.length > 0) {
-    const followUpGoalOverlap = countRecallTokenOverlap(newFollowUpTokens, candidate.goal, []);
+    const followUpGoalOverlap = countTokenSetOverlap(newFollowUpTokens, candidateGoalTokenSet);
     if (followUpGoalOverlap > 0) {
       edgeType = "follow_up_to_goal";
     }
@@ -324,7 +362,7 @@ async function readRecentTrajectories(
   memoryDir: string,
   causalTrajectoryStoreDir: string | undefined,
   currentSessionKey: string,
-  lookbackDays: number,
+  lookbackDays: number
 ): Promise<CausalTrajectoryRecord[]> {
   const root = resolveCausalTrajectoryStoreDir(memoryDir, causalTrajectoryStoreDir);
   const trajectoriesDir = path.join(root, "trajectories");
@@ -370,7 +408,7 @@ export async function stitchCausalChain(options: {
     memoryDir,
     causalTrajectoryStoreDir,
     newTrajectory.sessionKey,
-    stitchConfig.lookbackDays,
+    stitchConfig.lookbackDays
   );
 
   if (candidates.length === 0) return [];

--- a/packages/remnic-core/src/direct-answer.test.ts
+++ b/packages/remnic-core/src/direct-answer.test.ts
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  FILTER_LABELS,
-  isDirectAnswerEligible,
   type DirectAnswerCandidate,
   type DirectAnswerConfig,
+  FILTER_LABELS,
+  isDirectAnswerEligible,
 } from "./direct-answer.js";
 import type { MemoryFile } from "./types.js";
 
@@ -17,15 +17,17 @@ const DEFAULT_CONFIG: DirectAnswerConfig = {
   eligibleTaxonomyBuckets: ["decisions", "principles", "conventions", "runbooks", "entities"],
 };
 
-function makeMemory(overrides: {
-  id?: string;
-  path?: string;
-  content?: string;
-  tags?: string[];
-  status?: MemoryFile["frontmatter"]["status"];
-  verificationState?: MemoryFile["frontmatter"]["verificationState"];
-  entityRef?: string;
-} = {}): MemoryFile {
+function makeMemory(
+  overrides: {
+    id?: string;
+    path?: string;
+    content?: string;
+    tags?: string[];
+    status?: MemoryFile["frontmatter"]["status"];
+    verificationState?: MemoryFile["frontmatter"]["verificationState"];
+    entityRef?: string;
+  } = {}
+): MemoryFile {
   const id = overrides.id ?? "mem-1";
   return {
     path: overrides.path ?? `/memory/${id}.md`,
@@ -46,14 +48,15 @@ function makeMemory(overrides: {
   };
 }
 
-function makeCandidate(overrides: Partial<DirectAnswerCandidate> & { memory?: MemoryFile } = {}): DirectAnswerCandidate {
+function makeCandidate(
+  overrides: Partial<DirectAnswerCandidate> & { memory?: MemoryFile } = {}
+): DirectAnswerCandidate {
   return {
     memory: overrides.memory ?? makeMemory(),
     // Use `in` so callers can pass an explicit `null` without it being
     // clobbered by the default.
-    trustZone: "trustZone" in overrides ? overrides.trustZone ?? null : "trusted",
-    taxonomyBucket:
-      "taxonomyBucket" in overrides ? overrides.taxonomyBucket ?? null : "decisions",
+    trustZone: "trustZone" in overrides ? (overrides.trustZone ?? null) : "trusted",
+    taxonomyBucket: "taxonomyBucket" in overrides ? (overrides.taxonomyBucket ?? null) : "decisions",
     importanceScore: overrides.importanceScore ?? 0.9,
     matchScore: overrides.matchScore,
   };
@@ -350,6 +353,555 @@ test("isDirectAnswerEligible rejects when no candidate meets the token-overlap f
   assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
 });
 
+test("isDirectAnswerEligible does not pass CJK direct answers on shared common characters", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户讨厌深色主题",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "用户喜欢深色模式",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.tokenOverlap === undefined);
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible does not pass short CJK direct answers on shared suffixes", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢浅色模式",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "深色模式",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible does not pass CJK direct answers on shared prefixes with opposite values", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢浅色模式",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "用户喜欢深色模式",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible requires every independent CJK phrase before direct answering", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢深色模式",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "用户喜欢深色模式 and 客户账户升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible does not require punctuation-bridged CJK aggregate phrases", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢深色模式 and 客户账户升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "用户喜欢深色模式，客户账户升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible treats space-separated long CJK clauses as independent phrases", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢深色模式 and 客户账户升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "用户喜欢深色模式 客户账户升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible bridges short spaced CJK query chunks", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢深色模式",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "用户 喜欢 深色 模式",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible requires ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户erp升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户crm升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible accepts matching ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户crm升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户crm升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible requires spaced ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户 ERP 升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户 CRM 升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible requires short spaced ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户 v1 升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户 v2 升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible accepts matching spaced ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户 CRM 升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户 CRM 升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible accepts matching short spaced ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户 v2 升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户 v2 升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible requires end-boundary ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户 ERP",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户 CRM",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible accepts matching end-boundary ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户 CRM",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户 CRM",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible requires start-boundary ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "ERP 客户",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "CRM 客户",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible requires short CJK chunks around mixed-script discriminators", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户crm降级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户crm升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible requires short contiguous ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户v1升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户v2升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible accepts matching short contiguous ASCII discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户v2升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户v2升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible requires non-Latin discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户α升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户β升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible accepts matching non-Latin discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户β升级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户β升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible requires boundary non-Latin discriminators in mixed CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户 α",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户 β",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible requires all non-CJK Unicode query tokens before direct answering", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "пользователь ненавидит темный режим",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "пользователь любит темный режим",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible accepts matching non-CJK Unicode query tokens", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "пользователь любит темный режим",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "пользователь любит темный режим",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible requires ASCII discriminators in non-CJK Unicode queries", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "клиент erp режим",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "клиент crm режим",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible accepts matching ASCII discriminators in non-CJK Unicode queries", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "клиент crm режим",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "клиент crm режим",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible does not require English prompt words before non-CJK Unicode terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "клиент режим",
+    }),
+  });
+  for (const promptWord of ["find", "get", "status", "include"]) {
+    const result = isDirectAnswerEligible({
+      query: `${promptWord} клиент режим`,
+      candidates: [candidate],
+      config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+    });
+    assert.equal(result.eligible, true, promptWord);
+    assert.equal(result.reason, "eligible", promptWord);
+    assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55, promptWord);
+  }
+});
+
+test("isDirectAnswerEligible does not require Russian prompt words before non-CJK Unicode terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "пользователь любит темный режим",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "найди пользователь любит темный режим",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible matches CJK direct answers across inserted spaces", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户 喜欢 深色 模式",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "用户喜欢深色模式",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.55 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.55);
+});
+
+test("isDirectAnswerEligible does not require English prompt words before CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢深色模式",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "what is 用户喜欢深色模式",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.5 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.5);
+});
+
+test("isDirectAnswerEligible does not require a single English prompt word before CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢深色模式",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "what 用户喜欢深色模式",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.5 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.5);
+});
+
+test("isDirectAnswerEligible does not require English recall verbs before CJK terms", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户喜欢深色模式",
+    }),
+  });
+  for (const promptWord of ["find", "status", "include"]) {
+    const result = isDirectAnswerEligible({
+      query: `${promptWord} 用户喜欢深色模式`,
+      candidates: [candidate],
+      config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0.5 },
+    });
+    assert.equal(result.eligible, true, promptWord);
+    assert.equal(result.reason, "eligible", promptWord);
+    assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap >= 0.5, promptWord);
+  }
+});
+
 test("isDirectAnswerEligible with tokenOverlapFloor=0 accepts any overlap (rule 45)", () => {
   const candidate = makeCandidate({
     memory: makeMemory({
@@ -363,6 +915,57 @@ test("isDirectAnswerEligible with tokenOverlapFloor=0 accepts any overlap (rule 
     config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0 },
   });
   assert.equal(result.eligible, true);
+});
+
+test("isDirectAnswerEligible rejects required CJK phrase misses when tokenOverlapFloor=0", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "用户讨厌深色主题",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "用户喜欢深色模式",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible rejects required mixed-script misses when tokenOverlapFloor=0", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "客户crm降级",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "客户crm升级",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible rejects required non-CJK Unicode misses when tokenOverlapFloor=0", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "пользователь ненавидит темный режим",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "пользователь любит темный режим",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
 });
 
 // ── Gate: ambiguity margin ──────────────────────────────────────────────────

--- a/packages/remnic-core/src/direct-answer.ts
+++ b/packages/remnic-core/src/direct-answer.ts
@@ -18,12 +18,9 @@
  * Not wired into retrieval yet — see slice 3.
  */
 
-import type { MemoryFile, MemoryStatus } from "./types.js";
+import { normalizeRecallTokenSet, normalizeRecallTokens } from "./recall-tokenization.js";
 import type { TrustZoneName } from "./trust-zones.js";
-import {
-  countRecallTokenOverlap,
-  normalizeRecallTokens,
-} from "./recall-tokenization.js";
+import type { MemoryFile, MemoryStatus } from "./types.js";
 
 /**
  * Caller-supplied candidate.
@@ -105,9 +102,246 @@ export const FILTER_LABELS = {
   belowTokenOverlapFloor: "below-token-overlap-floor",
 } as const;
 
+const PROMPT_RECALL_WORDS = new Set([
+  "what",
+  "who",
+  "where",
+  "when",
+  "why",
+  "how",
+  "is",
+  "are",
+  "was",
+  "were",
+  "do",
+  "does",
+  "did",
+  "find",
+  "get",
+  "show",
+  "search",
+  "lookup",
+  "recall",
+  "remember",
+  "list",
+  "status",
+  "include",
+  "tell",
+  "me",
+  "give",
+  "about",
+  "please",
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "into",
+  "that",
+  "this",
+  "найди",
+  "найти",
+  "поиск",
+  "покажи",
+  "статус",
+  "включи",
+]);
+
 interface ScoredCandidate {
   candidate: DirectAnswerCandidate;
   tokenOverlap: number;
+  requiredTokenMismatch: boolean;
+}
+
+function hasUnsegmentableRecallChar(token: string): boolean {
+  if (token.includes("ー") || token.includes("ｰ")) return true;
+  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(token);
+}
+
+function requiredCjkPhraseTokens(query: string): string[] {
+  const phrases = new Set<string>();
+  let segment = "";
+
+  const addPhrase = (phrase: string) => {
+    if ([...phrase].length >= 4) {
+      phrases.add(phrase);
+    }
+  };
+
+  const flushSegment = () => {
+    let buffered = "";
+    for (const run of segment.split(/\s+/)) {
+      if (!run) continue;
+      if ([...run].length >= 4) {
+        addPhrase(buffered);
+        buffered = "";
+        addPhrase(run);
+        continue;
+      }
+      buffered += run;
+    }
+    addPhrase(buffered);
+    segment = "";
+  };
+
+  for (const ch of query.toLowerCase().normalize("NFC")) {
+    if (hasUnsegmentableRecallChar(ch)) {
+      segment += ch;
+      continue;
+    }
+    if (/\p{M}/u.test(ch) && segment.length > 0 && !/\s$/u.test(segment)) {
+      segment += ch;
+      continue;
+    }
+    if (/\s/u.test(ch)) {
+      segment += " ";
+      continue;
+    }
+    flushSegment();
+  }
+  flushSegment();
+
+  return [...phrases];
+}
+
+function requiredMixedScriptTokens(query: string): string[] {
+  const required = new Set<string>();
+  const parts: string[] = [];
+  let segment = "";
+
+  const flushSegment = () => {
+    if (segment) {
+      parts.push(segment);
+    }
+    segment = "";
+  };
+
+  const segmentableRecallTokens = (value: string) => {
+    const tokens = new Set<string>();
+    let segment = "";
+    const flushSegmentableSegment = () => {
+      for (const token of normalizeRecallTokenSet(segment, [], { minTokenLength: 1 })) {
+        tokens.add(token);
+      }
+      segment = "";
+    };
+
+    for (const ch of value) {
+      if (/[\p{L}\p{N}]/u.test(ch) && !hasUnsegmentableRecallChar(ch)) {
+        segment += ch;
+        continue;
+      }
+      if (/\p{M}/u.test(ch) && segment.length > 0) {
+        segment += ch;
+        continue;
+      }
+      flushSegmentableSegment();
+    }
+    flushSegmentableSegment();
+    return tokens;
+  };
+
+  const hasRequiredSegmentableToken = (value: string) => {
+    return segmentableRecallTokens(value).size > 0;
+  };
+
+  const hasBoundarySegmentableToken = (value: string) => {
+    for (const token of segmentableRecallTokens(value)) {
+      if (PROMPT_RECALL_WORDS.has(token)) {
+        continue;
+      }
+      const hasNonAsciiCodepoint = [...token].some((ch) => (ch.codePointAt(0) ?? 0) > 0x7f);
+      if (token.length >= 3 || /\p{N}/u.test(token) || hasNonAsciiCodepoint) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const addRequiredTokens = (value: string) => {
+    for (const token of normalizeRecallTokenSet(value, [], { minTokenLength: 1 })) {
+      required.add(token);
+    }
+  };
+
+  for (const ch of query.toLowerCase().normalize("NFC")) {
+    if (/[\p{L}\p{N}\p{M}]/u.test(ch) || hasUnsegmentableRecallChar(ch)) {
+      segment += ch;
+      continue;
+    }
+    flushSegment();
+  }
+  flushSegment();
+
+  for (const part of parts) {
+    if (hasUnsegmentableRecallChar(part) && hasRequiredSegmentableToken(part)) {
+      addRequiredTokens(part);
+    }
+  }
+
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const current = parts[i];
+    const next = parts[i + 1];
+    const currentHasUnsegmentable = hasUnsegmentableRecallChar(current);
+    const nextHasUnsegmentable = hasUnsegmentableRecallChar(next);
+    if (currentHasUnsegmentable === nextHasUnsegmentable) {
+      continue;
+    }
+    const segmentablePart = currentHasUnsegmentable ? next : current;
+    if (!hasBoundarySegmentableToken(segmentablePart)) {
+      continue;
+    }
+    addRequiredTokens(current);
+    addRequiredTokens(next);
+  }
+
+  for (let i = 1; i < parts.length - 1; i += 1) {
+    const prev = parts[i - 1];
+    const current = parts[i];
+    const next = parts[i + 1];
+    if (!hasUnsegmentableRecallChar(prev) || hasUnsegmentableRecallChar(current) || !hasUnsegmentableRecallChar(next)) {
+      continue;
+    }
+    if (!hasRequiredSegmentableToken(current)) {
+      continue;
+    }
+    addRequiredTokens(prev);
+    addRequiredTokens(current);
+    addRequiredTokens(next);
+  }
+
+  return [...required];
+}
+
+function requiredSegmentableUnicodeTokens(queryTokens: Set<string>): string[] {
+  const segmentableTokens = [...queryTokens].filter((token) => !hasUnsegmentableRecallChar(token));
+  const hasSegmentableUnicodeToken = segmentableTokens.some((token) =>
+    [...token].some((ch) => (ch.codePointAt(0) ?? 0) > 0x7f)
+  );
+  if (!hasSegmentableUnicodeToken) {
+    return [];
+  }
+  return segmentableTokens.filter((token) => {
+    if (PROMPT_RECALL_WORDS.has(token)) {
+      return false;
+    }
+    const hasNonAsciiCodepoint = [...token].some((ch) => (ch.codePointAt(0) ?? 0) > 0x7f);
+    if (hasNonAsciiCodepoint) {
+      return true;
+    }
+    if (!/^[a-z0-9]+$/u.test(token)) {
+      return false;
+    }
+    return token.length >= 3 || /\p{N}/u.test(token);
+  });
+}
+
+function countTokenOverlap(queryTokens: Set<string>, valueTokens: Set<string>): number {
+  let matches = 0;
+  for (const token of queryTokens) {
+    if (valueTokens.has(token)) matches += 1;
+  }
+  return matches;
 }
 
 /**
@@ -123,9 +357,7 @@ interface ScoredCandidate {
  *   6. top two candidates within ambiguityMargin → "ambiguous"
  *   7. otherwise → "eligible"
  */
-export function isDirectAnswerEligible(
-  input: DirectAnswerInput,
-): DirectAnswerResult {
+export function isDirectAnswerEligible(input: DirectAnswerInput): DirectAnswerResult {
   const { query, candidates, config, queryEntityRefs } = input;
 
   if (!config.enabled) {
@@ -164,17 +396,13 @@ export function isDirectAnswerEligible(
     return status === "active";
   });
 
-  working = applyFilter(working, filteredBy, FILTER_LABELS.notTrustedZone, (c) =>
-    c.trustZone === "trusted",
-  );
+  working = applyFilter(working, filteredBy, FILTER_LABELS.notTrustedZone, (c) => c.trustZone === "trusted");
 
   working = applyFilter(
     working,
     filteredBy,
     FILTER_LABELS.ineligibleTaxonomyBucket,
-    (c) =>
-      c.taxonomyBucket !== null &&
-      config.eligibleTaxonomyBuckets.includes(c.taxonomyBucket),
+    (c) => c.taxonomyBucket !== null && config.eligibleTaxonomyBuckets.includes(c.taxonomyBucket)
   );
 
   working = applyFilter(working, filteredBy, FILTER_LABELS.belowImportanceFloor, (c) => {
@@ -201,13 +429,24 @@ export function isDirectAnswerEligible(
   }
 
   const scored: ScoredCandidate[] = working.map((candidate) => {
-    const searchable =
-      `${candidate.memory.frontmatter.tags?.join(" ") ?? ""} ${candidate.memory.content}`.trim();
-    const matches = countRecallTokenOverlap(queryTokens, searchable);
-    return { candidate, tokenOverlap: matches / queryTokens.size };
+    const searchable = `${candidate.memory.frontmatter.tags?.join(" ") ?? ""} ${candidate.memory.content}`.trim();
+    const searchableTokens = normalizeRecallTokenSet(searchable);
+    const requiredSearchableTokens = normalizeRecallTokenSet(searchable, [], { minTokenLength: 1 });
+    const requiredPhrases = requiredCjkPhraseTokens(query);
+    const requiredMixedTokens = requiredMixedScriptTokens(query);
+    const requiredUnicodeTokens = requiredSegmentableUnicodeTokens(queryTokens);
+    const hasRequiredPhrase =
+      requiredPhrases.length === 0 || requiredPhrases.every((token) => searchableTokens.has(token));
+    const hasRequiredMixedTokens =
+      requiredMixedTokens.length === 0 || requiredMixedTokens.every((token) => requiredSearchableTokens.has(token));
+    const hasRequiredUnicodeTokens =
+      requiredUnicodeTokens.length === 0 || requiredUnicodeTokens.every((token) => searchableTokens.has(token));
+    const requiredTokenMismatch = !hasRequiredPhrase || !hasRequiredMixedTokens || !hasRequiredUnicodeTokens;
+    const matches = requiredTokenMismatch ? 0 : countTokenOverlap(queryTokens, searchableTokens);
+    return { candidate, tokenOverlap: matches / queryTokens.size, requiredTokenMismatch };
   });
 
-  const overlapSurvivors = scored.filter((s) => s.tokenOverlap >= config.tokenOverlapFloor);
+  const overlapSurvivors = scored.filter((s) => !s.requiredTokenMismatch && s.tokenOverlap >= config.tokenOverlapFloor);
   if (overlapSurvivors.length < scored.length) {
     filteredBy.push(FILTER_LABELS.belowTokenOverlapFloor);
   }
@@ -252,7 +491,7 @@ function applyFilter(
   working: DirectAnswerCandidate[],
   filteredBy: string[],
   label: string,
-  keep: (c: DirectAnswerCandidate) => boolean,
+  keep: (c: DirectAnswerCandidate) => boolean
 ): DirectAnswerCandidate[] {
   const before = working.length;
   const next = working.filter(keep);

--- a/packages/remnic-core/src/recall-query-policy.ts
+++ b/packages/remnic-core/src/recall-query-policy.ts
@@ -1,3 +1,5 @@
+import { normalizeRecallTokens } from "./recall-tokenization.js";
+
 export type RecallPromptShape = "standard" | "instruction_heavy";
 export type CronConversationRecallMode = "auto" | "always" | "never";
 export type RecallBudgetMode = "full" | "minimal";
@@ -16,7 +18,7 @@ export interface RecallQueryPolicyResult {
   retrievalBudgetMode: RecallBudgetMode;
 }
 
-const DEFAULT_STOPWORDS = new Set([
+const DEFAULT_STOPWORDS = [
   "the",
   "and",
   "for",
@@ -72,7 +74,9 @@ const DEFAULT_STOPWORDS = new Set([
   "data",
   "gathering",
   "context",
-]);
+];
+const MAX_COMPACT_TOKENS_PER_SOURCE_TERM = 8;
+const COMPACT_IDENTIFIER_RE = /^[a-z0-9]+(?:[:_-][a-z0-9]+)+$/i;
 
 function collapseWhitespace(text: string): string {
   return text.replace(/\s+/g, " ").trim();
@@ -83,6 +87,24 @@ function stripFilesystemLikePaths(text: string): string {
     .replace(/(?:^|\s)(~\/[^\s)]+)(?=\s|$)/g, " ")
     .replace(/(?:^|\s)(\/[A-Za-z0-9._\-\/]+)(?=\s|$)/g, " ")
     .replace(/(?:^|\s)([A-Za-z]:\\[^\s)]+)(?=\s|$)/g, " ");
+}
+
+function trimCompactSourceTerm(term: string): string {
+  return term.replace(/^[^\p{L}\p{N}\p{M}]+|[^\p{L}\p{N}\p{M}]+$/gu, "");
+}
+
+function splitCompactSourceTerm(term: string): string[] {
+  return term
+    .split(/[^\p{L}\p{N}\p{M}:_-]+/gu)
+    .map((part) => trimCompactSourceTerm(part))
+    .filter((part) => part.length > 0);
+}
+
+function capCompactSourceTermTokens(tokens: string[]): string[] {
+  if (tokens.length <= MAX_COMPACT_TOKENS_PER_SOURCE_TERM) return tokens;
+  const last = tokens.at(-1);
+  if (!last) return tokens.slice(0, MAX_COMPACT_TOKENS_PER_SOURCE_TERM);
+  return [...tokens.slice(0, MAX_COMPACT_TOKENS_PER_SOURCE_TERM - 1), last];
 }
 
 function isBulletOrNumberedLine(line: string): boolean {
@@ -112,16 +134,14 @@ function scoreInstructionHeavyShape(prompt: string): number {
   const headingLineCount = lines.filter(
     (line) =>
       /^(goal|output format|tone rules|grounding rules|data gathering|date computation|crm context|follow-up|social|current time|return)\b/i.test(
-        line,
-      ) || /^[A-Z][A-Z\s/-]{4,}:$/.test(line),
+        line
+      ) || /^[A-Z][A-Z\s/-]{4,}:$/.test(line)
   ).length;
   const bulletLineCount = lines.filter((line) => isBulletOrNumberedLine(line)).length;
   const longLineCount = lines.filter((line) => line.length >= 180).length;
-  const hasPathDensity =
-    (prompt.match(/(?:~\/|\/Users\/|[A-Za-z]:\\)/g)?.length ?? 0) >= 2;
+  const hasPathDensity = (prompt.match(/(?:~\/|\/Users\/|[A-Za-z]:\\)/g)?.length ?? 0) >= 2;
   const hasImperativeDensity =
-    (prompt.match(/\b(run|extract|read|parse|determine|include|omit|skip)\b/gi)?.length ?? 0) >=
-    8;
+    (prompt.match(/\b(run|extract|read|parse|determine|include|omit|skip)\b/gi)?.length ?? 0) >= 8;
 
   let score = 0;
   if (lineCount >= 24) score += 2;
@@ -139,27 +159,29 @@ export function classifyRecallPromptShape(prompt: string): RecallPromptShape {
 }
 
 function tokenizeForCompactQuery(text: string): string[] {
-  const raw = text
-    .toLowerCase()
-    .replace(/[^a-z0-9\s:_-]+/g, " ")
-    .split(/\s+/)
-    .filter((token) => token.length >= 3);
-  const deduped: string[] = [];
+  const tokens: string[] = [];
   const seen = new Set<string>();
-  for (const token of raw) {
-    if (DEFAULT_STOPWORDS.has(token)) continue;
-    if (seen.has(token)) continue;
+  const addToken = (token: string) => {
+    if (token.length === 0 || seen.has(token)) return;
     seen.add(token);
-    deduped.push(token);
+    tokens.push(token);
+  };
+
+  for (const rawTerm of text.split(/\s+/)) {
+    for (const sourceTerm of splitCompactSourceTerm(trimCompactSourceTerm(rawTerm))) {
+      if (COMPACT_IDENTIFIER_RE.test(sourceTerm)) {
+        addToken(sourceTerm.toLowerCase());
+        continue;
+      }
+      for (const token of capCompactSourceTermTokens(normalizeRecallTokens(sourceTerm, DEFAULT_STOPWORDS))) {
+        addToken(token);
+      }
+    }
   }
-  return deduped;
+  return tokens;
 }
 
-function buildInstructionHeavyQuery(
-  prompt: string,
-  tokenCap: number,
-  maxChars: number,
-): string {
+function buildInstructionHeavyQuery(prompt: string, tokenCap: number, maxChars: number): string {
   const cleaned = stripFilesystemLikePaths(prompt);
   const tokens = tokenizeForCompactQuery(cleaned).slice(0, Math.max(8, tokenCap));
   const joined = tokens.join(" ");
@@ -182,7 +204,7 @@ function buildStandardQuery(prompt: string, maxChars: number): string {
 export function buildRecallQueryPolicy(
   prompt: string,
   sessionKey: string | undefined,
-  cfg: RecallQueryPolicyConfig,
+  cfg: RecallQueryPolicyConfig
 ): RecallQueryPolicyResult {
   const normalizedPrompt = collapseWhitespace(prompt);
   const isCron = (sessionKey ?? "").includes(":cron:");
@@ -207,8 +229,8 @@ export function buildRecallQueryPolicy(
     cfg.cronConversationRecallMode === "never"
       ? true
       : cfg.cronConversationRecallMode === "always"
-      ? false
-      : promptShape === "instruction_heavy";
+        ? false
+        : promptShape === "instruction_heavy";
 
   const retrievalBudgetMode = promptShape === "instruction_heavy" ? "minimal" : "full";
 

--- a/packages/remnic-core/src/recall-tokenization.ts
+++ b/packages/remnic-core/src/recall-tokenization.ts
@@ -1,32 +1,142 @@
-export function normalizeRecallTokens(value: string, extraStopWords: string[] = []): string[] {
-  const stopWords = new Set([
-    "the",
-    "and",
-    "for",
-    "with",
-    "from",
-    "into",
-    "that",
-    "this",
-    "why",
-    "did",
-    ...extraStopWords,
-  ]);
+export interface NormalizeRecallTokenOptions {
+  minTokenLength?: number;
+}
 
-  return value
+const DEFAULT_RECALL_STOP_WORDS = ["the", "and", "for", "with", "from", "into", "that", "this", "why", "did"];
+
+function isUnsegmentableRecallChar(char: string): boolean {
+  if (char === "ー" || char === "ｰ") return true;
+  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(char);
+}
+
+function isRecallCombiningMark(char: string): boolean {
+  return /\p{M}/u.test(char);
+}
+
+function buildRecallStopWords(extraStopWords: string[]): Set<string> {
+  return new Set([...DEFAULT_RECALL_STOP_WORDS, ...extraStopWords.map((word) => word.toLowerCase())]);
+}
+
+function shouldKeepRecallToken(token: string, minTokenLength: number, stopWords: Set<string>): boolean {
+  if (stopWords.has(token)) return false;
+  if (token.length >= minTokenLength) return true;
+  const hasNonAsciiCodepoint = [...token].some((ch) => (ch.codePointAt(0) ?? 0) > 0x7f);
+  return token.length >= 2 && hasNonAsciiCodepoint && /\p{L}/u.test(token);
+}
+
+function addUnsegmentableRecallSegment(tokens: Set<string>, segment: string, stopWords: Set<string>): void {
+  const chars = [...segment].filter((ch) => /[\p{L}\p{N}\p{M}]/u.test(ch) || isUnsegmentableRecallChar(ch));
+  for (const ch of chars) {
+    if (!stopWords.has(ch)) tokens.add(ch);
+  }
+  for (const size of [2, 3, 4]) {
+    if (chars.length < size) continue;
+    for (let index = 0; index <= chars.length - size; index += 1) {
+      const token = chars.slice(index, index + size).join("");
+      if (!stopWords.has(token)) tokens.add(token);
+    }
+  }
+  const whole = chars.join("");
+  if (whole.length > 3 && !stopWords.has(whole)) {
+    tokens.add(whole);
+  }
+}
+
+function isUnsegmentableRecallToken(token: string): boolean {
+  const chars = [...token].filter((ch) => /[\p{L}\p{N}\p{M}]/u.test(ch) || isUnsegmentableRecallChar(ch));
+  return (
+    chars.length > 0 &&
+    chars.some(isUnsegmentableRecallChar) &&
+    chars.every((ch) => isUnsegmentableRecallChar(ch) || isRecallCombiningMark(ch))
+  );
+}
+
+function addBridgedUnsegmentableRecallSegments(tokens: Set<string>, cleaned: string, stopWords: Set<string>): void {
+  let segment = "";
+  const flushSegment = () => {
+    addUnsegmentableRecallSegment(tokens, segment, stopWords);
+    segment = "";
+  };
+
+  for (const token of cleaned.split(/\s+/)) {
+    if (isUnsegmentableRecallToken(token)) {
+      segment += token;
+    } else {
+      flushSegment();
+    }
+  }
+  flushSegment();
+}
+
+export function normalizeRecallTokenSet(
+  value: string,
+  extraStopWords: string[] = [],
+  options: NormalizeRecallTokenOptions = {}
+): Set<string> {
+  const minTokenLength = Math.max(1, Math.floor(options.minTokenLength ?? 3));
+  const stopWords = buildRecallStopWords(extraStopWords);
+  const cleaned = value
     .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .map((token) => token.trim())
-    .filter((token) => token.length >= 3 && !stopWords.has(token));
+    .normalize("NFC")
+    .replace(/[^\p{L}\p{N}\p{M}\u30fc\uff70]+/gu, " ")
+    .trim();
+  if (cleaned.length === 0) return new Set();
+
+  const tokens = new Set<string>();
+  addBridgedUnsegmentableRecallSegments(tokens, cleaned, stopWords);
+  for (const token of cleaned.split(/\s+/)) {
+    if (!token) continue;
+    if ([...token].some(isUnsegmentableRecallChar)) {
+      let segment = "";
+      let unsegmentableSegment = "";
+      const flushSegment = () => {
+        if (shouldKeepRecallToken(segment, minTokenLength, stopWords)) {
+          tokens.add(segment);
+        }
+        segment = "";
+      };
+      const flushUnsegmentableSegment = () => {
+        addUnsegmentableRecallSegment(tokens, unsegmentableSegment, stopWords);
+        unsegmentableSegment = "";
+      };
+      for (const ch of token) {
+        if (!/[\p{L}\p{N}\p{M}]/u.test(ch) && !isUnsegmentableRecallChar(ch)) continue;
+        if (isUnsegmentableRecallChar(ch)) {
+          flushSegment();
+          unsegmentableSegment += ch;
+        } else if (isRecallCombiningMark(ch)) {
+          if (unsegmentableSegment.length > 0) {
+            unsegmentableSegment += ch;
+          } else {
+            segment += ch;
+          }
+        } else {
+          flushUnsegmentableSegment();
+          segment += ch;
+        }
+      }
+      flushUnsegmentableSegment();
+      flushSegment();
+      continue;
+    }
+    if (shouldKeepRecallToken(token, minTokenLength, stopWords)) {
+      tokens.add(token);
+    }
+  }
+  return tokens;
+}
+
+export function normalizeRecallTokens(value: string, extraStopWords: string[] = []): string[] {
+  return Array.from(normalizeRecallTokenSet(value, extraStopWords));
 }
 
 export function countRecallTokenOverlap(
   queryTokens: Set<string>,
   value: string | undefined,
-  extraStopWords: string[] = [],
+  extraStopWords: string[] = []
 ): number {
   if (!value) return 0;
-  const tokens = new Set(normalizeRecallTokens(value, extraStopWords));
+  const tokens = normalizeRecallTokenSet(value, extraStopWords);
   let matches = 0;
   for (const token of queryTokens) {
     if (tokens.has(token)) matches += 1;

--- a/packages/remnic-core/src/temporal-index.ts
+++ b/packages/remnic-core/src/temporal-index.ts
@@ -76,9 +76,7 @@ function tagIndexPath(memoryDir: string): string {
 
 function ensureStateDir(memoryDir: string): void {
   const dir = stateDir(memoryDir);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  fs.mkdirSync(dir, { recursive: true });
 }
 
 function readJsonSafe<T>(filePath: string, fallback: T): T {
@@ -187,6 +185,13 @@ function lockOwnerIsRunning(owner: IndexLockOwner): boolean {
   return runningStartedAtMs <= owner.processStartedAtMs + INDEX_PROCESS_START_TOLERANCE_MS;
 }
 
+function lockIsFresh(lockInfo: fs.Stats, owner: IndexLockOwner | null): boolean {
+  const ownerCreatedAtMs =
+    typeof owner?.createdAt === "string" && owner.createdAt.length > 0 ? Date.parse(owner.createdAt) : Number.NaN;
+  const referenceMs = Number.isFinite(ownerCreatedAtMs) ? ownerCreatedAtMs : lockInfo.mtimeMs;
+  return Date.now() - referenceMs < INDEX_LOCK_STALE_MS;
+}
+
 function removeAbandonedIndexLock(lockDir: string): IndexLockCleanupResult {
   try {
     const info = fs.lstatSync(lockDir);
@@ -196,11 +201,14 @@ function removeAbandonedIndexLock(lockDir: string): IndexLockCleanupResult {
       return "removed";
     }
     const owner = readIndexLockOwner(lockDir);
-    if (owner !== null && lockOwnerIsRunning(owner)) return "wait";
-    if (owner === null && Date.now() - info.mtimeMs < INDEX_LOCK_STALE_MS) return "wait";
+    if (owner !== null) {
+      if (lockOwnerIsRunning(owner)) return "wait";
+    }
+    if (owner === null && lockIsFresh(info, null)) return "wait";
     fs.rmSync(lockDir, { recursive: true, force: true });
     return "removed";
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return "removed";
     // Fail silently — indexes are advisory only
     return "blocked";
   }
@@ -217,6 +225,15 @@ function withIndexFileLock(filePath: string, update: () => void): void {
       acquired = true;
     } catch (error) {
       const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") {
+        try {
+          fs.mkdirSync(path.dirname(lockDir), { recursive: true });
+        } catch {
+          return;
+        }
+        sleepSync(INDEX_LOCK_POLL_MS);
+        continue;
+      }
       if (code !== "EEXIST") return;
       const cleanupResult = removeAbandonedIndexLock(lockDir);
       if (cleanupResult === "blocked") return;

--- a/tests/causal-chain.test.ts
+++ b/tests/causal-chain.test.ts
@@ -1,20 +1,20 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, readFile } from "node:fs/promises";
+import test from "node:test";
 import {
-  makeEdgeId,
-  validateCausalEdge,
-  scoreStitchCandidate,
-  readChainIndex,
-  writeChainIndex,
-  resolveChainsDir,
-  stitchCausalChain,
-  type CausalEdge,
   type CausalChainIndex,
+  type CausalEdge,
+  makeEdgeId,
+  readChainIndex,
+  resolveChainsDir,
+  scoreStitchCandidate,
+  stitchCausalChain,
+  validateCausalEdge,
+  writeChainIndex,
 } from "../src/causal-chain.js";
-import { recordCausalTrajectory, type CausalTrajectoryRecord } from "../src/causal-trajectory.js";
+import { type CausalTrajectoryRecord, recordCausalTrajectory } from "../src/causal-trajectory.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -62,7 +62,7 @@ test("validateCausalEdge rejects invalid schemaVersion", () => {
       confidence: 0.5,
       stitchMethod: "lexical",
       createdAt: "2026-03-16T10:00:00.000Z",
-    }),
+    })
   );
 });
 
@@ -77,7 +77,7 @@ test("validateCausalEdge rejects invalid edgeType", () => {
       confidence: 0.5,
       stitchMethod: "lexical",
       createdAt: "2026-03-16T10:00:00.000Z",
-    }),
+    })
   );
 });
 
@@ -92,7 +92,7 @@ test("validateCausalEdge rejects confidence out of range", () => {
       confidence: 1.5,
       stitchMethod: "lexical",
       createdAt: "2026-03-16T10:00:00.000Z",
-    }),
+    })
   );
 });
 
@@ -192,6 +192,23 @@ test("scoreStitchCandidate returns zero for unrelated trajectories", () => {
   const result = scoreStitchCandidate(newTraj, candidate);
   // unrelated goals with no overlapping tokens/entities should score low
   assert.ok(result.score < 2.5, `Expected low score for unrelated, got ${result.score}`);
+});
+
+test("scoreStitchCandidate does not inflate CJK n-gram overlap for opposite goals", () => {
+  const newTraj = makeTrajectory({
+    trajectoryId: "new-1",
+    sessionKey: "session-2",
+    goal: "记录用户喜欢深色模式",
+    followUpSummary: "用户喜欢深色模式",
+  });
+  const candidate = makeTrajectory({
+    trajectoryId: "old-1",
+    sessionKey: "session-1",
+    goal: "用户讨厌深色模式",
+  });
+
+  const result = scoreStitchCandidate(newTraj, candidate);
+  assert.ok(result.score < 2.5, `Expected low score for opposite CJK goals, got ${result.score}`);
 });
 
 // ─── Chain Index ─────────────────────────────────────────────────────────────
@@ -360,9 +377,7 @@ test("stitchCausalChain serializes concurrent index updates", async () => {
   ]);
 
   const index = await readChainIndex(resolveChainsDir(memoryDir));
-  const destinations = new Set(
-    Object.values(index.edges).map((edge) => edge.toTrajectoryId),
-  );
+  const destinations = new Set(Object.values(index.edges).map((edge) => edge.toTrajectoryId));
   assert.ok(destinations.has("traj-new-a"));
   assert.ok(destinations.has("traj-new-b"));
 });

--- a/tests/recall-query-policy.test.ts
+++ b/tests/recall-query-policy.test.ts
@@ -1,9 +1,6 @@
-import test from "node:test";
 import assert from "node:assert/strict";
-import {
-  buildRecallQueryPolicy,
-  classifyRecallPromptShape,
-} from "../src/recall-query-policy.js";
+import test from "node:test";
+import { buildRecallQueryPolicy, classifyRecallPromptShape } from "../src/recall-query-policy.js";
 
 const baseConfig = {
   cronRecallPolicyEnabled: true,
@@ -68,11 +65,7 @@ GROUNDING RULES:
 Return your summary as plain text.
 `.trim();
 
-  const result = buildRecallQueryPolicy(
-    prompt,
-    "agent:generalist:cron:deckard-morning-briefing",
-    baseConfig,
-  );
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:cron:deckard-morning-briefing", baseConfig);
 
   assert.equal(result.promptShape, "instruction_heavy");
   assert.equal(result.skipConversationRecall, true);
@@ -83,13 +76,217 @@ Return your summary as plain text.
   assert.equal(result.retrievalQuery.includes("~/"), false);
 });
 
+test("buildRecallQueryPolicy preserves multilingual terms in instruction-heavy cron prompts", () => {
+  const prompt = `
+[cron:global-support-briefing] You are OpenClaw automation.
+Goal: Generate multilingual support recall.
+DATA GATHERING:
+1. Read /Users/josh/support/ru.md
+2. Read /Users/josh/support/el.md
+3. Read /Users/josh/support/ar.md
+4. Read /Users/josh/support/zh.md
+5. Extract Привет incident notes
+6. Include Καλημέρα launch notes
+7. Include שלום account notes
+8. Include مرحبا escalation notes
+9. Include 用户喜欢深色模式 preferences
+OUTPUT FORMAT:
+- greeting
+- tasks
+- followups
+- incidents
+- blockers
+GROUNDING RULES:
+- Never invent details
+- Skip empty sections
+- Omit stale items
+Return your summary as plain text.
+`.trim();
+
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:cron:global-support-briefing", baseConfig);
+
+  assert.equal(result.promptShape, "instruction_heavy");
+  assert.match(result.retrievalQuery, /привет/u);
+  assert.match(result.retrievalQuery, /καλημέρα/u);
+  assert.match(result.retrievalQuery, /שלום/u);
+  assert.match(result.retrievalQuery, /مرحبا/u);
+  assert.equal(result.retrievalQuery.includes("用"), true);
+  assert.equal(result.retrievalQuery.includes("/Users/"), false);
+});
+
+test("buildRecallQueryPolicy preserves combining-mark terms in instruction-heavy cron prompts", () => {
+  const prompt = `
+[cron:global-support-briefing] You are OpenClaw automation.
+Goal: Generate multilingual support recall.
+DATA GATHERING:
+1. Read /Users/josh/support/hi.md
+2. Read /Users/josh/support/th.md
+3. Read /Users/josh/support/ta.md
+4. Include हिंदी escalation notes
+5. Include สวัสดี support notes
+6. Include தமிழ் account notes
+7. Extract unresolved owners
+8. Determine escalation blockers
+9. Omit stale resolved cases
+OUTPUT FORMAT:
+- greeting
+- tasks
+- followups
+- incidents
+- blockers
+- accounts
+- renewals
+- risks
+GROUNDING RULES:
+- Never invent details
+- Skip empty sections
+- Omit stale items
+FOLLOW-UP:
+- Extract unresolved actions
+- Include owners and due dates
+Current time: Monday, February 23rd, 2026
+Return your summary as plain text.
+`.trim();
+
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:cron:global-support-briefing", baseConfig);
+
+  assert.equal(result.promptShape, "instruction_heavy");
+  assert.match(result.retrievalQuery, /हिंदी/u);
+  assert.match(result.retrievalQuery, /สวัสดี/u);
+  assert.match(result.retrievalQuery, /தமிழ்/u);
+});
+
+test("buildRecallQueryPolicy preserves exact identifiers in instruction-heavy cron prompts", () => {
+  const prompt = `
+[cron:support-queue] You are OpenClaw automation.
+Goal: Generate support recall.
+DATA GATHERING:
+1. Read /Users/josh/support/incidents.md
+2. Parse ~/workspace/crm.md
+3. Include INC-123 incident status
+4. Include crm:deal_456 account notes
+5. Include api_retry runbook notes
+6. Extract unresolved owners
+7. Determine escalation blockers
+8. Include renewal risk notes
+9. Omit stale resolved cases
+OUTPUT FORMAT:
+- greeting
+- tasks
+- followups
+- incidents
+- blockers
+- accounts
+- renewals
+- risks
+GROUNDING RULES:
+- Never invent details
+- Skip empty sections
+- Omit stale items
+FOLLOW-UP:
+- Extract unresolved actions
+- Include owners and due dates
+Current time: Monday, February 23rd, 2026
+Return your summary as plain text.
+`.trim();
+
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:cron:support-queue", baseConfig);
+
+  assert.equal(result.promptShape, "instruction_heavy");
+  assert.match(result.retrievalQuery, /\binc-123\b/u);
+  assert.match(result.retrievalQuery, /\bcrm:deal_456\b/u);
+  assert.match(result.retrievalQuery, /\bapi_retry\b/u);
+});
+
+test("buildRecallQueryPolicy preserves adjacent exact identifiers in instruction-heavy cron prompts", () => {
+  const prompt = `
+[cron:support-queue] You are OpenClaw automation.
+Goal: Generate support recall.
+DATA GATHERING:
+1. Read /Users/josh/support/incidents.md
+2. Parse ~/workspace/crm.md
+3. Include INC-123/INC-456 incident status
+4. Include CRM-789,crm:deal_456 account notes
+5. Extract unresolved owners
+6. Determine escalation blockers
+7. Include renewal risk notes
+8. Omit stale resolved cases
+OUTPUT FORMAT:
+- greeting
+- tasks
+- followups
+- incidents
+- blockers
+- accounts
+- renewals
+- risks
+GROUNDING RULES:
+- Never invent details
+- Skip empty sections
+- Omit stale items
+FOLLOW-UP:
+- Extract unresolved actions
+- Include owners and due dates
+Current time: Monday, February 23rd, 2026
+Return your summary as plain text.
+`.trim();
+
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:cron:support-queue", baseConfig);
+
+  assert.equal(result.promptShape, "instruction_heavy");
+  assert.match(result.retrievalQuery, /\binc-123\b/u);
+  assert.match(result.retrievalQuery, /\binc-456\b/u);
+  assert.match(result.retrievalQuery, /\bcrm-789\b/u);
+  assert.match(result.retrievalQuery, /\bcrm:deal_456\b/u);
+});
+
+test("buildRecallQueryPolicy preserves later terms after expanded CJK cron terms", () => {
+  const prompt = `
+[cron:global-support-briefing] You are OpenClaw automation.
+Goal: Generate multilingual support recall.
+DATA GATHERING:
+1. Read /Users/josh/support/zh.md
+2. Read /Users/josh/support/ru.md
+3. Include 用户喜欢深色模式并且需要同步客户账户升级阻塞事项
+4. Include Привет incident notes
+5. Include INC-123 escalation notes
+6. Extract unresolved owners
+7. Determine escalation blockers
+8. Include renewal risk notes
+9. Omit stale resolved cases
+OUTPUT FORMAT:
+- greeting
+- tasks
+- followups
+- incidents
+- blockers
+- accounts
+- renewals
+- risks
+GROUNDING RULES:
+- Never invent details
+- Skip empty sections
+- Omit stale items
+FOLLOW-UP:
+- Extract unresolved actions
+- Include owners and due dates
+Current time: Monday, February 23rd, 2026
+Return your summary as plain text.
+`.trim();
+
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:cron:global-support-briefing", {
+    ...baseConfig,
+    cronRecallInstructionHeavyTokenCap: 24,
+  });
+
+  assert.equal(result.promptShape, "instruction_heavy");
+  assert.match(result.retrievalQuery, /привет/u);
+  assert.match(result.retrievalQuery, /\binc-123\b/u);
+});
+
 test("buildRecallQueryPolicy keeps standard non-cron prompts full", () => {
   const prompt = "Can you   remind me\nwhat we decided last week about API retries?  ";
-  const result = buildRecallQueryPolicy(
-    prompt,
-    "agent:generalist:main",
-    baseConfig,
-  );
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:main", baseConfig);
 
   assert.equal(result.promptShape, "standard");
   assert.equal(result.skipConversationRecall, false);
@@ -99,11 +296,10 @@ test("buildRecallQueryPolicy keeps standard non-cron prompts full", () => {
 
 test("buildRecallQueryPolicy keeps raw prompt when cron policy is disabled", () => {
   const prompt = "  Keep   this\nas-is for recall query. ";
-  const result = buildRecallQueryPolicy(
-    prompt,
-    "agent:generalist:cron:deckard-morning-briefing",
-    { ...baseConfig, cronRecallPolicyEnabled: false },
-  );
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:cron:deckard-morning-briefing", {
+    ...baseConfig,
+    cronRecallPolicyEnabled: false,
+  });
 
   assert.equal(result.promptShape, "standard");
   assert.equal(result.skipConversationRecall, false);
@@ -127,11 +323,10 @@ GROUNDING RULES:
 - Return plain text
 `.trim();
 
-  const result = buildRecallQueryPolicy(
-    prompt,
-    "agent:generalist:cron:job-123",
-    { ...baseConfig, cronConversationRecallMode: "always" },
-  );
+  const result = buildRecallQueryPolicy(prompt, "agent:generalist:cron:job-123", {
+    ...baseConfig,
+    cronConversationRecallMode: "always",
+  });
 
   assert.equal(result.skipConversationRecall, false);
 });

--- a/tests/recall-tokenization.test.ts
+++ b/tests/recall-tokenization.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { countRecallTokenOverlap, normalizeRecallTokens } from "../src/recall-tokenization.js";
+
+test("normalizeRecallTokens preserves non-Latin word tokens", () => {
+  const tokens = normalizeRecallTokens("Привет, мир! Καλημέρα κόσμε. שלום לצוות. مرحبا بالعالم.");
+
+  assert.equal(tokens.includes("привет"), true);
+  assert.equal(tokens.includes("καλημέρα"), true);
+  assert.equal(tokens.includes("שלום"), true);
+  assert.equal(tokens.includes("مرحبا"), true);
+});
+
+test("normalizeRecallTokens preserves combining-mark words", () => {
+  const tokens = normalizeRecallTokens("हिंदी สวัสดี தமிழ் සිංහල");
+
+  assert.equal(tokens.includes("हिंदी"), true);
+  assert.equal(tokens.includes("สวัสดี"), true);
+  assert.equal(tokens.includes("தமிழ்"), true);
+  assert.equal(tokens.includes("සිංහල"), true);
+});
+
+test("normalizeRecallTokens keeps Hangul words intact", () => {
+  const tokens = normalizeRecallTokens("사용자 설정");
+
+  assert.equal(tokens.includes("사용자"), true);
+  assert.equal(tokens.includes("설정"), true);
+  assert.equal(tokens.includes("사"), false);
+  assert.equal(tokens.includes("설"), false);
+});
+
+test("normalizeRecallTokens keeps CJK no-whitespace phrases searchable", () => {
+  const tokens = normalizeRecallTokens("用户喜欢深色模式");
+
+  assert.equal(tokens.includes("用"), true);
+  assert.equal(tokens.includes("户"), true);
+  assert.equal(tokens.includes("用户"), true);
+  assert.equal(tokens.includes("喜欢深"), true);
+  assert.equal(tokens.includes("深"), true);
+  assert.equal(tokens.includes("色"), true);
+  assert.equal(tokens.includes("用户喜欢深色模式"), true);
+});
+
+test("normalizeRecallTokens keeps Japanese long-vowel marks in Katakana runs", () => {
+  const tokens = normalizeRecallTokens("メールサーバー");
+
+  assert.equal(tokens.includes("メール"), true);
+  assert.equal(tokens.includes("サーバー"), true);
+  assert.equal(tokens.includes("メールサーバー"), true);
+});
+
+test("normalizeRecallTokens preserves decomposed Kana combining marks", () => {
+  const decomposed = "パス";
+  const composed = "パス";
+  const tokens = normalizeRecallTokens(decomposed);
+
+  assert.equal(tokens.includes(composed), true);
+  assert.ok(countRecallTokenOverlap(new Set(normalizeRecallTokens(composed)), decomposed) >= 2);
+});
+
+test("normalizeRecallTokens preserves non-CJK segments inside mixed CJK tokens", () => {
+  const tokens = normalizeRecallTokens("用户api喜欢oauth登录");
+
+  assert.equal(tokens.includes("api"), true);
+  assert.equal(tokens.includes("oauth"), true);
+  assert.equal(tokens.includes("a"), false);
+  assert.equal(tokens.includes("o"), false);
+  assert.equal(tokens.includes("用"), true);
+  assert.equal(tokens.includes("户"), true);
+});
+
+test("countRecallTokenOverlap matches multilingual recall text", () => {
+  const queryTokens = new Set(normalizeRecallTokens("привет καλημέρα שלום مرحبا 用户喜欢深色模式"));
+
+  assert.ok(countRecallTokenOverlap(queryTokens, "Привет мир") > 0);
+  assert.ok(countRecallTokenOverlap(queryTokens, "μια Καλημέρα για την ομάδα") > 0);
+  assert.ok(countRecallTokenOverlap(queryTokens, "שלום לצוות") > 0);
+  assert.ok(countRecallTokenOverlap(queryTokens, "مرحبا بالفريق") > 0);
+  assert.ok(countRecallTokenOverlap(queryTokens, "用户偏好深色模式") >= 4);
+});


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-c9390ed6f4-d696_041cf3074b`.

Summary:
- Make shared recall tokenization Unicode-aware so non-Latin recall terms are preserved.
- Split no-whitespace CJK recall phrases into searchable codepoint tokens.
- Route instruction-heavy recall query compaction through the shared tokenizer.
- Add regression coverage for Cyrillic, Greek, Hebrew, Arabic, and CJK recall overlap/query policy behavior.

Verification:
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec biome check --diagnostic-level=error --write packages/remnic-core/src/recall-tokenization.ts packages/remnic-core/src/recall-query-policy.ts tests/recall-tokenization.test.ts tests/recall-query-policy.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/recall-tokenization.test.ts tests/recall-query-policy.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm rebuild better-sqlite3`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:entity-hardening`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core recall overlap and eligibility logic across multiple retrieval paths; wrong tuning could miss valid recalls or still allow false direct answers, but scope is matching heuristics rather than security or persistence contracts.
> 
> **Overview**
> This PR makes **shared recall tokenization Unicode-aware** and threads it through recall compaction, direct-answer gating, and causal-chain stitching so non-Latin and CJK text behave consistently instead of being stripped or over-matched on character n-grams.
> 
> **`recall-tokenization`** now exposes `normalizeRecallTokenSet` with NFC normalization, combining marks, Hangul words, CJK character/n-gram tokens (including space-bridged phrases), and mixed-script segments (e.g. `api` inside CJK runs). **`recall-query-policy`** compacts instruction-heavy cron prompts via that tokenizer while keeping exact identifiers (`inc-123`, `crm:deal_456`) and multilingual terms. **`direct-answer`** adds required CJK phrases, mixed-script discriminators, and segmentable Unicode token checks so near-misses (opposite preferences, `erp` vs `crm`) fail even at `tokenOverlapFloor=0`, while legitimate spaced/CJK queries still pass. **`causal-chain`** stitch lexical scoring uses phrase-aware tokens to avoid inflating opposite CJK goals.
> 
> **`temporal-index`** lock cleanup is tightened (owner freshness, parent `mkdir` on `ENOENT`). Root **`package.json`** is formatting-only. Large new test suites cover tokenization, cron policy, direct-answer, and CJK stitch scoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2244829e9e0ebe5653743ad9b4bca298bb2fd974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->