### PR TITLE
Skip symlinked provenance scan roots

### DIFF
--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -18,7 +18,7 @@
  */
 
 import path from "node:path";
-import { access, readdir, readFile, stat } from "node:fs/promises";
+import { lstat, readdir, readFile, realpath, stat } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import type { StorageManager } from "./storage.js";
 import {
@@ -499,7 +499,7 @@ export async function runConsolidationProvenanceCheck(options: {
     const scanRoots = ["facts", "corrections", "procedures", "reasoning-traces"];
     for (const rootName of scanRoots) {
       const rootPath = path.join(memoryDir, rootName);
-      for await (const file of walkMarkdownFiles(rootPath)) {
+      for await (const file of walkMarkdownFiles(rootPath, memoryDir)) {
         if (seenPaths.has(file)) continue;
         try {
           const raw = await readFile(file, "utf-8");
@@ -531,21 +531,40 @@ export async function runConsolidationProvenanceCheck(options: {
 /**
  * Recursively yield all `.md` file paths under `root`.  Silent on
  * missing directories — the facts/corrections dirs may not exist in
- * fresh installs.
+ * fresh installs.  Symlinked roots/directories are skipped so the
+ * best-effort parse-failure pass cannot escape `memoryDir`.
  */
-async function* walkMarkdownFiles(root: string): AsyncGenerator<string> {
+async function* walkMarkdownFiles(root: string, memoryDir: string): AsyncGenerator<string> {
   let entries;
+  let memoryDirReal: string;
   try {
+    const rootStat = await lstat(root);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return;
+    memoryDirReal = await realpath(memoryDir);
+    const rootReal = await realpath(root);
+    if (!isPathWithin(rootReal, memoryDirReal)) return;
     entries = await readdir(root, { withFileTypes: true });
   } catch {
     return;
   }
   for (const entry of entries) {
     const full = path.join(root, entry.name);
+    if (entry.isSymbolicLink()) continue;
     if (entry.isDirectory()) {
-      yield* walkMarkdownFiles(full);
+      yield* walkMarkdownFiles(full, memoryDirReal);
     } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      try {
+        const fileReal = await realpath(full);
+        if (!isPathWithin(fileReal, memoryDirReal)) continue;
+      } catch {
+        continue;
+      }
       yield full;
     }
   }
+}
+
+function isPathWithin(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
 }

--- a/tests/consolidation-provenance-check.test.ts
+++ b/tests/consolidation-provenance-check.test.ts
@@ -18,7 +18,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { StorageManager } from "../src/storage.ts";
 import {
   runConsolidationProvenanceCheck,
@@ -404,6 +404,39 @@ test("runConsolidationProvenanceCheck surfaces parse-failed files that carry pro
     assert.equal(parseFailed.length, 1);
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runConsolidationProvenanceCheck does not follow symlinked scan roots outside memoryDir", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-symlink-root-"));
+  const outsideDir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-outside-"));
+  try {
+    await mkdir(path.join(outsideDir, "2026-04-20"), { recursive: true });
+    const outsideFile = path.join(outsideDir, "2026-04-20", "outside.md");
+    await writeFile(
+      outsideFile,
+      [
+        "---",
+        "id: outside-fact",
+        "category: fact",
+        'derived_from: ["facts/a.md:1"]',
+        "derived_via: merge",
+        "body text with no closing delimiter",
+      ].join("\n"),
+      "utf-8",
+    );
+    await symlink(outsideDir, path.join(dir, "facts"), "dir");
+    const storage = {
+      readAllMemories: async () => [],
+    } as unknown as StorageManager;
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+
+    assert.equal(report.withProvenance, 0);
+    assert.deepEqual(report.issues, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Fixes ClawPatch finding fnd_sig-feat-library-8ae3cbb500-b840_a07f8e2549.

## Summary
- skip symlinked provenance parse-failure scan roots/directories
- verify scanned markdown files resolve under the real memoryDir before reading
- add a regression covering a symlinked facts root pointing outside memoryDir

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/consolidation-provenance-check.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem traversal for a diagnostic scan; incorrect containment could miss real corruption or still leak paths, but scope is limited to the doctor provenance check.
> 
> **Overview**
> Hardens the consolidation provenance **parse-failure** filesystem pass so it cannot read markdown outside the configured `memoryDir` via symlinks.
> 
> `walkMarkdownFiles` now takes `memoryDir`, resolves real paths with `lstat`/`realpath`, skips symlinked scan roots and directory entries, and only yields `.md` files whose resolved path stays under the real memory directory (`isPathWithin`). A regression test symlinks `facts/` to an outside tree with broken provenance YAML and asserts the scan reports nothing from that escape hatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8cc54cbe67982a7ef927c0aa5c36bc312c78979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->