### PR TITLE
feat: LLM-based recall planning (recallPlannerLlmEnabled) (#1367)

### DIFF
--- a/docs/architecture/retrieval-pipeline.md
+++ b/docs/architecture/retrieval-pipeline.md
@@ -84,7 +84,8 @@ By default the mode above is chosen by a fast regex heuristic (`planRecallMode()
   - `recallPlannerModel` must be a **`provider/model`** string (e.g. `openai/gpt-5.5`, `anthropic/claude-haiku-4-5`) — a bare model name cannot be resolved and is ignored (routing then relies on the gateway chain). The legacy default `gpt-5.5` is bare, so to enable LLM planning you must either set a `provider/model` value **or** have a gateway model chain / agent persona configured. If you opt in but nothing routable resolves, the planner logs a one-time warning and stays on the heuristic.
 - Is bounded by `recallPlannerTimeoutMs` and **always falls back to the heuristic** on timeout, error, empty response, or an unavailable backend — recall never fails because of the planner.
 - Honors `recallPlannerShadowMode` (run the LLM for comparison/telemetry but keep the heuristic's effective decision) and `recallPlannerTelemetryEnabled` (log planned-vs-heuristic mode, model, latency, and fallback).
-- Is skipped entirely when the caller forces a `mode`, when the planner is disabled, or for empty prompts.
+- Is skipped entirely when the caller forces a `mode`, when the planner is disabled, when the recall is already aborted, or for empty prompts. It also participates in the recall cancellation contract — an aborted/timed-out outer recall cancels the planner call.
+- Classifies on the prompt alone today. `recallPlannerMaxMemoryHints` is **reserved**: the planner accepts optional recent-memory hints, but the default recall path runs before search and does not gather them, so none are sent yet.
 
 The `src/index.ts` active-recall preflight stays heuristic-only (it runs before recall and is latency-sensitive); the LLM decision is authoritative for the main recall path.
 

--- a/docs/architecture/retrieval-pipeline.md
+++ b/docs/architecture/retrieval-pipeline.md
@@ -76,6 +76,19 @@ The planner classifies each request and selects a recall mode before any search:
 
 Config: `recallPlannerEnabled` (default `true`).
 
+### Heuristic vs LLM planning (issue #1367, Option C)
+
+By default the mode above is chosen by a fast regex heuristic (`planRecallMode()` in `intent.ts`). Operators can opt into **LLM-based planning** with `recallPlannerLlmEnabled: true` (requires `recallPlannerEnabled`). The LLM classifier:
+
+- Routes through the gateway/fallback chain, so it is **provider-agnostic** — OpenAI, Anthropic, Ollama, Codex, or gateway agent personas all work. The configured `recallPlannerModel` is tried first; `taskModelChain` / gateway defaults are resilient fallbacks.
+- Is bounded by `recallPlannerTimeoutMs` and **always falls back to the heuristic** on timeout, error, empty response, or an unavailable backend — recall never fails because of the planner.
+- Honors `recallPlannerShadowMode` (run the LLM for comparison/telemetry but keep the heuristic's effective decision) and `recallPlannerTelemetryEnabled` (log planned-vs-heuristic mode, model, latency, and fallback).
+- Is skipped entirely when the caller forces a `mode`, when the planner is disabled, or for empty prompts.
+
+The `src/index.ts` active-recall preflight stays heuristic-only (it runs before recall and is latency-sensitive); the LLM decision is authoritative for the main recall path.
+
+> `recallPlannerUseResponsesApi` is reserved: the chat-vs-Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's `api` field, so this flag does not override routing.
+
 ## QMD Retrieval
 
 The current QMD architecture is documented in [QMD 2.0 Integration Decision](./qmd-2-integration-decision.md).

--- a/docs/architecture/retrieval-pipeline.md
+++ b/docs/architecture/retrieval-pipeline.md
@@ -81,6 +81,7 @@ Config: `recallPlannerEnabled` (default `true`).
 By default the mode above is chosen by a fast regex heuristic (`planRecallMode()` in `intent.ts`). Operators can opt into **LLM-based planning** with `recallPlannerLlmEnabled: true` (requires `recallPlannerEnabled`). The LLM classifier:
 
 - Routes through the gateway/fallback chain, so it is **provider-agnostic** — OpenAI, Anthropic, Ollama, Codex, or gateway agent personas all work. The configured `recallPlannerModel` is tried first; `taskModelChain` / gateway defaults are resilient fallbacks.
+  - `recallPlannerModel` must be a **`provider/model`** string (e.g. `openai/gpt-5.5`, `anthropic/claude-haiku-4-5`) — a bare model name cannot be resolved and is ignored (routing then relies on the gateway chain). The legacy default `gpt-5.5` is bare, so to enable LLM planning you must either set a `provider/model` value **or** have a gateway model chain / agent persona configured. If you opt in but nothing routable resolves, the planner logs a one-time warning and stays on the heuristic.
 - Is bounded by `recallPlannerTimeoutMs` and **always falls back to the heuristic** on timeout, error, empty response, or an unavailable backend — recall never fails because of the planner.
 - Honors `recallPlannerShadowMode` (run the LLM for comparison/telemetry but keep the heuristic's effective decision) and `recallPlannerTelemetryEnabled` (log planned-vs-heuristic mode, model, latency, and fallback).
 - Is skipped entirely when the caller forces a `mode`, when the planner is disabled, or for empty prompts.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -332,6 +332,7 @@ Direct `includeFiles` sync plus the OpenClaw workspace adapter both persist incr
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `recallPlannerEnabled` | `true` | Lightweight retrieve-vs-think gating |
+| `recallPlannerLlmEnabled` | `false` | Opt in to **LLM-based** recall planning (issue #1367). When off, recall mode is decided by the regex heuristic. When on, `recallPlannerModel` classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires `recallPlannerEnabled`. See [Heuristic vs LLM planning](architecture/retrieval-pipeline.md#heuristic-vs-llm-planning-issue-1367-option-c). |
 | `recallPlannerMaxQmdResultsMinimal` | `4` | QMD cap in `minimal` recall mode |
 | `memoryBoxesEnabled` | `false` | Enable Memory Box topic-windowed grouping |
 | `traceWeaverEnabled` | `false` | Link recurring-topic boxes into named traces |
@@ -1219,6 +1220,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `boostAccessCount` | `true` | `true` |
 | `recordEmptyRecallImpressions` | `false` | `false` |
 | `recallPlannerEnabled` | `true` | `true` |
+| `recallPlannerLlmEnabled` | `false` | `false` |
 | `recallPlannerModel` | `gpt-5.5` | `gpt-5.5` |
 | `recallPlannerTimeoutMs` | `1500` | `1500` |
 | `recallPlannerUseResponsesApi` | `true` | `true` |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1904,10 +1904,15 @@
         "default": true,
         "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
       },
+      "recallPlannerLlmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
+      },
       "recallPlannerModel": {
         "type": "string",
         "default": "gpt-5.5",
-        "description": "Model to use for the recall planner."
+        "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain — any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
       },
       "recallPlannerTimeoutMs": {
         "type": "number",
@@ -1917,7 +1922,7 @@
       "recallPlannerUseResponsesApi": {
         "type": "boolean",
         "default": true,
-        "description": "Use OpenAI Responses API for recall planner calls."
+        "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
       },
       "recallPlannerMaxPromptChars": {
         "type": "number",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1932,7 +1932,7 @@
       "recallPlannerMaxMemoryHints": {
         "type": "number",
         "default": 24,
-        "description": "Maximum number of recent memory hints included in the recall planner prompt."
+        "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
       },
       "recallPlannerShadowMode": {
         "type": "boolean",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1904,10 +1904,15 @@
         "default": true,
         "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
       },
+      "recallPlannerLlmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
+      },
       "recallPlannerModel": {
         "type": "string",
         "default": "gpt-5.5",
-        "description": "Model to use for the recall planner."
+        "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain — any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
       },
       "recallPlannerTimeoutMs": {
         "type": "number",
@@ -1917,7 +1922,7 @@
       "recallPlannerUseResponsesApi": {
         "type": "boolean",
         "default": true,
-        "description": "Use OpenAI Responses API for recall planner calls."
+        "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
       },
       "recallPlannerMaxPromptChars": {
         "type": "number",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1932,7 +1932,7 @@
       "recallPlannerMaxMemoryHints": {
         "type": "number",
         "default": 24,
-        "description": "Maximum number of recent memory hints included in the recall planner prompt."
+        "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
       },
       "recallPlannerShadowMode": {
         "type": "boolean",

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -72,6 +72,13 @@ test("parseConfig codex missing entirely → installExtension defaults to true",
   assert.equal(result.codex.installExtension, true);
 });
 
+test("parseConfig recallPlannerLlmEnabled defaults to false (opt-in, issue #1367)", () => {
+  assert.equal(parseConfig({}).recallPlannerLlmEnabled, false);
+  assert.equal(parseConfig({ recallPlannerLlmEnabled: true }).recallPlannerLlmEnabled, true);
+  // Only an explicit boolean true enables it; truthy strings must not.
+  assert.equal(parseConfig({ recallPlannerLlmEnabled: "true" }).recallPlannerLlmEnabled, false);
+});
+
 test("parseConfig dreaming.maxEntries=0 preserves the runtime disable switch", () => {
   const result = parseConfig({ dreaming: { maxEntries: 0 } });
   assert.equal(result.dreaming.maxEntries, 0);

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -72,11 +72,16 @@ test("parseConfig codex missing entirely → installExtension defaults to true",
   assert.equal(result.codex.installExtension, true);
 });
 
-test("parseConfig recallPlannerLlmEnabled defaults to false (opt-in, issue #1367)", () => {
+test("parseConfig recallPlannerLlmEnabled defaults to false and coerces boolean-like strings (opt-in, issue #1367)", () => {
   assert.equal(parseConfig({}).recallPlannerLlmEnabled, false);
   assert.equal(parseConfig({ recallPlannerLlmEnabled: true }).recallPlannerLlmEnabled, true);
-  // Only an explicit boolean true enables it; truthy strings must not.
-  assert.equal(parseConfig({ recallPlannerLlmEnabled: "true" }).recallPlannerLlmEnabled, false);
+  // CLI/env surfaces pass strings — these must enable the gate (gotcha #36).
+  assert.equal(parseConfig({ recallPlannerLlmEnabled: "true" }).recallPlannerLlmEnabled, true);
+  assert.equal(parseConfig({ recallPlannerLlmEnabled: "1" }).recallPlannerLlmEnabled, true);
+  assert.equal(parseConfig({ recallPlannerLlmEnabled: "on" }).recallPlannerLlmEnabled, true);
+  // Boolean-like falses and junk stay off.
+  assert.equal(parseConfig({ recallPlannerLlmEnabled: "false" }).recallPlannerLlmEnabled, false);
+  assert.equal(parseConfig({ recallPlannerLlmEnabled: "0" }).recallPlannerLlmEnabled, false);
 });
 
 test("parseConfig dreaming.maxEntries=0 preserves the runtime disable switch", () => {

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -84,6 +84,21 @@ test("parseConfig recallPlannerLlmEnabled defaults to false and coerces boolean-
   assert.equal(parseConfig({ recallPlannerLlmEnabled: "0" }).recallPlannerLlmEnabled, false);
 });
 
+test("parseConfig coerces boolean-like strings for all recallPlanner gates (issue #1367, gotcha #36)", () => {
+  // Rollout switches must honor string config from CLI/env surfaces.
+  assert.equal(parseConfig({ recallPlannerShadowMode: "true" }).recallPlannerShadowMode, true);
+  assert.equal(parseConfig({ recallPlannerShadowMode: "off" }).recallPlannerShadowMode, false);
+  assert.equal(parseConfig({}).recallPlannerShadowMode, false);
+
+  assert.equal(parseConfig({ recallPlannerTelemetryEnabled: "false" }).recallPlannerTelemetryEnabled, false);
+  assert.equal(parseConfig({}).recallPlannerTelemetryEnabled, true);
+
+  // The enable gate must be disableable via string "false" (the old `!== false`
+  // check treated "false" as truthy → could not disable).
+  assert.equal(parseConfig({ recallPlannerEnabled: "false" }).recallPlannerEnabled, false);
+  assert.equal(parseConfig({}).recallPlannerEnabled, true);
+});
+
 test("parseConfig dreaming.maxEntries=0 preserves the runtime disable switch", () => {
   const result = parseConfig({ dreaming: { maxEntries: 0 } });
   assert.equal(result.dreaming.maxEntries, 0);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2841,7 +2841,11 @@ export function parseConfig(raw: unknown): PluginConfig {
           .filter((param): param is string => typeof param === "string" && param.trim().length > 0)
       : [...DEFAULT_BEHAVIOR_LOOP_PROTECTED_PARAMS],
     // v8.0 phase 1
-    recallPlannerEnabled: cfg.recallPlannerEnabled !== false,
+    // All recallPlanner boolean gates coerce boolean-like strings so CLI/env
+    // surfaces (`--config recallPlanner*=true|false`) behave correctly — the
+    // shadow-mode/telemetry/enable flags are documented rollout switches and
+    // must not silently ignore string values (gotcha #36, #1428 review).
+    recallPlannerEnabled: coerceBooleanLike(cfg.recallPlannerEnabled) ?? true,
     // Issue #1367 / Option C: LLM-based recall planning is opt-in so the
     // default recall path stays heuristic (no added latency / LLM call unless
     // the operator asks for it — gotcha #30). Coerce boolean-like strings so
@@ -2854,13 +2858,13 @@ export function parseConfig(raw: unknown): PluginConfig {
         : DEFAULT_REASONING_MODEL,
     recallPlannerTimeoutMs:
       typeof cfg.recallPlannerTimeoutMs === "number" ? cfg.recallPlannerTimeoutMs : 1500,
-    recallPlannerUseResponsesApi: cfg.recallPlannerUseResponsesApi !== false,
+    recallPlannerUseResponsesApi: coerceBooleanLike(cfg.recallPlannerUseResponsesApi) ?? true,
     recallPlannerMaxPromptChars:
       typeof cfg.recallPlannerMaxPromptChars === "number" ? cfg.recallPlannerMaxPromptChars : 4000,
     recallPlannerMaxMemoryHints:
       typeof cfg.recallPlannerMaxMemoryHints === "number" ? cfg.recallPlannerMaxMemoryHints : 24,
-    recallPlannerShadowMode: cfg.recallPlannerShadowMode === true,
-    recallPlannerTelemetryEnabled: cfg.recallPlannerTelemetryEnabled !== false,
+    recallPlannerShadowMode: coerceBooleanLike(cfg.recallPlannerShadowMode) ?? false,
+    recallPlannerTelemetryEnabled: coerceBooleanLike(cfg.recallPlannerTelemetryEnabled) ?? true,
     recallPlannerMaxQmdResultsMinimal:
       typeof cfg.recallPlannerMaxQmdResultsMinimal === "number"
         ? cfg.recallPlannerMaxQmdResultsMinimal

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2842,6 +2842,10 @@ export function parseConfig(raw: unknown): PluginConfig {
       : [...DEFAULT_BEHAVIOR_LOOP_PROTECTED_PARAMS],
     // v8.0 phase 1
     recallPlannerEnabled: cfg.recallPlannerEnabled !== false,
+    // Issue #1367 / Option C: LLM-based recall planning is opt-in so the
+    // default recall path stays heuristic (no added latency / LLM call unless
+    // the operator asks for it — gotcha #30).
+    recallPlannerLlmEnabled: cfg.recallPlannerLlmEnabled === true,
     recallPlannerModel:
       typeof cfg.recallPlannerModel === "string" && cfg.recallPlannerModel.trim().length > 0
         ? cfg.recallPlannerModel.trim()

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2844,8 +2844,10 @@ export function parseConfig(raw: unknown): PluginConfig {
     recallPlannerEnabled: cfg.recallPlannerEnabled !== false,
     // Issue #1367 / Option C: LLM-based recall planning is opt-in so the
     // default recall path stays heuristic (no added latency / LLM call unless
-    // the operator asks for it — gotcha #30).
-    recallPlannerLlmEnabled: cfg.recallPlannerLlmEnabled === true,
+    // the operator asks for it — gotcha #30). Coerce boolean-like strings so
+    // CLI/env surfaces (`--config recallPlannerLlmEnabled=true`) actually
+    // enable it (gotcha #36); defaults off.
+    recallPlannerLlmEnabled: coerceBooleanLike(cfg.recallPlannerLlmEnabled) ?? false,
     recallPlannerModel:
       typeof cfg.recallPlannerModel === "string" && cfg.recallPlannerModel.trim().length > 0
         ? cfg.recallPlannerModel.trim()

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -546,6 +546,12 @@ export interface RecallModeDecision {
   /** Model that served the LLM classification, when one was used. */
   plannerModelUsed?: string;
   /**
+   * The regex-heuristic baseline mode, captured whenever the LLM planner ran
+   * (any source). Lets operators compare planned-vs-heuristic during rollout —
+   * distinct from `plannedMode`, which on the LLM path is the LLM's choice.
+   */
+  plannerHeuristicMode?: RecallPlanMode;
+  /**
    * In shadow mode, the mode the LLM *would* have chosen (recorded for
    * comparison) while `effectiveMode` stays on the heuristic decision.
    */
@@ -1170,6 +1176,7 @@ export async function resolveRecallModeDecisionAsync(
       plannerLatencyMs: planned.latencyMs,
       plannerFallbackUsed: planned.fallbackUsed,
       plannerModelUsed: planned.modelUsed,
+      plannerHeuristicMode: planned.heuristicMode,
       shadowLlmMode: planned.mode,
     };
   }
@@ -1182,6 +1189,7 @@ export async function resolveRecallModeDecisionAsync(
     plannerLatencyMs: planned.latencyMs,
     plannerFallbackUsed: planned.fallbackUsed,
     plannerModelUsed: planned.modelUsed,
+    plannerHeuristicMode: planned.heuristicMode,
   };
 }
 
@@ -6523,7 +6531,8 @@ export class Orchestrator {
       log.debug(
         `[recall-planner] mode=${recallDecision.shadowLlmMode ?? recallDecision.effectiveMode} ` +
           `source=${recallDecision.plannerSource} ` +
-          `heuristic=${recallDecision.plannedMode} ` +
+          `planned=${recallDecision.plannedMode} ` +
+          `heuristic=${recallDecision.plannerHeuristicMode ?? recallDecision.plannedMode} ` +
           `model=${recallDecision.plannerModelUsed ?? "n/a"} ` +
           `latencyMs=${recallDecision.plannerLatencyMs ?? 0} ` +
           `fallback=${recallDecision.plannerFallbackUsed ?? false}` +

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1149,6 +1149,7 @@ export async function resolveRecallModeDecisionAsync(
     config: PluginConfig;
     hints?: string[];
     llm?: FallbackLlmClient;
+    signal?: AbortSignal;
   },
 ): Promise<RecallModeDecision> {
   const heuristicDecision = resolveRecallModeDecision(options);
@@ -1164,6 +1165,7 @@ export async function resolveRecallModeDecisionAsync(
     options.hints,
     options.config,
     options.llm,
+    options.signal,
   );
 
   // Shadow mode: record what the LLM would have chosen but keep the heuristic
@@ -6522,6 +6524,7 @@ export class Orchestrator {
         : await resolveRecallModeDecisionAsync({
             ...recallModeDecisionOptions,
             config: this.config,
+            signal: options.abortSignal,
           });
     if (
       this.config.recallPlannerTelemetryEnabled &&

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -530,6 +530,26 @@ export interface RecallModeDecision {
   effectiveMode: RecallPlanMode;
   graphExpandedIntentDetected: boolean;
   graphReason?: string;
+  /**
+   * Where `plannedMode` came from (issue #1367 / Option C). `"heuristic"` for
+   * the regex planner; `"llm"` when the LLM planner classified it; and
+   * `"heuristic-fallback"` when the LLM was enabled but errored/timed out and we
+   * fell back. Absent on the synchronous heuristic-only path.
+   */
+  plannerSource?: "heuristic" | "llm" | "heuristic-fallback";
+  /** Short rationale from the planner (for telemetry / x-ray). */
+  plannerReason?: string;
+  /** Wall-clock spent in the LLM planner call, when one was made. */
+  plannerLatencyMs?: number;
+  /** True when the LLM planner was enabled but fell back to the heuristic. */
+  plannerFallbackUsed?: boolean;
+  /** Model that served the LLM classification, when one was used. */
+  plannerModelUsed?: string;
+  /**
+   * In shadow mode, the mode the LLM *would* have chosen (recorded for
+   * comparison) while `effectiveMode` stays on the heuristic decision.
+   */
+  shadowLlmMode?: RecallPlanMode;
 }
 
 /**
@@ -1053,16 +1073,27 @@ export function resolveEffectiveRecallMode(options: {
   return resolveRecallModeDecision(options).effectiveMode;
 }
 
-export function resolveRecallModeDecision(options: {
+interface RecallModeGraphOptions {
   plannerEnabled: boolean;
   graphRecallEnabled: boolean;
   multiGraphMemoryEnabled: boolean;
   graphExpandedIntentEnabled?: boolean;
   prompt: string;
-}): RecallModeDecision {
-  let plannedMode: RecallPlanMode = options.plannerEnabled
-    ? planRecallMode(options.prompt)
-    : "full";
+}
+
+/**
+ * Apply the graph-mode overlay + gating to a planner-produced mode.
+ *
+ * Shared by the heuristic ({@link resolveRecallModeDecision}) and LLM
+ * ({@link resolveRecallModeDecisionAsync}) paths so graph promotion and the
+ * "graph disabled → fall back to full" gating behave identically regardless of
+ * which planner produced `plannedModeRaw` (gotcha #39).
+ */
+function finalizeRecallModeDecision(
+  plannedModeRaw: RecallPlanMode,
+  options: RecallModeGraphOptions,
+): RecallModeDecision {
+  let plannedMode: RecallPlanMode = plannedModeRaw;
   const graphExpandedIntentDetected =
     options.plannerEnabled &&
     options.graphExpandedIntentEnabled === true &&
@@ -1087,6 +1118,70 @@ export function resolveRecallModeDecision(options: {
     plannedMode,
     effectiveMode: plannedMode,
     graphExpandedIntentDetected,
+  };
+}
+
+export function resolveRecallModeDecision(options: RecallModeGraphOptions): RecallModeDecision {
+  const plannedMode: RecallPlanMode = options.plannerEnabled
+    ? planRecallMode(options.prompt)
+    : "full";
+  return finalizeRecallModeDecision(plannedMode, options);
+}
+
+/**
+ * Async recall-mode decision with optional LLM-based planning (issue #1367 /
+ * Option C). Falls back to the heuristic decision when the LLM planner is
+ * disabled, in shadow mode, or unavailable/failed — so this is always safe to
+ * await on the recall hot path. Provider-agnostic: the LLM call routes through
+ * the gateway/fallback chain.
+ *
+ * `recallPlannerEnabled === false` keeps the legacy "always full" behavior and
+ * skips the LLM entirely (the planner as a whole is off).
+ */
+export async function resolveRecallModeDecisionAsync(
+  options: RecallModeGraphOptions & {
+    config: PluginConfig;
+    hints?: string[];
+    llm?: FallbackLlmClient;
+  },
+): Promise<RecallModeDecision> {
+  const heuristicDecision = resolveRecallModeDecision(options);
+
+  // Planner globally off, or LLM planning not opted into → heuristic only.
+  if (!options.plannerEnabled || !options.config.recallPlannerLlmEnabled) {
+    return heuristicDecision;
+  }
+
+  const { planRecallModeLLM } = await import("./recall-planner-llm.js");
+  const planned = await planRecallModeLLM(
+    options.prompt,
+    options.hints,
+    options.config,
+    options.llm,
+  );
+
+  // Shadow mode: record what the LLM would have chosen but keep the heuristic
+  // effective decision (safe rollout / comparison — gotcha #30).
+  if (options.config.recallPlannerShadowMode) {
+    return {
+      ...heuristicDecision,
+      plannerSource: planned.source,
+      plannerReason: `shadow:${planned.reason}`,
+      plannerLatencyMs: planned.latencyMs,
+      plannerFallbackUsed: planned.fallbackUsed,
+      plannerModelUsed: planned.modelUsed,
+      shadowLlmMode: planned.mode,
+    };
+  }
+
+  const llmDecision = finalizeRecallModeDecision(planned.mode, options);
+  return {
+    ...llmDecision,
+    plannerSource: planned.source,
+    plannerReason: planned.reason,
+    plannerLatencyMs: planned.latencyMs,
+    plannerFallbackUsed: planned.fallbackUsed,
+    plannerModelUsed: planned.modelUsed,
   };
 }
 
@@ -6400,16 +6495,42 @@ export class Orchestrator {
     let identityInjectedChars = 0;
     let identityInjectionTruncated = false;
     timings.queryPolicy = `${queryPolicy.promptShape}/${queryPolicy.retrievalBudgetMode}${queryPolicy.skipConversationRecall ? "/skip-conv" : ""}`;
-    const recallDecision = resolveRecallModeDecision({
+    const recallModeDecisionOptions = {
       plannerEnabled: this.config.recallPlannerEnabled,
       graphRecallEnabled: this.config.graphRecallEnabled,
       multiGraphMemoryEnabled: this.config.multiGraphMemoryEnabled,
       graphExpandedIntentEnabled:
         this.config.graphExpandedIntentEnabled === true,
       prompt,
-    });
-    this.profiler.endSpan("planning", profileTraceId);
+    };
     const requestedMode = options.mode;
+    // When the caller forces a mode, skip the (async, possibly LLM-backed)
+    // planner entirely — the decision is overridden anyway. Otherwise consult
+    // the LLM planner when opted in (issue #1367 / Option C); it falls back to
+    // the heuristic on disable / shadow / timeout / error.
+    const recallDecision =
+      requestedMode !== undefined
+        ? resolveRecallModeDecision(recallModeDecisionOptions)
+        : await resolveRecallModeDecisionAsync({
+            ...recallModeDecisionOptions,
+            config: this.config,
+          });
+    if (
+      this.config.recallPlannerTelemetryEnabled &&
+      recallDecision.plannerSource &&
+      recallDecision.plannerSource !== "heuristic"
+    ) {
+      log.debug(
+        `[recall-planner] mode=${recallDecision.shadowLlmMode ?? recallDecision.effectiveMode} ` +
+          `source=${recallDecision.plannerSource} ` +
+          `heuristic=${recallDecision.plannedMode} ` +
+          `model=${recallDecision.plannerModelUsed ?? "n/a"} ` +
+          `latencyMs=${recallDecision.plannerLatencyMs ?? 0} ` +
+          `fallback=${recallDecision.plannerFallbackUsed ?? false}` +
+          (recallDecision.shadowLlmMode ? " (shadow)" : ""),
+      );
+    }
+    this.profiler.endSpan("planning", profileTraceId);
     const recallMode: RecallPlanMode =
       requestedMode ?? recallDecision.effectiveMode;
     const queryIntent = inferIntentFromText(retrievalQuery);

--- a/packages/remnic-core/src/recall-planner-llm.test.ts
+++ b/packages/remnic-core/src/recall-planner-llm.test.ts
@@ -130,11 +130,12 @@ test("falls back to heuristic when the LLM returns no parseable result", async (
   assert.equal(result.reason, "llm-empty");
 });
 
-test("falls back to heuristic when no model is available and no explicit model override", async () => {
-  // parseConfig always defaults recallPlannerModel to gpt-5.5, so to exercise
-  // the "unavailable" guard (no chain AND no model override) we clear the model
-  // explicitly — mirrors a hand-built config with no planner model.
-  const config = { ...parseConfig({ recallPlannerLlmEnabled: true }), recallPlannerModel: "" };
+test("falls back without a network attempt when the chain is empty and the model is bare (default gpt-5.5)", async () => {
+  // The legacy default recallPlannerModel "gpt-5.5" is bare (no provider/),
+  // which FallbackLlmClient cannot resolve — so with no gateway chain there is
+  // nothing routable and the planner must short-circuit to the heuristic
+  // (issue #1367 review on PR #1428), not log an invalid-model warning per call.
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
   const captured: Array<Record<string, unknown>> = [];
   const llm = stubLlm({ available: false, capturedOptions: captured, result: { mode: "full" } });
 
@@ -143,19 +144,21 @@ test("falls back to heuristic when no model is available and no explicit model o
   assert.equal(captured.length, 0, "no network attempt when nothing is routable");
   assert.equal(result.source, "heuristic-fallback");
   assert.equal(result.fallbackUsed, true);
-  assert.equal(result.reason, "llm-unavailable");
+  assert.equal(result.reason, "llm-no-model");
 });
 
-test("attempts the call (and falls back) when a model override is set even if the chain is empty", async () => {
-  // recallPlannerModel defaults to gpt-5.5, so the override may still resolve to
-  // a provider the chain probe doesn't know about — we attempt, then fall back.
-  const config = parseConfig({ recallPlannerLlmEnabled: true });
+test("attempts the call (and falls back) when a provider-qualified model override is set even if the chain is empty", async () => {
+  // A qualified `provider/model` override is genuinely routable, so we attempt
+  // it even when the chain probe reports unavailable, then fall back on a null
+  // response.
+  const config = parseConfig({ recallPlannerLlmEnabled: true, recallPlannerModel: "openai/gpt-5.5" });
   const captured: Array<Record<string, unknown>> = [];
   const llm = stubLlm({ available: false, capturedOptions: captured, result: null });
 
   const result = await planRecallModeLLM("anything", undefined, config, llm);
 
-  assert.equal(captured.length, 1, "model override → still attempt the call");
+  assert.equal(captured.length, 1, "qualified model override → still attempt the call");
+  assert.equal(captured[0]?.model, "openai/gpt-5.5");
   assert.equal(result.source, "heuristic-fallback");
   assert.equal(result.reason, "llm-empty");
 });
@@ -178,4 +181,17 @@ test("resolveRecallPlannerLlmOptions clamps timeout and sets deterministic decod
   assert.equal(options.temperature, 0);
   assert.equal(options.maxTokens, 64);
   assert.equal(options.timeoutMs, 1500, "non-positive timeout falls back to 1500");
+});
+
+test("resolveRecallPlannerLlmOptions drops bare model names but keeps provider-qualified ones", () => {
+  // Bare "gpt-5.5" is unresolvable by FallbackLlmClient → dropped (routing falls
+  // through to the chain); a qualified value is forwarded as the override.
+  const bare = resolveRecallPlannerLlmOptions(
+    parseConfig({ recallPlannerLlmEnabled: true, recallPlannerModel: "gpt-5.5" }),
+  );
+  assert.equal(bare.model, undefined);
+  const qualified = resolveRecallPlannerLlmOptions(
+    parseConfig({ recallPlannerLlmEnabled: true, recallPlannerModel: "anthropic/claude-haiku-4-5" }),
+  );
+  assert.equal(qualified.model, "anthropic/claude-haiku-4-5");
 });

--- a/packages/remnic-core/src/recall-planner-llm.test.ts
+++ b/packages/remnic-core/src/recall-planner-llm.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseConfig } from "./config.js";
+import {
+  planRecallModeLLM,
+  resolveRecallPlannerLlmOptions,
+} from "./recall-planner-llm.js";
+import type { FallbackLlmClient } from "./fallback-llm.js";
+import type { RecallPlanMode } from "./types.js";
+
+// A stub FallbackLlmClient that records the options it was called with and
+// returns a scripted classification (or simulates a failure).
+function stubLlm(opts: {
+  available?: boolean;
+  capturedOptions?: Array<Record<string, unknown>>;
+  result?: { mode: RecallPlanMode; reason?: string | null } | null;
+  modelUsed?: string;
+  throwError?: string;
+}): FallbackLlmClient {
+  return {
+    isAvailable: () => opts.available !== false,
+    parseWithSchemaDetailed: async (
+      _messages: unknown,
+      schema: { parse: (v: unknown) => unknown },
+      options: Record<string, unknown>,
+    ) => {
+      opts.capturedOptions?.push(options);
+      if (opts.throwError) throw new Error(opts.throwError);
+      if (opts.result === null || opts.result === undefined) return null;
+      // Exercise the real schema so malformed scripted output is caught too.
+      const parsed = schema.parse(opts.result);
+      return { result: parsed, modelUsed: opts.modelUsed ?? "test/model" };
+    },
+  } as unknown as FallbackLlmClient;
+}
+
+test("returns heuristic without calling the LLM when recallPlannerLlmEnabled is false", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: false });
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ capturedOptions: captured, result: { mode: "no_recall" } });
+
+  const result = await planRecallModeLLM("what did we decide about auth?", undefined, config, llm);
+
+  assert.equal(captured.length, 0, "LLM must not be contacted when disabled");
+  assert.equal(result.source, "heuristic");
+  assert.equal(result.fallbackUsed, false);
+  // Memory-seeking question → heuristic "full".
+  assert.equal(result.mode, "full");
+  assert.equal(result.heuristicMode, "full");
+});
+
+test("uses the LLM classification when enabled", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  const llm = stubLlm({ result: { mode: "graph_mode", reason: "asks for root cause" }, modelUsed: "anthropic/claude" });
+
+  const result = await planRecallModeLLM("restart the gateway", undefined, config, llm);
+
+  assert.equal(result.source, "llm");
+  assert.equal(result.mode, "graph_mode");
+  assert.equal(result.reason, "asks for root cause");
+  assert.equal(result.modelUsed, "anthropic/claude");
+  assert.equal(result.fallbackUsed, false);
+});
+
+test("forwards taskModelChain AND recallPlannerModel in gateway mode (provider-agnostic routing)", async () => {
+  const config = parseConfig({
+    recallPlannerLlmEnabled: true,
+    modelSource: "gateway",
+    gatewayAgentId: "persona-agent",
+    taskModelChain: { primary: "zai/glm-4.7-flash", fallbacks: ["fireworks/x/glm-5p1"] },
+    recallPlannerModel: "anthropic/claude-haiku-4-5",
+  });
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ capturedOptions: captured, result: { mode: "minimal" } });
+
+  await planRecallModeLLM("check status", undefined, config, llm);
+
+  assert.equal(captured.length, 1);
+  // recallPlannerModel is tried first (prepended), taskModelChain is the fallback chain.
+  assert.equal(captured[0]?.model, "anthropic/claude-haiku-4-5");
+  assert.deepEqual(captured[0]?.modelChain, {
+    primary: "zai/glm-4.7-flash",
+    fallbacks: ["fireworks/x/glm-5p1"],
+  });
+  // taskModelChain wins over the agent persona (gotcha #22).
+  assert.equal(captured[0]?.agentId, undefined);
+  assert.equal(captured[0]?.timeoutMs, config.recallPlannerTimeoutMs);
+});
+
+test("plugin mode passes only the explicit model, no gateway chain", async () => {
+  const config = parseConfig({
+    recallPlannerLlmEnabled: true,
+    modelSource: "plugin",
+    recallPlannerModel: "openai/gpt-5.5",
+  });
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ capturedOptions: captured, result: { mode: "full" } });
+
+  await planRecallModeLLM("summarize the project", undefined, config, llm);
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0]?.model, "openai/gpt-5.5");
+  assert.equal(captured[0]?.modelChain, undefined);
+  assert.equal(captured[0]?.agentId, undefined);
+});
+
+test("falls back to heuristic when the LLM throws", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  const llm = stubLlm({ throwError: "boom" });
+
+  const result = await planRecallModeLLM("what happened during the outage?", undefined, config, llm);
+
+  assert.equal(result.source, "heuristic-fallback");
+  assert.equal(result.fallbackUsed, true);
+  assert.match(result.reason, /llm-error:boom/);
+  // "what happened" → heuristic graph_mode.
+  assert.equal(result.mode, "graph_mode");
+  assert.equal(result.mode, result.heuristicMode);
+});
+
+test("falls back to heuristic when the LLM returns no parseable result", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  const llm = stubLlm({ result: null });
+
+  const result = await planRecallModeLLM("how did we get here?", undefined, config, llm);
+
+  assert.equal(result.source, "heuristic-fallback");
+  assert.equal(result.fallbackUsed, true);
+  assert.equal(result.reason, "llm-empty");
+});
+
+test("falls back to heuristic when no model is available and no explicit model override", async () => {
+  // parseConfig always defaults recallPlannerModel to gpt-5.5, so to exercise
+  // the "unavailable" guard (no chain AND no model override) we clear the model
+  // explicitly — mirrors a hand-built config with no planner model.
+  const config = { ...parseConfig({ recallPlannerLlmEnabled: true }), recallPlannerModel: "" };
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ available: false, capturedOptions: captured, result: { mode: "full" } });
+
+  const result = await planRecallModeLLM("anything", undefined, config, llm);
+
+  assert.equal(captured.length, 0, "no network attempt when nothing is routable");
+  assert.equal(result.source, "heuristic-fallback");
+  assert.equal(result.fallbackUsed, true);
+  assert.equal(result.reason, "llm-unavailable");
+});
+
+test("attempts the call (and falls back) when a model override is set even if the chain is empty", async () => {
+  // recallPlannerModel defaults to gpt-5.5, so the override may still resolve to
+  // a provider the chain probe doesn't know about — we attempt, then fall back.
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ available: false, capturedOptions: captured, result: null });
+
+  const result = await planRecallModeLLM("anything", undefined, config, llm);
+
+  assert.equal(captured.length, 1, "model override → still attempt the call");
+  assert.equal(result.source, "heuristic-fallback");
+  assert.equal(result.reason, "llm-empty");
+});
+
+test("empty prompts skip the LLM entirely", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ capturedOptions: captured, result: { mode: "full" } });
+
+  const result = await planRecallModeLLM("   ", undefined, config, llm);
+
+  assert.equal(captured.length, 0);
+  assert.equal(result.mode, "no_recall"); // heuristic returns no_recall for empty
+  assert.equal(result.source, "heuristic");
+});
+
+test("resolveRecallPlannerLlmOptions clamps timeout and sets deterministic decoding", () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true, recallPlannerTimeoutMs: 0 });
+  const options = resolveRecallPlannerLlmOptions(config);
+  assert.equal(options.temperature, 0);
+  assert.equal(options.maxTokens, 64);
+  assert.equal(options.timeoutMs, 1500, "non-positive timeout falls back to 1500");
+});

--- a/packages/remnic-core/src/recall-planner-llm.test.ts
+++ b/packages/remnic-core/src/recall-planner-llm.test.ts
@@ -163,6 +163,33 @@ test("attempts the call (and falls back) when a provider-qualified model overrid
   assert.equal(result.reason, "llm-empty");
 });
 
+test("an already-aborted recall short-circuits to the heuristic without an LLM call", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true, recallPlannerModel: "openai/gpt-5.5" });
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ capturedOptions: captured, result: { mode: "full" } });
+  const ac = new AbortController();
+  ac.abort();
+
+  const result = await planRecallModeLLM("what did we decide?", undefined, config, llm, ac.signal);
+
+  assert.equal(captured.length, 0, "no LLM call when the recall is already aborted");
+  assert.equal(result.source, "heuristic-fallback");
+  assert.equal(result.reason, "aborted");
+  assert.equal(result.fallbackUsed, true);
+});
+
+test("forwards the abort signal into the LLM call (cancellation contract)", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true, recallPlannerModel: "openai/gpt-5.5" });
+  const captured: Array<Record<string, unknown>> = [];
+  const llm = stubLlm({ capturedOptions: captured, result: { mode: "minimal" } });
+  const ac = new AbortController();
+
+  await planRecallModeLLM("check status", undefined, config, llm, ac.signal);
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0]?.signal, ac.signal, "recall abort signal must reach FallbackLlmClient");
+});
+
 test("empty prompts skip the LLM entirely", async () => {
   const config = parseConfig({ recallPlannerLlmEnabled: true });
   const captured: Array<Record<string, unknown>> = [];

--- a/packages/remnic-core/src/recall-planner-llm.ts
+++ b/packages/remnic-core/src/recall-planner-llm.ts
@@ -1,0 +1,246 @@
+import { z } from "zod";
+
+import type { PluginConfig, RecallPlanMode } from "./types.js";
+import { planRecallMode } from "./intent.js";
+import {
+  FallbackLlmClient,
+  fallbackLlmRuntimeContextFromConfig,
+  gatewayTaskChainOptions,
+  type FallbackLlmOptions,
+} from "./fallback-llm.js";
+import { log } from "./logger.js";
+
+/**
+ * LLM-based recall planning (issue #1367, Option C).
+ *
+ * Classifies an incoming prompt into a {@link RecallPlanMode} using an LLM
+ * instead of (or alongside) the regex heuristic in {@link planRecallMode}.
+ *
+ * Provider-agnostic by construction: it routes through {@link FallbackLlmClient},
+ * which resolves the model chain from gateway providers (OpenAI, Anthropic,
+ * Ollama, Codex, …) or gateway agent personas / `taskModelChain`. Nothing here
+ * is hard-coded to a single provider or to OpenAI's Responses API — the API
+ * dialect is chosen per-provider by the client based on each provider's `api`
+ * field. The configured `recallPlannerModel` is tried first, with the broader
+ * task chain (and the gateway default) as resilient fallbacks.
+ *
+ * Invariants:
+ *  - Never throws to the caller (gotcha #13). Any LLM failure, timeout, empty
+ *    response, or unavailable backend falls back to the heuristic result and
+ *    sets `fallbackUsed: true` (gotcha #34 — failures are distinct from a valid
+ *    classification).
+ *  - When `recallPlannerLlmEnabled` is false the LLM is never contacted.
+ */
+
+export type RecallPlannerSource = "llm" | "heuristic" | "heuristic-fallback";
+
+export interface RecallPlannerLlmResult {
+  /** The mode to act on. */
+  mode: RecallPlanMode;
+  /** The heuristic mode, always computed (the fallback floor / shadow baseline). */
+  heuristicMode: RecallPlanMode;
+  /** Where `mode` came from. */
+  source: RecallPlannerSource;
+  /** Short human-readable rationale (LLM reason, or why we fell back). */
+  reason: string;
+  /** Model that actually served the classification, when an LLM was used. */
+  modelUsed?: string;
+  /** Wall-clock spent in the LLM call (0 when no call was made). */
+  latencyMs: number;
+  /** True when the LLM was enabled but we had to fall back to the heuristic. */
+  fallbackUsed: boolean;
+}
+
+const PLANNER_SCHEMA = z.object({
+  // gotcha #2: optional fields use .optional().nullable()
+  mode: z.enum(["no_recall", "minimal", "full", "graph_mode"]),
+  reason: z.string().max(280).optional().nullable(),
+});
+
+const SYSTEM_PROMPT = [
+  "You are a recall-planning classifier for a long-term memory system.",
+  "Given the user's latest message, decide how much stored memory should be retrieved before the assistant responds.",
+  "Reply with a single JSON object: {\"mode\": <one of no_recall|minimal|full|graph_mode>, \"reason\": <short string>}.",
+  "",
+  "Modes:",
+  '- "no_recall": low-information acknowledgements or chit-chat with nothing to look up (e.g. "ok", "thanks", "sounds good"). Retrieve nothing.',
+  '- "minimal": short, self-contained operational directives that rarely need history (e.g. "restart the service", "run the tests", "show status"). Retrieve a little.',
+  '- "full": anything memory-seeking, analytical, or a question that benefits from prior context, decisions, or facts. This is the safe default when unsure.',
+  '- "graph_mode": queries about timelines, sequences, history, causal chains, or root cause ("how did we get here", "what led to this regression"). Retrieve relationship/graph context.',
+  "",
+  "When uncertain, prefer \"full\" over dropping recall. Never invent facts; only classify intent.",
+].join("\n");
+
+/** Clamp a planner prompt to the configured character budget. */
+function clampPrompt(prompt: string, maxChars: number): string {
+  const safeMax = Number.isFinite(maxChars) && maxChars > 0 ? Math.floor(maxChars) : 4000;
+  if (prompt.length <= safeMax) return prompt;
+  return prompt.slice(0, safeMax);
+}
+
+/** Trim and cap the optional memory hints used to ground the classification. */
+function clampHints(hints: string[] | undefined, maxHints: number): string[] {
+  if (!Array.isArray(hints) || hints.length === 0) return [];
+  const safeMax = Number.isFinite(maxHints) && maxHints > 0 ? Math.floor(maxHints) : 0;
+  if (safeMax <= 0) return [];
+  const cleaned: string[] = [];
+  for (const hint of hints) {
+    if (typeof hint !== "string") continue;
+    const trimmed = hint.trim();
+    if (trimmed.length === 0) continue;
+    cleaned.push(trimmed);
+    if (cleaned.length >= safeMax) break;
+  }
+  return cleaned;
+}
+
+function buildMessages(
+  prompt: string,
+  hints: string[],
+  config: PluginConfig,
+): Array<{ role: "system" | "user" | "assistant"; content: string }> {
+  const clampedPrompt = clampPrompt(prompt, config.recallPlannerMaxPromptChars);
+  const userParts = [`User message:\n${clampedPrompt}`];
+  if (hints.length > 0) {
+    userParts.push(
+      `\nRecent memory topics (for grounding only, do not treat as the message):\n- ${hints.join("\n- ")}`,
+    );
+  }
+  userParts.push('\nRespond with JSON only: {"mode": "...", "reason": "..."}.');
+  return [
+    { role: "system", content: SYSTEM_PROMPT },
+    { role: "user", content: userParts.join("\n") },
+  ];
+}
+
+/**
+ * Resolve the FallbackLlmClient routing options for the recall planner.
+ *
+ * - The dedicated `recallPlannerModel` is tried first (as the `model`
+ *   override — it is prepended to the chain by FallbackLlmClient). If it does
+ *   not resolve to a configured provider it is silently skipped, so a stale
+ *   default never breaks routing.
+ * - In gateway mode the shared `gatewayTaskChainOptions` (taskModelChain >
+ *   gatewayAgentId, gotcha #22) is layered in as the fallback chain, plus the
+ *   implicit gateway default appended by the client.
+ * - In plugin mode only the explicit model + gateway providers apply.
+ */
+export function resolveRecallPlannerLlmOptions(
+  config: Pick<
+    PluginConfig,
+    "modelSource" | "taskModelChain" | "gatewayAgentId" | "recallPlannerModel" | "recallPlannerTimeoutMs"
+  >,
+): FallbackLlmOptions {
+  const chainOptions =
+    config.modelSource === "gateway" ? gatewayTaskChainOptions(config) : {};
+  const model =
+    typeof config.recallPlannerModel === "string" && config.recallPlannerModel.trim().length > 0
+      ? config.recallPlannerModel.trim()
+      : undefined;
+  return {
+    ...chainOptions,
+    model,
+    temperature: 0,
+    maxTokens: 64,
+    timeoutMs:
+      typeof config.recallPlannerTimeoutMs === "number" && config.recallPlannerTimeoutMs > 0
+        ? config.recallPlannerTimeoutMs
+        : 1500,
+  };
+}
+
+function heuristicResult(
+  heuristicMode: RecallPlanMode,
+  source: RecallPlannerSource,
+  reason: string,
+  latencyMs: number,
+  fallbackUsed: boolean,
+): RecallPlannerLlmResult {
+  return { mode: heuristicMode, heuristicMode, source, reason, latencyMs, fallbackUsed };
+}
+
+/**
+ * Plan the recall mode for `prompt`, optionally consulting an LLM.
+ *
+ * Always safe to call: returns the heuristic result when the LLM is disabled,
+ * unavailable, or fails.
+ *
+ * @param llm  injectable client (tests pass a stub); constructed from gateway
+ *             config when omitted.
+ */
+export async function planRecallModeLLM(
+  prompt: string,
+  hints: string[] | undefined,
+  config: PluginConfig,
+  llm?: FallbackLlmClient,
+): Promise<RecallPlannerLlmResult> {
+  const heuristicMode = planRecallMode(prompt);
+
+  if (!config.recallPlannerLlmEnabled) {
+    return heuristicResult(heuristicMode, "heuristic", "llm-disabled", 0, false);
+  }
+
+  const safePrompt = typeof prompt === "string" ? prompt.trim() : "";
+  if (safePrompt.length === 0) {
+    // Empty prompts never need an LLM round-trip.
+    return heuristicResult(heuristicMode, "heuristic", "empty-prompt", 0, false);
+  }
+
+  const client =
+    llm ??
+    new FallbackLlmClient(
+      config.gatewayConfig,
+      fallbackLlmRuntimeContextFromConfig(config),
+    );
+
+  const options = resolveRecallPlannerLlmOptions(config);
+
+  // Availability check uses the same routing options so plugin-mode / empty
+  // chains short-circuit to the heuristic without a network attempt.
+  const availabilityProbe = {
+    agentId: options.agentId,
+    modelChain: options.modelChain,
+  };
+  if (!client.isAvailable(availabilityProbe) && !options.model) {
+    return heuristicResult(heuristicMode, "heuristic-fallback", "llm-unavailable", 0, true);
+  }
+
+  const clampedHints = clampHints(hints, config.recallPlannerMaxMemoryHints);
+  const messages = buildMessages(safePrompt, clampedHints, config);
+
+  const start = Date.now();
+  try {
+    const detailed = await client.parseWithSchemaDetailed(messages, PLANNER_SCHEMA, options);
+    const latencyMs = Date.now() - start;
+    if (!detailed?.result) {
+      // Distinguish failure from a valid empty (gotcha #34): a null here means
+      // no parseable classification, so fall back to the heuristic.
+      return heuristicResult(heuristicMode, "heuristic-fallback", "llm-empty", latencyMs, true);
+    }
+    const mode = detailed.result.mode;
+    const reason =
+      typeof detailed.result.reason === "string" && detailed.result.reason.trim().length > 0
+        ? detailed.result.reason.trim()
+        : "llm-classified";
+    return {
+      mode,
+      heuristicMode,
+      source: "llm",
+      reason,
+      modelUsed: detailed.modelUsed,
+      latencyMs,
+      fallbackUsed: false,
+    };
+  } catch (err) {
+    const latencyMs = Date.now() - start;
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`[recall-planner] LLM failed, falling back to heuristic: ${message}`);
+    return heuristicResult(
+      heuristicMode,
+      "heuristic-fallback",
+      `llm-error:${message}`,
+      latencyMs,
+      true,
+    );
+  }
+}

--- a/packages/remnic-core/src/recall-planner-llm.ts
+++ b/packages/remnic-core/src/recall-planner-llm.ts
@@ -125,6 +125,20 @@ function buildMessages(
  *   implicit gateway default appended by the client.
  * - In plugin mode only the explicit model + gateway providers apply.
  */
+/**
+ * A `recallPlannerModel` value is only usable as a FallbackLlmClient `model`
+ * override when it is provider-qualified (`provider/model`). The client's
+ * `parseModelString` rejects bare names, so forwarding a bare value (e.g. the
+ * legacy default `"gpt-5.5"`) would log "invalid model format" on every call
+ * and never resolve. Bare values are dropped so routing falls through to the
+ * gateway chain / agent / default instead (issue #1367 review on PR #1428).
+ */
+function qualifiedPlannerModel(recallPlannerModel: string | undefined): string | undefined {
+  if (typeof recallPlannerModel !== "string") return undefined;
+  const trimmed = recallPlannerModel.trim();
+  return trimmed.includes("/") ? trimmed : undefined;
+}
+
 export function resolveRecallPlannerLlmOptions(
   config: Pick<
     PluginConfig,
@@ -133,13 +147,9 @@ export function resolveRecallPlannerLlmOptions(
 ): FallbackLlmOptions {
   const chainOptions =
     config.modelSource === "gateway" ? gatewayTaskChainOptions(config) : {};
-  const model =
-    typeof config.recallPlannerModel === "string" && config.recallPlannerModel.trim().length > 0
-      ? config.recallPlannerModel.trim()
-      : undefined;
   return {
     ...chainOptions,
-    model,
+    model: qualifiedPlannerModel(config.recallPlannerModel),
     temperature: 0,
     maxTokens: 64,
     timeoutMs:
@@ -148,6 +158,11 @@ export function resolveRecallPlannerLlmOptions(
         : 1500,
   };
 }
+
+// One-time warning per distinct routing signature so an opted-in operator with
+// no usable model learns why planning silently uses the heuristic, without
+// spamming a line on every recall.
+const warnedNoRoutingSignatures = new Set<string>();
 
 function heuristicResult(
   heuristicMode: RecallPlanMode,
@@ -196,13 +211,27 @@ export async function planRecallModeLLM(
   const options = resolveRecallPlannerLlmOptions(config);
 
   // Availability check uses the same routing options so plugin-mode / empty
-  // chains short-circuit to the heuristic without a network attempt.
+  // chains short-circuit to the heuristic without a network attempt. `model`
+  // here is already provider-qualified (bare names were dropped), so a present
+  // model means the override is genuinely routable.
   const availabilityProbe = {
     agentId: options.agentId,
     modelChain: options.modelChain,
   };
   if (!client.isAvailable(availabilityProbe) && !options.model) {
-    return heuristicResult(heuristicMode, "heuristic-fallback", "llm-unavailable", 0, true);
+    // Opted-in but nothing routable resolves (e.g. plugin mode with the bare
+    // default `recallPlannerModel` and no gateway chain). Warn once so it's not
+    // a silent no-op, then fall back to the heuristic.
+    const signature = `${config.modelSource}:${config.recallPlannerModel ?? ""}`;
+    if (!warnedNoRoutingSignatures.has(signature)) {
+      warnedNoRoutingSignatures.add(signature);
+      log.warn(
+        "[recall-planner] recallPlannerLlmEnabled is on but no routable model resolves — " +
+          "set recallPlannerModel to a 'provider/model' value or configure a gateway model chain. " +
+          "Falling back to the heuristic planner.",
+      );
+    }
+    return heuristicResult(heuristicMode, "heuristic-fallback", "llm-no-model", 0, true);
   }
 
   const clampedHints = clampHints(hints, config.recallPlannerMaxMemoryHints);

--- a/packages/remnic-core/src/recall-planner-llm.ts
+++ b/packages/remnic-core/src/recall-planner-llm.ts
@@ -188,11 +188,19 @@ export async function planRecallModeLLM(
   hints: string[] | undefined,
   config: PluginConfig,
   llm?: FallbackLlmClient,
+  signal?: AbortSignal,
 ): Promise<RecallPlannerLlmResult> {
   const heuristicMode = planRecallMode(prompt);
 
   if (!config.recallPlannerLlmEnabled) {
     return heuristicResult(heuristicMode, "heuristic", "llm-disabled", 0, false);
+  }
+
+  // Participate in the recall cancellation contract: if the outer recall is
+  // already aborted (outer timeout / reset / session abort), don't start an LLM
+  // round-trip — fall back to the heuristic immediately (#1428 review).
+  if (signal?.aborted) {
+    return heuristicResult(heuristicMode, "heuristic-fallback", "aborted", 0, true);
   }
 
   const safePrompt = typeof prompt === "string" ? prompt.trim() : "";
@@ -208,7 +216,9 @@ export async function planRecallModeLLM(
       fallbackLlmRuntimeContextFromConfig(config),
     );
 
-  const options = resolveRecallPlannerLlmOptions(config);
+  // Forward the recall abort signal so an aborted/timed-out outer recall can
+  // cancel an in-flight planner call (FallbackLlmClient honors `signal`).
+  const options = { ...resolveRecallPlannerLlmOptions(config), signal };
 
   // Availability check uses the same routing options so plugin-mode / empty
   // chains short-circuit to the heuristic without a network attempt. `model`
@@ -262,6 +272,10 @@ export async function planRecallModeLLM(
     };
   } catch (err) {
     const latencyMs = Date.now() - start;
+    if (signal?.aborted) {
+      // Cancelled by the outer recall — expected, not an error worth warning on.
+      return heuristicResult(heuristicMode, "heuristic-fallback", "aborted", latencyMs, true);
+    }
     const message = err instanceof Error ? err.message : String(err);
     log.warn(`[recall-planner] LLM failed, falling back to heuristic: ${message}`);
     return heuristicResult(

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1471,6 +1471,15 @@ export interface PluginConfig {
   behaviorLoopProtectedParams: string[];
   // v8.0 Phase 1: recall planner + intent routing + verbatim artifacts
   recallPlannerEnabled: boolean;
+  /**
+   * Opt-in gate for LLM-based recall planning (issue #1367 / Option C). When
+   * false (the default) recall mode is decided by the regex heuristic
+   * `planRecallMode()`. When true, the planner consults an LLM (routed through
+   * the gateway/fallback chain — provider-agnostic) and falls back to the
+   * heuristic on timeout/error/unavailable. `recallPlannerShadowMode` runs the
+   * LLM for telemetry only without changing the effective mode.
+   */
+  recallPlannerLlmEnabled: boolean;
   recallPlannerModel: string;
   recallPlannerTimeoutMs: number;
   recallPlannerUseResponsesApi: boolean;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1904,10 +1904,15 @@
         "default": true,
         "description": "Use lightweight retrieve-vs-think planning to avoid unnecessary recall work."
       },
+      "recallPlannerLlmEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to LLM-based recall planning (issue #1367). When false, recall mode is decided by the regex heuristic. When true, the configured recallPlannerModel classifies recall intent via the gateway/fallback LLM chain (provider-agnostic) and falls back to the heuristic on timeout/error. Requires recallPlannerEnabled."
+      },
       "recallPlannerModel": {
         "type": "string",
         "default": "gpt-5.5",
-        "description": "Model to use for the recall planner."
+        "description": "Model for LLM-based recall planning (recallPlannerLlmEnabled). A 'provider/model' string resolved through the gateway providers/chain — any configured provider works (OpenAI, Anthropic, Ollama, Codex, gateway personas). Tried first, with taskModelChain / gateway defaults as fallback."
       },
       "recallPlannerTimeoutMs": {
         "type": "number",
@@ -1917,7 +1922,7 @@
       "recallPlannerUseResponsesApi": {
         "type": "boolean",
         "default": true,
-        "description": "Use OpenAI Responses API for recall planner calls."
+        "description": "Reserved. The chat vs Responses API dialect is chosen per-provider by the gateway/fallback client based on each provider's api field, so this flag does not override routing; OpenAI providers already use Responses (gotcha #1)."
       },
       "recallPlannerMaxPromptChars": {
         "type": "number",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1932,7 +1932,7 @@
       "recallPlannerMaxMemoryHints": {
         "type": "number",
         "default": 24,
-        "description": "Maximum number of recent memory hints included in the recall planner prompt."
+        "description": "Reserved. Caps recent-memory hints in the recall planner prompt when a caller supplies them; the default recall path does not populate hints (the LLM planner classifies on the prompt alone)."
       },
       "recallPlannerShadowMode": {
         "type": "boolean",

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -249,6 +249,9 @@ for (const manifestPath of OPENCLAW_MANIFEST_PATHS) {
 
     assert.equal(configSchema.model?.default, "gpt-5.5");
     assert.equal(configSchema.recallPlannerModel?.default, "gpt-5.5");
+    // Issue #1367 / Option C: LLM recall planning is opt-in (default off).
+    assert.equal(configSchema.recallPlannerLlmEnabled?.type, "boolean");
+    assert.equal(configSchema.recallPlannerLlmEnabled?.default, false);
   });
 
   test(`${manifestPath} keeps memory-slot compatibility metadata for older OpenClaw hosts`, () => {

--- a/tests/recall-mode-gating.test.ts
+++ b/tests/recall-mode-gating.test.ts
@@ -102,6 +102,11 @@ test("resolveRecallModeDecisionAsync applies the LLM classification when opted i
   assert.equal(decision.plannedMode, "graph_mode");
   assert.equal(decision.plannerSource, "llm");
   assert.equal(decision.plannerReason, "wants history");
+  // The heuristic baseline is preserved distinctly from the LLM's choice so
+  // telemetry can compare them (cursor review on PR #1428): "restart the
+  // gateway" → heuristic "minimal", LLM → "graph_mode".
+  assert.equal(decision.plannerHeuristicMode, "minimal");
+  assert.notEqual(decision.plannerHeuristicMode, decision.plannedMode);
 });
 
 test("resolveRecallModeDecisionAsync gates an LLM graph_mode to full when graph recall is disabled (gotcha #39)", async () => {

--- a/tests/recall-mode-gating.test.ts
+++ b/tests/recall-mode-gating.test.ts
@@ -4,7 +4,21 @@ import {
   hasIdentityRecoveryIntent,
   resolveEffectiveIdentityInjectionMode,
   resolveEffectiveRecallMode,
+  resolveRecallModeDecisionAsync,
 } from "../src/orchestrator.js";
+import { parseConfig } from "../src/config.js";
+import type { FallbackLlmClient } from "../src/fallback-llm.js";
+import type { RecallPlanMode } from "../src/types.js";
+
+function stubPlannerLlm(mode: RecallPlanMode, reason = "stub"): FallbackLlmClient {
+  return {
+    isAvailable: () => true,
+    parseWithSchemaDetailed: async (
+      _messages: unknown,
+      schema: { parse: (v: unknown) => unknown },
+    ) => ({ result: schema.parse({ mode, reason }), modelUsed: "test/model" }),
+  } as unknown as FallbackLlmClient;
+}
 
 test("resolveEffectiveRecallMode downgrades graph_mode to full when graph recall is disabled", () => {
   const mode = resolveEffectiveRecallMode({
@@ -55,6 +69,96 @@ test("resolveEffectiveRecallMode broad intent can escalate to graph_mode when en
     prompt: "How did we get here with recall regressions?",
   });
   assert.equal(mode, "graph_mode");
+});
+
+// --- LLM recall planning (issue #1367 / Option C) ---
+
+test("resolveRecallModeDecisionAsync uses heuristic when LLM planning is not opted in", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: false });
+  const decision = await resolveRecallModeDecisionAsync({
+    plannerEnabled: true,
+    graphRecallEnabled: true,
+    multiGraphMemoryEnabled: true,
+    prompt: "restart the gateway",
+    config,
+    llm: stubPlannerLlm("graph_mode"),
+  });
+  // LLM stub says graph_mode, but it must not be consulted.
+  assert.equal(decision.effectiveMode, "minimal");
+  assert.equal(decision.plannerSource, undefined);
+});
+
+test("resolveRecallModeDecisionAsync applies the LLM classification when opted in", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  const decision = await resolveRecallModeDecisionAsync({
+    plannerEnabled: true,
+    graphRecallEnabled: true,
+    multiGraphMemoryEnabled: true,
+    prompt: "restart the gateway",
+    config,
+    llm: stubPlannerLlm("graph_mode", "wants history"),
+  });
+  assert.equal(decision.effectiveMode, "graph_mode");
+  assert.equal(decision.plannedMode, "graph_mode");
+  assert.equal(decision.plannerSource, "llm");
+  assert.equal(decision.plannerReason, "wants history");
+});
+
+test("resolveRecallModeDecisionAsync gates an LLM graph_mode to full when graph recall is disabled (gotcha #39)", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  const decision = await resolveRecallModeDecisionAsync({
+    plannerEnabled: true,
+    graphRecallEnabled: false,
+    multiGraphMemoryEnabled: true,
+    prompt: "restart the gateway",
+    config,
+    llm: stubPlannerLlm("graph_mode"),
+  });
+  // Same graph gating as the heuristic path.
+  assert.equal(decision.plannedMode, "graph_mode");
+  assert.equal(decision.effectiveMode, "full");
+  assert.equal(decision.graphReason, "graph recall disabled by config");
+});
+
+test("resolveRecallModeDecisionAsync shadow mode keeps the heuristic effective decision", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true, recallPlannerShadowMode: true });
+  const decision = await resolveRecallModeDecisionAsync({
+    plannerEnabled: true,
+    graphRecallEnabled: true,
+    multiGraphMemoryEnabled: true,
+    prompt: "restart the gateway", // heuristic → minimal
+    config,
+    llm: stubPlannerLlm("graph_mode"),
+  });
+  // Effective stays on the heuristic; the LLM's choice is recorded for comparison.
+  assert.equal(decision.effectiveMode, "minimal");
+  assert.equal(decision.shadowLlmMode, "graph_mode");
+  assert.match(decision.plannerReason ?? "", /^shadow:/);
+});
+
+test("resolveRecallModeDecisionAsync skips the LLM entirely when the planner is disabled", async () => {
+  const config = parseConfig({ recallPlannerLlmEnabled: true });
+  let called = false;
+  const llm = {
+    isAvailable: () => {
+      called = true;
+      return true;
+    },
+    parseWithSchemaDetailed: async () => {
+      called = true;
+      return null;
+    },
+  } as unknown as FallbackLlmClient;
+  const decision = await resolveRecallModeDecisionAsync({
+    plannerEnabled: false,
+    graphRecallEnabled: true,
+    multiGraphMemoryEnabled: true,
+    prompt: "what happened in the timeline",
+    config,
+    llm,
+  });
+  assert.equal(decision.effectiveMode, "full");
+  assert.equal(called, false, "planner disabled → LLM must not be consulted");
 });
 
 test("hasIdentityRecoveryIntent detects recovery/continuity phrasing", () => {


### PR DESCRIPTION
## Summary

Implements **Option C** from #1367: the `recallPlannerModel` config was accepted but never consumed — recall planning was purely the regex heuristic `planRecallMode()`, and a whole "v8.0 phase-1" `recallPlanner*` LLM-config family was dead. This wires up **opt-in, LLM-based recall-mode classification** that is provider-agnostic.

Closes #1367.

## What changed

- **`recall-planner-llm.ts` (new)** — `planRecallModeLLM()` classifies a prompt into `no_recall` / `minimal` / `full` / `graph_mode` via an LLM. Routes through `FallbackLlmClient`, so it works with **any** backend the gateway exposes (gateway agent personas, `taskModelChain`, OpenAI, Anthropic, Ollama, Codex). The configured `recallPlannerModel` is tried first, with the task chain + gateway default as resilient fallbacks.
- **New opt-in flag `recallPlannerLlmEnabled`** (default `false`) — the default recall path stays heuristic with no added latency unless the operator opts in (gotcha #30). Requires `recallPlannerEnabled`.
- **`orchestrator.ts`** — `resolveRecallModeDecisionAsync()` consults the planner when opted in; a shared `finalizeRecallModeDecision()` keeps graph-mode gating identical across the heuristic and LLM paths (gotcha #39). Wired into `recallInternal` (skipped when the caller forces a mode). Honors `recallPlannerShadowMode` (evaluate-but-don't-apply) and `recallPlannerTelemetryEnabled`.
- **Resilience** — bounded by `recallPlannerTimeoutMs`; **always falls back to the heuristic** on disable / timeout / error / empty / unavailable (gotchas #13, #34). Never throws into the recall hot path.
- **Schema honesty** — clarified the previously misleading `recallPlannerModel` / `recallPlannerUseResponsesApi` descriptions across all three manifests (the chat-vs-Responses API dialect is provider-driven, not a per-call toggle).
- **Docs** — `config-reference.md` + `architecture/retrieval-pipeline.md`.

## Provider-agnostic by design

Nothing is hard-coded to OpenAI or the Responses API. Routing goes through the same `FallbackLlmClient` + `gatewayTaskChainOptions` path that extraction / summarization / the judge use (#1365/#1425), so gateway personas, `taskModelChain`, and direct OpenAI/Anthropic/Ollama/Codex providers all work. `recallPlannerModel` is prepended to the chain (tried first) and silently skipped if it doesn't resolve to a configured provider.

## Testing

- `recall-planner-llm.test.ts` (new): routing precedence (taskModelChain + recallPlannerModel together; plugin-mode), fallback on error/empty/unavailable, deterministic decoding, empty-prompt short-circuit.
- `recall-mode-gating.test.ts`: async-decision opt-in gating, LLM `graph_mode` gated to `full` when graph disabled, shadow mode keeps the heuristic effective decision, planner-disabled skips the LLM entirely.
- `config.test.ts` + `openclaw-plugin-runtime-surfaces.test.ts`: `recallPlannerLlmEnabled` default `false` and schema default across all manifests.
- Local verification: `tsc --noEmit` clean (core/root/plugin), config-contract OK, and a 116-test recall/intent/graph/namespace/orchestrator regression sweep green.

> Note: verified locally with `bun` (this environment has no `node`); CI will run the full `npm`/`pnpm`/`turbo` preflight (`lint`, `check-types`, `check-config-contract`, `test:entity-hardening`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall hot-path planning (async LLM call, latency, mode selection) but defaults off and always falls back to the heuristic; misconfiguration could alter retrieval depth when enabled.
> 
> **Overview**
> Adds **opt-in LLM recall planning** (`recallPlannerLlmEnabled`, default off) so `recallPlannerModel` and related planner settings are actually used: new `planRecallModeLLM()` routes through `FallbackLlmClient` (gateway/`taskModelChain`, provider-qualified `provider/model` only) and always **fails open** to the regex heuristic on timeout, error, empty response, abort, or no routable model.
> 
> The main recall path now uses `resolveRecallModeDecisionAsync()` (skipped when the caller forces `mode`); shared `finalizeRecallModeDecision()` keeps graph-mode gating identical for heuristic vs LLM. **Shadow mode** records the LLM choice without changing `effectiveMode`; telemetry fields on `RecallModeDecision` support rollout comparison.
> 
> Config parsing now **coerces boolean-like strings** for recall planner flags (CLI/env). Plugin schema/docs clarify reserved/misleading knobs (`recallPlannerUseResponsesApi`, memory hints). Tests cover the LLM module, async gating, and manifest defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac0032069522bdad8b10feb61fd8ba78f7c95d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->