### PR TITLE
Pin GitHub host keys for release deploy pushes

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -403,8 +403,14 @@ jobs:
           mkdir -p ~/.ssh
           echo "${RELEASE_DEPLOY_KEY}" > ~/.ssh/release_deploy_key
           chmod 600 ~/.ssh/release_deploy_key
+          cat > ~/.ssh/known_hosts <<'EOF'
+          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+          github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+          github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+          EOF
+          chmod 600 ~/.ssh/known_hosts
           trap 'rm -f ~/.ssh/release_deploy_key' EXIT
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o StrictHostKeyChecking=no"
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
           git push "git@github.com:${{ github.repository }}.git" "${RELEASE_COMMIT}:refs/heads/main"
 
       - name: Prepare publish-order helper
@@ -479,7 +485,13 @@ jobs:
           mkdir -p ~/.ssh
           echo "${RELEASE_DEPLOY_KEY}" > ~/.ssh/release_deploy_key
           chmod 600 ~/.ssh/release_deploy_key
-          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o StrictHostKeyChecking=no"
+          cat > ~/.ssh/known_hosts <<'EOF'
+          github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+          github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+          github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+          EOF
+          chmod 600 ~/.ssh/known_hosts
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
           git push "git@github.com:${{ github.repository }}.git" "refs/tags/${TAG}"
           echo "tag_created=true" >> "$GITHUB_OUTPUT"
 

--- a/tests/release-workflow-order.test.ts
+++ b/tests/release-workflow-order.test.ts
@@ -125,3 +125,25 @@ test("release workflow pins publish tooling", () => {
   assert.match(workflow, /npm install -g npm@11\.16\.0/);
   assert.match(workflow, /npm install -g clawhub@0\.18\.0/);
 });
+
+test("release workflow pins GitHub SSH host keys for deploy-key pushes", () => {
+  assert.doesNotMatch(workflow, /StrictHostKeyChecking=no/);
+  assert.match(workflow, /github\.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl/);
+  assert.match(workflow, /github\.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY/);
+  assert.match(workflow, /github\.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQow/);
+
+  const strictCommands = workflow.match(/GIT_SSH_COMMAND="ssh -i ~\/\.ssh\/release_deploy_key -o UserKnownHostsFile=\$HOME\/\.ssh\/known_hosts -o StrictHostKeyChecking=yes"/g) ?? [];
+  assert.equal(strictCommands.length, 2);
+
+  const knownHostsWrites = workflow.match(/cat > ~\/\.ssh\/known_hosts <<'EOF'/g) ?? [];
+  assert.equal(knownHostsWrites.length, 2);
+
+  assert.ok(
+    workflow.indexOf("cat > ~/.ssh/known_hosts <<'EOF'") <
+      workflow.indexOf('git push "git@github.com:${{ github.repository }}.git" "${RELEASE_COMMIT}:refs/heads/main"'),
+  );
+  assert.ok(
+    workflow.lastIndexOf("cat > ~/.ssh/known_hosts <<'EOF'") <
+      workflow.indexOf('git push "git@github.com:${{ github.repository }}.git" "refs/tags/${TAG}"'),
+  );
+});


### PR DESCRIPTION
## Summary
- replace release deploy-key SSH pushes' disabled host checking with pinned GitHub known_hosts entries
- force StrictHostKeyChecking=yes and UserKnownHostsFile for both main and tag pushes
- add a static release workflow regression against StrictHostKeyChecking=no

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/release-workflow-order.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-and-publish.yml"); puts "yaml ok"'\n\nGitHub host keys are from GitHub Docs: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints\n\nFixes ClawPatch finding fnd_sig-feat-config-8bf6e36a2f-b2d14_b26d0d2755.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only SSH hardening for release automation; no runtime app or auth logic changes.
> 
> **Overview**
> Release deploy-key SSH pushes no longer disable host key verification. Both **push release commits to main** and **ensure version tag** steps now write GitHub’s documented `known_hosts` entries, set `UserKnownHostsFile`, and use **`StrictHostKeyChecking=yes`** instead of `no`.
> 
> A new regression test in `tests/release-workflow-order.test.ts` asserts the workflow omits `StrictHostKeyChecking=no`, includes the pinned keys, and wires strict SSH before each `git push`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091a3804fec062bf7944be50807cecae1b0870b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->