### PR TITLE
Reject invalid training export timezone offsets

### DIFF
--- a/packages/remnic-core/src/training-export/cli-date-validation.test.ts
+++ b/packages/remnic-core/src/training-export/cli-date-validation.test.ts
@@ -135,6 +135,42 @@ describe("parseStrictCliDate", () => {
     assert.equal(d.getUTCHours(), 9);
   });
 
+  it("accepts ISO datetime with ordinary negative timezone offset", () => {
+    const d = parseStrictCliDate("2026-01-15T23:00:00-08:00", "--since");
+    // 2026-01-15T23:00:00-08:00 => 2026-01-16T07:00:00Z
+    assert.equal(d.getUTCFullYear(), 2026);
+    assert.equal(d.getUTCDate(), 16);
+    assert.equal(d.getUTCHours(), 7);
+  });
+
+  it("rejects timezone offset hour beyond UTC+14", () => {
+    assert.throws(
+      () => parseStrictCliDate("2024-01-15T10:00:00+15:00", "--since"),
+      /timezone offset out of range/,
+    );
+  });
+
+  it("rejects timezone offset minute beyond 59", () => {
+    assert.throws(
+      () => parseStrictCliDate("2024-01-15T10:00:00+05:61", "--since"),
+      /timezone offset out of range/,
+    );
+  });
+
+  it("rejects timezone offset minutes at the UTC+14 boundary", () => {
+    assert.throws(
+      () => parseStrictCliDate("2024-01-15T10:00:00+14:01", "--until"),
+      /timezone offset out of range/,
+    );
+  });
+
+  it("rejects timezone offset minutes at the UTC-14 boundary", () => {
+    assert.throws(
+      () => parseStrictCliDate("2024-01-15T10:00:00-14:01", "--until"),
+      /timezone offset out of range/,
+    );
+  });
+
   it("still rejects overflow dates in UTC form (Z suffix)", () => {
     assert.throws(
       () => parseStrictCliDate("2026-02-31T00:00:00Z", "--since"),

--- a/packages/remnic-core/src/training-export/date-parse.ts
+++ b/packages/remnic-core/src/training-export/date-parse.ts
@@ -10,6 +10,7 @@
  *   - Calendar overflows (Feb 30, Feb 29 in non-leap years, Apr 31, etc.)
  *     regardless of timezone suffix
  *   - Out-of-range time components (hour >= 24, minute >= 60, second >= 60)
+ *   - Out-of-range timezone offsets (beyond ±14:00, or offset minute >= 60)
  *
  * Calendar overflow is validated structurally on the Y-M-D components, so
  * results are independent of the host's local timezone.
@@ -65,7 +66,7 @@ export function parseStrictCliDate(value: string, flagName: string): Date {
   // 1. Shape check: must begin YYYY-MM-DD and use ISO 8601 structure.
   //    This rejects "12/25/2026", "December 25, 2026", RFC 2822, etc.
   const shape =
-    /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+    /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(?:Z|([+-])(\d{2}):(\d{2}))?)?$/;
   const match = value.match(shape);
   if (!match) {
     throw new Error(
@@ -103,7 +104,25 @@ export function parseStrictCliDate(value: string, flagName: string): Date {
     }
   }
 
-  // 4. Finally parse via Date for the actual timestamp value. At this point
+  // 4. Timezone offset validation.
+  //    Date accepts offset hours beyond the real-world UTC offset range and
+  //    normalizes impossible offsets into a shifted instant. Reject those
+  //    before constructing the Date so the CLI cannot silently apply them.
+  if (match[8] !== undefined) {
+    const offsetHour = Number(match[9]);
+    const offsetMinute = Number(match[10]);
+    if (
+      offsetHour > 14 ||
+      offsetMinute > 59 ||
+      (offsetHour === 14 && offsetMinute !== 0)
+    ) {
+      throw new Error(
+        `Invalid ${flagName} value "${value}": timezone offset out of range.`,
+      );
+    }
+  }
+
+  // 5. Finally parse via Date for the actual timestamp value. At this point
   //    we've already validated structure and calendar correctness, so any
   //    remaining NaN (extremely unlikely) still fails closed.
   const d = new Date(value);


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-3dda51b4d1-58c8_72562c9f22`.

## Summary
- validate training-export CLI timezone offsets before constructing `Date`
- reject offsets beyond ±14:00, offset minutes above 59, and non-zero minutes at the ±14 boundary
- add focused parser regression tests for invalid and still-valid offsets

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core exec tsx --test src/training-export/cli-date-validation.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core run check-types`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to training-export `--since`/`--until` validation; stricter input rejection with no auth or data-path changes.
> 
> **Overview**
> **Training export CLI date parsing** now rejects invalid ISO timezone offsets in `parseStrictCliDate` before `Date` is constructed, so impossible offsets are not silently normalized.
> 
> The regex is adjusted to capture offset sign and hour/minute components, and a new validation step throws `timezone offset out of range` for hours above 14, offset minutes above 59, and any non-zero minutes when the offset hour is 14 (only `±14:00` is allowed at the boundary). Documentation in `date-parse.ts` is updated to describe this rule.
> 
> Regression tests cover a valid negative offset (`-08:00`) and rejection cases for `+15:00`, `+05:61`, `+14:01`, and `-14:01`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b245ff88511051d46ead91b05fca4fb511cb5385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->