### PR TITLE
Accept sub-millisecond Gemini timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -960,12 +958,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -988,9 +981,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1043,12 +1034,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/import-gemini/src/parser.test.ts
+++ b/packages/import-gemini/src/parser.test.ts
@@ -1,15 +1,12 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { extractUserPrompt, parseGeminiExport } from "./parser.js";
 
-const FIXTURE_DIR = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../fixtures",
-);
+const FIXTURE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../fixtures");
 
 function loadFixture(name: string): string {
   return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
@@ -42,10 +39,7 @@ describe("parseGeminiExport", () => {
   });
 
   it("strict mode rejects non-object top-level entries", () => {
-    assert.throws(
-      () => parseGeminiExport(JSON.stringify(["bad"]), { strict: true }),
-      /must be an object/,
-    );
+    assert.throws(() => parseGeminiExport(JSON.stringify(["bad"]), { strict: true }), /must be an object/);
   });
 
   it("preserves filePath in output", () => {
@@ -68,10 +62,7 @@ describe("parseGeminiExport", () => {
   // which reports "object" for null (JS trap). The message must say
   // "null" instead.
   it("strict mode reports 'null' for JSON null input, not 'object'", () => {
-    assert.throws(
-      () => parseGeminiExport("null", { strict: true }),
-      /received null/,
-    );
+    assert.throws(() => parseGeminiExport("null", { strict: true }), /received null/);
   });
 
   // Codex review on PR #600 — pointing --file at a random JSON object
@@ -79,14 +70,8 @@ describe("parseGeminiExport", () => {
   // of surfacing an error. Now throws for objects that lack any of the
   // recognized activity keys.
   it("rejects object payloads without a recognized activity key", () => {
-    assert.throws(
-      () => parseGeminiExport({ foo: "bar" }),
-      /no recognized activity key/,
-    );
-    assert.throws(
-      () => parseGeminiExport(JSON.stringify({ random: [1, 2] })),
-      /no recognized activity key/,
-    );
+    assert.throws(() => parseGeminiExport({ foo: "bar" }), /no recognized activity key/);
+    assert.throws(() => parseGeminiExport(JSON.stringify({ random: [1, 2] })), /no recognized activity key/);
   });
 
   // Codex review on PR #600 — a JSON primitive payload (number, boolean,
@@ -94,18 +79,9 @@ describe("parseGeminiExport", () => {
   // returning 0 memories on `true`, `123`, or `"text"` would let an
   // automation pipeline treat an obviously broken invocation as healthy.
   it("rejects primitive JSON payloads in every mode", () => {
-    assert.throws(
-      () => parseGeminiExport("true"),
-      /must be a JSON array or object/,
-    );
-    assert.throws(
-      () => parseGeminiExport("123"),
-      /must be a JSON array or object/,
-    );
-    assert.throws(
-      () => parseGeminiExport('"some text"'),
-      /must be a JSON array or object/,
-    );
+    assert.throws(() => parseGeminiExport("true"), /must be a JSON array or object/);
+    assert.throws(() => parseGeminiExport("123"), /must be a JSON array or object/);
+    assert.throws(() => parseGeminiExport('"some text"'), /must be a JSON array or object/);
   });
 
   it("rejects invalid Gemini activity timestamps", () => {
@@ -130,7 +106,7 @@ describe("parseGeminiExport", () => {
             },
           ]),
         /Gemini activity time must be/,
-        `time should be rejected: ${time}`,
+        `time should be rejected: ${time}`
       );
     }
   });
@@ -149,6 +125,11 @@ describe("parseGeminiExport", () => {
       },
       {
         header: "Gemini Apps",
+        text: "Tell me about sub-millisecond timestamp imports.",
+        time: "2026-01-02T00:00:00.123456Z",
+      },
+      {
+        header: "Gemini Apps",
         text: "Tell me about zero-offset timestamp imports.",
         time: "2026-01-03T00:00:00+00:00",
       },
@@ -156,35 +137,22 @@ describe("parseGeminiExport", () => {
 
     assert.deepEqual(
       parsed.activities.map((activity) => activity.time),
-      [
-        "2026-01-01T00:00:00Z",
-        "2026-01-02T00:00:00.123Z",
-        "2026-01-03T00:00:00+00:00",
-      ],
+      ["2026-01-01T00:00:00Z", "2026-01-02T00:00:00.123Z", "2026-01-02T00:00:00.123456Z", "2026-01-03T00:00:00+00:00"]
     );
   });
 });
 
 describe("extractUserPrompt", () => {
   it("prefers `text` when present", () => {
-    assert.equal(
-      extractUserPrompt({ header: "Gemini Apps", text: "hello" }),
-      "hello",
-    );
+    assert.equal(extractUserPrompt({ header: "Gemini Apps", text: "hello" }), "hello");
   });
 
   it("falls back to `title` and strips legacy Asked: prefix", () => {
-    assert.equal(
-      extractUserPrompt({ header: "Bard", title: "Asked: why is the sky blue?" }),
-      "why is the sky blue?",
-    );
+    assert.equal(extractUserPrompt({ header: "Bard", title: "Asked: why is the sky blue?" }), "why is the sky blue?");
   });
 
   it("returns undefined for records with no usable text", () => {
     assert.equal(extractUserPrompt({ header: "Gemini Apps" }), undefined);
-    assert.equal(
-      extractUserPrompt({ header: "Gemini Apps", title: "   " }),
-      undefined,
-    );
+    assert.equal(extractUserPrompt({ header: "Gemini Apps", title: "   " }), undefined);
   });
 });

--- a/packages/import-gemini/src/parser.ts
+++ b/packages/import-gemini/src/parser.ts
@@ -1,6 +1,8 @@
 // ---------------------------------------------------------------------------
 // Gemini (Google Takeout "Gemini Apps Activity") parser (issue #568 slice 4)
 // ---------------------------------------------------------------------------
+
+import { parseIsoOffsetTimestamp } from "@remnic/core";
 //
 // Google Takeout bundles Gemini Apps activity into `My Activity.json` (and a
 // legacy `MyActivity.json` spelling). Each record represents one prompt the
@@ -48,8 +50,7 @@ export interface GeminiActivityRecord {
   details?: Array<{ name?: string }>;
 }
 
-const UTC_ISO_INSTANT_RE =
-  /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?(Z|[+-]00:00)$/;
+const UTC_ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]00:00)$/;
 
 export interface ParsedGeminiExport {
   /** Prompts filtered to `header === "Gemini Apps"`. */
@@ -75,10 +76,7 @@ export interface GeminiParseOptions {
  * Parse a Takeout activity payload. Accepts a JSON string, parsed object, or
  * parsed array. Non-Gemini records are filtered out by default.
  */
-export function parseGeminiExport(
-  input: unknown,
-  options: GeminiParseOptions = {},
-): ParsedGeminiExport {
+export function parseGeminiExport(input: unknown, options: GeminiParseOptions = {}): ParsedGeminiExport {
   // File-backed adapter contract: `runImportCommand` passes `undefined` when
   // `--file` is omitted. Gemini is a file-only importer (Takeout doesn't
   // expose an API), so a missing payload MUST surface as a user-facing
@@ -87,7 +85,7 @@ export function parseGeminiExport(
   if (input === undefined || input === null) {
     throw new Error(
       "The 'gemini' importer requires a file. Pass `--file <path>` pointing at " +
-        "your Google Takeout `My Activity.json` (Gemini Apps section).",
+        "your Google Takeout `My Activity.json` (Gemini Apps section)."
     );
   }
   const raw = coerceJson(input);
@@ -122,7 +120,7 @@ export function parseGeminiExport(
       throw new Error(
         "Gemini export object has no recognized activity key. Expected one of " +
           "'activities', 'MyActivity', or 'activity'. Point --file at your " +
-          "Google Takeout `My Activity.json` (Gemini Apps section).",
+          "Google Takeout `My Activity.json` (Gemini Apps section)."
       );
     }
     return result;
@@ -136,9 +134,7 @@ export function parseGeminiExport(
   // `typeof null === "object"` is the JS trap CLAUDE.md rule 18 calls
   // out. Using describeType() sidesteps the "received object" message
   // for null inputs.
-  throw new Error(
-    `Gemini export must be a JSON array or object; received ${describeType(raw)}`,
-  );
+  throw new Error(`Gemini export must be a JSON array or object; received ${describeType(raw)}`);
 }
 
 function describeType(value: unknown): string {
@@ -146,11 +142,7 @@ function describeType(value: unknown): string {
   return typeof value;
 }
 
-function appendActivities(
-  dest: GeminiActivityRecord[],
-  src: unknown[],
-  options: GeminiParseOptions,
-): void {
+function appendActivities(dest: GeminiActivityRecord[], src: unknown[], options: GeminiParseOptions): void {
   for (const entry of src) {
     if (!entry || typeof entry !== "object") {
       if (options.strict) {
@@ -170,14 +162,10 @@ function validateGeminiTimestamp(value: unknown): void {
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new Error("Gemini activity time must be an ISO-8601 UTC timestamp");
   }
-  const match = UTC_ISO_INSTANT_RE.exec(value);
-  if (!match) {
+  if (!UTC_ISO_INSTANT_RE.test(value)) {
     throw new Error("Gemini activity time must be an ISO-8601 UTC timestamp");
   }
-  const milliseconds = (match[2] ?? "").padEnd(3, "0");
-  const canonical = `${match[1]}.${milliseconds}Z`;
-  const parsedMs = Date.parse(canonical);
-  if (!Number.isFinite(parsedMs) || new Date(parsedMs).toISOString() !== canonical) {
+  if (parseIsoOffsetTimestamp(value) === null) {
     throw new Error("Gemini activity time must be a valid ISO-8601 UTC timestamp");
   }
 }
@@ -185,10 +173,7 @@ function validateGeminiTimestamp(value: unknown): void {
 function isGeminiRecord(record: GeminiActivityRecord): boolean {
   if (record.header === "Gemini Apps") return true;
   if (record.header === "Bard") return true; // pre-rebrand exports
-  if (
-    Array.isArray(record.products) &&
-    record.products.some((p) => p === "Gemini Apps" || p === "Bard")
-  ) {
+  if (Array.isArray(record.products) && record.products.some((p) => p === "Gemini Apps" || p === "Bard")) {
     return true;
   }
   return false;
@@ -203,11 +188,7 @@ function coerceJson(input: unknown): unknown {
     try {
       return JSON.parse(input);
     } catch (err) {
-      throw new Error(
-        `Gemini export is not valid JSON: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+      throw new Error(`Gemini export is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
   return input;


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-da59534e56-ba18_233405b476` (`Valid UTC timestamps with more than millisecond precision are rejected`).

Changes:
- Allow Gemini UTC timestamp strings with arbitrary-length fractional seconds while keeping the importer UTC-only (`Z` or `+00:00`).
- Delegate calendar/instant validation to the shared `parseIsoOffsetTimestamp` helper.
- Add regression coverage preserving `2026-01-01T00:00:00.123456Z`.

Verification:
- `pnpm exec biome check --diagnostic-level=error --files-ignore-unknown=true packages/import-gemini/src/parser.ts packages/import-gemini/src/parser.test.ts`
- `pnpm --filter @remnic/import-gemini test`
- `pnpm --filter @remnic/import-gemini check-types`
- direct repro preserves `["2026-01-01T00:00:00.123456Z"]`
- `OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Gemini export timestamp validation and formatting; no auth, storage, or API surface changes beyond allowing more precise valid UTC strings.
> 
> **Overview**
> The Gemini Takeout importer now accepts **UTC activity timestamps with fractional seconds longer than three digits** (e.g. `2026-01-02T00:00:00.123456Z`) while still requiring `Z` or `+00:00`.
> 
> `validateGeminiTimestamp` in `packages/import-gemini/src/parser.ts` widens the format regex to `\.\d+` and uses shared **`parseIsoOffsetTimestamp`** from `@remnic/core` instead of padding milliseconds and comparing against `Date.toISOString()`. Tests assert the sub-millisecond case is kept on import.
> 
> Root **`package.json`** changes are formatting-only (Biome-style single-line arrays); no dependency or behavior changes there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2485ce83d898b0bf86affe8894a2b01a2eb0392f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->