### PR TITLE
Preserve packaged Codex final flush cursor

### DIFF
--- a/packages/plugin-codex/hooks/bin/session-end.sh
+++ b/packages/plugin-codex/hooks/bin/session-end.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Remnic Stop hook for Codex.
-# Performs final observe flush then cleans up cursor/lock files.
+# Performs final observe flush then cleans up cursor/lock files only after the
+# pending transcript tail is observed or confirmed empty.
 
 set -euo pipefail
 
@@ -167,11 +168,13 @@ remove_cursor_file() {
 }
 
 # Final observe flush if we have transcript
+REMOVE_CURSOR_AFTER_FLUSH=1
 if [ -n "$REMNIC_TOKEN" ] && [ "$SESSION_ID_SAFE" -eq 1 ] && [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   LAST_COUNT=0
   migrate_tmp_cursor_file
   if LAST_COUNT="$(read_cursor_file)"; then
-    PAYLOAD="$(node -e "
+    PAYLOAD=""
+    if ! PAYLOAD="$(node -e "
       const fs = require('fs');
       const lines = fs.readFileSync(process.argv[1], 'utf8').split('\n').filter(Boolean);
       const messages = [];
@@ -192,16 +195,28 @@ if [ -n "$REMNIC_TOKEN" ] && [ "$SESSION_ID_SAFE" -eq 1 ] && [ -n "$TRANSCRIPT_P
       if (newMessages.length) {
         process.stdout.write(JSON.stringify({ sessionKey: process.argv[2], messages: newMessages }));
       }
-    " "$TRANSCRIPT_PATH" "$SESSION_ID" "$LAST_COUNT" 2>/dev/null)"
+    " "$TRANSCRIPT_PATH" "$SESSION_ID" "$LAST_COUNT" 2>/dev/null)"; then
+      log "final flush parse failed for $SESSION_ID; cursor retained for retry"
+      REMOVE_CURSOR_AFTER_FLUSH=0
+      PAYLOAD=""
+    fi
 
     if [ -n "$PAYLOAD" ]; then
       log "final flush for $SESSION_ID"
-      curl -s --max-time 30 \
+      CURL_EXIT=0
+      RAW="$(curl -s -w "\n%{http_code}" --max-time 30 \
         -X POST "$REMNIC_URL" \
         -H "Authorization: Bearer ${REMNIC_TOKEN}" \
         -H "Content-Type: application/json" \
         -H "X-Engram-Client-Id: codex" \
-        -d "$PAYLOAD" >/dev/null 2>&1 || log "final flush failed"
+        -d "$PAYLOAD" 2>/dev/null)" || CURL_EXIT=$?
+      HTTP_STATUS="$(printf '%s\n' "$RAW" | tail -1)"
+      if [ "$CURL_EXIT" -eq 0 ] && [[ "$HTTP_STATUS" =~ ^2 ]]; then
+        log "final flush OK for $SESSION_ID"
+      else
+        log "final flush failed for $SESSION_ID (curl=$CURL_EXIT http=${HTTP_STATUS:-unknown}); cursor retained for retry"
+        REMOVE_CURSOR_AFTER_FLUSH=0
+      fi
     fi
   else
     log "final flush skipped for $SESSION_ID due to unsafe cursor"
@@ -210,7 +225,9 @@ fi
 
 # Cleanup
 if [ "$SESSION_ID_SAFE" -eq 1 ]; then
-  remove_cursor_file || true
+  if [ "$REMOVE_CURSOR_AFTER_FLUSH" -eq 1 ]; then
+    remove_cursor_file || true
+  fi
   rmdir "$LOCK_DIR" 2>/dev/null || true
   if [ "$CURSOR_FILE" != "$LEGACY_CURSOR_FILE" ] && [ -e "$LEGACY_CURSOR_FILE" ] && [ ! -L "$LEGACY_CURSOR_FILE" ]; then
     rm -f "$LEGACY_CURSOR_FILE" 2>/dev/null || true

--- a/tests/codex-session-end-hook.test.ts
+++ b/tests/codex-session-end-hook.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 const sessionEndHook = "packages/plugin-codex/hooks/bin/session-end.sh";
@@ -27,4 +31,72 @@ test("Codex session-end hook retries legacy engram tokens when remnic token pars
   assert.match(content, /\[ ! -f "\$TOKEN_FILE" \] && continue/);
   assert.match(content, /JSON\.parse\(fs\.readFileSync\(tokenFile, 'utf8'\)\)/);
   assert.match(content, /\[ -n "\$REMNIC_TOKEN" \] && break/);
+});
+
+async function waitFor(predicate: () => Promise<boolean>, message: string) {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.fail(message);
+}
+
+test("Codex session-end hook preserves cursor when final flush observe fails", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-codex-session-end-"));
+  const home = path.join(root, "home");
+  const stateHome = path.join(root, "state");
+  const stateDir = path.join(stateHome, "remnic", "hooks");
+  const fakeBin = path.join(root, "bin");
+  const fakeCurl = path.join(fakeBin, "curl");
+  const transcriptPath = path.join(root, "transcript.jsonl");
+  const sessionId = `codex-final-flush-fail-${process.pid}`;
+  const cursorPath = path.join(stateDir, `remnic-cursor-${sessionId}`);
+  const logPath = path.join(home, ".remnic", "logs", "remnic-codex-session-end.log");
+
+  try {
+    await mkdir(home, { recursive: true });
+    await mkdir(stateDir, { recursive: true, mode: 0o700 });
+    await mkdir(fakeBin, { recursive: true });
+    await writeFile(cursorPath, "1\n", "utf8");
+    await writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ type: "user", message: { role: "user", content: "already observed" } }),
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: "pending tail" } }),
+      ].join("\n") + "\n",
+      "utf8"
+    );
+    await writeFile(fakeCurl, "#!/usr/bin/env bash\nexit 7\n", "utf8");
+    await chmod(fakeCurl, 0o700);
+
+    const result = spawnSync("bash", [sessionEndHook], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: home,
+        XDG_STATE_HOME: stateHome,
+        OPENCLAW_REMNIC_ACCESS_TOKEN: "test-token",
+        REMNIC_CODEX_MATERIALIZE: "0",
+        PATH: `${fakeBin}:${process.env.PATH}`,
+      },
+      input: JSON.stringify({
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }),
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, '{"continue":true}\n');
+
+    await waitFor(async () => {
+      if (!existsSync(logPath)) return false;
+      return (await readFile(logPath, "utf8")).includes("cursor retained for retry");
+    }, "final flush failure was not logged");
+
+    assert.equal(await readFile(cursorPath, "utf8"), "1\n");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- retain the packaged Codex session-end cursor when final flush parsing or observe delivery fails
- log final-flush failure details instead of deleting retry state
- add an executable packaged-hook regression with a failing curl shim

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/codex-session-end-hook.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

Follow-up for ClawPatch finding fnd_sig-feat-config-517d26eb09-484ab_9ee69fb349 after revalidation found the active packaged hook path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized hook and test changes around retry state for transcript observe; no auth or API contract changes beyond safer cleanup timing.
> 
> **Overview**
> The Codex **session-end** hook now keeps the observe **cursor** when the final transcript flush cannot be confirmed, instead of always deleting it at session end.
> 
> A `REMOVE_CURSOR_AFTER_FLUSH` flag stays set only when parsing succeeds and `curl` returns a 2xx; parse failures and failed observe POSTs log details and skip cursor removal so a later run can retry the pending tail. Cleanup still removes locks and legacy paths as before.
> 
> Tests add an integration run with a failing `curl` shim to assert the cursor file and retry log line remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90071b5d026114a779dcfa1b28a2dfafe2c63fb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->