### PR TITLE
Validate changelog edits by section ranges

### DIFF
--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -1,7 +1,7 @@
 name: Changelog Guard
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
@@ -17,9 +17,100 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const RELEASE_HEADING_RE = /^## \[(?:Unreleased|v?\d+\.\d+\.\d+)/;
+            const SECTION_HEADING_RE = /^##\s+/;
+
+            function parseAllowedReleaseSections(content) {
+              const lines = content.split(/\r?\n/);
+              const ranges = [];
+
+              for (let index = 0; index < lines.length; index += 1) {
+                if (!RELEASE_HEADING_RE.test(lines[index])) continue;
+
+                let end = lines.length;
+                for (let next = index + 1; next < lines.length; next += 1) {
+                  if (SECTION_HEADING_RE.test(lines[next])) {
+                    end = next;
+                    break;
+                  }
+                }
+                ranges.push({ start: index + 1, end });
+              }
+
+              return ranges;
+            }
+
+            function parseChangedLineNumbers(patch) {
+              const oldLines = [];
+              const newLines = [];
+              let oldLine = 0;
+              let newLine = 0;
+
+              for (const line of patch.split(/\r?\n/)) {
+                const header = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+                if (header) {
+                  oldLine = Number(header[1]);
+                  newLine = Number(header[2]);
+                  continue;
+                }
+
+                if (line.startsWith("\\ No newline")) continue;
+
+                if (line.startsWith("+") && !line.startsWith("+++")) {
+                  newLines.push(newLine);
+                  newLine += 1;
+                  continue;
+                }
+
+                if (line.startsWith("-") && !line.startsWith("---")) {
+                  oldLines.push(oldLine);
+                  oldLine += 1;
+                  continue;
+                }
+
+                if (oldLine > 0 || newLine > 0) {
+                  oldLine += 1;
+                  newLine += 1;
+                }
+              }
+
+              return { oldLines, newLines };
+            }
+
+            function lineInRanges(line, ranges) {
+              return ranges.some((range) => line >= range.start && line <= range.end);
+            }
+
+            function validateChangelogPatch({ patch, baseContent, headContent }) {
+              if (!patch || !patch.trim()) {
+                return { allowed: false, reason: 'CHANGELOG.md patch data is unavailable.' };
+              }
+
+              const changed = parseChangedLineNumbers(patch);
+              const baseRanges = parseAllowedReleaseSections(baseContent ?? '');
+              const headRanges = parseAllowedReleaseSections(headContent ?? '');
+
+              const invalidOld = changed.oldLines.filter((line) => !lineInRanges(line, baseRanges));
+              const invalidNew = changed.newLines.filter((line) => !lineInRanges(line, headRanges));
+
+              if (invalidOld.length > 0 || invalidNew.length > 0) {
+                return {
+                  allowed: false,
+                  reason: 'CHANGELOG.md changes must be inside `## [Unreleased]` or a versioned release section.',
+                };
+              }
+
+              if (changed.oldLines.length === 0 && changed.newLines.length === 0) {
+                return { allowed: false, reason: 'CHANGELOG.md patch did not contain changed lines.' };
+              }
+
+              return { allowed: true };
+            }
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pull_number = context.payload.pull_request.number;
+            const pull = context.payload.pull_request;
 
             const labels = (context.payload.pull_request.labels || []).map(l => (l.name || '').toLowerCase());
             if (labels.includes('skip-changelog')) {
@@ -44,13 +135,37 @@ jobs:
 
             const changelogFile = files.find(f => f.filename === 'CHANGELOG.md');
             const patch = changelogFile?.patch || '';
-            const touchedReleaseSection =
-              patch.includes('## [Unreleased]') ||
-              /## \[v?\d+\.\d+\.\d+/.test(patch);
+            async function readChangelogAt(ref) {
+              const response = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: 'CHANGELOG.md',
+                ref,
+              });
+              const data = response.data;
+              if (Array.isArray(data) || data.type !== 'file' || typeof data.content !== 'string') {
+                throw new Error(`CHANGELOG.md at ${ref} is not a file`);
+              }
+              return Buffer.from(data.content, data.encoding || 'base64').toString('utf8');
+            }
 
-            if (!touchedReleaseSection) {
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${pull.base.sha}...${pull.head.sha}`,
+            });
+            const mergeBaseSha = comparison.data.merge_base_commit?.sha;
+            if (!mergeBaseSha) {
+              throw new Error('Unable to determine PR merge base for CHANGELOG.md validation');
+            }
+
+            const baseContent = await readChangelogAt(mergeBaseSha);
+            const headContent = await readChangelogAt(pull.head.sha);
+            const verdict = validateChangelogPatch({ patch, baseContent, headContent });
+
+            if (!verdict.allowed) {
               core.setFailed(
-                'CHANGELOG.md was edited directly, but the diff does not update `## [Unreleased]` or a versioned release section. Keep normal PRs out of CHANGELOG.md, or edit the actual release section intentionally.',
+                `CHANGELOG.md was edited directly, but ${verdict.reason} Keep normal PRs out of CHANGELOG.md, or edit the actual release section intentionally.`,
               );
               return;
             }

--- a/scripts/changelog-guard.mjs
+++ b/scripts/changelog-guard.mjs
@@ -1,0 +1,92 @@
+const RELEASE_HEADING_RE = /^## \[(?:Unreleased|v?\d+\.\d+\.\d+)/;
+const SECTION_HEADING_RE = /^##\s+/;
+
+export function parseAllowedReleaseSections(content) {
+  const lines = content.split(/\r?\n/);
+  const ranges = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!RELEASE_HEADING_RE.test(lines[index])) continue;
+
+    let end = lines.length;
+    for (let next = index + 1; next < lines.length; next += 1) {
+      if (SECTION_HEADING_RE.test(lines[next])) {
+        end = next;
+        break;
+      }
+    }
+    ranges.push({ start: index + 1, end });
+  }
+
+  return ranges;
+}
+
+export function parseChangedLineNumbers(patch) {
+  const oldLines = [];
+  const newLines = [];
+  let oldLine = 0;
+  let newLine = 0;
+
+  for (const line of patch.split(/\r?\n/)) {
+    const header = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (header) {
+      oldLine = Number(header[1]);
+      newLine = Number(header[2]);
+      continue;
+    }
+
+    if (line.startsWith("\\ No newline")) continue;
+
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      newLines.push(newLine);
+      newLine += 1;
+      continue;
+    }
+
+    if (line.startsWith("-") && !line.startsWith("---")) {
+      oldLines.push(oldLine);
+      oldLine += 1;
+      continue;
+    }
+
+    if (oldLine > 0 || newLine > 0) {
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  return { oldLines, newLines };
+}
+
+function lineInRanges(line, ranges) {
+  return ranges.some((range) => line >= range.start && line <= range.end);
+}
+
+export function validateChangelogPatch({ patch, baseContent, headContent }) {
+  if (!patch || !patch.trim()) {
+    return { allowed: false, reason: "CHANGELOG.md patch data is unavailable." };
+  }
+
+  const changed = parseChangedLineNumbers(patch);
+  const baseRanges = parseAllowedReleaseSections(baseContent ?? "");
+  const headRanges = parseAllowedReleaseSections(headContent ?? "");
+
+  const invalidOld = changed.oldLines.filter((line) => !lineInRanges(line, baseRanges));
+  const invalidNew = changed.newLines.filter((line) => !lineInRanges(line, headRanges));
+
+  if (invalidOld.length > 0 || invalidNew.length > 0) {
+    return {
+      allowed: false,
+      reason:
+        "CHANGELOG.md changes must be inside `## [Unreleased]` or a versioned release section.",
+      invalidOld,
+      invalidNew,
+    };
+  }
+
+  if (changed.oldLines.length === 0 && changed.newLines.length === 0) {
+    return { allowed: false, reason: "CHANGELOG.md patch did not contain changed lines." };
+  }
+
+  return { allowed: true };
+}

--- a/tests/changelog-guard.test.mjs
+++ b/tests/changelog-guard.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { validateChangelogPatch } from "../scripts/changelog-guard.mjs";
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+function changelogWithDeepUnreleasedEntry(extraLine) {
+  const body = Array.from({ length: 20 }, (_, index) => `- Existing unreleased entry ${index + 1}`);
+  if (extraLine) body.splice(14, 0, extraLine);
+
+  return `# Changelog
+
+## [Unreleased]
+
+### Fixed
+${body.join("\n")}
+
+## [v9.3.0] - 2026-06-01
+
+### Fixed
+- Previous release entry.
+`;
+}
+
+test("validateChangelogPatch accepts allowed section edits when the heading is outside the hunk", () => {
+  const baseContent = changelogWithDeepUnreleasedEntry();
+  const headContent = changelogWithDeepUnreleasedEntry("- Added deep unreleased fix.");
+  const patch = `@@ -17,6 +17,7 @@
+ - Existing unreleased entry 12
+ - Existing unreleased entry 13
+ - Existing unreleased entry 14
++- Added deep unreleased fix.
+ - Existing unreleased entry 15
+ - Existing unreleased entry 16
+ - Existing unreleased entry 17`;
+
+  assert.deepEqual(validateChangelogPatch({ patch, baseContent, headContent }), { allowed: true });
+});
+
+test("validateChangelogPatch rejects edits outside release sections", () => {
+  const baseContent = `# Changelog
+
+Intro text.
+
+## Other Notes
+
+- Internal maintenance.
+
+## [Unreleased]
+
+- Valid future entry.
+`;
+  const headContent = baseContent.replace("- Internal maintenance.", "- Changed internal maintenance.");
+  const patch = [
+    "@@ -5,7 +5,7 @@",
+    " ## Other Notes",
+    " ",
+    "-- Internal maintenance.",
+    "+- Changed internal maintenance.",
+    " ",
+    " ## [Unreleased]",
+  ].join("\n");
+
+  const verdict = validateChangelogPatch({ patch, baseContent, headContent });
+
+  assert.equal(verdict.allowed, false);
+  assert.deepEqual(verdict.invalidOld, [7]);
+  assert.deepEqual(verdict.invalidNew, [7]);
+});
+
+test("changelog guard workflow runs from the trusted target context", async () => {
+  const workflow = await readFile(".github/workflows/changelog-guard.yml", "utf8");
+
+  assert.match(workflow, /\non:\n  pull_request_target:/);
+  assert.doesNotMatch(workflow, /\n  pull_request:\n/);
+  assert.doesNotMatch(workflow, /actions\/checkout/);
+});
+
+async function loadWorkflowScript() {
+  const workflow = await readFile(".github/workflows/changelog-guard.yml", "utf8");
+  const lines = workflow.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === "script: |");
+  assert.notEqual(start, -1, "workflow script block not found");
+
+  const scriptLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.startsWith("            ")) {
+      scriptLines.push(line.slice(12));
+      continue;
+    }
+    if (line.trim() === "") {
+      scriptLines.push("");
+      continue;
+    }
+    break;
+  }
+
+  return scriptLines.join("\n");
+}
+
+async function runWorkflowScript({ patch, baseContent, headContent }) {
+  const script = await loadWorkflowScript();
+  const notices = [];
+  let failure = "";
+
+  const github = {
+    paginate: async () => [{ filename: "CHANGELOG.md", patch }],
+    rest: {
+      pulls: {
+        listFiles: async () => {
+          throw new Error("listFiles should be called through paginate");
+        },
+      },
+      repos: {
+        compareCommitsWithBasehead: async () => ({
+          data: { merge_base_commit: { sha: "merge-base-sha" } },
+        }),
+        getContent: async ({ path, ref }) => {
+          assert.equal(path, "CHANGELOG.md");
+          const content = ref === "head-sha" ? headContent : baseContent;
+          return {
+            data: {
+              type: "file",
+              content: Buffer.from(content).toString("base64"),
+              encoding: "base64",
+            },
+          };
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "owner", repo: "repo" },
+    payload: {
+      pull_request: {
+        number: 123,
+        labels: [],
+        base: { sha: "base-sha" },
+        head: { sha: "head-sha" },
+      },
+    },
+  };
+  const core = {
+    notice(message) {
+      notices.push(message);
+    },
+    setFailed(message) {
+      failure = message;
+    },
+  };
+
+  await AsyncFunction("github", "context", "core", "Buffer", script)(
+    github,
+    context,
+    core,
+    Buffer,
+  );
+
+  return { notices, failure };
+}
+
+test("changelog guard workflow accepts omitted-heading edits inside release sections", async () => {
+  const baseContent = changelogWithDeepUnreleasedEntry();
+  const headContent = changelogWithDeepUnreleasedEntry("- Added deep unreleased fix.");
+  const patch = `@@ -17,6 +17,7 @@
+ - Existing unreleased entry 12
+ - Existing unreleased entry 13
+ - Existing unreleased entry 14
++- Added deep unreleased fix.
+ - Existing unreleased entry 15
+ - Existing unreleased entry 16
+ - Existing unreleased entry 17`;
+
+  const result = await runWorkflowScript({ patch, baseContent, headContent });
+
+  assert.equal(result.failure, "");
+  assert.deepEqual(result.notices, [
+    "CHANGELOG.md edited directly in a release section; changelog guard passed.",
+  ]);
+});
+
+test("changelog guard workflow rejects edits outside release sections", async () => {
+  const baseContent = `# Changelog
+
+Intro text.
+
+## Other Notes
+
+- Internal maintenance.
+
+## [Unreleased]
+
+- Valid future entry.
+`;
+  const headContent = baseContent.replace("- Internal maintenance.", "- Changed internal maintenance.");
+  const patch = `@@ -5,7 +5,7 @@
+ ## Other Notes
+ 
+-- Internal maintenance.
++- Changed internal maintenance.
+ 
+ ## [Unreleased]`;
+
+  const result = await runWorkflowScript({ patch, baseContent, headContent });
+
+  assert.match(result.failure, /CHANGELOG\.md changes must be inside/);
+  assert.deepEqual(result.notices, []);
+});


### PR DESCRIPTION
## Summary
- move changelog guard release-section detection into a testable helper
- fetch full base/head CHANGELOG.md contents and validate changed hunk line numbers against allowed section ranges
- add omitted-heading hunk and outside-section regression tests

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --test tests/changelog-guard.test.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

Fixes ClawPatch finding fnd_sig-feat-config-b086d8627a-b311a_187daf20a4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching to `pull_request_target` changes CI trust boundaries for PR workflows; the new API calls and stricter validation could block legitimate changelog edits if line mapping is wrong.
> 
> **Overview**
> **Tightens the changelog guard** so `CHANGELOG.md` edits are allowed only inside `## [Unreleased]` or a versioned `## [vX.Y.Z]` block, even when the diff hunk does not include those headings.
> 
> The workflow no longer passes if the patch merely mentions a release heading. It loads `CHANGELOG.md` at the PR merge base and head, maps allowed section line ranges, parses changed line numbers from the patch, and fails when any edit falls outside those ranges. Fail messages now include the specific validation reason.
> 
> The guard trigger moves from `pull_request` to **`pull_request_target`** (tests assert no `checkout` of untrusted PR code). Shared helpers live in `scripts/changelog-guard.mjs`, with regression tests for deep unreleased edits, edits outside release sections, and end-to-end workflow script behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 439e4a5dcc92af18916e6fce15bc5d57e8af9dd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->