### PR TITLE
Verify Gitleaks download checksum

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -24,7 +24,9 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="8.24.3"
+          EXPECTED_SHA256="9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c"
           curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" -o gitleaks.tar.gz
+          echo "${EXPECTED_SHA256}  gitleaks.tar.gz" | sha256sum -c -
           tar -xzf gitleaks.tar.gz
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
 

--- a/tests/gitleaks-workflow.test.mjs
+++ b/tests/gitleaks-workflow.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(".github/workflows/gitleaks.yml", "utf8");
+
+test("Gitleaks workflow verifies downloaded scanner before extraction", () => {
+  assert.match(
+    workflow,
+    /EXPECTED_SHA256="9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c"/,
+  );
+  assert.match(workflow, /sha256sum -c -/);
+
+  const checksumIndex = workflow.indexOf("sha256sum -c -");
+  const extractIndex = workflow.indexOf("tar -xzf gitleaks.tar.gz");
+  const installIndex = workflow.indexOf("sudo install -m 0755 gitleaks");
+
+  assert.ok(checksumIndex > -1, "checksum verification is missing");
+  assert.ok(extractIndex > -1, "archive extraction is missing");
+  assert.ok(installIndex > -1, "binary install is missing");
+  assert.ok(checksumIndex < extractIndex, "checksum must run before extraction");
+  assert.ok(checksumIndex < installIndex, "checksum must run before install");
+});


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-config-c22433fccf-1968c_732981824a`.

Changes:
- Verify the pinned Gitleaks 8.24.3 Linux x64 tarball with the upstream SHA256 before extraction/install.
- Add a workflow policy test that enforces checksum verification before extraction/install.

Verification:
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --test tests/gitleaks-workflow.test.mjs`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only supply-chain hardening for the Gitleaks install step; no runtime app or auth/data paths change.
> 
> **Overview**
> Hardens the **Secret Scan** workflow so the pinned Gitleaks **8.24.3** Linux tarball is verified with a fixed **SHA256** via `sha256sum -c -` **before** `tar` extraction and `sudo install`, addressing unsigned/unverified download risk (ClawPatch finding).
> 
> Adds **`tests/gitleaks-workflow.test.mjs`**, which asserts the workflow contains the expected hash, uses checksum verification, and that verification runs ahead of extract/install so the policy cannot regress silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20260541ae3668d1ef2aa49c2434508a1449b575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->