### PR TITLE
Preserve mixed OpenAI message parts

### DIFF
--- a/packages/remnic-core/src/message-parts/index.ts
+++ b/packages/remnic-core/src/message-parts/index.ts
@@ -143,6 +143,12 @@ export function parseOpenAiMessageParts(
     }
     if (type === "message") {
       for (const block of gatherContentBlocks(item.content)) {
+        if (isOpenAiResponseItem(block)) {
+          parts.push(
+            ...parseOpenAiMessageParts([block]).map(({ ordinal: _ordinal, ...part }) => part),
+          );
+          continue;
+        }
         const text = asNonEmptyString(block.text ?? block.content);
         if (text) parts.push(makePart("text", { type, text }, { filePath: firstFilePath(text) }));
       }

--- a/packages/remnic-core/src/message-parts/message-parts.test.ts
+++ b/packages/remnic-core/src/message-parts/message-parts.test.ts
@@ -46,6 +46,36 @@ describe("message-parts parsers", () => {
     assert.equal(parts[0]!.filePath, "src/config.ts");
   });
 
+  it("preserves OpenAI message content arrays with mixed tool and result blocks", () => {
+    const parts = parseOpenAiMessageParts({
+      type: "message",
+      content: [
+        { type: "output_text", text: "Updated src/a.ts" },
+        {
+          type: "function_call",
+          name: "apply_patch",
+          arguments: JSON.stringify({
+            patch: "*** Begin Patch\n*** Update File: src/a.ts\n*** End Patch",
+          }),
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: "Patched src/a.ts",
+        },
+      ],
+    });
+
+    assert.equal(parts.length, 3);
+    assert.equal(parts[0]!.kind, "text");
+    assert.equal(parts[0]!.filePath, "src/a.ts");
+    assert.equal(parts[1]!.kind, "patch");
+    assert.equal(parts[1]!.toolName, "apply_patch");
+    assert.equal(parts[1]!.filePath, "src/a.ts");
+    assert.equal(parts[2]!.kind, "tool_result");
+    assert.equal(parts[2]!.filePath, "src/a.ts");
+  });
+
   it("infers top-level OpenAI response item arrays before Anthropic arrays", () => {
     const parts = parseMessageParts([
       {


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-02343f97d8-dea1_ade74905b5`.

Changes:
- Preserve nested OpenAI response items inside `type: "message"` content arrays instead of parsing only text blocks.
- Add regression coverage for mixed `output_text`, `function_call`, and `function_call_output` blocks in one OpenAI message.

Verification:
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/remnic-core/src/message-parts/message-parts.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run test:entity-hardening`

Note: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm turbo run test --filter @remnic/core` was also attempted and failed on the existing unrelated macOS `/tmp` symlink assertion in `access-service-namespace.test.ts`; the same target fails with `TMPDIR=/private/tmp` because that test explicitly exercises `/tmp`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to OpenAI message-part parsing with a focused unit test; no auth, persistence, or API surface changes.
> 
> **Overview**
> Fixes **OpenAI message parsing** when a single `type: "message"` item carries a **mixed `content` array** (e.g. `output_text`, `function_call`, and `function_call_output` in one message).
> 
> Previously, blocks inside that array were treated as plain text carriers only, so **tool calls and tool results nested in message content were dropped**. The parser now detects nested OpenAI response items via `isOpenAiResponseItem` and **reuses `parseOpenAiMessageParts`** on those blocks so patches, tool calls, and tool results are preserved with file-path inference.
> 
> Adds a **regression test** for the mixed-block message shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4683fd0b14b05cdf620a0bf66755ed1d602fbea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->