### PR TITLE
Validate MemoryAgentBench trialLimit inputs

### DIFF
--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.test.ts
@@ -555,13 +555,13 @@ test("MemoryAgentBench rejects malformed primary dataset instead of falling back
   }
 });
 
-test("MemoryAgentBench trialLimit caps scored questions before extra adapter work", async () => {
+test("MemoryAgentBench trialLimit numeric string caps scored questions before extra adapter work", async () => {
   let resetCount = 0;
 
   const result = await runMemoryAgentBenchBenchmark({
     benchmark: memoryAgentBenchDefinition,
     mode: "quick",
-    benchmarkOptions: { trialLimit: 2 },
+    benchmarkOptions: { trialLimit: "2" },
     system: {
       async reset() {
         resetCount += 1;
@@ -737,6 +737,63 @@ test("MemoryAgentBench trialLimit null is treated as unlimited", async () => {
       "mab-smoke-cr-q1",
     ],
   );
+});
+
+test("MemoryAgentBench trialLimit rejects values that coerce to zero", async () => {
+  const invalidTrialLimits: unknown[] = ["", "   ", false, true, []];
+
+  for (const trialLimit of invalidTrialLimits) {
+    let resetCalled = false;
+
+    await assert.rejects(
+      runMemoryAgentBenchBenchmark({
+        benchmark: memoryAgentBenchDefinition,
+        mode: "quick",
+        benchmarkOptions: { trialLimit },
+        system: {
+          async reset() {
+            resetCalled = true;
+          },
+          async store() {},
+          async recall() {
+            return "";
+          },
+          async search() {
+            return [];
+          },
+          async destroy() {},
+          async getStats() {
+            return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+          },
+          responder: {
+            async respond() {
+              return {
+                text: "",
+                tokens: { input: 0, output: 0 },
+                latencyMs: 0,
+                model: "mab-test-responder",
+              };
+            },
+          },
+          judge: {
+            async score() {
+              return 0;
+            },
+            async scoreWithMetrics() {
+              return {
+                score: 0,
+                tokens: { input: 0, output: 0 },
+                latencyMs: 0,
+                model: "mab-test-judge",
+              };
+            },
+          },
+        },
+      }),
+      /MemoryAgentBench benchmarkOptions\.trialLimit must be a non-negative integer/,
+    );
+    assert.equal(resetCalled, false);
+  }
 });
 
 test("MemoryAgentBench trialLimit 0 runs zero scored questions", async () => {

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -396,7 +396,12 @@ function resolveTrialLimit(raw: unknown): number | undefined {
   if (raw === undefined || raw === null) {
     return undefined;
   }
-  const parsed = typeof raw === "number" ? raw : Number(raw);
+  const parsed =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string" && raw.trim().length > 0 && /^[0-9]+$/.test(raw.trim())
+        ? Number(raw.trim())
+        : Number.NaN;
   if (!Number.isInteger(parsed) || parsed < 0) {
     throw new Error(
       "MemoryAgentBench benchmarkOptions.trialLimit must be a non-negative integer.",


### PR DESCRIPTION
## Summary
- reject MemoryAgentBench `benchmarkOptions.trialLimit` values that only become zero through JavaScript coercion
- keep explicit numeric `0` valid and keep non-empty numeric strings normalized for CLI-style inputs
- add regression coverage for empty strings, whitespace, booleans, and arrays

ClawPatch finding: `fnd_sig-feat-library-7777d8c1d7-9118_7e74b1a10c`

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/bench/src/benchmarks/published/memoryagentbench/runner.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-option validation only in the MemoryAgentBench runner; no auth, data, or production runtime paths.
> 
> **Overview**
> Tightens **MemoryAgentBench** `benchmarkOptions.trialLimit` parsing so only non-negative integers and **non-empty digit-only strings** (e.g. `"2"`) are accepted.
> 
> **`resolveTrialLimit`** no longer uses bare `Number(raw)` on arbitrary values. Empty strings, whitespace-only strings, booleans, and arrays now fail validation instead of silently becoming `0` and running zero trials. Explicit numeric **`0`** and **`null`** (unlimited) behavior is unchanged; valid string inputs are still normalized to numbers in the run config.
> 
> Adds regression tests for coercible-to-zero inputs and updates the cap test to use a numeric string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 340bf8f842d462ca5d6134396bdf65fa639f50b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->