### PR TITLE
Resolve bench UI results asset path

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -924,12 +922,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -952,9 +945,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1007,12 +998,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/bench-ui/src/App.test.tsx
+++ b/packages/bench-ui/src/App.test.tsx
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fetchBenchResultsPayload, resolveBenchResultsUrl, resolveBenchResultsUrls } from "./App";
+
+test("resolveBenchResultsUrl uses Vite base URL for subpath static deployments", () => {
+  assert.equal(resolveBenchResultsUrl("/"), "/api/results");
+  assert.equal(resolveBenchResultsUrl("/bench/"), "/bench/api/results");
+  assert.equal(resolveBenchResultsUrl("/bench"), "/bench/api/results");
+});
+
+test("resolveBenchResultsUrl supports relative static deployments", () => {
+  assert.equal(resolveBenchResultsUrl("./"), "api/results");
+  assert.equal(resolveBenchResultsUrl("."), "api/results");
+});
+
+test("resolveBenchResultsUrl keeps dev server requests on the middleware route", () => {
+  assert.equal(resolveBenchResultsUrl("/bench/", true), "/api/results");
+});
+
+test("resolveBenchResultsUrls falls back to preview middleware after the static asset URL", () => {
+  assert.deepEqual(resolveBenchResultsUrls("/bench/"), ["/bench/api/results", "/api/results"]);
+});
+
+test("fetchBenchResultsPayload tries the middleware fallback after non-OK static asset responses", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+  const payload = { resultsDir: "preview", summaries: [], skippedFiles: [] };
+
+  try {
+    globalThis.fetch = async (input) => {
+      requestedUrls.push(String(input));
+      if (requestedUrls.length === 1) {
+        return new Response("missing", { status: 404 });
+      }
+
+      return Response.json(payload);
+    };
+
+    assert.deepEqual(await fetchBenchResultsPayload(["/bench/api/results", "/api/results"]), payload);
+    assert.deepEqual(requestedUrls, ["/bench/api/results", "/api/results"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/bench-ui/src/App.tsx
+++ b/packages/bench-ui/src/App.tsx
@@ -27,6 +27,64 @@ const emptyPayload: BenchResultSummaryPayload = {
   skippedFiles: [],
 };
 
+type ViteImportMeta = ImportMeta & {
+  env?: {
+    BASE_URL?: string;
+    DEV?: boolean;
+  };
+};
+
+export function resolveBenchResultsUrl(
+  baseUrl = (import.meta as ViteImportMeta).env?.BASE_URL ?? "/",
+  isDev = (import.meta as ViteImportMeta).env?.DEV === true
+): string {
+  return resolveBenchResultsUrls(baseUrl, isDev)[0] ?? "/api/results";
+}
+
+export function resolveBenchResultsUrls(
+  baseUrl = (import.meta as ViteImportMeta).env?.BASE_URL ?? "/",
+  isDev = (import.meta as ViteImportMeta).env?.DEV === true
+): string[] {
+  if (isDev) {
+    return ["/api/results"];
+  }
+
+  const normalizedBaseUrl = baseUrl.trim() || "/";
+  if (normalizedBaseUrl === "." || normalizedBaseUrl === "./") {
+    return ["api/results"];
+  }
+
+  const baseResultsUrl = `${normalizedBaseUrl.endsWith("/") ? normalizedBaseUrl : `${normalizedBaseUrl}/`}api/results`;
+  return baseResultsUrl === "/api/results" ? [baseResultsUrl] : [baseResultsUrl, "/api/results"];
+}
+
+export async function fetchBenchResultsPayload(urls = resolveBenchResultsUrls()): Promise<BenchResultSummaryPayload> {
+  let lastError: unknown;
+
+  for (const url of urls) {
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (cause) {
+      lastError = cause;
+      continue;
+    }
+
+    if (!response.ok) {
+      lastError = new Error(`Failed to load bench results: ${response.status}`);
+      continue;
+    }
+
+    try {
+      return (await response.json()) as BenchResultSummaryPayload;
+    } catch (cause) {
+      lastError = cause;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 function AppShell({
   children,
   payload,
@@ -46,10 +104,7 @@ function AppShell({
         <div className="brand-lockup">
           <span className="brand-kicker">@remnic/bench-ui</span>
           <h1>Bench dashboard</h1>
-          <p>
-            Local benchmark views for overview, run history, comparison, benchmark
-            diagnosis, and provider drift.
-          </p>
+          <p>Local benchmark views for overview, run history, comparison, benchmark diagnosis, and provider drift.</p>
         </div>
 
         <div className="sidebar-summary">
@@ -69,9 +124,7 @@ function AppShell({
               key={item.path}
               to={item.path}
               end={item.path === "/"}
-              className={({ isActive }) =>
-                `nav-item${isActive ? " nav-item--active" : ""}`
-              }
+              className={({ isActive }) => `nav-item${isActive ? " nav-item--active" : ""}`}
             >
               {item.label}
             </NavLink>
@@ -96,8 +149,8 @@ function AppShell({
               <p className="warning-copy">
                 {payload.skippedFiles!.length} result file
                 {payload.skippedFiles!.length === 1 ? "" : "s"} skipped:{" "}
-                {payload.skippedFiles!
-                  .slice(0, 3)
+                {payload
+                  .skippedFiles!.slice(0, 3)
                   .map((entry) => entry.filePath.split(/[\\/]/u).pop() || entry.filePath)
                   .join(", ")}
               </p>
@@ -138,12 +191,7 @@ export function App() {
     setError(null);
 
     try {
-      const response = await fetch("/api/results");
-      if (!response.ok) {
-        throw new Error(`Failed to load bench results: ${response.status}`);
-      }
-
-      const next = (await response.json()) as BenchResultSummaryPayload;
+      const next = await fetchBenchResultsPayload();
       if (requestId !== requestIdRef.current) return;
       setPayload(next);
     } catch (cause) {
@@ -179,10 +227,7 @@ export function App() {
           <Route path="/ingestion" element={<Ingestion payload={payload} />} />
           <Route path="/runs" element={<Runs payload={payload} />} />
           <Route path="/compare" element={<Compare payload={payload} />} />
-          <Route
-            path="/benchmark/:benchmarkId"
-            element={<BenchmarkDetail payload={payload} />}
-          />
+          <Route path="/benchmark/:benchmarkId" element={<BenchmarkDetail payload={payload} />} />
           <Route path="/providers" element={<Providers payload={payload} />} />
           <Route
             path="/benchmark"


### PR DESCRIPTION
## Summary
- fix ClawPatch finding fnd_sig-feat-library-dcc50fa733-a6dd_ff7e647535
- resolve the bench UI results endpoint from Vite BASE_URL so static builds hosted under a subpath load dist/api/results
- add coverage for root, subpath, and relative static deployment URL resolution

## Verification
- pnpm exec biome check --diagnostic-level=error --write packages/bench-ui/src/App.tsx packages/bench-ui/src/App.test.tsx
- pnpm --filter @remnic/bench-ui test
- pnpm --filter @remnic/bench-ui check-types
- node scripts/check-test-types.mjs
- pnpm exec tsx --test packages/bench-ui/vite.config.test.ts
- pnpm --filter @remnic/bench-ui build
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to bench dashboard client fetch URL logic and tests; no auth, data, or core library changes.
> 
> **Overview**
> The bench UI no longer hardcodes **`/api/results`**. It derives the results endpoint from Vite’s **`BASE_URL`** (and **`DEV`**) so static builds served under a subpath (e.g. `/bench/`) request **`{base}api/results`**, with a second try at **`/api/results`** when the base isn’t root.
> 
> **`fetchBenchResultsPayload`** walks those candidate URLs until one succeeds; the app refresh path uses it instead of a single **`fetch`**. New tests cover root, subpath, relative base, dev middleware, and fallback after a failed static asset response. Root **`package.json`** array fields are reformatted only (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e29c627fc873c561a3cfc928edbf7383a65c7164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->