### PR TITLE
Avoid overeager graph edge decay cron

### DIFF
--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -388,40 +388,50 @@ export async function ensureGraphEdgeDecayCron(
 
   const scheduleLabel = graphEdgeDecayScheduleLabel(scheduleExpr);
 
-  return ensureCronJob(jobsPath, GRAPH_EDGE_DECAY_CRON_ID, () => ({
-    id: GRAPH_EDGE_DECAY_CRON_ID,
-    agentId,
-    // Schedule label reflects the actual cron expression (`daily` /
-    // `weekly` / `custom`) so cron dashboards do not show "weekly"
-    // when the schedule is in fact daily — Cursor review on PR #729.
-    name: `Remnic Graph Edge Decay (${scheduleLabel})`,
-    enabled: true,
-    schedule: {
-      kind: "cron",
-      expr: scheduleExpr,
-      tz: options.timezone,
+  return ensureCronJob(
+    jobsPath,
+    GRAPH_EDGE_DECAY_CRON_ID,
+    () => ({
+      id: GRAPH_EDGE_DECAY_CRON_ID,
+      agentId,
+      // Schedule label reflects the actual cron expression (`daily` /
+      // `weekly` / `custom`) so cron dashboards do not show "weekly"
+      // when the schedule is in fact daily — Cursor review on PR #729.
+      name: `Remnic Graph Edge Decay (${scheduleLabel})`,
+      enabled: true,
+      schedule: {
+        kind: "cron",
+        expr: scheduleExpr,
+        tz: options.timezone,
+      },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        timeoutSeconds: 900,
+        thinking: "off",
+        message:
+          "You are OpenClaw automation. Call tool `engram.graph_edge_decay_run` with empty params. " +
+          "If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
+      },
+      delivery: { mode: "none" },
+    }),
+    {
+      updateExisting: true,
+      updateFields: ["name", "schedule"],
     },
-    sessionTarget: "isolated",
-    wakeMode: "now",
-    payload: {
-      kind: "agentTurn",
-      timeoutSeconds: 900,
-      thinking: "off",
-      message:
-        "You are OpenClaw automation. Call tool `engram.graph_edge_decay_run` with empty params. " +
-        "If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
-    },
-    delivery: { mode: "none" },
-  }));
+  );
 }
 
 /**
  * Pick a cron expression that approximates a cadence in milliseconds.
  *
- * - cadence < 7 days → daily at 04:13 (sub-daily cadence is not natively
- *   expressible in 5-field cron without `*\/N` patterns; daily is the
- *   safe upper bound that won't trip the cron more often than requested).
- * - cadence ≥ 7 days → weekly on Sunday 04:13.
+ * - cadence <= 1 day → daily at 04:13. Sub-daily cadence is not natively
+ *   expressible in 5-field cron without hour/minute step patterns; daily
+ *   preserves the previous conservative behavior for those values.
+ * - cadence > 1 day → weekly on Sunday 04:13. Multi-day intervals like
+ *   2-6 days cannot be represented accurately by a portable 5-field cron
+ *   expression, and daily would run more often than requested.
  *
  * Operators who need finer-grained control should set `scheduleExpr`
  * directly via `ensureGraphEdgeDecayCron`.
@@ -431,7 +441,7 @@ export function graphEdgeDecayCadenceToCronExpr(cadenceMs: number): string {
     return "13 4 * * 0";
   }
   const day = 24 * 60 * 60 * 1000;
-  if (cadenceMs < 7 * day) return "13 4 * * *";
+  if (cadenceMs <= day) return "13 4 * * *";
   return "13 4 * * 0";
 }
 

--- a/tests/memory-governance-cron.test.ts
+++ b/tests/memory-governance-cron.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import {
   ensureDaySummaryCron,
+  ensureGraphEdgeDecayCron,
+  graphEdgeDecayCadenceToCronExpr,
   ensureNightlyGovernanceCron,
   ensureProceduralMiningCron,
   ensurePatternReinforcementCron,
@@ -116,6 +118,75 @@ test("pattern reinforcement cron registers once and references engram.pattern_re
     // Cron expression must offset from sibling crons.
     assert.equal(job.schedule.expr, "53 4 * * 0");
     assert.match(job.payload.message, /engram\.pattern_reinforcement_run/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("graph edge decay cadence maps to non-overeager cron expressions", () => {
+  const day = 24 * 60 * 60 * 1000;
+
+  assert.equal(graphEdgeDecayCadenceToCronExpr(Number.NaN), "13 4 * * 0");
+  assert.equal(graphEdgeDecayCadenceToCronExpr(0), "13 4 * * 0");
+  assert.equal(graphEdgeDecayCadenceToCronExpr(-day), "13 4 * * 0");
+
+  assert.equal(graphEdgeDecayCadenceToCronExpr(60 * 60 * 1000), "13 4 * * *");
+  assert.equal(graphEdgeDecayCadenceToCronExpr(day), "13 4 * * *");
+
+  assert.equal(graphEdgeDecayCadenceToCronExpr(2 * day), "13 4 * * 0");
+  assert.equal(graphEdgeDecayCadenceToCronExpr(6 * day), "13 4 * * 0");
+  assert.equal(graphEdgeDecayCadenceToCronExpr(7 * day), "13 4 * * 0");
+  assert.equal(graphEdgeDecayCadenceToCronExpr(30 * day), "13 4 * * 0");
+});
+
+test("graph edge decay cron reconciles an existing overeager daily schedule", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "engram-graph-edge-decay-cron-"));
+  const jobsPath = path.join(tempDir, "jobs.json");
+
+  try {
+    await writeFile(
+      jobsPath,
+      JSON.stringify({
+        version: 1,
+        jobs: [
+          {
+            id: "engram-graph-edge-decay",
+            agentId: "main",
+            name: "Remnic Graph Edge Decay (daily)",
+            enabled: true,
+            schedule: {
+              kind: "cron",
+              expr: "13 4 * * *",
+              tz: "UTC",
+            },
+            payload: {
+              kind: "agentTurn",
+              message: "keep payload",
+            },
+          },
+        ],
+      }, null, 2) + "\n",
+      "utf-8",
+    );
+
+    const result = await ensureGraphEdgeDecayCron(jobsPath, {
+      timezone: "UTC",
+      scheduleExpr: "13 4 * * 0",
+    });
+    assert.equal(result.created, false);
+
+    const parsed = JSON.parse(await readFile(jobsPath, "utf-8")) as {
+      jobs: Array<{ id: string; name: string; schedule: { expr: string; tz: string }; payload: { message: string } }>;
+    };
+    const job = parsed.jobs.find((candidate) => candidate.id === "engram-graph-edge-decay");
+    assert.ok(job);
+    assert.equal(job.name, "Remnic Graph Edge Decay (weekly)");
+    assert.deepEqual(job.schedule, {
+      kind: "cron",
+      expr: "13 4 * * 0",
+      tz: "UTC",
+    });
+    assert.equal(job.payload.message, "keep payload");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-258e0b24d6-7bd4_a143321e56`.

Changes:
- Map graph-edge decay cadences greater than one day to the weekly cron fallback instead of daily.
- Keep sub-daily and daily cadences on the existing daily schedule.
- Add focused coverage for invalid, zero, negative, sub-daily, daily, multi-day, weekly, and longer cadences.

Verification:
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/memory-governance-cron.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scheduling-only maintenance cron changes with tests; may change how often graph edge decay runs for multi-day cadence configs.
> 
> **Overview**
> Fixes graph edge decay cron mapping so **cadences longer than one day** use the weekly fallback (`13 4 * * 0`) instead of running **daily**, which was too frequent for multi-day intervals (e.g. 2–6 days). Sub-daily and up-to-one-day cadences still map to the daily expression.
> 
> **`ensureGraphEdgeDecayCron`** now registers with **`updateExisting: true`** and updates only **`name`** and **`schedule`** on existing jobs, so deployments can **reconcile** mislabeled or overeager schedules (e.g. daily → weekly) **without replacing** the job payload.
> 
> Adds tests pass for **`graphEdgeDecayCadenceToCronExpr`** (invalid/zero/negative, sub-daily, daily, multi-day) and a test that an existing daily job is updated to weekly while preserving payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816cb30f1bea2aef3013fb9a82e81272cabde75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->