### PR TITLE
Preserve rollback file modes

### DIFF
--- a/packages/remnic-core/src/migrate/from-engram.ts
+++ b/packages/remnic-core/src/migrate/from-engram.ts
@@ -30,6 +30,7 @@ interface RollbackManifestEntry {
   backupPath?: string;
   createdByMigration?: boolean;
   contentHash?: string;
+  mode?: number;
 }
 
 interface RollbackManifest {
@@ -42,6 +43,7 @@ interface ValidatedRollbackManifestEntry extends RollbackManifestEntry {
   targetPath: string;
   backupPath?: string;
   contentHash?: string;
+  mode?: number;
 }
 
 export interface MigrationOptions {
@@ -308,11 +310,19 @@ function parseRollbackManifestEntry(raw: unknown, index: number): RollbackManife
   if (raw.contentHash !== undefined && (typeof raw.contentHash !== "string" || !/^[a-f0-9]{64}$/u.test(raw.contentHash))) {
     throw new Error(`rollback manifest entry ${index} has an invalid contentHash`);
   }
+  const rawMode = raw.mode;
+  if (
+    rawMode !== undefined &&
+    (typeof rawMode !== "number" || !Number.isInteger(rawMode) || rawMode < 0 || rawMode > 0o777)
+  ) {
+    throw new Error(`rollback manifest entry ${index} has an invalid mode`);
+  }
   return {
     targetPath: raw.targetPath,
     ...(raw.backupPath === undefined ? {} : { backupPath: raw.backupPath }),
     ...(raw.createdByMigration === undefined ? {} : { createdByMigration: raw.createdByMigration }),
     ...(raw.contentHash === undefined ? {} : { contentHash: raw.contentHash }),
+    ...(rawMode === undefined ? {} : { mode: rawMode }),
   };
 }
 
@@ -486,6 +496,7 @@ async function validateRollbackManifestEntries(
       ...(backupPath === undefined ? {} : { backupPath }),
       ...(entry.createdByMigration === undefined ? {} : { createdByMigration: entry.createdByMigration }),
       ...(entry.contentHash === undefined ? {} : { contentHash: entry.contentHash }),
+      ...(entry.mode === undefined ? {} : { mode: entry.mode }),
     });
   }
 
@@ -697,14 +708,16 @@ async function backupFile(
   }
   const backupPath = connectorBackupPathForTarget(targetPath, homeDir);
   await ensureParent(backupPath);
+  const originalMode = isRemnicTokenStorePath(targetPath, homeDir)
+    ? TOKEN_STORE_MODE
+    : (await stat(targetPath)).mode & 0o777;
   if (isRemnicTokenStorePath(targetPath, homeDir)) {
     await writeOwnerOnlyFile(backupPath, originalContent);
   } else {
-    const originalMode = (await stat(targetPath)).mode & 0o777;
     await writeFile(backupPath, originalContent, { encoding: "utf8", mode: originalMode });
     await chmod(backupPath, originalMode);
   }
-  manifest.entries.push({ targetPath, backupPath });
+  manifest.entries.push({ targetPath, backupPath, mode: originalMode });
   await persistManifest?.();
 }
 
@@ -990,9 +1003,10 @@ export async function rollbackFromEngramMigration(options?: MigrationOptions): P
       await assertExistingRegularFileNoFollow(entry.backupPath, "rollback manifest backup");
       await ensureParent(entry.targetPath);
       await copyFile(entry.backupPath, entry.targetPath);
-      if (isRemnicTokenStorePath(entry.targetPath, homeDir)) {
-        await secureTokenFilePermissions(entry.targetPath);
-      }
+      const restoreMode = isRemnicTokenStorePath(entry.targetPath, homeDir)
+        ? TOKEN_STORE_MODE
+        : entry.mode ?? ((await lstat(entry.backupPath)).mode & 0o777);
+      await chmod(entry.targetPath, restoreMode);
       restored.push(entry.targetPath);
       continue;
     }

--- a/tests/remnic-migration.test.ts
+++ b/tests/remnic-migration.test.ts
@@ -851,6 +851,63 @@ test("rollbackFromEngramMigration restores backed up connector configs and remov
   await assertFileMode(claudeConfig, 0o644);
 });
 
+test("rollbackFromEngramMigration restores backed up connector config permissions", {
+  skip: process.platform === "win32",
+}, async () => {
+  const homeDir = await makeTempHome("remnic-migrate-rollback-mode-");
+  const cwd = path.join(homeDir, "repo");
+  const claudeConfig = path.join(cwd, "packages", "plugin-claude-code", ".mcp.json");
+  const legacyRoot = path.join(homeDir, ".engram");
+
+  await mkdir(legacyRoot, { recursive: true });
+  await mkdir(path.dirname(claudeConfig), { recursive: true });
+  await writeFile(path.join(legacyRoot, "tokens.json"), JSON.stringify({ tokens: [] }), "utf8");
+  await writeFile(
+    claudeConfig,
+    JSON.stringify({
+      mcpServers: {
+        engram: {
+          headers: {
+            Authorization: "Bearer {{ENGRAM_TOKEN}}",
+          },
+        },
+      },
+    }),
+    "utf8",
+  );
+  await setModeIfPosix(claudeConfig, 0o600);
+
+  await migrateFromEngram({
+    homeDir,
+    cwd,
+    quiet: true,
+    connectorConfigPaths: [claudeConfig],
+  });
+
+  const manifest = JSON.parse(await readFile(path.join(homeDir, ".remnic", ".rollback.json"), "utf8")) as {
+    entries: Array<{ targetPath: string; backupPath?: string; mode?: number }>;
+  };
+  const configEntry = manifest.entries.find((entry) => entry.targetPath === claudeConfig);
+  assert.equal(configEntry?.mode, 0o600);
+
+  await writeFile(claudeConfig, "mode drift\n", "utf8");
+  await setModeIfPosix(claudeConfig, 0o644);
+
+  const rollback = await rollbackFromEngramMigration({
+    homeDir,
+    cwd,
+    quiet: true,
+  });
+
+  assert.ok(rollback.restored.includes(claudeConfig));
+  const restoredConfig = JSON.parse(await readFile(claudeConfig, "utf8")) as {
+    mcpServers: Record<string, unknown>;
+  };
+  assert.ok(restoredConfig.mcpServers.engram);
+  assert.equal(restoredConfig.mcpServers.remnic, undefined);
+  await assertFileMode(claudeConfig, 0o600);
+});
+
 test("rollbackFromEngramMigration restores repo connector configs from a different cwd", async () => {
   const homeDir = await makeTempHome("remnic-migrate-repo-rollback-home-");
   const rollbackCwd = await makeTempHome("remnic-migrate-repo-rollback-other-cwd-");


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-10121b507d-2f91_858dbbc1ba`.

Changes:
- Store original file modes in migration rollback manifest backup entries.
- Validate manifest mode values and chmod restored files to the recorded mode, while keeping Remnic token stores owner-only.
- Add regression coverage for restoring a connector config whose permissions drifted before rollback.

Verification:
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/remnic-migration.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core build`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b466dfc6286df3b1ba9c47ff2417cda4d704a25e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->