### PR TITLE
Validate surprise buffer snapshot before promotion

### DIFF
--- a/packages/remnic-core/src/buffer-session.test.ts
+++ b/packages/remnic-core/src/buffer-session.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { SmartBuffer } from "./buffer.js";
 import { parseConfig } from "./config.js";
+import type { BufferSurpriseProbe } from "./buffer.js";
 import type { BufferState, BufferTurn } from "./types.js";
 
 class FakeStorage {
@@ -108,6 +109,63 @@ test("SmartBuffer serializes concurrent addTurn mutations", async () => {
   assert.deepEqual(
     turns.map((turn) => turn.content).sort(),
     ["alpha memory", "beta memory"],
+  );
+});
+
+test("SmartBuffer ignores stale surprise promotion after newer turns arrive", async () => {
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  let resolveFirstProbe = (_score: number): void => {
+    throw new Error("first surprise probe did not start");
+  };
+  let markFirstProbeStarted = (): void => {
+    throw new Error("probe start marker was not initialized");
+  };
+  const firstProbeStarted = new Promise<void>((resolve) => {
+    markFirstProbeStarted = resolve;
+  });
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn(_bufferKey, turn) {
+      if (turn.content !== "turn A") return null;
+      markFirstProbeStarted();
+      return new Promise<number>((probeResolve) => {
+        resolveFirstProbe = probeResolve;
+      });
+    },
+  };
+  const buffer = new SmartBuffer(
+    parseConfig({
+      bufferSurpriseTriggerEnabled: true,
+      bufferSurpriseThreshold: 0.35,
+      bufferSurpriseProbeTimeoutMs: 10_000,
+      triggerMode: "smart",
+    }),
+    storage as any,
+    probe,
+  );
+
+  const firstOutcomePromise = buffer.addTurnWithOutcome(
+    "thread-a",
+    makeTurn("thread-a", "turn A"),
+  );
+  await firstProbeStarted;
+
+  const secondOutcome = await buffer.addTurnWithOutcome(
+    "thread-a",
+    makeTurn("thread-a", "turn B"),
+  );
+  assert.deepEqual(secondOutcome, { decision: "keep_buffering" });
+
+  resolveFirstProbe(1);
+  const firstOutcome = await firstOutcomePromise;
+
+  assert.deepEqual(firstOutcome, { decision: "keep_buffering" });
+  assert.deepEqual(
+    buffer.getTurns("thread-a").map((turn) => turn.content),
+    ["turn A", "turn B"],
   );
 });
 

--- a/packages/remnic-core/src/buffer-surprise-trigger.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-trigger.test.ts
@@ -643,7 +643,7 @@ test("flag on: slow-probe promotion survives prefix clears before the scored tur
   );
 });
 
-test("flag on: slow-probe promotion survives later appends to same buffer", async () => {
+test("flag on: slow-probe promotion is ignored after later appends to same buffer", async () => {
   const storage = new FakeStorage(emptyBuffer());
   let releaseOldProbe: (() => void) | null = null;
   let oldProbeStarted: (() => void) | null = null;
@@ -684,8 +684,8 @@ test("flag on: slow-probe promotion survives later appends to same buffer", asyn
   (releaseOldProbe as () => void)();
   assert.equal(
     await oldDecision,
-    "extract_now",
-    "a later append must not suppress a valid surprise flush for the older turn",
+    "keep_buffering",
+    "a later append must suppress stale surprise promotion for the older turn",
   );
   const turns = buffer.getTurns("sess-1");
   assert.equal(turns.length, 2);
@@ -695,18 +695,9 @@ test("flag on: slow-probe promotion survives later appends to same buffer", asyn
 
 test("flag on: extraction clear preserves turns appended after the queued snapshot", async () => {
   const storage = new FakeStorage(emptyBuffer());
-  let releaseOldProbe: (() => void) | null = null;
-  let oldProbeStarted: (() => void) | null = null;
-  const oldProbeStartedPromise = new Promise<void>((resolve) => {
-    oldProbeStarted = resolve;
-  });
   const probe: BufferSurpriseProbe = {
     async scoreTurn(_key, turn) {
-      if (turn.content !== "old surprising turn") return null;
-      oldProbeStarted?.();
-      return new Promise<number | null>((resolve) => {
-        releaseOldProbe = () => resolve(0.99);
-      });
+      return turn.content === "old surprising turn" ? 0.99 : null;
     },
   };
   const config = parseConfig({
@@ -722,11 +713,6 @@ test("flag on: extraction clear preserves turns appended after the queued snapsh
     "sess-1",
     makeTurn("sess-1", "old surprising turn"),
   );
-  await oldProbeStartedPromise;
-
-  await buffer.addTurn("sess-1", makeTurn("sess-1", "newer ordinary turn"));
-  assert.ok(releaseOldProbe);
-  (releaseOldProbe as () => void)();
   assert.equal(await oldDecision, "extract_now");
 
   const queuedSnapshot = buffer.getTurns("sess-1");

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -85,7 +85,8 @@ interface AddTurnMutationResult {
   decision: TriggerDecision;
   signalLevel: SignalLevel;
   priorTurns: BufferTurn[];
-  turnSnapshot: BufferTurn;
+  activeTurnsSnapshot: BufferTurn[];
+  retainedTurnsSnapshot: BufferTurn[];
   turnCountInWindow: number;
 }
 
@@ -298,9 +299,10 @@ export class SmartBuffer {
         const shouldPromote = surprise > this.config.bufferSurpriseThreshold;
         let triggered = false;
         if (shouldPromote) {
-          const currentTurns = await this.getExtractionTurnsIfTurnSnapshotStillCurrent(
+          const currentTurns = await this.getExtractionTurnsIfBufferSnapshotStillCurrent(
             bufferKey,
-            mutation.turnSnapshot,
+            mutation.activeTurnsSnapshot,
+            mutation.retainedTurnsSnapshot,
           );
           if (currentTurns) {
             log.debug(
@@ -361,7 +363,8 @@ export class SmartBuffer {
     const entry = this.entryFor(bufferKey);
     const priorTurns = entry.turns.slice();
     entry.turns.push(turn);
-    const turnSnapshot = copyBufferTurn(turn);
+    const activeTurnsSnapshot = entry.turns.map(copyBufferTurn);
+    const retainedTurnsSnapshot = (entry.retainedTurns ?? []).map(copyBufferTurn);
     if (bufferKey === "default") {
       this.state.turns = entry.turns;
     }
@@ -376,24 +379,26 @@ export class SmartBuffer {
       decision,
       signalLevel: signal.level,
       priorTurns,
-      turnSnapshot,
+      activeTurnsSnapshot,
+      retainedTurnsSnapshot,
       turnCountInWindow,
     };
   }
 
-  private async getExtractionTurnsIfTurnSnapshotStillCurrent(
+  private async getExtractionTurnsIfBufferSnapshotStillCurrent(
     bufferKey: string,
-    turnSnapshot: BufferTurn,
+    activeTurnsSnapshot: readonly BufferTurn[],
+    retainedTurnsSnapshot: readonly BufferTurn[],
   ): Promise<BufferTurn[] | null> {
     return this.enqueueMutation(async () => {
       await this.loadUnlocked();
       const entry = this.peekEntry(bufferKey);
       if (!entry) return null;
-      const stillCurrent = entry.turns.some((turn) =>
-        bufferTurnsEqual(turn, turnSnapshot),
-      );
-      if (!stillCurrent) return null;
       const retained = entry.retainedTurns ?? [];
+      const stillCurrent =
+        bufferTurnArrayIsSuffixOfSnapshot(entry.turns, activeTurnsSnapshot) &&
+        bufferTurnArraysEqual(retained, retainedTurnsSnapshot);
+      if (!stillCurrent) return null;
       return [...retained, ...entry.turns];
     });
   }
@@ -799,6 +804,29 @@ function bufferTurnsEqual(left: BufferTurn | undefined, right: BufferTurn): bool
     left.providerThreadId === right.providerThreadId &&
     left.turnFingerprint === right.turnFingerprint &&
     left.persistProcessedFingerprint === right.persistProcessedFingerprint
+  );
+}
+
+function bufferTurnArraysEqual(
+  left: readonly BufferTurn[],
+  right: readonly BufferTurn[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((turn, index) => bufferTurnsEqual(turn, right[index]))
+  );
+}
+
+function bufferTurnArrayIsSuffixOfSnapshot(
+  liveTurns: readonly BufferTurn[],
+  snapshot: readonly BufferTurn[],
+): boolean {
+  if (liveTurns.length === 0 || liveTurns.length > snapshot.length) {
+    return false;
+  }
+  const offset = snapshot.length - liveTurns.length;
+  return liveTurns.every((turn, index) =>
+    bufferTurnsEqual(turn, snapshot[offset + index]),
   );
 }
 


### PR DESCRIPTION
## Summary
- snapshot active and retained buffer turns when a surprise probe starts
- only promote stale surprise decisions if the live buffer still matches that snapshot
- add a delayed-probe regression for overlapping SmartBuffer.addTurnWithOutcome calls

Fixes ClawPatch finding fnd_sig-feat-library-454b0189c0-ca9d_82e4f453e0.

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core exec tsx --test src/buffer-session.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core run check-types
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when surprise-gated extractions fire under concurrent turns and slow probes, which affects memory extraction timing but fixes incorrect premature flushes.
> 
> **Overview**
> **SmartBuffer** no longer promotes a delayed surprise probe to **`extract_now`** unless the live buffer still matches the state captured when that turn was recorded.
> 
> When a turn is appended, the buffer now snapshots **all active turns** and **retained deferred turns** (not just the new turn). After an async surprise score returns above threshold, promotion runs only if current live turns are still a **suffix** of that active snapshot and retained turns are unchanged; otherwise the decision stays **`keep_buffering`** and a debug log notes the buffer changed.
> 
> Tests are aligned with this behavior: slow-probe promotion after a **later append** to the same session is expected to be **ignored**; a new **`addTurnWithOutcome`** regression covers overlapping probes; the post-extraction clear test no longer depends on a slow probe race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9367c3022c2b8089ce051463eb63ea0a7ee577d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->