### PR TITLE
Serialize concurrent task updates

### DIFF
--- a/packages/remnic-core/src/work/storage.ts
+++ b/packages/remnic-core/src/work/storage.ts
@@ -23,6 +23,7 @@ const TASK_TRANSITIONS: Record<WorkTaskStatus, Set<WorkTaskStatus>> = {
 };
 
 const PROJECT_MUTATION_CHAINS = new Map<string, Promise<unknown>>();
+const TASK_MUTATION_CHAINS = new Map<string, Promise<unknown>>();
 
 function serializeFrontmatter(values: object): string {
   const lines = Object.entries(values).map(([k, v]) => `${k}: ${JSON.stringify(v)}`);
@@ -179,6 +180,19 @@ export class WorkStorage {
     return run;
   }
 
+  private async enqueueTaskMutation<T>(taskId: string, op: () => Promise<T>): Promise<T> {
+    const mutationKey = this.taskPath(taskId);
+    const previous = TASK_MUTATION_CHAINS.get(mutationKey) ?? Promise.resolve();
+    const run = previous.catch(() => undefined).then(op);
+    const cleanup = run.then(() => undefined, () => undefined).then(() => {
+      if (TASK_MUTATION_CHAINS.get(mutationKey) === cleanup) {
+        TASK_MUTATION_CHAINS.delete(mutationKey);
+      }
+    });
+    TASK_MUTATION_CHAINS.set(mutationKey, cleanup);
+    return run;
+  }
+
   private parseTask(raw: string): WorkTask | null {
     const parsed = parseFrontmatter(raw);
     if (!parsed) return null;
@@ -289,6 +303,15 @@ export class WorkStorage {
   }
 
   async updateTask(
+    id: string,
+    patch: UpdateWorkTaskInput,
+    now = new Date(),
+    options?: { skipStatusTransitionValidation?: boolean },
+  ): Promise<WorkTask | null> {
+    return this.enqueueTaskMutation(id, async () => this.updateTaskUnlocked(id, patch, now, options));
+  }
+
+  private async updateTaskUnlocked(
     id: string,
     patch: UpdateWorkTaskInput,
     now = new Date(),

--- a/tests/work-board.test.ts
+++ b/tests/work-board.test.ts
@@ -10,6 +10,10 @@ import {
   importWorkBoardSnapshot,
 } from "../src/work/board.js";
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 test("work board export groups tasks by status and filters by project", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-work-board-export-"));
   const storage = new WorkStorage(memoryDir);
@@ -135,6 +139,38 @@ test("work board import creates missing tasks and updates existing tasks", async
   assert.ok(created);
   assert.equal(created.projectId, project.id);
   assert.deepEqual(created.tags, ["imported"]);
+});
+
+test("work storage serializes concurrent task updates for the same task", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-work-task-concurrent-update-"));
+  const storage = new WorkStorage(memoryDir);
+
+  await storage.createTask({
+    id: "task-race",
+    title: "Race",
+    status: "todo",
+  });
+
+  const originalGetTask = storage.getTask.bind(storage);
+  let getTaskCalls = 0;
+  storage.getTask = async (id: string) => {
+    const call = ++getTaskCalls;
+    const task = await originalGetTask(id);
+    if (id === "task-race" && call === 1) {
+      await delay(50);
+    }
+    return task;
+  };
+
+  await Promise.all([
+    storage.updateTask("task-race", { status: "in_progress" }, new Date("2026-02-27T00:00:00.000Z")),
+    storage.updateTask("task-race", { assignee: "alice" }, new Date("2026-02-27T00:00:01.000Z")),
+  ]);
+
+  const updated = await originalGetTask("task-race");
+  assert.ok(updated);
+  assert.equal(updated.status, "in_progress");
+  assert.equal(updated.assignee, "alice");
 });
 
 test("work board import bypasses transition guardrails for snapshot restores", async () => {


### PR DESCRIPTION
## Summary
- serialize `WorkStorage.updateTask` mutations per task path using the existing project mutation-chain pattern
- keep task patches based on the latest on-disk task record when concurrent updates target different fields
- add a deterministic regression test for stale-read concurrent task updates

Finding: fnd_sig-feat-library-5ee249cbb8-a619_66995090bd

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/work-board.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task persistence and concurrent write behavior; mitigated by mirroring the existing project mutation pattern and a targeted regression test.
> 
> **Overview**
> **Serializes per-task `updateTask` mutations** so concurrent patches to the same task no longer race on read-modify-write and drop fields.
> 
> `WorkStorage.updateTask` now runs through a new `enqueueTaskMutation` queue keyed by the task file path—the same promise-chain approach already used for project mutations. The previous update logic lives in private `updateTaskUnlocked`, so each update still reads the latest on-disk record before applying its patch.
> 
> A regression test runs two overlapping `updateTask` calls (status vs assignee) with an artificial delay on the first read and asserts both changes land on the final task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce29007094a96c3da5e51a912a4271e06a74ed57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->