### PR TITLE
Keep contradiction verdict metrics out of tasks

### DIFF
--- a/packages/bench/src/benchmarks/remnic/contradiction-detection/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/contradiction-detection/runner.test.ts
@@ -31,14 +31,13 @@ test("contradictionDetectionDefinition has the expected shape", () => {
   assert.equal(contradictionDetectionDefinition.meta.category, "retrieval");
 });
 
-test("runContradictionDetectionBenchmark produces tasks per fixture case plus aggregate", async () => {
+test("runContradictionDetectionBenchmark produces tasks only for real fixture cases", async () => {
   const result = await runContradictionDetectionBenchmark(
     buildOptions({ mode: "full" }),
   );
-  // 19 cases + 1 aggregate task
-  assert.equal(
-    result.results.tasks.length,
-    CONTRADICTION_DETECTION_FIXTURE.length + 1,
+  assert.equal(result.results.tasks.length, CONTRADICTION_DETECTION_FIXTURE.length);
+  assert.ok(
+    !result.results.tasks.some((task) => task.taskId === "_aggregate_verdict_metrics"),
   );
   for (const task of result.results.tasks) {
     assert.ok(typeof task.scores === "object");
@@ -49,16 +48,29 @@ test("runContradictionDetectionBenchmark includes per-verdict metrics", async ()
   const result = await runContradictionDetectionBenchmark(
     buildOptions({ mode: "full" }),
   );
-  const agg = result.results.tasks.find(
-    (t) => t.taskId === "_aggregate_verdict_metrics",
+  assert.ok(typeof result.results.aggregates.precision_contradicts?.mean === "number");
+  assert.ok(typeof result.results.aggregates.recall_contradicts?.mean === "number");
+  assert.ok(typeof result.results.aggregates.f1_contradicts?.mean === "number");
+  assert.ok(typeof result.results.aggregates.precision_duplicates?.mean === "number");
+  assert.ok(typeof result.results.aggregates.recall_independent?.mean === "number");
+  assert.ok(typeof result.results.aggregates.overall_accuracy?.mean === "number");
+});
+
+test("runContradictionDetectionBenchmark quick mode exposes only smoke tasks plus verdict aggregates", async () => {
+  const result = await runContradictionDetectionBenchmark(
+    buildOptions({ mode: "quick" }),
   );
-  assert.ok(agg, "aggregate task must exist");
-  assert.ok(typeof agg.scores.precision_contradicts === "number");
-  assert.ok(typeof agg.scores.recall_contradicts === "number");
-  assert.ok(typeof agg.scores.f1_contradicts === "number");
-  assert.ok(typeof agg.scores.precision_duplicates === "number");
-  assert.ok(typeof agg.scores.recall_independent === "number");
-  assert.ok(typeof agg.scores.overall_accuracy === "number");
+  assert.equal(result.results.tasks.length, CONTRADICTION_DETECTION_SMOKE_FIXTURE.length);
+  assert.deepEqual(
+    result.results.tasks.map((task) => task.taskId),
+    CONTRADICTION_DETECTION_SMOKE_FIXTURE.map((sample) => sample.id),
+  );
+  assert.ok(
+    !result.results.tasks.some((task) => task.taskId === "_aggregate_verdict_metrics"),
+  );
+  assert.ok(typeof result.results.aggregates.precision_contradicts?.mean === "number");
+  assert.ok(typeof result.results.aggregates.recall_contradicts?.mean === "number");
+  assert.ok(typeof result.results.aggregates.f1_contradicts?.mean === "number");
 });
 
 test("runContradictionDetectionBenchmark emits per-task completion callbacks", async () => {
@@ -67,7 +79,14 @@ test("runContradictionDetectionBenchmark emits per-task completion callbacks", a
     buildOptions({
       mode: "full",
       onTaskComplete(task, completedCount, totalCount) {
-        progress.push({ taskId: task.taskId, completedCount, totalCount });
+        const taskId = task.taskId;
+        if (typeof taskId !== "string") {
+          throw new Error("expected completed task to include a taskId");
+        }
+        if (typeof completedCount !== "number" || typeof totalCount !== "number") {
+          throw new Error("expected progress counts");
+        }
+        progress.push({ taskId, completedCount, totalCount });
       },
     }),
   );
@@ -88,7 +107,7 @@ test("runContradictionDetectionBenchmark quick mode runs the smoke subset", asyn
     buildOptions({ mode: "quick" }),
   );
   assert.ok(quick.results.tasks.length < full.results.tasks.length);
-  assert.ok(quick.results.tasks.length > 0);
+  assert.equal(quick.results.tasks.length, CONTRADICTION_DETECTION_SMOKE_FIXTURE.length);
 });
 
 test("runContradictionDetectionBenchmark rejects invalid limit", async () => {

--- a/packages/bench/src/benchmarks/remnic/contradiction-detection/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/contradiction-detection/runner.ts
@@ -227,23 +227,9 @@ export async function runContradictionDetectionBenchmark(
   const correctCount = tasks.filter((t) => t.scores.accuracy === 1).length;
   verdictScores.overall_accuracy = cases.length > 0 ? correctCount / cases.length : 0;
 
-  // Compute latency metrics BEFORE adding the synthetic aggregate task
-  // so meanQueryLatencyMs denominator reflects real cases only.
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
   const meanQueryLatencyMs = tasks.length > 0 ? totalLatencyMs / tasks.length : 0;
-
-  // Add a synthetic aggregate task so verdict-level scores appear in aggregates.
-  // Excluded from latency computation above.
-  tasks.push({
-    taskId: "_aggregate_verdict_metrics",
-    question: "Per-verdict precision/recall/F1",
-    expected: "see scores",
-    actual: "see scores",
-    scores: verdictScores,
-    latencyMs: 0,
-    tokens: { input: 0, output: 0 },
-  });
 
   return {
     meta: {
@@ -274,7 +260,10 @@ export async function runContradictionDetectionBenchmark(
     },
     results: {
       tasks,
-      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+      aggregates: {
+        ...aggregateTaskScores(tasks.map((task) => task.scores)),
+        ...aggregateTaskScores([verdictScores]),
+      },
     },
     environment: {
       os: process.platform,

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -53,7 +53,6 @@ packages/bench/src/benchmarks/remnic/assistant-morning-brief/fixture.test.ts(16,
 packages/bench/src/benchmarks/remnic/coding-recall/runner.test.ts(133,20): TS7006
 packages/bench/src/benchmarks/remnic/coding-recall/runner.test.ts(133,26): TS7006
 packages/bench/src/benchmarks/remnic/coding-recall/runner.test.ts(133,42): TS7006
-packages/bench/src/benchmarks/remnic/contradiction-detection/runner.test.ts(70,62): TS2322
 packages/bench/src/benchmarks/remnic/enrichment-fidelity/runner.test.ts(29,62): TS2322
 packages/bench/src/benchmarks/remnic/ingestion-schema-completeness/runner.test.ts(113,20): TS18048
 packages/bench/src/benchmarks/remnic/ingestion-schema-completeness/runner.test.ts(114,20): TS18048


### PR DESCRIPTION
## Summary
- stop appending the synthetic `_aggregate_verdict_metrics` row to contradiction benchmark tasks
- expose per-verdict precision/recall/F1 through result aggregates instead
- add quick-mode regression coverage that tasks contain only smoke fixture cases
- tighten the edited callback test and remove its stale test-typecheck baseline entry

Finding: fnd_sig-feat-library-a10f7dd09f-c35c_8c05948937

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test packages/bench/src/benchmarks/remnic/contradiction-detection/runner.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" node scripts/check-test-types.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark result shape change for one synthetic remnic bench; no production auth or data paths, covered by updated unit tests.
> 
> **Overview**
> The contradiction-detection benchmark no longer appends a synthetic **`_aggregate_verdict_metrics`** row to **`results.tasks`**. Per-verdict precision/recall/F1 and **`overall_accuracy`** are merged into **`results.aggregates`** (alongside per-case **`accuracy`** means) via a second **`aggregateTaskScores`** pass on the computed verdict score object.
> 
> Tests now assert tasks match fixture cases only (full and quick/smoke), verdict metrics live under **`aggregates`**, progress callbacks never see the synthetic task, and the **`onTaskComplete`** callback test uses explicit type narrowing. The stale **`runner.test.ts`** typecheck baseline line is dropped from **`scripts/test-typecheck-baseline.txt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07165d26e2239c762472dbba71df522391531a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->