### PR TITLE
Preserve AMB leaderboard compare failures

### DIFF
--- a/.github/workflows/amb-beam-remnic.yml
+++ b/.github/workflows/amb-beam-remnic.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Compare against public BEAM leaderboard
         if: env.BEAM_QUERY_LIMIT == ''
         run: |
+          set -o pipefail
           result="$AMB_DIR/outputs/beam/remnic/rag/$BEAM_SPLIT.json"
           node integrations/amb/compare-beam-result.mjs "$result" | tee "$RUNNER_TEMP/remnic-beam-comparison.txt"
 

--- a/tests/amb-workflow.test.ts
+++ b/tests/amb-workflow.test.ts
@@ -41,3 +41,28 @@ test("AMB BEAM workflow job env avoids runner-only expression contexts", async (
   assert.match(beamEnv, /^\s+AMB_DIR: \/tmp\/agent-memory-benchmark$/m);
   assert.match(beamEnv, /^\s+UV_CACHE_DIR: \/tmp\/uv-cache$/m);
 });
+
+test("AMB BEAM workflow preserves leaderboard comparison failures through tee", async () => {
+  const workflow = await readFile(
+    path.join(repoRoot, ".github", "workflows", "amb-beam-remnic.yml"),
+    "utf8",
+  );
+  const lines = workflow.split(/\r?\n/);
+  const compareStep = readIndentedBlock(
+    lines,
+    "      - name: Compare against public BEAM leaderboard",
+    6,
+  );
+  const runBlock = readIndentedBlock(compareStep.split(/\r?\n/), "        run: |", 8);
+  const pipefailIndex = runBlock.indexOf("set -o pipefail");
+  const comparisonIndex = runBlock.indexOf(
+    'node integrations/amb/compare-beam-result.mjs "$result" | tee "$RUNNER_TEMP/remnic-beam-comparison.txt"',
+  );
+
+  assert.notEqual(pipefailIndex, -1, "compare step must enable pipefail before piping through tee");
+  assert.notEqual(comparisonIndex, -1, "compare step must pipe comparison output through tee");
+  assert.ok(
+    pipefailIndex < comparisonIndex,
+    "pipefail must be enabled before the compare-beam-result.mjs pipeline",
+  );
+});


### PR DESCRIPTION
## Summary
- enable pipefail before the AMB BEAM leaderboard comparison pipeline
- add a workflow regression asserting pipefail precedes the node | tee comparison command

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/amb-workflow.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

Fixes ClawPatch finding fnd_sig-feat-config-80f324e02e-0cfab_4a2b71ee98.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell and test changes; no runtime product or security surface.
> 
> **Overview**
> The AMB BEAM Remnic workflow’s **Compare against public BEAM leaderboard** step now runs **`set -o pipefail`** before piping `compare-beam-result.mjs` through **`tee`**, so a non-zero exit from the Node comparison (e.g. not SOTA or errors) fails the job instead of being hidden by **`tee`**’s success exit code.
> 
> A new workflow test in **`tests/amb-workflow.test.ts`** locks in that **`pipefail`** appears before the **`node … | tee`** line in that step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15df5fbf3010f9bfeb79d19f85749f2429bd5125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->