### PR TITLE
feat: task-specific gateway model chain (taskModelChain) (#1365)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -490,6 +490,7 @@ Route all Engram LLM calls through the OpenClaw gateway's agent model chain inst
 | `modelSource` | `gateway` for new OpenClaw installs; `plugin` otherwise | `gateway` delegates to a gateway agent's model chain; `plugin` uses Engram's own openai/localLlm config |
 | `gatewayAgentId` | `""` | Agent persona ID from `openclaw.json → agents.list[]` for primary LLM calls (extraction, consolidation, summarization). Falls back to `agents.defaults.model` if empty. |
 | `fastGatewayAgentId` | `""` | Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). Uses `gatewayAgentId` chain when empty. |
+| `taskModelChain` | _(unset)_ | Optional inline `{ "primary", "fallbacks": [] }` model chain for Remnic's background tasks (extraction, fact/profile/identity consolidation, summarization, causal consolidation). Resolves through gateway providers. When set, it overrides `gatewayAgentId`/`agents.defaults.model` for these tasks only. **Requires `modelSource: "gateway"`** — ignored (with a startup warning) in `plugin` mode. |
 
 When `modelSource` is `gateway`:
 
@@ -498,6 +499,30 @@ When `modelSource` is `gateway`:
 - The existing `openaiApiKey`, `model`, and `localLlm*` settings are ignored for LLM dispatch but retained as config for backward compatibility; `OPENAI_API_KEY` is not inherited in gateway mode
 - `localLlmFast*` settings are also bypassed when `fastGatewayAgentId` is set
 - **Reranking** uses the `fastGatewayAgentId` chain (or `gatewayAgentId` if fast is unset) instead of the local LLM — this can dramatically reduce rerank latency when the fast chain points at a cloud provider
+
+#### Task-specific model chain (`taskModelChain`)
+
+By default, gateway-mode background work (extraction, consolidation, summarization, causal consolidation) shares the `gatewayAgentId` persona chain — or `agents.defaults.model` when no persona is set. That ties lightweight memory tasks to whatever chain the main agent uses, which is often larger/pricier than these tasks need.
+
+Set `taskModelChain` to give those tasks their own cheap/fast chain **without** defining a persona or touching `agents.defaults.model`:
+
+```jsonc
+{
+  "modelSource": "gateway",
+  "taskModelChain": {
+    "primary": "zai/glm-4.7-flash",
+    "fallbacks": ["fireworks/accounts/fireworks/models/glm-5p1"]
+  }
+}
+```
+
+Notes:
+
+- Models resolve through the same `models.providers` auth/routing as everything else — only the chain differs.
+- `taskModelChain` takes precedence over `gatewayAgentId` for these tasks; the main agent persona is unaffected.
+- A reachable `agents.defaults.model` is appended as an implicit last resort to a `taskModelChain` only, so an exhausted task chain never blocks a flush. Persona/default chains are never augmented this way.
+- It **only applies in `gateway` mode.** In `plugin` mode it is ignored and Remnic logs a startup warning. Plugin-mode users who hit non-OpenAI model-ID failures at the direct client should switch to `modelSource: "gateway"` and use `taskModelChain` (see issue #1365).
+- A present-but-malformed value (missing `primary`, wrong types) is rejected at config-parse time rather than silently ignored.
 
 ### Setup
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -490,7 +490,7 @@ Route all Engram LLM calls through the OpenClaw gateway's agent model chain inst
 | `modelSource` | `gateway` for new OpenClaw installs; `plugin` otherwise | `gateway` delegates to a gateway agent's model chain; `plugin` uses Engram's own openai/localLlm config |
 | `gatewayAgentId` | `""` | Agent persona ID from `openclaw.json → agents.list[]` for primary LLM calls (extraction, consolidation, summarization). Falls back to `agents.defaults.model` if empty. |
 | `fastGatewayAgentId` | `""` | Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). Uses `gatewayAgentId` chain when empty. |
-| `taskModelChain` | _(unset)_ | Optional inline `{ "primary", "fallbacks": [] }` model chain for Remnic's background tasks (extraction, fact/profile/identity consolidation, summarization, causal consolidation). Resolves through gateway providers. When set, it overrides `gatewayAgentId`/`agents.defaults.model` for these tasks only. **Requires `modelSource: "gateway"`** — ignored (with a startup warning) in `plugin` mode. |
+| `taskModelChain` | _(unset)_ | Optional inline `{ "primary", "fallbacks": [] }` model chain for Remnic's background tasks (extraction, extraction judge, fact/profile/identity consolidation, summarization, semantic consolidation, calibration, causal consolidation). Resolves through gateway providers. When set, it overrides `gatewayAgentId`/`agents.defaults.model` for these tasks only. **Requires `modelSource: "gateway"`** — ignored (with a startup warning) in `plugin` mode. |
 
 When `modelSource` is `gateway`:
 
@@ -502,7 +502,7 @@ When `modelSource` is `gateway`:
 
 #### Task-specific model chain (`taskModelChain`)
 
-By default, gateway-mode background work (extraction, consolidation, summarization, causal consolidation) shares the `gatewayAgentId` persona chain — or `agents.defaults.model` when no persona is set. That ties lightweight memory tasks to whatever chain the main agent uses, which is often larger/pricier than these tasks need.
+By default, gateway-mode background work — extraction, the extraction judge, fact/profile/identity consolidation, summarization, semantic consolidation, calibration, and causal consolidation — shares the `gatewayAgentId` persona chain, or `agents.defaults.model` when no persona is set. That ties lightweight memory tasks to whatever chain the main agent uses, which is often larger/pricier than these tasks need. (The one exception: `semanticConsolidationModel: "fast"` keeps using `fastGatewayAgentId` — an explicit fast-tier choice is honored over `taskModelChain`.)
 
 Set `taskModelChain` to give those tasks their own cheap/fast chain **without** defining a persona or touching `agents.defaults.model`:
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3151,19 +3151,24 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
-      "extractionModelChain": {
+      "taskModelChain": {
         "type": "object",
-        "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
-        "required": ["primary"],
+        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
+        "required": [
+          "primary"
+        ],
+        "additionalProperties": false,
         "properties": {
           "primary": {
             "type": "string",
+            "minLength": 1,
             "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
           },
           "fallbacks": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "default": [],
             "description": "Fallback gateway models tried after primary"
@@ -5492,10 +5497,10 @@
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
     },
-    "extractionModelChain": {
-      "label": "Extraction Model Chain",
+    "taskModelChain": {
+      "label": "Task Model Chain",
       "advanced": true,
-      "help": "Optional primary/fallback gateway model chain for extraction, consolidation, and summarization. Overrides gatewayAgentId/defaults for these tasks only."
+      "help": "Optional primary/fallback gateway model chain for Remnic background tasks (extraction, consolidation, summarization). Overrides gatewayAgentId/defaults for these tasks only. Requires modelSource: 'gateway'."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3151,6 +3151,24 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
+      "extractionModelChain": {
+        "type": "object",
+        "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "properties": {
+          "primary": {
+            "type": "string",
+            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Fallback gateway models tried after primary"
+          }
+        }
+      },
       "localLlmEnabled": {
         "type": "boolean",
         "default": false,
@@ -5472,6 +5490,11 @@
       "advanced": true,
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
+    },
+    "extractionModelChain": {
+      "label": "Extraction Model Chain",
+      "advanced": true,
+      "help": "Optional primary/fallback gateway model chain for extraction, consolidation, and summarization. Overrides gatewayAgentId/defaults for these tasks only."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3154,6 +3154,7 @@
       "extractionModelChain": {
         "type": "object",
         "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "required": ["primary"],
         "properties": {
           "primary": {
             "type": "string",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3151,6 +3151,24 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
+      "extractionModelChain": {
+        "type": "object",
+        "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "properties": {
+          "primary": {
+            "type": "string",
+            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Fallback gateway models tried after primary"
+          }
+        }
+      },
       "localLlmEnabled": {
         "type": "boolean",
         "default": false,
@@ -5472,6 +5490,11 @@
       "advanced": true,
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
+    },
+    "extractionModelChain": {
+      "label": "Extraction Model Chain",
+      "advanced": true,
+      "help": "Optional primary/fallback gateway model chain for extraction, consolidation, and summarization. Overrides gatewayAgentId/defaults for these tasks only."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3151,19 +3151,22 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
-      "extractionModelChain": {
+      "taskModelChain": {
         "type": "object",
-        "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
         "required": ["primary"],
+        "additionalProperties": false,
         "properties": {
           "primary": {
             "type": "string",
+            "minLength": 1,
             "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
           },
           "fallbacks": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "default": [],
             "description": "Fallback gateway models tried after primary"
@@ -5492,10 +5495,10 @@
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
     },
-    "extractionModelChain": {
-      "label": "Extraction Model Chain",
+    "taskModelChain": {
+      "label": "Task Model Chain",
       "advanced": true,
-      "help": "Optional primary/fallback gateway model chain for extraction, consolidation, and summarization. Overrides gatewayAgentId/defaults for these tasks only."
+      "help": "Optional primary/fallback gateway model chain for Remnic background tasks (extraction, consolidation, summarization). Overrides gatewayAgentId/defaults for these tasks only. Requires modelSource: 'gateway'."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3154,6 +3154,7 @@
       "extractionModelChain": {
         "type": "object",
         "description": "Optional task-specific gateway model chain for extraction, consolidation, and summarization. When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model.",
+        "required": ["primary"],
         "properties": {
           "primary": {
             "type": "string",

--- a/packages/remnic-core/src/calibration.ts
+++ b/packages/remnic-core/src/calibration.ts
@@ -16,7 +16,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { FallbackLlmClient } from "./fallback-llm.js";
-import type { GatewayConfig, MemoryFile } from "./types.js";
+import type { AgentPersonaModelConfig, GatewayConfig, MemoryFile } from "./types.js";
 import { listJsonFiles, readJsonFile } from "./json-store.js";
 import { isRecord } from "./store-contract.js";
 import { log } from "./logger.js";
@@ -226,6 +226,7 @@ export async function synthesizeCalibrationRules(
   llm: FallbackLlmClient,
   existingRules: CalibrationRule[],
   agentId?: string,
+  modelChain?: AgentPersonaModelConfig,
 ): Promise<CalibrationRule[]> {
   if (corrections.length < 2) return [];
 
@@ -244,7 +245,7 @@ export async function synthesizeCalibrationRules(
       { role: "system", content: CLUSTER_PROMPT },
       { role: "user", content: `Here are ${corrections.length} corrections from this user:\n\n${correctionText}${existingRulesText}` },
     ],
-    { temperature: 0.3, maxTokens: 3000, agentId },
+    { temperature: 0.3, maxTokens: 3000, agentId, modelChain },
   );
 
   if (!response?.content) return [];
@@ -349,13 +350,14 @@ export async function runCalibrationConsolidation(options: {
   memoryDir: string;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  modelChain?: AgentPersonaModelConfig;
   workspaceDir?: string;
 }): Promise<CalibrationRule[]> {
   try {
     const llm = new FallbackLlmClient(options.gatewayConfig, {
       workspaceDir: options.workspaceDir,
     });
-    if (!llm.isAvailable(options.gatewayAgentId)) {
+    if (!llm.isAvailable({ agentId: options.gatewayAgentId, modelChain: options.modelChain })) {
       log.debug("[calibration] no LLM available — skipping consolidation");
       return [];
     }
@@ -368,7 +370,7 @@ export async function runCalibrationConsolidation(options: {
 
     const existingIndex = await readCalibrationIndex(options.memoryDir);
 
-    const newRules = await synthesizeCalibrationRules(corrections, llm, existingIndex.rules, options.gatewayAgentId);
+    const newRules = await synthesizeCalibrationRules(corrections, llm, existingIndex.rules, options.gatewayAgentId, options.modelChain);
     if (newRules.length === 0) {
       log.debug("[calibration] no new calibration rules synthesized");
       return existingIndex.rules;

--- a/packages/remnic-core/src/calibration.ts
+++ b/packages/remnic-core/src/calibration.ts
@@ -416,6 +416,8 @@ export async function runCalibrationIfEnabled(options: {
   memoryDir: string;
   calibrationEnabled: boolean;
   gatewayConfig?: GatewayConfig;
+  gatewayAgentId?: string;
+  modelChain?: AgentPersonaModelConfig;
   workspaceDir?: string;
 }): Promise<CalibrationRule[]> {
   if (!options.calibrationEnabled) {
@@ -424,6 +426,8 @@ export async function runCalibrationIfEnabled(options: {
   return runCalibrationConsolidation({
     memoryDir: options.memoryDir,
     gatewayConfig: options.gatewayConfig,
+    gatewayAgentId: options.gatewayAgentId,
+    modelChain: options.modelChain,
     workspaceDir: options.workspaceDir,
   });
 }

--- a/packages/remnic-core/src/causal-consolidation.test.ts
+++ b/packages/remnic-core/src/causal-consolidation.test.ts
@@ -49,14 +49,24 @@ async function withTrajectoryStore<T>(
 
 function llmStub() {
   let calls = 0;
+  let availableOptions: unknown;
+  let completionOptions: unknown;
   return {
     get calls() {
       return calls;
     },
-    isAvailable() {
+    get availableOptions() {
+      return availableOptions;
+    },
+    get completionOptions() {
+      return completionOptions;
+    },
+    isAvailable(options?: unknown) {
+      availableOptions = options;
       return true;
     },
-    async chatCompletion() {
+    async chatCompletion(_messages?: unknown, options?: unknown) {
+      completionOptions = options;
       calls += 1;
       return {
         content: JSON.stringify({
@@ -150,6 +160,41 @@ test("deriveCausalPromotionCandidates calls LLM when recurrence session and succ
       assert.equal(llm.calls, 1);
       assert.equal(candidates.length, 1);
       assert.equal(candidates[0]?.content, "Prefer focused regressions before broad benchmark reruns.");
+    },
+  );
+});
+
+test("deriveCausalPromotionCandidates forwards task model chain to availability and chat completion", async () => {
+  const llm = llmStub();
+  const modelChain = {
+    primary: "openai/task-primary",
+    fallbacks: ["openai/task-fallback"],
+  };
+  await withTrajectoryStore(
+    [
+      trajectory("t1", "a", "success"),
+      trajectory("t2", "b", "success"),
+      trajectory("t3", "c", "partial"),
+    ],
+    async ({ memoryDir, storeDir }) => {
+      const candidates = await deriveCausalPromotionCandidates({
+        memoryDir,
+        causalTrajectoryStoreDir: storeDir,
+        config: { minRecurrence: 3, minSessions: 2, successThreshold: 0.7 },
+        gatewayAgentId: "expensive-agent",
+        modelChain,
+        llmClient: llm,
+      });
+
+      assert.equal(llm.calls, 1);
+      assert.equal(candidates.length, 1);
+      assert.deepEqual(llm.availableOptions, { agentId: "expensive-agent", modelChain });
+      assert.deepEqual(llm.completionOptions, {
+        temperature: 0.2,
+        maxTokens: 2000,
+        agentId: "expensive-agent",
+        modelChain,
+      });
     },
   );
 });

--- a/packages/remnic-core/src/causal-consolidation.ts
+++ b/packages/remnic-core/src/causal-consolidation.ts
@@ -18,7 +18,7 @@ import { readChainIndex, resolveChainsDir, type CausalChainIndex, type CausalEdg
 import { listJsonFiles, readJsonFile } from "./json-store.js";
 import { isRecord } from "./store-contract.js";
 import { FallbackLlmClient, fallbackLlmRuntimeContextFromConfig } from "./fallback-llm.js";
-import type { GatewayConfig, MemoryFile, PluginConfig } from "./types.js";
+import type { AgentPersonaModelConfig, GatewayConfig, MemoryFile, PluginConfig } from "./types.js";
 import path from "node:path";
 import { log } from "./logger.js";
 import { runPostConsolidationMaterialize } from "./connectors/codex-materialize-runner.js";
@@ -64,10 +64,10 @@ export interface LlmConsolidationResult {
 const CAUSAL_RULE_CATEGORIES = new Set(["rule", "principle", "preference"]);
 
 interface ConsolidationLlmClient {
-  isAvailable(agentId?: string): boolean;
+  isAvailable(options?: { agentId?: string; modelChain?: AgentPersonaModelConfig }): boolean;
   chatCompletion(
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
-    options?: { temperature?: number; maxTokens?: number; agentId?: string },
+    options?: { temperature?: number; maxTokens?: number; agentId?: string; modelChain?: AgentPersonaModelConfig },
   ): Promise<{ content: string } | null>;
 }
 
@@ -188,14 +188,14 @@ If no clear patterns exist, return {"rules": [], "preferences": []}.`;
 async function consolidateWithLlm(
   context: string,
   llm: ConsolidationLlmClient,
-  agentId?: string,
+  options: { agentId?: string; modelChain?: AgentPersonaModelConfig } = {},
 ): Promise<LlmConsolidationResult> {
   const response = await llm.chatCompletion(
     [
       { role: "system", content: CONSOLIDATION_PROMPT },
       { role: "user", content: context },
     ],
-    { temperature: 0.2, maxTokens: 2000, agentId },
+    { temperature: 0.2, maxTokens: 2000, agentId: options.agentId, modelChain: options.modelChain },
   );
 
   if (!response?.content) {
@@ -369,6 +369,7 @@ export async function deriveCausalPromotionCandidates(options: {
   config: ConsolidationConfig;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  modelChain?: AgentPersonaModelConfig;
   workspaceDir?: string;
   pluginConfig?: PluginConfig;
   llmClient?: ConsolidationLlmClient;
@@ -400,13 +401,14 @@ export async function deriveCausalPromotionCandidates(options: {
           })
         : { workspaceDir: options.workspaceDir },
     );
-    if (!llm.isAvailable(options.gatewayAgentId)) {
+    const llmOptions = { agentId: options.gatewayAgentId, modelChain: options.modelChain };
+    if (!llm.isAvailable(llmOptions)) {
       log.debug("[cmc] no LLM available for consolidation — skipping");
       return [];
     }
 
     // Call LLM for pattern analysis
-    const result = await consolidateWithLlm(context, llm, options.gatewayAgentId);
+    const result = await consolidateWithLlm(context, llm, llmOptions);
     const candidates = llmResultToCandidates(result);
 
     log.debug(`[cmc] LLM consolidation produced ${candidates.length} rule(s) and ${result.preferences.length} preference(s)`);
@@ -426,6 +428,7 @@ export async function synthesizeCausalPreferencesViaLlm(options: {
   causalTrajectoryStoreDir?: string;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  modelChain?: AgentPersonaModelConfig;
   workspaceDir?: string;
   minTrajectories?: number;
 }): Promise<string | null> {
@@ -440,9 +443,10 @@ export async function synthesizeCausalPreferencesViaLlm(options: {
     const llm = new FallbackLlmClient(options.gatewayConfig, {
       workspaceDir: options.workspaceDir,
     });
-    if (!llm.isAvailable(options.gatewayAgentId)) return null;
+    const llmOptions = { agentId: options.gatewayAgentId, modelChain: options.modelChain };
+    if (!llm.isAvailable(llmOptions)) return null;
 
-    const result = await consolidateWithLlm(context, llm, options.gatewayAgentId);
+    const result = await consolidateWithLlm(context, llm, llmOptions);
     if (result.preferences.length === 0 && result.rules.length === 0) return null;
 
     const lines: string[] = ["## Behavioral Insights (from Causal Chain Analysis)", ""];

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -492,7 +492,7 @@ export class CompoundingEngine {
           causalTrajectoryStoreDir: this.config.causalTrajectoryStoreDir,
           gatewayConfig: this.config.gatewayConfig,
           gatewayAgentId: this.config.modelSource === "gateway" ? (this.config.gatewayAgentId || undefined) : undefined,
-          modelChain: this.config.modelSource === "gateway" ? this.config.extractionModelChain : undefined,
+          modelChain: this.config.modelSource === "gateway" ? this.config.taskModelChain : undefined,
           workspaceDir: this.config.workspaceDir,
           pluginConfig: this.config,
           config: {

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -492,6 +492,7 @@ export class CompoundingEngine {
           causalTrajectoryStoreDir: this.config.causalTrajectoryStoreDir,
           gatewayConfig: this.config.gatewayConfig,
           gatewayAgentId: this.config.modelSource === "gateway" ? (this.config.gatewayAgentId || undefined) : undefined,
+          modelChain: this.config.modelSource === "gateway" ? this.config.extractionModelChain : undefined,
           workspaceDir: this.config.workspaceDir,
           pluginConfig: this.config,
           config: {

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -535,6 +535,7 @@ export class CompoundingEngine {
           memoryDir: this.config.memoryDir,
           gatewayConfig: this.config.gatewayConfig,
           gatewayAgentId: this.config.modelSource === "gateway" ? (this.config.gatewayAgentId || undefined) : undefined,
+          modelChain: this.config.modelSource === "gateway" ? this.config.taskModelChain : undefined,
           workspaceDir: this.config.workspaceDir,
         });
         log.debug(`[calibration] weekly synthesis produced ${calRules.length} calibration rule(s)`);

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -193,25 +193,40 @@ test("parseConfig modelSource=gateway does not inherit OPENAI_API_KEY from the p
   }
 });
 
-test("parseConfig normalizes extractionModelChain", () => {
+test("parseConfig normalizes taskModelChain", () => {
   const cfg = parseConfig({
-    extractionModelChain: {
+    taskModelChain: {
       primary: " openai/cheap-primary ",
       fallbacks: ["openai/cheap-primary", " fireworks/accounts/fireworks/models/glm-5p1 ", ""],
     },
   });
 
-  assert.deepEqual(cfg.extractionModelChain, {
+  assert.deepEqual(cfg.taskModelChain, {
     primary: "openai/cheap-primary",
     fallbacks: ["fireworks/accounts/fireworks/models/glm-5p1"],
   });
 });
 
-test("parseConfig ignores invalid extractionModelChain", () => {
-  assert.equal(parseConfig({ extractionModelChain: null }).extractionModelChain, undefined);
-  assert.equal(parseConfig({ extractionModelChain: [] }).extractionModelChain, undefined);
-  assert.equal(parseConfig({ extractionModelChain: { primary: " " } }).extractionModelChain, undefined);
-  assert.equal(parseConfig({ extractionModelChain: { fallbacks: ["openai/fallback-only"] } }).extractionModelChain, undefined);
+test("parseConfig treats an absent taskModelChain as not configured", () => {
+  assert.equal(parseConfig({}).taskModelChain, undefined);
+  assert.equal(parseConfig({ taskModelChain: null }).taskModelChain, undefined);
+  assert.equal(parseConfig({ taskModelChain: undefined }).taskModelChain, undefined);
+});
+
+test("parseConfig rejects a present-but-malformed taskModelChain (gotcha #51)", () => {
+  // A typo'd chain must surface loudly instead of silently reverting to defaults.
+  assert.throws(() => parseConfig({ taskModelChain: [] }), /taskModelChain must be an object/);
+  assert.throws(() => parseConfig({ taskModelChain: "openai/x" }), /taskModelChain must be an object/);
+  assert.throws(() => parseConfig({ taskModelChain: { primary: " " } }), /taskModelChain\.primary is required/);
+  assert.throws(() => parseConfig({ taskModelChain: { fallbacks: ["openai/fallback-only"] } }), /taskModelChain\.primary is required/);
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "openai/p", fallbacks: "not-an-array" } }),
+    /taskModelChain\.fallbacks must be an array/,
+  );
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "openai/p", fallbacks: [123] } }),
+    /taskModelChain\.fallbacks must contain only strings/,
+  );
 });
 
 test("parseConfig modelSource=gateway still honors an explicit openaiApiKey override", () => {

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -193,6 +193,27 @@ test("parseConfig modelSource=gateway does not inherit OPENAI_API_KEY from the p
   }
 });
 
+test("parseConfig normalizes extractionModelChain", () => {
+  const cfg = parseConfig({
+    extractionModelChain: {
+      primary: " openai/cheap-primary ",
+      fallbacks: ["openai/cheap-primary", " fireworks/accounts/fireworks/models/glm-5p1 ", ""],
+    },
+  });
+
+  assert.deepEqual(cfg.extractionModelChain, {
+    primary: "openai/cheap-primary",
+    fallbacks: ["fireworks/accounts/fireworks/models/glm-5p1"],
+  });
+});
+
+test("parseConfig ignores invalid extractionModelChain", () => {
+  assert.equal(parseConfig({ extractionModelChain: null }).extractionModelChain, undefined);
+  assert.equal(parseConfig({ extractionModelChain: [] }).extractionModelChain, undefined);
+  assert.equal(parseConfig({ extractionModelChain: { primary: " " } }).extractionModelChain, undefined);
+  assert.equal(parseConfig({ extractionModelChain: { fallbacks: ["openai/fallback-only"] } }).extractionModelChain, undefined);
+});
+
 test("parseConfig modelSource=gateway still honors an explicit openaiApiKey override", () => {
   const original = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -257,6 +257,18 @@ test("parseConfig rejects unqualified taskModelChain model strings (codex review
   );
 });
 
+test("parseConfig rejects unknown taskModelChain keys (codex review #1425)", () => {
+  // A misspelled "fallback" must not silently drop the fallback chain.
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "openai/p", fallback: ["openai/q"] } }),
+    /taskModelChain has unknown property: fallback/,
+  );
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "openai/p", fallbackModels: ["openai/q"], extra: 1 } }),
+    /taskModelChain has unknown properties:/,
+  );
+});
+
 test("parseConfig modelSource=gateway still honors an explicit openaiApiKey override", () => {
   const original = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -229,6 +229,34 @@ test("parseConfig rejects a present-but-malformed taskModelChain (gotcha #51)", 
   );
 });
 
+test("parseConfig rejects unqualified taskModelChain model strings (codex review #1425)", () => {
+  // A slash-less id like "gpt-4.1" parses here but FallbackLlmClient.parseModelString
+  // drops it, leaving the chain silently using a different model — reject at parse.
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "gpt-4.1" } }),
+    /taskModelChain\.primary must be in "provider\/model" form/,
+  );
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "openai/" } }),
+    /taskModelChain\.primary must be in "provider\/model" form/,
+  );
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "/gpt-4.1" } }),
+    /taskModelChain\.primary must be in "provider\/model" form/,
+  );
+  assert.throws(
+    () => parseConfig({ taskModelChain: { primary: "openai/gpt", fallbacks: ["bare-model"] } }),
+    /taskModelChain\.fallbacks entries must be in "provider\/model" form/,
+  );
+  // Multi-slash provider/model paths remain valid.
+  assert.deepEqual(
+    parseConfig({
+      taskModelChain: { primary: "fireworks/accounts/fireworks/models/glm-5p1" },
+    }).taskModelChain,
+    { primary: "fireworks/accounts/fireworks/models/glm-5p1" },
+  );
+});
+
 test("parseConfig modelSource=gateway still honors an explicit openaiApiKey override", () => {
   const original = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = "sk-env-should-not-be-used";

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -13,6 +13,7 @@ import type {
   HeartbeatConfig,
   IdentityInjectionMode,
   MemoryOsPresetName,
+  AgentPersonaModelConfig,
   PluginConfig,
   PrincipalRule,
   RecallPipelineConfig,
@@ -67,6 +68,30 @@ function parseBoundedIntegerMs(
   const coerced = coerceNumber(value);
   if (coerced === undefined) return fallback;
   return Math.min(max, Math.max(min, Math.floor(coerced)));
+}
+
+function parseModelChainConfig(value: unknown): AgentPersonaModelConfig | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  const primary = typeof raw.primary === "string" && raw.primary.trim().length > 0
+    ? raw.primary.trim()
+    : undefined;
+  if (!primary) return undefined;
+
+  const fallbacks = Array.isArray(raw.fallbacks)
+    ? raw.fallbacks
+        .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+        .map((item) => item.trim())
+    : undefined;
+
+  const dedupedFallbacks = fallbacks
+    ? [...new Set(fallbacks.filter((item) => item !== primary))]
+    : undefined;
+
+  return {
+    primary,
+    ...(dedupedFallbacks && dedupedFallbacks.length > 0 ? { fallbacks: dedupedFallbacks } : {}),
+  };
 }
 
 function parsePositiveInteger(value: unknown, keyName: string): number | undefined {
@@ -2425,6 +2450,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.fastGatewayAgentId === "string" && cfg.fastGatewayAgentId.length > 0
         ? cfg.fastGatewayAgentId
         : "",
+    extractionModelChain: parseModelChainConfig(cfg.extractionModelChain),
 
     // v3.0 namespaces (default off)
     namespacesEnabled: cfg.namespacesEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -70,23 +70,44 @@ function parseBoundedIntegerMs(
   return Math.min(max, Math.max(min, Math.floor(coerced)));
 }
 
-function parseModelChainConfig(value: unknown): AgentPersonaModelConfig | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+function parseModelChainConfig(
+  value: unknown,
+  keyName: string,
+): AgentPersonaModelConfig | undefined {
+  // Absent → not configured (no error).
+  if (value === undefined || value === null) return undefined;
+
+  // Present but malformed → reject loudly rather than silently dropping it,
+  // so a typo'd chain surfaces instead of quietly reverting to defaults
+  // (gotcha #51). Issue #1365 / PR #1370.
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      `${keyName} must be an object like { "primary": "provider/model", "fallbacks": ["provider/model", ...] }; got ${JSON.stringify(value)}`,
+    );
+  }
   const raw = value as Record<string, unknown>;
-  const primary = typeof raw.primary === "string" && raw.primary.trim().length > 0
-    ? raw.primary.trim()
-    : undefined;
-  if (!primary) return undefined;
+  if (typeof raw.primary !== "string" || raw.primary.trim().length === 0) {
+    throw new Error(
+      `${keyName}.primary is required and must be a non-empty "provider/model" string; got ${JSON.stringify(raw.primary)}`,
+    );
+  }
+  const primary = raw.primary.trim();
 
-  const fallbacks = Array.isArray(raw.fallbacks)
-    ? raw.fallbacks
-        .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
-        .map((item) => item.trim())
-    : undefined;
-
-  const dedupedFallbacks = fallbacks
-    ? [...new Set(fallbacks.filter((item) => item !== primary))]
-    : undefined;
+  let dedupedFallbacks: string[] | undefined;
+  if (raw.fallbacks !== undefined) {
+    if (!Array.isArray(raw.fallbacks)) {
+      throw new Error(
+        `${keyName}.fallbacks must be an array of "provider/model" strings; got ${JSON.stringify(raw.fallbacks)}`,
+      );
+    }
+    if (raw.fallbacks.some((item) => typeof item !== "string")) {
+      throw new Error(`${keyName}.fallbacks must contain only strings`);
+    }
+    const trimmed = raw.fallbacks
+      .map((item) => (item as string).trim())
+      .filter((item) => item.length > 0 && item !== primary);
+    dedupedFallbacks = [...new Set(trimmed)];
+  }
 
   return {
     primary,
@@ -2450,7 +2471,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.fastGatewayAgentId === "string" && cfg.fastGatewayAgentId.length > 0
         ? cfg.fastGatewayAgentId
         : "",
-    extractionModelChain: parseModelChainConfig(cfg.extractionModelChain),
+    taskModelChain: parseModelChainConfig(cfg.taskModelChain, "taskModelChain"),
 
     // v3.0 namespaces (default off)
     namespacesEnabled: cfg.namespacesEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -95,6 +95,15 @@ function parseModelChainConfig(
     );
   }
   const raw = value as Record<string, unknown>;
+  // Reject unknown keys (matches the manifest's additionalProperties:false) so a
+  // misspelled "fallback"/"fallbackModels" doesn't silently drop the fallback
+  // chain (gotcha #51, codex review #1425).
+  const unknownKeys = Object.keys(raw).filter((k) => k !== "primary" && k !== "fallbacks");
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `${keyName} has unknown propert${unknownKeys.length === 1 ? "y" : "ies"}: ${unknownKeys.join(", ")}. Allowed: "primary", "fallbacks".`,
+    );
+  }
   if (typeof raw.primary !== "string" || raw.primary.trim().length === 0) {
     throw new Error(
       `${keyName}.primary is required and must be a non-empty "provider/model" string; got ${JSON.stringify(raw.primary)}`,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -70,6 +70,15 @@ function parseBoundedIntegerMs(
   return Math.min(max, Math.max(min, Math.floor(coerced)));
 }
 
+// A gateway model string must be "provider/model" — at least one "/" with a
+// non-empty provider segment and a non-empty model segment. This mirrors
+// FallbackLlmClient.parseModelString (which requires >= 2 slash-parts), so a
+// model the runtime would silently drop is rejected at config time instead.
+function isQualifiedModelString(value: string): boolean {
+  const slash = value.indexOf("/");
+  return slash > 0 && slash < value.length - 1;
+}
+
 function parseModelChainConfig(
   value: unknown,
   keyName: string,
@@ -92,6 +101,11 @@ function parseModelChainConfig(
     );
   }
   const primary = raw.primary.trim();
+  if (!isQualifiedModelString(primary)) {
+    throw new Error(
+      `${keyName}.primary must be in "provider/model" form (e.g. "zai/glm-4.7-flash"); got ${JSON.stringify(primary)}`,
+    );
+  }
 
   let dedupedFallbacks: string[] | undefined;
   if (raw.fallbacks !== undefined) {
@@ -106,6 +120,13 @@ function parseModelChainConfig(
     const trimmed = raw.fallbacks
       .map((item) => (item as string).trim())
       .filter((item) => item.length > 0 && item !== primary);
+    for (const fb of trimmed) {
+      if (!isQualifiedModelString(fb)) {
+        throw new Error(
+          `${keyName}.fallbacks entries must be in "provider/model" form; got ${JSON.stringify(fb)}`,
+        );
+      }
+    }
     dedupedFallbacks = [...new Set(trimmed)];
   }
 

--- a/packages/remnic-core/src/extraction-judge-chain.test.ts
+++ b/packages/remnic-core/src/extraction-judge-chain.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import { judgeFactDurability } from "./extraction-judge.js";
+import type { FallbackLlmClient } from "./fallback-llm.js";
+
+// Regression for cursor review on #1425: the extraction judge must route gateway
+// fallback calls through the SAME precedence as ExtractionEngine.withGatewayAgent
+// — taskModelChain wins over gatewayAgentId — so judge-gated extractions use the
+// configured task chain instead of silently using the persona/default chain.
+
+function captureLlm(captured: Array<Record<string, unknown>>): FallbackLlmClient {
+  return {
+    isAvailable: () => true,
+    chatCompletion: async (_messages: unknown, options: Record<string, unknown>) => {
+      captured.push(options);
+      // A parseable batch verdict so the judge doesn't error after the call.
+      return { content: JSON.stringify([{ index: 0, durable: true, reason: "ok" }]) };
+    },
+  } as unknown as FallbackLlmClient;
+}
+
+// "preference" is not auto-approved (only "correction"/"principle" are), so a
+// non-critical preference candidate reaches the LLM path.
+const candidate = { text: "user prefers dark mode", category: "preference", confidence: 0.5 };
+
+test("judge forwards taskModelChain to the fallback LLM in gateway mode", async () => {
+  const config = parseConfig({
+    modelSource: "gateway",
+    gatewayAgentId: "persona-agent",
+    taskModelChain: { primary: "zai/glm-4.7-flash", fallbacks: ["fireworks/x/glm-5p1"] },
+  });
+  const captured: Array<Record<string, unknown>> = [];
+
+  await judgeFactDurability([candidate], config, null, captureLlm(captured), new Map(), new Map());
+
+  assert.equal(captured.length, 1, "judge should call the fallback LLM once");
+  assert.deepEqual(captured[0]?.modelChain, {
+    primary: "zai/glm-4.7-flash",
+    fallbacks: ["fireworks/x/glm-5p1"],
+  });
+  assert.equal(captured[0]?.agentId, undefined, "taskModelChain takes precedence over gatewayAgentId");
+});
+
+test("judge falls back to gatewayAgentId when no taskModelChain is set", async () => {
+  const config = parseConfig({ modelSource: "gateway", gatewayAgentId: "persona-agent" });
+  const captured: Array<Record<string, unknown>> = [];
+
+  await judgeFactDurability([candidate], config, null, captureLlm(captured), new Map(), new Map());
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0]?.agentId, "persona-agent");
+  assert.equal(captured[0]?.modelChain, undefined);
+});

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -656,13 +656,20 @@ async function callJudgeLlm(
   // routing preference.
   const skipLocal = config.modelSource === "gateway";
 
-  // Resolve the gateway agent ID so the fallback LLM routes through the
-  // correct agent persona's model chain — identical to the pattern used
-  // by ExtractionEngine.withGatewayAgent().
-  const agentId =
+  // Resolve gateway routing for the fallback LLM using the SAME precedence as
+  // ExtractionEngine.withGatewayAgent(): in gateway mode, an explicit
+  // taskModelChain wins over the gateway agent persona, so judge-gated
+  // extractions use the same task chain as extraction/consolidation rather
+  // than silently falling back to the persona/default chain (gotcha #39).
+  // Issue #1365 / PR #1425.
+  const gatewayChain: { modelChain?: typeof config.taskModelChain; agentId?: string } =
     config.modelSource === "gateway"
-      ? (config.gatewayAgentId || undefined)
-      : undefined;
+      ? config.taskModelChain
+        ? { modelChain: config.taskModelChain }
+        : config.gatewayAgentId
+          ? { agentId: config.gatewayAgentId }
+          : {}
+      : {};
 
   // Try local LLM first (unless modelSource says gateway)
   if (localLlm && !skipLocal) {
@@ -695,7 +702,7 @@ async function callJudgeLlm(
           maxTokens: 2048,
           timeoutMs: 1500,
           ...(modelOverride ? { model: modelOverride } : {}),
-          ...(agentId ? { agentId } : {}),
+          ...gatewayChain,
         },
       );
       if (result?.content) {

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -17,7 +17,7 @@ import { createHash } from "node:crypto";
 import { log } from "./logger.js";
 import type { PluginConfig, ImportanceLevel } from "./types.js";
 import type { LocalLlmClient } from "./local-llm.js";
-import type { FallbackLlmClient } from "./fallback-llm.js";
+import { type FallbackLlmClient, gatewayTaskChainOptions } from "./fallback-llm.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
 
@@ -656,20 +656,11 @@ async function callJudgeLlm(
   // routing preference.
   const skipLocal = config.modelSource === "gateway";
 
-  // Resolve gateway routing for the fallback LLM using the SAME precedence as
-  // ExtractionEngine.withGatewayAgent(): in gateway mode, an explicit
-  // taskModelChain wins over the gateway agent persona, so judge-gated
-  // extractions use the same task chain as extraction/consolidation rather
-  // than silently falling back to the persona/default chain (gotcha #39).
-  // Issue #1365 / PR #1425.
-  const gatewayChain: { modelChain?: typeof config.taskModelChain; agentId?: string } =
-    config.modelSource === "gateway"
-      ? config.taskModelChain
-        ? { modelChain: config.taskModelChain }
-        : config.gatewayAgentId
-          ? { agentId: config.gatewayAgentId }
-          : {}
-      : {};
+  // Route judge-gated extractions through the SAME shared resolution as every
+  // other background task (taskModelChain > gatewayAgentId in gateway mode), so
+  // the judge never silently falls back to the persona/default chain when a
+  // task chain is configured (gotcha #22, #39). Issue #1365 / PR #1425.
+  const gatewayChain = gatewayTaskChainOptions(config);
 
   // Try local LLM first (unless modelSource says gateway)
   if (localLlm && !skipLocal) {

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -123,7 +123,8 @@ export class ExtractionEngine {
     if (config.modelSource === "gateway") {
       log.debug(
         `extraction engine: gateway model source active; extraction uses the gateway chain as its primary path` +
-          (config.gatewayAgentId ? ` (agent: ${config.gatewayAgentId})` : " (defaults)"),
+          (config.extractionModelChain ? " (extractionModelChain)" :
+            config.gatewayAgentId ? ` (agent: ${config.gatewayAgentId})` : " (defaults)"),
       );
     }
   }
@@ -157,6 +158,8 @@ export class ExtractionEngine {
    */
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
+    const modelChain = this.config.extractionModelChain;
+    if (modelChain) return { ...options, modelChain };
     const agentId = this.config.gatewayAgentId || undefined;
     return agentId ? { ...options, agentId } : options;
   }
@@ -1098,7 +1101,8 @@ export class ExtractionEngine {
     if (this.useGatewayModelSource) {
       log.debug(
         `extraction: using gateway model chain as primary path` +
-          (this.config.gatewayAgentId ? ` (agent: ${this.config.gatewayAgentId})` : " (defaults)"),
+          (this.config.extractionModelChain ? " (extractionModelChain)" :
+            this.config.gatewayAgentId ? ` (agent: ${this.config.gatewayAgentId})` : " (defaults)"),
       );
     } else {
       log.info("extraction: falling back to gateway default AI");

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -123,8 +123,16 @@ export class ExtractionEngine {
     if (config.modelSource === "gateway") {
       log.debug(
         `extraction engine: gateway model source active; extraction uses the gateway chain as its primary path` +
-          (config.extractionModelChain ? " (extractionModelChain)" :
+          (config.taskModelChain ? " (taskModelChain)" :
             config.gatewayAgentId ? ` (agent: ${config.gatewayAgentId})` : " (defaults)"),
+      );
+    } else if (config.taskModelChain) {
+      // taskModelChain resolves through gateway providers, so it only applies
+      // under modelSource: "gateway". Warn rather than silently ignore it so a
+      // misconfigured plugin-mode setup is visible. Issue #1365 / PR #1370.
+      log.warn(
+        `taskModelChain is set but modelSource is "${config.modelSource}"; the chain is ignored. ` +
+          `Set modelSource: "gateway" to use it for extraction/consolidation/summarization.`,
       );
     }
   }
@@ -158,7 +166,7 @@ export class ExtractionEngine {
    */
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
-    const modelChain = this.config.extractionModelChain;
+    const modelChain = this.config.taskModelChain;
     if (modelChain) return { ...options, modelChain };
     const agentId = this.config.gatewayAgentId || undefined;
     return agentId ? { ...options, agentId } : options;
@@ -1101,7 +1109,7 @@ export class ExtractionEngine {
     if (this.useGatewayModelSource) {
       log.debug(
         `extraction: using gateway model chain as primary path` +
-          (this.config.extractionModelChain ? " (extractionModelChain)" :
+          (this.config.taskModelChain ? " (taskModelChain)" :
             this.config.gatewayAgentId ? ` (agent: ${this.config.gatewayAgentId})` : " (defaults)"),
       );
     } else {

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -2,7 +2,7 @@ import OpenAI from "openai";
 import { log } from "./logger.js";
 import { delinearize } from "./delinearize.js";
 import { LocalLlmClient } from "./local-llm.js";
-import { FallbackLlmClient, fallbackLlmRuntimeContextFromConfig } from "./fallback-llm.js";
+import { FallbackLlmClient, fallbackLlmRuntimeContextFromConfig, gatewayTaskChainOptions } from "./fallback-llm.js";
 import {
   ExtractionResultSchema,
   ConsolidationResultSchema,
@@ -166,10 +166,9 @@ export class ExtractionEngine {
    */
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
-    const modelChain = this.config.taskModelChain;
-    if (modelChain) return { ...options, modelChain };
-    const agentId = this.config.gatewayAgentId || undefined;
-    return agentId ? { ...options, agentId } : options;
+    // Shared resolution (taskModelChain > gatewayAgentId) so every background
+    // task routes identically (gotcha #22). Issue #1365.
+    return { ...options, ...gatewayTaskChainOptions(this.config) };
   }
 
   private emit(event: LlmTraceEvent): void {

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -1281,6 +1281,197 @@ test("fallback llm normalizes anthropic-compatible base URLs that omit /v1", { c
   }
 });
 
+test("fallback llm appends gateway default model as implicit last resort when chain is exhausted", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    if (body.model === "stale-primary" || body.model === "stale-fallback") {
+      return new Response(JSON.stringify({ error: { message: "provider gone" } }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "default-model ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        modelChain: {
+          primary: "openai/stale-primary",
+          fallbacks: ["openai/stale-fallback"],
+        },
+      },
+    );
+
+    // All chain models failed, but gateway default model was appended and succeeds
+    assert.equal(response?.content, "default-model ok");
+    assert.equal(response?.modelUsed, "openai/default-model");
+    assert.deepEqual(attemptedModels, ["stale-primary", "stale-fallback", "default-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm does not duplicate gateway default model when it is already in chain", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        modelChain: {
+          primary: "openai/default-model",
+        },
+      },
+    );
+
+    // The default model is already primary in the chain — should not be appended again
+    assert.equal(response?.content, "ok");
+    assert.equal(response?.modelUsed, "openai/default-model");
+    assert.deepEqual(attemptedModels, ["default-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm does not append gateway default model when no chain is provided", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      { temperature: 0, maxTokens: 16 },
+    );
+
+    // Without modelChainOverride, the chain is built from agents.defaults.model;
+    // the default model is already the primary, so no duplication
+    assert.equal(response?.content, "ok");
+    assert.equal(response?.modelUsed, "openai/default-model");
+    assert.deepEqual(attemptedModels, ["default-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 function disableGatewaySecretResolverForTest(): void {
   __setGatewayResolverForTest(async () => null);
 }

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -1472,6 +1472,57 @@ test("fallback llm does not append gateway default model when no chain is provid
   }
 });
 
+test("fallback llm does NOT append gateway default to a persona chain (last-resort is scoped to task chains)", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  // A persona chain that deliberately excludes the gateway default. Without a
+  // modelChain override, the implicit last-resort must NOT augment it, so the
+  // main agent's persona fallback behavior is preserved (gotcha #39).
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: { model: { primary: "openai/default-model" } },
+      list: [{ id: "main-agent", model: { primary: "openai/persona-model" } }],
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      { temperature: 0, maxTokens: 16, agentId: "main-agent" },
+    );
+
+    assert.equal(response?.modelUsed, "openai/persona-model");
+    // The gateway default must not be appended to the persona chain.
+    assert.deepEqual(attemptedModels, ["persona-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 function disableGatewaySecretResolverForTest(): void {
   __setGatewayResolverForTest(async () => null);
 }

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -210,6 +210,31 @@ test("fallback llm tries an explicit model override before a model chain overrid
   }
 });
 
+test("fallback llm availability checks an explicit model chain override", () => {
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  assert.equal(llm.isAvailable({ modelChain: { primary: "openai/task-primary" } }), true);
+  assert.equal(llm.isAvailable({ modelChain: {} }), true);
+});
+
 test("fallback llm deduplicates a model override that matches the model chain primary", { concurrency: false }, async () => {
   clearModelsJsonCache();
   clearSecretCache();

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -73,6 +73,207 @@ test("fallback llm prefers the active gateway provider config over models.json",
   }
 });
 
+test("fallback llm uses an explicit model chain override instead of gateway defaults", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+          fallbacks: ["openai/default-fallback"],
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    if (body.model === "cheap-primary") {
+      return new Response(JSON.stringify({ error: { message: "try fallback" } }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "fallback ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        modelChain: {
+          primary: "openai/cheap-primary",
+          fallbacks: ["openai/cheap-primary", "openai/cheap-fallback"],
+        },
+      },
+    );
+
+    assert.equal(response?.content, "fallback ok");
+    assert.equal(response?.modelUsed, "openai/cheap-fallback");
+    assert.deepEqual(attemptedModels, ["cheap-primary", "cheap-fallback"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm tries an explicit model override before a model chain override", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    if (body.model === "judge-model") {
+      return new Response(JSON.stringify({ error: { message: "try task chain" } }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "task chain ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Judge this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        model: "openai/judge-model",
+        modelChain: { primary: "openai/task-primary" },
+      },
+    );
+
+    assert.equal(response?.content, "task chain ok");
+    assert.equal(response?.modelUsed, "openai/task-primary");
+    assert.deepEqual(attemptedModels, ["judge-model", "task-primary"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("fallback llm deduplicates a model override that matches the model chain primary", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/default-model",
+        },
+      },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "dedupe ok" } }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Judge this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        model: "openai/task-primary",
+        modelChain: {
+          primary: "openai/task-primary",
+          fallbacks: ["openai/task-fallback"],
+        },
+      },
+    );
+
+    assert.equal(response?.content, "dedupe ok");
+    assert.equal(response?.modelUsed, "openai/task-primary");
+    assert.deepEqual(attemptedModels, ["task-primary"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 test("fallback llm tries an explicit model override before the configured chain", { concurrency: false }, async () => {
   clearModelsJsonCache();
   clearSecretCache();

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -1523,6 +1523,56 @@ test("fallback llm does NOT append gateway default to a persona chain (last-reso
   }
 });
 
+test("fallback llm does NOT append default for a primary-less override that falls through to a persona chain (cursor #1425)", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  // A primary-less override ({}) is inactive — chain resolution uses the persona
+  // chain. The implicit last-resort must key on the SAME activation condition
+  // (override.primary), so the persona chain is not augmented with the default.
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: { model: { primary: "openai/default-model" } },
+      list: [{ id: "main-agent", model: { primary: "openai/persona-model" } }],
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attemptedModels: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attemptedModels.push(String(body.model ?? ""));
+    return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      { temperature: 0, maxTokens: 16, agentId: "main-agent", modelChain: {} },
+    );
+
+    assert.equal(response?.modelUsed, "openai/persona-model");
+    assert.deepEqual(attemptedModels, ["persona-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
 function disableGatewaySecretResolverForTest(): void {
   __setGatewayResolverForTest(async () => null);
 }

--- a/packages/remnic-core/src/fallback-llm.test.ts
+++ b/packages/remnic-core/src/fallback-llm.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import test from "node:test";
 
-import { FallbackLlmClient } from "./fallback-llm.js";
+import { FallbackLlmClient, gatewayTaskChainOptions } from "./fallback-llm.js";
 import { __codexCliFallbackTestHooks } from "./codex-cli-fallback.js";
 import { clearModelsJsonCache, __setModelsJsonForTest } from "./models-json.js";
 import {
@@ -1465,6 +1465,87 @@ test("fallback llm does not append gateway default model when no chain is provid
     assert.equal(response?.content, "ok");
     assert.equal(response?.modelUsed, "openai/default-model");
     assert.deepEqual(attemptedModels, ["default-model"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearModelsJsonCache();
+    clearSecretCache();
+  }
+});
+
+test("gatewayTaskChainOptions resolves the single source of truth for task routing", () => {
+  // taskModelChain wins over gatewayAgentId in gateway mode.
+  assert.deepEqual(
+    gatewayTaskChainOptions({ modelSource: "gateway", gatewayAgentId: "persona", taskModelChain: { primary: "zai/glm-4.7-flash" } }),
+    { modelChain: { primary: "zai/glm-4.7-flash" } },
+  );
+  // Falls back to gatewayAgentId when no taskModelChain.
+  assert.deepEqual(
+    gatewayTaskChainOptions({ modelSource: "gateway", gatewayAgentId: "persona", taskModelChain: undefined }),
+    { agentId: "persona" },
+  );
+  // Empty when gateway mode but neither configured.
+  assert.deepEqual(
+    gatewayTaskChainOptions({ modelSource: "gateway", gatewayAgentId: "", taskModelChain: undefined }),
+    {},
+  );
+  // Plugin mode never routes through the chain, even if taskModelChain is set.
+  assert.deepEqual(
+    gatewayTaskChainOptions({ modelSource: "plugin", gatewayAgentId: "persona", taskModelChain: { primary: "zai/glm-4.7-flash" } }),
+    {},
+  );
+});
+
+test("fallback llm last-resort appends the full gateway default chain (primary + fallbacks)", { concurrency: false }, async () => {
+  clearModelsJsonCache();
+  clearSecretCache();
+
+  // taskModelChain exhausted AND default primary unreachable — a listed default
+  // fallback must still be tried (cursor review #1425).
+  const llm = new FallbackLlmClient({
+    agents: {
+      defaults: { model: { primary: "openai/default-primary", fallbacks: ["openai/default-fallback"] } },
+    },
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai.example/v1",
+          api: "openai-completions",
+          apiKey: "openai-key",
+          models: [],
+        },
+      },
+    },
+  });
+
+  const originalFetch = globalThis.fetch;
+  const attempted: string[] = [];
+  globalThis.fetch = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string };
+    attempted.push(String(body.model ?? ""));
+    if (body.model === "default-fallback") {
+      return new Response(JSON.stringify({ choices: [{ message: { content: "default-fallback ok" } }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ error: { message: "gone" } }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await llm.chatCompletion(
+      [{ role: "user", content: "Extract this" }],
+      {
+        temperature: 0,
+        maxTokens: 16,
+        modelChain: { primary: "openai/stale-primary", fallbacks: ["openai/stale-fallback"] },
+      },
+    );
+
+    assert.equal(response?.modelUsed, "openai/default-fallback");
+    assert.deepEqual(attempted, ["stale-primary", "stale-fallback", "default-primary", "default-fallback"]);
   } finally {
     globalThis.fetch = originalFetch;
     clearModelsJsonCache();

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -341,11 +341,13 @@ export class FallbackLlmClient {
       }
     }
 
-    // Implicit last-resort: always append the gateway default model so that a
-    // stale or exhausted extractionModelChain never leaves the chain empty.
-    // This guarantees Remnic can never be the reason a chat is interrupted
-    // by a flush failure — there is always at least one reachable model.
-    if (modelStrings.length > 0) {
+    // Implicit last-resort: when a task-specific modelChain override is active,
+    // append the gateway default model so a stale or exhausted taskModelChain
+    // never leaves the chain empty — Remnic should never be the reason a chat is
+    // interrupted by a flush failure. Scoped to the override path so the main
+    // agent's persona/default chains keep their exact configured fallback
+    // behavior (gotcha #39). Issue #1365 / PR #1370.
+    if (modelChainOverride && modelStrings.length > 0) {
       const defaultModel = this.gatewayConfig?.agents?.defaults?.model?.primary;
       if (
         defaultModel &&

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -1,6 +1,6 @@
 import { log } from "./logger.js";
 import path from "node:path";
-import type { GatewayConfig, ModelProviderConfig, AgentPersona } from "./types.js";
+import type { AgentPersonaModelConfig, GatewayConfig, ModelProviderConfig } from "./types.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import {
   buildChatCompletionTemperature,
@@ -25,6 +25,8 @@ export interface FallbackLlmOptions {
   signal?: AbortSignal;
   /** Explicit "provider/model" override to try before the configured chain. */
   model?: string;
+  /** Explicit model chain override to use instead of the configured agent/default chain. */
+  modelChain?: AgentPersonaModelConfig;
   /** Override which agent persona's model chain to use (by ID from agents.list[]). */
   agentId?: string;
 }
@@ -134,7 +136,7 @@ export class FallbackLlmClient {
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
     options: FallbackLlmOptions = {},
   ): Promise<FallbackLlmResponse | null> {
-    const models = this.getModelChain(options.agentId, options.model);
+    const models = this.getModelChain(options.agentId, options.model, options.modelChain);
     if (models.length === 0) {
       log.warn("fallback LLM: no models configured in gateway");
       return null;
@@ -262,18 +264,28 @@ export class FallbackLlmClient {
    * Get the full model chain from gateway config.
    * Returns array of models in order: [primary, fallback1, fallback2, ...]
    *
-   * When agentId is provided, looks up the matching entry in agents.list[]
-   * and uses that persona's model chain. Falls back to agents.defaults.model
-   * if agentId is not found or not provided.
+   * When modelChainOverride is provided, uses it instead of any configured
+   * agent/default chain. Otherwise, when agentId is provided, looks up the
+   * matching entry in agents.list[] and uses that persona's model chain.
+   * Falls back to agents.defaults.model if agentId is not found or not provided.
    */
-  private getModelChain(agentId?: string, modelOverride?: string): ModelRef[] {
+  private getModelChain(
+    agentId?: string,
+    modelOverride?: string,
+    modelChainOverride?: AgentPersonaModelConfig,
+  ): ModelRef[] {
     const chain: ModelRef[] = [];
     const providers = this.gatewayConfig?.models?.providers ?? {};
 
-    // Resolve the model config: agent persona chain or global defaults
-    let modelConfig: { primary?: string; fallbacks?: string[] } | undefined;
+    // Resolve the model config: explicit task chain, agent persona chain, or global defaults
+    let modelConfig: AgentPersonaModelConfig | undefined;
 
-    if (agentId) {
+    if (modelChainOverride) {
+      modelConfig = modelChainOverride;
+      log.debug("fallback LLM: using explicit model chain override");
+    }
+
+    if (!modelConfig && agentId) {
       const persona = this.gatewayConfig?.agents?.list?.find(
         (a) => a.id === agentId,
       );
@@ -294,21 +306,20 @@ export class FallbackLlmClient {
     // Build list of model strings: primary + fallbacks
     const modelStrings: string[] = [];
 
-    if (typeof modelOverride === "string" && modelOverride.trim().length > 0) {
-      modelStrings.push(modelOverride.trim());
-    }
-
-    if (modelConfig?.primary) {
-      if (!modelStrings.includes(modelConfig.primary)) {
-        modelStrings.push(modelConfig.primary);
+    const addModelString = (value: unknown): void => {
+      if (typeof value !== "string") return;
+      const trimmed = value.trim();
+      if (trimmed.length > 0 && !modelStrings.includes(trimmed)) {
+        modelStrings.push(trimmed);
       }
-    }
+    };
+
+    addModelString(modelOverride);
+    addModelString(modelConfig?.primary);
 
     if (Array.isArray(modelConfig?.fallbacks)) {
       for (const fb of modelConfig.fallbacks) {
-        if (typeof fb === "string" && !modelStrings.includes(fb)) {
-          modelStrings.push(fb);
-        }
+        addModelString(fb);
       }
     }
 

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -31,6 +31,11 @@ export interface FallbackLlmOptions {
   agentId?: string;
 }
 
+export interface FallbackLlmAvailabilityOptions {
+  agentId?: string;
+  modelChain?: AgentPersonaModelConfig;
+}
+
 export interface FallbackLlmResponse {
   content: string;
   modelUsed: string;
@@ -122,8 +127,11 @@ export class FallbackLlmClient {
   /**
    * Check if fallback is available (gateway config has at least one model).
    */
-  isAvailable(agentId?: string): boolean {
-    const models = this.getModelChain(agentId);
+  isAvailable(agentIdOrOptions?: string | FallbackLlmAvailabilityOptions): boolean {
+    const options = typeof agentIdOrOptions === "string"
+      ? { agentId: agentIdOrOptions }
+      : (agentIdOrOptions ?? {});
+    const models = this.getModelChain(options.agentId, undefined, options.modelChain);
     return models.length > 0;
   }
 
@@ -280,9 +288,11 @@ export class FallbackLlmClient {
     // Resolve the model config: explicit task chain, agent persona chain, or global defaults
     let modelConfig: AgentPersonaModelConfig | undefined;
 
-    if (modelChainOverride) {
+    if (modelChainOverride?.primary) {
       modelConfig = modelChainOverride;
       log.debug("fallback LLM: using explicit model chain override");
+    } else if (modelChainOverride) {
+      log.warn("fallback LLM: ignoring explicit model chain override without primary model");
     }
 
     if (!modelConfig && agentId) {

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -341,6 +341,28 @@ export class FallbackLlmClient {
       }
     }
 
+    // Implicit last-resort: always append the gateway default model so that a
+    // stale or exhausted extractionModelChain never leaves the chain empty.
+    // This guarantees Remnic can never be the reason a chat is interrupted
+    // by a flush failure — there is always at least one reachable model.
+    if (modelStrings.length > 0) {
+      const defaultModel = this.gatewayConfig?.agents?.defaults?.model?.primary;
+      if (
+        defaultModel &&
+        typeof defaultModel === "string" &&
+        defaultModel.trim().length > 0 &&
+        !modelStrings.includes(defaultModel.trim())
+      ) {
+        const defaultRef = this.parseModelString(defaultModel.trim(), providers);
+        if (defaultRef) {
+          chain.push(defaultRef);
+          log.debug(
+            `fallback LLM: appended gateway default model "${defaultModel.trim()}" as implicit last resort`,
+          );
+        }
+      }
+    }
+
     return chain;
   }
 

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -344,10 +344,11 @@ export class FallbackLlmClient {
     // Implicit last-resort: when a task-specific modelChain override is active,
     // append the gateway default model so a stale or exhausted taskModelChain
     // never leaves the chain empty — Remnic should never be the reason a chat is
-    // interrupted by a flush failure. Scoped to the override path so the main
-    // agent's persona/default chains keep their exact configured fallback
-    // behavior (gotcha #39). Issue #1365 / PR #1370.
-    if (modelChainOverride && modelStrings.length > 0) {
+    // interrupted by a flush failure. Keyed on `modelChainOverride?.primary` —
+    // the SAME activation condition chain resolution uses above — so a
+    // primary-less override (e.g. {}) that falls through to a persona/default
+    // chain does NOT get the default appended (gotcha #39). Issue #1365 / PR #1370.
+    if (modelChainOverride?.primary && modelStrings.length > 0) {
       const defaultModel = this.gatewayConfig?.agents?.defaults?.model?.primary;
       if (
         defaultModel &&

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -1,6 +1,6 @@
 import { log } from "./logger.js";
 import path from "node:path";
-import type { AgentPersonaModelConfig, GatewayConfig, ModelProviderConfig } from "./types.js";
+import type { AgentPersonaModelConfig, GatewayConfig, ModelProviderConfig, PluginConfig } from "./types.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import {
   buildChatCompletionTemperature,
@@ -34,6 +34,23 @@ export interface FallbackLlmOptions {
 export interface FallbackLlmAvailabilityOptions {
   agentId?: string;
   modelChain?: AgentPersonaModelConfig;
+}
+
+/**
+ * Resolve the gateway routing options Remnic's background tasks should pass to
+ * FallbackLlmClient — extraction, fact/profile/identity consolidation,
+ * summarization, calibration, and causal/semantic consolidation. Single source
+ * of truth so every task path stays consistent and can't diverge (gotcha #22):
+ * in gateway mode an explicit `taskModelChain` wins over the gateway agent
+ * persona; otherwise the persona (if any) is used. Returns `{}` in plugin mode
+ * because the chain resolves through gateway providers only. Issue #1365.
+ */
+export function gatewayTaskChainOptions(
+  config: Pick<PluginConfig, "modelSource" | "taskModelChain" | "gatewayAgentId">,
+): Pick<FallbackLlmOptions, "modelChain" | "agentId"> {
+  if (config.modelSource !== "gateway") return {};
+  if (config.taskModelChain) return { modelChain: config.taskModelChain };
+  return config.gatewayAgentId ? { agentId: config.gatewayAgentId } : {};
 }
 
 export interface FallbackLlmResponse {
@@ -349,18 +366,24 @@ export class FallbackLlmClient {
     // primary-less override (e.g. {}) that falls through to a persona/default
     // chain does NOT get the default appended (gotcha #39). Issue #1365 / PR #1370.
     if (modelChainOverride?.primary && modelStrings.length > 0) {
-      const defaultModel = this.gatewayConfig?.agents?.defaults?.model?.primary;
-      if (
-        defaultModel &&
-        typeof defaultModel === "string" &&
-        defaultModel.trim().length > 0 &&
-        !modelStrings.includes(defaultModel.trim())
-      ) {
-        const defaultRef = this.parseModelString(defaultModel.trim(), providers);
+      // Append the FULL gateway default chain (primary + fallbacks), not just
+      // the primary — if the default primary is also unreachable, a listed
+      // default fallback may still succeed (cursor review #1425).
+      const defaults = this.gatewayConfig?.agents?.defaults?.model;
+      const defaultStrings: string[] = [
+        ...(typeof defaults?.primary === "string" ? [defaults.primary] : []),
+        ...(Array.isArray(defaults?.fallbacks) ? defaults.fallbacks : []),
+      ];
+      for (const candidate of defaultStrings) {
+        if (typeof candidate !== "string") continue;
+        const trimmed = candidate.trim();
+        if (trimmed.length === 0 || modelStrings.includes(trimmed)) continue;
+        const defaultRef = this.parseModelString(trimmed, providers);
         if (defaultRef) {
           chain.push(defaultRef);
+          modelStrings.push(trimmed); // keep dedupe correct for later default fallbacks
           log.debug(
-            `fallback LLM: appended gateway default model "${defaultModel.trim()}" as implicit last resort`,
+            `fallback LLM: appended gateway default model "${trimmed}" as implicit last resort`,
           );
         }
       }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -263,6 +263,7 @@ import {
 import { normalizeReplaySessionKey, type ReplayTurn } from "./replay/types.js";
 import type { ImportTurn } from "./bulk-import/types.js";
 import {
+  type AgentPersonaModelConfig,
   confidenceTier,
   type MemoryIntent,
   type MemorySummary,
@@ -3392,22 +3393,31 @@ export class Orchestrator {
 
     // Use FallbackLlmClient for LLM calls (same pattern as causal-consolidation.ts)
     // Honor semanticConsolidationModel: "auto" = primary, "fast" = local fast, or specific model
-    const { FallbackLlmClient } = await import("./fallback-llm.js");
+    const { FallbackLlmClient, gatewayTaskChainOptions } = await import("./fallback-llm.js");
     const useGateway = this.config.modelSource === "gateway";
     const modelSetting = this.config.semanticConsolidationModel;
     if (modelSetting === "fast" && this.fastLlm && !useGateway) {
       log.info("[semantic-consolidation] using fast local LLM for synthesis");
     }
-    const gatewayAgentId = useGateway
-      ? (modelSetting === "fast" && this.config.fastGatewayAgentId
-          ? this.config.fastGatewayAgentId
-          : this.config.gatewayAgentId || undefined)
-      : undefined;
+    // Gateway routing: an explicit "fast" setting keeps the fast persona chain
+    // (the operator's deliberate fast-tier choice). Otherwise route through the
+    // shared task-chain resolution so taskModelChain applies to semantic
+    // consolidation like every other background task (gotcha #22). Issue #1365.
+    const gatewayChainOptions: { modelChain?: AgentPersonaModelConfig; agentId?: string } =
+      !useGateway
+        ? {}
+        : modelSetting === "fast"
+          ? (this.config.fastGatewayAgentId
+              ? { agentId: this.config.fastGatewayAgentId }
+              : this.config.gatewayAgentId
+                ? { agentId: this.config.gatewayAgentId }
+                : {})
+          : gatewayTaskChainOptions(this.config);
     const llm = new FallbackLlmClient(
       this.config.gatewayConfig,
       fallbackLlmRuntimeContextFromConfig(this.config),
     );
-    if (!llm.isAvailable(gatewayAgentId) && !(modelSetting === "fast" && this.fastLlm && !useGateway)) {
+    if (!llm.isAvailable(gatewayChainOptions) && !(modelSetting === "fast" && this.fastLlm && !useGateway)) {
       log.warn(
         "[semantic-consolidation] no LLM available — skipping synthesis",
       );
@@ -3456,7 +3466,7 @@ export class Orchestrator {
         let response: { content: string } | null = null;
         if (useGateway) {
           // Gateway model source — use the appropriate agent chain
-          response = await llm.chatCompletion(messages, { ...llmOpts, agentId: gatewayAgentId });
+          response = await llm.chatCompletion(messages, { ...llmOpts, ...gatewayChainOptions });
         } else if (modelSetting === "fast" && this.fastLlm) {
           const fastResult = await this.fastLlm.chatCompletion(messages, {
             operation: "semantic-consolidation",

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -85,7 +85,7 @@ export class HourlySummarizer {
 
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
-    const modelChain = this.config.extractionModelChain;
+    const modelChain = this.config.taskModelChain;
     if (modelChain) return { ...options, modelChain };
     const agentId = this.config.gatewayAgentId || undefined;
     return agentId ? { ...options, agentId } : options;

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -85,6 +85,8 @@ export class HourlySummarizer {
 
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
+    const modelChain = this.config.extractionModelChain;
+    if (modelChain) return { ...options, modelChain };
     const agentId = this.config.gatewayAgentId || undefined;
     return agentId ? { ...options, agentId } : options;
   }

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { z } from "zod";
 import { log } from "./logger.js";
 import { LocalLlmClient } from "./local-llm.js";
-import { FallbackLlmClient, fallbackLlmRuntimeContextFromConfig } from "./fallback-llm.js";
+import { FallbackLlmClient, fallbackLlmRuntimeContextFromConfig, gatewayTaskChainOptions } from "./fallback-llm.js";
 import { ModelRegistry } from "./model-registry.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import type { HourlySummary, TranscriptEntry, PluginConfig, GatewayConfig } from "./types.js";
@@ -85,10 +85,8 @@ export class HourlySummarizer {
 
   private withGatewayAgent(options: import("./fallback-llm.js").FallbackLlmOptions): import("./fallback-llm.js").FallbackLlmOptions {
     if (!this.useGatewayModelSource) return options;
-    const modelChain = this.config.taskModelChain;
-    if (modelChain) return { ...options, modelChain };
-    const agentId = this.config.gatewayAgentId || undefined;
-    return agentId ? { ...options, agentId } : options;
+    // Shared resolution (taskModelChain > gatewayAgentId) — gotcha #22. Issue #1365.
+    return { ...options, ...gatewayTaskChainOptions(this.config) };
   }
 
   async initialize(): Promise<void> {

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1269,11 +1269,15 @@ export interface PluginConfig {
   gatewayAgentId: string;
   fastGatewayAgentId: string;
   /**
-   * Optional task-specific model chain for extraction/consolidation/summarization
-   * fallback calls. When set, this chain is resolved through gateway providers
+   * Optional task-specific model chain for Remnic's background LLM work —
+   * extraction, fact/profile/identity consolidation, summarization, and causal
+   * consolidation. When set, this chain is resolved through gateway providers
    * instead of using gatewayAgentId or agents.defaults.model.
+   *
+   * Only takes effect when `modelSource: "gateway"`; ignored (with a startup
+   * warning) under `modelSource: "plugin"`. See issue #1365 / PR #1370.
    */
-  extractionModelChain?: AgentPersonaModelConfig;
+  taskModelChain?: AgentPersonaModelConfig;
 
   // v3.0 Multi-agent memory (namespaces)
   namespacesEnabled: boolean;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1268,6 +1268,12 @@ export interface PluginConfig {
   modelSource: "plugin" | "gateway";
   gatewayAgentId: string;
   fastGatewayAgentId: string;
+  /**
+   * Optional task-specific model chain for extraction/consolidation/summarization
+   * fallback calls. When set, this chain is resolved through gateway providers
+   * instead of using gatewayAgentId or agents.defaults.model.
+   */
+  extractionModelChain?: AgentPersonaModelConfig;
 
   // v3.0 Multi-agent memory (namespaces)
   namespacesEnabled: boolean;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1270,9 +1270,11 @@ export interface PluginConfig {
   fastGatewayAgentId: string;
   /**
    * Optional task-specific model chain for Remnic's background LLM work —
-   * extraction, fact/profile/identity consolidation, summarization, and causal
+   * extraction, the extraction judge, fact/profile/identity consolidation,
+   * summarization, semantic consolidation, calibration, and causal
    * consolidation. When set, this chain is resolved through gateway providers
-   * instead of using gatewayAgentId or agents.defaults.model.
+   * instead of using gatewayAgentId or agents.defaults.model. All task paths
+   * route through the shared `gatewayTaskChainOptions` helper.
    *
    * Only takes effect when `modelSource: "gateway"`; ignored (with a startup
    * warning) under `modelSource: "plugin"`. See issue #1365 / PR #1370.

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3151,6 +3151,28 @@
         "default": "",
         "description": "Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). When modelSource is 'gateway' and this is empty, fast ops use the same chain as gatewayAgentId."
       },
+      "taskModelChain": {
+        "type": "object",
+        "description": "Optional task-specific gateway model chain for Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation). When set, this chain is resolved through gateway providers instead of gatewayAgentId or agents.defaults.model. Only applies when modelSource is 'gateway'.",
+        "required": ["primary"],
+        "additionalProperties": false,
+        "properties": {
+          "primary": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Primary gateway model, e.g. zai/glm-4.7-flash"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": [],
+            "description": "Fallback gateway models tried after primary"
+          }
+        }
+      },
       "localLlmEnabled": {
         "type": "boolean",
         "default": false,
@@ -5472,6 +5494,11 @@
       "advanced": true,
       "placeholder": "engram-llm-fast",
       "help": "Agent persona ID for fast-tier ops. Leave empty to use the primary gatewayAgentId."
+    },
+    "taskModelChain": {
+      "label": "Task Model Chain",
+      "advanced": true,
+      "help": "Optional primary/fallback gateway model chain for Remnic background tasks (extraction, consolidation, summarization). Overrides gatewayAgentId/defaults for these tasks only. Requires modelSource: 'gateway'."
     },
     "localLlmEnabled": {
       "label": "Enable Local LLM",


### PR DESCRIPTION
Closes #1365. Supersedes #1370 (re-homed from @rmichelena's fork to an origin branch so the AI-reviewer gate can run — Cursor doesn't review fork PRs. Original commits and authorship preserved; thanks @rmichelena).

## Summary

Adds an optional `taskModelChain` config for `modelSource: "gateway"` so Remnic's background LLM work (extraction, fact/profile/identity consolidation, summarization, causal consolidation) can use a task-specific primary/fallback chain — resolved through gateway providers — without changing `agents.defaults.model` or the main agent persona chain.

```jsonc
{
  "modelSource": "gateway",
  "taskModelChain": {
    "primary": "zai/glm-4.7-flash",
    "fallbacks": ["fireworks/accounts/fireworks/models/glm-5p1"]
  }
}
```

## What it does

- `FallbackLlmClient.getModelChain` gains a `modelChain` override; priority is: explicit `model` string → task `modelChain` → `agentId` persona → `agents.defaults.model`.
- Wired into every gateway background path: `ExtractionEngine` (extraction + fact/profile/identity consolidation via `parseWithGatewayFallback`), `HourlySummarizer`, and causal consolidation (`compounding/engine.ts` → `causal-consolidation.ts`).
- Backward compatible: `isAvailable` accepts both the legacy `string` and the new options object; defaults and `modelSource: "plugin"` behavior unchanged.

## Maintainer hardening on top of the original PR

1. **Renamed `extractionModelChain` → `taskModelChain`** (covers more than extraction; matches the branch intent). Never shipped, so a clean rename.
2. **Strict config validation (gotcha #51):** a present-but-malformed value (non-object, missing/blank `primary`, bad `fallbacks`) now throws instead of silently reverting to defaults. Absent still means "not configured." Schema tightened (`additionalProperties: false`, `minLength`).
3. **Gateway-only scope made explicit:** plugin mode logs a startup warning instead of silently ignoring the chain; docs note plugin-mode users hitting non-OpenAI model-ID failures should switch to gateway mode (the other half of #1365).
4. **Scoped the implicit last-resort default** (gotcha #39): the gateway default is appended only to an exhausted `taskModelChain` (so a flush is never blocked), never to the main agent's persona/default chains.

## Validation

- `tsc --noEmit` clean
- fallback-llm + config + causal-consolidation: 129 passed
- entity-hardening: 205 passed
- `check-config-contract` OK · `check:openclaw-plugin-sync` OK · both manifests valid JSON

## Checklist
- [x] Defaults preserved; new behavior gated behind `modelSource: "gateway"` + `taskModelChain`
- [x] Config key wired end-to-end + both manifests (gotcha #4, #55)
- [x] Invalid config rejected, not silently dropped (gotcha #51)
- [x] No personal data / secrets (public repo)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core LLM dispatch and fallback chains across extraction, consolidation, and summarization; misconfiguration is mitigated by strict parse-time validation and scoped last-resort defaults.
> 
> **Overview**
> Adds optional **`taskModelChain`** (`primary` + `fallbacks`) for **`modelSource: "gateway"`**, so Remnic background LLM work can use a dedicated cheap/fast gateway chain without changing the main agent persona or `agents.defaults.model`.
> 
> **Routing:** New **`gatewayTaskChainOptions`** centralizes precedence — **`taskModelChain` > `gatewayAgentId`** in gateway mode; plugin mode ignores the chain (startup warning). **`FallbackLlmClient`** accepts **`modelChain`** on `chatCompletion` / `isAvailable`; when a task chain is active and exhausted, it appends the **full gateway default chain** as implicit last resort (persona/default chains are **not** augmented). **`semanticConsolidationModel: "fast"`** still uses **`fastGatewayAgentId`**.
> 
> **Wiring:** Extraction, extraction judge, summarizer, semantic consolidation (non-fast), calibration, and causal consolidation (including compounding weekly paths) all pass the resolved chain through.
> 
> **Config & docs:** Strict **`parseModelChainConfig`** (unknown keys, `provider/model` validation, deduped fallbacks); schema/UI in plugin manifests; config reference expanded.
> 
> **Tests:** Broad coverage for config parsing, fallback chain behavior, judge routing, and causal consolidation forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198372ed9b9b94a9d720811bcf04d29ad38b72aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->