### PR TITLE
Import missing lossless message parts on retry

### DIFF
--- a/packages/import-lossless-claw/src/importer.test.ts
+++ b/packages/import-lossless-claw/src/importer.test.ts
@@ -58,9 +58,11 @@ function buildSourceDb(seed: {
   conversations: SeedConversation[];
   messages: SeedMessage[];
   messageParts?: SeedMessagePart[];
+  messagePartsHaveOrdinal?: boolean;
   summaries?: SeedSummary[];
 }): DbHandle {
   const db = new BetterSqlite3(":memory:");
+  const messagePartsHaveOrdinal = seed.messagePartsHaveOrdinal ?? true;
   db.exec(`
     CREATE TABLE conversations (
       conversation_id TEXT PRIMARY KEY,
@@ -96,15 +98,24 @@ function buildSourceDb(seed: {
       parent_summary_id TEXT NOT NULL,
       ordinal           INTEGER NOT NULL
     );
-    CREATE TABLE message_parts (
-      message_id TEXT NOT NULL,
-      ordinal    INTEGER NOT NULL,
-      kind       TEXT NOT NULL,
-      payload    TEXT NOT NULL,
-      tool_name  TEXT,
-      file_path  TEXT,
-      created_at TEXT
-    );
+    ${messagePartsHaveOrdinal
+      ? `CREATE TABLE message_parts (
+          message_id TEXT NOT NULL,
+          ordinal    INTEGER NOT NULL,
+          kind       TEXT NOT NULL,
+          payload    TEXT NOT NULL,
+          tool_name  TEXT,
+          file_path  TEXT,
+          created_at TEXT
+        );`
+      : `CREATE TABLE message_parts (
+          message_id TEXT NOT NULL,
+          kind       TEXT NOT NULL,
+          payload    TEXT NOT NULL,
+          tool_name  TEXT,
+          file_path  TEXT,
+          created_at TEXT
+        );`}
   `);
 
   const insConv = db.prepare(
@@ -136,20 +147,37 @@ function buildSourceDb(seed: {
     );
   }
 
-  const insPart = db.prepare(
-    "INSERT INTO message_parts (message_id, ordinal, kind, payload, tool_name, file_path, created_at) " +
-      "VALUES (?, ?, ?, ?, ?, ?, ?)",
-  );
-  for (const part of seed.messageParts ?? []) {
-    insPart.run(
-      part.message_id,
-      part.ordinal,
-      part.kind,
-      part.payload,
-      part.tool_name ?? null,
-      part.file_path ?? null,
-      part.created_at ?? null,
+  if (messagePartsHaveOrdinal) {
+    const insPart = db.prepare(
+      "INSERT INTO message_parts (message_id, ordinal, kind, payload, tool_name, file_path, created_at) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
     );
+    for (const part of seed.messageParts ?? []) {
+      insPart.run(
+        part.message_id,
+        part.ordinal,
+        part.kind,
+        part.payload,
+        part.tool_name ?? null,
+        part.file_path ?? null,
+        part.created_at ?? null,
+      );
+    }
+  } else {
+    const insPart = db.prepare(
+      "INSERT INTO message_parts (message_id, kind, payload, tool_name, file_path, created_at) " +
+        "VALUES (?, ?, ?, ?, ?, ?)",
+    );
+    for (const part of seed.messageParts ?? []) {
+      insPart.run(
+        part.message_id,
+        part.kind,
+        part.payload,
+        part.tool_name ?? null,
+        part.file_path ?? null,
+        part.created_at ?? null,
+      );
+    }
   }
 
   if (seed.summaries) {
@@ -268,6 +296,7 @@ const TWO_CONVS = (): {
   conversations: SeedConversation[];
   messages: SeedMessage[];
   messageParts?: SeedMessagePart[];
+  messagePartsHaveOrdinal?: boolean;
   summaries: SeedSummary[];
 } => ({
   conversations: [
@@ -498,6 +527,114 @@ describe("importLosslessClaw — idempotency", () => {
 
     assert.equal(result.messagePartsInserted, 1);
     assert.equal(result.messagePartsSkipped, 0);
+  });
+
+  it("retries insert missing message_parts when a previous import was partial", () => {
+    const partialSeed = TWO_CONVS();
+    partialSeed.messageParts = [
+      {
+        message_id: "m-a-2",
+        ordinal: 0,
+        kind: "file_write",
+        payload: JSON.stringify({ path: "src/auth.ts" }),
+        tool_name: "Edit",
+        file_path: "src/auth.ts",
+        created_at: "2026-04-01T00:00:01.500Z",
+      },
+    ];
+    const retrySeed = TWO_CONVS();
+    retrySeed.messageParts = [
+      ...partialSeed.messageParts,
+      {
+        message_id: "m-a-2",
+        ordinal: 1,
+        kind: "file_write",
+        payload: JSON.stringify({ path: "src/session.ts" }),
+        tool_name: "Edit",
+        file_path: "src/session.ts",
+        created_at: "2026-04-01T00:00:01.750Z",
+      },
+    ];
+    const dst = buildDestDb();
+
+    const first = importLosslessClaw({
+      sourceDb: buildSourceDb(partialSeed),
+      destDb: dst,
+    });
+    const retry = importLosslessClaw({
+      sourceDb: buildSourceDb(retrySeed),
+      destDb: dst,
+    });
+
+    assert.equal(first.messagePartsInserted, 1);
+    assert.equal(retry.messagePartsInserted, 1);
+    assert.equal(retry.messagePartsSkipped, 1);
+
+    const parts = dst
+      .prepare(
+        "SELECT p.ordinal, p.file_path, m.session_id, m.turn_index " +
+          "FROM lcm_message_parts p JOIN lcm_messages m ON m.id = p.message_id " +
+          "ORDER BY p.ordinal",
+      )
+      .all();
+    assert.deepEqual(parts, [
+      {
+        ordinal: 0,
+        file_path: "src/auth.ts",
+        session_id: "sess-A",
+        turn_index: 1,
+      },
+      {
+        ordinal: 1,
+        file_path: "src/session.ts",
+        session_id: "sess-A",
+        turn_index: 1,
+      },
+    ]);
+  });
+
+  it("imports multiple legacy message_parts rows when ordinal is absent", () => {
+    const seed = TWO_CONVS();
+    seed.messagePartsHaveOrdinal = false;
+    seed.messageParts = [
+      {
+        message_id: "m-a-2",
+        ordinal: 0,
+        kind: "file_write",
+        payload: JSON.stringify({ path: "src/auth.ts" }),
+        tool_name: "Edit",
+        file_path: "src/auth.ts",
+        created_at: "2026-04-01T00:00:01.500Z",
+      },
+      {
+        message_id: "m-a-2",
+        ordinal: 0,
+        kind: "file_write",
+        payload: JSON.stringify({ path: "src/session.ts" }),
+        tool_name: "Edit",
+        file_path: "src/session.ts",
+        created_at: "2026-04-01T00:00:01.750Z",
+      },
+    ];
+    const dst = buildDestDb();
+
+    const result = importLosslessClaw({
+      sourceDb: buildSourceDb(seed),
+      destDb: dst,
+    });
+
+    assert.equal(result.messagePartsInserted, 2);
+    assert.equal(result.messagePartsSkipped, 0);
+
+    const parts = dst
+      .prepare(
+        "SELECT ordinal, file_path FROM lcm_message_parts ORDER BY ordinal",
+      )
+      .all();
+    assert.deepEqual(parts, [
+      { ordinal: 0, file_path: "src/auth.ts" },
+      { ordinal: 1, file_path: "src/session.ts" },
+    ]);
   });
 });
 

--- a/packages/import-lossless-claw/src/importer.ts
+++ b/packages/import-lossless-claw/src/importer.ts
@@ -335,7 +335,7 @@ export function importLosslessClaw(
   const destHasMessageParts = sqliteTableExists(destDb, "lcm_message_parts");
   const existingPartsStmt = destHasMessageParts
     ? destDb.prepare(
-      "SELECT COUNT(*) AS cnt FROM lcm_message_parts WHERE message_id = ?",
+      "SELECT ordinal FROM lcm_message_parts WHERE message_id = ?",
     )
     : undefined;
   const insertPartStmt = destHasMessageParts
@@ -346,8 +346,22 @@ export function importLosslessClaw(
     : undefined;
 
   function processMessageParts(forWrite: boolean): void {
-    const seenDestMessages = new Set<number>();
-    const blockedDestMessages = new Set<number>();
+    const existingPartOrdinalsByMessage = new Map<number, Set<number>>();
+    const getExistingPartOrdinals = (destMessageId: number): Set<number> => {
+      let ordinals = existingPartOrdinalsByMessage.get(destMessageId);
+      if (!ordinals) {
+        ordinals = new Set<number>();
+        if (existingPartsStmt) {
+          const rows = existingPartsStmt.all(destMessageId) as Array<{ ordinal: number }>;
+          for (const row of rows) {
+            ordinals.add(row.ordinal);
+          }
+        }
+        existingPartOrdinalsByMessage.set(destMessageId, ordinals);
+      }
+      return ordinals;
+    };
+
     for (const sourcePart of messageParts) {
       if (!turnIndexByMessageId.has(sourcePart.message_id)) {
         result.messagePartsSkipped += 1;
@@ -355,19 +369,10 @@ export function importLosslessClaw(
       }
       const destMessageId = destRowIdByMessageId.get(sourcePart.message_id);
       if (destMessageId !== undefined && destMessageId >= 0) {
-        if (blockedDestMessages.has(destMessageId)) {
+        const existingOrdinals = getExistingPartOrdinals(destMessageId);
+        if (existingOrdinals.has(sourcePart.ordinal)) {
           result.messagePartsSkipped += 1;
           continue;
-        }
-        if (existingPartsStmt && !seenDestMessages.has(destMessageId)) {
-          const existing = existingPartsStmt.get(destMessageId) as { cnt: number };
-          if (existing.cnt > 0) {
-            seenDestMessages.add(destMessageId);
-            blockedDestMessages.add(destMessageId);
-            result.messagePartsSkipped += 1;
-            continue;
-          }
-          seenDestMessages.add(destMessageId);
         }
       } else if (forWrite) {
         result.messagePartsSkipped += 1;
@@ -388,6 +393,9 @@ export function importLosslessClaw(
           mapped.filePath ?? null,
           mapped.createdAt ?? sourcePart.created_at ?? new Date().toISOString(),
         );
+      }
+      if (destMessageId !== undefined && destMessageId >= 0) {
+        getExistingPartOrdinals(destMessageId).add(sourcePart.ordinal);
       }
       result.messagePartsInserted += 1;
       const session = sessionByMessageId.get(sourcePart.message_id);

--- a/packages/import-lossless-claw/src/source.ts
+++ b/packages/import-lossless-claw/src/source.ts
@@ -199,11 +199,14 @@ export function listMessageParts(db: Database.Database): LosslessClawMessagePart
 
   const select = (name: string, fallback: string): string =>
     columns.has(name) ? name : `${fallback} AS ${name}`;
+  const ordinalSelect = columns.has("ordinal")
+    ? "ordinal"
+    : "ROW_NUMBER() OVER (PARTITION BY message_id ORDER BY rowid) - 1 AS ordinal";
   return db
     .prepare(
       "SELECT " +
         "message_id, " +
-        `${select("ordinal", "0")}, ` +
+        `${ordinalSelect}, ` +
         `${select("kind", "'tool_call'")}, ` +
         `${select("payload", "'{}'")}, ` +
         `${select("tool_name", "NULL")}, ` +


### PR DESCRIPTION
ClawPatch finding: `fnd_sig-feat-library-6a4e38aa2f-f593_40f32a59f5`

Fixes retry behavior in lossless Claw imports when a previous run inserted only some `lcm_message_parts` rows for a destination message. The importer now tracks existing part ordinals per destination message and skips only the ordinals already present, allowing missing parts to be inserted on retry without duplicating existing parts.

Verification:
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/import-lossless-claw test`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes import deduplication and ordinal assignment for migrated SQLite data; behavior is localized to the import package with new integration tests, but incorrect logic could duplicate or omit tool/file sidecar rows.
> 
> **Overview**
> Fixes **lossless Claw** `lcm_message_parts` import so a **retry after a partial run** can backfill missing rows instead of skipping the whole message.
> 
> **Importer (`processMessageParts`)** no longer treats “any existing part” as a hard block. It loads **existing ordinals per destination message**, skips only ordinals already present, and records newly written ordinals in memory so duplicates are not inserted on the same pass.
> 
> **Source reader (`listMessageParts`)** assigns synthetic ordinals when the legacy `message_parts` table has **no `ordinal` column**, using `ROW_NUMBER()` per `message_id` so multiple rows for one message import as distinct parts (0, 1, …) instead of colliding at ordinal 0.
> 
> Tests add fixtures without `ordinal` and cover partial-retry plus legacy multi-part import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b884a3549f0e2eb7f53ece5b9e3f663ec8a4d0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->