### PR TITLE
Detect wrapped PluginConfig keys in contract check

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -960,12 +958,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -988,9 +981,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1043,12 +1034,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/scripts/validate-config-contract.ts
+++ b/scripts/validate-config-contract.ts
@@ -29,11 +29,7 @@ function collectTsFiles(dirPath: string): string[] {
         stack.push(full);
         continue;
       }
-      if (
-        entry.isFile() &&
-        full.endsWith(".ts") &&
-        !full.endsWith(".d.ts")
-      ) {
+      if (entry.isFile() && full.endsWith(".ts") && !full.endsWith(".d.ts")) {
         out.push(full);
       }
     }
@@ -82,24 +78,86 @@ function formatNodePos(sourceFile: ts.SourceFile, node: ts.Node): { line: number
   return { line: pos.line + 1, column: pos.character + 1 };
 }
 
+function typeReferencesSymbol(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  targetSymbol: ts.Symbol,
+  seen = new Set<ts.Type>()
+): boolean {
+  if (seen.has(type)) return false;
+  seen.add(type);
+
+  if (type.getSymbol() === targetSymbol || type.aliasSymbol === targetSymbol) {
+    return true;
+  }
+
+  if (type.isUnionOrIntersection()) {
+    return type.types.some((child) => typeReferencesSymbol(checker, child, targetSymbol, seen));
+  }
+
+  const aliasArgs = type.aliasTypeArguments ?? [];
+  if (aliasArgs.some((child) => typeReferencesSymbol(checker, child, targetSymbol, seen))) {
+    return true;
+  }
+
+  if (
+    (type.flags & ts.TypeFlags.Object) !== 0 &&
+    ((type as ts.ObjectType).objectFlags & ts.ObjectFlags.Reference) !== 0
+  ) {
+    const reference = type as ts.TypeReference;
+    const referenceArgs = checker.getTypeArguments(reference);
+    if (reference.target && typeReferencesSymbol(checker, reference.target, targetSymbol, seen)) {
+      return true;
+    }
+    if (referenceArgs.some((child) => typeReferencesSymbol(checker, child, targetSymbol, seen))) {
+      return true;
+    }
+  }
+
+  if (type.isClassOrInterface()) {
+    const baseTypes = checker.getBaseTypes(type) ?? [];
+    if (baseTypes.some((child) => typeReferencesSymbol(checker, child, targetSymbol, seen))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function typeHasPluginConfigShape(type: ts.Type, pluginConfigKeys: Set<string>): boolean {
+  return type.getProperties().some((prop) => pluginConfigKeys.has(prop.getName()));
+}
+
+function typeHasIndexSignature(checker: ts.TypeChecker, type: ts.Type): boolean {
+  return (
+    checker.getIndexTypeOfType(type, ts.IndexKind.String) !== undefined ||
+    checker.getIndexTypeOfType(type, ts.IndexKind.Number) !== undefined
+  );
+}
+
 function collectUnknownPluginConfigObjectKeys(
   program: ts.Program,
   pluginConfigType: ts.Type,
-  pluginConfigKeys: Set<string>,
+  pluginConfigKeys: Set<string>
 ): Failure[] {
   const checker = program.getTypeChecker();
   const failures: Failure[] = [];
-  const pluginConfigSymbolName = pluginConfigType.getSymbol()?.getName();
+  const pluginConfigSymbol = pluginConfigType.getSymbol();
+  if (!pluginConfigSymbol) {
+    throw new Error("Could not resolve TypeScript symbol for PluginConfig");
+  }
 
   function visit(sourceFile: ts.SourceFile, node: ts.Node) {
     if (ts.isObjectLiteralExpression(node)) {
       const contextualType = checker.getContextualType(node);
-      const contextualSymbolName = contextualType?.getSymbol()?.getName();
       const contextualIsPluginConfig =
         contextualType !== undefined &&
-        (contextualSymbolName === pluginConfigSymbolName || checker.typeToString(contextualType) === "PluginConfig");
+        typeReferencesSymbol(checker, contextualType, pluginConfigSymbol) &&
+        !typeHasIndexSignature(checker, contextualType) &&
+        typeHasPluginConfigShape(contextualType, pluginConfigKeys);
 
       if (contextualIsPluginConfig) {
+        const contextualKeys = new Set(contextualType.getProperties().map((prop) => prop.getName()));
         for (const prop of node.properties) {
           let key: string | null = null;
           if (ts.isPropertyAssignment(prop)) {
@@ -108,7 +166,7 @@ function collectUnknownPluginConfigObjectKeys(
             key = prop.name.text;
           }
 
-          if (key && !pluginConfigKeys.has(key)) {
+          if (key && !pluginConfigKeys.has(key) && !contextualKeys.has(key)) {
             const pos = formatNodePos(sourceFile, prop);
             failures.push({
               message: `Unknown PluginConfig key "${key}" in object literal`,
@@ -125,7 +183,11 @@ function collectUnknownPluginConfigObjectKeys(
 
   for (const sourceFile of program.getSourceFiles()) {
     if (sourceFile.isDeclarationFile) continue;
-    if (!sourceFile.fileName.includes(`${path.sep}src${path.sep}`) && !sourceFile.fileName.includes(`${path.sep}tests${path.sep}`)) continue;
+    if (
+      !sourceFile.fileName.includes(`${path.sep}src${path.sep}`) &&
+      !sourceFile.fileName.includes(`${path.sep}tests${path.sep}`)
+    )
+      continue;
     visit(sourceFile, sourceFile);
   }
 
@@ -140,12 +202,7 @@ function main() {
   const repoRoot = process.cwd();
   const tsconfigPath = path.join(repoRoot, "tsconfig.json");
   const parsed = loadTsConfig(tsconfigPath);
-  const rootNames = Array.from(
-    new Set([
-      ...parsed.fileNames,
-      ...collectTsFiles(path.join(repoRoot, "tests")),
-    ]),
-  );
+  const rootNames = Array.from(new Set([...parsed.fileNames, ...collectTsFiles(path.join(repoRoot, "tests"))]));
   const program = ts.createProgram({
     rootNames,
     options: parsed.options,
@@ -159,7 +216,9 @@ function main() {
   const typesSf = program.getSourceFile(typesPath);
   const configSf = program.getSourceFile(configPath);
   if (!typesSf || !configSf) {
-    throw new Error("Could not load packages/remnic-core/src/types.ts or packages/remnic-core/src/config.ts from TypeScript program");
+    throw new Error(
+      "Could not load packages/remnic-core/src/types.ts or packages/remnic-core/src/config.ts from TypeScript program"
+    );
   }
 
   const pluginConfigKeys = getPluginConfigKeys(typesSf);
@@ -174,10 +233,7 @@ function main() {
     "runtimeAuthForModelResolver",
   ]);
   const expectedSchemaExtra = new Set(["dreams"]);
-  const expectedParseMissing = new Set<string>([
-    "providerApiKeyResolver",
-    "runtimeAuthForModelResolver",
-  ]);
+  const expectedParseMissing = new Set<string>(["providerApiKeyResolver", "runtimeAuthForModelResolver"]);
 
   const failures: Failure[] = [];
 
@@ -225,7 +281,7 @@ function main() {
   }
 
   console.log(
-    `Config contract OK: PluginConfig=${pluginConfigKeys.size}, parseConfig.return=${parseConfigReturnKeys.size}, schema=${schemaKeys.size}`,
+    `Config contract OK: PluginConfig=${pluginConfigKeys.size}, parseConfig.return=${parseConfigReturnKeys.size}, schema=${schemaKeys.size}`
   );
 }
 

--- a/tests/config-contract-validator.test.ts
+++ b/tests/config-contract-validator.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const SCRIPT = path.join(ROOT, "scripts", "validate-config-contract.ts");
+const TSX = path.join(ROOT, "node_modules", ".bin", "tsx");
+
+test("config contract validator scans PluginConfig wrapper contextual types", () => {
+  withConfigFixture((fixtureRoot) => {
+    const result = spawnSync(process.execPath, [TSX, SCRIPT], {
+      cwd: fixtureRoot,
+      encoding: "utf-8",
+      env: process.env,
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Unknown PluginConfig key "unknownExact"/);
+    assert.match(result.stderr, /Unknown PluginConfig key "unknownPartial"/);
+    assert.match(result.stderr, /Unknown PluginConfig key "unknownRequired"/);
+    assert.match(result.stderr, /Unknown PluginConfig key "unknownAlias"/);
+    assert.match(result.stderr, /Unknown PluginConfig key "unknownIntersection"/);
+    assert.match(result.stderr, /Unknown PluginConfig key "unknownScoped"/);
+    assert.match(result.stderr, /Unknown PluginConfig key "unknownNested"/);
+    assert.match(result.stderr, /Unknown PluginConfig key "unknownIndexedNested"/);
+    assert.doesNotMatch(result.stderr, /Unknown PluginConfig key "extraScope"/);
+    assert.doesNotMatch(result.stderr, /Unknown PluginConfig key "default"/);
+    assert.doesNotMatch(result.stderr, /Unknown PluginConfig key "production"/);
+  });
+});
+
+function withConfigFixture(fn: (fixtureRoot: string) => void) {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-config-contract-"));
+  try {
+    fs.mkdirSync(path.join(fixtureRoot, "packages", "remnic-core", "src"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(fixtureRoot, "tests"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            strict: true,
+            target: "ES2022",
+          },
+          include: ["packages/**/*.ts", "tests/**/*.ts"],
+        },
+        null,
+        2
+      )
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          configSchema: {
+            properties: {
+              enabled: { type: "boolean" },
+              label: { type: "string" },
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "packages", "remnic-core", "src", "types.ts"),
+      ["export interface PluginConfig {", "  enabled?: boolean;", "  label?: string;", "}", ""].join("\n")
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "packages", "remnic-core", "src", "config.ts"),
+      [
+        'import type { PluginConfig } from "./types.js";',
+        "",
+        "export function parseConfig(): PluginConfig {",
+        '  return { enabled: true, label: "ok" };',
+        "}",
+        "",
+      ].join("\n")
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tests", "config-fixture.ts"),
+      [
+        'import type { PluginConfig } from "../packages/remnic-core/src/types.js";',
+        "",
+        "type AliasConfig = Partial<PluginConfig>;",
+        "type IntersectionConfig = Partial<PluginConfig> & { label?: string };",
+        "type ScopedConfig = Partial<PluginConfig> & { extraScope?: string };",
+        "type IndexedConfigMap = Record<string, PluginConfig> & Partial<PluginConfig>;",
+        "",
+        "const exact: PluginConfig = { unknownExact: true };",
+        "const partial: Partial<PluginConfig> = { unknownPartial: true };",
+        "const required: Required<PluginConfig> = {",
+        "  enabled: true,",
+        '  label: "ok",',
+        "  unknownRequired: true,",
+        "};",
+        "const alias: AliasConfig = { unknownAlias: true };",
+        "const intersection: IntersectionConfig = { unknownIntersection: true };",
+        'const scoped: ScopedConfig = { extraScope: "ok", unknownScoped: true };',
+        "const configMap: Record<string, PluginConfig> = {",
+        "  default: { enabled: true },",
+        "  production: { unknownNested: true },",
+        "};",
+        "const indexedConfigMap: IndexedConfigMap = {",
+        "  production: { unknownIndexedNested: true },",
+        "};",
+        "",
+        "void exact;",
+        "void partial;",
+        "void required;",
+        "void alias;",
+        "void intersection;",
+        "void scoped;",
+        "void configMap;",
+        "void indexedConfigMap;",
+        "",
+      ].join("\n")
+    );
+
+    fn(fixtureRoot);
+  } finally {
+    fs.rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
## Summary
- follow PluginConfig through contextual wrapper types when scanning object literals
- allow wrapper-owned extension keys while still flagging stale unknown config keys
- add a temp-repo regression test covering exact, Partial, Required, alias, and intersection contexts

ClawPatch finding: fnd_sig-feat-service-3c894e5dbf-c1b7_3436387272

## Verification
- pnpm exec tsx --test tests/config-contract-validator.test.ts
- npm run check-config-contract
- pnpm exec biome check --write --unsafe --diagnostic-level=error --files-ignore-unknown=true scripts/validate-config-contract.ts tests/config-contract-validator.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a dev-time validation script and its tests; runtime plugin config behavior is unchanged.
> 
> **Overview**
> The **config contract validator** no longer treats only bare `PluginConfig` object literals as in-scope. It walks contextual types with the TypeScript checker so **`Partial` / `Required` / aliases / intersections / nested `PluginConfig` values** are scanned the same way, and still reports keys that are not on `PluginConfig`.
> 
> **False positives are reduced** by ignoring keys declared on the wrapper type (e.g. `extraScope` on an intersection) and by **skipping** literals whose contextual type has a string/number index signature, so map keys like `default` / `production` are not mistaken for config fields.
> 
> A **temp-repo regression test** runs the validator against fixture code covering exact, partial, required, alias, intersection, scoped, and nested map shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69ddcbb0a0d498fff690432d49535660ac48222b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->