### PR TITLE
Refresh both tier search collections on migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -936,12 +934,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -964,9 +957,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1019,12 +1010,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/search/lancedb-backend.ts
+++ b/packages/remnic-core/src/search/lancedb-backend.ts
@@ -128,12 +128,16 @@ export class LanceDbBackend implements SearchBackend {
   }
 
   async updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void> {
+    await this.updateCollectionFromDir(collection, this.memoryDir, execution);
+  }
+
+  async updateCollectionFromDir(collection: string, memoryDir: string, execution?: SearchExecutionOptions): Promise<void> {
     if (isSearchAborted(execution)) return;
     let table = await this.ensureTableForCollection(collection);
     if (isSearchAborted(execution)) return;
     if (!table) return;
 
-    const docs = await scanMemoryDir(this.memoryDir);
+    const docs = await scanMemoryDir(memoryDir);
     if (isSearchAborted(execution)) return;
     if (docs.length === 0) {
       // Clear stale data when no docs remain

--- a/packages/remnic-core/src/search/meilisearch-backend.ts
+++ b/packages/remnic-core/src/search/meilisearch-backend.ts
@@ -124,14 +124,19 @@ export class MeilisearchBackend implements SearchBackend {
   }
 
   async updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void> {
-    if (!this.autoIndex || !this.memoryDir) return;
+    if (!this.memoryDir) return;
+    await this.updateCollectionFromDir(collection, this.memoryDir, execution);
+  }
+
+  async updateCollectionFromDir(collection: string, memoryDir: string, execution?: SearchExecutionOptions): Promise<void> {
+    if (!this.autoIndex) return;
     if (!this.available) return;
     if (isSearchAborted(execution)) return;
 
     try {
       const client = await this.ensureClient();
       if (isSearchAborted(execution)) return;
-      const docs = await scanMemoryDir(this.memoryDir);
+      const docs = await scanMemoryDir(memoryDir);
       if (isSearchAborted(execution)) return;
       const index = client.index(collection);
 

--- a/packages/remnic-core/src/search/orama-backend.ts
+++ b/packages/remnic-core/src/search/orama-backend.ts
@@ -149,13 +149,17 @@ export class OramaBackend implements SearchBackend {
   }
 
   async updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void> {
+    await this.updateCollectionFromDir(collection, this.memoryDir, execution);
+  }
+
+  async updateCollectionFromDir(collection: string, memoryDir: string, execution?: SearchExecutionOptions): Promise<void> {
     if (isSearchAborted(execution)) return;
     const db = await this.ensureDbForCollection(collection);
     if (isSearchAborted(execution)) return;
     if (!db) return;
     const { search: oramaSearch, insert, remove, count, getByID } = this.oramaModule;
 
-    const docs = await scanMemoryDir(this.memoryDir);
+    const docs = await scanMemoryDir(memoryDir);
     if (isSearchAborted(execution)) return;
     const docMap = new Map(docs.map((d) => [d.docid, d]));
     const { update: oramaUpdate } = this.oramaModule;

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -66,6 +66,7 @@ export interface SearchBackend {
   // ── Maintenance ──
   update(execution?: SearchExecutionOptions): Promise<void>;
   updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void>;
+  updateCollectionFromDir?(collection: string, memoryDir: string, execution?: SearchExecutionOptions): Promise<void>;
   /**
    * True when update() refreshes every indexed collection, not just this
    * backend's configured collection. Namespace routers use this to avoid

--- a/packages/remnic-core/src/tier-migration.ts
+++ b/packages/remnic-core/src/tier-migration.ts
@@ -91,8 +91,10 @@ export class TierMigrationExecutor {
     if (result.changed) {
       const destinationCollection = this.collectionForTier(toTier);
       const sourceCollection = this.collectionForTier(fromTier);
-      // QMD update is effectively global in current CLI versions. One update call is enough.
-      await this.qmd.updateCollection(destinationCollection);
+      await this.updateCollectionFromTierRoot(destinationCollection, toTier);
+      if (sourceCollection !== destinationCollection && this.qmd.updatesAllCollections?.() !== true) {
+        await this.updateCollectionFromTierRoot(sourceCollection, fromTier);
+      }
       if (this.autoEmbed) {
         await this.qmd.embedCollection(destinationCollection);
         if (sourceCollection !== destinationCollection) {
@@ -106,6 +108,15 @@ export class TierMigrationExecutor {
 
   private collectionForTier(tier: MemoryTier): string {
     return tier === "cold" ? this.coldCollection : this.hotCollection;
+  }
+
+  private async updateCollectionFromTierRoot(collection: string, tier: MemoryTier): Promise<void> {
+    const memoryDir = tier === "cold" ? path.join(this.storage.dir, "cold") : this.storage.dir;
+    if (this.qmd.updatesAllCollections?.() !== true && this.qmd.updateCollectionFromDir) {
+      await this.qmd.updateCollectionFromDir(collection, memoryDir);
+      return;
+    }
+    await this.qmd.updateCollection(collection);
   }
 
   private async appendJournal(result: TierMigrationResult): Promise<void> {

--- a/tests/lifecycle/first-start-migration.test.ts
+++ b/tests/lifecycle/first-start-migration.test.ts
@@ -282,7 +282,7 @@ test("first-start migration: journals demotions and updates cold QMD collection"
     });
 
     assert.equal(result.demotedCount, 1);
-    assert.deepEqual(qmdUpdates, ["cold-test"]);
+    assert.deepEqual(qmdUpdates, ["cold-test", "hot-test"]);
 
     const journalPath = path.join(dir, "state", "tier-migration-journal.jsonl");
     const journalRaw = await readFile(journalPath, "utf-8");

--- a/tests/tier-migration.test.ts
+++ b/tests/tier-migration.test.ts
@@ -8,7 +8,7 @@ import { TierMigrationExecutor } from "../src/tier-migration.js";
 import type { MemoryFile } from "../src/types.js";
 
 type QmdCallLog = {
-  updates: string[];
+  updates: string[]; updateDirs?: Array<{ collection: string; memoryDir: string }>;
   embeds: string[];
 };
 
@@ -78,7 +78,7 @@ function createQmdStub(logs: QmdCallLog) {
   };
 }
 
-test("tier migration demotes hot memory into cold path and cold collection", async () => {
+test("tier migration demotes hot memory and refreshes source and destination collections", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-tier-migrate-"));
   try {
     const storage = new StorageManager(memoryDir);
@@ -116,14 +116,14 @@ test("tier migration demotes hot memory into cold path and cold collection", asy
     const oldPathMemory = await storage.readMemoryByPath(source.path);
     assert.equal(oldPathMemory, null, "expected source hot file to be removed after demotion");
 
-    assert.deepEqual(logs.updates, ["openclaw-engram-cold"]);
+    assert.deepEqual(logs.updates, ["openclaw-engram-cold", "openclaw-engram"]);
     assert.deepEqual(logs.embeds, []);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
 
-test("tier migration promotes cold memory back into hot path and collection", async () => {
+test("tier migration promotes cold memory and refreshes source and destination collections", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-tier-promote-"));
   try {
     const storage = new StorageManager(memoryDir);
@@ -164,7 +164,7 @@ test("tier migration promotes cold memory back into hot path and collection", as
     assert.ok(hotAgain, "expected promoted memory in hot path");
     assert.equal(hotAgain!.frontmatter.id, source.frontmatter.id);
 
-    assert.deepEqual(logs.updates, ["openclaw-engram"]);
+    assert.deepEqual(logs.updates, ["openclaw-engram", "openclaw-engram-cold"]);
     assert.deepEqual(logs.embeds, []);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
@@ -276,8 +276,77 @@ test("tier migration autoEmbed embeds both destination and source collections", 
       reason: "autoembed",
     });
 
-    assert.deepEqual(logs.updates, ["openclaw-engram-cold"]);
+    assert.deepEqual(logs.updates, ["openclaw-engram-cold", "openclaw-engram"]);
     assert.deepEqual(logs.embeds, ["openclaw-engram-cold", "openclaw-engram"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("tier migration avoids duplicate source update for global-update backends", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-tier-global-update-"));
+  try {
+    const storage = new StorageManager(memoryDir);
+    const source = await createHotFactWithParityFields(storage);
+
+    const logs: QmdCallLog = { updates: [], embeds: [] };
+    const executor = new TierMigrationExecutor({
+      storage,
+      qmd: {
+        ...createQmdStub(logs),
+        updatesAllCollections: () => true,
+      } as any,
+      hotCollection: "openclaw-engram",
+      coldCollection: "openclaw-engram-cold",
+      autoEmbed: false,
+    });
+
+    await executor.migrateMemory({
+      memory: source,
+      fromTier: "hot",
+      toTier: "cold",
+      reason: "global-update",
+    });
+
+    assert.deepEqual(logs.updates, ["openclaw-engram-cold"]);
+    assert.deepEqual(logs.embeds, []);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("tier migration refreshes scoped collections from their tier roots", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-tier-scoped-roots-"));
+  try {
+    const storage = new StorageManager(memoryDir);
+    const source = await createHotFactWithParityFields(storage);
+
+    const logs: QmdCallLog = { updates: [], updateDirs: [], embeds: [] };
+    const executor = new TierMigrationExecutor({
+      storage,
+      qmd: {
+        ...createQmdStub(logs),
+        updateCollectionFromDir: async (collection: string, dir: string): Promise<void> => {
+          logs.updateDirs!.push({ collection, memoryDir: dir });
+        },
+      } as any,
+      hotCollection: "openclaw-engram",
+      coldCollection: "openclaw-engram-cold",
+      autoEmbed: false,
+    });
+
+    await executor.migrateMemory({
+      memory: source,
+      fromTier: "hot",
+      toTier: "cold",
+      reason: "scoped-roots",
+    });
+
+    assert.deepEqual(logs.updates, []);
+    assert.deepEqual(logs.updateDirs, [
+      { collection: "openclaw-engram-cold", memoryDir: path.join(memoryDir, "cold") },
+      { collection: "openclaw-engram", memoryDir },
+    ]);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- refresh both destination and source search collections after a changed tier migration
- update tier migration tests to assert hot-to-cold and cold-to-hot moves refresh both collections

ClawPatch finding: fnd_sig-feat-library-320c425704-fcb9_526c64c769

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/tier-migration.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" node scripts/check-test-types.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=local-test-key npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tier-migration and search index refresh behavior; risk is mitigated by tests and skipping duplicate updates when backends report global collection updates.
> 
> **Overview**
> After a **hot/cold tier move**, search indexes are refreshed for **both** the destination and source collections so removed or relocated memories do not leave stale hits in the tier that was left behind.
> 
> Search backends (Orama, LanceDB, Meilisearch) gain an optional **`updateCollectionFromDir`** hook that reindexes from a caller-supplied memory root; **`TierMigrationExecutor`** uses each tier’s on-disk root (hot storage dir vs `cold/`) when the backend is not a single global **`updatesAllCollections`** refresh. Backends that already update everything in one call still get only the destination update to avoid duplicate work.
> 
> Tests and first-start lifecycle expectations now assert **both** collection names are updated on demotion/promotion, including scoped-dir and global-backend cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 631c0007078bf4eebe53ebe34d0b8de5da0a354e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->