### PR TITLE
Return resolved public artifact paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -960,12 +958,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -988,9 +981,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1043,12 +1034,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -12,7 +12,7 @@
  * is explicitly excluded.
  */
 
-import { readdir, access, stat, lstat, realpath } from "node:fs/promises";
+import { access, lstat, readdir, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 
 /**
@@ -57,9 +57,7 @@ const PUBLIC_FILES: ReadonlyArray<{
   relativePath: string;
   kind: string;
   contentType: PublicArtifactContentType;
-}> = [
-  { relativePath: "profile.md", kind: "memory-root", contentType: "markdown" },
-];
+}> = [{ relativePath: "profile.md", kind: "memory-root", contentType: "markdown" }];
 
 /**
  * Check whether a path is contained within a boundary directory.
@@ -67,13 +65,20 @@ const PUBLIC_FILES: ReadonlyArray<{
  * starts with the boundary prefix, preventing symlink traversal.
  */
 async function isContainedWithin(target: string, boundary: string): Promise<boolean> {
+  return (await resolveContainedPath(target, boundary)) !== undefined;
+}
+
+async function resolveContainedPath(target: string, boundary: string): Promise<string | undefined> {
   try {
     const resolvedTarget = await realpath(target);
     const resolvedBoundary = await realpath(boundary);
     // Ensure the resolved path is within the boundary (with trailing sep)
-    return resolvedTarget === resolvedBoundary || resolvedTarget.startsWith(resolvedBoundary + path.sep);
+    if (resolvedTarget === resolvedBoundary || resolvedTarget.startsWith(resolvedBoundary + path.sep)) {
+      return resolvedTarget;
+    }
+    return undefined;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
@@ -85,7 +90,7 @@ async function isContainedWithin(target: string, boundary: string): Promise<bool
 async function listMarkdownFilesRecursive(
   rootDir: string,
   boundary?: string,
-  ancestorRealPaths?: ReadonlySet<string>,
+  ancestorRealPaths?: ReadonlySet<string>
 ): Promise<string[]> {
   const boundaryDir = boundary ?? rootDir;
   // Cycle detection uses only the current recursion path — the set of real
@@ -108,7 +113,7 @@ async function listMarkdownFilesRecursive(
 
   let entries: import("node:fs").Dirent[];
   try {
-    entries = await readdir(rootDir, { withFileTypes: true }) as import("node:fs").Dirent[];
+    entries = (await readdir(rootDir, { withFileTypes: true })) as import("node:fs").Dirent[];
   } catch {
     return [];
   }
@@ -149,7 +154,10 @@ async function listMarkdownFilesRecursive(
       continue;
     }
     if (isFile && String(entry.name).endsWith(".md")) {
-      files.push(fullPath);
+      const resolvedFilePath = await resolveContainedPath(fullPath, boundaryDir);
+      if (resolvedFilePath !== undefined) {
+        files.push(resolvedFilePath);
+      }
     }
   }
   return files.sort((a, b) => a.localeCompare(b));
@@ -190,6 +198,12 @@ export async function listRemnicPublicArtifacts(params: {
 }): Promise<RemnicPublicArtifact[]> {
   const { memoryDir, workspaceDir, agentIds } = params;
   const artifacts: RemnicPublicArtifact[] = [];
+  let resolvedMemoryDir: string;
+  try {
+    resolvedMemoryDir = await realpath(memoryDir);
+  } catch {
+    return [];
+  }
 
   // Scan public directories
   for (const spec of PUBLIC_DIRS) {
@@ -220,7 +234,7 @@ export async function listRemnicPublicArtifacts(params: {
     const files = await listMarkdownFilesRecursive(dirPath, dirPath);
 
     for (const absolutePath of files) {
-      const relativePath = path.relative(memoryDir, absolutePath).replace(/\\/g, "/");
+      const relativePath = path.relative(resolvedMemoryDir, absolutePath).replace(/\\/g, "/");
       artifacts.push({
         kind: spec.kind,
         workspaceDir,
@@ -237,23 +251,19 @@ export async function listRemnicPublicArtifacts(params: {
     const absolutePath = path.join(memoryDir, spec.relativePath);
     if (!(await pathExists(absolutePath))) continue;
     // Block symlink traversal for standalone files
-    if (!(await isContainedWithin(absolutePath, memoryDir))) continue;
-    // Reject symlinks that redirect to a different file (e.g., profile.md -> state/index.md)
+    const resolvedPath = await resolveContainedPath(absolutePath, memoryDir);
+    if (resolvedPath === undefined) continue;
+    // Reject symlinks for standalone files so returned paths cannot be swapped
+    // after validation but before downstream ingestion reads them.
     try {
       const linkStat = await lstat(absolutePath);
-      if (linkStat.isSymbolicLink()) {
-        const resolvedPath = await realpath(absolutePath);
-        const expectedParent = await realpath(memoryDir);
-        // Resolved path must be directly in memoryDir with the expected basename
-        if (path.dirname(resolvedPath) !== expectedParent) continue;
-        if (path.basename(resolvedPath) !== path.basename(spec.relativePath)) continue;
-      }
+      if (linkStat.isSymbolicLink()) continue;
     } catch {
       continue;
     }
     // Verify it's a file (not a directory)
     try {
-      const fileStat = await stat(absolutePath);
+      const fileStat = await stat(resolvedPath);
       if (!fileStat.isFile()) continue;
     } catch {
       continue;
@@ -262,7 +272,7 @@ export async function listRemnicPublicArtifacts(params: {
       kind: spec.kind,
       workspaceDir,
       relativePath: spec.relativePath,
-      absolutePath,
+      absolutePath: resolvedPath,
       agentIds: [...agentIds],
       contentType: spec.contentType,
     });
@@ -272,9 +282,7 @@ export async function listRemnicPublicArtifacts(params: {
   // overlapping scans or symlinks.
   const deduped = new Map<string, RemnicPublicArtifact>();
   for (const artifact of artifacts) {
-    const key = [artifact.workspaceDir, artifact.relativePath, artifact.kind].join(
-      String.fromCharCode(0),
-    );
+    const key = [artifact.workspaceDir, artifact.relativePath, artifact.kind].join(String.fromCharCode(0));
     deduped.set(key, artifact);
   }
 

--- a/tests/public-artifacts.test.ts
+++ b/tests/public-artifacts.test.ts
@@ -1,11 +1,11 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, rm, mkdir, writeFile, symlink } from "node:fs/promises";
+import test from "node:test";
 import {
-  listRemnicPublicArtifacts,
   type RemnicPublicArtifact,
+  listRemnicPublicArtifacts,
 } from "../packages/plugin-openclaw/src/public-artifacts.ts";
 
 const AGENT_IDS = ["generalist"];
@@ -58,7 +58,7 @@ test("discovers facts in dated subdirectories", async () => {
       assert.equal(a.workspaceDir, "/tmp/workspace");
       assert.deepStrictEqual(a.agentIds, AGENT_IDS);
       assert.ok(a.relativePath.startsWith("facts/2026-04-10/"));
-      assert.ok(a.absolutePath.startsWith(dir));
+      assert.ok(path.isAbsolute(a.absolutePath));
     }
   } finally {
     await rm(dir, { recursive: true, force: true });
@@ -313,12 +313,54 @@ test("follows symlinks within memoryDir boundary", async () => {
       agentIds: AGENT_IDS,
     });
 
-    // Should find both the real file and the symlinked file (since it's within boundary)
+    // Should find the contained symlink target, but report the resolved
+    // target path so later symlink swaps cannot redirect ingestion reads.
     const entityPaths = artifacts.filter((a) => a.kind === "entity").map((a) => a.relativePath);
     assert.ok(
-      entityPaths.some((p) => p.includes("linked-data/entity.md")),
-      "should follow contained symlinks: " + JSON.stringify(entityPaths),
+      entityPaths.some((p) => p.includes("real-target/entity.md")),
+      `should expose contained symlink targets by resolved path: ${JSON.stringify(entityPaths)}`
     );
+    assert.ok(
+      !entityPaths.some((p) => p.includes("linked-data/entity.md")),
+      `should not expose mutable symlink alias paths: ${JSON.stringify(entityPaths)}`
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("returns resolved file targets for public symlinks to prevent later swaps", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const factsDir = path.join(dir, "facts");
+    const stateDir = path.join(dir, "state");
+    await mkdir(factsDir, { recursive: true });
+    await mkdir(stateDir, { recursive: true });
+
+    const publicPath = path.join(factsDir, "public.md");
+    const privatePath = path.join(stateDir, "private.md");
+    const linkPath = path.join(factsDir, "link.md");
+    await writeFile(publicPath, "public fact");
+    await writeFile(privatePath, "private runtime state");
+    await symlink(publicPath, linkPath, "file");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.ok(
+      !artifacts.some((a) => a.absolutePath === linkPath || a.relativePath === "facts/link.md"),
+      "public artifacts must not return mutable symlink paths"
+    );
+
+    await rm(linkPath, { force: true });
+    await symlink(privatePath, linkPath, "file");
+
+    const publicArtifact = artifacts.find((a) => a.relativePath === "facts/public.md");
+    assert.ok(publicArtifact, "should expose the resolved public target");
+    assert.equal(await readFile(publicArtifact.absolutePath, "utf8"), "public fact");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-29feeb69b6-a56f_b8a281f501` (`Validated symlink artifact paths can be swapped before ingestion`).

Changes:
- Return resolved real paths for accepted public markdown files instead of mutable symlink aliases.
- Compute artifact relative paths against the resolved memory root.
- Reject standalone `profile.md` symlinks so downstream ingestion never reads a path that can be swapped after validation.
- Add a regression test that swaps `facts/link.md` after enumeration and verifies the returned artifact still reads the original public target.

Verification:
- `pnpm exec tsx --test tests/public-artifacts.test.ts`
- `pnpm --filter @remnic/plugin-openclaw check-types`
- `OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive path validation for memory exposed to wiki ingestion; behavior change is intentional and narrow, with targeted tests.
> 
> **Overview**
> Hardens **public artifact enumeration** for wiki/ingestion so callers get stable, resolved filesystem paths instead of symlink aliases that could be retargeted after validation.
> 
> `listRemnicPublicArtifacts` now resolves the memory root with `realpath`, computes `relativePath` against that resolved root, and returns **canonical absolute paths** for markdown under public dirs (via `resolveContainedPath`). Standalone **`profile.md` symlinks are rejected** outright. Tests were updated and extended to assert resolved targets, no mutable symlink paths in listings, and that a post-enumeration symlink swap does not change what the returned `absolutePath` reads.
> 
> Root `package.json` changes are formatting-only (array literals on one line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9c147d3b41844c15fc114641b1b002ebc99910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->