### PR TITLE
Reject unsafe eval benchmark ids

### DIFF
--- a/packages/remnic-core/src/evals.ts
+++ b/packages/remnic-core/src/evals.ts
@@ -359,7 +359,7 @@ export function validateEvalBenchmarkManifest(
 
   return {
     schemaVersion: 1,
-    benchmarkId: assertString(raw.benchmarkId, "benchmarkId"),
+    benchmarkId: assertSafeBenchmarkId(assertString(raw.benchmarkId, "benchmarkId")),
     benchmarkType,
     title: assertString(raw.title, "title"),
     description:

--- a/tests/evals-benchmark-tools.test.ts
+++ b/tests/evals-benchmark-tools.test.ts
@@ -8,6 +8,7 @@ import {
   runBenchmarkStatusCliCommand,
   runBenchmarkValidateCliCommand,
 } from "../src/cli.js";
+import { validateEvalBenchmarkManifest } from "../packages/remnic-core/src/evals.js";
 
 async function writeManifest(
   filePath: string,
@@ -36,6 +37,30 @@ async function writeManifest(
     "utf8",
   );
 }
+
+test("validateEvalBenchmarkManifest rejects unsafe benchmarkId path segments", () => {
+  const baseManifest = {
+    schemaVersion: 1,
+    benchmarkId: "ama-memory",
+    title: "AMA-style benchmark pack",
+    cases: [
+      {
+        id: "case-1",
+        prompt: "Recover the last changed system state and explain the next action.",
+      },
+    ],
+  };
+
+  assert.equal(validateEvalBenchmarkManifest(baseManifest).benchmarkId, "ama-memory");
+
+  for (const benchmarkId of [".", "..", "../x", "a/b"]) {
+    assert.throws(
+      () => validateEvalBenchmarkManifest({ ...baseManifest, benchmarkId }),
+      /benchmarkId must be a safe path segment/,
+      `${benchmarkId} should be rejected`,
+    );
+  }
+});
 
 test("benchmark-validate accepts a manifest JSON file", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "engram-bench-validate-file-"));


### PR DESCRIPTION
## Summary
- validate eval benchmark manifests with the existing safe benchmark id guard
- add regression coverage rejecting unsafe path-like benchmark ids

Finding: fnd_sig-feat-library-530363e974-c4c7_0b2695ba0d

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/evals-benchmark-tools.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation hardening on eval manifest parsing; legitimate benchmark ids are unchanged and tests cover rejection cases.
> 
> **Overview**
> **Eval benchmark manifests** now run `benchmarkId` through the existing `assertSafeBenchmarkId` guard during `validateEvalBenchmarkManifest`, so path-like values (`.`, `..`, slashes, backslashes) fail validation with `benchmarkId must be a safe path segment` instead of being accepted.
> 
> That closes a gap where a malicious or mistaken `benchmarkId` could still pass manifest parsing even though import and store layout use the id as a directory name under `benchmarks/`.
> 
> A focused unit test confirms normal ids still work and rejects `".", "..", "../x", "a/b"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4156824b3ff00682c7fe4536a32ace4556cf7936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->