### PR TITLE
Replace stale temporal index memberships

### DIFF
--- a/packages/remnic-core/src/temporal-index.test.ts
+++ b/packages/remnic-core/src/temporal-index.test.ts
@@ -218,3 +218,21 @@ test("tag queries distinguish missing index from valid no-match results", async 
   assert.deepEqual(noFilterPrefilter.expandedTags, []);
   assert.equal(noFilterPrefilter.paths, null);
 });
+
+test("indexMemory replaces stale date and tag memberships for an existing path", async () => {
+  const memoryDir = await mkdtemp(join(tmpdir(), "remnic-temporal-index-update-"));
+  const memoryPath = "/tmp/remnic-temporal-updated-memory.md";
+
+  indexMemory(memoryDir, memoryPath, "2026-01-01T00:00:00.000Z", ["alpha"]);
+  indexMemory(memoryDir, memoryPath, "2026-02-01T00:00:00.000Z", ["beta"]);
+
+  const januaryMatches = await queryByDateRangeAsync(memoryDir, "2026-01-01", "2026-01-02");
+  const februaryMatches = await queryByDateRangeAsync(memoryDir, "2026-02-01", "2026-02-02");
+  const alphaMatches = await queryByTagsAsync(memoryDir, ["alpha"]);
+  const betaMatches = await queryByTagsAsync(memoryDir, ["beta"]);
+
+  assert.deepEqual(januaryMatches, new Set());
+  assert.deepEqual(februaryMatches, new Set([memoryPath]));
+  assert.deepEqual(alphaMatches, new Set());
+  assert.deepEqual(betaMatches, new Set([memoryPath]));
+});

--- a/packages/remnic-core/src/temporal-index.ts
+++ b/packages/remnic-core/src/temporal-index.ts
@@ -322,6 +322,12 @@ function removePathFromSet(record: Record<string, string[]>, key: string, p: str
   }
 }
 
+function removePathFromAllSets(record: Record<string, string[]>, p: string): void {
+  for (const key of Object.keys(record)) {
+    removePathFromSet(record, key, p);
+  }
+}
+
 function normalizeTagSegment(segment: string): string {
   return segment
     .trim()
@@ -499,6 +505,41 @@ function removeTagGraphEntry(index: TagIndex, rawTag: string, memoryPath: string
   node.paths = node.paths.filter((value) => value !== memoryPath);
   if (node.paths.length === 0) {
     delete index.tags[canonical];
+    pruneTagAliases(index);
+  }
+}
+
+function removePathFromAllTagEntries(index: TagIndex, memoryPath: string): void {
+  for (const [canonical, nodeOrPaths] of Object.entries(index.tags)) {
+    if (Array.isArray(nodeOrPaths)) {
+      const paths = nodeOrPaths.filter((value) => value !== memoryPath);
+      if (paths.length === 0) {
+        delete index.tags[canonical];
+      } else {
+        index.tags[canonical] = paths;
+      }
+      continue;
+    }
+
+    nodeOrPaths.paths = nodeOrPaths.paths.filter((value) => value !== memoryPath);
+    if (nodeOrPaths.paths.length === 0) {
+      delete index.tags[canonical];
+    }
+  }
+  pruneTagAliases(index);
+}
+
+function pruneTagAliases(index: TagIndex): void {
+  if (!index.aliases) return;
+  for (const [alias, canonicals] of Object.entries(index.aliases)) {
+    const filtered = [...new Set(canonicals.map(normalizeCanonicalTag))].filter(
+      (canonical) => canonical.length > 0 && index.tags[canonical] !== undefined
+    );
+    if (filtered.length === 0) {
+      delete index.aliases[alias];
+    } else {
+      index.aliases[alias] = filtered;
+    }
   }
 }
 
@@ -555,10 +596,12 @@ export function indexMemory(memoryDir: string, memoryPath: string, createdAt: st
 
     const dateKey = isoDateFromTimestamp(createdAt);
     updateTemporalIndex(memoryDir, (index) => {
+      removePathFromAllSets(index.dates, memoryPath);
       addPathToSet(index.dates, dateKey, memoryPath);
     });
 
     updateTagIndex(memoryDir, (index) => {
+      removePathFromAllTagEntries(index, memoryPath);
       for (const tag of tags) {
         if (tag && typeof tag === "string") {
           addTagGraphEntry(index, tag, memoryPath);
@@ -645,12 +688,14 @@ export function indexMemoriesBatch(
     updateTemporalIndex(memoryDir, (index) => {
       for (const entry of entries) {
         const dateKey = isoDateFromTimestamp(entry.createdAt);
+        removePathFromAllSets(index.dates, entry.path);
         addPathToSet(index.dates, dateKey, entry.path);
       }
     });
 
     updateTagIndex(memoryDir, (index) => {
       for (const entry of entries) {
+        removePathFromAllTagEntries(index, entry.path);
         for (const tag of entry.tags) {
           if (tag && typeof tag === "string") {
             addTagGraphEntry(index, tag, entry.path);


### PR DESCRIPTION
## Summary
- remove an existing memory path from old temporal buckets before adding its new date bucket
- remove an existing memory path from old tag nodes before adding its new tags, pruning empty alias mappings
- apply the same replacement behavior to batch indexing and cover stale date/tag queries with a regression test

ClawPatch finding: `fnd_sig-feat-library-7c74e01f37-f3d9_0f98876982`

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/remnic-core/src/temporal-index.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes advisory retrieval prefilters; wrong behavior could skew search narrowing, but indexes remain fail-open and scoped to index update paths.
> 
> **Overview**
> **Re-indexing the same memory path now replaces prior temporal and tag memberships** instead of only appending, so date/tag prefilters no longer return stale hits after metadata changes.
> 
> `indexMemory` and `indexMemoriesBatch` clear the path from every date bucket and tag node (including legacy array-shaped tag entries) before writing the new `createdAt` and tags. Empty tag nodes trigger **`pruneTagAliases`** so alias maps do not keep pointing at removed canonical tags; single-tag removal via `removeTagGraphEntry` uses the same pruning.
> 
> A regression test re-indexes one path from January/`alpha` to February/`beta` and asserts old buckets are empty while only the new date/tag match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910a8fc91345897568b530d42fd107b444fd8ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->