### PR TITLE
fix(openclaw): scope SDK-surface scanner to the plugin-author surface

### DIFF
--- a/scripts/check-openclaw-sdk-surface.mjs
+++ b/scripts/check-openclaw-sdk-surface.mjs
@@ -169,14 +169,49 @@ async function inspectOpenClawSurface(root) {
   const hooks = new Set();
   const manifestContracts = new Set();
 
+  // Prefer the authoritative plugin-author surface:
+  //  - plugin hooks from the `PLUGIN_HOOK_NAMES` array / `PluginHookName` union
+  //  - registrars from the `OpenClawPluginApi` type body
+  // Sourcing from these declarations excludes AgentHarness-internal events
+  // (e.g. session_before_compact, after_provider_response, agent_message_chunk)
+  // and non-plugin registrars (e.g. registerCommandGroups, registerCliMetadata)
+  // that merely appear as tokens elsewhere in the plugin-sdk type tree — those
+  // are not registerable via `api.on(...)` / `OpenClawPluginApi`, so reporting
+  // them as "drift" was a false positive (issue #1431).
+  let sawHookSource = false;
+  let sawRegistrarSource = false;
   for (const file of files) {
     const text = await readFile(file, "utf-8").catch(() => "");
-    for (const match of text.matchAll(/\b(register[A-Z][A-Za-z0-9]+)\b/g)) {
-      registrars.add(match[1]);
+    const hookNames = extractPluginHookNames(text);
+    if (hookNames.length > 0) {
+      sawHookSource = true;
+      for (const name of hookNames) hooks.add(name);
     }
-    for (const match of text.matchAll(/["'`]([a-z]+(?:[._-][a-z0-9]+)+)["'`]/g)) {
-      const value = match[1];
-      if (looksLikeHookName(value)) hooks.add(value);
+    const apiRegistrars = extractPluginApiRegistrars(text);
+    if (apiRegistrars.length > 0) {
+      sawRegistrarSource = true;
+      for (const name of apiRegistrars) registrars.add(name);
+    }
+  }
+
+  // Fallback for older OpenClaw layouts (or test fixtures) that do not expose
+  // the canonical `PLUGIN_HOOK_NAMES` / `OpenClawPluginApi` declarations: keep
+  // the historical token heuristic so the check still runs. Only applied to the
+  // dimension whose authoritative source was missing.
+  if (!sawHookSource || !sawRegistrarSource) {
+    for (const file of files) {
+      const text = await readFile(file, "utf-8").catch(() => "");
+      if (!sawRegistrarSource) {
+        for (const match of text.matchAll(/\b(register[A-Z][A-Za-z0-9]+)\b/g)) {
+          registrars.add(match[1]);
+        }
+      }
+      if (!sawHookSource) {
+        for (const match of text.matchAll(/["'`]([a-z]+(?:[._-][a-z0-9]+)+)["'`]/g)) {
+          const value = match[1];
+          if (looksLikeHookName(value)) hooks.add(value);
+        }
+      }
     }
   }
 
@@ -230,6 +265,58 @@ function extractPluginManifestContractsBlock(text) {
     }
   }
   return null;
+}
+
+function extractTypeBody(text, name) {
+  // Match a real declaration (not a re-export): `interface Name ... {` or
+  // `type Name ... = {`. Re-export forms like `type Name, Other` end at `;`
+  // before any `{`/`=` and are intentionally not matched.
+  const re = new RegExp(
+    `\\b(?:export\\s+)?(?:interface\\s+${name}\\b[^{};]*\\{|type\\s+${name}\\b[^=;{]*=\\s*\\{)`,
+  );
+  const match = re.exec(text);
+  if (!match) return null;
+  const openBraceIndex = text.indexOf("{", match.index);
+  if (openBraceIndex === -1) return null;
+  let depth = 0;
+  for (let index = openBraceIndex; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return text.slice(openBraceIndex + 1, index);
+    }
+  }
+  return null;
+}
+
+function extractPluginHookNames(text) {
+  const names = new Set();
+  // `PLUGIN_HOOK_NAMES` readonly array literal (declaration may use `:` or `=`).
+  const arrayMatch = /\bPLUGIN_HOOK_NAMES\b[^[]*\[([^\]]*)\]/.exec(text);
+  if (arrayMatch) {
+    for (const m of arrayMatch[1].matchAll(/["'`]([a-z][a-z0-9_]*)["'`]/g)) {
+      names.add(m[1]);
+    }
+  }
+  // `PluginHookName` string-literal union type.
+  const unionMatch = /\b(?:export\s+)?type\s+PluginHookName\b[^=]*=\s*([^;]+);/.exec(text);
+  if (unionMatch) {
+    for (const m of unionMatch[1].matchAll(/["'`]([a-z][a-z0-9_]*)["'`]/g)) {
+      names.add(m[1]);
+    }
+  }
+  return [...names];
+}
+
+function extractPluginApiRegistrars(text) {
+  const body = extractTypeBody(text, "OpenClawPluginApi");
+  if (!body) return [];
+  const names = new Set();
+  for (const m of body.matchAll(/\b(register[A-Z][A-Za-z0-9]+)\b/g)) {
+    names.add(m[1]);
+  }
+  return [...names];
 }
 
 async function collectFiles(root) {

--- a/tests/openclaw-sdk-surface-check.test.ts
+++ b/tests/openclaw-sdk-surface-check.test.ts
@@ -177,6 +177,64 @@ test("OpenClaw SDK surface check resolves a package-local peer install", (t) => 
   }
 });
 
+test("OpenClaw SDK surface check ignores AgentHarness-internal events and non-API registrars (issue #1431)", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-openclaw-harness-"));
+  try {
+    const packageRoot = path.join(tempRoot, "openclaw");
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "0.0.0-test" }, null, 2),
+    );
+    // Authoritative plugin-author surface + harness-internal noise that must be
+    // excluded: AgentHarness events (session_before_compact, ...) are not in
+    // PluginHookName, and registerCommandGroups is a standalone helper, not an
+    // OpenClawPluginApi member.
+    fs.writeFileSync(
+      path.join(packageRoot, "plugin-sdk.d.ts"),
+      `
+export type OpenClawPluginApi = {
+  id: string;
+  registerMemoryPromptSection: (builder: unknown) => void;
+  registerTool: (tool: unknown) => void;
+};
+export type PluginHookName = "before_prompt_build" | "agent_end";
+export declare function registerCommandGroups(program: unknown): void;
+interface AgentHarnessOwnEvent {
+  type: "session_before_compact" | "after_provider_response" | "agent_message_chunk";
+}
+export interface PluginManifestContracts {
+  tools?: string[];
+}
+`,
+    );
+    const expectedPath = path.join(tempRoot, "expected.json");
+    fs.writeFileSync(
+      expectedPath,
+      JSON.stringify(
+        {
+          description: "test snapshot",
+          registrars: ["registerMemoryPromptSection", "registerTool"],
+          hooks: ["agent_end", "before_prompt_build"],
+          manifestContracts: ["tools"],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = runCheck(["--package-root", packageRoot, "--expected", expectedPath]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /matches expected snapshot/);
+    assert.doesNotMatch(result.stderr, /session_before_compact/);
+    assert.doesNotMatch(result.stderr, /after_provider_response/);
+    assert.doesNotMatch(result.stderr, /registerCommandGroups/);
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
 const expectedRegistrars = [
   "registerCli",
   "registerCliBackend",


### PR DESCRIPTION
## Summary

Part of the #1431 investigation. `check:openclaw-sdk-surface` walked the **entire** `plugin-sdk` type tree and treated any `register*`-looking token and any hook-shaped quoted string as part of the plugin surface. As of OpenClaw 2026.6.x that swept in **AgentHarness-internal events** (`session_before_compact`, `after_provider_response`, `agent_message_chunk`, the `session_*`/`provider_*` families) and **non-plugin registrars** (`registerCommandGroups`, `registerCliMetadata`, `registerToolEventRecipient`).

None of those are plugin-registerable (`api.on` only accepts `PLUGIN_HOOK_NAMES`; registrars must be members of `OpenClawPluginApi`). The result was a **false "surface drift"** that wrongly implied new adoptable plugin hooks existed — which seeded #1431.

## Fix

Source the surface from the authoritative plugin-author declarations:
- **hooks** from `PLUGIN_HOOK_NAMES` / the `PluginHookName` union
- **registrars** from the `OpenClawPluginApi` type body

Falls back to the historical token heuristic when those declarations are absent (older OpenClaw layouts / the test fixture), so the check still runs everywhere.

## Result

Against `openclaw@2026.6.5-beta.1` the scanned surface is **unchanged** (14 registrars, 22 hooks, 2 manifest contracts) — the committed snapshot needs no refresh; the false drift is simply gone. Adds a regression test asserting harness-internal events (`session_before_compact`, `after_provider_response`) and non-API registrars (`registerCommandGroups`) are excluded.

## Tests

`preflight:quick` ✅. `openclaw-sdk-surface-check.test.ts` 10/10 (incl. new regression test). Verified `check:openclaw-sdk-surface --package-root <openclaw@2026.6.5-beta.1>` reports no drift.

Refs #1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the SDK surface validation script and its tests; no runtime plugin or adapter behavior is modified.
> 
> **Overview**
> **`check-openclaw-sdk-surface`** no longer treats every `register*` token and hook-shaped string in the plugin-sdk tree as part of the adoptable plugin surface. It now builds **hooks** from **`PLUGIN_HOOK_NAMES`** / **`PluginHookName`** and **registrars** from members on **`OpenClawPluginApi`**, which drops false drift from AgentHarness-only events and standalone helpers (e.g. **`registerCommandGroups`**) that are not **`api.on`** / plugin-API registerable.
> 
> When those canonical declarations are missing (older layouts or minimal fixtures), the script still falls back to the previous heuristics **only for the dimension** that lacked an authoritative source.
> 
> Adds helpers to parse type bodies and hook declarations, plus a regression test that noisy harness types must not fail the check against a matching snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce62a47f63df61762107dc7e8796586c1f19185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->