### PR TITLE
Fail pnpm lockfile check on unexpected errors

### DIFF
--- a/scripts/check-review-patterns.sh
+++ b/scripts/check-review-patterns.sh
@@ -117,11 +117,17 @@ fi
 if command -v pnpm &>/dev/null; then
   # Check if pnpm-lock.yaml is stale
   # Simple check: does running install change anything?
-  DIFF=$(pnpm install --frozen-lockfile 2>&1 || true)
-  if echo "$DIFF" | grep -qE "ERR_PNPM_FROZEN_LOCKFILE|ERR_PNPM_OUTDATED_LOCKFILE"; then
-    fail "pnpm-lock.yaml is out of sync — run 'pnpm install' and commit the updated lockfile"
-  else
+  PNPM_OUTPUT=""
+  if PNPM_OUTPUT=$(pnpm install --frozen-lockfile 2>&1); then
     echo "  OK: Lock file is in sync"
+  else
+    PNPM_STATUS=$?
+    if echo "$PNPM_OUTPUT" | grep -qE "ERR_PNPM_FROZEN_LOCKFILE|ERR_PNPM_OUTDATED_LOCKFILE"; then
+      fail "pnpm-lock.yaml is out of sync — run 'pnpm install' and commit the updated lockfile"
+    else
+      fail "pnpm lockfile verification failed with exit ${PNPM_STATUS} — inspect 'pnpm install --frozen-lockfile' output"
+      printf '%s\n' "$PNPM_OUTPUT" | sed 's/^/    /' | head -20 || true
+    fi
   fi
 fi
 

--- a/tests/check-review-patterns-script.test.mjs
+++ b/tests/check-review-patterns-script.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+test("check-review-patterns fails non-lockfile pnpm install errors", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-review-patterns-"));
+  const fakeBin = path.join(root, "bin");
+  const fakePnpm = path.join(fakeBin, "pnpm");
+
+  try {
+    await mkdir(fakeBin, { recursive: true });
+    await writeFile(
+      fakePnpm,
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "install" ] && [ "$2" = "--frozen-lockfile" ]; then',
+        '  echo "ERR_PNPM_FETCH_404 simulated registry failure" >&2',
+        "  exit 42",
+        "fi",
+        'echo "unexpected pnpm invocation: $*" >&2',
+        "exit 99",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakePnpm, 0o700);
+
+    const result = spawnSync("bash", ["scripts/check-review-patterns.sh"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+      },
+    });
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    assert.notEqual(result.status, 0, output);
+    assert.match(output, /pnpm lockfile verification failed with exit 42/);
+    assert.match(output, /ERR_PNPM_FETCH_404 simulated registry failure/);
+    assert.doesNotMatch(output, /OK: Lock file is in sync/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- preserve pnpm install --frozen-lockfile exit status in the review-pattern lockfile check
- fail non-lockfile pnpm verification errors instead of reporting the lockfile as in sync
- add a regression with a fake pnpm that exits nonzero with a non-lockfile error

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/check-review-patterns-script.test.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

Fixes ClawPatch finding fnd_sig-feat-config-92d31e00da-b6efa_413a57c52f.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to a CI/preflight shell guard and a focused regression test; no runtime product or security-sensitive logic.
> 
> **Overview**
> The **workspace lockfile check** in `scripts/check-review-patterns.sh` no longer treats every failed `pnpm install --frozen-lockfile` as “in sync” when the stderr doesn’t mention frozen/outdated lockfile errors. It now branches on exit status: success still prints OK; known lockfile mismatch codes get the existing remediation message; **any other failure** fails the script with the exit code and a short excerpt of pnpm output.
> 
> A new **Node test** (`tests/check-review-patterns-script.test.mjs`) prepends a fake `pnpm` that simulates a registry fetch error and asserts the script exits non‑zero, surfaces that message, and does **not** print the misleading “Lock file is in sync” line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit debd85220ad12ccc87eed29af4085ed0b59e02b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->