### PR TITLE
Preserve Supermemory offset timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -960,12 +958,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -988,9 +981,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1043,12 +1034,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/import-supermemory/src/transform.test.ts
+++ b/packages/import-supermemory/src/transform.test.ts
@@ -1,5 +1,5 @@
-import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import { transformSupermemoryExport } from "./transform.js";
 
 describe("transformSupermemoryExport", () => {
@@ -17,7 +17,7 @@ describe("transformSupermemoryExport", () => {
           { id: "b", content: "second memo" },
         ],
       },
-      { maxMemories: 1 },
+      { maxMemories: 1 }
     );
 
     assert.equal(out.length, 1);
@@ -36,10 +36,7 @@ describe("transformSupermemoryExport", () => {
   it("does not synthesize colliding source IDs for id-less memories", () => {
     const sharedPrefix = "x".repeat(64);
     const out = transformSupermemoryExport({
-      memories: [
-        { content: `${sharedPrefix}a` },
-        { content: `${sharedPrefix}b` },
-      ],
+      memories: [{ content: `${sharedPrefix}a` }, { content: `${sharedPrefix}b` }],
       importedFromPath: "/exports/supermemory.json",
     });
 
@@ -87,11 +84,40 @@ describe("transformSupermemoryExport", () => {
 
   it("falls back to createdAt when updatedAt is an impossible calendar date", () => {
     const out = transformSupermemoryExport({
-      memories: [{ id: "a", content: "memo", updatedAt: "2026-02-31T00:00:00.000Z", createdAt: "2026-05-05T00:00:00.000Z" }],
+      memories: [
+        { id: "a", content: "memo", updatedAt: "2026-02-31T00:00:00.000Z", createdAt: "2026-05-05T00:00:00.000Z" },
+      ],
     });
 
     assert.equal(out.length, 1);
     assert.equal(out[0]?.sourceTimestamp, "2026-05-05T00:00:00.000Z");
+  });
+
+  it("falls back to createdAt when updatedAt uses an invalid RFC 3339 hour", () => {
+    const out = transformSupermemoryExport({
+      memories: [{ id: "a", content: "memo", updatedAt: "2026-05-05T24:00:00Z", createdAt: "2026-05-05T00:00:00Z" }],
+    });
+
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.sourceTimestamp, "2026-05-05T00:00:00Z");
+  });
+
+  it("preserves valid positive-offset timestamps across UTC date boundaries", () => {
+    const out = transformSupermemoryExport({
+      memories: [{ id: "a", content: "memo", updatedAt: "2026-05-05T00:30:00+02:00" }],
+    });
+
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.sourceTimestamp, "2026-05-05T00:30:00+02:00");
+  });
+
+  it("preserves valid negative-offset timestamps across UTC date boundaries", () => {
+    const out = transformSupermemoryExport({
+      memories: [{ id: "a", content: "memo", updatedAt: "2026-05-04T23:30:00-02:00" }],
+    });
+
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.sourceTimestamp, "2026-05-04T23:30:00-02:00");
   });
 
   it("omits sourceTimestamp when exported timestamps are invalid", () => {

--- a/packages/import-supermemory/src/transform.ts
+++ b/packages/import-supermemory/src/transform.ts
@@ -1,4 +1,4 @@
-import type { ImportedMemory } from "@remnic/core";
+import { type ImportedMemory, parseIsoOffsetTimestamp } from "@remnic/core";
 import type { ParsedSupermemoryExport, SupermemoryRecord } from "./parser.js";
 
 export const SUPERMEMORY_SOURCE_LABEL = "supermemory";
@@ -10,7 +10,7 @@ export interface SupermemoryTransformOptions {
 
 export function transformSupermemoryExport(
   parsed: ParsedSupermemoryExport,
-  options: SupermemoryTransformOptions = {},
+  options: SupermemoryTransformOptions = {}
 ): ImportedMemory[] {
   const out: ImportedMemory[] = [];
   const cap = options.maxMemories;
@@ -57,17 +57,7 @@ function pickValidTimestamp(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   if (trimmed.length === 0) return undefined;
-  const match = /^(\d{4})-(\d{2})-(\d{2})T/.exec(trimmed);
-  if (!match) return undefined;
-  const parsed = Date.parse(trimmed);
-  if (!Number.isFinite(parsed)) return undefined;
-  const date = new Date(parsed);
-  const [, year, month, day] = match;
-  if (
-    date.getUTCFullYear() !== Number(year) ||
-    date.getUTCMonth() + 1 !== Number(month) ||
-    date.getUTCDate() !== Number(day)
-  ) {
+  if (parseIsoOffsetTimestamp(trimmed) === null) {
     return undefined;
   }
   return trimmed;


### PR DESCRIPTION
## Summary
- validate Supermemory timestamp calendar dates in the source timestamp context instead of comparing to UTC date fields
- preserve valid timezone-offset timestamps that cross UTC date boundaries
- add positive- and negative-offset boundary regression coverage

ClawPatch finding: fnd_sig-feat-library-4f2bee553d-52d3_a5f55d1efb

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/import-supermemory/src/transform.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/import-supermemory test
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/import-supermemory check-types
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/import-supermemory/src/transform.ts packages/import-supermemory/src/transform.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Supermemory transform timestamp validation and formatting; no auth, persistence, or API surface changes beyond import metadata timestamps.
> 
> **Overview**
> Supermemory import now validates `sourceTimestamp` strings with **`parseIsoOffsetTimestamp`** from `@remnic/core` instead of a local `Date.parse` + UTC calendar-day check, so valid **RFC 3339 offsets** are kept verbatim and are no longer dropped when the instant falls on a different UTC calendar day than the literal date in the string.
> 
> Regression tests cover invalid hours (e.g. `24:00`), **positive/negative offset** timestamps across UTC date boundaries, and existing fallback behavior for bad `updatedAt` values. Root **`package.json`** array fields are collapsed to single-line formatting only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa7c63992167e60afde39834e1ba3baa406a1aeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->