### PR TITLE
Run OpenClaw security scanner from trusted source

### DIFF
--- a/.github/workflows/openclaw-plugin-security.yml
+++ b/.github/workflows/openclaw-plugin-security.yml
@@ -12,6 +12,7 @@ on:
       - "src/**"
       - "scripts/openclaw-plugin-security-scan.mjs"
       - "tests/openclaw-plugin-dangerous-scan.test.ts"
+      - "tests/openclaw-plugin-security-workflow-policy.test.ts"
   push:
     branches: [main]
     paths:
@@ -23,6 +24,7 @@ on:
       - "src/**"
       - "scripts/openclaw-plugin-security-scan.mjs"
       - "tests/openclaw-plugin-dangerous-scan.test.ts"
+      - "tests/openclaw-plugin-security-workflow-policy.test.ts"
   schedule:
     - cron: "17 9 * * *"
   workflow_dispatch:
@@ -42,6 +44,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout trusted scanner source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+          path: trusted-scanner-source
+          sparse-checkout: |
+            scripts/openclaw-plugin-security-scan.mjs
+          sparse-checkout-cone-mode: false
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
@@ -81,7 +92,7 @@ jobs:
           echo "OPENCLAW_PACKAGE_DIR=$install_dir/node_modules/openclaw" >> "$GITHUB_ENV"
 
       - name: Run real OpenClaw dangerous-plugin scanner
-        run: pnpm run scan:openclaw-plugin -- "$SCANNED_PACKAGE_DIR"
+        run: node "$GITHUB_WORKSPACE/trusted-scanner-source/scripts/openclaw-plugin-security-scan.mjs" "$SCANNED_PACKAGE_DIR"
 
   latest-openclaw-scanner:
     name: latest-openclaw-scanner
@@ -94,6 +105,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout trusted scanner source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+          path: trusted-scanner-source
+          sparse-checkout: |
+            scripts/openclaw-plugin-security-scan.mjs
+          sparse-checkout-cone-mode: false
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
@@ -133,4 +153,4 @@ jobs:
           echo "OPENCLAW_PACKAGE_DIR=$install_dir/node_modules/openclaw" >> "$GITHUB_ENV"
 
       - name: Run real OpenClaw dangerous-plugin scanner
-        run: pnpm run scan:openclaw-plugin -- "$SCANNED_PACKAGE_DIR"
+        run: node "$GITHUB_WORKSPACE/trusted-scanner-source/scripts/openclaw-plugin-security-scan.mjs" "$SCANNED_PACKAGE_DIR"

--- a/tests/openclaw-plugin-security-workflow-policy.test.ts
+++ b/tests/openclaw-plugin-security-workflow-policy.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(".github/workflows/openclaw-plugin-security.yml", "utf8");
+
+test("OpenClaw plugin security workflow runs scanner from trusted source checkout", () => {
+  assert.doesNotMatch(workflow, /pnpm\s+run\s+scan:openclaw-plugin/);
+
+  const trustedCheckoutCount = (workflow.match(/name: Checkout trusted scanner source/g) ?? []).length;
+  assert.equal(trustedCheckoutCount, 2);
+  assert.match(
+    workflow,
+    /ref: \$\{\{ github\.event_name == 'pull_request' && github\.event\.pull_request\.base\.sha \|\| github\.sha \}\}/
+  );
+  assert.match(workflow, /path: trusted-scanner-source/);
+  assert.match(workflow, /sparse-checkout:[\s\S]*scripts\/openclaw-plugin-security-scan\.mjs/);
+
+  const trustedScannerCommand =
+    /node "\$GITHUB_WORKSPACE\/trusted-scanner-source\/scripts\/openclaw-plugin-security-scan\.mjs" "\$SCANNED_PACKAGE_DIR"/g;
+  assert.equal((workflow.match(trustedScannerCommand) ?? []).length, 2);
+});


### PR DESCRIPTION
## Summary\n- add a trusted scanner-source checkout for OpenClaw plugin security scans\n- invoke the scanner script from that trusted checkout instead of the PR-controlled package script\n- add a workflow policy test that rejects package-script scanner invocation\n\n## Verification\n- PATH="/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin" pnpm exec tsx --test tests/openclaw-plugin-security-workflow-policy.test.ts\n- PATH="/opt/homebrew/opt/node@22/bin:/opt/local/bin:/opt/local/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/joshuawarren/.cargo/bin:/Users/joshuawarren/.orbstack/bin:/Users/joshuawarren/.codex/tmp/arg0/codex-arg0tg9G8b:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin/:/Users/joshuawarren/Library/Application Support/JetBrains/Toolbox/scripts:/Users/joshuawarren/.orbstack/bin" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only hardening that reduces supply-chain risk in the security workflow; no runtime product behavior changes.
> 
> **Overview**
> **Hardens OpenClaw plugin security CI** so the dangerous-plugin scan no longer runs via `pnpm run scan:openclaw-plugin` from the PR checkout (which could be pointed at attacker-controlled code in `package.json`).
> 
> Both **pinned** and **latest** scanner jobs now perform a second sparse checkout of `scripts/openclaw-plugin-security-scan.mjs` into `trusted-scanner-source`, using the **base branch SHA on pull requests** and the current commit otherwise. The scan step invokes that script with `node` directly.
> 
> A new **workflow policy test** locks in this behavior (no package-script invocation, two trusted checkouts, correct ref/path/sparse-checkout, and the trusted `node` command in both jobs). Workflow path filters include the new test file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a02a70f26aa752f6dd2823870583b2e8ec7a8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->