### PR TITLE
Guard judge training export reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -948,12 +946,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -976,9 +969,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1031,12 +1022,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/remnic-core/src/extraction-judge-training.ts
+++ b/packages/remnic-core/src/extraction-judge-training.ts
@@ -22,7 +22,7 @@
 
 import path from "node:path";
 import { homedir } from "node:os";
-import { appendFile, chmod, mkdir, readFile, readdir } from "node:fs/promises";
+import { appendFile, chmod, lstat, mkdir, readFile, readdir, realpath } from "node:fs/promises";
 import { log } from "./logger.js";
 import type { JudgeVerdictKind } from "./extraction-judge.js";
 
@@ -101,11 +101,13 @@ function dateStamp(iso: string): string {
   return `${yyyy}-${mm}-${dd}`;
 }
 
-export function trainingFilePathFor(
-  directory: string,
-  iso: string,
-): string {
+export function trainingFilePathFor(directory: string, iso: string): string {
   return path.join(directory, `${dateStamp(iso)}.jsonl`);
+}
+
+function isPathInsideDirectory(filePath: string, directory: string): boolean {
+  const relative = path.relative(directory, filePath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 /**
@@ -113,10 +115,7 @@ export function trainingFilePathFor(
  * debug level and swallowed, same policy as the telemetry emitter.
  * No-op when `options.enabled` is false.
  */
-export async function recordJudgeTrainingPair(
-  row: JudgeTrainingPair,
-  options: JudgeTrainingOptions,
-): Promise<void> {
+export async function recordJudgeTrainingPair(row: JudgeTrainingPair, options: JudgeTrainingOptions): Promise<void> {
   if (!options.enabled) return;
   const dir = resolveTrainingDir(options);
   const filePath = trainingFilePathFor(dir, row.ts);
@@ -129,7 +128,7 @@ export async function recordJudgeTrainingPair(
     await chmod(filePath, 0o600);
   } catch (err) {
     log.debug(
-      `extraction-judge-training: append failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      `extraction-judge-training: append failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
     );
   }
 }
@@ -140,9 +139,23 @@ export async function recordJudgeTrainingPair(
  * counted in the returned `malformed` tally.
  */
 export async function readJudgeTrainingPairs(
-  options: Pick<JudgeTrainingOptions, "directory">,
+  options: Pick<JudgeTrainingOptions, "directory">
 ): Promise<{ rows: JudgeTrainingPair[]; malformed: number }> {
   const dir = resolveTrainingDir({ enabled: true, ...options });
+  try {
+    const dirStat = await lstat(dir);
+    if (dirStat.isSymbolicLink()) {
+      throw new Error("Judge training directory must not be a symlink");
+    }
+    if (!dirStat.isDirectory()) {
+      throw new Error("Judge training path must be a directory");
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return { rows: [], malformed: 0 };
+    throw err;
+  }
+
   let entries: string[];
   try {
     entries = await readdir(dir);
@@ -154,11 +167,33 @@ export async function readJudgeTrainingPairs(
 
   const rows: JudgeTrainingPair[] = [];
   let malformed = 0;
+  const resolvedDir = await realpath(dir);
   // Sort so reads are deterministic across platforms.
   entries.sort();
   for (const name of entries) {
     if (!name.endsWith(".jsonl")) continue;
-    const raw = await readFile(path.join(dir, name), "utf-8");
+    const filePath = path.join(dir, name);
+    let fileStat: Awaited<ReturnType<typeof lstat>>;
+    try {
+      fileStat = await lstat(filePath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") continue;
+      throw err;
+    }
+    if (fileStat.isSymbolicLink() || !fileStat.isFile()) continue;
+
+    let resolvedFilePath: string;
+    try {
+      resolvedFilePath = await realpath(filePath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") continue;
+      throw err;
+    }
+    if (!isPathInsideDirectory(resolvedFilePath, resolvedDir)) continue;
+
+    const raw = await readFile(resolvedFilePath, "utf-8");
     for (const line of raw.split("\n")) {
       if (!line.trim()) continue;
       let parsed: unknown;
@@ -192,18 +227,11 @@ export function isValidTrainingPair(value: unknown): value is JudgeTrainingPair 
   if (typeof p.ts !== "string") return false;
   if (typeof p.candidateText !== "string") return false;
   if (typeof p.candidateCategory !== "string") return false;
-  if (
-    p.verdictKind !== "accept" &&
-    p.verdictKind !== "reject" &&
-    p.verdictKind !== "defer"
-  ) {
+  if (p.verdictKind !== "accept" && p.verdictKind !== "reject" && p.verdictKind !== "defer") {
     return false;
   }
   if (typeof p.reason !== "string") return false;
-  if (
-    p.candidateConfidence !== undefined &&
-    typeof p.candidateConfidence !== "number"
-  ) {
+  if (p.candidateConfidence !== undefined && typeof p.candidateConfidence !== "number") {
     return false;
   }
   if (p.priorDeferrals !== undefined && typeof p.priorDeferrals !== "number") {

--- a/tests/extraction-judge-training.test.ts
+++ b/tests/extraction-judge-training.test.ts
@@ -1,15 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import {
-  chmod,
-  mkdtemp,
-  readFile,
-  rm,
-  stat,
-  writeFile,
-  mkdir,
-  readdir,
-} from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile, mkdir, readdir, symlink } from "node:fs/promises";
 import path from "node:path";
 import { homedir, tmpdir } from "node:os";
 import {
@@ -57,18 +48,9 @@ test("PR 4: recordJudgeTrainingPair appends one row per day file", async () => {
   const dir = await mkdirTmp();
   try {
     const opts = { enabled: true, directory: dir };
-    await recordJudgeTrainingPair(
-      basePair({ ts: "2026-04-10T00:00:00.000Z", verdictKind: "accept" }),
-      opts,
-    );
-    await recordJudgeTrainingPair(
-      basePair({ ts: "2026-04-10T23:59:59.000Z", verdictKind: "defer" }),
-      opts,
-    );
-    await recordJudgeTrainingPair(
-      basePair({ ts: "2026-04-11T00:00:00.000Z", verdictKind: "reject" }),
-      opts,
-    );
+    await recordJudgeTrainingPair(basePair({ ts: "2026-04-10T00:00:00.000Z", verdictKind: "accept" }), opts);
+    await recordJudgeTrainingPair(basePair({ ts: "2026-04-10T23:59:59.000Z", verdictKind: "defer" }), opts);
+    await recordJudgeTrainingPair(basePair({ ts: "2026-04-11T00:00:00.000Z", verdictKind: "reject" }), opts);
     const files = (await readdir(dir)).sort();
     assert.deepEqual(files, ["2026-04-10.jsonl", "2026-04-11.jsonl"]);
     const day1 = await readFile(path.join(dir, "2026-04-10.jsonl"), "utf-8");
@@ -149,7 +131,7 @@ test("PR 4: resolveTrainingDir defaults to ~/.remnic/judge-training", () => {
   const p = resolveTrainingDir({ enabled: true });
   assert.ok(
     p.endsWith(path.join(".remnic", "judge-training")),
-    `default path should end with .remnic/judge-training, got ${p}`,
+    `default path should end with .remnic/judge-training, got ${p}`
   );
 });
 
@@ -159,10 +141,7 @@ test("PR 4: resolveTrainingDir expands leading ~ in directory override (CLAUDE.m
     enabled: true,
     directory: "~/custom-training-dir",
   });
-  assert.ok(
-    expanded.startsWith(home + "/"),
-    `~/ should expand to ${home}, got ${expanded}`,
-  );
+  assert.ok(expanded.startsWith(home + "/"), `~/ should expand to ${home}, got ${expanded}`);
   assert.ok(expanded.endsWith("custom-training-dir"));
 });
 
@@ -172,10 +151,7 @@ test("PR 4: resolveTrainingDir expands $HOME prefix in directory override", () =
     enabled: true,
     directory: "$HOME/custom",
   });
-  assert.ok(
-    expanded.startsWith(home + "/"),
-    `$HOME/ should expand to ${home}, got ${expanded}`,
-  );
+  assert.ok(expanded.startsWith(home + "/"), `$HOME/ should expand to ${home}, got ${expanded}`);
 });
 
 test("PR 4: trainingFilePathFor uses UTC date stamp", () => {
@@ -200,14 +176,8 @@ test("PR 4: readJudgeTrainingPairs returns rows from all day files sorted", asyn
   const dir = await mkdirTmp();
   try {
     const opts = { enabled: true, directory: dir };
-    await recordJudgeTrainingPair(
-      basePair({ ts: "2026-04-11T00:00:00.000Z", verdictKind: "reject" }),
-      opts,
-    );
-    await recordJudgeTrainingPair(
-      basePair({ ts: "2026-04-10T00:00:00.000Z", verdictKind: "accept" }),
-      opts,
-    );
+    await recordJudgeTrainingPair(basePair({ ts: "2026-04-11T00:00:00.000Z", verdictKind: "reject" }), opts);
+    await recordJudgeTrainingPair(basePair({ ts: "2026-04-10T00:00:00.000Z", verdictKind: "accept" }), opts);
     const result = await readJudgeTrainingPairs({ directory: dir });
     assert.equal(result.rows.length, 2);
     // Deterministic ordering: files are sorted lexicographically by name,
@@ -216,6 +186,84 @@ test("PR 4: readJudgeTrainingPairs returns rows from all day files sorted", asyn
     assert.equal(result.rows[1].verdictKind, "reject");
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("readJudgeTrainingPairs reads regular .jsonl files after path guards", async () => {
+  const dir = await mkdirTmp();
+  try {
+    await mkdir(dir, { recursive: true });
+    const pair = basePair({ verdictKind: "accept" });
+    await writeFile(path.join(dir, "2026-04-10.jsonl"), `${JSON.stringify(pair)}\n`, "utf-8");
+
+    const result = await readJudgeTrainingPairs({ directory: dir });
+
+    assert.equal(result.rows.length, 1);
+    assert.equal(result.rows[0].candidateText, pair.candidateText);
+    assert.equal(result.malformed, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("readJudgeTrainingPairs skips symlinked .jsonl entries outside the training directory", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("symlink creation requires platform-specific privileges on Windows");
+    return;
+  }
+
+  const dir = await mkdirTmp();
+  const outsideDir = await mkdirTmp();
+  try {
+    const outsidePair = basePair({
+      candidateText: "outside training directory",
+      verdictKind: "reject",
+    });
+    const insidePair = basePair({
+      candidateText: "inside training directory",
+      verdictKind: "accept",
+    });
+    await writeFile(path.join(outsideDir, "outside.jsonl"), `${JSON.stringify(outsidePair)}\n`, "utf-8");
+    await writeFile(path.join(dir, "2026-04-10.jsonl"), `${JSON.stringify(insidePair)}\n`, "utf-8");
+    await symlink(path.join(outsideDir, "outside.jsonl"), path.join(dir, "2026-04-11.jsonl"));
+
+    const result = await readJudgeTrainingPairs({ directory: dir });
+
+    assert.deepEqual(
+      result.rows.map((row) => row.candidateText),
+      ["inside training directory"]
+    );
+    assert.equal(result.malformed, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  }
+});
+
+test("readJudgeTrainingPairs rejects symlinked training directory roots", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("symlink creation requires platform-specific privileges on Windows");
+    return;
+  }
+
+  const parentDir = await mkdirTmp();
+  const targetDir = await mkdirTmp();
+  try {
+    await writeFile(
+      path.join(targetDir, "2026-04-10.jsonl"),
+      `${JSON.stringify(basePair({ candidateText: "outside symlink root" }))}\n`,
+      "utf-8"
+    );
+    const symlinkDir = path.join(parentDir, "judge-training-link");
+    await symlink(targetDir, symlinkDir, "dir");
+
+    await assert.rejects(
+      () => readJudgeTrainingPairs({ directory: symlinkDir }),
+      /Judge training directory must not be a symlink/
+    );
+  } finally {
+    await rm(parentDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
   }
 });
 
@@ -229,11 +277,7 @@ test("PR 4: readJudgeTrainingPairs counts malformed rows separately", async () =
       JSON.stringify({ version: 1, ts: "now", verdictKind: "bogus" }),
       JSON.stringify(basePair({ verdictKind: "defer" })),
     ];
-    await writeFile(
-      path.join(dir, "2026-04-10.jsonl"),
-      lines.join("\n") + "\n",
-      "utf-8",
-    );
+    await writeFile(path.join(dir, "2026-04-10.jsonl"), lines.join("\n") + "\n", "utf-8");
     const result = await readJudgeTrainingPairs({ directory: dir });
     assert.equal(result.rows.length, 2);
     assert.equal(result.malformed, 2);
@@ -246,23 +290,11 @@ test("PR 4: isValidTrainingPair structural validation", () => {
   assert.equal(isValidTrainingPair(null), false);
   assert.equal(isValidTrainingPair({}), false);
   assert.equal(isValidTrainingPair(basePair()), true);
-  assert.equal(
-    isValidTrainingPair(basePair({ verdictKind: "bogus" as any })),
-    false,
-  );
-  assert.equal(
-    isValidTrainingPair(basePair({ groundTruthLabel: "defer" })),
-    true,
-  );
-  assert.equal(
-    isValidTrainingPair(basePair({ groundTruthLabel: "bogus" as any })),
-    false,
-  );
+  assert.equal(isValidTrainingPair(basePair({ verdictKind: "bogus" as any })), false);
+  assert.equal(isValidTrainingPair(basePair({ groundTruthLabel: "defer" })), true);
+  assert.equal(isValidTrainingPair(basePair({ groundTruthLabel: "bogus" as any })), false);
   assert.equal(isValidTrainingPair({ ...basePair(), version: 99 }), false);
-  assert.equal(
-    isValidTrainingPair({ ...basePair(), candidateConfidence: "hi" }),
-    false,
-  );
+  assert.equal(isValidTrainingPair({ ...basePair(), candidateConfidence: "hi" }), false);
 });
 
 test("PR 4: training pair schema preserves ground truth label round-trip", async () => {


### PR DESCRIPTION
Fixes ClawPatch finding fnd_sig-feat-library-a6f7939be7-aa36_7641644141.

Summary:
- Skip symlinked and non-regular .jsonl entries when reading judge training exports.
- Resolve the training root and candidate file path before reading, and require the file to remain under the resolved training directory.
- Add regression coverage for normal guarded reads and symlinked .jsonl entries pointing outside the training directory.

Verification:
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/extraction-judge-training.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets filesystem read safety for local training exports (symlink/path traversal); behavior change is scoped to read paths with added tests, not auth or network surfaces.
> 
> **Overview**
> Hardens **judge training export reads** so `readJudgeTrainingPairs` cannot follow unsafe filesystem paths when loading daily `.jsonl` files.
> 
> The reader now **rejects a symlinked training root** and requires the configured path to be a real directory. For each `*.jsonl` entry it uses **`lstat` / `realpath`**, skips **symlinks and non-regular files**, and only reads files whose resolved path stays **inside the resolved training directory**. Regression tests cover normal reads, symlinked `.jsonl` entries pointing outside the dir, and a symlinked directory root.
> 
> `package.json` changes are **formatting-only** (single-line array fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da3b7b82b6fbc77b0b61351ab182ac230b4af3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->