### PR TITLE
Handle malformed Claude session end cursors

### DIFF
--- a/scripts/hooks/claude-code/engram-session-end.sh
+++ b/scripts/hooks/claude-code/engram-session-end.sh
@@ -97,6 +97,19 @@ read_cursor_file() {
   [ -f "$CURSOR_FILE" ] && cat "$CURSOR_FILE" 2>/dev/null || echo 0
 }
 
+normalize_cursor_value() {
+  RAW_CURSOR_VALUE="$1"
+  case "$RAW_CURSOR_VALUE" in
+    ""|*[!0-9]*)
+      log "session-end[$SESSION_ID]: invalid cursor value; defaulting to 0"
+      echo 0
+      ;;
+    *)
+      echo "$RAW_CURSOR_VALUE"
+      ;;
+  esac
+}
+
 write_cursor_file() {
   NEW_CURSOR_VALUE="$1"
   validate_cursor_file || {
@@ -197,6 +210,7 @@ remove_cursor_file() {
 
   LAST_COUNT=0
   LAST_COUNT="$(read_cursor_file)" || exit 0
+  LAST_COUNT="$(normalize_cursor_value "$LAST_COUNT")"
 
   PAYLOAD="$(python3 - "$TRANSCRIPT_PATH" "$SESSION_ID" "$LAST_COUNT" <<'PYEOF'
 import sys, json

--- a/tests/engram-session-store-hook.test.mjs
+++ b/tests/engram-session-store-hook.test.mjs
@@ -211,3 +211,84 @@ test("codex session store preserves cursor when final-stop observe fails", async
     await rm(fixture.root, { recursive: true, force: true });
   }
 });
+
+test("claude-code session end flushes final messages when cursor is malformed", async () => {
+  const fixture = await makeFixture();
+  const sessionId = `bad-cursor-session-claude-${process.pid}`;
+  const stateDir = path.join(fixture.stateHome, "remnic", "hooks");
+  const cursorPath = path.join(stateDir, `engram-cursor-${sessionId}`);
+  const fakeBin = path.join(fixture.root, "bin");
+  const fakeCurl = path.join(fakeBin, "curl");
+  const capturePath = path.join(fixture.root, "observe-payload.json");
+  const logPath = path.join(fixture.home, ".claude", "logs", "engram-session-store.log");
+
+  try {
+    await mkdir(stateDir, { recursive: true, mode: 0o700 });
+    await mkdir(fakeBin, { recursive: true });
+    await writeFile(cursorPath, "abc\n", "utf8");
+    await writeFile(
+      fixture.transcript,
+      [
+        JSON.stringify({ type: "user", message: { role: "user", content: "first final turn" } }),
+        JSON.stringify({ type: "assistant", message: { role: "assistant", content: "second final turn" } }),
+      ].join("\n") + "\n",
+      "utf8"
+    );
+    await writeFile(
+      fakeCurl,
+      [
+        "#!/usr/bin/env bash",
+        "payload=''",
+        "while [ $# -gt 0 ]; do",
+        "  case \"$1\" in",
+        "    -d)",
+        "      shift",
+        "      payload=\"$1\"",
+        "      ;;",
+        "  esac",
+        "  shift || true",
+        "done",
+        "printf '%s\\n' \"$payload\" > \"$CURL_CAPTURE_PATH\"",
+        "printf '{\"accepted\":2,\"lcmArchived\":0,\"extractionQueued\":true}\\n200\\n'",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(fakeCurl, 0o700);
+
+    const result = spawnSync("bash", ["scripts/hooks/claude-code/engram-session-end.sh"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: fixture.home,
+        XDG_STATE_HOME: fixture.stateHome,
+        OPENCLAW_ENGRAM_ACCESS_TOKEN: "test-token",
+        CURL_CAPTURE_PATH: capturePath,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+      },
+      input: JSON.stringify({
+        session_id: sessionId,
+        transcript_path: fixture.transcript,
+        cwd: process.cwd(),
+      }),
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "{}\n");
+
+    await waitFor(
+      async () => existsSync(capturePath) && !existsSync(cursorPath),
+      "observe payload was not emitted or cursor was not removed"
+    );
+
+    const payload = JSON.parse(await readFile(capturePath, "utf8"));
+    assert.equal(payload.sessionKey, sessionId);
+    assert.deepEqual(payload.messages, [
+      { role: "user", content: "first final turn" },
+      { role: "assistant", content: "second final turn" },
+    ]);
+    assert.match(await readFile(logPath, "utf8"), /invalid cursor value; defaulting to 0/);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- normalize malformed Claude Code SessionEnd cursor contents to 0 before Python payload parsing
- log invalid cursor state distinctly while preserving the final flush safety net
- add a hook-level regression that stubs curl and verifies final messages are still observed

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test --test-name-pattern "claude-code session end flushes final messages when cursor is malformed" tests/engram-session-store-hook.test.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/engram-session-store-hook.test.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

Fixes ClawPatch finding fnd_sig-feat-config-aee11c582e-df9b8_d36e21c254.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in the session-end hook and tests only; no auth or API contract changes beyond safer cursor handling.
> 
> **Overview**
> Fixes **Claude Code SessionEnd** failing to flush remaining transcript messages when the Engram cursor file contains non-numeric text (e.g. `abc`).
> 
> Adds **`normalize_cursor_value`** in `engram-session-end.sh` so empty or non-digit cursor contents are logged (`invalid cursor value; defaulting to 0`) and treated as **0** before the Python payload step calls `int(last_count)`. That keeps the final observe/flush path working instead of aborting on parse errors.
> 
> Adds a hook test that seeds a bad cursor, stubs **`curl`**, and asserts both transcript turns are posted to Engram, the cursor is removed on success, and the invalid-cursor log line appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500e1b9e924ea4f663e75961cde4d87c061f1875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->