### PR TITLE
Expose root utility shim exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -809,6 +807,18 @@
     "./types.js": {
       "import": "./dist/types.js"
     },
+    "./utility-learner": {
+      "import": "./dist/utility-learner.js"
+    },
+    "./utility-learner.js": {
+      "import": "./dist/utility-learner.js"
+    },
+    "./utility-telemetry": {
+      "import": "./dist/utility-telemetry.js"
+    },
+    "./utility-telemetry.js": {
+      "import": "./dist/utility-telemetry.js"
+    },
     "./session-observer-bands": {
       "import": "./dist/session-observer-bands.js"
     },
@@ -948,12 +958,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -976,9 +981,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1031,12 +1034,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/tests/root-utility-package-surface.test.ts
+++ b/tests/root-utility-package-surface.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+type RootPackageJson = {
+  exports?: Record<string, { import?: string }>;
+};
+
+const utilityShims = ["utility-learner", "utility-telemetry"] as const;
+
+test("root utility shims are exported and built as package subpaths", async () => {
+  const [packageJsonRaw, tsupConfigRaw] = await Promise.all([
+    readFile(path.join(repoRoot, "package.json"), "utf8"),
+    readFile(path.join(repoRoot, "tsup.config.ts"), "utf8"),
+  ]);
+  const pkg = JSON.parse(packageJsonRaw) as RootPackageJson;
+
+  for (const name of utilityShims) {
+    const distPath = `./dist/${name}.js`;
+
+    assert.equal(pkg.exports?.[`./${name}`]?.import, distPath);
+    assert.equal(pkg.exports?.[`./${name}.js`]?.import, distPath);
+    assert.match(tsupConfigRaw, new RegExp(`"src/${name}\\.ts"`));
+  }
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -131,6 +131,8 @@ export default defineConfig({
     "src/transcript.ts",
     "src/trust-zones.ts",
     "src/types.ts",
+    "src/utility-learner.ts",
+    "src/utility-telemetry.ts",
     "src/transfer/autodetect.ts",
     "src/transfer/backup.ts",
     "src/transfer/capsule-export.ts",


### PR DESCRIPTION
## Summary
- export the root utility-learner and utility-telemetry shims through the package exports map
- include both utility shims in the root tsup entry list so their dist files are built
- add a root package-surface regression test for the utility shim subpaths

ClawPatch finding: fnd_sig-feat-library-f747bf091a-d2e2_d75f3654e1

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/root-utility-package-surface.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run lint
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true tsup.config.ts tests/root-utility-package-surface.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and build-surface changes only; no runtime logic changes beyond ensuring shims are built and importable.
> 
> **Overview**
> This PR wires the root **`utility-learner`** and **`utility-telemetry`** shim modules into the published package surface so consumers can import them as stable subpaths.
> 
> **`package.json`** gains `exports` entries for `./utility-learner`, `./utility-learner.js`, `./utility-telemetry`, and `./utility-telemetry.js`, each pointing at the matching **`dist/*.js`** artifacts. **`tsup.config.ts`** now builds **`src/utility-learner.ts`** and **`src/utility-telemetry.ts`** (re-exports from **`@remnic/core`**) so those dist files exist on release. A new regression test in **`tests/root-utility-package-surface.test.ts`** asserts exports and tsup entries stay aligned for both shims.
> 
> Some unrelated **`package.json`** array formatting is collapsed to single lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71108c46fd4d64b2a62c5d469c782098129c7ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->