### PR TITLE
fix(ci): publish GitHub release before best-effort ClawHub publish (unstick releases)

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -598,6 +598,18 @@ jobs:
           fi
           npm publish --access public --provenance
 
+      # Publish the GitHub release BEFORE the best-effort ClawHub publish below.
+      # ClawHub is a third-party host whose backend can fail transiently (e.g.
+      # the "Too many bytes read" search-digest-sync error); creating the release
+      # first guarantees a ClawHub-side failure can never leave a release stuck
+      # as a draft after npm has already published.
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release_metadata.outputs.tag_name }}
+          name: ${{ steps.release_metadata.outputs.tag_name }}
+          generate_release_notes: true
+
       - name: Publish OpenClaw plugin to ClawHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
@@ -656,8 +668,8 @@ jobs:
               exit 0
             fi
             if grep -q "Too many bytes read in a single function execution" "${publish_log}" \
-              && grep -q "syncPackageCapabilitySearchDigests" "${publish_log}"; then
-              echo "::notice title=ClawHub publish skipped::ClawHub publish failed in its backend search-digest sync. npm and GitHub release publication will continue; retry the ClawHub publish after ClawHub fixes or clears the digest limit."
+              && grep -qE "syncPackage[A-Za-z]*SearchDigest" "${publish_log}"; then
+              echo "::notice title=ClawHub publish skipped::ClawHub publish failed in its backend search-digest sync. npm and GitHub release publication already completed; retry the ClawHub publish after ClawHub fixes or clears the digest limit."
               rm -f "${publish_log}"
               exit 0
             fi
@@ -666,10 +678,3 @@ jobs:
           fi
 
           clawhub package rescan "${CLAWHUB_PACKAGE_NAME}" --yes --json || true
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.release_metadata.outputs.tag_name }}
-          name: ${{ steps.release_metadata.outputs.tag_name }}
-          generate_release_notes: true

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -668,7 +668,7 @@ jobs:
               exit 0
             fi
             if grep -q "Too many bytes read in a single function execution" "${publish_log}" \
-              && grep -qE "syncPackage[A-Za-z]*SearchDigest" "${publish_log}"; then
+              && grep -qE "syncPackage[A-Za-z]*SearchDigests?" "${publish_log}"; then
               echo "::notice title=ClawHub publish skipped::ClawHub publish failed in its backend search-digest sync. npm and GitHub release publication already completed; retry the ClawHub publish after ClawHub fixes or clears the digest limit."
               rm -f "${publish_log}"
               exit 0

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "url": "https://github.com/joshuaswarren/remnic/issues"
   },
   "author": "Joshua Warren",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -960,12 +958,7 @@
       "import": "./dist/transfer/types.js"
     }
   },
-  "files": [
-    "dist",
-    "bin/engram-access.js",
-    "openclaw.plugin.json",
-    "scripts/ensure-better-sqlite3.mjs"
-  ],
+  "files": ["dist", "bin/engram-access.js", "openclaw.plugin.json", "scripts/ensure-better-sqlite3.mjs"],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
@@ -988,9 +981,7 @@
   },
   "openclaw": {
     "plugin": "./openclaw.plugin.json",
-    "extensions": [
-      "./dist/index.js"
-    ]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
     "sync:openclaw-plugin": "node scripts/sync-openclaw-plugin.mjs",
@@ -1043,12 +1034,6 @@
     "typescript": "^5.9.3"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild",
-      "sharp",
-      "koffi",
-      "protobufjs"
-    ]
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "sharp", "koffi", "protobufjs"]
   }
 }

--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { spawnSync } from "node:child_process";
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -121,6 +122,25 @@ for (const relativePath of packagePaths) {
     await writeJson(absolutePath, packageJson);
   }
   changed.push(...await syncCompanionManifestVersion(relativePath));
+}
+
+// `JSON.stringify(..., 2)` expands every array onto multiple lines, which biome's
+// formatter rejects for the short arrays in the root package.json (`workspaces`,
+// `files`, `openclaw.extensions`, `pnpm.onlyBuiltDependencies`). Re-format the
+// root manifest so the committed release bump stays lint-clean; otherwise every
+// release would break the `quality` lint gate on main and all subsequent PRs.
+if (!dryRun) {
+  const biome = spawnSync(
+    process.platform === "win32" ? "pnpm.cmd" : "pnpm",
+    ["exec", "biome", "format", "--write", "package.json"],
+    { cwd: repoRoot, stdio: "inherit" },
+  );
+  if (biome.status !== 0) {
+    console.warn(
+      "Warning: could not biome-format package.json after the version bump; " +
+        "the release commit may not be lint-clean.",
+    );
+  }
 }
 
 if (changed.length === 0) {

--- a/tests/release-workflow-order.test.ts
+++ b/tests/release-workflow-order.test.ts
@@ -30,7 +30,10 @@ test("release workflow pushes release commits before public publication", () => 
   assert.ok(stepIndex("Publish workspace packages to npm") < stepIndex("Publish root package to npm"));
   assert.ok(stepIndex("Ensure version tag on release commit") < stepIndex("Publish OpenClaw plugin to ClawHub"));
   assert.ok(pushMain < stepIndex("Publish OpenClaw plugin to ClawHub"));
-  assert.ok(stepIndex("Publish OpenClaw plugin to ClawHub") < stepIndex("Create GitHub release"));
+  // The GitHub release is published BEFORE the best-effort ClawHub publish so a
+  // ClawHub backend failure can never leave a release stuck as a draft after npm
+  // has already published (#1447).
+  assert.ok(stepIndex("Create GitHub release") < stepIndex("Publish OpenClaw plugin to ClawHub"));
 });
 
 test("release workflow tags the same commit pushed to main", () => {

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -87,10 +87,10 @@ test("release workflow treats known ClawHub backend digest limits as nonfatal", 
     /Too many bytes read in a single function execution/,
     "release workflow must recognize ClawHub's Convex read-limit backend failure",
   );
-  assert.match(
-    workflow,
-    /syncPackageCapabilitySearchDigests/,
-    "release workflow must constrain the nonfatal skip to ClawHub search-digest failures",
+  assert.ok(
+    workflow.includes("syncPackage[A-Za-z]*SearchDigests?"),
+    "release workflow must constrain the nonfatal skip to ClawHub search-digest failures " +
+      "(matching both syncPackageSearchDigest and syncPackageCapabilitySearchDigests)",
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Problem

The newest **published** GitHub release is v9.3.613 (2026-06-05) even though npm is already at **9.3.615**. Every `Release and Publish` run since 2026-06-05 has failed.

## Three release-pipeline bugs fixed

**1. ClawHub failure blocked the GitHub release.** The `Publish OpenClaw plugin to ClawHub` step fails on ClawHub's backend error:
```
Too many bytes read in a single function execution (limit: 16777216 bytes)
    at async syncPackageSearchDigest (convex/functions.ts:131)
```
There's already a graceful-skip for this, but its guard grepped `syncPackageCapabilitySearchDigests` while the real frame is `syncPackageSearchDigest`, so the step `exit`ed non-zero. Because `Create GitHub release` ran **after** it, the release was skipped on every run.
- **Fix:** move `Create GitHub release` **before** the best-effort ClawHub publish, and widen the skip guard to `syncPackage[A-Za-z]*SearchDigest`.

**2. The version bump broke lint on main.** `scripts/set-release-version.mjs` writes package.json via `JSON.stringify(..., 2)`, expanding the short root arrays onto multiple lines, which biome rejects — so each `chore(release)` commit fails the required `quality` lint gate on main and every subsequent PR.
- **Fix:** `biome format --write package.json` at the end of the bump script, and re-format the current root package.json to unbreak main.

## Backfill (done outside this PR)

Published the stuck releases so the list matches npm: **v9.3.615 = Latest**, v9.3.614 published, no drafts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI release ordering, ClawHub error-string matching, and release-bump formatting; no runtime application logic.
> 
> **Overview**
> Unsticks the release pipeline when **npm** is ahead of **GitHub releases** by reordering publish steps and tightening ClawHub failure handling.
> 
> **Create GitHub release** now runs **after** npm publish and **before** the best-effort ClawHub step, so a third-party ClawHub backend error cannot fail the job before the GitHub release is created. The ClawHub graceful-skip guard now matches `syncPackageSearchDigest` as well as `syncPackageCapabilitySearchDigests` via `syncPackage[A-Za-z]*SearchDigests?`, and the skip notice reflects that npm/GitHub release are already done.
> 
> `scripts/set-release-version.mjs` runs **`biome format --write package.json`** after bumping versions so `JSON.stringify` multi-line arrays do not fail the root **`quality`** lint on every `chore(release)` commit; root `package.json` array formatting is aligned in the same change. Workflow order and ClawHub nonfatal-skip tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167b85a54ca2d4c8ae77cb3c32a7f9ea840332a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->