### PR TITLE
Map inspector action provenance by recall result

### DIFF
--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -75,7 +75,7 @@ export function buildChatGptMemoryInspectorActionRequest(
   const provenances = buildRecallProvenances(recall, xray);
   const hasUnsafeOrMissingProvenance = provenances.some(
     (provenance) => provenance.safeToUse === false || provenance.safety === "blocked",
-  );
+  ) || provenances.length < recall.count;
 
   const request: ActionConfidenceRequest = {
     intendedAction: `Use Remnic memory to answer: ${input.query}`,

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -72,12 +72,10 @@ export function buildChatGptMemoryInspectorActionRequest(
   recall: EngramAccessRecallResponse,
   xray: RecallXraySnapshot | null,
 ): ActionConfidenceRequest {
-  const provenances = xray === null
-    ? recall.results.map(missingRecallProvenance)
-    : xray.results.map((result) => result.provenance ?? missingProvenance(result));
+  const provenances = buildRecallProvenances(recall, xray);
   const hasUnsafeOrMissingProvenance = provenances.some(
     (provenance) => provenance.safeToUse === false || provenance.safety === "blocked",
-  ) || provenances.length < recall.count;
+  );
 
   const request: ActionConfidenceRequest = {
     intendedAction: `Use Remnic memory to answer: ${input.query}`,
@@ -117,15 +115,7 @@ export function buildChatGptMemoryInspectorResult(
   actionConfidence: ActionConfidenceResult,
 ): RemnicChatGptMemoryInspectorResult {
   const xrayUnavailable = xray === null;
-  const xrayById = new Map<string, RecallXrayResult>();
-  const xrayByPath = new Map<string, RecallXrayResult>();
-  for (const result of xray?.results ?? []) {
-    xrayById.set(result.memoryId, result);
-    xrayByPath.set(result.path, result);
-  }
-  const matchXrayResult = (summary: EngramAccessRecallResponse["results"][number]) =>
-    (summary.path ? xrayByPath.get(summary.path) : undefined)
-    ?? xrayById.get(summary.id);
+  const matchXrayResult = buildXrayResultMatcher(xray);
   const matchedXrayResults = recall.results.map(matchXrayResult);
 
   const memories = recall.results.slice(0, 8).map((summary) => {
@@ -375,6 +365,40 @@ function average(values: number[]): number | undefined {
   return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
+function buildRecallProvenances(
+  recall: EngramAccessRecallResponse,
+  xray: RecallXraySnapshot | null,
+): RetrievedMemoryProvenance[] {
+  if (xray === null) {
+    return recall.results.map(missingRecallProvenance);
+  }
+  const matchXrayResult = buildXrayResultMatcher(xray);
+  return recall.results.map((summary) => {
+    const result = matchXrayResult(summary);
+    if (result === undefined) {
+      return missingXrayResultProvenance(summary);
+    }
+    return result.provenance ?? missingProvenance(result);
+  });
+}
+
+function buildXrayResultMatcher(
+  xray: RecallXraySnapshot | null,
+): (summary: EngramAccessRecallResponse["results"][number]) => RecallXrayResult | undefined {
+  const xrayById = new Map<string, RecallXrayResult>();
+  const xrayByPath = new Map<string, RecallXrayResult>();
+  for (const result of xray?.results ?? []) {
+    xrayById.set(result.memoryId, result);
+    xrayByPath.set(result.path, result);
+  }
+  return (summary) => {
+    if (summary.path) {
+      return xrayByPath.get(summary.path);
+    }
+    return xrayById.get(summary.id);
+  };
+}
+
 function missingProvenance(result: RecallXrayResult): RetrievedMemoryProvenance {
   return {
     source: "unknown",
@@ -388,6 +412,24 @@ function missingProvenance(result: RecallXrayResult): RetrievedMemoryProvenance 
     safeToUse: false,
     safety: "blocked",
     safetyReasons: ["X-ray provenance was missing for this memory."],
+  };
+}
+
+function missingXrayResultProvenance(
+  summary: EngramAccessRecallResponse["results"][number],
+): RetrievedMemoryProvenance {
+  return {
+    source: "unknown",
+    scope: "unknown",
+    userContextScopes: [],
+    retrievalReason: `X-ray result missing for ${summary.path || summary.id}`,
+    confidence: 0,
+    stale: false,
+    corrected: false,
+    correctionState: "none",
+    safeToUse: false,
+    safety: "blocked",
+    safetyReasons: ["X-ray result was missing for this recalled memory."],
   };
 }
 

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -932,3 +932,68 @@ test("ChatGPT Apps inspector action confidence blocks recalled memories missing 
     /X-ray result was missing/,
   );
 });
+
+test("ChatGPT Apps inspector action confidence stays partial when recall count exceeds summaries", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "safe work detail",
+    count: 2,
+    memoryIds: ["mem-safe", "mem-unlisted"],
+    results: [
+      {
+        id: "mem-safe",
+        path: "work/mem-safe.md",
+        category: "preference",
+        status: "active",
+        tags: [],
+        preview: "safe work detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const xray = {
+    schemaVersion: "1",
+    query: "show preferences",
+    snapshotId: "snap-short-summaries",
+    capturedAt: 1_779_000_000_000,
+    tierExplain: null,
+    results: [
+      {
+        memoryId: "mem-safe",
+        path: "work/mem-safe.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.8 },
+        admittedBy: ["test"],
+        provenance: {
+          source: "conversation",
+          scope: "namespace:work",
+          userContextScopes: ["work"],
+          retrievalReason: "test",
+          confidence: 0.8,
+          stale: false,
+          corrected: false,
+          correctionState: "none",
+          safeToUse: true,
+          safety: "safe",
+          safetyReasons: [],
+        },
+      },
+    ],
+    filters: [],
+    budget: { chars: 4096, used: 100 },
+    namespace: "work",
+  } satisfies import("../src/recall-xray.js").RecallXraySnapshot;
+
+  const actionRequest = buildChatGptMemoryInspectorActionRequest(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    xray,
+  );
+
+  assert.equal(actionRequest.contextReadiness, "partial");
+  assert.equal(actionRequest.confidence, 0.8);
+  assert.equal(actionRequest.retrievedMemories?.length, 1);
+});

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -852,3 +852,83 @@ test("ChatGPT Apps inspector rejects malformed currentContextScopes before servi
   assert.match(resultText(response), /currentContextScopes must be an array of strings/);
   assert.deepEqual(capture, { recalls: [], xrays: [], actionRequests: [] });
 });
+
+test("ChatGPT Apps inspector action confidence blocks recalled memories missing X-ray rows", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "safe work detail\nunverified private detail",
+    count: 2,
+    memoryIds: ["mem-shared", "mem-shared"],
+    results: [
+      {
+        id: "mem-shared",
+        path: "work/mem-shared.md",
+        category: "preference",
+        status: "active",
+        tags: [],
+        preview: "safe work detail",
+      },
+      {
+        id: "mem-shared",
+        path: "private/mem-shared.md",
+        category: "preference",
+        status: "active",
+        tags: [],
+        preview: "unverified private detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const xray = {
+    schemaVersion: "1",
+    query: "show preferences",
+    snapshotId: "snap-missing-xray-row",
+    capturedAt: 1_779_000_000_000,
+    tierExplain: null,
+    results: [
+      {
+        memoryId: "mem-shared",
+        path: "work/mem-shared.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.8 },
+        admittedBy: ["test"],
+        provenance: {
+          source: "conversation",
+          scope: "namespace:work",
+          userContextScopes: ["work"],
+          retrievalReason: "test",
+          confidence: 0.8,
+          stale: false,
+          corrected: false,
+          correctionState: "none",
+          safeToUse: true,
+          safety: "safe",
+          safetyReasons: [],
+        },
+      },
+    ],
+    filters: [],
+    budget: { chars: 4096, used: 100 },
+    namespace: "work",
+  } satisfies import("../src/recall-xray.js").RecallXraySnapshot;
+  const actionRequest = buildChatGptMemoryInspectorActionRequest(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    xray,
+  );
+
+  assert.equal(actionRequest.contextReadiness, "partial");
+  assert.equal(actionRequest.confidence, 0.4);
+  assert.equal(actionRequest.retrievedMemories?.length, 2);
+  assert.equal(actionRequest.retrievedMemories?.[0]?.safeToUse, true);
+  assert.equal(actionRequest.retrievedMemories?.[0]?.safety, "safe");
+  assert.equal(actionRequest.retrievedMemories?.[1]?.safeToUse, false);
+  assert.equal(actionRequest.retrievedMemories?.[1]?.safety, "blocked");
+  assert.match(
+    actionRequest.retrievedMemories?.[1]?.safetyReasons?.[0] ?? "",
+    /X-ray result was missing/,
+  );
+});


### PR DESCRIPTION
Fixes ClawPatch finding fnd_sig-feat-library-2da00b2b0e-a3b7_024c5a14bd.

This maps ChatGPT memory-inspector action provenance from each recalled memory, matching X-ray rows by recalled path first and falling back to id only when the recall row has no path. Recalled memories with no matching X-ray result now contribute blocked provenance instead of being omitted from action confidence.

Verification:
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/access-mcp-chatgpt-app.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" node scripts/check-test-types.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how retrieved-memory safety is computed for action confidence; incorrect matching could wrongly block or allow memories, but behavior is tightened with tests for duplicate ids and missing X-ray rows.
> 
> **Overview**
> **Aligns ChatGPT memory-inspector action confidence with each recalled memory**, instead of iterating X-ray rows only.
> 
> `buildChatGptMemoryInspectorActionRequest` now builds provenance via **`buildRecallProvenances`**, which walks **`recall.results`** and joins X-ray data through a shared **`buildXrayResultMatcher`**. When a recall row has a **path**, matching uses that path only (no id fallback), so duplicate memory ids across namespaces resolve to the correct X-ray row. Recalls with **no matching X-ray row** get **`missingXrayResultProvenance`** (blocked / not safe to use) rather than being dropped from **`retrievedMemories`**.
> 
> **`contextReadiness`** still goes **partial** when any provenance is unsafe or when **`provenances.length < recall.count`**. New tests cover a missing X-ray row for one of two recalls (shared id, different paths) and **`count > results.length`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3c02082727ce42ba10bade42ec047fac76f843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->