### PR TITLE
Distinguish empty tag prefilter results

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -924,12 +922,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -952,9 +945,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1007,12 +998,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -953,7 +953,8 @@ function applyQueryAwareCandidateFilter(
   candidates: QmdSearchResult[],
   candidatePaths: Set<string> | null,
 ): QmdSearchResult[] {
-  if (!candidatePaths || candidatePaths.size === 0) return candidates;
+  if (!candidatePaths) return candidates;
+  if (candidatePaths.size === 0) return [];
   const filtered = candidates.filter((candidate) =>
     candidatePaths.has(candidate.path),
   );
@@ -5316,7 +5317,7 @@ export class Orchestrator {
     paths: Set<string> | null,
     recallNamespaces: string[],
   ): Set<string> | null {
-    if (!paths || paths.size === 0) return null;
+    if (!paths) return null;
     const scoped = new Set<string>();
     for (const memoryPath of paths) {
       if (!memoryPath || isArtifactMemoryPath(memoryPath)) continue;
@@ -5328,7 +5329,7 @@ export class Orchestrator {
       }
       scoped.add(memoryPath);
     }
-    return scoped.size > 0 ? scoped : null;
+    return scoped;
   }
 
   private async buildQueryAwarePrefilter(
@@ -5376,7 +5377,14 @@ export class Orchestrator {
     let combination: QueryAwarePrefilter["combination"] = "none";
     let filteredToFullSearch = false;
 
-    if (temporalCandidates && tagCandidates) {
+    if (
+      tagSignals.matchedTags.length > 0 &&
+      tagCandidates !== null &&
+      tagCandidates.size === 0
+    ) {
+      candidatePaths = tagCandidates;
+      combination = "tag";
+    } else if (temporalCandidates !== null && tagCandidates !== null) {
       const intersection = new Set(
         Array.from(temporalCandidates).filter((memoryPath) =>
           tagCandidates.has(memoryPath),
@@ -5389,10 +5397,10 @@ export class Orchestrator {
         candidatePaths = new Set([...temporalCandidates, ...tagCandidates]);
         combination = "union";
       }
-    } else if (temporalCandidates) {
+    } else if (temporalCandidates !== null) {
       candidatePaths = temporalCandidates;
       combination = "temporal";
-    } else if (tagCandidates) {
+    } else if (tagCandidates !== null) {
       candidatePaths = tagCandidates;
       combination = "tag";
     }
@@ -5565,6 +5573,10 @@ export class Orchestrator {
         })),
       });
     };
+    if (queryAwarePrefilter.candidatePaths?.size === 0) {
+      await emitDebugSnapshot([], fetchLimit);
+      return [];
+    }
 
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
       throwIfRecallAborted(options.abortSignal);
@@ -7778,6 +7790,15 @@ export class Orchestrator {
         );
         const staleQmdFallback =
           cachedQmd?.source === "stale" ? cachedQmd : null;
+        const queryAwarePrefilter = await queryAwarePrefilterPromise;
+        const queryAwarePrefilterIsEmpty =
+          queryAwarePrefilter.candidatePaths?.size === 0;
+        const emptyQueryAwareQmdResult: Exclude<QmdPhaseResult, null> = {
+          memoryResultsLists: [[]],
+          globalResults: [],
+          preAugmentTopScore: 0,
+          maxSpecializedScore: 0,
+        };
         if (cachedQmd?.source === "fresh") {
           recordRecallSectionMetric({
             section: "qmd",
@@ -7788,6 +7809,9 @@ export class Orchestrator {
             success: true,
             timing: `${Math.max(0, Math.round(cachedQmd.ageMs))}ms-cache`,
           });
+          if (queryAwarePrefilterIsEmpty) {
+            return emptyQueryAwareQmdResult;
+          }
           return cachedQmd.value;
         }
 
@@ -7808,6 +7832,9 @@ export class Orchestrator {
                 success: true,
                 timing: `stale-cache(reprobe-cooldown:${Math.max(0, Math.round(staleQmdFallback.ageMs))}ms)`,
               });
+              if (queryAwarePrefilterIsEmpty) {
+                return emptyQueryAwareQmdResult;
+              }
               return staleQmdFallback.value;
             }
             recordRecallSectionMetric({
@@ -7834,6 +7861,9 @@ export class Orchestrator {
                 success: true,
                 timing: `stale-cache(reprobe-failed:${Math.max(0, Math.round(staleQmdFallback.ageMs))}ms)`,
               });
+              if (queryAwarePrefilterIsEmpty) {
+                return emptyQueryAwareQmdResult;
+              }
               return staleQmdFallback.value;
             }
             recordRecallSectionMetric({
@@ -7853,11 +7883,11 @@ export class Orchestrator {
           log.info(`QMD re-probe succeeded: ${this.qmd.debugStatus()}`);
         }
 
-        const queryAwarePrefilter = await queryAwarePrefilterPromise;
         const maxPerAgent = this.config.parallelMaxResultsPerAgent;
         const specializedAgentPromise: Promise<
           [ParallelSearchResult[], ParallelSearchResult[]]
         > | null =
+          !queryAwarePrefilterIsEmpty &&
           this.config.parallelRetrievalEnabled && maxPerAgent > 0
             ? Promise.all([
                 shouldRunAgent("direct", retrievalQuery, 0)
@@ -7981,6 +8011,9 @@ export class Orchestrator {
               success: true,
               timing: `stale-cache(${err instanceof Error ? err.message : String(err)})`,
             });
+            if (queryAwarePrefilterIsEmpty) {
+              return emptyQueryAwareQmdResult;
+            }
             return staleQmdFallback.value;
           }
           throw err;
@@ -9462,6 +9495,7 @@ export class Orchestrator {
         // When the gate rejects, all recall pathways are skipped to prevent
         // low-relevance results from polluting context.
         const queryAwarePrefilter = await queryAwarePrefilterPromise;
+        if (queryAwarePrefilter.candidatePaths?.size !== 0) {
         const embeddingResults = await this.searchEmbeddingFallback(
           retrievalQuery,
           embeddingFetchLimit,
@@ -9566,6 +9600,7 @@ export class Orchestrator {
             impressionRecorded = true;
           }
         }
+        }
       }
 
       if (globalResults.length > 0) {
@@ -9607,6 +9642,7 @@ export class Orchestrator {
     } else if (recallResultLimit > 0 && !this.qmd.isAvailable()) {
       // Fallback: embeddings first, then recency-only.
       const queryAwarePrefilter = await queryAwarePrefilterPromise;
+      if (queryAwarePrefilter.candidatePaths?.size !== 0) {
       const embeddingResults = await this.searchEmbeddingFallback(
         retrievalQuery,
         embeddingFetchLimit,
@@ -9921,6 +9957,7 @@ export class Orchestrator {
             impressionRecorded = true;
           }
         }
+      }
       }
 
       if (isDisagreementPrompt(prompt)) {
@@ -15553,6 +15590,7 @@ export class Orchestrator {
     throwIfRecallAborted(abortSignal);
     const cappedLimit = Math.max(0, limit);
     if (cappedLimit === 0) return [];
+    if (queryAwarePrefilter?.candidatePaths?.size === 0) return [];
 
     const scopedSeedResults = queryAwarePrefilter?.candidatePaths?.size
       ? await this.searchScopedMemoryCandidates(
@@ -15639,6 +15677,11 @@ export class Orchestrator {
     /** Issue #681 — when true, bypass graphTraversalConfidenceFloor. */
     includeLowConfidence?: boolean;
   }): Promise<QmdSearchResult[]> {
+    if (options.queryAwarePrefilter?.candidatePaths?.size === 0) {
+      if (options.xrayPoolSizeSink) options.xrayPoolSizeSink.size = 0;
+      return [];
+    }
+
     const coldQmdEnabled = this.config.qmdColdTierEnabled === true;
     const coldCollection =
       this.config.qmdColdCollection ?? "openclaw-engram-cold";
@@ -15953,7 +15996,7 @@ export class Orchestrator {
         // Intersect with result paths first so out-of-scope paths don't exhaust the budget
         const scoped = new Set(Array.from(s).filter((p) => resultPaths.has(p)));
         if (maxCandidates === 0 || scoped.size <= maxCandidates)
-          return scoped.size > 0 ? scoped : null;
+          return scoped;
         return new Set(Array.from(scoped).slice(0, maxCandidates));
       };
       if (temporalFromDate !== null) {

--- a/packages/remnic-core/src/temporal-index.test.ts
+++ b/packages/remnic-core/src/temporal-index.test.ts
@@ -6,7 +6,12 @@ import { join } from "node:path";
 import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
 
-import { queryByDateRangeAsync, queryByTagsAsync } from "./temporal-index.js";
+import {
+  indexMemory,
+  queryByDateRangeAsync,
+  queryByTagsAsync,
+  resolvePromptTagPrefilterAsync,
+} from "./temporal-index.js";
 
 async function runIndexWorker(moduleUrl: string, memoryDir: string, workerId: number, count: number): Promise<void> {
   const workerSource = `
@@ -188,4 +193,28 @@ test("temporal index writers fail open on symlink lock blockers", async () => {
   const tagMatches = await queryByTagsAsync(memoryDir, ["concurrency/shared"]);
   assert.equal(dateMatches, null);
   assert.deepEqual(tagMatches, new Set(["/tmp/remnic-temporal-worker-101-memory-0.md"]));
+});
+
+test("tag queries distinguish missing index from valid no-match results", async () => {
+  const memoryDir = await mkdtemp(join(tmpdir(), "remnic-temporal-index-tag-miss-"));
+
+  const unavailableMatches = await queryByTagsAsync(memoryDir, ["beta"]);
+  assert.equal(unavailableMatches, null);
+
+  indexMemory(memoryDir, "/tmp/remnic-temporal-alpha-memory.md", "2026-03-11T12:00:00.000Z", ["alpha"]);
+
+  const matchingPaths = await queryByTagsAsync(memoryDir, ["alpha"]);
+  assert.deepEqual(matchingPaths, new Set(["/tmp/remnic-temporal-alpha-memory.md"]));
+
+  const noMatchPaths = await queryByTagsAsync(memoryDir, ["beta"]);
+  assert.deepEqual(noMatchPaths, new Set());
+
+  const promptPrefilter = await resolvePromptTagPrefilterAsync(memoryDir, "find #beta notes");
+  assert.deepEqual(promptPrefilter.matchedTags, ["beta"]);
+  assert.deepEqual(promptPrefilter.paths, new Set());
+
+  const noFilterPrefilter = await resolvePromptTagPrefilterAsync(memoryDir, "find project notes");
+  assert.deepEqual(noFilterPrefilter.matchedTags, []);
+  assert.deepEqual(noFilterPrefilter.expandedTags, []);
+  assert.equal(noFilterPrefilter.paths, null);
 });

--- a/packages/remnic-core/src/temporal-index.ts
+++ b/packages/remnic-core/src/temporal-index.ts
@@ -732,7 +732,7 @@ export async function queryByTagsAsync(memoryDir: string, tags: string[]): Promi
     try {
       gIndex = normalizeTagIndex(JSON.parse(raw) as TagIndex);
     } catch {
-      gIndex = { version: TAG_INDEX_VERSION, tags: {}, aliases: {} };
+      return null;
     }
 
     return queryByTagsFromIndex(gIndex, tags);
@@ -741,7 +741,7 @@ export async function queryByTagsAsync(memoryDir: string, tags: string[]): Promi
   }
 }
 
-function queryByTagsFromIndex(index: TagIndex, tags: string[]): Set<string> | null {
+function queryByTagsFromIndex(index: TagIndex, tags: string[]): Set<string> {
   const expandedTags = expandCanonicalTags(index, tags);
   const results = new Set<string>();
   for (const canonical of expandedTags) {
@@ -751,7 +751,7 @@ function queryByTagsFromIndex(index: TagIndex, tags: string[]): Set<string> | nu
       results.add(pathValue);
     }
   }
-  return results.size > 0 ? results : null;
+  return results;
 }
 
 /**
@@ -796,6 +796,13 @@ export async function resolvePromptTagPrefilterAsync(
       for (const canonical of canonicals) {
         matched.add(canonical);
       }
+    }
+    if (matched.size === 0) {
+      return {
+        matchedTags: [],
+        expandedTags: [],
+        paths: null,
+      };
     }
 
     const expandedTags = expandCanonicalTags(tagIndex, Array.from(matched));

--- a/tests/query-aware-prefilter.test.ts
+++ b/tests/query-aware-prefilter.test.ts
@@ -365,6 +365,196 @@ test("query-aware max candidate limit treats 0 as uncapped for advisory seed res
   assert.equal(results.length, 2);
 });
 
+test("explicit tag misses preserve an empty prefilter through QMD retrieval", async () => {
+  const orchestrator = await makeOrchestrator("engram-query-aware-tag-miss-");
+  const storage = (orchestrator as any).storage;
+
+  const unrelatedId = await storage.writeMemory(
+    "fact",
+    "The marketing team updated homepage messaging for the spring launch.",
+    { tags: ["marketing/content"], confidence: 0.9 },
+  );
+  const alphaId = await storage.writeMemory(
+    "fact",
+    "Alpha-tagged infrastructure note that should not match beta.",
+    { tags: ["alpha"], confidence: 0.9 },
+  );
+
+  const memories = await storage.readAllMemories();
+  indexMemoriesBatch(
+    orchestrator.config.memoryDir,
+    memories.map((memory: any) => ({
+      path: memory.path,
+      createdAt: memory.frontmatter.created,
+      tags: memory.frontmatter.tags ?? [],
+    })),
+  );
+
+  const byId = new Map<string, any>(memories.map((memory: any) => [memory.frontmatter.id, memory]));
+  let backendCalls = 0;
+  (orchestrator as any).qmd = {
+    isAvailable: () => true,
+    debugStatus: () => "available",
+    search: async () => {
+      backendCalls += 1;
+      return [
+        {
+          docid: unrelatedId,
+          path: byId.get(unrelatedId)?.path,
+          score: 0.99,
+          snippet: "unrelated result",
+        },
+      ];
+    },
+    hybridSearch: async () => {
+      backendCalls += 1;
+      return [
+        {
+          docid: alphaId,
+          path: byId.get(alphaId)?.path,
+          score: 0.9,
+          snippet: "alpha result",
+        },
+      ];
+    },
+  };
+
+  const prefilter = await (orchestrator as any).buildQueryAwarePrefilter(
+    "What happened with #beta?",
+    ["default"],
+  );
+  assert.equal(prefilter.candidatePaths?.size, 0);
+  assert.equal(prefilter.combination, "tag");
+
+  const results = await (orchestrator as any).fetchQmdMemoryResultsWithArtifactTopUp(
+    "What happened with #beta?",
+    5,
+    5,
+    {
+      namespacesEnabled: false,
+      recallNamespaces: ["default"],
+      resolveNamespace: () => "default",
+      queryAwarePrefilter: prefilter,
+    },
+  );
+
+  assert.equal(backendCalls, 0);
+  assert.deepEqual(results, []);
+});
+
+test("explicit tag misses dominate temporal matches and skip non-QMD fallbacks", async () => {
+  const orchestrator = await makeOrchestrator("engram-query-aware-tag-temporal-miss-", {
+    qmdEnabled: false,
+    embeddingFallbackEnabled: true,
+  });
+  const storage = (orchestrator as any).storage;
+
+  const alphaId = await storage.writeMemory(
+    "fact",
+    "Alpha-tagged incident note from today that should not match beta.",
+    { tags: ["alpha"], confidence: 0.9 },
+  );
+
+  const memories = await storage.readAllMemories();
+  indexMemoriesBatch(
+    orchestrator.config.memoryDir,
+    memories.map((memory: any) => ({
+      path: memory.path,
+      createdAt: memory.frontmatter.created,
+      tags: memory.frontmatter.tags ?? [],
+    })),
+  );
+
+  const byId = new Map<string, any>(memories.map((memory: any) => [memory.frontmatter.id, memory]));
+  let embeddingCalls = 0;
+  (orchestrator as any).embeddingFallback = {
+    isAvailable: async () => true,
+    search: async () => {
+      embeddingCalls += 1;
+      return [
+        {
+          id: alphaId,
+          path: byId.get(alphaId)?.path,
+          score: 0.99,
+        },
+      ];
+    },
+  };
+
+  const prefilter = await (orchestrator as any).buildQueryAwarePrefilter(
+    "What happened today with #beta?",
+    ["default"],
+  );
+  assert.equal(prefilter.candidatePaths?.size, 0);
+  assert.equal(prefilter.combination, "tag");
+
+  const context = await (orchestrator as any).recallInternal(
+    "What happened today with #beta?",
+    "user:test:query-aware-tag-temporal-miss",
+  );
+
+  assert.equal(embeddingCalls, 0);
+  assert.doesNotMatch(context, /Alpha-tagged incident note/i);
+});
+
+test("explicit tag misses suppress fresh QMD cache hits", async () => {
+  const orchestrator = await makeOrchestrator("engram-query-aware-tag-cache-miss-");
+  const storage = (orchestrator as any).storage;
+
+  const alphaId = await storage.writeMemory(
+    "fact",
+    "Alpha-tagged cached QMD result that should not match beta.",
+    { tags: ["alpha"], confidence: 0.9 },
+  );
+  const memories = await storage.readAllMemories();
+  const byId = new Map<string, any>(memories.map((memory: any) => [memory.frontmatter.id, memory]));
+
+  let qmdCalls = 0;
+  (orchestrator as any).qmd = {
+    isAvailable: () => true,
+    debugStatus: () => "available",
+    search: async () => {
+      qmdCalls += 1;
+      return [
+        {
+          docid: alphaId,
+          path: byId.get(alphaId)?.path,
+          score: 0.99,
+          snippet: "alpha result",
+        },
+      ];
+    },
+    hybridSearch: async () => {
+      qmdCalls += 1;
+      return [];
+    },
+  };
+
+  const cachedContext = await (orchestrator as any).recallInternal(
+    "What happened with #beta?",
+    "user:test:query-aware-tag-cache-miss",
+  );
+  assert.match(cachedContext, /alpha result/i);
+  assert.equal(qmdCalls, 2);
+
+  indexMemoriesBatch(
+    orchestrator.config.memoryDir,
+    memories.map((memory: any) => ({
+      path: memory.path,
+      createdAt: memory.frontmatter.created,
+      tags: memory.frontmatter.tags ?? [],
+    })),
+  );
+
+  const context = await (orchestrator as any).recallInternal(
+    "What happened with #beta?",
+    "user:test:query-aware-tag-cache-miss",
+  );
+
+  assert.equal(qmdCalls, 2);
+  assert.doesNotMatch(context, /alpha result/i);
+});
+
 test("query-aware prefilter scopes candidate paths to authorized namespaces", async () => {
   const orchestrator = await makeOrchestrator("engram-query-aware-ns-", {
     namespacesEnabled: true,


### PR DESCRIPTION
## Summary
- keep `null` reserved for missing/unreadable/malformed tag indexes and no tag filter requested
- return an empty `Set` when a readable tag index successfully resolves a query to zero matching paths
- add regression coverage for direct tag queries and prompt tag prefilter semantics

## Verification
- `pnpm exec biome check --diagnostic-level=error --write packages/remnic-core/src/temporal-index.ts packages/remnic-core/src/temporal-index.test.ts`
- `pnpm exec tsx --test packages/remnic-core/src/temporal-index.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core check-types`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run test:entity-hardening`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

ClawPatch finding: `fnd_sig-feat-library-7c74e01f37-f389_c9c846a5f8`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall behavior for explicit hashtag queries with zero tag matches; wrong empty-set signaling could over-suppress or still leak unrelated memories.
> 
> **Overview**
> Tag-aware query prefilters now treat **`null`** as “no filter / index unavailable” and an **empty `Set`** as “tags were resolved but nothing matched,” instead of collapsing both into unfiltered recall.
> 
> **`temporal-index`** returns an empty set for valid no-match tag lookups, treats corrupt tag index JSON as unavailable (`null`), and returns `paths: null` when the prompt has no tag intent.
> 
> **`orchestrator`** honors an empty tag prefilter end-to-end: explicit `#tag` misses win over temporal union, QMD/hybrid search is skipped, fresh/stale QMD cache is bypassed, and embedding/cold/archive fallbacks stay empty. Scoped path sets are no longer dropped when namespace scoping yields zero paths.
> 
> Regression tests cover tag-miss behavior across QMD, embeddings, cache, and prompt prefilter helpers. Root **`package.json`** changes are formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9dfb8e3bb736c8dedb1f77293b1b756df4bae77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->