### PR TITLE
Quote conversation chunk metadata scalars

### DIFF
--- a/packages/remnic-core/src/conversation-index/indexer.test.ts
+++ b/packages/remnic-core/src/conversation-index/indexer.test.ts
@@ -98,6 +98,28 @@ test("writeConversationChunks keeps distinct raw session keys from overwriting a
   }
 });
 
+test("writeConversationChunks quotes metadata scalars in front matter", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
+  try {
+    const sessionKey = "agent\nkind: other\n---\ncolon: value";
+    const written = await writeConversationChunks(root, [
+      sampleChunk({
+        sessionKey,
+        startTs: "2026-05-17T00:00:00.000Z",
+        endTs: "2026-05-17T00:01:00.000Z",
+      }),
+    ]);
+
+    const content = await readFile(written[0]!, "utf-8");
+    assert.match(content, /^sessionKey: "agent\\nkind: other\\n---\\ncolon: value"$/m);
+    assert.match(content, /^startTs: "2026-05-17T00:00:00.000Z"$/m);
+    assert.match(content, /^endTs: "2026-05-17T00:01:00.000Z"$/m);
+    assert.doesNotMatch(content, /^kind: other$/m);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("writeConversationChunks rejects invalid chunk timestamps before deriving paths", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-conversation-index-"));
   try {

--- a/packages/remnic-core/src/conversation-index/indexer.ts
+++ b/packages/remnic-core/src/conversation-index/indexer.ts
@@ -40,6 +40,10 @@ function sanitizeChunkId(id: string): string {
   return sanitizePathComponent(id, "chunk");
 }
 
+function yamlQuotedScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
 function datePathComponent(startTs: string): string {
   const match = typeof startTs === "string"
     ? /^(\d{4})-(\d{2})-(\d{2})T/.exec(startTs)
@@ -153,9 +157,9 @@ export async function writeConversationChunks(
     const content =
       `---\n` +
       `kind: conversation_chunk\n` +
-      `sessionKey: ${c.sessionKey}\n` +
-      `startTs: ${c.startTs}\n` +
-      `endTs: ${c.endTs}\n` +
+      `sessionKey: ${yamlQuotedScalar(c.sessionKey)}\n` +
+      `startTs: ${yamlQuotedScalar(c.startTs)}\n` +
+      `endTs: ${yamlQuotedScalar(c.endTs)}\n` +
       `---\n\n` +
       c.text +
       "\n";


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-41e0d2eb4b-e7cd_f395aab98a`.

## Summary
- serialize conversation chunk front-matter metadata as YAML-safe quoted scalars
- keep path sanitization unchanged while preventing raw session/timestamp metadata from injecting front-matter lines
- add hostile metadata coverage for newline, colon-space, and `---` delimiter content

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core exec tsx --test src/conversation-index/indexer.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core run check-types`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to how chunk `.md` files are serialized; reduces front-matter injection risk without altering index paths or FAISS behavior.
> 
> **Overview**
> **Conversation chunk markdown** now writes `sessionKey`, `startTs`, and `endTs` in YAML front matter as **quoted scalars** via a new `yamlQuotedScalar` helper (`JSON.stringify`), instead of embedding raw strings.
> 
> This stops hostile metadata (newlines, `key: value` patterns, or `---` delimiters) from being interpreted as extra front-matter fields while **filesystem path sanitization stays the same**.
> 
> A regression test asserts quoted output and that injected lines like `kind: other` do not appear as real front-matter keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac98941b0cad301a9182a13da1c189424d5ae6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->