### PR TITLE
Deny cross-namespace reads at hard limit

### DIFF
--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -37,15 +37,15 @@ test("createMitigatedTarget returns empty hits when budget is exceeded", async (
     assert.ok(Array.isArray(hits), `same-ns query ${i} should return array`);
   }
 
-  // Cross-namespace queries should exhaust the budget and still return hits
+  // Cross-namespace queries under the hard limit still return hits
   // (the raw target returns matches from namespace "other").
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 2; i++) {
     const hits = await mitigated.recall("alpha", { namespace: "other" });
     assert.ok(Array.isArray(hits), `cross-ns query ${i} should return array`);
     assert.ok(hits.length > 0, `cross-ns query ${i} should return non-empty hits before budget exhausted`);
   }
 
-  // 4th cross-namespace query should be denied (empty hits from budget).
+  // 3rd cross-namespace query reaches the hard limit and should be denied.
   const denied = await mitigated.recall("delta", { namespace: "other" });
   assert.equal(denied.length, 0, "should return empty after budget exhausted");
 });
@@ -58,7 +58,7 @@ test("createMitigatedTarget treats missing namespace as budget-eligible (fail-cl
 
   const mitigated = createMitigatedTarget({
     target: rawTarget,
-    budgetHardLimit: 1,
+    budgetHardLimit: 2,
     budgetWindowMs: 60_000,
     principalNamespace: "default",
   });
@@ -74,7 +74,7 @@ test("createMitigatedTarget treats missing namespace as budget-eligible (fail-cl
   assert.equal(denied.length, 0, "should return empty after budget exhausted with no namespace");
 });
 
-test("createMitigatedTarget expires budget entries at the window boundary", async () => {
+test("createMitigatedTarget keeps budget entries through the exact window boundary", async () => {
   const rawTarget = createSyntheticTarget({
     memories: [
       { id: "tm-boundary", content: "alpha beta gamma", category: "fact", tokens: ["alpha"], namespace: "other" },
@@ -89,7 +89,7 @@ test("createMitigatedTarget expires budget entries at the window boundary", asyn
   try {
     const mitigated = createMitigatedTarget({
       target: rawTarget,
-      budgetHardLimit: 1,
+      budgetHardLimit: 2,
       budgetWindowMs: 1_000,
       principalNamespace: "default",
     });
@@ -99,7 +99,11 @@ test("createMitigatedTarget expires budget entries at the window boundary", asyn
 
     now = 1_000;
     const second = await mitigated.recall("alpha", { namespace: "other" });
-    assert.ok(second.length > 0, "query at exactly the budget window boundary should be allowed");
+    assert.equal(second.length, 0, "query at exactly the budget window boundary should be denied");
+
+    now = 1_001;
+    const third = await mitigated.recall("alpha", { namespace: "other" });
+    assert.ok(third.length > 0, "query after the budget window boundary should be allowed");
   } finally {
     Date.now = originalNow;
   }

--- a/packages/bench/src/security/extraction-attack/mitigated-target.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.ts
@@ -75,10 +75,11 @@ export function createMitigatedTarget(
 
   function recordAndCheck(now: number): boolean {
     const cutoff = now - budgetWindowMs;
-    while (timestamps.length > 0 && timestamps[0].ts <= cutoff) {
+    while (timestamps.length > 0 && timestamps[0].ts < cutoff) {
       timestamps.shift();
     }
-    if (timestamps.length >= budgetHardLimit) {
+    const projected = timestamps.length + 1;
+    if (projected >= budgetHardLimit) {
       return false;
     }
     timestamps.push({ ts: now });

--- a/packages/remnic-core/src/cross-namespace-budget.test.ts
+++ b/packages/remnic-core/src/cross-namespace-budget.test.ts
@@ -40,16 +40,45 @@ test("enabled budget warns past soft and denies past hard", () => {
   const limiter = new CrossNamespaceBudget({
     enabled: true,
     softLimit: 2,
-    hardLimit: 3,
+    hardLimit: 4,
     windowMs: 10_000,
   });
   assert.equal(limiter.record("p1", 1).reason, "allowed-under-soft");
   assert.equal(limiter.record("p1", 2).reason, "allowed-under-soft");
   assert.equal(limiter.record("p1", 3).reason, "warn-over-soft");
-  // 4th call crosses hardLimit (count would be 4 > 3) => deny.
+  // 4th call reaches hardLimit and is denied.
   const deny = limiter.record("p1", 4);
   assert.equal(deny.allowed, false);
   assert.equal(deny.reason, "deny-over-hard");
+});
+
+test("enabled budget denies the threshold-crossing hard-limit request", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 0,
+    hardLimit: 2,
+    windowMs: 10_000,
+  });
+
+  const first = limiter.record("p1", 1);
+  assert.equal(first.allowed, true);
+  assert.equal(first.reason, "warn-over-soft");
+  assert.equal(first.count, 1);
+
+  const beforeSecond = limiter.peek({
+    principal: "p1",
+    principalNamespace: "alice",
+    queryNamespace: "bob",
+    now: 2,
+  });
+  assert.equal(beforeSecond.allowed, false);
+  assert.equal(beforeSecond.reason, "deny-over-hard");
+  assert.equal(beforeSecond.count, 1);
+
+  const second = limiter.record("p1", 2);
+  assert.equal(second.allowed, false);
+  assert.equal(second.reason, "deny-over-hard");
+  assert.equal(second.count, 1);
 });
 
 test("sliding window drops old timestamps", () => {
@@ -61,10 +90,9 @@ test("sliding window drops old timestamps", () => {
   });
   // Fill to hard.
   limiter.record("p1", 0);
-  limiter.record("p1", 50);
-  assert.equal(limiter.record("p1", 80).reason, "deny-over-hard");
+  assert.equal(limiter.record("p1", 50).reason, "deny-over-hard");
 
-  // Walk past the window so the first two slide out.
+  // Walk past the window so the first allowed timestamp slides out.
   const d = limiter.record("p1", 201);
   assert.equal(d.allowed, true);
   assert.equal(d.reason, "allowed-under-soft");
@@ -75,7 +103,7 @@ test("per-principal isolation: one principal's denial does not affect another", 
   const limiter = new CrossNamespaceBudget({
     enabled: true,
     softLimit: 1,
-    hardLimit: 1,
+    hardLimit: 2,
     windowMs: 10_000,
   });
   limiter.record("alice", 10);
@@ -107,7 +135,7 @@ test("check() engages on cross-namespace", () => {
   const limiter = new CrossNamespaceBudget({
     enabled: true,
     softLimit: 1,
-    hardLimit: 1,
+    hardLimit: 2,
     windowMs: 10_000,
   });
   const d1 = limiter.check({
@@ -131,7 +159,7 @@ test("denied calls do not push bucket forward", () => {
   const limiter = new CrossNamespaceBudget({
     enabled: true,
     softLimit: 1,
-    hardLimit: 1,
+    hardLimit: 2,
     windowMs: 100,
   });
   limiter.record("p1", 0);
@@ -150,7 +178,7 @@ test("missing principal is bucketed under __anonymous__ rather than failing open
   const limiter = new CrossNamespaceBudget({
     enabled: true,
     softLimit: 0,
-    hardLimit: 1,
+    hardLimit: 2,
     windowMs: 10_000,
   });
   // An empty-string principal shares the anonymous bucket.
@@ -168,8 +196,7 @@ test("reset clears all state", () => {
     windowMs: 10_000,
   });
   limiter.record("p1", 1);
-  limiter.record("p1", 2);
-  assert.equal(limiter.record("p1", 3).reason, "deny-over-hard");
+  assert.equal(limiter.record("p1", 2).reason, "deny-over-hard");
   limiter.reset();
   const after = limiter.record("p1", 4);
   assert.equal(after.allowed, true);
@@ -231,7 +258,7 @@ test("record() normalizes non-finite clocks before mutating limiter state", () =
   const limiter = new CrossNamespaceBudget({
     enabled: true,
     softLimit: 1,
-    hardLimit: 1,
+    hardLimit: 2,
     windowMs: 100,
   });
 
@@ -254,7 +281,7 @@ test("peek() with a non-finite clock is read-only and does not poison state", ()
   const limiter = new CrossNamespaceBudget({
     enabled: true,
     softLimit: 0,
-    hardLimit: 1,
+    hardLimit: 2,
     windowMs: 100,
   });
 
@@ -293,14 +320,10 @@ test("bucket is evicted after a denial rolls the only timestamp back", () => {
     hardLimit: 1,
     windowMs: 100,
   });
-  limiter.record("p1", 0);
-  // Denial at t=150 after the earlier timestamp has slid out. The
-  // timestamp just added gets rolled back; bucket becomes empty; must
-  // be evicted.
-  limiter.record("p1", 150);
-  // (wait — the above is allowed because the earlier timestamp slid out.)
-  // Force a deny path differently:
-  assert.equal(limiter.bucketCount(), 1);
+  const denied = limiter.record("p1", 0);
+  assert.equal(denied.allowed, false);
+  assert.equal(denied.reason, "deny-over-hard");
+  assert.equal(limiter.bucketCount(), 0);
 });
 
 test("check() does NOT fail-open when both namespaces are empty or undefined", () => {

--- a/packages/remnic-core/src/cross-namespace-budget.ts
+++ b/packages/remnic-core/src/cross-namespace-budget.ts
@@ -207,7 +207,7 @@ export class CrossNamespaceBudget {
     this.buckets.set(principal, bucket);
     const count = bucket.timestamps.length;
 
-    if (count > hardLimit) {
+    if (count >= hardLimit) {
       // Denied: roll back the timestamp we just added so a repeated denied
       // call does not push the bucket further into the future. This keeps
       // the limiter stateless with respect to denied attempts.
@@ -290,7 +290,7 @@ export class CrossNamespaceBudget {
       if (ts >= cutoff) liveCount++;
     }
     const projected = liveCount + 1; // +1 for the current call
-    if (projected > hardLimit) {
+    if (projected >= hardLimit) {
       return { allowed: false, reason: "deny-over-hard", count: liveCount, limit };
     }
     if (projected > softLimit) {

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -3808,7 +3808,7 @@ test("access service recall enforces cross-namespace budget when enabled", async
       recallCrossNamespaceBudgetEnabled: true,
       recallCrossNamespaceBudgetWindowMs: 60_000,
       recallCrossNamespaceBudgetSoftLimit: 2,
-      recallCrossNamespaceBudgetHardLimit: 3,
+      recallCrossNamespaceBudgetHardLimit: 4,
     },
     recall: async () => "ctx",
     lastRecall: {
@@ -3822,7 +3822,7 @@ test("access service recall enforces cross-namespace budget when enabled", async
   };
   const service = new EngramAccessService(orchestrator as any);
 
-  // First 3 cross-namespace recalls should succeed (under hard limit)
+  // First 3 cross-namespace recalls should succeed (under hard limit).
   for (let i = 0; i < 3; i++) {
     const res = await service.recall({
       query: `query ${i}`,
@@ -3832,7 +3832,7 @@ test("access service recall enforces cross-namespace budget when enabled", async
     assert.ok(res, `recall ${i} should succeed`);
   }
 
-  // 4th cross-namespace recall should be denied
+  // 4th cross-namespace recall reaches the hard limit and should be denied.
   await assert.rejects(
     () => service.recall({
       query: "one more",
@@ -3968,7 +3968,7 @@ test("access service idempotent recall retries do not double count cross-namespa
       recallCrossNamespaceBudgetEnabled: true,
       recallCrossNamespaceBudgetWindowMs: 60_000,
       recallCrossNamespaceBudgetSoftLimit: 0,
-      recallCrossNamespaceBudgetHardLimit: 1,
+      recallCrossNamespaceBudgetHardLimit: 2,
       dreamsPhases: dreamsPhasesConfig(),
     },
     recall: async () => {
@@ -4045,7 +4045,7 @@ test("access service serializes recall budget records under the hard limit", asy
       recallCrossNamespaceBudgetEnabled: true,
       recallCrossNamespaceBudgetWindowMs: 60_000,
       recallCrossNamespaceBudgetSoftLimit: 0,
-      recallCrossNamespaceBudgetHardLimit: 1,
+      recallCrossNamespaceBudgetHardLimit: 2,
       dreamsPhases: dreamsPhasesConfig(),
     },
     recall: async () => {


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-530363e974-bb41_3f09464dd4` (Hard-limit check allows the threshold-crossing request).

## Changes
- Treat the hard limit as an exclusive threshold for both `record()` and `peek()`, so a request that would reach the hard cap is denied.
- Preserve rollback behavior for denied records so threshold-crossing attempts do not consume budget.
- Update boundary coverage for soft-limit warnings and hard-limit denials.

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/core exec tsx --test src/cross-namespace-budget.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes enforcement semantics for a security-critical cross-namespace budget on recall; misconfiguration could over- or under-block reads until operators reconcile limits with the new inclusive threshold.
> 
> **Overview**
> Fixes cross-namespace recall budgeting so the **Nth** request at the configured hard cap is denied, not the one after it.
> 
> **`CrossNamespaceBudget`** now treats the hard limit as inclusive in `record()` (`count >= hardLimit`) and `peek()` (`projected >= hardLimit`). Denied `record()` calls still roll back the tentative timestamp so rejected attempts do not advance the window.
> 
> **`createMitigatedTarget`** (bench harness) is aligned: window eviction uses strict `< cutoff`, and the pre-record check uses `projected >= budgetHardLimit` so behavior matches core.
> 
> Tests across `cross-namespace-budget`, `mitigated-target`, and access-service recall budget scenarios were updated (including a dedicated threshold-crossing case and window-boundary expectations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9001860ce8c58f1dce44313b7bfb03d02feeab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->