### PR TITLE
Isolate bench smoke adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -924,12 +922,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -952,9 +945,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1007,12 +998,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/scripts/bench/bench-smoke.ts
+++ b/scripts/bench/bench-smoke.ts
@@ -24,10 +24,10 @@
  *   1 — regression detected OR CLI usage error
  */
 
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, realpath, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import type {
   BenchJudge,
@@ -418,8 +418,20 @@ function extractMetrics(aggregates: Record<string, { mean: number }>): Record<st
   return out;
 }
 
-const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
-if (import.meta.url === invokedPath) {
+async function isDirectInvocation(argvPath: string | undefined): Promise<boolean> {
+  if (!argvPath) {
+    return false;
+  }
+
+  const [invokedPath, modulePath] = await Promise.all([
+    realpath(argvPath).catch(() => path.resolve(argvPath)),
+    realpath(fileURLToPath(import.meta.url)).catch(() => fileURLToPath(import.meta.url)),
+  ]);
+
+  return pathToFileURL(invokedPath).href === pathToFileURL(modulePath).href;
+}
+
+if (await isDirectInvocation(process.argv[1])) {
   main(process.argv.slice(2))
     .then((code) => {
       process.exitCode = code;

--- a/scripts/bench/bench-smoke.ts
+++ b/scripts/bench/bench-smoke.ts
@@ -27,15 +27,8 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
-import {
-  locomoDefinition,
-  runLoCoMoBenchmark,
-} from "../../packages/bench/src/benchmarks/published/locomo/runner.js";
-import {
-  longMemEvalDefinition,
-  runLongMemEvalBenchmark,
-} from "../../packages/bench/src/benchmarks/published/longmemeval/runner.js";
 import type {
   BenchJudge,
   BenchMemoryAdapter,
@@ -43,6 +36,11 @@ import type {
   Message,
   SearchResult,
 } from "../../packages/bench/src/adapters/types.js";
+import { locomoDefinition, runLoCoMoBenchmark } from "../../packages/bench/src/benchmarks/published/locomo/runner.js";
+import {
+  longMemEvalDefinition,
+  runLongMemEvalBenchmark,
+} from "../../packages/bench/src/benchmarks/published/longmemeval/runner.js";
 
 // Tolerance for each metric. Issue #566 spec: fail if score drops > 5%
 // vs committed baseline. This is a RELATIVE drop: a metric regresses
@@ -82,30 +80,20 @@ interface CliArgs {
  * tokens (`--foo`, `-x`). This prevents `--baseline --update-baseline`
  * from silently swallowing the next flag as a path (CLAUDE.md rule 14).
  */
-function requireFlagValue(
-  argv: readonly string[],
-  index: number,
-  flag: string,
-  kind: string,
-): string {
+function requireFlagValue(argv: readonly string[], index: number, flag: string, kind: string): string {
   const value = argv[index + 1];
   if (value === undefined || value.length === 0) {
     throw new Error(`${flag} requires ${kind}`);
   }
   if (value.startsWith("-")) {
-    throw new Error(
-      `${flag} requires ${kind}; got option-like token "${value}"`,
-    );
+    throw new Error(`${flag} requires ${kind}; got option-like token "${value}"`);
   }
   return value;
 }
 
 function parseArgs(argv: readonly string[]): CliArgs {
   let seed = 1;
-  let baselinePath = path.resolve(
-    process.cwd(),
-    "tests/fixtures/bench-smoke/baseline.json",
-  );
+  let baselinePath = path.resolve(process.cwd(), "tests/fixtures/bench-smoke/baseline.json");
   let updateBaseline = false;
   let tolerance = REGRESSION_TOLERANCE;
 
@@ -132,9 +120,7 @@ function parseArgs(argv: readonly string[]): CliArgs {
         const value = requireFlagValue(argv, index, "--tolerance", "a number");
         const parsed = Number(value);
         if (!Number.isFinite(parsed) || parsed < 0) {
-          throw new Error(
-            `--tolerance must be a non-negative number; got ${value}`,
-          );
+          throw new Error(`--tolerance must be a non-negative number; got ${value}`);
         }
         tolerance = parsed;
         index += 1;
@@ -149,9 +135,7 @@ function parseArgs(argv: readonly string[]): CliArgs {
         process.exit(0);
         break;
       default:
-        throw new Error(
-          `Unknown argument: ${arg}. Run --help for usage.`,
-        );
+        throw new Error(`Unknown argument: ${arg}. Run --help for usage.`);
     }
   }
 
@@ -172,7 +156,7 @@ function printUsage(): void {
       "  --tolerance N        Max allowed RELATIVE metric drop (default 0.05 = 5%)",
       "  --update-baseline    Overwrite the baseline JSON with current run",
       "",
-    ].join("\n"),
+    ].join("\n")
   );
 }
 
@@ -180,7 +164,7 @@ function printUsage(): void {
 // Deterministic adapter + responder + judge
 // ---------------------------------------------------------------------------
 
-function createDeterministicAdapter(): BenchMemoryAdapter {
+export function createDeterministicAdapter(): BenchMemoryAdapter {
   const store = new Map<string, Message[]>();
   const responder: BenchResponder = {
     async respond(_question, recalledText) {
@@ -223,10 +207,7 @@ function createDeterministicAdapter(): BenchMemoryAdapter {
       for (const [sessionId, messages] of store) {
         for (let turnIndex = 0; turnIndex < messages.length; turnIndex += 1) {
           const message = messages[turnIndex]!;
-          if (
-            typeof message.content === "string" &&
-            message.content.toLowerCase().includes(lowered)
-          ) {
+          if (typeof message.content === "string" && message.content.toLowerCase().includes(lowered)) {
             results.push({
               turnIndex,
               role: message.role,
@@ -250,15 +231,33 @@ function createDeterministicAdapter(): BenchMemoryAdapter {
     },
     async getStats() {
       return {
-        totalMessages: [...store.values()].reduce(
-          (total, messages) => total + messages.length,
-          0,
-        ),
+        totalMessages: [...store.values()].reduce((total, messages) => total + messages.length, 0),
         totalSummaryNodes: 0,
         maxDepth: 0,
       };
     },
   };
+}
+
+export async function runSmokeBenchmarks(
+  seed: number,
+  createAdapter: () => BenchMemoryAdapter = createDeterministicAdapter
+) {
+  const longmemeval = await runLongMemEvalBenchmark({
+    benchmark: longMemEvalDefinition,
+    mode: "quick",
+    seed,
+    system: createAdapter(),
+  });
+
+  const locomo = await runLoCoMoBenchmark({
+    benchmark: locomoDefinition,
+    mode: "quick",
+    seed,
+    system: createAdapter(),
+  });
+
+  return { longmemeval, locomo };
 }
 
 // ---------------------------------------------------------------------------
@@ -270,32 +269,14 @@ async function main(argv: readonly string[]): Promise<number> {
   try {
     args = parseArgs(argv);
   } catch (error) {
-    process.stderr.write(
-      `bench-smoke: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
+    process.stderr.write(`bench-smoke: ${error instanceof Error ? error.message : String(error)}\n`);
     printUsage();
     return 1;
   }
 
-  const adapter = createDeterministicAdapter();
+  process.stdout.write(`bench-smoke: running LongMemEval + LoCoMo smoke fixtures (seed=${args.seed})\n`);
 
-  process.stdout.write(
-    `bench-smoke: running LongMemEval + LoCoMo smoke fixtures (seed=${args.seed})\n`,
-  );
-
-  const longmemeval = await runLongMemEvalBenchmark({
-    benchmark: longMemEvalDefinition,
-    mode: "quick",
-    seed: args.seed,
-    system: adapter,
-  });
-
-  const locomo = await runLoCoMoBenchmark({
-    benchmark: locomoDefinition,
-    mode: "quick",
-    seed: args.seed,
-    system: adapter,
-  });
+  const { longmemeval, locomo } = await runSmokeBenchmarks(args.seed);
 
   const current: SmokeBaseline = {
     schemaVersion: 1,
@@ -306,14 +287,8 @@ async function main(argv: readonly string[]): Promise<number> {
   };
 
   if (args.updateBaseline) {
-    await writeFile(
-      args.baselinePath,
-      JSON.stringify(current, null, 2) + "\n",
-      "utf8",
-    );
-    process.stdout.write(
-      `bench-smoke: wrote baseline → ${args.baselinePath}\n`,
-    );
+    await writeFile(args.baselinePath, `${JSON.stringify(current, null, 2)}\n`, "utf8");
+    process.stdout.write(`bench-smoke: wrote baseline → ${args.baselinePath}\n`);
     return 0;
   }
 
@@ -328,49 +303,31 @@ async function main(argv: readonly string[]): Promise<number> {
     }
     const record = parsed as Record<string, unknown>;
     if (record.schemaVersion !== 1) {
-      throw new Error(
-        `baseline schemaVersion must be 1; got ${String(record.schemaVersion)}`,
-      );
+      throw new Error(`baseline schemaVersion must be 1; got ${String(record.schemaVersion)}`);
     }
-    if (
-      !record.benchmarks ||
-      typeof record.benchmarks !== "object" ||
-      Array.isArray(record.benchmarks)
-    ) {
+    if (!record.benchmarks || typeof record.benchmarks !== "object" || Array.isArray(record.benchmarks)) {
       throw new Error("baseline.benchmarks must be an object");
     }
-    for (const [benchmarkId, bench] of Object.entries(
-      record.benchmarks as Record<string, unknown>,
-    )) {
+    for (const [benchmarkId, bench] of Object.entries(record.benchmarks as Record<string, unknown>)) {
       if (!bench || typeof bench !== "object" || Array.isArray(bench)) {
-        throw new Error(
-          `baseline.benchmarks.${benchmarkId} must be an object`,
-        );
+        throw new Error(`baseline.benchmarks.${benchmarkId} must be an object`);
       }
       const metrics = (bench as { metrics?: unknown }).metrics;
       if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) {
-        throw new Error(
-          `baseline.benchmarks.${benchmarkId}.metrics must be an object`,
-        );
+        throw new Error(`baseline.benchmarks.${benchmarkId}.metrics must be an object`);
       }
-      for (const [metric, value] of Object.entries(
-        metrics as Record<string, unknown>,
-      )) {
+      for (const [metric, value] of Object.entries(metrics as Record<string, unknown>)) {
         if (typeof value !== "number" || !Number.isFinite(value)) {
-          throw new Error(
-            `baseline.benchmarks.${benchmarkId}.metrics.${metric} must be a finite number`,
-          );
+          throw new Error(`baseline.benchmarks.${benchmarkId}.metrics.${metric} must be a finite number`);
         }
       }
     }
     baseline = parsed as SmokeBaseline;
   } catch (error) {
     process.stderr.write(
-      `bench-smoke: failed to read baseline from ${args.baselinePath}: ${error instanceof Error ? error.message : String(error)}\n`,
+      `bench-smoke: failed to read baseline from ${args.baselinePath}: ${error instanceof Error ? error.message : String(error)}\n`
     );
-    process.stderr.write(
-      "bench-smoke: run with --update-baseline to generate one.\n",
-    );
+    process.stderr.write("bench-smoke: run with --update-baseline to generate one.\n");
     return 1;
   }
 
@@ -383,9 +340,7 @@ async function main(argv: readonly string[]): Promise<number> {
     for (const [metric, value] of Object.entries(bench.metrics)) {
       const baselineValue = baselineMetrics[metric];
       if (baselineValue === undefined) {
-        process.stdout.write(
-          `bench-smoke: [${benchmarkId}] ${metric}=${value.toFixed(4)} (new metric, no baseline)\n`,
-        );
+        process.stdout.write(`bench-smoke: [${benchmarkId}] ${metric}=${value.toFixed(4)} (new metric, no baseline)\n`);
         continue;
       }
       const delta = value - baselineValue;
@@ -396,18 +351,14 @@ async function main(argv: readonly string[]): Promise<number> {
       const denom = Math.abs(baselineValue);
       const relativeDrop = denom === 0 ? -delta : (baselineValue - value) / denom;
       const regressed = relativeDrop > args.tolerance;
-      const verdict = regressed
-        ? `REGRESSION (tol=${args.tolerance} relative)`
-        : "ok";
-      const relDisplay = denom === 0
-        ? `abs-delta=${delta.toFixed(4)}`
-        : `rel-drop=${(relativeDrop * 100).toFixed(2)}%`;
+      const verdict = regressed ? `REGRESSION (tol=${args.tolerance} relative)` : "ok";
+      const relDisplay = denom === 0 ? `abs-delta=${delta.toFixed(4)}` : `rel-drop=${(relativeDrop * 100).toFixed(2)}%`;
       process.stdout.write(
-        `bench-smoke: [${benchmarkId}] ${metric} baseline=${baselineValue.toFixed(4)} current=${value.toFixed(4)} delta=${delta >= 0 ? "+" : ""}${delta.toFixed(4)} ${relDisplay} ${verdict}\n`,
+        `bench-smoke: [${benchmarkId}] ${metric} baseline=${baselineValue.toFixed(4)} current=${value.toFixed(4)} delta=${delta >= 0 ? "+" : ""}${delta.toFixed(4)} ${relDisplay} ${verdict}\n`
       );
       if (regressed) {
         regressions.push(
-          `${benchmarkId}.${metric} dropped ${Math.abs(delta).toFixed(4)} (baseline=${baselineValue.toFixed(4)}, current=${value.toFixed(4)}, relative=${(relativeDrop * 100).toFixed(2)}%, tolerance=${(args.tolerance * 100).toFixed(2)}%)`,
+          `${benchmarkId}.${metric} dropped ${Math.abs(delta).toFixed(4)} (baseline=${baselineValue.toFixed(4)}, current=${value.toFixed(4)}, relative=${(relativeDrop * 100).toFixed(2)}%, tolerance=${(args.tolerance * 100).toFixed(2)}%)`
         );
       }
     }
@@ -416,27 +367,17 @@ async function main(argv: readonly string[]): Promise<number> {
   // 2) Verify every baseline benchmark + metric still exists in the
   // current run. A silently vanished metric (e.g. scorer bug drops
   // `f1`) must fail the gate instead of passing quietly.
-  for (const [benchmarkId, benchBaseline] of Object.entries(
-    baseline.benchmarks,
-  )) {
+  for (const [benchmarkId, benchBaseline] of Object.entries(baseline.benchmarks)) {
     const currentBench = current.benchmarks[benchmarkId];
     if (!currentBench) {
-      missing.push(
-        `${benchmarkId}: entire benchmark missing from current run`,
-      );
-      process.stdout.write(
-        `bench-smoke: [${benchmarkId}] MISSING (benchmark absent from current run)\n`,
-      );
+      missing.push(`${benchmarkId}: entire benchmark missing from current run`);
+      process.stdout.write(`bench-smoke: [${benchmarkId}] MISSING (benchmark absent from current run)\n`);
       continue;
     }
     for (const metric of Object.keys(benchBaseline.metrics)) {
       if (currentBench.metrics[metric] === undefined) {
-        missing.push(
-          `${benchmarkId}.${metric}: present in baseline, absent in current run`,
-        );
-        process.stdout.write(
-          `bench-smoke: [${benchmarkId}] ${metric} MISSING (metric absent from current run)\n`,
-        );
+        missing.push(`${benchmarkId}.${metric}: present in baseline, absent in current run`);
+        process.stdout.write(`bench-smoke: [${benchmarkId}] ${metric} MISSING (metric absent from current run)\n`);
       }
     }
   }
@@ -444,7 +385,7 @@ async function main(argv: readonly string[]): Promise<number> {
   if (regressions.length > 0 || missing.length > 0) {
     if (regressions.length > 0) {
       process.stderr.write(
-        `\nbench-smoke: REGRESSION detected (${regressions.length} metric${regressions.length === 1 ? "" : "s"}):\n`,
+        `\nbench-smoke: REGRESSION detected (${regressions.length} metric${regressions.length === 1 ? "" : "s"}):\n`
       );
       for (const regression of regressions) {
         process.stderr.write(`  - ${regression}\n`);
@@ -452,15 +393,13 @@ async function main(argv: readonly string[]): Promise<number> {
     }
     if (missing.length > 0) {
       process.stderr.write(
-        `\nbench-smoke: MISSING metric(s) present in baseline but absent in current run (${missing.length}):\n`,
+        `\nbench-smoke: MISSING metric(s) present in baseline but absent in current run (${missing.length}):\n`
       );
       for (const entry of missing) {
         process.stderr.write(`  - ${entry}\n`);
       }
     }
-    process.stderr.write(
-      "\nIf this change is intentional, re-run with --update-baseline.\n",
-    );
+    process.stderr.write("\nIf this change is intentional, re-run with --update-baseline.\n");
     return 1;
   }
 
@@ -468,9 +407,7 @@ async function main(argv: readonly string[]): Promise<number> {
   return 0;
 }
 
-function extractMetrics(
-  aggregates: Record<string, { mean: number }>,
-): Record<string, number> {
+function extractMetrics(aggregates: Record<string, { mean: number }>): Record<string, number> {
   const out: Record<string, number> = {};
   for (const key of Object.keys(aggregates).sort()) {
     const mean = aggregates[key]?.mean;
@@ -481,13 +418,16 @@ function extractMetrics(
   return out;
 }
 
-main(process.argv.slice(2))
-  .then((code) => {
-    process.exitCode = code;
-  })
-  .catch((error) => {
-    process.stderr.write(
-      `bench-smoke crashed: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
-    );
-    process.exitCode = 1;
-  });
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
+if (import.meta.url === invokedPath) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      process.stderr.write(
+        `bench-smoke crashed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
+      );
+      process.exitCode = 1;
+    });
+}

--- a/tests/bench-smoke.test.ts
+++ b/tests/bench-smoke.test.ts
@@ -4,37 +4,32 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createDeterministicAdapter, runSmokeBenchmarks } from "../scripts/bench/bench-smoke.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const scriptPath = path.join(repoRoot, "scripts", "bench", "bench-smoke.ts");
-const committedBaseline = path.join(
-  repoRoot,
-  "tests",
-  "fixtures",
-  "bench-smoke",
-  "baseline.json",
-);
+const committedBaseline = path.join(repoRoot, "tests", "fixtures", "bench-smoke", "baseline.json");
 
-function runSmoke(args: readonly string[], cwd: string = repoRoot): {
+function runSmoke(
+  args: readonly string[],
+  cwd: string = repoRoot
+): {
   code: number;
   stdout: string;
   stderr: string;
 } {
   const result = spawnSync(
     process.execPath,
-    [
-      path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs"),
-      scriptPath,
-      ...args,
-    ],
+    [path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs"), scriptPath, ...args],
     {
       cwd,
       env: process.env,
       encoding: "utf8",
-    },
+    }
   );
   return {
     code: result.status ?? -1,
@@ -45,12 +40,36 @@ function runSmoke(args: readonly string[], cwd: string = repoRoot): {
 
 test("bench-smoke passes against the committed baseline", () => {
   const { code, stdout } = runSmoke([]);
-  assert.equal(
-    code,
-    0,
-    `bench-smoke exited non-zero:\n${stdout}`,
-  );
+  assert.equal(code, 0, `bench-smoke exited non-zero:\n${stdout}`);
   assert.match(stdout, /all metrics within tolerance/);
+});
+
+test("deterministic adapter instances do not share search state", async () => {
+  const first = createDeterministicAdapter();
+  const second = createDeterministicAdapter();
+
+  await first.store("longmemeval-session", [
+    {
+      role: "user",
+      content: "adapter isolation sentinel only in the first benchmark",
+    },
+  ]);
+
+  assert.equal((await first.search("adapter isolation sentinel", 10)).length, 1);
+  assert.equal((await second.search("adapter isolation sentinel", 10)).length, 0);
+});
+
+test("bench-smoke creates a fresh adapter for each benchmark family", async () => {
+  const adapters: ReturnType<typeof createDeterministicAdapter>[] = [];
+
+  await runSmokeBenchmarks(1, () => {
+    const adapter = createDeterministicAdapter();
+    adapters.push(adapter);
+    return adapter;
+  });
+
+  assert.equal(adapters.length, 2);
+  assert.notEqual(adapters[0], adapters[1]);
 });
 
 test("bench-smoke rejects invalid --seed", () => {
@@ -106,7 +125,7 @@ test("bench-smoke fails when a baseline metric disappears from the current run",
     // will never produce. This simulates a runner-side regression that
     // stops emitting a metric.
     for (const benchmarkId of Object.keys(baseline.benchmarks)) {
-      baseline.benchmarks[benchmarkId]!.metrics["phantom_metric"] = 0.5;
+      baseline.benchmarks[benchmarkId]!.metrics.phantom_metric = 0.5;
     }
     const tamperedPath = path.join(dir, "baseline.json");
     await writeFile(tamperedPath, JSON.stringify(baseline, null, 2), "utf8");
@@ -128,7 +147,7 @@ test("bench-smoke fails when an entire baseline benchmark disappears", async () 
       benchmarks: Record<string, { metrics: Record<string, number> }>;
     };
     // Inject a phantom benchmark entirely.
-    baseline.benchmarks["phantom_bench"] = { metrics: { score: 0.5 } };
+    baseline.benchmarks.phantom_bench = { metrics: { score: 0.5 } };
     const tamperedPath = path.join(dir, "baseline.json");
     await writeFile(tamperedPath, JSON.stringify(baseline, null, 2), "utf8");
     const { code, stderr } = runSmoke(["--baseline", tamperedPath]);
@@ -203,11 +222,7 @@ test("bench-smoke rejects baseline with bad schemaVersion", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-shape-"));
   try {
     const tamperedPath = path.join(dir, "baseline.json");
-    await writeFile(
-      tamperedPath,
-      JSON.stringify({ schemaVersion: 99, benchmarks: {} }),
-      "utf8",
-    );
+    await writeFile(tamperedPath, JSON.stringify({ schemaVersion: 99, benchmarks: {} }), "utf8");
     const { code, stderr } = runSmoke(["--baseline", tamperedPath]);
     assert.equal(code, 1);
     assert.match(stderr, /schemaVersion must be 1/);
@@ -220,11 +235,7 @@ test("bench-smoke rejects baseline with non-finite metric", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-infinite-"));
   try {
     const tamperedPath = path.join(dir, "baseline.json");
-    await writeFile(
-      tamperedPath,
-      '{"schemaVersion":1,"benchmarks":{"longmemeval":{"metrics":{"f1":1e309}}}}',
-      "utf8",
-    );
+    await writeFile(tamperedPath, '{"schemaVersion":1,"benchmarks":{"longmemeval":{"metrics":{"f1":1e309}}}}', "utf8");
     const { code, stderr } = runSmoke(["--baseline", tamperedPath]);
     assert.equal(code, 1);
     assert.match(stderr, /must be a finite number/);
@@ -258,7 +269,7 @@ test("bench-smoke --update-baseline writes a stable file (no timestamp)", async 
     assert.ok(parsed.benchmarks.locomo);
     assert.ok(
       !Object.prototype.hasOwnProperty.call(parsed, "generatedAt"),
-      "baseline must not carry a generatedAt timestamp",
+      "baseline must not carry a generatedAt timestamp"
     );
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/tests/bench-smoke.test.ts
+++ b/tests/bench-smoke.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -16,7 +16,8 @@ const committedBaseline = path.join(repoRoot, "tests", "fixtures", "bench-smoke"
 
 function runSmoke(
   args: readonly string[],
-  cwd: string = repoRoot
+  cwd: string = repoRoot,
+  targetScript: string = scriptPath
 ): {
   code: number;
   stdout: string;
@@ -24,7 +25,7 @@ function runSmoke(
 } {
   const result = spawnSync(
     process.execPath,
-    [path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs"), scriptPath, ...args],
+    [path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs"), targetScript, ...args],
     {
       cwd,
       env: process.env,
@@ -70,6 +71,20 @@ test("bench-smoke creates a fresh adapter for each benchmark family", async () =
 
   assert.equal(adapters.length, 2);
   assert.notEqual(adapters[0], adapters[1]);
+});
+
+test("bench-smoke runs when invoked through a symlinked script path", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-symlink-"));
+  try {
+    const linkedScript = path.join(dir, "bench-smoke.ts");
+    await symlink(scriptPath, linkedScript);
+
+    const { code, stdout } = runSmoke(["--help"], repoRoot, linkedScript);
+    assert.equal(code, 0);
+    assert.match(stdout, /LongMemEval \+ LoCoMo smoke regression gate/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("bench-smoke rejects invalid --seed", () => {


### PR DESCRIPTION
## Summary
- create a fresh deterministic adapter for each smoke benchmark family
- export the smoke runner helper so adapter isolation can be tested directly
- add regression coverage for adapter state isolation across benchmark families

## ClawPatch
- Fixes finding `fnd_sig-feat-library-cb97cbdff6-084d_11e9f4bf48` (Smoke runs reuse one adapter instance across benchmarks)

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec biome check --diagnostic-level=error --write scripts/bench/bench-smoke.ts tests/bench-smoke.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/bench-smoke.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect the CI smoke regression harness and tests only, not production memory or runtime paths.
> 
> **Overview**
> Fixes **bench-smoke** so LongMemEval and LoCoMo no longer share one in-memory deterministic adapter. A new **`runSmokeBenchmarks`** helper runs each benchmark family with its own adapter via a factory (default **`createDeterministicAdapter`**), preventing stored messages from one smoke run from affecting the other.
> 
> **`createDeterministicAdapter`** and **`runSmokeBenchmarks`** are exported for direct tests. CLI entry is gated with **`isDirectInvocation`** (realpath-aware) so importing the script does not start the regression gate; symlinked invocations still work.
> 
> Tests add coverage for adapter state isolation, per-family adapter creation, and symlink **`--help`**. **`package.json`** changes are formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93db37713b3b8805609026d119964903d2dc764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->