### PR TITLE
Expose root temporal shim exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -747,6 +747,18 @@
     "./summary-snapshot.js": {
       "import": "./dist/summary-snapshot.js"
     },
+    "./temporal-index": {
+      "import": "./dist/temporal-index.js"
+    },
+    "./temporal-index.js": {
+      "import": "./dist/temporal-index.js"
+    },
+    "./temporal-validity": {
+      "import": "./dist/temporal-validity.js"
+    },
+    "./temporal-validity.js": {
+      "import": "./dist/temporal-validity.js"
+    },
     "./threading": {
       "import": "./dist/threading.js"
     },

--- a/src/temporal-index.ts
+++ b/src/temporal-index.ts
@@ -1,1 +1,15 @@
+export {
+  clearIndexes,
+  deindexMemory,
+  extractTagsFromPrompt,
+  indexMemoriesBatch,
+  indexMemory,
+  indexesExist,
+  isTemporalQuery,
+  queryByDateRangeAsync,
+  queryByTagsAsync,
+  recencyWindowBoundsFromPrompt,
+  recencyWindowFromPrompt,
+  resolvePromptTagPrefilterAsync,
+} from "@remnic/core/temporal-index";
 export * from "@remnic/core/temporal-index";

--- a/tests/connectors-root-exports.test.ts
+++ b/tests/connectors-root-exports.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
@@ -66,8 +67,41 @@ test("root package export map exposes compat and source shims", async () => {
     ["extraction", "./dist/extraction.js"],
     ["secure-store", "./dist/secure-store/index.js"],
     ["secure-store/index", "./dist/secure-store/index.js"],
+    ["temporal-index", "./dist/temporal-index.js"],
+    ["temporal-validity", "./dist/temporal-validity.js"],
   ] as const) {
     assert.deepEqual(exportsMap[`./${subpath}`], { import: expectedTarget }, subpath);
     assert.deepEqual(exportsMap[`./${subpath}.js`], { import: expectedTarget }, `${subpath}.js`);
+  }
+});
+
+test("root package resolver exposes temporal shims", () => {
+  for (const subpath of ["temporal-index", "temporal-validity"] as const) {
+    const expectedUrl = new URL(`../dist/${subpath}.js`, import.meta.url).href;
+    assert.equal(import.meta.resolve(`remnic-workspace/${subpath}`), expectedUrl, subpath);
+    assert.equal(import.meta.resolve(`remnic-workspace/${subpath}.js`), expectedUrl, `${subpath}.js`);
+  }
+});
+
+test("root build emits temporal shim artifacts", () => {
+  const tsupConfig = readFileSync(new URL("../tsup.config.ts", import.meta.url), "utf8");
+
+  for (const entry of ["src/temporal-index.ts", "src/temporal-validity.ts"] as const) {
+    assert.match(tsupConfig, new RegExp(`"${entry}"`), entry);
+  }
+});
+
+test("root temporal index shim preserves public core exports", () => {
+  const shimSource = readFileSync(new URL("../src/temporal-index.ts", import.meta.url), "utf8");
+
+  for (const exportName of [
+    "indexMemory",
+    "indexesExist",
+    "isTemporalQuery",
+    "queryByTagsAsync",
+    "recencyWindowFromPrompt",
+    "resolvePromptTagPrefilterAsync",
+  ] as const) {
+    assert.match(shimSource, new RegExp(`\\b${exportName}\\b`), exportName);
   }
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -121,6 +121,8 @@ export default defineConfig({
     "src/store-contract.ts",
     "src/summarizer.ts",
     "src/summary-snapshot.ts",
+    "src/temporal-index.ts",
+    "src/temporal-validity.ts",
     "src/threading.ts",
     "src/tmt.ts",
     "src/topics.ts",


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-fdd02c0ed3-eb29_facbfe186f` (`Temporal root shims are not reachable through package exports`).

## Summary
- Add root package export-map entries for `remnic-workspace/temporal-index` and `remnic-workspace/temporal-validity`, including `.js` aliases.
- Extend the root export contract test to assert both JSON entries and Node self-reference resolution for the temporal shims.

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/connectors-root-exports.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node scripts/check-test-types.mjs`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and test-only surface changes; no runtime logic beyond re-export wiring.
> 
> **Overview**
> Makes **`remnic-workspace/temporal-index`** and **`remnic-workspace/temporal-validity`** importable from the root package by wiring them into the **export map** (including `.js` aliases), adding **`src/temporal-index.ts`** as a thin re-export of `@remnic/core/temporal-index`, and registering both shims in **`tsup`** so they build to `dist/`.
> 
> Contract tests now assert the export-map targets, **`import.meta.resolve`** for both subpaths, that **`tsup.config.ts`** lists the temporal entry files, and that the temporal-index shim still exposes key public symbols like `indexMemory` and `isTemporalQuery`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dd61d7f221c138463872262e449142fa85b5f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->