### PR TITLE
Preserve final-stop cursor on observe failure

### DIFF
--- a/scripts/hooks/codex/engram-session-store.sh
+++ b/scripts/hooks/codex/engram-session-store.sh
@@ -4,7 +4,8 @@
 # Fires after every agent turn (Stop) and also on final exit (stop_hook_active=false).
 # Tracks a cursor per session in a private per-user state directory so only NEW
 # messages are sent each call. When stop_hook_active is false (final stop),
-# the cursor file is also cleaned up.
+# the cursor file is cleaned up only after the pending transcript tail is
+# observed or confirmed empty.
 # Runs observe in the background — never blocks the stop.
 #
 # Required env vars:
@@ -264,7 +265,7 @@ PYEOF
 
   if [ -z "$PAYLOAD" ]; then
     log "stop[$SESSION_ID]: parse failed"
-    [ "$IS_FINAL_STOP" = "true" ] && remove_cursor_file
+    [ "$IS_FINAL_STOP" = "true" ] && log "final-stop[$SESSION_ID]: parse failed, cursor retained for retry"
     exit 0
   fi
 
@@ -310,7 +311,7 @@ print(f\"accepted={d.get('accepted','?')} lcm={d.get('lcmArchived','?')} extract
     [ "$IS_FINAL_STOP" = "true" ] && remove_cursor_file
   else
     log "$LABEL[$SESSION_ID]: observe failed (curl=$CURL_EXIT http=$HTTP_STATUS) — cursor not advanced"
-    [ "$IS_FINAL_STOP" = "true" ] && remove_cursor_file
+    [ "$IS_FINAL_STOP" = "true" ] && log "$LABEL[$SESSION_ID]: final stop observe failed, cursor retained for retry"
   fi
 ) >> "$LOG" 2>&1 &
 

--- a/tests/engram-session-store-hook.test.mjs
+++ b/tests/engram-session-store-hook.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -39,7 +39,7 @@ async function makeFixture() {
   return { root, home, stateHome, transcript };
 }
 
-function runHook(hookCase, fixture, sessionId) {
+function runHook(hookCase, fixture, sessionId, options = {}) {
   return spawnSync("bash", [hookCase.scriptPath], {
     cwd: process.cwd(),
     encoding: "utf8",
@@ -48,11 +48,13 @@ function runHook(hookCase, fixture, sessionId) {
       HOME: fixture.home,
       XDG_STATE_HOME: fixture.stateHome,
       OPENCLAW_ENGRAM_ACCESS_TOKEN: "test-token",
+      PATH: options.pathPrefix ? `${options.pathPrefix}:${process.env.PATH}` : process.env.PATH,
     },
     input: JSON.stringify({
       session_id: sessionId,
       transcript_path: fixture.transcript,
       cwd: process.cwd(),
+      ...options.input,
     }),
   });
 }
@@ -120,7 +122,7 @@ for (const hookCase of hookCases) {
       await writeFile(
         fixture.transcript,
         `${JSON.stringify({ type: "user", message: { role: "user", content: "hello" } })}\n`,
-        "utf8",
+        "utf8"
       );
 
       const result = runHook(hookCase, fixture, sessionId);
@@ -164,3 +166,48 @@ for (const hookCase of hookCases) {
     }
   });
 }
+
+test("codex session store preserves cursor when final-stop observe fails", async () => {
+  const hookCase = hookCases.find((entry) => entry.name === "codex");
+  assert.ok(hookCase);
+  const fixture = await makeFixture();
+  const sessionId = `final-fail-session-codex-${process.pid}`;
+  const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+  const cursorPath = path.join(stateDir, `engram-cursor-${sessionId}`);
+  const fakeBin = path.join(fixture.root, "bin");
+  const fakeCurl = path.join(fakeBin, "curl");
+
+  try {
+    await mkdir(stateDir, { recursive: true, mode: 0o700 });
+    await mkdir(fakeBin, { recursive: true });
+    await writeFile(cursorPath, "1\n", "utf8");
+    await writeFile(
+      fixture.transcript,
+      [
+        JSON.stringify({ type: "user", message: { role: "user", content: "already observed" } }),
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: "pending tail" } }),
+      ].join("\n") + "\n",
+      "utf8"
+    );
+    await writeFile(fakeCurl, "#!/usr/bin/env bash\nexit 7\n", "utf8");
+    await chmod(fakeCurl, 0o700);
+
+    const result = runHook(hookCase, fixture, sessionId, {
+      input: { stop_hook_active: false },
+      pathPrefix: fakeBin,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "{}\n");
+
+    const logPath = path.join(fixture.home, ...hookCase.logPath);
+    await waitFor(async () => {
+      if (!existsSync(logPath)) return false;
+      const log = await readFile(logPath, "utf8");
+      return log.includes("final-stop") && log.includes("cursor retained for retry");
+    }, "final-stop failure was not logged");
+
+    assert.equal(await readFile(cursorPath, "utf8"), "1\n");
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- retain the Codex session-store cursor when final-stop parsing or observe delivery fails
- log that retry state was preserved instead of deleting the cursor prematurely
- add a regression test with a failing curl shim for final-stop observe failure

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/engram-session-store-hook.test.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in a background hook plus a targeted test; no auth or API surface changes.
> 
> **Overview**
> The Codex **Engram session-store** stop hook no longer deletes the per-session cursor on **final stop** when transcript parsing fails or the observe `curl` call fails. Cursor cleanup on exit now happens only after the pending tail is successfully observed or confirmed empty; failures log that the cursor was **retained for retry** instead of being removed.
> 
> Tests gain optional `PATH` / hook input overrides and a **Codex-only** regression that simulates a failing `curl` on final stop and asserts the cursor file and log message stay intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93d19fa55a5bca3c520e1f3e3d31b689f3f4ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->