### PR TITLE
feat: add gateway extraction model chain

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -490,6 +490,7 @@ Route all Engram LLM calls through the OpenClaw gateway's agent model chain inst
 | `modelSource` | `gateway` for new OpenClaw installs; `plugin` otherwise | `gateway` delegates to a gateway agent's model chain; `plugin` uses Engram's own openai/localLlm config |
 | `gatewayAgentId` | `""` | Agent persona ID from `openclaw.json → agents.list[]` for primary LLM calls (extraction, consolidation, summarization). Falls back to `agents.defaults.model` if empty. |
 | `fastGatewayAgentId` | `""` | Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). Uses `gatewayAgentId` chain when empty. |
+| `taskModelChain` | _(unset)_ | Optional inline `{ "primary", "fallbacks": [] }` model chain for Remnic's background tasks (extraction, fact/profile/identity consolidation, summarization, causal consolidation). Resolves through gateway providers. When set, it overrides `gatewayAgentId`/`agents.defaults.model` for these tasks only. **Requires `modelSource: "gateway"`** — ignored (with a startup warning) in `plugin` mode. |
 
 When `modelSource` is `gateway`:
 
@@ -498,6 +499,30 @@ When `modelSource` is `gateway`:
 - The existing `openaiApiKey`, `model`, and `localLlm*` settings are ignored for LLM dispatch but retained as config for backward compatibility; `OPENAI_API_KEY` is not inherited in gateway mode
 - `localLlmFast*` settings are also bypassed when `fastGatewayAgentId` is set
 - **Reranking** uses the `fastGatewayAgentId` chain (or `gatewayAgentId` if fast is unset) instead of the local LLM — this can dramatically reduce rerank latency when the fast chain points at a cloud provider
+
+#### Task-specific model chain (`taskModelChain`)
+
+By default, gateway-mode background work (extraction, consolidation, summarization, causal consolidation) shares the `gatewayAgentId` persona chain — or `agents.defaults.model` when no persona is set. That ties lightweight memory tasks to whatever chain the main agent uses, which is often larger/pricier than these tasks need.
+
+Set `taskModelChain` to give those tasks their own cheap/fast chain **without** defining a persona or touching `agents.defaults.model`:
+
+```jsonc
+{
+  "modelSource": "gateway",
+  "taskModelChain": {
+    "primary": "zai/glm-4.7-flash",
+    "fallbacks": ["fireworks/accounts/fireworks/models/glm-5p1"]
+  }
+}
+```
+
+Notes:
+
+- Models resolve through the same `models.providers` auth/routing as everything else — only the chain differs.
+- `taskModelChain` takes precedence over `gatewayAgentId` for these tasks; the main agent persona is unaffected.
+- A reachable `agents.defaults.model` is appended as an implicit last resort to a `taskModelChain` only, so an exhausted task chain never blocks a flush. Persona/default chains are never augmented this way.
+- It **only applies in `gateway` mode.** In `plugin` mode it is ignored and Remnic logs a startup warning. Plugin-mode users who hit non-OpenAI model-ID failures at the direct client should switch to `modelSource: "gateway"` and use `taskModelChain` (see issue #1365).
+- A present-but-malformed value (missing `primary`, wrong types) is rejected at config-parse time rather than silently ignored.
 
 ### Setup
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3151,19 +3151,24 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
-      "extractionModelChain": {
+      "taskModelChain": {
         "type": "object",
-        "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
-        "required": ["primary"],
+        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
+        "required": [
+          "primary"
+        ],
+        "additionalProperties": false,
         "properties": {
           "primary": {
             "type": "string",
+            "minLength": 1,
             "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
           },
           "fallbacks": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "default": [],
             "description": "Fallback gateway models tried after primary"
@@ -5492,10 +5497,10 @@
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
     },
-    "extractionModelChain": {
-      "label": "Extraction Model Chain",
+    "taskModelChain": {
+      "label": "Task Model Chain",
       "advanced": true,
-      "help": "Optional primary/fallback gateway model chain for extraction, consolidation, and summarization. Overrides gatewayAgentId/defaults for these tasks only."
+      "help": "Optional primary/fallback gateway model chain for Remnic background tasks (extraction, consolidation, summarization). Overrides gatewayAgentId/defaults for these tasks only. Requires modelSource: 'gateway'."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3151,6 +3151,24 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
+      "extractionModelChain": {
+        "type": "object",
+        "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "properties": {
+          "primary": {
+            "type": "string",
+            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Fallback gateway models tried after primary"
+          }
+        }
+      },
       "localLlmEnabled": {
         "type": "boolean",
         "default": false,
@@ -5472,6 +5490,11 @@
       "advanced": true,
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
+    },
+    "extractionModelChain": {
+      "label": "Extraction Model Chain",
+      "advanced": true,
+      "help": "Optional primary/fallback gateway model chain for extraction, consolidation, and summarization. Overrides gatewayAgentId/defaults for these tasks only."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3154,6 +3154,7 @@
       "extractionModelChain": {
         "type": "object",
         "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "required": ["primary"],
         "properties": {
           "primary": {
             "type": "string",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3151,6 +3151,24 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
+      "extractionModelChain": {
+        "type": "object",
+        "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "properties": {
+          "primary": {
+            "type": "string",
+            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Fallback gateway models tried after primary"
+          }
+        }
+      },
       "localLlmEnabled": {
         "type": "boolean",
         "default": false,
@@ -5472,6 +5490,11 @@
       "advanced": true,
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
+    },
+    "extractionModelChain": {
+      "label": "Extraction Model Chain",
+      "advanced": true,
+      "help": "Optional primary/fallback gateway model chain for extraction, consolidation, and summarization. Overrides gatewayAgentId/defaults for these tasks only."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3151,19 +3151,22 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
-      "extractionModelChain": {
+      "taskModelChain": {
         "type": "object",
-        "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
         "required": ["primary"],
+        "additionalProperties": false,
         "properties": {
           "primary": {
             "type": "string",
+            "minLength": 1,
             "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
           },
           "fallbacks": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "default": [],
             "description": "Fallback gateway models tried after primary"
@@ -5492,10 +5495,10 @@
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
     },
-    "extractionModelChain": {
-      "label": "Extraction Model Chain",
+    "taskModelChain": {
+      "label": "Task Model Chain",
       "advanced": true,
-      "help": "Optional primary/fallback gateway model chain for extraction, consolidation, and summarization. Overrides gatewayAgentId/defaults for these tasks only."
+      "help": "Optional primary/fallback gateway model chain for Remnic background tasks (extraction, consolidation, summarization). Overrides gatewayAgentId/defaults for these tasks only. Requires modelSource: 'gateway'."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3154,6 +3154,7 @@
       "extractionModelChain": {
         "type": "object",
         "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "required": ["primary"],
         "properties": {
           "primary": {
             "type": "string",

--- a/packages/remnic-core/src/causal-consolidation.test.ts
+++ b/packages/remnic-core/src/causal-consolidation.test.ts
@@ -49,14 +49,24 @@ async function withTrajectoryStore<T>(
 
 function llmStub() {
   let calls = 0;
+  let availableOptions: unknown;
+  let completionOptions: unknown;
   return {
     get calls() {
       return calls;
     },
-    isAvailable() {
+    get availableOptions() {
+      return availableOptions;
+    },
+    get completionOptions() {
+      return completionOptions;
+    },
+    isAvailable(options?: unknown) {
+      availableOptions = options;
       return true;
     },
-    async chatCompletion() {
+    async chatCompletion(_messages?: unknown, options?: unknown) {
+      completionOptions = options;
       calls += 1;
       return {
         content: JSON.stringify({
@@ -150,6 +160,41 @@ test("deriveCausalPromotionCandidates calls LLM when recurrence session and succ
       assert.equal(llm.calls, 1);
       assert.equal(candidates.length, 1);
       assert.equal(candidates[0]?.content, "Prefer focused regressions before broad benchmark reruns.");
+    },
+  );
+});
+
+test("deriveCausalPromotionCandidates forwards task model chain to availability and chat completion", async () => {
+  const llm = llmStub();
+  const modelChain = {
+    primary: "openai/task-primary",
+    fallbacks: ["openai/task-fallback"],
+  };
+  await withTrajectoryStore(
+    [
+      trajectory("t1", "a", "success"),
+      trajectory("t2", "b", "success"),
+      trajectory("t3", "c", "partial"),
+    ],
+    async ({ memoryDir, storeDir }) => {
+      const candidates = await deriveCausalPromotionCandidates({
+        memoryDir,
+        causalTrajectoryStoreDir: storeDir,
+        config: { minRecurrence: 3, minSessions: 2, successThreshold: 0.7 },
+        gatewayAgentId: "expensive-agent",
+        modelChain,
+        llmClient: llm,
+      });
+
+      assert.equal(llm.calls, 1);
+      assert.equal(candidates.length, 1);
+      assert.deepEqual(llm.availableOptions, { agentId: "expensive-agent", modelChain });
+      assert.deepEqual(llm.completionOptions, {
+        temperature: 0.2,
+        maxTokens: 2000,
+        agentId: "expensive-agent",
+        modelChain,
+      });
     },
   );
 });

--- a/packages/remnic-core/src/causal-consolidation.ts
+++ b/packages/remnic-core/src/causal-consolidation.ts
@@ -18,7 +18,7 @@ import { readChainIndex, resolveChainsDir, type CausalChainIndex, type CausalEdg
 import { listJsonFiles, readJsonFile } from "./json-store.js";
 import { isRecord } from "./store-contract.js";
 import { FallbackLlmClient, fallbackLlmRuntimeContextFromConfig } from "./fallback-llm.js";
-import type { GatewayConfig, MemoryFile, PluginConfig } from "./types.js";
+import type { AgentPersonaModelConfig, GatewayConfig, MemoryFile, PluginConfig } from "./types.js";
 import path from "node:path";
 import { log } from "./logger.js";
 import { runPostConsolidationMaterialize } from "./connectors/codex-materialize-runner.js";
@@ -64,10 +64,10 @@ export interface LlmConsolidationResult {
 const CAUSAL_RULE_CATEGORIES = new Set(["rule", "principle", "preference"]);
 
 interface ConsolidationLlmClient {
-  isAvailable(agentId?: string): boolean;
+  isAvailable(options?: { agentId?: string; modelChain?: AgentPersonaModelConfig }): boolean;
   chatCompletion(
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
-    options?: { temperature?: number; maxTokens?: number; agentId?: string },
+    options?: { temperature?: number; maxTokens?: number; agentId?: string; modelChain?: AgentPersonaModelConfig },
   ): Promise<{ content: string } | null>;
 }
 
@@ -188,14 +188,14 @@ If no clear patterns exist, return {"rules": [], "preferences": []}.`;
 async function consolidateWithLlm(
   context: string,
   llm: ConsolidationLlmClient,
-  agentId?: string,
+  options: { agentId?: string; modelChain?: AgentPersonaModelConfig } = {},
 ): Promise<LlmConsolidationResult> {
   const response = await llm.chatCompletion(
     [
       { role: "system", content: CONSOLIDATION_PROMPT },
       { role: "user", content: context },
     ],
-    { temperature: 0.2, maxTokens: 2000, agentId },
+    { temperature: 0.2, maxTokens: 2000, agentId: options.agentId, modelChain: options.modelChain },
   );
 
   if (!response?.content) {
@@ -369,6 +369,7 @@ export async function deriveCausalPromotionCandidates(options: {
   config: ConsolidationConfig;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  modelChain?: AgentPersonaModelConfig;
   workspaceDir?: string;
   pluginConfig?: PluginConfig;
   llmClient?: ConsolidationLlmClient;
@@ -400,13 +401,14 @@ export async function deriveCausalPromotionCandidates(options: {
           })
         : { workspaceDir: options.workspaceDir },
     );
-    if (!llm.isAvailable(options.gatewayAgentId)) {
+    const llmOptions = { agentId: options.gatewayAgentId, modelChain: options.modelChain };
+    if (!llm.isAvailable(llmOptions)) {
       log.debug("[cmc] no LLM available for consolidation — skipping");
       return [];
     }
 
     // Call LLM for pattern analysis
-    const result = await consolidateWithLlm(context, llm, options.gatewayAgentId);
+    const result = await consolidateWithLlm(context, llm, llmOptions);
     const candidates = llmResultToCandidates(result);
 
     log.debug(`[cmc] LLM consolidation produced ${candidates.length} rule(s) and ${result.preferences.length} preference(s)`);
@@ -426,6 +428,7 @@ export async function synthesizeCausalPreferencesViaLlm(options: {
   causalTrajectoryStoreDir?: string;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  modelChain?: AgentPersonaModelConfig;
   workspaceDir?: string;
   minTrajectories?: number;
 }): Promise<string | null> {
@@ -440,9 +443,10 @@ export async function synthesizeCausalPreferencesViaLlm(options: {
     const llm = new FallbackLlmClient(options.gatewayConfig, {
       workspaceDir: options.workspaceDir,
     });
-    if (!llm.isAvailable(options.gatewayAgentId)) return null;
+    const llmOptions = { agentId: options.gatewayAgentId, modelChain: options.modelChain };
+    if (!llm.isAvailable(llmOptions)) return null;
 
-    const result = await consolidateWithLlm(context, llm, options.gatewayAgentId);
+    const result = await consolidateWithLlm(context, llm, llmOptions);
     if (result.preferences.length === 0 && result.rules.length === 0) return null;
 
     const lines: string[] = ["## Behavioral Insights (from Causal Chain Analysis)", ""];

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -492,7 +492,7 @@ export class CompoundingEngine {
           causalTrajectoryStoreDir: this.config.causalTrajectoryStoreDir,
           gatewayConfig: this.config.gatewayConfig,
           gatewayAgentId: this.config.modelSource === "gateway" ? (this.config.gatewayAgentId || undefined) : undefined,
-          modelChain: this.config.modelSource === "gateway" ? this.config.extractionModelChain : undefined,
+          modelChain: this.config.modelSource === "gateway" ? this.config.taskModelChain : undefined,
           workspaceDir: this.config.workspaceDir,
           pluginConfig: this.config,
           config: {

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -492,6 +492,7 @@ export class CompoundingEngine {
           causalTrajectoryStoreDir: this.config.causalTrajectoryStoreDir,
           gatewayConfig: this.config.gatewayConfig,
           gatewayAgentId: this.config.modelSource === "gateway" ? (this.config.gatewayAgentId || undefined) : undefined,
+          modelChain: this.config.modelSource === "gateway" ? this.config.extractionModelChain : undefined,
           workspaceDir: this.config.workspaceDir,
           pluginConfig: this.config,
           config: {

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -193,25 +193,40 @@ test("parseConfig modelSource=gateway does not inherit OPENAI_API_KEY from the p
   }
 });
 
-test("parseConfig normalizes extractionModelChain", () => {
+test("parseConfig normalizes taskModelChain", () => {
   const cfg = parseConfig({
-    extractionModelChain: {
+    taskModelChain: {
       primary: " openai/cheap-primary ",
       fallbacks: ["openai/cheap-primary", " fireworks/accounts/fireworks/models/glm-5p1 ", ""],
     },
   });
 
-  assert.deepEqual(cfg.extractionModelChain, {
+  assert.deepEqual(cfg.taskModelChain, {
     primary: "openai/cheap-primary",
     fallbacks: ["fireworks/accounts/fireworks/models/glm-5p1"],
   });
 });
 
-test("parseConfig ignores invalid extractionModelChain", () => {
-  assert.equal(parseConfig({ extractionModelChain: null }).extractionModelChain, undefined);
-  assert.equal(parseConfig({ extractionModelChain: [] }).extractionModelChain, undefined);
-  assert.equal(parseConfig({ extractionModelChain: { primary: " " } }).extractionModelChain, undefined);
-  assert.equal(parseConfig({ extractionModelChain: { fallbacks: ["openai/fallback-only"] } }).extractionModelChain, undefined);
+test("parseConfig treats an absent taskModelChain as not configured", () => {
+  assert.equal(parseConfig({}).taskModelChain, undefined);
+  assert.equal(parseConfig({ taskModelChain: null }).taskModelChain, undefined);
+  assert.equal(parseConfig({ taskModelChain: undefined }).taskModelChain, undefined);
+});
+
+test("parseConfig rejects a present-but-malformed taskModelChain (gotcha #51)", () => {
+  // A typo'd chain must surface loudly instead of silently reverting to defaults.
+  assert.throws(() => parseConfig({ taskModelChain: [] }), /taskModelChain must be an object/);
+  assert.throws(() => parseConfig({ taskModelChain: "openai/x" }), /taskModelChain must be an object/);
+  assert.throws(() => parseConfig({ taskModelChain: { primary: " " } }), /taskModelChain\.primary is required/);
+  assert.throws(() => parseConfig({ taskModelChain: { fallbacks: ["openai/fallback-only"] } }), /taskModelChain\.primary is required/);
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "openai/p", fallbacks: "not-an-array" } }),
+    /taskModelChain\.fallbacks must be an array/,
+  );
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "openai/p", fallbacks: [123] } }),
+    /taskModelChain\.fallbacks must contain only strings/,
+  );
 });
 
 test("parseConfig modelSource=gateway still honors an explicit openaiApiKey override", () => {

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -193,6 +193,27 @@ test("parseConfig modelSource=gateway does not inherit OPENAI_API_KEY from the p
   }
 });
 
+test("parseConfig normalizes extractionModelChain", () => {
+  const cfg = parseConfig({
+    extractionModelChain: {
+      primary: " openai/cheap-primary ",
+      fallbacks: ["openai/cheap-primary", " fireworks/accounts/fireworks/models/glm-5p1 ", ""],
+    },
+  });
+
+  assert.deepEqual(cfg.extractionModelChain, {
+    primary: "openai/cheap-primary",
+    fallbacks: ["fireworks/accounts/fireworks/models/glm-5p1"],
+  });
+});
+
+test("parseConfig ignores invalid extractionModelChain", () => {
+  assert.equal(parseConfig({ extractionModelChain: null }).extractionModelChain, undefined);
+  assert.equal(parseConfig({ extractionModelChain: [] }).extractionModelChain, undefined);
+  assert.equal(parseConfig({ extractionModelChain: { primary: " " } }).extractionModelChain, undefined);
+  assert.equal(parseConfig({ extractionModelChain: { fallbacks: ["openai/fallback-only"] } }).extractionModelChain, undefined);
+});
+
 test("parseConfig modelSource=gateway still honors an explicit openaiApiKey override", () => {
   const original = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -13,6 +13,7 @@ import type {
   HeartbeatConfig,
   IdentityInjectionMode,
   MemoryOsPresetName,
+  AgentPersonaModelConfig,
   PluginConfig,
   PrincipalRule,
   RecallPipelineConfig,
@@ -67,6 +68,30 @@ function parseBoundedIntegerMs(
   const coerced = coerceNumber(value);
   if (coerced === undefined) return fallback;
   return Math.min(max, Math.max(min, Math.floor(coerced)));
+}
+
+function parseModelChainConfig(value: unknown): AgentPersonaModelConfig | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  const primary = typeof raw.primary === "string" && raw.primary.trim().length > 0
+    ? raw.primary.trim()
+    : undefined;
+  if (!primary) return undefined;
+
+  const fallbacks = Array.isArray(raw.fallbacks)
+    ? raw.fallbacks
+        .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+        .map((item) => item.trim())
+    : undefined;
+
+  const dedupedFallbacks = fallbacks
+    ? [...new Set(fallbacks.filter((item) => item !== primary))]
+    : undefined;
+
+  return {
+    primary,
+    ...(dedupedFallbacks && dedupedFallbacks.length > 0 ? { fallbacks: dedupedFallbacks } : {}),
+  };
 }
 
 function parsePositiveInteger(value: unknown, keyName: string): number | undefined {
@@ -2425,6 +2450,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.fastGatewayAgentId === "string" && cfg.fastGatewayAgentId.length > 0
         ? cfg.fastGatewayAgentId
         : "",
+    extractionModelChain: parseModelChainConfig(cfg.extractionModelChain),
 
     // v3.0 namespaces (default off)
     namespacesEnabled: cfg.namespacesEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -70,23 +70,44 @@ function parseBoundedIntegerMs(
   return Math.min(max, Math.max(min, Math.floor(coerced)));
 }
 
-function parseModelChainConfig(value: unknown): AgentPersonaModelConfig | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+function parseModelChainConfig(
+  value: unknown,
+  keyName: string,
+): AgentPersonaModelConfig | undefined {
+  // Absent → not configured (no error).
+  if (value === undefined || value === null) return undefined;
+
+  // Present but malformed → reject loudly rather than silently dropping it,
+  // so a typo'd chain surfaces instead of quietly reverting to defaults
+  // (gotcha #51). Issue #1365 / PR #1370.
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `${keyName} must be an object like { "primary": "provider/model", "fallbacks": ["provider/model", ...] }; got ${JSON.stringify(value)}`,
+    );
+  }
   const raw = value as Record<string, unknown>;
-  const primary = typeof raw.primary === "string" && raw.primary.trim().length > 0
-    ? raw.primary.trim()
-    : undefined;
-  if (!primary) return undefined;
+  if (typeof raw.primary !== "string" || raw.primary.trim().length === 0) {
+    throw new Error(
+      `${keyName}.primary is required and must be a non-empty "provider/model" string; got ${JSON.stringify(raw.primary)}`,
+    );
+  }
+  const primary = raw.primary.trim();
 
-  const fallbacks = Array.isArray(raw.fallbacks)
-    ? raw.fallbacks
-        .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
-        .map((item) => item.trim())
-    : undefined;
-
-  const dedupedFallbacks = fallbacks
-    ? [...new Set(fallbacks.filter((item) => item !== primary))]
-    : undefined;
+  let dedupedFallbacks: string[] | undefined;
+  if (raw.fallbacks !== undefined) {
+    if (!Array.isArray(raw.fallbacks)) {
+      throw new Error(
+        `${keyName}.fallbacks must be an array of "provider/model" strings; got ${JSON.stringify(raw.fallbacks)}`,
+      );
+    }
+    if (raw.fallbacks.some((item) => typeof item !== "string")) {
+      throw new Error(`${keyName}.fallbacks must contain only strings`);
+    }
+    const trimmed = raw.fallbacks
+      .map((item) => (item as string).trim())
+      .filter((item) => item.length > 0 && item !== primary);
+    dedupedFallbacks = [...new Set(trimmed)];
+  }
 
   return {
     primary,
@@ -2450,7 +2471,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.fastGatewayAgentId === "string" && cfg.fastGatewayAgentId.length > 0
         ? cfg.fastGatewayAgentId
         : "",
-    extractionModelChain: parseModelChainConfig(cfg.extractionModelChain),
+    taskModelChain: parseModelChainConfig(cfg.taskModelChain, "taskModelChain"),
 
     // v3.0 namespaces (default off)
     namespacesEnabled: cfg.namespacesEnabled === true,

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -123,7 +123,8 @@ export class ExtractionEngine {
     if (config.modelSource === "gateway") {
       log.debug(
         `extraction engine: gateway model source active; extraction uses the gateway chain as its primary path` +
-          (config.gatewayAgentId ? ` (agent: ${config.gatewayAgentId})` : " (defaults)"),
+          (config.extractionModelChain ? " (extractionModelChain)" :
+            config.gatewayAgentId ? ` (agent: ${config.gatewayAgentId})` : " (defaults)"),
       );
     }
   }
@@ -157,6 +158,8 @@ export class ExtractionEngine {
    */
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
+    const modelChain = this.config.extractionModelChain;
+    if (modelChain) return { ...options, modelChain };
     const agentId = this.config.gatewayAgentId || undefined;
     return agentId ? { ...options, agentId } : options;
   }
@@ -1098,7 +1101,8 @@ export class ExtractionEngine {
     if (this.useGatewayModelSource) {
       log.debug(
         `extraction: using gateway model chain as primary path` +
-          (this.config.gatewayAgentId ? ` (agent: ${this.config.gatewayAgentId})` : " (defaults)"),
+          (this.config.extractionModelChain ? " (extractionModelChain)" :
+            this.config.gatewayAgentId ? ` (agent: ${this.config.gatewayAgentId})` : " (defaults)"),
       );
     } else {
       log.info("extraction: falling back to gateway default AI");

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -123,8 +123,16 @@ export class ExtractionEngine {
     if (config.modelSource === "gateway") {
       log.debug(
         `extraction engine: gateway model source active; extraction uses the gateway chain as its primary path` +
-          (config.extractionModelChain ? " (extractionModelChain)" :
+          (config.taskModelChain ? " (taskModelChain)" :
             config.gatewayAgentId ? ` (agent: ${config.gatewayAgentId})` : " (defaults)"),
+      );
+    } else if (config.taskModelChain) {
+      // taskModelChain resolves through gateway providers, so it only applies
+      // under modelSource: "gateway". Warn rather than silently ignore it so a
+      // misconfigured plugin-mode setup is visible. Issue #1365 / PR #1370.
+      log.warn(
+        `taskModelChain is set but modelSource is "${config.modelSource}"; the chain is ignored. ` +
+          `Set modelSource: "gateway" to use it for extraction/consolidation/summarization.`,
       );
     }
   }
@@ -158,7 +166,7 @@ export class ExtractionEngine {
    */
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
-    const modelChain = this.config.extractionModelChain;
+    const modelChain = this.config.taskModelChain;
     if (modelChain) return { ...options, modelChain };
     const agentId = this.config.gatewayAgentId || undefined;
     return agentId ? { ...options, agentId } : options;
@@ -1101,7 +1109,7 @@ export class ExtractionEngine {
     if (this.useGatewayModelSource) {
       log.debug(
         `extraction: using gateway model chain as primary path` +
-          (this.config.extractionModelChain ? " (extractionModelChain)" :
+          (this.config.taskModelChain ? " (taskModelChain)" :
             this.config.gatewayAgentId ? ` (agent: ${this.config.gatewayAgentId})` : " (defaults)"),
       );
     } else {

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -1281,6 +1281,197 @@ test("fallback llm normalizes anthropic-compatible base URLs that omit /v1", { c
   }
 });
 
+test("fallback llm appends gateway default model as implicit last resort when chain is exhausted", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    if (body.model === "stale-primary" || body.model === "stale-fallback") {
+      return new Response(JSON.stringify({ error: { message: "provider gone" } }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "default-model ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        modelChain: {
+          primary: "openai/stale-primary",
+          fallbacks: ["openai/stale-fallback"],
+        },
+      },
+    );
+
+    // All chain models failed, but gateway default model was appended and succeeds
+    assert.equal(response?.content, "default-model ok");
+    assert.equal(response?.modelUsed, "openai/default-model");
+    assert.deepEqual(attemptedModels, ["stale-primary", "stale-fallback", "default-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm does not duplicate gateway default model when it is already in chain", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        modelChain: {
+          primary: "openai/default-model",
+        },
+      },
+    );
+
+    // The default model is already primary in the chain — should not be appended again
+    assert.equal(response?.content, "ok");
+    assert.equal(response?.modelUsed, "openai/default-model");
+    assert.deepEqual(attemptedModels, ["default-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm does not append gateway default model when no chain is provided", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    // Without modelChainOverride, the chain is built from agents.defaults.model;
+    // the default model is already the primary, so no duplication
+    assert.equal(response?.content, "ok");
+    assert.equal(response?.modelUsed, "openai/default-model");
+    assert.deepEqual(attemptedModels, ["default-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 function disableGatewaySecretResolverForTest(): void {
   __setGatewayResolverForTest(async () => null);
 }

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -1472,6 +1472,57 @@ test("fallback llm does not append gateway default model when no chain is provid
   }
 });
 
+test("fallback llm does NOT append gateway default to a persona chain (last-resort is scoped to task chains)", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  // A persona chain that deliberately excludes the gateway default. Without a
+  // modelChain override, the implicit last-resort must NOT augment it, so the
+  // main agent's persona fallback behavior is preserved (gotcha #39).
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: { model: { primary: "openai/default-model" } },
+      list: [{ id: "main-agent", model: { primary: "openai/persona-model" } }],
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      { temperature: 0, maxTokens: 16, agentId: "main-agent" },
+    );
+
+    assert.equal(response?.modelUsed, "openai/persona-model");
+    // The gateway default must not be appended to the persona chain.
+    assert.deepEqual(attemptedModels, ["persona-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 function disableGatewaySecretResolverForTest(): void {
   __setGatewayResolverForTest(async () => null);
 }

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -210,6 +210,31 @@ test("fallback llm tries an explicit model override before a model chain overrid
   }
 });
 
+test("fallback llm availability checks an explicit model chain override", () => {
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  assert.equal(llm.isAvailable({ modelChain: { primary: "openai/task-primary" } }), true);
+  assert.equal(llm.isAvailable({ modelChain: {} }), true);
+});
+
 test("fallback llm deduplicates a model override that matches the model chain primary", { concurrency: false }, async () => {
   clearModelsJsonCache();
   clearSecretCache();

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -73,6 +73,207 @@ test("fallback llm prefers the active gateway provider config over models.json",
   }
 });
 
+test("fallback llm uses an explicit model chain override instead of gateway defaults", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+          fallbacks: ["openai/default-fallback"],
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    if (body.model === "cheap-primary") {
+      return new Response(JSON.stringify({ error: { message: "try fallback" } }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "fallback ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        modelChain: {
+          primary: "openai/cheap-primary",
+          fallbacks: ["openai/cheap-primary", "openai/cheap-fallback"],
+        },
+      },
+    );
+
+    assert.equal(response?.content, "fallback ok");
+    assert.equal(response?.modelUsed, "openai/cheap-fallback");
+    assert.deepEqual(attemptedModels, ["cheap-primary", "cheap-fallback"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm tries an explicit model override before a model chain override", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    if (body.model === "judge-model") {
+      return new Response(JSON.stringify({ error: { message: "try task chain" } }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "task chain ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Judge this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        model: "openai/judge-model",
+        modelChain: { primary: "openai/task-primary" },
+      },
+    );
+
+    assert.equal(response?.content, "task chain ok");
+    assert.equal(response?.modelUsed, "openai/task-primary");
+    assert.deepEqual(attemptedModels, ["judge-model", "task-primary"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm deduplicates a model override that matches the model chain primary", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "dedupe ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Judge this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        model: "openai/task-primary",
+        modelChain: {
+          primary: "openai/task-primary",
+          fallbacks: ["openai/task-fallback"],
+        },
+      },
+    );
+
+    assert.equal(response?.content, "dedupe ok");
+    assert.equal(response?.modelUsed, "openai/task-primary");
+    assert.deepEqual(attemptedModels, ["task-primary"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 test("fallback llm tries an explicit model override before the configured chain", { concurrency: false }, async () => {
   clearModelsJsonCache();
   clearSecretCache();

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -341,11 +341,13 @@ export class FallbackLlmClient {
       }
     }
 
-    // Implicit last-resort: always append the gateway default model so that a
-    // stale or exhausted extractionModelChain never leaves the chain empty.
-    // This guarantees Remnic can never be the reason a chat is interrupted
-    // by a flush failure — there is always at least one reachable model.
-    if (modelStrings.length > 0) {
+    // Implicit last-resort: when a task-specific modelChain override is active,
+    // append the gateway default model so a stale or exhausted taskModelChain
+    // never leaves the chain empty — Remnic should never be the reason a chat is
+    // interrupted by a flush failure. Scoped to the override path so the main
+    // agent's persona/default chains keep their exact configured fallback
+    // behavior (gotcha #39). Issue #1365 / PR #1370.
+    if (modelChainOverride && modelStrings.length > 0) {
       const defaultModel = this.gatewayConfig?.agents?.defaults?.model?.primary;
       if (
         defaultModel &&

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -1,6 +1,6 @@
 import { log } from "./logger.js";
 import path from "node:path";
-import type { GatewayConfig, ModelProviderConfig, AgentPersona } from "./types.js";
+import type { AgentPersonaModelConfig, GatewayConfig, ModelProviderConfig } from "./types.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import {
   buildChatCompletionTemperature,
@@ -25,6 +25,8 @@ export interface FallbackLlmOptions {
   signal?: AbortSignal;
   /** Explicit "provider/model" override to try before the configured chain. */
   model?: string;
+  /** Explicit model chain override to use instead of the configured agent/default chain. */
+  modelChain?: AgentPersonaModelConfig;
   /** Override which agent persona's model chain to use (by ID from agents.list[]). */
   agentId?: string;
 }
@@ -134,7 +136,7 @@ export class FallbackLlmClient {
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
     options: FallbackLlmOptions = {},
   ): Promise<FallbackLlmResponse | null> {
-    const models = this.getModelChain(options.agentId, options.model);
+    const models = this.getModelChain(options.agentId, options.model, options.modelChain);
     if (models.length === 0) {
       log.warn("fallback LLM: no models configured in gateway");
       return null;
@@ -262,18 +264,28 @@ export class FallbackLlmClient {
    * Get the full model chain from gateway config.
    * Returns array of models in order: [primary, fallback1, fallback2, ...]
    *
-   * When agentId is provided, looks up the matching entry in agents.list[]
-   * and uses that persona's model chain. Falls back to agents.defaults.model
-   * if agentId is not found or not provided.
+   * When modelChainOverride is provided, uses it instead of any configured
+   * agent/default chain. Otherwise, when agentId is provided, looks up the
+   * matching entry in agents.list[] and uses that persona's model chain.
+   * Falls back to agents.defaults.model if agentId is not found or not provided.
    */
-  private getModelChain(agentId?: string, modelOverride?: string): ModelRef[] {
+  private getModelChain(
+    agentId?: string,
+    modelOverride?: string,
+    modelChainOverride?: AgentPersonaModelConfig,
+  ): ModelRef[] {
     const chain: ModelRef[] = [];
     const providers = this.gatewayConfig?.models?.providers ?? {};
 
-    // Resolve the model config: agent persona chain or global defaults
-    let modelConfig: { primary?: string; fallbacks?: string[] } | undefined;
+    // Resolve the model config: explicit task chain, agent persona chain, or global defaults
+    let modelConfig: AgentPersonaModelConfig | undefined;
 
-    if (agentId) {
+    if (modelChainOverride) {
+      modelConfig = modelChainOverride;
+      log.debug("fallback LLM: using explicit model chain override");
+    }
+
+    if (!modelConfig && agentId) {
       const persona = this.gatewayConfig?.agents?.list?.find(
         (a) => a.id === agentId,
       );
@@ -294,21 +306,20 @@ export class FallbackLlmClient {
     // Build list of model strings: primary + fallbacks
     const modelStrings: string[] = [];
 
-    if (typeof modelOverride === "string" && modelOverride.trim().length > 0) {
-      modelStrings.push(modelOverride.trim());
-    }
-
-    if (modelConfig?.primary) {
-      if (!modelStrings.includes(modelConfig.primary)) {
-        modelStrings.push(modelConfig.primary);
+    const addModelString = (value: unknown): void => {
+      if (typeof value !== "string") return;
+      const trimmed = value.trim();
+      if (trimmed.length > 0 && !modelStrings.includes(trimmed)) {
+        modelStrings.push(trimmed);
       }
-    }
+    };
+
+    addModelString(modelOverride);
+    addModelString(modelConfig?.primary);
 
     if (Array.isArray(modelConfig?.fallbacks)) {
       for (const fb of modelConfig.fallbacks) {
-        if (typeof fb === "string" && !modelStrings.includes(fb)) {
-          modelStrings.push(fb);
-        }
+        addModelString(fb);
       }
     }
 

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -31,6 +31,11 @@ export interface FallbackLlmOptions {
   agentId?: string;
 }
 
+export interface FallbackLlmAvailabilityOptions {
+  agentId?: string;
+  modelChain?: AgentPersonaModelConfig;
+}
+
 export interface FallbackLlmResponse {
   content: string;
   modelUsed: string;
@@ -122,8 +127,11 @@ export class FallbackLlmClient {
   /**
    * Check if fallback is available (gateway config has at least one model).
    */
-  isAvailable(agentId?: string): boolean {
-    const models = this.getModelChain(agentId);
+  isAvailable(agentIdOrOptions?: string | FallbackLlmAvailabilityOptions): boolean {
+    const options = typeof agentIdOrOptions === "string"
+      ? { agentId: agentIdOrOptions }
+      : (agentIdOrOptions ?? {});
+    const models = this.getModelChain(options.agentId, undefined, options.modelChain);
     return models.length > 0;
   }
 
@@ -280,9 +288,11 @@ export class FallbackLlmClient {
     // Resolve the model config: explicit task chain, agent persona chain, or global defaults
     let modelConfig: AgentPersonaModelConfig | undefined;
 
-    if (modelChainOverride) {
+    if (modelChainOverride?.primary) {
       modelConfig = modelChainOverride;
       log.debug("fallback LLM: using explicit model chain override");
+    } else if (modelChainOverride) {
+      log.warn("fallback LLM: ignoring explicit model chain override without primary model");
     }
 
     if (!modelConfig && agentId) {

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -341,6 +341,28 @@ export class FallbackLlmClient {
       }
     }
 
+    // Implicit last-resort: always append the gateway default model so that a
+    // stale or exhausted extractionModelChain never leaves the chain empty.
+    // This guarantees Remnic can never be the reason a chat is interrupted
+    // by a flush failure — there is always at least one reachable model.
+    if (modelStrings.length > 0) {
+      const defaultModel = this.gatewayConfig?.agents?.defaults?.model?.primary;
+      if (
+        defaultModel &&
+        typeof defaultModel === "string" &&
+        defaultModel.trim().length > 0 &&
+        !modelStrings.includes(defaultModel.trim())
+      ) {
+        const defaultRef = this.parseModelString(defaultModel.trim(), providers);
+        if (defaultRef) {
+          chain.push(defaultRef);
+          log.debug(
+            `fallback LLM: appended gateway default model "${defaultModel.trim()}" as implicit last resort`,
+          );
+        }
+      }
+    }
+
     return chain;
   }
 

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -85,7 +85,7 @@ export class HourlySummarizer {
 
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
-    const modelChain = this.config.extractionModelChain;
+    const modelChain = this.config.taskModelChain;
     if (modelChain) return { ...options, modelChain };
     const agentId = this.config.gatewayAgentId || undefined;
     return agentId ? { ...options, agentId } : options;

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -85,6 +85,8 @@ export class HourlySummarizer {
 
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
+    const modelChain = this.config.extractionModelChain;
+    if (modelChain) return { ...options, modelChain };
     const agentId = this.config.gatewayAgentId || undefined;
     return agentId ? { ...options, agentId } : options;
   }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1269,11 +1269,15 @@ export interface PluginConfig {
   gatewayAgentId: string;
   fastGatewayAgentId: string;
   /**
-   * Optional task-specific model chain for extraction/consolidation/summarization
-   * fallback calls. When set, this chain is resolved through gateway providers
+   * Optional task-specific model chain for Remnic's background LLM work —
+   * extraction, fact/profile/identity consolidation, summarization, and causal
+   * consolidation. When set, this chain is resolved through gateway providers
    * instead of using gatewayAgentId or agents.defaults.model.
+   *
+   * Only takes effect when `modelSource: "gateway"`; ignored (with a startup
+   * warning) under `modelSource: "plugin"`. See issue #1365 / PR #1370.
    */
-  extractionModelChain?: AgentPersonaModelConfig;
+  taskModelChain?: AgentPersonaModelConfig;
 
   // v3.0 Multi-agent memory (namespaces)
   namespacesEnabled: boolean;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1268,6 +1268,12 @@ export interface PluginConfig {
   modelSource: "plugin" | "gateway";
   gatewayAgentId: string;
   fastGatewayAgentId: string;
+  /**
+   * Optional task-specific model chain for extraction/consolidation/summarization
+   * fallback calls. When set, this chain is resolved through gateway providers
+   * instead of using gatewayAgentId or agents.defaults.model.
+   */
+  extractionModelChain?: AgentPersonaModelConfig;
 
   // v3.0 Multi-agent memory (namespaces)
   namespacesEnabled: boolean;


### PR DESCRIPTION
## Summary

Adds an optional `extractionModelChain` config for gateway mode so Remnic extraction/consolidation/summarization can use a task-specific primary/fallback model chain without changing `agents.defaults.model` or the main agent persona chain.

Example:

```json
{
  "modelSource": "gateway",
  "extractionModelChain": {
    "primary": "zai/glm-4.7-flash",
    "fallbacks": ["fireworks/accounts/fireworks/models/glm-5p1"]
  }
}
```

The configured models still resolve through the existing gateway provider/auth path.

## Changes

- Adds `modelChain` override support to `FallbackLlmOptions`.
- Preserves existing priority/compatibility:
  1. explicit `model` string override
  2. explicit task `modelChain`
  3. `agentId` persona chain
  4. `agents.defaults.model`
- Adds `extractionModelChain` parsing/normalization to config.
- Wires `extractionModelChain` into `ExtractionEngine` and `HourlySummarizer` when `modelSource: "gateway"`.
- Adds plugin schema/UI metadata for the new config key.
- Adds tests for chain override behavior, fallback order, dedupe, backward compatibility, and config parsing.

## Validation

- `corepack pnpm --filter @remnic/core exec tsx --test src/fallback-llm.test.ts src/config.test.ts` — 114 passed
- `corepack pnpm --filter @remnic/core run check-types` — passed
- `corepack pnpm --filter @remnic/core test` — 2717 passed
- `corepack pnpm run check:openclaw-plugin-sync` — passed
- `jq empty openclaw.plugin.json packages/plugin-openclaw/openclaw.plugin.json` — passed
- `git diff --check` — passed

Note: `corepack pnpm run lint` currently fails on pre-existing root `package.json` formatting only; this PR does not modify `package.json`.

Addresses #1365.
