### PR TITLE
Reserve enrichment rate limits before provider calls

### DIFF
--- a/packages/remnic-core/src/enrichment/pipeline.ts
+++ b/packages/remnic-core/src/enrichment/pipeline.ts
@@ -32,12 +32,12 @@ interface RateLimitBucket {
 
 const rateBuckets = new Map<string, RateLimitBucket>();
 
-function isRateLimited(
+function reserveRateLimitSlot(
   provider: EnrichmentProvider,
   config: EnrichmentPipelineConfig,
 ): boolean {
   const providerCfg = config.providers.find((p) => p.id === provider.id);
-  if (!providerCfg?.rateLimit) return false;
+  if (!providerCfg?.rateLimit) return true;
 
   const now = Date.now();
   let bucket = rateBuckets.get(provider.id);
@@ -62,17 +62,13 @@ function isRateLimited(
   }
 
   const { maxPerMinute, maxPerDay } = providerCfg.rateLimit;
-  return bucket.minuteCount >= maxPerMinute || bucket.dayCount >= maxPerDay;
-}
-
-function recordCall(
-  providerId: string,
-): void {
-  const bucket = rateBuckets.get(providerId);
-  if (bucket) {
-    bucket.minuteCount += 1;
-    bucket.dayCount += 1;
+  if (bucket.minuteCount >= maxPerMinute || bucket.dayCount >= maxPerDay) {
+    return false;
   }
+
+  bucket.minuteCount += 1;
+  bucket.dayCount += 1;
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -129,8 +125,9 @@ export async function runEnrichmentPipeline(
         continue;
       }
 
-      // Check rate limit
-      if (isRateLimited(provider, config)) {
+      // Reserve quota before the awaited provider call so concurrent pipelines
+      // cannot all pass the same pre-await rate-limit check.
+      if (!reserveRateLimitSlot(provider, config)) {
         log.debug?.(
           `enrichment: skipping provider ${provider.id} for ${entity.name} — rate limited`,
         );
@@ -154,7 +151,6 @@ export async function runEnrichmentPipeline(
       try {
         candidates = await provider.enrich(entity);
       } catch (err) {
-        recordCall(provider.id);
         log.error?.(
           `enrichment: provider ${provider.id} failed for ${entity.name}: ${err instanceof Error ? err.message : String(err)}`,
         );
@@ -169,7 +165,6 @@ export async function runEnrichmentPipeline(
         });
         continue;
       }
-      recordCall(provider.id);
 
       // Tag each candidate with provider id
       for (const candidate of candidates) {

--- a/tests/enrichment-pipeline.test.ts
+++ b/tests/enrichment-pipeline.test.ts
@@ -305,6 +305,76 @@ test("Pipeline: rate limiting persists across pipeline invocations", async () =>
   assert.equal(second[0].acceptedCandidates.length, 0);
 });
 
+test("Pipeline: concurrent calls reserve provider rate limit before await", async () => {
+  let callCount = 0;
+  let resolveProvider: (() => void) | undefined;
+  let resolveFirstStarted: (() => void) | undefined;
+  const providerRelease = new Promise<void>((resolve) => {
+    resolveProvider = resolve;
+  });
+  const firstStarted = new Promise<void>((resolve) => {
+    resolveFirstStarted = resolve;
+  });
+
+  const provider: EnrichmentProvider = {
+    id: "concurrent-limited",
+    costTier: "cheap",
+    async enrich() {
+      callCount++;
+      resolveFirstStarted?.();
+      await providerRelease;
+      return [{ text: "fact", source: "concurrent-limited", confidence: 0.5, category: "fact" }];
+    },
+    async isAvailable() {
+      return true;
+    },
+  };
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(provider);
+
+  const config = enabledConfig({
+    providers: [
+      {
+        id: "concurrent-limited",
+        enabled: true,
+        costTier: "cheap",
+        rateLimit: { maxPerMinute: 1, maxPerDay: 100 },
+      },
+    ],
+    importanceThresholds: {
+      critical: ["concurrent-limited"],
+      high: ["concurrent-limited"],
+      normal: ["concurrent-limited"],
+      low: ["concurrent-limited"],
+    },
+  });
+
+  const firstRun = runEnrichmentPipeline(
+    [makeEntity({ name: "ConcurrentA" })],
+    registry,
+    config,
+    NOOP_LOG,
+  );
+  const secondRun = runEnrichmentPipeline(
+    [makeEntity({ name: "ConcurrentB" })],
+    registry,
+    config,
+    NOOP_LOG,
+  );
+
+  await firstStarted;
+  assert.equal(callCount, 1);
+  resolveProvider?.();
+
+  const [first, second] = await Promise.all([firstRun, secondRun]);
+
+  assert.equal(callCount, 1);
+  assert.equal(first[0].candidatesFound, 1);
+  assert.equal(second[0].candidatesFound, 0);
+  assert.equal(second[0].acceptedCandidates.length, 0);
+});
+
 test("Pipeline: max candidates trims excess", async () => {
   const candidates: EnrichmentCandidate[] = Array.from({ length: 30 }, (_, i) => ({
     text: `Fact ${i}`,


### PR DESCRIPTION
## Summary
- reserve enrichment provider rate-limit slots before awaiting provider.enrich()
- keep failed provider attempts counted through the same reservation path
- add concurrent regression coverage for maxPerMinute=1

Finding: fnd_sig-feat-library-a40196b074-c9ef_8af529a59d

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/enrichment-pipeline.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" node scripts/check-test-types.mjs
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared in-process rate-limit state and call ordering for all enrichment provider invocations; behavior is intentional but affects quota enforcement under concurrency.
> 
> **Overview**
> Fixes a **race in enrichment provider rate limiting** where concurrent `runEnrichmentPipeline` runs could all pass a pre-`await` check and exceed `maxPerMinute` / `maxPerDay` against external APIs.
> 
> `isRateLimited` and post-call `recordCall` are replaced by **`reserveRateLimitSlot`**, which increments the in-memory bucket **before** `provider.enrich()` runs. Skipped providers behave the same; failed enrich attempts still consume quota because reservation happens up front (aligned with existing failure-counting behavior).
> 
> A new test runs two pipelines concurrently with `maxPerMinute: 1` and a blocking mock provider to ensure only one call proceeds while the other is rate-limited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fda4968632fceac303f27a0e8e67c26d55e375b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->