### PR TITLE
Persist prototype-safe observer session keys

### DIFF
--- a/packages/remnic-core/src/session-observer-state.ts
+++ b/packages/remnic-core/src/session-observer-state.ts
@@ -242,7 +242,7 @@ export class SessionObserverState {
   }
 
   private async writeSessions(sessionsMap: Map<string, SessionObserverCursor>): Promise<void> {
-    const sessions: Record<string, SessionObserverCursor> = {};
+    const sessions = Object.create(null) as Record<string, SessionObserverCursor>;
     for (const [key, value] of sessionsMap.entries()) {
       sessions[key] = value;
     }

--- a/tests/session-observer-state.test.ts
+++ b/tests/session-observer-state.test.ts
@@ -174,6 +174,53 @@ test("session observer save merges shared state across instances", async () => {
   }
 });
 
+test("session observer persists prototype-sensitive session keys as data", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-session-observer-special-key-"));
+  try {
+    const observer = new SessionObserverState({
+      memoryDir: dir,
+      debounceMs: 60_000,
+      bands: [{ maxBytes: 100_000, triggerDeltaBytes: 1_000, triggerDeltaTokens: 200 }],
+    });
+    await observer.load();
+
+    await observer.observe({
+      sessionKey: "__proto__",
+      totalBytes: 100,
+      totalTokens: 10,
+      observedAt: "2026-02-25T00:00:00.000Z",
+    });
+
+    const raw = await readFile(path.join(dir, "state", "session-observer-state.json"), "utf-8");
+    const parsed = JSON.parse(raw) as {
+      sessions: Record<string, { cursorBytes: number; cursorTokens: number }>;
+    };
+    assert.equal(Object.hasOwn(parsed.sessions, "__proto__"), true);
+    assert.equal(parsed.sessions["__proto__"].cursorBytes, 100);
+    assert.equal(parsed.sessions["__proto__"].cursorTokens, 10);
+    assert.equal(({} as { cursorBytes?: number }).cursorBytes, undefined);
+
+    const reloaded = new SessionObserverState({
+      memoryDir: dir,
+      debounceMs: 60_000,
+      bands: [{ maxBytes: 100_000, triggerDeltaBytes: 1_000, triggerDeltaTokens: 200 }],
+    });
+    await reloaded.load();
+
+    const decision = await reloaded.observe({
+      sessionKey: "__proto__",
+      totalBytes: 1_600,
+      totalTokens: 320,
+      observedAt: "2026-02-25T00:01:00.000Z",
+    });
+    assert.equal(decision.triggered, true);
+    assert.equal(decision.deltaBytes, 1_500);
+    assert.equal(decision.deltaTokens, 310);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("session observer does not trigger when both thresholds are zero", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "engram-session-observer-zero-threshold-"));
   try {


### PR DESCRIPTION
## Summary
- serialize session observer cursors through a null-prototype record so prototype-sensitive session keys persist as data
- add a regression covering save, reload, and threshold behavior for `__proto__` session keys

## ClawPatch
- Fixes `fnd_sig-feat-library-b377f718d1-5289_2d34012ddd`

## Verification
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec tsx --test tests/session-observer-state.test.ts`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" node scripts/check-test-types.mjs`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" OLLAMA_API_KEY=dummy npm run preflight:quick`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized serialization hardening in session observer persistence with targeted test coverage; no auth or broader API surface changes.
> 
> **Overview**
> Fixes prototype pollution when persisting session observer state by building the `sessions` object written to disk with **`Object.create(null)`** instead of a plain `{}` in `writeSessions`. That keeps keys like `__proto__` as ordinary data on the serialized record rather than affecting `Object.prototype` after `JSON.parse`.
> 
> Adds a regression test that observes a `__proto__` session key, asserts the value is stored with `Object.hasOwn`, confirms an empty object is not polluted, and checks reload plus threshold triggering still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb79d4cbf04a93cf866d63a3ee4a03d5154fe086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->