### PR TITLE
Surface routing rules read failures

### DIFF
--- a/packages/remnic-core/src/routing/store.ts
+++ b/packages/remnic-core/src/routing/store.ts
@@ -85,14 +85,10 @@ export class RoutingRulesStore {
   }
 
   async read(options?: RoutingEngineOptions): Promise<RouteRule[]> {
-    try {
-      const persisted = await this.readPersistedRules();
-      return persisted
-        .map((rule) => normalizeRule(rule, options))
-        .filter((rule): rule is RouteRule => rule !== null);
-    } catch {
-      return [];
-    }
+    const persisted = await this.readPersistedRules();
+    return persisted
+      .map((rule) => normalizeRule(rule, options))
+      .filter((rule): rule is RouteRule => rule !== null);
   }
 
   async write(rules: RouteRule[], options?: RoutingEngineOptions): Promise<RouteRule[]> {

--- a/tests/orchestrator-routing-rules.test.ts
+++ b/tests/orchestrator-routing-rules.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { access, mkdtemp, readFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 import { selectRouteRule } from "../src/routing/engine.js";
@@ -193,4 +193,17 @@ test("persistExtraction preserves index bootstrap when no memory IDs are persist
   }
   assert.equal(await exists(timeIndexPath), true);
   assert.equal(await exists(tagIndexPath), true);
+});
+
+test("RoutingRulesStore read surfaces malformed persisted state", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-routing-malformed-"));
+  const stateDir = path.join(memoryDir, "state");
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(path.join(stateDir, "routing-rules.json"), "{not json", "utf-8");
+
+  const store = new RoutingRulesStore(memoryDir);
+  await assert.rejects(
+    () => store.read(),
+    /failed to parse routing rules state/,
+  );
 });

--- a/tests/routing-store.test.ts
+++ b/tests/routing-store.test.ts
@@ -32,15 +32,17 @@ test("routing store round-trips valid rules", async () => {
   }
 });
 
-test("routing store fail-opens malformed file", async () => {
+test("routing store surfaces malformed file read failures", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-routing-store-malformed-"));
   try {
     const statePath = path.join(memoryDir, "state", "routing-rules.json");
     await mkdir(path.dirname(statePath), { recursive: true });
     await writeFile(statePath, "{bad-json", "utf-8");
     const store = new RoutingRulesStore(memoryDir);
-    const rules = await store.read();
-    assert.deepEqual(rules, []);
+    await assert.rejects(
+      async () => store.read(),
+      /failed to parse routing rules state/,
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -296,8 +298,10 @@ test("routing store blocks symlink-based state path escapes", async () => {
     await assert.rejects(async () => store.write([sampleRule()]));
 
     await assert.rejects(async () => readFile(path.join(outsideDir, "routing-rules.json"), "utf-8"));
-    const rules = await store.read();
-    assert.deepEqual(rules, []);
+    await assert.rejects(
+      async () => store.read(),
+      /routing rules state path escaped memoryDir/,
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
     await rm(outsideDir, { recursive: true, force: true });
@@ -322,8 +326,10 @@ test("routing store blocks final state-file symlink escapes", async () => {
 
     const outsideRaw = await readFile(outsideFile, "utf-8");
     assert.equal(outsideRaw, "{}");
-    const rules = await store.read();
-    assert.deepEqual(rules, []);
+    await assert.rejects(
+      async () => store.read(),
+      /routing rules state path must not be a symlink/,
+    );
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
     await rm(outsideDir, { recursive: true, force: true });
@@ -423,8 +429,10 @@ test("routing store does not create out-of-root directories before scope rejecti
   try {
     await symlink(outsideDir, path.join(memoryDir, "state-link"));
     const store = new RoutingRulesStore(memoryDir, "state-link/sub/routing-rules.json");
-    const rules = await store.read();
-    assert.deepEqual(rules, []);
+    await assert.rejects(
+      async () => store.read(),
+      /routing rules state path escaped memoryDir/,
+    );
 
     await assert.rejects(async () => stat(path.join(outsideDir, "sub")));
   } finally {


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-3e55154249-9c49_e80e8f88f8`.

## Summary
- remove the blanket `RoutingRulesStore.read()` catch that converted malformed or inaccessible state into an empty rule set
- keep missing state behavior as an empty rule set through `readPersistedRules()`'s existing ENOENT handling
- add malformed persisted-state coverage so invalid JSON is surfaced

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/orchestrator-routing-rules.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core run check-types`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node scripts/check-test-types.mjs`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Callers that assumed `read()` always succeeded may now see errors during routing; behavior change is intentional but can affect orchestration when on-disk state is bad.
> 
> **Overview**
> **`RoutingRulesStore.read()` no longer fail-opens on bad or unsafe persisted state.** The outer `try/catch` that turned any read failure into an empty rule list was removed, so parse errors, invalid state shape, and path-scoping failures from `readPersistedRules()` now propagate to callers. **Missing state files still yield `[]`** via existing `ENOENT` handling inside `readPersistedRules()`.
> 
> Tests were aligned with that behavior: malformed JSON and symlink/escape scenarios now **`assert.rejects`** with the expected messages instead of expecting `[]`, plus a new orchestrator-level malformed-state test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02c520cd7b0038af0c8490ebcaba2e53bd2aa7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->