### PR TITLE
Read implicit default materialize namespace from legacy root

### DIFF
--- a/packages/remnic-core/src/connectors/codex-materialize-runner.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize-runner.ts
@@ -199,8 +199,10 @@ function resolveNamespaceDir(
 ): string {
   if (!cfg.namespacesEnabled) return memoryDir;
 
-  const defaultNamespace = (cfg.defaultNamespace ?? "").trim();
-  const ns = (namespace || defaultNamespace || "default").trim();
+  const configuredDefaultNamespace = (cfg.defaultNamespace ?? "").trim();
+  const defaultNamespace =
+    configuredDefaultNamespace.length > 0 ? configuredDefaultNamespace : "default";
+  const ns = (namespace || defaultNamespace).trim();
   if (!isSafeRouteNamespace(ns)) {
     throw new Error(`invalid materialize namespace: ${ns}`);
   }

--- a/tests/codex-materialize-runner.test.ts
+++ b/tests/codex-materialize-runner.test.ts
@@ -367,6 +367,56 @@ test("runner falls back to legacy root for trimmed default namespace without mig
   }
 });
 
+test("runner falls back to legacy root for implicit default namespace without migrated directory", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-implicit-default-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-implicit-default-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    const storage = new StorageManager(memoryDir);
+    await storage.writeMemory(
+      "fact",
+      "synthetic implicit default legacy-root memory.",
+      { source: "runner-test" },
+    );
+    assert.equal(
+      existsSync(path.join(memoryDir, "namespaces", "default")),
+      false,
+      "test setup should not create a migrated default namespace directory",
+    );
+    ensureSentinel(memoriesDir, "default", new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      namespacesEnabled: true,
+      codexMaterializeMemories: true,
+    });
+    (config as any).defaultNamespace = undefined;
+
+    const result = await runCodexMaterialize({
+      config,
+      codexHome,
+      reason: "manual",
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.ok(result, "runner should materialize from the legacy root");
+    assert.equal(result.namespace, "default");
+    const rawContents = (await import("node:fs")).readFileSync(
+      path.join(memoriesDir, "raw_memories.md"),
+      "utf-8",
+    );
+    assert.match(rawContents, /synthetic implicit default legacy-root memory/);
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
 test("runner skips when reason=session_end and codexMaterializeOnSessionEnd=false (P2 fix)", async () => {
   const memoryDir = makeTempDir("codex-materialize-runner-sessend-memdir-");
   const workspaceDir = makeTempDir("codex-materialize-runner-sessend-workspace-");


### PR DESCRIPTION
## Summary
- treat an unset materialize default namespace as the effective `default` namespace when resolving storage roots
- keep implicit default materialization on the legacy memory root unless `memoryDir/namespaces/default` already exists
- add regression coverage for namespaces enabled with `defaultNamespace` actually unset

ClawPatch finding: `fnd_sig-feat-library-73b8f5a3ce-86b6_ee8a62e9b6`

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/codex-materialize-runner.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted path-resolution fix with regression test; affects Codex materialize read location for edge-case config only.
> 
> **Overview**
> **Aligns Codex materialize storage resolution when `defaultNamespace` is unset** so it matches the rest of the runner: an empty or missing config value is treated as the effective **`default`** namespace, not an empty string.
> 
> In `resolveNamespaceDir`, the effective default is now **`default`** when nothing is configured, and the resolved namespace uses that value directly. **Legacy-root fallback** still applies for that default when `memoryDir/namespaces/default` does not exist, so pre-migration installs keep reading from the top-level `memoryDir` instead of switching paths silently.
> 
> Adds a regression test for **namespaces enabled** with **`defaultNamespace` actually undefined**, asserting materialization reads from the legacy root and reports namespace **`default`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2374afd9f7e50e43df3c776989e3aa499f474f79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->