### PR TITLE
Expose root tier shim exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -761,6 +759,18 @@
     "./temporal-validity.js": {
       "import": "./dist/temporal-validity.js"
     },
+    "./tier-migration": {
+      "import": "./dist/tier-migration.js"
+    },
+    "./tier-migration.js": {
+      "import": "./dist/tier-migration.js"
+    },
+    "./tier-routing": {
+      "import": "./dist/tier-routing.js"
+    },
+    "./tier-routing.js": {
+      "import": "./dist/tier-routing.js"
+    },
     "./threading": {
       "import": "./dist/threading.js"
     },
@@ -936,12 +946,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -964,9 +969,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1019,12 +1022,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/tests/connectors-root-exports.test.ts
+++ b/tests/connectors-root-exports.test.ts
@@ -69,24 +69,31 @@ test("root package export map exposes compat and source shims", async () => {
     ["secure-store/index", "./dist/secure-store/index.js"],
     ["temporal-index", "./dist/temporal-index.js"],
     ["temporal-validity", "./dist/temporal-validity.js"],
+    ["tier-migration", "./dist/tier-migration.js"],
+    ["tier-routing", "./dist/tier-routing.js"],
   ] as const) {
     assert.deepEqual(exportsMap[`./${subpath}`], { import: expectedTarget }, subpath);
     assert.deepEqual(exportsMap[`./${subpath}.js`], { import: expectedTarget }, `${subpath}.js`);
   }
 });
 
-test("root package resolver exposes temporal shims", () => {
-  for (const subpath of ["temporal-index", "temporal-validity"] as const) {
+test("root package resolver exposes temporal and tier shims", () => {
+  for (const subpath of ["temporal-index", "temporal-validity", "tier-migration", "tier-routing"] as const) {
     const expectedUrl = new URL(`../dist/${subpath}.js`, import.meta.url).href;
     assert.equal(import.meta.resolve(`remnic-workspace/${subpath}`), expectedUrl, subpath);
     assert.equal(import.meta.resolve(`remnic-workspace/${subpath}.js`), expectedUrl, `${subpath}.js`);
   }
 });
 
-test("root build emits temporal shim artifacts", () => {
+test("root build emits temporal and tier shim artifacts", () => {
   const tsupConfig = readFileSync(new URL("../tsup.config.ts", import.meta.url), "utf8");
 
-  for (const entry of ["src/temporal-index.ts", "src/temporal-validity.ts"] as const) {
+  for (const entry of [
+    "src/temporal-index.ts",
+    "src/temporal-validity.ts",
+    "src/tier-migration.ts",
+    "src/tier-routing.ts",
+  ] as const) {
     assert.match(tsupConfig, new RegExp(`"${entry}"`), entry);
   }
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -123,6 +123,8 @@ export default defineConfig({
     "src/summary-snapshot.ts",
     "src/temporal-index.ts",
     "src/temporal-validity.ts",
+    "src/tier-migration.ts",
+    "src/tier-routing.ts",
     "src/threading.ts",
     "src/tmt.ts",
     "src/topics.ts",


### PR DESCRIPTION
## Summary
- add root package export map entries for tier-migration and tier-routing shims
- include the tier shim root entries in the root tsup build
- extend root export coverage to assert resolver and emitted build artifacts

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/connectors-root-exports.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

ClawPatch finding: fnd_sig-feat-library-f0f0a8271c-5254_43a14f54ea

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and test-only surface expansion; no runtime logic changes beyond publishing existing core re-export shims.
> 
> **Overview**
> This PR wires **tier-migration** and **tier-routing** into the root `remnic-workspace` public API the same way existing temporal shims work: consumers can import `remnic-workspace/tier-migration` and `remnic-workspace/tier-routing` and get built artifacts under `dist/`.
> 
> **package.json** gains `exports` entries (with and without `.js`) pointing at `./dist/tier-migration.js` and `./dist/tier-routing.js`. **tsup** now builds `src/tier-migration.ts` and `src/tier-routing.ts`, which are thin re-exports from `@remnic/core`.
> 
> **tests/connectors-root-exports.test.ts** is extended so export-map coverage, `import.meta.resolve`, and tsup entry presence all include the two tier shims alongside temporal ones. Unrelated **package.json** array formatting is collapsed to single lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ac00d0c0164586240be71d35bd2adb1071ec47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->