### PR TITLE
Reject unsafe benchmark seed sequences

### DIFF
--- a/packages/bench/src/run-seeds.test.ts
+++ b/packages/bench/src/run-seeds.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildBenchmarkRunSeeds } from "./run-seeds.js";
+
+test("buildBenchmarkRunSeeds builds deterministic consecutive seeds", () => {
+  assert.deepEqual(buildBenchmarkRunSeeds(3), [0, 1, 2]);
+  assert.deepEqual(buildBenchmarkRunSeeds(3, 7), [7, 8, 9]);
+});
+
+test("buildBenchmarkRunSeeds allows the maximum safe integer only as the final seed", () => {
+  assert.deepEqual(buildBenchmarkRunSeeds(1, Number.MAX_SAFE_INTEGER), [
+    Number.MAX_SAFE_INTEGER,
+  ]);
+  assert.deepEqual(buildBenchmarkRunSeeds(2, Number.MAX_SAFE_INTEGER - 1), [
+    Number.MAX_SAFE_INTEGER - 1,
+    Number.MAX_SAFE_INTEGER,
+  ]);
+});
+
+test("buildBenchmarkRunSeeds rejects unsafe starting seeds", () => {
+  assert.throws(
+    () => buildBenchmarkRunSeeds(1, Number.MAX_SAFE_INTEGER + 1),
+    /non-negative safe integer/,
+  );
+});
+
+test("buildBenchmarkRunSeeds rejects sequences that cross the safe integer limit", () => {
+  assert.throws(
+    () => buildBenchmarkRunSeeds(3, Number.MAX_SAFE_INTEGER),
+    /safe integer range/,
+  );
+  assert.throws(
+    () => buildBenchmarkRunSeeds(2, Number.MAX_SAFE_INTEGER),
+    /safe integer range/,
+  );
+});

--- a/packages/bench/src/run-seeds.test.ts
+++ b/packages/bench/src/run-seeds.test.ts
@@ -21,7 +21,7 @@ test("buildBenchmarkRunSeeds allows the maximum safe integer only as the final s
 test("buildBenchmarkRunSeeds rejects unsafe starting seeds", () => {
   assert.throws(
     () => buildBenchmarkRunSeeds(1, Number.MAX_SAFE_INTEGER + 1),
-    /non-negative safe integer/,
+    /non-negative integer/,
   );
 });
 

--- a/packages/bench/src/run-seeds.ts
+++ b/packages/bench/src/run-seeds.ts
@@ -10,13 +10,18 @@ export function buildBenchmarkRunSeeds(
   runCount: number,
   baseSeed?: number,
 ): number[] {
-  if (!Number.isInteger(runCount) || runCount <= 0) {
-    throw new Error("benchmark run count must be a positive integer");
+  if (!Number.isSafeInteger(runCount) || runCount <= 0) {
+    throw new Error("benchmark run count must be a positive safe integer");
   }
 
   const firstSeed = baseSeed ?? 0;
-  if (!Number.isInteger(firstSeed) || firstSeed < 0) {
-    throw new Error("benchmark seed must be a non-negative integer");
+  if (!Number.isSafeInteger(firstSeed) || firstSeed < 0) {
+    throw new Error("benchmark seed must be a non-negative safe integer");
+  }
+
+  const maxOffset = Number.MAX_SAFE_INTEGER - firstSeed;
+  if (runCount - 1 > maxOffset) {
+    throw new Error("benchmark seed sequence must stay within JavaScript safe integer range");
   }
 
   return Array.from({ length: runCount }, (_, index) => firstSeed + index);

--- a/packages/bench/src/run-seeds.ts
+++ b/packages/bench/src/run-seeds.ts
@@ -11,12 +11,12 @@ export function buildBenchmarkRunSeeds(
   baseSeed?: number,
 ): number[] {
   if (!Number.isSafeInteger(runCount) || runCount <= 0) {
-    throw new Error("benchmark run count must be a positive safe integer");
+    throw new Error("benchmark run count must be a positive integer within JavaScript safe integer range");
   }
 
   const firstSeed = baseSeed ?? 0;
   if (!Number.isSafeInteger(firstSeed) || firstSeed < 0) {
-    throw new Error("benchmark seed must be a non-negative safe integer");
+    throw new Error("benchmark seed must be a non-negative integer within JavaScript safe integer range");
   }
 
   const maxOffset = Number.MAX_SAFE_INTEGER - firstSeed;


### PR DESCRIPTION
Fixes ClawPatch finding fnd_sig-feat-library-304d884bdd-d956_3138118a64.

This rejects unsafe benchmark seed inputs and seed sequences that would cross JavaScript's safe integer boundary before generating the seed array. It compares requested offset against remaining safe-integer headroom to avoid overflow-prone last-seed arithmetic.

Verification:
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/bench exec tsx --test src/run-seeds.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/bench run check-types
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input validation only in bench seed generation; no auth, data, or runtime behavior changes beyond failing earlier on invalid inputs.
> 
> **Overview**
> Tightens **`buildBenchmarkRunSeeds`** so benchmark runs cannot use unsafe numeric inputs or produce seed sequences that overflow JavaScript’s safe integer range.
> 
> Validation now uses **`Number.isSafeInteger`** (instead of **`Number.isInteger`**) for **`runCount`** and the optional base seed, with clearer error messages. Before building the array, it checks that **`runCount - 1`** does not exceed **`Number.MAX_SAFE_INTEGER - firstSeed`**, rejecting sequences that would cross the boundary (while still allowing **`MAX_SAFE_INTEGER`** as the last seed when valid).
> 
> Adds **`run-seeds.test.ts`** covering consecutive seeds, edge cases at **`MAX_SAFE_INTEGER`**, and the new rejection paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd05c553130e9e74a3b27206855b95898f494e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->