### PR TITLE
Clear stale utility learning weights

### DIFF
--- a/packages/remnic-core/src/utility-learner.ts
+++ b/packages/remnic-core/src/utility-learner.ts
@@ -293,6 +293,7 @@ export async function learnUtilityPromotionWeights(options: {
   };
 
   if (weights.length === 0) {
+    await writeUtilityLearningSnapshot(statePath, snapshot);
     return {
       applied: false,
       reason: "insufficient_events",

--- a/tests/utility-learner.test.ts
+++ b/tests/utility-learner.test.ts
@@ -154,6 +154,68 @@ test("offline utility learner ignores stale events and no-ops below minimum samp
     assert.equal(result.applied, false);
     assert.equal(result.reason, "insufficient_events");
     assert.equal(result.snapshot?.weights.length, 0);
+
+    const persisted = await readUtilityLearningSnapshot(memoryDir);
+    assert.equal(persisted?.weights.length, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("offline utility learner clears stale persisted weights when samples become insufficient", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-utility-learner-clear-"));
+  try {
+    await recordEvent(memoryDir, {
+      eventId: "utility-pr30-clear-1",
+      target: "promotion",
+      decision: "promote",
+      outcome: "helpful",
+      utilityScore: 1,
+    });
+    await recordEvent(memoryDir, {
+      eventId: "utility-pr30-clear-2",
+      target: "promotion",
+      decision: "promote",
+      outcome: "helpful",
+      utilityScore: 0.8,
+    });
+
+    const learned = await learnUtilityPromotionWeights({
+      memoryDir,
+      enabled: true,
+      now: new Date("2026-03-08T06:00:00.000Z"),
+      learningWindowDays: 7,
+      minEventCount: 2,
+      maxWeightMagnitude: 0.35,
+    });
+    assert.equal(learned.applied, true);
+    assert.equal(learned.snapshot?.weights.length, 1);
+
+    const insufficient = await learnUtilityPromotionWeights({
+      memoryDir,
+      enabled: true,
+      now: new Date("2026-03-08T07:00:00.000Z"),
+      learningWindowDays: 7,
+      minEventCount: 3,
+      maxWeightMagnitude: 0.35,
+    });
+    assert.equal(insufficient.applied, false);
+    assert.equal(insufficient.reason, "insufficient_events");
+    assert.equal(insufficient.snapshot?.weights.length, 0);
+
+    const persisted = await readUtilityLearningSnapshot(memoryDir);
+    assert.equal(persisted?.weights.length, 0);
+    assert.equal(persisted?.updatedAt, "2026-03-08T07:00:00.000Z");
+
+    const status = await getUtilityLearningStatus({
+      memoryDir,
+      enabled: true,
+      promotionByOutcomeEnabled: true,
+    });
+    assert.equal(status.weights.total, 0);
+    assert.equal(status.weights.positive, 0);
+    assert.equal(status.weights.negative, 0);
+    assert.equal(status.weights.latestUpdatedAt, "2026-03-08T07:00:00.000Z");
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
@@ -217,7 +279,12 @@ test("utility learner sanitizes NaN numeric inputs before persisting a snapshot"
     assert.equal(result.snapshot?.minEventCount, 3);
     assert.equal(result.snapshot?.maxWeightMagnitude, 0.35);
     assert.equal(result.snapshot?.weights.length, 0);
-    assert.equal(await readUtilityLearningSnapshot(memoryDir), null);
+
+    const persisted = await readUtilityLearningSnapshot(memoryDir);
+    assert.equal(persisted?.weights.length, 0);
+    assert.equal(persisted?.windowDays, 14);
+    assert.equal(persisted?.minEventCount, 3);
+    assert.equal(persisted?.maxWeightMagnitude, 0.35);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
ClawPatch finding: `fnd_sig-feat-library-6d68cb7170-d740_e01c78702d`

Fixes utility learning state transitions when a later enabled learning run has insufficient samples. The learner now persists the empty snapshot before returning `insufficient_events`, so `learning-state.json` and `getUtilityLearningStatus()` no longer report stale weights from an earlier successful run.

Verification:
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/utility-learner.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to when learning fails for insufficient samples; it corrects on-disk state and status reporting without touching auth or core promotion logic.
> 
> **Overview**
> Fixes **stale utility learning weights** when a later run no longer has enough telemetry samples to learn.
> 
> `learnUtilityPromotionWeights` now **writes `learning-state.json` even when it returns `insufficient_events`**, persisting an empty `weights` array (with current window/min/magnitude metadata) instead of leaving the file from an earlier successful run untouched. **`getUtilityLearningStatus()`** therefore reflects zero weights after such a run.
> 
> Tests assert persistence on insufficient-sample paths and add a scenario where raising `minEventCount` after a successful learn **clears** previously stored weights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597503b40323d2aad1a579a6e03eae05feb3f9c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->