### PR TITLE
Tolerate ClawHub digest limit release failures

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -599,7 +599,7 @@ jobs:
             exit 0
           fi
 
-          npm install -g clawhub@0.12.2
+          npm install -g clawhub@0.18.0
           clawhub login --token "${CLAWHUB_TOKEN}" --no-browser
 
           package_version="$(node -p "require('./${NPM_PACKAGE_PATH}/package.json').version")"
@@ -640,6 +640,12 @@ jobs:
             cat "${publish_log}"
             if grep -q "publisher does not exist on ClawHub" "${publish_log}"; then
               echo "::notice title=ClawHub publish skipped::The authenticated ClawHub account is not provisioned as a package publisher yet."
+              rm -f "${publish_log}"
+              exit 0
+            fi
+            if grep -q "Too many bytes read in a single function execution" "${publish_log}" \
+              && grep -q "syncPackageCapabilitySearchDigests" "${publish_log}"; then
+              echo "::notice title=ClawHub publish skipped::ClawHub publish failed in its backend search-digest sync. npm and GitHub release publication will continue; retry the ClawHub publish after ClawHub fixes or clears the digest limit."
               rm -f "${publish_log}"
               exit 0
             fi

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -924,12 +922,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -952,9 +945,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1007,12 +998,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -547,7 +547,7 @@ tests/recall-hardening.test.ts(754,3): TS2349
 tests/recall-hardening.test.ts(812,3): TS2349
 tests/recall-hardening.test.ts(814,3): TS2349
 tests/recall-no-recall-short-circuit.test.ts(14,3): TS2740
-tests/release-workflow-public-packages.test.ts(123,41): TS7016
+tests/release-workflow-public-packages.test.ts(148,41): TS7016
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006
 tests/remnic-plugin-register-migration.test.ts(66,12): TS2352
 tests/remnic-server-cli.test.ts(9,30): TS7016

--- a/tests/release-workflow-order.test.ts
+++ b/tests/release-workflow-order.test.ts
@@ -121,5 +121,7 @@ test("release workflow fails existing tags with incomplete npm publication", () 
 
 test("release workflow pins publish tooling", () => {
   assert.doesNotMatch(workflow, /npm install -g npm@latest/);
+  assert.doesNotMatch(workflow, /npm install -g clawhub@latest/);
   assert.match(workflow, /npm install -g npm@11\.16\.0/);
+  assert.match(workflow, /npm install -g clawhub@0\.18\.0/);
 });

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -79,6 +79,31 @@ test("release workflow verifies the OpenClaw ClawHub packlist after build", asyn
   );
 });
 
+test("release workflow treats known ClawHub backend digest limits as nonfatal", async () => {
+  const workflow = await readFile(".github/workflows/release-and-publish.yml", "utf8");
+
+  assert.match(
+    workflow,
+    /Too many bytes read in a single function execution/,
+    "release workflow must recognize ClawHub's Convex read-limit backend failure",
+  );
+  assert.match(
+    workflow,
+    /syncPackageCapabilitySearchDigests/,
+    "release workflow must constrain the nonfatal skip to ClawHub search-digest failures",
+  );
+  assert.match(
+    workflow,
+    /ClawHub publish failed in its backend search-digest sync[\s\S]*exit 0/,
+    "known external ClawHub backend failures should not block GitHub release creation after npm publish",
+  );
+  assert.match(
+    workflow,
+    /rm -f "\$\{publish_log\}"\n            exit "\$\{publish_status\}"/,
+    "unknown ClawHub publish failures must remain fatal",
+  );
+});
+
 test("@remnic/server build verifies declared bin artifacts", async () => {
   const packageJson = JSON.parse(await readFile("packages/remnic-server/package.json", "utf8"));
 


### PR DESCRIPTION
## Summary
- bump the release workflow ClawHub CLI pin from 0.12.2 to 0.18.0
- treat the known ClawHub backend search-digest Convex read-limit failure as nonfatal so npm/GitHub release publication can continue
- keep unknown ClawHub publish failures fatal and cover both paths in workflow tests

## Test plan
- pnpm exec tsx --test tests/release-workflow-order.test.ts tests/release-workflow-public-packages.test.ts
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters release automation so a specific external ClawHub failure no longer blocks GitHub releases; misclassified errors could hide real publish problems, though unknown failures still fail the job.
> 
> **Overview**
> The **release workflow** now pins the global **ClawHub CLI** to `0.18.0` (was `0.12.2`) and forbids floating `clawhub@latest` in workflow tests.
> 
> When ClawHub publish fails with the known backend **Convex read-limit** during `syncPackageCapabilitySearchDigests` (“Too many bytes read in a single function execution”), the step logs a notice and **exits successfully** so **npm publish and GitHub release** still run. **Other** ClawHub publish errors remain **fatal**.
> 
> New workflow tests lock in the pin and the nonfatal-vs-fatal split. Root `package.json` changes are **formatting-only**; the typecheck baseline line shifts with the new test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595b6f99095e9134d2b615f53e81de4d4958c12f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->