### PR TITLE
Ensure target Meilisearch collections

### DIFF
--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -8,6 +8,7 @@ class FakeBackend implements SearchBackend {
   updates = 0;
   calls: Array<{ method: string; collection: string | undefined }> = [];
   ensureSignals: Array<AbortSignal | undefined> = [];
+  ensureCollections: Array<string | undefined> = [];
 
   constructor(
     private readonly globalUpdate: boolean,
@@ -64,8 +65,19 @@ class FakeBackend implements SearchBackend {
 
   async embedCollection(): Promise<void> {}
 
-  async ensureCollection(_memoryDir?: string, execution?: { signal?: AbortSignal }): Promise<"present"> {
-    this.ensureSignals.push(execution?.signal);
+  async ensureCollection(
+    _memoryDir?: string,
+    collectionOrExecution?: string | { signal?: AbortSignal },
+    execution?: { signal?: AbortSignal },
+  ): Promise<"present"> {
+    const collection = typeof collectionOrExecution === "string"
+      ? collectionOrExecution
+      : undefined;
+    const effectiveExecution = typeof collectionOrExecution === "string"
+      ? execution
+      : collectionOrExecution ?? execution;
+    this.ensureCollections.push(collection);
+    this.ensureSignals.push(effectiveExecution?.signal);
     return "present";
   }
 }
@@ -191,4 +203,5 @@ test("ensureNamespaceCollection forwards abort signals to backend collection che
 
   assert.equal(state, "present");
   assert.deepEqual(backend.ensureSignals, [controller.signal]);
+  assert.deepEqual(backend.ensureCollections, ["openclaw-engram--ns-6d61696e"]);
 });

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -203,7 +203,7 @@ export class NamespaceSearchRouter {
       const backend = this.createBackend(scopedConfig);
       const available = await backend.probe().catch(() => false);
       const collectionState = available
-        ? await backend.ensureCollection(storage.dir, execution).catch(() => "unknown" as const)
+        ? await backend.ensureCollection(storage.dir, scopedConfig.qmdCollection, execution).catch(() => "unknown" as const)
         : "unknown";
       return {
         backend,

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -89,6 +89,7 @@ interface QmdRuntimeLike {
   isAvailable(): boolean;
   ensureCollection(
     memoryDir: string,
+    collectionOrExecution?: string | { signal?: AbortSignal },
     execution?: { signal?: AbortSignal },
   ): Promise<"present" | "missing" | "unknown" | "skipped">;
   debugStatus(): string;
@@ -730,7 +731,10 @@ export async function runOperatorSetup(options: OperatorSetupOptions): Promise<O
 
   const qmdAvailable = await options.orchestrator.qmd.probe();
   const collectionState = options.orchestrator.config.qmdEnabled
-    ? await options.orchestrator.qmd.ensureCollection(options.orchestrator.config.memoryDir)
+    ? await options.orchestrator.qmd.ensureCollection(
+        options.orchestrator.config.memoryDir,
+        options.orchestrator.config.qmdCollection,
+      )
     : "skipped";
   const nativeKnowledgeStatus = await summarizeNativeKnowledgeStatus(options.orchestrator.config);
 
@@ -1108,7 +1112,7 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
 
   const qmdAvailable = await options.orchestrator.qmd.probe();
   const collectionState = config.qmdEnabled
-    ? await options.orchestrator.qmd.ensureCollection(config.memoryDir)
+    ? await options.orchestrator.qmd.ensureCollection(config.memoryDir, config.qmdCollection)
     : "skipped";
   checks.push({
     key: "qmd",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2512,9 +2512,11 @@ export class Orchestrator {
                       namespace,
                       { signal: collectionCheckAbort.signal },
                     )
-                  : this.qmd.ensureCollection(this.config.memoryDir, {
-                      signal: collectionCheckAbort.signal,
-                    }),
+                  : this.qmd.ensureCollection(
+                      this.config.memoryDir,
+                      this.config.qmdCollection,
+                      { signal: collectionCheckAbort.signal },
+                    ),
                 collectionCheckAbort,
                 namespace,
               );
@@ -2860,7 +2862,7 @@ export class Orchestrator {
         namespace,
         state: this.config.namespacesEnabled
           ? await this.namespaceSearchRouter.ensureNamespaceCollection(namespace, { signal })
-          : await this.qmd.ensureCollection(this.config.memoryDir, { signal }),
+          : await this.qmd.ensureCollection(this.config.memoryDir, this.config.qmdCollection, { signal }),
       })),
     );
 

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -9,7 +9,12 @@ import {
   throwIfAborted,
 } from "./abort-error.js";
 import type { QmdSearchExplain, QmdSearchResult } from "./types.js";
-import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "./search/port.js";
+import {
+  resolveEnsureCollectionArgs,
+  type SearchBackend,
+  type SearchExecutionOptions,
+  type SearchQueryOptions,
+} from "./search/port.js";
 import { launchProcess, type CommandChildProcess } from "./runtime/child-process.js";
 import { mergeEnv } from "./runtime/env.js";
 
@@ -2597,16 +2602,22 @@ export class QmdClient implements SearchBackend {
 
   async ensureCollection(
     memoryDir: string,
+    collectionOrExecution?: string | SearchExecutionOptions,
     execution?: SearchExecutionOptions,
   ): Promise<"present" | "missing" | "unknown" | "skipped"> {
+    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(
+      collectionOrExecution,
+      execution,
+    );
     if (this.available === false && !this.daemonAvailable) return "unknown";
     // If only daemon is available (no CLI), skip collection check
     if (this.available === false) return "skipped";
+    const targetCollection = collection ?? this.collection;
     try {
-      const { stdout } = await this.runQmdCommand(["collection", "list"], QMD_TIMEOUT_MS, execution?.signal);
+      const { stdout } = await this.runQmdCommand(["collection", "list"], QMD_TIMEOUT_MS, effectiveExecution?.signal);
       // Parse text output: "openclaw-engram (qmd://openclaw-engram/)"
       const collectionRegex = new RegExp(
-        `^${this.collection}\\s+\\(qmd://`,
+        `^${escapeRegExp(targetCollection)}\\s+\\(qmd://`,
         "m",
       );
       if (collectionRegex.test(stdout)) {
@@ -2616,15 +2627,19 @@ export class QmdClient implements SearchBackend {
       // Treat command/probe failures as unknown so callers do not disable features
       // permanently after a transient CLI or daemon hiccup.
       log.debug(
-        `QMD collection check unavailable for "${this.collection}" (will not disable features): ${err instanceof Error ? err.message : String(err)}`,
+        `QMD collection check unavailable for "${targetCollection}" (will not disable features): ${err instanceof Error ? err.message : String(err)}`,
       );
       return "unknown";
     }
 
     log.info(
-      `QMD collection "${this.collection}" not found. ` +
+      `QMD collection "${targetCollection}" not found. ` +
         `Add it to ~/.config/qmd/index.yml pointing at ${memoryDir}`,
     );
     return "missing";
   }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/remnic-core/src/search/lancedb-backend.ts
+++ b/packages/remnic-core/src/search/lancedb-backend.ts
@@ -1,5 +1,11 @@
 import { log } from "../logger.js";
-import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions, SearchResult } from "./port.js";
+import {
+  resolveEnsureCollectionArgs,
+  type SearchBackend,
+  type SearchExecutionOptions,
+  type SearchQueryOptions,
+  type SearchResult,
+} from "./port.js";
 import type { EmbedHelper, EmbedProviderIdentity, EmbedWithProviderResult } from "./embed-helper.js";
 import { scanMemoryDir } from "./document-scanner.js";
 import { isSearchAborted, throwIfSearchAborted } from "./abort.js";
@@ -305,10 +311,16 @@ export class LanceDbBackend implements SearchBackend {
 
   async ensureCollection(
     _memoryDir: string,
-    _execution?: SearchExecutionOptions,
+    collectionOrExecution?: string | SearchExecutionOptions,
+    execution?: SearchExecutionOptions,
   ): Promise<"present" | "missing" | "unknown" | "skipped"> {
+    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(
+      collectionOrExecution,
+      execution,
+    );
+    if (isSearchAborted(effectiveExecution)) return "skipped";
     try {
-      await this.ensureTable();
+      await this.ensureTableForCollection(collection ?? this.collection);
       return "present";
     } catch {
       return "missing";

--- a/packages/remnic-core/src/search/meilisearch-backend.ts
+++ b/packages/remnic-core/src/search/meilisearch-backend.ts
@@ -1,5 +1,11 @@
 import { log } from "../logger.js";
-import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions, SearchResult } from "./port.js";
+import {
+  resolveEnsureCollectionArgs,
+  type SearchBackend,
+  type SearchExecutionOptions,
+  type SearchQueryOptions,
+  type SearchResult,
+} from "./port.js";
 import { scanMemoryDir } from "./document-scanner.js";
 import { isSearchAborted, throwIfSearchAborted } from "./abort.js";
 
@@ -134,6 +140,8 @@ export class MeilisearchBackend implements SearchBackend {
     if (isSearchAborted(execution)) return;
 
     try {
+      const ensured = await this.ensureCollection(memoryDir, collection, execution);
+      if (ensured === "skipped" || ensured === "missing") return;
       const client = await this.ensureClient();
       if (isSearchAborted(execution)) return;
       const docs = await scanMemoryDir(memoryDir);
@@ -196,21 +204,47 @@ export class MeilisearchBackend implements SearchBackend {
 
   async ensureCollection(
     _memoryDir: string,
-    _execution?: SearchExecutionOptions,
+    collectionOrExecution?: string | SearchExecutionOptions,
+    execution?: SearchExecutionOptions,
   ): Promise<"present" | "missing" | "unknown" | "skipped"> {
+    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(
+      collectionOrExecution,
+      execution,
+    );
     if (!this.available) return "skipped";
+    if (isSearchAborted(effectiveExecution)) return "skipped";
+    const targetCollection = collection ?? this.collection;
     try {
       const client = await this.ensureClient();
+      if (isSearchAborted(effectiveExecution)) return "skipped";
       try {
-        await client.getIndex(this.collection);
+        await client.getIndex(targetCollection);
         return "present";
-      } catch {
+      } catch (err) {
+        if (!isMeilisearchIndexNotFoundError(err)) {
+          log.debug(
+            `MeilisearchBackend collection check unavailable for "${targetCollection}" (will not skip update): ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+          return "unknown";
+        }
         // Index doesn't exist — create it
-        await client.createIndex(this.collection, { primaryKey: "id" });
+        if (isSearchAborted(effectiveExecution)) return "skipped";
+        const createTask = await client.createIndex(targetCollection, { primaryKey: "id" });
+        if (isSearchAborted(effectiveExecution)) return "skipped";
+        if (createTask?.taskUid !== undefined && createTask?.taskUid !== null) {
+          await client.waitForTask(createTask.taskUid, { timeOutMs: this.timeoutMs });
+        }
         return "present";
       }
-    } catch {
-      return "skipped";
+    } catch (err) {
+      log.debug(
+        `MeilisearchBackend collection check failed for "${targetCollection}" (will not disable updates): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return "unknown";
     }
   }
 
@@ -260,4 +294,33 @@ export class MeilisearchBackend implements SearchBackend {
       score: hit._rankingScore ?? 0.5,
     }));
   }
+}
+
+function isMeilisearchIndexNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const record = err as Record<string, unknown>;
+  const code = typeof record.code === "string" ? record.code.toLowerCase() : "";
+  const type = typeof record.type === "string" ? record.type.toLowerCase() : "";
+  const status =
+    typeof record.status === "number"
+      ? record.status
+      : typeof record.statusCode === "number"
+        ? record.statusCode
+        : undefined;
+  const message = err instanceof Error
+    ? err.message.toLowerCase()
+    : typeof record.message === "string"
+      ? record.message.toLowerCase()
+      : "";
+
+  return (
+    code === "index_not_found"
+    || type === "index_not_found"
+    || status === 404
+    || message.includes("index_not_found")
+    || /index .*not found/.test(message)
+    || /index .*does not exist/.test(message)
+  );
 }

--- a/packages/remnic-core/src/search/noop-backend.ts
+++ b/packages/remnic-core/src/search/noop-backend.ts
@@ -51,7 +51,11 @@ export class NoopSearchBackend implements SearchBackend {
   async embed(): Promise<void> {}
   async embedCollection(_collection: string): Promise<void> {}
 
-  async ensureCollection(_memoryDir: string, _execution?: SearchExecutionOptions): Promise<"skipped"> {
+  async ensureCollection(
+    _memoryDir: string,
+    _collectionOrExecution?: string | SearchExecutionOptions,
+    _execution?: SearchExecutionOptions,
+  ): Promise<"skipped"> {
     return "skipped";
   }
 }

--- a/packages/remnic-core/src/search/orama-backend.ts
+++ b/packages/remnic-core/src/search/orama-backend.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
 import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { log } from "../logger.js";
-import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions, SearchResult } from "./port.js";
+import {
+  resolveEnsureCollectionArgs,
+  type SearchBackend,
+  type SearchExecutionOptions,
+  type SearchQueryOptions,
+  type SearchResult,
+} from "./port.js";
 import type { EmbedHelper, EmbedProviderIdentity, EmbedWithProviderResult } from "./embed-helper.js";
 import { scanMemoryDir } from "./document-scanner.js";
 import { isSearchAborted, throwIfSearchAborted } from "./abort.js";
@@ -357,11 +363,17 @@ export class OramaBackend implements SearchBackend {
 
   async ensureCollection(
     _memoryDir: string,
-    _execution?: SearchExecutionOptions,
+    collectionOrExecution?: string | SearchExecutionOptions,
+    execution?: SearchExecutionOptions,
   ): Promise<"present" | "missing" | "unknown" | "skipped"> {
+    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(
+      collectionOrExecution,
+      execution,
+    );
+    if (isSearchAborted(effectiveExecution)) return "skipped";
     try {
       await this.ensureModules();
-      await this.ensureDb();
+      await this.ensureDbForCollection(collection ?? this.collection);
       return "present";
     } catch {
       return "missing";

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -16,6 +16,16 @@ export interface SearchExecutionOptions {
   signal?: AbortSignal;
 }
 
+export function resolveEnsureCollectionArgs(
+  collectionOrExecution?: string | SearchExecutionOptions,
+  execution?: SearchExecutionOptions,
+): { collection?: string; execution?: SearchExecutionOptions } {
+  if (typeof collectionOrExecution === "string") {
+    return { collection: collectionOrExecution, execution };
+  }
+  return { collection: undefined, execution: collectionOrExecution ?? execution };
+}
+
 /**
  * Abstract search backend interface.
  *
@@ -85,6 +95,11 @@ export interface SearchBackend {
   // ── Collection management ──
   ensureCollection(
     memoryDir: string,
+    execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped">;
+  ensureCollection(
+    memoryDir: string,
+    collection?: string,
     execution?: SearchExecutionOptions,
   ): Promise<"present" | "missing" | "unknown" | "skipped">;
 }

--- a/packages/remnic-core/src/search/remote-backend.ts
+++ b/packages/remnic-core/src/search/remote-backend.ts
@@ -82,7 +82,11 @@ export class RemoteSearchBackend implements SearchBackend {
   async embed(): Promise<void> {}
   async embedCollection(_collection: string): Promise<void> {}
 
-  async ensureCollection(_memoryDir: string, _execution?: SearchExecutionOptions): Promise<"skipped"> {
+  async ensureCollection(
+    _memoryDir: string,
+    _collectionOrExecution?: string | SearchExecutionOptions,
+    _execution?: SearchExecutionOptions,
+  ): Promise<"skipped"> {
     return "skipped";
   }
 

--- a/tests/search-backends.test.ts
+++ b/tests/search-backends.test.ts
@@ -452,6 +452,153 @@ describe("non-QMD backend cancellation", () => {
       await rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("MeilisearchBackend ensures the requested collection before auto-indexing it", async () => {
+    const { MeilisearchBackend } = await import("../src/search/meilisearch-backend.js");
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "engram-meili-target-collection-"));
+    try {
+      await mkdir(path.join(tempDir, "facts"), { recursive: true });
+      await writeFile(path.join(tempDir, "facts", "other.md"), "Other collection memory.", "utf8");
+
+      const existingIndexes = new Set(["default"]);
+      const getIndexCalls: string[] = [];
+      const createIndexCalls: Array<{ uid: string; options: Record<string, unknown> }> = [];
+      const indexCalls: string[] = [];
+      const addCalls: Array<{ collection: string; docs: unknown[] }> = [];
+      const waitForTaskCalls: Array<{ taskUid: number; knownIndexes: string[] }> = [];
+      const client = {
+        getIndex: async (uid: string) => {
+          getIndexCalls.push(uid);
+          if (!existingIndexes.has(uid)) throw new Error("index not found");
+          return { uid };
+        },
+        createIndex: async (uid: string, options: Record<string, unknown>) => {
+          createIndexCalls.push({ uid, options });
+          existingIndexes.add(uid);
+          return { taskUid: 1 };
+        },
+        index: (uid: string) => {
+          indexCalls.push(uid);
+          return {
+            addDocuments: async (docs: unknown[]) => {
+              addCalls.push({ collection: uid, docs });
+              return { taskUid: 2 };
+            },
+            getDocuments: async () => ({ results: [] }),
+            deleteDocuments: async () => ({ taskUid: 3 }),
+          };
+        },
+        waitForTask: async (taskUid: number) => {
+          waitForTaskCalls.push({
+            taskUid,
+            knownIndexes: Array.from(existingIndexes).sort(),
+          });
+        },
+      };
+      const backend = new MeilisearchBackend({
+        host: "http://localhost:7700",
+        collection: "default",
+        autoIndex: true,
+        memoryDir: tempDir,
+      });
+      (backend as any).available = true;
+      (backend as any).client = client;
+
+      await backend.updateCollection("other");
+
+      assert.deepEqual(getIndexCalls, ["other"]);
+      assert.deepEqual(createIndexCalls, [{ uid: "other", options: { primaryKey: "id" } }]);
+      assert.deepEqual(indexCalls, ["other"]);
+      assert.deepEqual(waitForTaskCalls, [
+        { taskUid: 1, knownIndexes: ["default", "other"] },
+        { taskUid: 2, knownIndexes: ["default", "other"] },
+      ]);
+      assert.equal(addCalls.length, 1);
+      assert.equal(addCalls[0]?.collection, "other");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("MeilisearchBackend still auto-indexes when collection status check is unavailable", async () => {
+    const { MeilisearchBackend } = await import("../src/search/meilisearch-backend.js");
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "engram-meili-transient-collection-check-"));
+    try {
+      await mkdir(path.join(tempDir, "facts"), { recursive: true });
+      await writeFile(path.join(tempDir, "facts", "kept.md"), "Index this despite a transient status check failure.", "utf8");
+
+      const createIndexCalls: string[] = [];
+      const indexCalls: string[] = [];
+      const addCalls: Array<{ collection: string; docs: unknown[] }> = [];
+      const client = {
+        getIndex: async () => {
+          throw new Error("getIndex upstream timeout");
+        },
+        createIndex: async (uid: string) => {
+          createIndexCalls.push(uid);
+          throw new Error("createIndex should only run when getIndex reports a missing index");
+        },
+        index: (uid: string) => {
+          indexCalls.push(uid);
+          return {
+            addDocuments: async (docs: unknown[]) => {
+              addCalls.push({ collection: uid, docs });
+              return { taskUid: 4 };
+            },
+            getDocuments: async () => ({ results: [] }),
+            deleteDocuments: async () => ({ taskUid: 5 }),
+          };
+        },
+        waitForTask: async () => {},
+      };
+      const backend = new MeilisearchBackend({
+        host: "http://localhost:7700",
+        collection: "default",
+        autoIndex: true,
+        memoryDir: tempDir,
+      });
+      (backend as any).available = true;
+      (backend as any).client = client;
+
+      await backend.updateCollection("other");
+
+      assert.deepEqual(createIndexCalls, []);
+      assert.deepEqual(indexCalls, ["other"]);
+      assert.equal(addCalls.length, 1);
+      assert.equal(addCalls[0]?.collection, "other");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("MeilisearchBackend preserves legacy ensureCollection execution-argument calls", async () => {
+    const { MeilisearchBackend } = await import("../src/search/meilisearch-backend.js");
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "engram-meili-ensure-legacy-"));
+    try {
+      const getIndexCalls: unknown[] = [];
+      const client = {
+        getIndex: async (uid: unknown) => {
+          getIndexCalls.push(uid);
+          return { uid };
+        },
+      };
+      const backend = new MeilisearchBackend({
+        host: "http://localhost:7700",
+        collection: "default",
+        autoIndex: true,
+        memoryDir: tempDir,
+      });
+      (backend as any).available = true;
+      (backend as any).client = client;
+      const controller = new AbortController();
+
+      assert.equal(await backend.ensureCollection(tempDir, { signal: controller.signal }), "present");
+
+      assert.deepEqual(getIndexCalls, ["default"]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("embed helper", () => {


### PR DESCRIPTION
## Summary
- extend the search backend collection-management contract to accept an explicit collection
- make Meilisearch auto-indexing ensure the target collection before writing to it
- propagate scoped collection names through namespace startup checks and update backend mocks/tests

## Finding
- Fixes ClawPatch finding `fnd_sig-feat-library-83e671b43c-0b12_1c7b636776`

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/search-backends.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/remnic-core/src/namespaces/search.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup sync, namespace collection checks, and Meilisearch index creation paths; mistakes could mis-report collection state or write to the wrong index, but overload parsing and new tests reduce regression risk.
> 
> **Overview**
> Extends **`ensureCollection`** so callers can pass an explicit collection name (with backward-compatible overload via `resolveEnsureCollectionArgs`), then threads that name through namespace startup, operator setup/doctor, and orchestrator QMD checks instead of always using the backend default.
> 
> **Meilisearch** is the main behavior change: auto-indexing now **`ensureCollection`s the target index** before writes (creating it when missing), treats transient check failures as **`unknown`** so updates can still run, and only skips on abort or a confirmed missing path. **QMD** collection probes match the requested name with an escaped regex; **LanceDB/Orama** ensure the per-collection table/DB when a name is supplied.
> 
> Tests cover namespace collection forwarding and Meilisearch ensure-before-index plus legacy `ensureCollection(memoryDir, { signal })` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3897e00da4ceca575f18d01ec77b9dcff6452cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->