### PR TITLE
Honor custom benchmark iteration counts

### DIFF
--- a/packages/bench/src/benchmarks/custom/runner.test.ts
+++ b/packages/bench/src/benchmarks/custom/runner.test.ts
@@ -255,3 +255,89 @@ test("custom benchmarks score responder output and include responder usage", asy
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("custom benchmark full mode honors requested iterations", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-custom-bench-"));
+  const benchmarkPath = path.join(tempDir, "iterations.yaml");
+  const completions: Array<{ completed: number; total: number | undefined }> = [];
+
+  try {
+    await writeFile(
+      benchmarkPath,
+      [
+        "name: Custom Iterations",
+        "scoring: exact_match",
+        "tasks:",
+        "  - question: What is alpha?",
+        "    expected: alpha",
+        "  - question: What is beta?",
+        "    expected: beta",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await runCustomBenchmarkFile(benchmarkPath, {
+      mode: "full",
+      iterations: 2,
+      seed: 7,
+      system: {
+        async store() {},
+        async recall() {
+          return "";
+        },
+        async search(query) {
+          return [
+            {
+              turnIndex: 0,
+              role: "assistant",
+              snippet: query.includes("alpha") ? "alpha" : "beta",
+              sessionId: "session-1",
+            },
+          ];
+        },
+        async reset() {},
+        async getStats() {
+          return {
+            totalMessages: 0,
+            totalSummaryNodes: 0,
+            maxDepth: 0,
+          };
+        },
+        async destroy() {},
+      },
+      onTaskComplete(_task, completedCount, totalCount) {
+        completions.push({ completed: completedCount, total: totalCount });
+      },
+    });
+
+    assert.equal(result.meta.runCount, 2);
+    assert.deepEqual(result.meta.seeds, [7, 8]);
+    assert.equal(result.results.tasks.length, 4);
+    assert.deepEqual(
+      result.results.tasks.map((task) => task.question),
+      [
+        "What is alpha?",
+        "What is beta?",
+        "What is alpha?",
+        "What is beta?",
+      ],
+    );
+    assert.deepEqual(
+      result.results.tasks.map((task) => task.details?.runIndex),
+      [0, 0, 1, 1],
+    );
+    assert.deepEqual(
+      result.results.tasks.map((task) => task.details?.seed),
+      [7, 7, 8, 8],
+    );
+    assert.deepEqual(completions, [
+      { completed: 1, total: 4 },
+      { completed: 2, total: 4 },
+      { completed: 3, total: 4 },
+      { completed: 4, total: 4 },
+    ]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/custom/runner.ts
+++ b/packages/bench/src/benchmarks/custom/runner.ts
@@ -36,7 +36,7 @@ async function runCustomBenchmark(
     );
   }
 
-  const runCount = resolveBenchmarkRunCount(options.mode);
+  const runCount = resolveBenchmarkRunCount(options.mode, options.iterations);
   const tasksPerRun = selectTasks(spec, options.limit);
   const totalTaskCount = runCount * tasksPerRun.length;
   let completedTaskCount = 0;
@@ -54,7 +54,7 @@ async function runCustomBenchmark(
           options.onTaskComplete?.(taskResult, completedTaskCount, totalTaskCount);
         },
       ),
-    undefined,
+    options.iterations,
     options.seed,
   );
   const tasks = runs.flat();

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -203,6 +203,8 @@ export interface RunBenchmarkOptions {
   outputDir?: string;
   limit?: number;
   seed?: number;
+  /** Override the number of full-mode benchmark iterations. Quick mode remains single-run. */
+  iterations?: number;
   adapterMode?: string;
   runtimeProfile?: BenchRuntimeProfile | null;
   system: import("./adapters/types.js").BenchMemoryAdapter;


### PR DESCRIPTION
## Summary
- add `iterations` to benchmark run options for full-mode run-count overrides
- pass requested iterations into custom benchmark run-count and seed orchestration
- add full-mode custom benchmark coverage asserting two runs, two seeds, repeated tasks, and progress totals

ClawPatch finding: `fnd_sig-feat-library-a011fad959-1c23_5d56b88442`

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/bench/src/benchmarks/custom/runner.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bench-only wiring to pass through an existing orchestration option; no auth, data, or production runtime paths.
> 
> **Overview**
> Adds an optional **`iterations`** field on benchmark run options so **full** mode can override the default multi-run count; **quick** mode stays a single run.
> 
> The custom YAML benchmark runner now forwards **`options.iterations`** into run-count resolution and seed orchestration, so callers that request e.g. two full-mode passes get repeated task sets, distinct seeds per run, and progress totals that reflect `runCount × tasks`.
> 
> A new integration test locks in that behavior for **`mode: "full"`** with **`iterations: 2`** (meta, task order, `runIndex`/`seed` details, and `onTaskComplete` counts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b82bda0a9483bc118654d61a7360725c195e134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->