### PR TITLE
Persist active recall cache-hit transcripts

### DIFF
--- a/packages/remnic-core/src/active-recall.test.ts
+++ b/packages/remnic-core/src/active-recall.test.ts
@@ -198,6 +198,46 @@ test("active recall cache hits report cache-hit latency instead of reusing gener
   assert.equal(second.latencyMs, 1);
 });
 
+test("active recall cache hits append a fresh transcript entry", async () => {
+  const transcriptDir = await mkdtemp(path.join(os.tmpdir(), "active-recall-cache-transcript-"));
+  let generateCalls = 0;
+  const engine = createActiveRecallEngine(
+    {
+      async recall() {
+        return "CI worker drain after Redis reconnect storm.";
+      },
+      async generateSummary() {
+        generateCalls += 1;
+        return { text: "Redis reconnect storm caused the worker drain." };
+      },
+      now: (() => {
+        let tick = 40_000;
+        return () => tick++;
+      })(),
+    },
+    baseConfig({
+      cacheTtlMs: 5000,
+      persistTranscripts: true,
+      transcriptDir,
+    }),
+  );
+
+  const first = await engine.run(baseInput());
+  const second = await engine.run(baseInput());
+
+  assert.equal(generateCalls, 1);
+  assert.equal(first.cacheHit, false);
+  assert.equal(second.cacheHit, true);
+  assert.ok(first.transcriptPath, "expected first transcript path");
+  assert.ok(second.transcriptPath, "expected cache-hit transcript path");
+
+  const raw = await readFile(second.transcriptPath ?? "", "utf8");
+  const entries = raw.trim().split("\n").map((line) => JSON.parse(line) as { cacheHit: boolean });
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].cacheHit, false);
+  assert.equal(entries[1].cacheHit, true);
+});
+
 test("active recall cache stores an isolated snapshot instead of a mutable caller reference", async () => {
   let generateCalls = 0;
   const engine = createActiveRecallEngine(

--- a/packages/remnic-core/src/active-recall.ts
+++ b/packages/remnic-core/src/active-recall.ts
@@ -361,11 +361,26 @@ export function createActiveRecallEngine(
       }
       const cached = cache.get(cacheKey);
       if (cacheEnabled && cached) {
-        return {
+        const result: ActiveRecallResult = {
           ...cloneRecallResult(cached.value),
           latencyMs: Math.max(0, now() - currentTime),
           cacheHit: true,
         };
+        result.transcriptPath = null;
+        if (config.persistTranscripts) {
+          try {
+            result.transcriptPath = await appendActiveRecallTranscript(
+              config.transcriptDir,
+              input,
+              config,
+              result,
+              queryBundle,
+            );
+          } catch {
+            result.transcriptPath = null;
+          }
+        }
+        return result;
       }
 
       const start = currentTime;
@@ -451,9 +466,11 @@ export function createActiveRecallEngine(
 
       if (cacheEnabled) {
         const completedAt = now();
+        const cachedValue = cloneRecallResult(result);
+        cachedValue.transcriptPath = null;
         cache.set(cacheKey, {
           expiresAt: completedAt + config.cacheTtlMs,
-          value: cloneRecallResult(result),
+          value: cachedValue,
         });
         enforceCacheLimit(cache);
       }


### PR DESCRIPTION
Fixes ClawPatch finding `fnd_sig-feat-library-6f29ab0875-744e_db97bd5a69`.

## Summary
- append a fresh active-recall transcript entry on cache hits when transcript persistence is enabled
- avoid caching transcript paths so cache hits cannot return stale transcriptPath values
- add focused regression coverage for cache-hit transcript persistence

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/remnic-core/src/active-recall.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to active-recall caching and optional transcript logging; no auth or data-model changes.
> 
> **Overview**
> Fixes active recall audit gaps when responses are served from cache: **cache hits now append a new JSONL transcript line** (with `cacheHit: true`) whenever `persistTranscripts` is on, matching the behavior of uncached runs.
> 
> **Cached snapshots no longer store `transcriptPath`**, so repeated hits cannot surface a path from an earlier request; the path on the returned result comes only from the append for that invocation. A regression test checks two transcript lines (miss then hit) and that generation still runs once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ccfb697d7c8084553bf84c3082e208058e9c3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->