### PR TITLE
Reject invalid recallAtK cutoffs

### DIFF
--- a/packages/bench/src/scorer.test.ts
+++ b/packages/bench/src/scorer.test.ts
@@ -5,6 +5,7 @@ import {
   containsAnswer,
   llmBinaryJudgeScoreDetailed,
   llmJudgeScoreDetailed,
+  recallAtK,
 } from "./scorer.ts";
 
 function delay(ms: number): Promise<void> {
@@ -126,4 +127,11 @@ test("containsAnswer does not match short labels inside unrelated words", () => 
 test("containsAnswer allows short numeric answers with attached units", () => {
   assert.equal(containsAnswer("250ms", "250"), 1);
   assert.equal(containsAnswer("$50", "50"), 1);
+});
+
+test("recallAtK rejects invalid cutoff values", () => {
+  assert.equal(recallAtK(["a", "b"], ["a"], -1), 0);
+  assert.equal(recallAtK(["a"], ["a"], 0), 0);
+  assert.equal(recallAtK(["a"], ["a"], 1.5), 0);
+  assert.equal(recallAtK(["a"], ["a"], 1), 1);
 });

--- a/packages/bench/src/scorer.ts
+++ b/packages/bench/src/scorer.ts
@@ -61,6 +61,7 @@ export function recallAtK(
   relevant: string[],
   k: number,
 ): number {
+  if (!Number.isInteger(k) || k <= 0) return 0;
   if (relevant.length === 0) return 1;
 
   const topK = retrieved.slice(0, k).map(normalizeText);


### PR DESCRIPTION
## Summary
- reject non-integer, zero, and negative `recallAtK` cutoff values
- add scorer regression coverage for invalid cutoffs while preserving valid k behavior

ClawPatch finding: `fnd_sig-feat-library-9b5b22271d-e35a_9ed272f4af`

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/bench/src/scorer.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to bench scoring validation with tests; no auth, data, or production runtime impact.
> 
> **Overview**
> **`recallAtK`** now returns **0** when the cutoff `k` is not a positive integer (negative, zero, or fractional values), instead of slicing with invalid `k` and producing misleading scores.
> 
> Regression tests cover invalid cutoffs (`-1`, `0`, `1.5`) and confirm **`k = 1`** still behaves correctly when a relevant item is in the top result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 565661f4c78a2896926d9d0fff69091d910790fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->