### PR TITLE
Align WebDAV PROPFIND symlink handling

### DIFF
--- a/packages/remnic-core/src/network/webdav.ts
+++ b/packages/remnic-core/src/network/webdav.ts
@@ -86,7 +86,7 @@ export class WebDavServer {
 
   private constructor(
     options: Required<Omit<WebDavServerOptions, "auth">> & Pick<WebDavServerOptions, "auth">,
-    allowedRoots: AllowedRoot[],
+    allowedRoots: AllowedRoot[]
   ) {
     this.options = options;
     this.allowedRoots = allowedRoots;
@@ -313,7 +313,9 @@ export class WebDavServer {
     return out;
   }
 
-  private async resolvePath(requestPathname: string): Promise<
+  private async resolvePath(
+    requestPathname: string
+  ): Promise<
     | { ok: true; absolutePath: string; displayPath: string; rootAbsolute: string }
     | { ok: false; code: number; message: string }
   > {
@@ -355,11 +357,21 @@ export class WebDavServer {
       if (!this.isPathInside(root.absolute, canonicalCandidate)) {
         return { ok: false, code: 403, message: "path escaped allowlist via symlink" };
       }
-      return { ok: true, absolutePath: canonicalCandidate, displayPath: `/${segments.join("/")}`, rootAbsolute: root.absolute };
+      return {
+        ok: true,
+        absolutePath: canonicalCandidate,
+        displayPath: `/${segments.join("/")}`,
+        rootAbsolute: root.absolute,
+      };
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === "ENOENT") {
-        return { ok: true, absolutePath: candidate, displayPath: `/${segments.join("/")}`, rootAbsolute: root.absolute };
+        return {
+          ok: true,
+          absolutePath: candidate,
+          displayPath: `/${segments.join("/")}`,
+          rootAbsolute: root.absolute,
+        };
       }
       if (code === "ENOTDIR" || code === "ELOOP") {
         return { ok: false, code: 400, message: "invalid path" };
@@ -372,7 +384,7 @@ export class WebDavServer {
     method: "GET" | "HEAD",
     absolutePath: string,
     rootAbsolute: string,
-    res: ServerResponse,
+    res: ServerResponse
   ): Promise<void> {
     const revalidated = await this.revalidatePathInsideRoot(absolutePath, rootAbsolute);
     if (!revalidated.ok) {
@@ -410,7 +422,7 @@ export class WebDavServer {
     absolutePath: string,
     rootAbsolute: string,
     displayPath: string,
-    res: ServerResponse,
+    res: ServerResponse
   ): Promise<void> {
     const revalidated = await this.revalidatePathInsideRoot(absolutePath, rootAbsolute);
     if (!revalidated.ok) {
@@ -432,25 +444,56 @@ export class WebDavServer {
     if (info.isDirectory()) {
       const children = await readdir(absolutePath, { withFileTypes: true });
       for (const child of children) {
-        const childHref = toEncodedHref(`${displayPath.replace(/\/$/, "")}/${child.name}`);
-        entries.push(`
-  <d:response>
-    <d:href>${xmlEscape(childHref)}</d:href>
-    <d:propstat><d:prop><d:resourcetype>${child.isDirectory() ? "<d:collection/>" : ""}</d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
-  </d:response>`);
+        const entry = await this.renderPropfindChildEntry(absolutePath, rootAbsolute, displayPath, child.name);
+        if (entry) {
+          entries.push(entry);
+        }
       }
     }
 
     const xml = `<?xml version="1.0" encoding="utf-8"?>
 <d:multistatus xmlns:d="DAV:">
-  <d:response>
-    <d:href>${xmlEscape(toEncodedHref(displayPath))}</d:href>
-    <d:propstat><d:prop><d:resourcetype>${info.isDirectory() ? "<d:collection/>" : ""}</d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
-  </d:response>${entries.join("")}
+${this.renderPropfindResponse(toEncodedHref(displayPath), info.isDirectory())}${entries.join("")}
 </d:multistatus>`;
 
     res.writeHead(207, { "Content-Type": "application/xml; charset=utf-8" });
     res.end(xml);
+  }
+
+  private async renderPropfindChildEntry(
+    parentAbsolutePath: string,
+    rootAbsolute: string,
+    displayPath: string,
+    childName: string
+  ): Promise<string | null> {
+    const childAbsolutePath = path.join(parentAbsolutePath, childName);
+    let revalidated;
+    try {
+      revalidated = await this.revalidatePathInsideRoot(childAbsolutePath, rootAbsolute);
+    } catch {
+      return null;
+    }
+    if (!revalidated.ok) {
+      return null;
+    }
+
+    let info;
+    try {
+      info = await stat(revalidated.absolutePath);
+    } catch {
+      return null;
+    }
+
+    const childHref = toEncodedHref(`${displayPath.replace(/\/$/, "")}/${childName}`);
+    return this.renderPropfindResponse(childHref, info.isDirectory());
+  }
+
+  private renderPropfindResponse(href: string, isDirectory: boolean): string {
+    return `  <d:response>
+    <d:href>${xmlEscape(href)}</d:href>
+    <d:propstat><d:prop><d:resourcetype>${isDirectory ? "<d:collection/>" : ""}</d:resourcetype></d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+`;
   }
 
   private isPathInside(root: string, target: string): boolean {
@@ -463,11 +506,8 @@ export class WebDavServer {
 
   private async revalidatePathInsideRoot(
     absolutePath: string,
-    rootAbsolute: string,
-  ): Promise<
-    | { ok: true; absolutePath: string }
-    | { ok: false; code: number; message: string }
-  > {
+    rootAbsolute: string
+  ): Promise<{ ok: true; absolutePath: string } | { ok: false; code: number; message: string }> {
     try {
       const canonical = await realpath(absolutePath);
       if (!this.isPathInside(rootAbsolute, canonical)) {

--- a/tests/network-webdav.test.ts
+++ b/tests/network-webdav.test.ts
@@ -16,7 +16,7 @@ async function httpRequest(
   method: string,
   port: number,
   pathname: string,
-  headers?: Record<string, string>,
+  headers?: Record<string, string>
 ): Promise<HttpResult> {
   return new Promise((resolve, reject) => {
     const req = request(
@@ -37,7 +37,7 @@ async function httpRequest(
             headers: res.headers,
           });
         });
-      },
+      }
     );
     req.on("error", reject);
     req.end();
@@ -179,7 +179,7 @@ test("webdav rejects empty basic auth credentials at create time", async () => {
         allowlistDirs: [root],
         auth: { username: "", password: "pass123" },
       }),
-    /webdav auth\.username must be a non-empty string/,
+    /webdav auth\.username must be a non-empty string/
   );
   await assert.rejects(
     () =>
@@ -189,7 +189,7 @@ test("webdav rejects empty basic auth credentials at create time", async () => {
         allowlistDirs: [root],
         auth: { username: "engram", password: "" },
       }),
-    /webdav auth\.password must be a non-empty string/,
+    /webdav auth\.password must be a non-empty string/
   );
   await assert.rejects(
     () =>
@@ -199,7 +199,7 @@ test("webdav rejects empty basic auth credentials at create time", async () => {
         allowlistDirs: [root],
         auth: { username: "   ", password: "\t" },
       }),
-    /webdav auth\.username must be a non-empty string/,
+    /webdav auth\.username must be a non-empty string/
   );
 });
 
@@ -250,7 +250,82 @@ test("webdav blocks symlink escapes outside allowlisted root", async () => {
     const leakAttempt = await httpRequest("GET", started.port, `/${alias}/leak.txt`);
     assert.equal(leakAttempt.status, 403);
     assert.match(leakAttempt.body, /allowlist/i);
+
+    const listing = await httpRequest("PROPFIND", started.port, `/${alias}`);
+    assert.equal(listing.status, 207);
+    assert.doesNotMatch(listing.body, /leak\.txt/);
   } finally {
+    await server.stop();
+  }
+});
+
+test("webdav PROPFIND revalidates symlinked child directories before advertising collections", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "engram-webdav-propfind-symlink-"));
+  const targetDir = path.join(root, "target-dir");
+  await mkdir(targetDir, { recursive: true });
+  await writeFile(path.join(targetDir, "inside.txt"), "inside", "utf-8");
+
+  try {
+    await symlink(targetDir, path.join(root, "linked-dir"), "dir");
+  } catch {
+    return; // symlinks unavailable
+  }
+
+  const server = await WebDavServer.create({
+    enabled: true,
+    port: 0,
+    allowlistDirs: [root],
+  });
+  const started = await server.start();
+  const alias = path.basename(root);
+
+  try {
+    const listing = await httpRequest("PROPFIND", started.port, `/${alias}`);
+    assert.equal(listing.status, 207);
+    assert.match(listing.body, /<d:href>\/[^<]*\/linked-dir<\/d:href>[\s\S]*<d:collection\/>/);
+
+    const linkedListing = await httpRequest("PROPFIND", started.port, `/${alias}/linked-dir`);
+    assert.equal(linkedListing.status, 207);
+    assert.match(linkedListing.body, /inside\.txt/);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("webdav PROPFIND skips children whose symlink revalidation cannot traverse", async () => {
+  if (typeof process.getuid === "function" && process.getuid() === 0) {
+    return;
+  }
+
+  const root = await mkdtemp(path.join(os.tmpdir(), "engram-webdav-propfind-inaccessible-symlink-"));
+  await writeFile(path.join(root, "visible.txt"), "visible", "utf-8");
+  const blockedDir = path.join(root, "blocked");
+  const blockedTarget = path.join(blockedDir, "target");
+  await mkdir(blockedTarget, { recursive: true });
+
+  try {
+    await symlink(blockedTarget, path.join(root, "blocked-link"), "dir");
+  } catch {
+    return; // symlinks unavailable
+  }
+
+  await chmod(blockedDir, 0o000);
+
+  const server = await WebDavServer.create({
+    enabled: true,
+    port: 0,
+    allowlistDirs: [root],
+  });
+  const started = await server.start();
+  const alias = path.basename(root);
+
+  try {
+    const listing = await httpRequest("PROPFIND", started.port, `/${alias}`);
+    assert.equal(listing.status, 207);
+    assert.match(listing.body, /visible\.txt/);
+    assert.doesNotMatch(listing.body, /blocked-link/);
+  } finally {
+    await chmod(blockedDir, 0o700).catch(() => {});
     await server.stop();
   }
 });
@@ -454,7 +529,7 @@ test("webdav create rejects duplicate root aliases", async () => {
         port: 0,
         allowlistDirs: [dirA, dirB],
       }),
-    /duplicate webdav allowlist alias: shared/,
+    /duplicate webdav allowlist alias: shared/
   );
 });
 


### PR DESCRIPTION
## Summary\n- revalidate PROPFIND child entries through the same canonical allowlist check used by reads\n- advertise child resource type from the revalidated target instead of the raw directory entry\n- cover escaping symlinks and in-root symlinked directories in WebDAV tests\n\n## Verification\n- PATH="/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin" pnpm exec tsx --test tests/network-webdav.test.ts\n- PATH="/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens filesystem exposure in WebDAV listings (symlink/allowlist edge cases); behavior change for clients that relied on listing unsafe or symlinked names.
> 
> **Overview**
> **PROPFIND** directory listings now run each child through the same **canonical allowlist revalidation** (`realpath` + in-root check) used for **GET/HEAD**, instead of advertising every `readdir` name from the raw directory entry.
> 
> Children that fail revalidation or cannot be stat’d are **omitted** from the multistatus (e.g. symlinks escaping the allowlist no longer appear in listings). **Resource type** (`<d:collection/>` vs file) comes from the **revalidated target**, with shared XML helpers for the requested path and children.
> 
> Tests assert escaping symlinks are absent from **PROPFIND**, in-root symlinked dirs still list correctly, and inaccessible symlink children are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f0c51a7ff21b09335bd2e90b69b0a24c9bbc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->