### PR TITLE
Score top-level temporal timeline evidence

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -948,12 +946,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -976,9 +969,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1031,12 +1022,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts
@@ -141,6 +141,58 @@ test("retrieval-temporal scores adapter-returned page ids instead of fixture ran
   }
 });
 
+test("retrieval-temporal scores pages whose only in-window evidence is top-level timeline", async () => {
+  const sample: RetrievalTemporalCase = {
+    id: "clean:top-level-timeline-only",
+    title: "top-level-timeline-only (clean)",
+    tier: "clean",
+    query: "Which page has an in-window top-level timeline entry?",
+    window: {
+      start: "2026-03-01T00:00:00.000Z",
+      end: "2026-04-01T00:00:00.000Z",
+    },
+    expectedPageIds: ["timeline-only-page"],
+    pages: [
+      {
+        id: "timeline-only-page",
+        owner: "alex",
+        namespace: "personal",
+        canonicalTitle: "Timeline Only Page",
+        title: "Timeline Only Page",
+        type: "note",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        aliases: [],
+        body: "The only qualifying temporal evidence is in the top-level timeline.",
+        frontmatter: {
+          created: "2026-01-01T00:00:00.000Z",
+          timeline: ["2026-01-15: outside the target window"],
+        },
+        seeAlso: [],
+        timeline: ["2026-03-12: top-level in-window evidence"],
+        dirtySignals: [],
+      },
+    ],
+  };
+  RETRIEVAL_TEMPORAL_SMOKE_FIXTURE.unshift(sample);
+  const adapter = new SpyTemporalAdapter((caseSample) => `recall hit\npage_id: ${caseSample.expectedPageIds[0]}`);
+
+  try {
+    const result = await runRetrievalTemporalBenchmark({
+      ...buildOptions(adapter),
+      limit: 1,
+    } as ResolvedRunBenchmarkOptions);
+
+    const [task] = result.results.tasks;
+    assert.ok(task);
+    assert.ok(task.details);
+    assert.equal(task.scores.qrel_at_1, 1);
+    assert.deepEqual(task.details.matchingPageIds, ["timeline-only-page"]);
+  } finally {
+    const removed = RETRIEVAL_TEMPORAL_SMOKE_FIXTURE.shift();
+    assert.equal(removed, sample);
+  }
+});
+
 test("retrieval-temporal does not score prefixed page id matches", async () => {
   const adapter = new SpyTemporalAdapter(
     (sample) => `recall hit\npage_id: ${sample.expectedPageIds[0]}-shadow`,

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -196,6 +196,11 @@ function collectEvidenceTimestamps(page: SchemaTierPage): number[] {
     if (timestamp !== null) timestamps.add(timestamp);
   }
 
+  for (const entry of page.timeline) {
+    const timestamp = parseTimelineEntry(entry);
+    if (timestamp !== null) timestamps.add(timestamp);
+  }
+
   return [...timestamps];
 }
 

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -260,11 +260,13 @@ test("runBenchmark rejects overflowed timeline dates in retrieval-temporal evide
   const originalCreatedAt = targetPage.createdAt;
   const originalCreated = targetPage.frontmatter.created;
   const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
+  const originalTopLevelTimeline = [...targetPage.timeline];
 
   try {
     targetPage.createdAt = "2026-06-30T23:59:59.000Z";
     targetPage.frontmatter.created = undefined;
     targetPage.frontmatter.timeline = ["2026-08-32 impossible training block"];
+    targetPage.timeline = ["2026-08-32 impossible training block"];
 
     const result = await runBenchmark("retrieval-temporal", {
       mode: "full",
@@ -278,6 +280,7 @@ test("runBenchmark rejects overflowed timeline dates in retrieval-temporal evide
     targetPage.createdAt = originalCreatedAt;
     targetPage.frontmatter.created = originalCreated;
     targetPage.frontmatter.timeline = originalTimeline;
+    targetPage.timeline = originalTopLevelTimeline;
   }
 });
 
@@ -357,11 +360,13 @@ test("runBenchmark rejects overflowed created timestamps in retrieval-temporal e
   const originalCreatedAt = targetPage.createdAt;
   const originalCreated = targetPage.frontmatter.created;
   const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
+  const originalTopLevelTimeline = [...targetPage.timeline];
 
   try {
     targetPage.createdAt = "2026-06-31T07:00:00.000Z";
     targetPage.frontmatter.created = "2026-06-31T07:00:00.000Z";
     targetPage.frontmatter.timeline = [];
+    targetPage.timeline = [];
 
     const result = await runBenchmark("retrieval-temporal", {
       mode: "full",
@@ -375,6 +380,7 @@ test("runBenchmark rejects overflowed created timestamps in retrieval-temporal e
     targetPage.createdAt = originalCreatedAt;
     targetPage.frontmatter.created = originalCreated;
     targetPage.frontmatter.timeline = originalTimeline;
+    targetPage.timeline = originalTopLevelTimeline;
   }
 });
 
@@ -388,11 +394,13 @@ test("runBenchmark rejects timeline entries with extra day digits in retrieval-t
   const originalCreatedAt = targetPage.createdAt;
   const originalCreated = targetPage.frontmatter.created;
   const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
+  const originalTopLevelTimeline = [...targetPage.timeline];
 
   try {
     targetPage.createdAt = "2026-06-30T23:59:59.000Z";
     targetPage.frontmatter.created = undefined;
     targetPage.frontmatter.timeline = ["2026-08-032 malformed day"];
+    targetPage.timeline = ["2026-08-032 malformed day"];
 
     const result = await runBenchmark("retrieval-temporal", {
       mode: "full",
@@ -406,6 +414,7 @@ test("runBenchmark rejects timeline entries with extra day digits in retrieval-t
     targetPage.createdAt = originalCreatedAt;
     targetPage.frontmatter.created = originalCreated;
     targetPage.frontmatter.timeline = originalTimeline;
+    targetPage.timeline = originalTopLevelTimeline;
   }
 });
 
@@ -419,11 +428,13 @@ test("runBenchmark rejects timeline entries with trailing alpha suffixes in retr
   const originalCreatedAt = targetPage.createdAt;
   const originalCreated = targetPage.frontmatter.created;
   const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
+  const originalTopLevelTimeline = [...targetPage.timeline];
 
   try {
     targetPage.createdAt = "2026-06-30T23:59:59.000Z";
     targetPage.frontmatter.created = undefined;
     targetPage.frontmatter.timeline = ["2026-08-03x malformed day token"];
+    targetPage.timeline = ["2026-08-03x malformed day token"];
 
     const result = await runBenchmark("retrieval-temporal", {
       mode: "full",
@@ -437,5 +448,6 @@ test("runBenchmark rejects timeline entries with trailing alpha suffixes in retr
     targetPage.createdAt = originalCreatedAt;
     targetPage.frontmatter.created = originalCreated;
     targetPage.frontmatter.timeline = originalTimeline;
+    targetPage.timeline = originalTopLevelTimeline;
   }
 });


### PR DESCRIPTION
## Summary
- include top-level `SchemaTierPage.timeline` entries when collecting temporal evidence for retrieval-temporal scoring
- add a regression case where the expected page only qualifies through top-level timeline evidence

ClawPatch finding: `fnd_sig-feat-library-0ca7d8ea6f-5af5_5fecfdede9`

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/bench run check-types`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node scripts/check-test-types.mjs`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark scoring and test-only fixture mutations; no production retrieval or auth paths changed.
> 
> **Overview**
> **Retrieval-temporal** scoring now treats **top-level** `SchemaTierPage.timeline` the same as frontmatter timeline when deciding whether a page has in-window temporal evidence. Previously only `createdAt`, `frontmatter.created`, and `frontmatter.timeline` were considered, so pages that qualified only via the page-level timeline could be scored incorrectly.
> 
> A **regression test** covers the case where frontmatter timeline is out of window but top-level timeline is in window. **Integration tests** that inject invalid timeline strings now also set and restore `page.timeline`, so malformed-date checks apply to both timeline sources.
> 
> `package.json` changes are **formatting only** (single-line arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c787cdc70af7b0b46930fe5ade276283e38a131d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->