### PR TITLE
Honor parsed self participant roles

### DIFF
--- a/packages/import-weclone/src/participant.test.ts
+++ b/packages/import-weclone/src/participant.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { ImportTurn } from "@remnic/core";
 import { mapParticipants } from "./participant.js";
+import { parseWeCloneExport } from "./parser.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -30,6 +31,10 @@ const T1 = "2025-01-10T08:00:00.000Z";
 const T2 = "2025-01-10T09:00:00.000Z";
 const T3 = "2025-01-10T10:00:00.000Z";
 const T4 = "2025-01-10T11:00:00.000Z";
+
+function makeMsg(sender: string, text: string, timestamp: string) {
+  return { sender, text, timestamp };
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -60,6 +65,47 @@ describe("mapParticipants", () => {
     const participants = mapParticipants(turns);
     const alice = participants.find((p) => p.id === "Alice");
     assert.equal(alice?.relationship, "self");
+  });
+
+  it("uses explicit parser selfSender roles instead of top sender volume", () => {
+    const source = parseWeCloneExport(
+      {
+        platform: "telegram",
+        messages: [
+          makeMsg("Alice", "first", T1),
+          makeMsg("Alice", "second", T2),
+          makeMsg("Bob", "self reply", T3),
+        ],
+      },
+      { selfSender: "Bob" },
+    );
+
+    const participants = mapParticipants(source.turns);
+    const alice = participants.find((p) => p.id === "Alice");
+    const bob = participants.find((p) => p.id === "Bob");
+
+    assert.equal(source.turns.find((t) => t.participantId === "Bob")?.role, "user");
+    assert.equal(bob?.relationship, "self");
+    assert.equal(alice?.relationship, "frequent");
+  });
+
+  it("uses parser-inferred user roles instead of top sender volume", () => {
+    const source = parseWeCloneExport({
+      platform: "telegram",
+      messages: [
+        makeMsg("Bob", "self first", T1),
+        makeMsg("Alice", "first", T2),
+        makeMsg("Alice", "second", T3),
+      ],
+    });
+
+    const participants = mapParticipants(source.turns);
+    const alice = participants.find((p) => p.id === "Alice");
+    const bob = participants.find((p) => p.id === "Bob");
+
+    assert.equal(source.turns.find((t) => t.participantId === "Bob")?.role, "user");
+    assert.equal(bob?.relationship, "self");
+    assert.equal(alice?.relationship, "frequent");
   });
 
   it("classifies participants with >10% messages as 'frequent'", () => {

--- a/packages/import-weclone/src/participant.ts
+++ b/packages/import-weclone/src/participant.ts
@@ -33,7 +33,8 @@ const FREQUENT_THRESHOLD = 0.1;
 /**
  * Build participant entity records from an array of import turns.
  *
- * - The participant with the most messages is tagged "self".
+ * - The parser-inferred user participant is tagged "self" when role data exists.
+ * - The participant with the most messages is tagged "self" as a fallback.
  * - Participants with >10% of total messages are "frequent".
  * - Everyone else is "occasional".
  * - Turns without `participantId` are silently skipped.
@@ -46,6 +47,7 @@ export function mapParticipants(turns: ImportTurn[]): ParticipantEntity[] {
     {
       name: string;
       count: number;
+      userRoleCount: number;
       firstTs: number;
       lastTs: number;
       firstRaw: string;
@@ -62,6 +64,7 @@ export function mapParticipants(turns: ImportTurn[]): ParticipantEntity[] {
 
     if (existing) {
       existing.count += 1;
+      if (turn.role === "user") existing.userRoleCount += 1;
       if (ts < existing.firstTs) {
         existing.firstTs = ts;
         existing.firstRaw = turn.timestamp;
@@ -74,6 +77,7 @@ export function mapParticipants(turns: ImportTurn[]): ParticipantEntity[] {
       stats.set(id, {
         name: turn.participantName ?? id,
         count: 1,
+        userRoleCount: turn.role === "user" ? 1 : 0,
         firstTs: ts,
         lastTs: ts,
         firstRaw: turn.timestamp,
@@ -84,7 +88,17 @@ export function mapParticipants(turns: ImportTurn[]): ParticipantEntity[] {
 
   if (stats.size === 0) return [];
 
-  // Find the top sender (most messages)
+  // Prefer the participant the parser already classified as the user.
+  let roleSelfId = "";
+  let topUserRoleCount = 0;
+  for (const [id, s] of stats.entries()) {
+    if (s.userRoleCount > topUserRoleCount) {
+      topUserRoleCount = s.userRoleCount;
+      roleSelfId = id;
+    }
+  }
+
+  // Fall back to the top sender for legacy turns without role data.
   let topId = "";
   let topCount = 0;
   for (const [id, s] of stats.entries()) {
@@ -101,9 +115,10 @@ export function mapParticipants(turns: ImportTurn[]): ParticipantEntity[] {
   const totalMessages = turns.filter((t) => !!t.participantId).length;
 
   const result: ParticipantEntity[] = [];
+  const selfId = roleSelfId || topId;
   for (const [id, s] of stats.entries()) {
     let relationship: string;
-    if (id === topId) {
+    if (id === selfId) {
       relationship = "self";
     } else if (s.count / totalMessages > FREQUENT_THRESHOLD) {
       relationship = "frequent";


### PR DESCRIPTION
## Summary
- classify WeClone self participant from parsed user-role turns before falling back to top sender volume
- add regressions for explicit selfSender and parser-inferred self when another participant has more messages

ClawPatch finding: fnd_sig-feat-library-8d64db301b-6302_22f0164ded

## Tests
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/import-weclone/src/participant.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm --filter @remnic/import-weclone test
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized import mapping logic with clear fallback behavior and targeted regressions; no auth or persistence changes.
> 
> **Overview**
> **`mapParticipants`** no longer treats the highest-volume sender as `"self"` when turns carry parser role metadata. It tracks per-participant **`user`** role counts and picks that participant for **`relationship: "self"`**, only falling back to the top sender when no role data exists.
> 
> New tests wire **`parseWeCloneExport`** end-to-end so **`selfSender: "Bob"`** and parser-inferred self both win over a more prolific Alice, with the non-self participant classified as **`frequent`** when volume warrants it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8720c1ca4543fdd0e449496edaa5af45dbc4d870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->