### PR TITLE
fix(tests): spawn config-contract validator via tsx cli.mjs, not the .bin shim

### DIFF
--- a/tests/config-contract-validator.test.ts
+++ b/tests/config-contract-validator.test.ts
@@ -7,11 +7,15 @@ import test from "node:test";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const SCRIPT = path.join(ROOT, "scripts", "validate-config-contract.ts");
-const TSX = path.join(ROOT, "node_modules", ".bin", "tsx");
+// Resolve tsx's real JS CLI entry rather than the node_modules/.bin/tsx shim:
+// under pnpm on CI the shim is a POSIX shell script, and `node <shell-shim>`
+// throws "SyntaxError: missing ) after argument list". Running node against the
+// .mjs entry works regardless of how the bin shim was materialized.
+const tsxCli = path.join(ROOT, "node_modules", "tsx", "dist", "cli.mjs");
 
 test("config contract validator scans PluginConfig wrapper contextual types", () => {
   withConfigFixture((fixtureRoot) => {
-    const result = spawnSync(process.execPath, [TSX, SCRIPT], {
+    const result = spawnSync(process.execPath, [tsxCli, SCRIPT], {
       cwd: fixtureRoot,
       encoding: "utf-8",
       env: process.env,


### PR DESCRIPTION
## Impact
The **`Release and Publish` workflow has been failing on every merge** (last ~6+, since ~06-06), so **no package has published to npm in ~a day** — `@remnic/*` is stuck at `9.3.613`. It fails at the **`Verify quality gates`** step (`node scripts/run-root-tests.mjs`), not in PR `quality` CI, which is why it slipped through.

## Root cause
`tests/config-contract-validator.test.ts` spawned the validator with:
```ts
const TSX = path.join(ROOT, "node_modules", ".bin", "tsx");
spawnSync(process.execPath, [TSX, SCRIPT], …)   // = node node_modules/.bin/tsx …
```
Under **pnpm on CI**, `node_modules/.bin/tsx` is a **POSIX shell shim** (`#!/bin/sh` … `basedir=$(dirname …)`). Running `node <shell-shim>` makes Node parse shell as JS:
```
node_modules/.bin/tsx:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^
SyntaxError: missing ) after argument list
```
So the child crashed, never printed `Unknown PluginConfig key …`, and the assertions failed. (Locally the shim is often a JS symlink, so it passes — hence CI-only.)

## Fix
Resolve tsx's real JS entry and run Node against it, matching the existing pattern in `tests/migrate-source-cli.test.ts`:
```ts
const tsxCli = path.join(ROOT, "node_modules", "tsx", "dist", "cli.mjs");
spawnSync(process.execPath, [tsxCli, SCRIPT], …)
```
Works regardless of how the bin shim is materialized (symlink vs. shell/cmd shim).

## Verification
- `tsx --test tests/config-contract-validator.test.ts` → **1/1 pass**.
- Reproduced the failure mode: `node` against a hand-written POSIX sh-shim throws the exact `SyntaxError: missing ) after argument list` from the release log.
- `pnpm run lint` clean.

Unblocks the release pipeline so the pending `9.3.x` bump (incl. #1445's OpenClaw 2026.6.5-beta.2 compat) can publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only spawn path change with no production or security impact; unblocks release quality gates.
> 
> **Overview**
> Fixes a **CI-only failure** in `tests/config-contract-validator.test.ts` by spawning the config contract validator through **`node_modules/tsx/dist/cli.mjs`** instead of **`node_modules/.bin/tsx`**.
> 
> On pnpm in release CI, the `.bin` entry is a POSIX shell shim; `spawnSync(process.execPath, [shim, …])` makes Node parse shell as JavaScript and the child dies before stderr assertions run. The change matches the existing pattern in `migrate-source-cli.test.ts` and related tests, with a short comment explaining why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297866b7eb462b8eabecfe614f7c64990350c125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->