### PR TITLE
Create SQLite export parent directory

### DIFF
--- a/packages/remnic-core/src/transfer/export-sqlite.ts
+++ b/packages/remnic-core/src/transfer/export-sqlite.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { mkdir } from "node:fs/promises";
 import { SQLITE_SCHEMA_VERSION, SQLITE_TABLES_SQL } from "./sqlite-schema.js";
 import { listFilesRecursive, readUtf8FileStrict, toPosixRelPath } from "./fs-utils.js";
 import { openBetterSqlite3 } from "../runtime/better-sqlite.js";
@@ -25,6 +26,8 @@ export async function exportSqlite(opts: ExportSqliteOptions): Promise<void> {
     const { content, sha256, bytes } = await readUtf8FileStrict(abs);
     rows.push({ rel: relPosix, bytes, sha256, content });
   }
+
+  await mkdir(path.dirname(outAbs), { recursive: true });
 
   const db = openBetterSqlite3(outAbs);
   try {

--- a/tests/export-import-sqlite.test.ts
+++ b/tests/export-import-sqlite.test.ts
@@ -78,6 +78,24 @@ test("sqlite re-export to an existing archive removes stale rows", async () => {
   await assertPathMissing(path.join(targetDir, "b.md"));
 });
 
+test("sqlite export creates missing output parent directories", async () => {
+  const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
+  await writeFixtureMemoryDir(memDir);
+
+  const outRoot = await mkdtemp(path.join(os.tmpdir(), "engram-sqlite-"));
+  const sqliteFile = path.join(outRoot, "new-parent", "remnic", "export.sqlite");
+
+  await exportSqlite({ memoryDir: memDir, outFile: sqliteFile, pluginVersion: "2.2.3" });
+
+  const db = openBetterSqlite3(sqliteFile);
+  try {
+    const count = db.prepare("SELECT COUNT(*) AS count FROM files").get() as { count: number };
+    assert.ok(count.count > 0);
+  } finally {
+    db.close();
+  }
+});
+
 test("sqlite export rejects non-UTF8 files instead of emitting unverifiable v1 checksums", async () => {
   const memDir = await mkdtemp(path.join(os.tmpdir(), "engram-mem-"));
   await mkdir(path.join(memDir, "binary-lifecycle"), { recursive: true });


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-09a0248c5b-cdd3_fbcff62c88`.

Changes:
- Create the SQLite export output parent directory before opening the database file.
- Add regression coverage for exporting to a missing nested parent path.

Verification:
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/export-import-sqlite.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small filesystem guard in the transfer export path; no auth, schema, or import behavior changes.
> 
> **Overview**
> **SQLite export** now creates the output file’s parent path with `mkdir(..., { recursive: true })` before opening the database, so exports to nested paths (e.g. `new-parent/remnic/export.sqlite`) no longer fail when those folders are missing.
> 
> A regression test asserts that exporting to a non-existent nested path produces a valid SQLite file with exported rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5c4849748fafd8ccdcbe5e45e5e72a89c99dabb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->