### PR TITLE
Ignore future behavior learner signals

### DIFF
--- a/packages/remnic-core/src/behavior-learner.ts
+++ b/packages/remnic-core/src/behavior-learner.ts
@@ -68,13 +68,15 @@ function aggregateSignalPressure(signals: BehaviorSignalEvent[]): number {
 }
 
 function selectRecentSignals(input: BehaviorLearnerInput): BehaviorSignalEvent[] {
-  if (input.learningWindowDays <= 0) return [...input.signals];
   const nowMs = (input.now ?? new Date()).getTime();
-  const minTs = nowMs - input.learningWindowDays * 86_400_000;
+  const minTs =
+    input.learningWindowDays <= 0
+      ? Number.NEGATIVE_INFINITY
+      : nowMs - input.learningWindowDays * 86_400_000;
   return input.signals.filter((signal) => {
     const ts = Date.parse(signal.timestamp);
     if (!Number.isFinite(ts)) return false;
-    return ts >= minTs;
+    return ts >= minTs && ts <= nowMs;
   });
 }
 

--- a/tests/behavior-learner.test.ts
+++ b/tests/behavior-learner.test.ts
@@ -141,6 +141,84 @@ test("learner rejects updates below min signal count", () => {
   assert.equal(state.adjustments.length, 0);
 });
 
+test("learner ignores future-dated signals when selecting recent evidence", () => {
+  const state = learnBehaviorPolicyAdjustments({
+    signals: [
+      signal({
+        memoryId: "current-positive",
+        signalHash: "current-positive",
+        timestamp: "2026-02-28T00:00:00.000Z",
+        direction: "positive",
+        confidence: 0.6,
+      }),
+      signal({
+        memoryId: "future-negative",
+        signalHash: "future-negative",
+        timestamp: "2026-03-01T00:00:00.000Z",
+        direction: "negative",
+        category: "correction",
+        signalType: "correction_override",
+        confidence: 1,
+      }),
+    ],
+    learningWindowDays: 14,
+    minSignalCount: 1,
+    maxDeltaPerCycle: 0.1,
+    protectedParams: [],
+    currentPolicy: {
+      recencyWeight: 0.2,
+      lifecyclePromoteHeatThreshold: 0.55,
+      lifecycleStaleDecayThreshold: 0.65,
+      cronRecallInstructionHeavyTokenCap: 24,
+    },
+    now: new Date("2026-02-28T00:00:00.000Z"),
+  });
+
+  const recency = state.adjustments.find((a) => a.parameter === "recencyWeight");
+  assert.ok(recency);
+  assert.equal(recency.evidenceCount, 1);
+  assert.equal(recency.delta > 0, true);
+});
+
+test("learner ignores future-dated signals when the learning window is disabled", () => {
+  const state = learnBehaviorPolicyAdjustments({
+    signals: [
+      signal({
+        memoryId: "historical-positive",
+        signalHash: "historical-positive",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        direction: "positive",
+        confidence: 0.6,
+      }),
+      signal({
+        memoryId: "future-negative",
+        signalHash: "future-negative",
+        timestamp: "2026-03-01T00:00:00.000Z",
+        direction: "negative",
+        category: "correction",
+        signalType: "correction_override",
+        confidence: 1,
+      }),
+    ],
+    learningWindowDays: 0,
+    minSignalCount: 1,
+    maxDeltaPerCycle: 0.1,
+    protectedParams: [],
+    currentPolicy: {
+      recencyWeight: 0.2,
+      lifecyclePromoteHeatThreshold: 0.55,
+      lifecycleStaleDecayThreshold: 0.65,
+      cronRecallInstructionHeavyTokenCap: 24,
+    },
+    now: new Date("2026-02-28T00:00:00.000Z"),
+  });
+
+  const recency = state.adjustments.find((a) => a.parameter === "recencyWeight");
+  assert.ok(recency);
+  assert.equal(recency.evidenceCount, 1);
+  assert.equal(recency.delta > 0, true);
+});
+
 test("learner treats maxDeltaPerCycle=0 as hard no-op for all parameters", () => {
   const signals = Array.from({ length: 20 }, (_, idx) =>
     signal({


### PR DESCRIPTION
## Summary
- exclude behavior signals timestamped after the learner evaluation time
- add regression coverage proving future opposing evidence is ignored

ClawPatch finding: fnd_sig-feat-library-8d05463181-676b_6af8cc7d34

## Tests
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/behavior-learner.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to signal filtering for tunable policy parameters, with dedicated regression tests and no auth or data-path changes.
> 
> **Overview**
> **`selectRecentSignals`** in the behavior learner now caps evidence at evaluation time: signals with `timestamp` after `input.now` are dropped, so future-dated events (e.g. strong negative corrections) cannot skew policy pressure.
> 
> When **`learningWindowDays <= 0`**, the old early return that passed through every signal is replaced by filtering with `minTs = -Infinity` but the same **`ts <= nowMs`** rule, so “all history” mode still excludes future timestamps.
> 
> Two regression tests assert that only in-window / historical positive evidence counts when a future opposing signal is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3894ff798dadd44bbe5c2a8cb1155b7012291336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->