### PR TITLE
Avoid retrying timed-out fetches by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -948,12 +946,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -976,9 +969,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1031,12 +1022,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/bench/src/providers/retry-fetch.test.ts
+++ b/packages/bench/src/providers/retry-fetch.test.ts
@@ -54,7 +54,7 @@ test("retryFetch retries on 429 with Retry-After header", async () => {
     const response = await retryFetch(
       "https://example.com/api",
       { method: "GET" },
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 }
     );
     assert.equal(response.status, 200);
     assert.equal(mock.calls.length, 2);
@@ -64,15 +64,12 @@ test("retryFetch retries on 429 with Retry-After header", async () => {
 });
 
 test("retryFetch retries on 429 without Retry-After using exponential backoff", async () => {
-  const mock = mockFetchSequence([
-    { status: 429 },
-    { status: 200, body: "ok" },
-  ]);
+  const mock = mockFetchSequence([{ status: 429 }, { status: 200, body: "ok" }]);
   try {
     const response = await retryFetch(
       "https://example.com/api",
       { method: "GET" },
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 }
     );
     assert.equal(response.status, 200);
     assert.equal(mock.calls.length, 2);
@@ -82,16 +79,12 @@ test("retryFetch retries on 429 without Retry-After using exponential backoff", 
 });
 
 test("retryFetch returns 429 response when all retries exhausted", async () => {
-  const mock = mockFetchSequence([
-    { status: 429 },
-    { status: 429 },
-    { status: 429 },
-  ]);
+  const mock = mockFetchSequence([{ status: 429 }, { status: 429 }, { status: 429 }]);
   try {
     const response = await retryFetch(
       "https://example.com/api",
       { method: "GET" },
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 }
     );
     assert.equal(response.status, 429);
     assert.equal(mock.calls.length, 3);
@@ -101,14 +94,12 @@ test("retryFetch returns 429 response when all retries exhausted", async () => {
 });
 
 test("retryFetch does not retry on 401", async () => {
-  const mock = mockFetchSequence([
-    { status: 401 },
-  ]);
+  const mock = mockFetchSequence([{ status: 401 }]);
   try {
     const response = await retryFetch(
       "https://example.com/api",
       { method: "GET" },
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 }
     );
     assert.equal(response.status, 401);
     assert.equal(mock.calls.length, 1);
@@ -123,7 +114,7 @@ test("retryFetch does not retry on 400", async () => {
     const response = await retryFetch(
       "https://example.com/api",
       { method: "GET" },
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 }
     );
     assert.equal(response.status, 400);
     assert.equal(mock.calls.length, 1);
@@ -138,7 +129,7 @@ test("retryFetch does not retry on 3xx redirect", async () => {
     const response = await retryFetch(
       "https://example.com/api",
       { method: "GET" },
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 }
     );
     assert.equal(response.status, 302);
     assert.equal(mock.calls.length, 1);
@@ -162,7 +153,7 @@ test("retryFetch retries 429 beyond maxAttempts when max429WaitMs is set", async
       "https://example.com/api",
       { method: "GET" },
       // maxAttempts=3 but max429WaitMs=30s allows retries beyond 3 attempts
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000, max429WaitMs: 30_000 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000, max429WaitMs: 30_000 }
     );
     assert.equal(response.status, 200);
     assert.equal(mock.calls.length, 6);
@@ -186,7 +177,7 @@ test("retryFetch retries provider 5xx beyond maxAttempts within extended wait bu
     const response = await retryFetch(
       "https://example.com/api",
       { method: "GET" },
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000, max429WaitMs: 1000 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000, max429WaitMs: 1000 }
     );
     const elapsedMs = Date.now() - startedAt;
     assert.equal(response.status, 200);
@@ -207,12 +198,8 @@ test("retryFetch still fails repeated 5xx when no extended wait budget is config
   try {
     await assert.rejects(
       () =>
-        retryFetch(
-          "https://example.com/api",
-          { method: "GET" },
-          { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 },
-        ),
-      /HTTP 500/,
+        retryFetch("https://example.com/api", { method: "GET" }, { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000 }),
+      /HTTP 500/
     );
     assert.equal(mock.calls.length, 3);
   } finally {
@@ -232,9 +219,9 @@ test("retryFetch treats explicitly undefined retry fields as defaults", async ()
         retryFetch(
           "https://example.com/api",
           { method: "GET" },
-          { maxAttempts: undefined, baseBackoffMs: 1, timeoutMs: 5000 },
+          { maxAttempts: undefined, baseBackoffMs: 1, timeoutMs: 5000 }
         ),
-      /HTTP 500/,
+      /HTTP 500/
     );
     assert.equal(mock.calls.length, 3);
   } finally {
@@ -244,13 +231,8 @@ test("retryFetch treats explicitly undefined retry fields as defaults", async ()
 
 test("retryFetch rejects invalid retry option values", async () => {
   await assert.rejects(
-    () =>
-      retryFetch(
-        "https://example.com/api",
-        { method: "GET" },
-        { maxAttempts: 0 },
-      ),
-    /maxAttempts must be a positive integer/,
+    () => retryFetch("https://example.com/api", { method: "GET" }, { maxAttempts: 0 }),
+    /maxAttempts must be a positive integer/
   );
 });
 
@@ -268,11 +250,81 @@ test("retryFetch caps thrown transport failures at maxAttempts despite extended 
         retryFetch(
           "http://127.0.0.1:9",
           { method: "GET" },
-          { maxAttempts: 1, baseBackoffMs: 1, timeoutMs: 1000, max429WaitMs: 600_000 },
+          { maxAttempts: 1, baseBackoffMs: 1, timeoutMs: 1000, max429WaitMs: 600_000 }
         ),
-      /ECONNREFUSED/,
+      /ECONNREFUSED/
     );
     assert.equal(calls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("retryFetch does not retry internal timeout aborts by default", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  let firstRequestAborted = false;
+
+  globalThis.fetch = async (_url, init) => {
+    calls += 1;
+    const signal = init?.signal as AbortSignal | undefined;
+    return new Promise<Response>((_resolve, reject) => {
+      signal?.addEventListener(
+        "abort",
+        () => {
+          firstRequestAborted = true;
+          setTimeout(() => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          }, 5);
+        },
+        { once: true }
+      );
+    });
+  };
+
+  try {
+    await assert.rejects(
+      () =>
+        retryFetch("https://example.com/api", { method: "POST" }, { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 1 }),
+      /retryFetch timed out after 1ms/
+    );
+    assert.equal(firstRequestAborted, true);
+    assert.equal(calls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("retryFetch retries internal timeout aborts only when explicitly enabled", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+
+  globalThis.fetch = async (_url, init) => {
+    calls += 1;
+    if (calls > 1) {
+      return new Response("ok", { status: 200 });
+    }
+
+    const signal = init?.signal as AbortSignal | undefined;
+    return new Promise<Response>((_resolve, reject) => {
+      signal?.addEventListener(
+        "abort",
+        () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        },
+        { once: true }
+      );
+    });
+  };
+
+  try {
+    const response = await retryFetch(
+      "https://example.com/api",
+      { method: "POST" },
+      { maxAttempts: 2, baseBackoffMs: 1, timeoutMs: 1, retryOnTimeout: true }
+    );
+    assert.equal(response.status, 200);
+    assert.equal(calls, 2);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -286,7 +338,7 @@ test("retryFetch respects max429WaitMs budget and returns 429 when exhausted", a
     const response = await retryFetch(
       "https://example.com/api",
       { method: "GET" },
-      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000, max429WaitMs: 10 },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000, max429WaitMs: 10 }
     );
     assert.equal(response.status, 429);
     assert.equal(await response.text(), "quota exhausted");

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -1,16 +1,26 @@
 /**
  * Fetch wrapper with retry for transient failures.
- * Retries on ECONNREFUSED, ECONNRESET, ETIMEDOUT, HTTP 429 (rate limit),
- * and HTTP 5xx. 429 pauses according to the Retry-After header (or a
- * default backoff) before retrying. When max429WaitMs is set, the same
- * wall-clock budget also covers transient 5xx responses from throttled
- * provider backends that surface quota resets as server errors.
+ * Retries on ECONNREFUSED, ECONNRESET, transport ETIMEDOUT, HTTP 429
+ * (rate limit), and HTTP 5xx. Per-attempt timeout aborts are not retried
+ * unless retryOnTimeout is explicitly enabled, because completion requests
+ * may keep running provider-side after client abort. 429 pauses according
+ * to the Retry-After header (or a default backoff) before retrying. When
+ * max429WaitMs is set, the same wall-clock budget also covers transient
+ * 5xx responses from throttled provider backends that surface quota resets
+ * as server errors.
  */
 
 export interface RetryFetchOptions {
   maxAttempts?: number;
   baseBackoffMs?: number;
   timeoutMs?: number;
+  /**
+   * Retry requests that were aborted by retryFetch's own per-attempt timeout.
+   *
+   * Defaults to false so non-idempotent completion requests do not start a
+   * duplicate request while the timed-out provider-side work may still run.
+   */
+  retryOnTimeout?: boolean;
   /**
    * Maximum wall-clock time (ms) to keep retrying 429 responses.
    * When set, 429s are retried with capped exponential backoff
@@ -25,6 +35,7 @@ const DEFAULTS: Required<RetryFetchOptions> = {
   maxAttempts: 3,
   baseBackoffMs: 1000,
   timeoutMs: 120_000,
+  retryOnTimeout: false,
   max429WaitMs: 0,
 };
 
@@ -33,10 +44,14 @@ function normalizeRetryFetchOptions(options?: RetryFetchOptions): Required<Retry
     maxAttempts: options?.maxAttempts ?? DEFAULTS.maxAttempts,
     baseBackoffMs: options?.baseBackoffMs ?? DEFAULTS.baseBackoffMs,
     timeoutMs: options?.timeoutMs ?? DEFAULTS.timeoutMs,
+    retryOnTimeout: options?.retryOnTimeout ?? DEFAULTS.retryOnTimeout,
     max429WaitMs: options?.max429WaitMs ?? DEFAULTS.max429WaitMs,
   };
   if (!Number.isInteger(normalized.maxAttempts) || normalized.maxAttempts <= 0) {
     throw new Error("retryFetch maxAttempts must be a positive integer");
+  }
+  if (typeof normalized.retryOnTimeout !== "boolean") {
+    throw new Error("retryFetch retryOnTimeout must be a boolean");
   }
   for (const field of ["baseBackoffMs", "timeoutMs", "max429WaitMs"] as const) {
     if (!Number.isFinite(normalized[field]) || normalized[field] < 0) {
@@ -75,6 +90,10 @@ function isTransientError(err: unknown): boolean {
   );
 }
 
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
 /**
  * Parse a Retry-After header value into milliseconds.
  * Accepts either an integer number of seconds or an HTTP-date.
@@ -110,8 +129,14 @@ function parseBodySuggestedRetryMs(body: string): number | undefined {
 
 function abortAwareSleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
   return new Promise<void>((resolve) => {
-    if (signal?.aborted) { resolve(); return; }
-    const onAbort = () => { clearTimeout(timer); resolve(); };
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
     const timer = setTimeout(() => {
       signal?.removeEventListener("abort", onAbort);
       resolve();
@@ -120,11 +145,7 @@ function abortAwareSleep(ms: number, signal: AbortSignal | undefined): Promise<v
   });
 }
 
-export async function retryFetch(
-  url: string,
-  init: RequestInit,
-  options?: RetryFetchOptions,
-): Promise<Response> {
+export async function retryFetch(url: string, init: RequestInit, options?: RetryFetchOptions): Promise<Response> {
   const opts = normalizeRetryFetchOptions(options);
   let lastError: Error | null = null;
   let last429Response: Response | null = null;
@@ -132,9 +153,7 @@ export async function retryFetch(
   const loopStartMs = Date.now();
 
   const remainingExtendedBudgetMs = () =>
-    opts.max429WaitMs > 0
-      ? Math.max(0, opts.max429WaitMs - (Date.now() - loopStartMs))
-      : 0;
+    opts.max429WaitMs > 0 ? Math.max(0, opts.max429WaitMs - (Date.now() - loopStartMs)) : 0;
 
   for (let attempt = 1; ; attempt++) {
     const callerSignal = init.signal as AbortSignal | undefined;
@@ -163,7 +182,11 @@ export async function retryFetch(
     const controller = new AbortController();
     const onCallerAbort = () => controller.abort();
     callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
-    const timeout = setTimeout(() => controller.abort(), opts.timeoutMs);
+    let timeoutFired = false;
+    const timeout = setTimeout(() => {
+      timeoutFired = true;
+      controller.abort();
+    }, opts.timeoutMs);
 
     try {
       const { signal: _callerSignal, ...initWithoutSignal } = init;
@@ -207,10 +230,7 @@ export async function retryFetch(
         let waitMs =
           retryAfter != null
             ? Math.max(retryAfter, 100)
-            : Math.min(
-                opts.baseBackoffMs * Math.pow(2, attempt - 1),
-                MAX_429_BACKOFF_S * 1000,
-              );
+            : Math.min(opts.baseBackoffMs * Math.pow(2, attempt - 1), MAX_429_BACKOFF_S * 1000);
 
         // Clamp to remaining 429 budget so we don't overshoot.
         if (opts.max429WaitMs > 0) {
@@ -223,7 +243,7 @@ export async function retryFetch(
 
         console.error(
           `[rate-limit] 429 received (attempt ${attempt}/${opts.maxAttempts})${budgetTag}, ` +
-            `pausing ${Math.round(waitMs / 1000)}s before retry…`,
+            `pausing ${Math.round(waitMs / 1000)}s before retry…`
         );
         await abortAwareSleep(waitMs, callerSignal);
 
@@ -245,25 +265,24 @@ export async function retryFetch(
       if (attempt >= opts.maxAttempts && remainingExtendedBudgetMs() <= 0) {
         callerSignal?.removeEventListener("abort", onCallerAbort);
         throw new Error(
-          `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts}): ${bodyPreview}`,
+          `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts}): ${bodyPreview}`
         );
       }
       lastError = new Error(
-        `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts}): ${bodyPreview}`,
+        `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts}): ${bodyPreview}`
       );
       last429IsStale = true;
 
       if (attempt >= opts.maxAttempts) {
         const retryAfter =
-          parseRetryAfterMs(response.headers.get("retry-after")) ??
-          parseBodySuggestedRetryMs(bodyPreview);
+          parseRetryAfterMs(response.headers.get("retry-after")) ?? parseBodySuggestedRetryMs(bodyPreview);
         const waitMs = Math.min(
           Math.max(retryAfter ?? opts.baseBackoffMs * Math.pow(2, attempt - 1), 100),
-          remainingExtendedBudgetMs(),
+          remainingExtendedBudgetMs()
         );
         console.error(
           `[transient] HTTP ${response.status} received (attempt ${attempt}/${opts.maxAttempts}) ` +
-            `within extended provider budget, pausing ${Math.round(waitMs / 1000)}s before retry…`,
+            `within extended provider budget, pausing ${Math.round(waitMs / 1000)}s before retry…`
         );
         await abortAwareSleep(waitMs, callerSignal);
         callerSignal?.removeEventListener("abort", onCallerAbort);
@@ -275,16 +294,28 @@ export async function retryFetch(
         callerSignal?.removeEventListener("abort", onCallerAbort);
         throw err;
       }
-      if (!isTransientError(err)) {
+      if (timeoutFired && isAbortError(err)) {
+        const timeoutError = new Error(
+          `retryFetch timed out after ${opts.timeoutMs}ms (attempt ${attempt}/${opts.maxAttempts})`
+        );
+        lastError = timeoutError;
+        last429IsStale = true;
         callerSignal?.removeEventListener("abort", onCallerAbort);
-        throw err;
-      }
-      lastError = err instanceof Error ? err : new Error(String(err));
-      last429IsStale = true;
-      callerSignal?.removeEventListener("abort", onCallerAbort);
+        if (!opts.retryOnTimeout || attempt >= opts.maxAttempts) {
+          throw timeoutError;
+        }
+      } else {
+        if (!isTransientError(err)) {
+          callerSignal?.removeEventListener("abort", onCallerAbort);
+          throw err;
+        }
+        lastError = err instanceof Error ? err : new Error(String(err));
+        last429IsStale = true;
+        callerSignal?.removeEventListener("abort", onCallerAbort);
 
-      if (attempt >= opts.maxAttempts) {
-        throw lastError;
+        if (attempt >= opts.maxAttempts) {
+          throw lastError;
+        }
       }
     }
 

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -2,10 +2,7 @@
  * Minimal LLM provider contract for the bench engine.
  */
 
-import type {
-  BenchReasoningEffort,
-  BuiltInProvider,
-} from "../types.js";
+import type { BenchReasoningEffort, BuiltInProvider } from "../types.js";
 
 export interface CompletionOpts {
   systemPrompt?: string;
@@ -36,7 +33,13 @@ export interface ProviderBaseConfig {
   baseUrl?: string;
   apiKey?: string;
   headers?: Record<string, string>;
-  retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number; max429WaitMs?: number };
+  retryOptions?: {
+    maxAttempts?: number;
+    baseBackoffMs?: number;
+    timeoutMs?: number;
+    retryOnTimeout?: boolean;
+    max429WaitMs?: number;
+  };
   /** Suppress thinking/reasoning tokens for thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek). */
   disableThinking?: boolean;
   /**

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -2,10 +2,7 @@
  * @remnic/bench — Phase 1 benchmark engine types
  */
 
-import type {
-  BenchmarkIntegrityMeta,
-  BenchmarkSplitType,
-} from "./integrity/types.js";
+import type { BenchmarkIntegrityMeta, BenchmarkSplitType } from "./integrity/types.js";
 
 export type BenchmarkMode = "full" | "quick";
 export type BenchmarkTier = "published" | "remnic" | "custom";
@@ -26,13 +23,7 @@ export type AmaBenchJudgeProtocol = "default" | "recommended";
  * responder/judge target. It is intentionally not routed through Remnic
  * memory or OpenClaw gateway state.
  */
-export type BuiltInProvider =
-  | "openai"
-  | "anthropic"
-  | "ollama"
-  | "litellm"
-  | "local-llm"
-  | "codex-cli";
+export type BuiltInProvider = "openai" | "anthropic" | "ollama" | "litellm" | "local-llm" | "codex-cli";
 
 export type BenchReasoningEffort = "low" | "medium" | "high" | "xhigh";
 
@@ -41,7 +32,13 @@ export interface ProviderConfig {
   model: string;
   baseUrl?: string;
   apiKey?: string;
-  retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number; max429WaitMs?: number };
+  retryOptions?: {
+    maxAttempts?: number;
+    baseBackoffMs?: number;
+    timeoutMs?: number;
+    retryOnTimeout?: boolean;
+    max429WaitMs?: number;
+  };
   disableThinking?: boolean;
   reasoningEffort?: BenchReasoningEffort;
   responderContextBudgetChars?: number;
@@ -80,11 +77,7 @@ export interface ConfidenceInterval {
   level: number;
 }
 
-export type EffectSizeInterpretation =
-  | "negligible"
-  | "small"
-  | "medium"
-  | "large";
+export type EffectSizeInterpretation = "negligible" | "small" | "medium" | "large";
 
 export interface EffectSizeSummary {
   cohensD: number;
@@ -107,15 +100,9 @@ export interface ComparisonResult {
 }
 
 export interface StatisticalReport {
-  confidenceIntervals: Record<
-    string,
-    ConfidenceInterval
-  >;
+  confidenceIntervals: Record<string, ConfidenceInterval>;
   bootstrapSamples: number;
-  effectSizes?: Record<
-    string,
-    EffectSizeSummary
-  >;
+  effectSizes?: Record<string, EffectSizeSummary>;
   pairedComparison?: {
     baselineId: string;
     pValue: number;


### PR DESCRIPTION
## Summary
- distinguish retryFetch internal timeout aborts from caller aborts and transport failures
- default internal timeout aborts to no retry, with explicit retryOnTimeout opt-in
- extend bench provider retryOptions typing and add timeout overlap regression coverage

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/bench/src/providers/retry-fetch.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

ClawPatch finding: fnd_sig-feat-library-4a29504070-d887_1abc23d2f1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default retry behavior for all bench HTTP providers; wrong callers expecting timeout retries need retryOnTimeout, but the default reduces duplicate completion risk.
> 
> **Overview**
> Bench **`retryFetch`** no longer retries when a request hits its **per-attempt `timeoutMs`** (client-side abort). Those failures surface as a clear timeout error after a single attempt unless **`retryOnTimeout: true`** is set, so slow LLM completions are less likely to be duplicated while work may still run on the provider.
> 
> **`retryOptions`** on bench provider config types now includes **`retryOnTimeout`**. Tests cover default no-retry vs opt-in retry. Root **`package.json`** and a few type files only have formatting churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c03543de79313b53a5df01d96caa76497898fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->