### PR TITLE
fix(plugin-pi): cap startup Remnic probes

### DIFF
--- a/docs/integration/pi.md
+++ b/docs/integration/pi.md
@@ -75,7 +75,8 @@ Supported config keys:
 | `compactionEnabled` | `true` | Enable LCM flush/checkpoint coordination |
 | `mcpToolsEnabled` | `true` | Register Remnic MCP tools as Pi tools |
 | `statusEnabled` | `true` | Set Pi UI status from daemon health |
-| `requestTimeoutMs` | `60000` | HTTP/MCP request timeout |
+| `requestTimeoutMs` | `60000` | HTTP/MCP request timeout for recall/observe/compaction/commands |
+| `startupRequestTimeoutMs` | `1000` | Shorter timeout for startup-sensitive probes (MCP `tools/list` registration and the `session_start` health/status check) so a slow or offline daemon can't stall Pi boot |
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 

--- a/packages/plugin-pi/README.md
+++ b/packages/plugin-pi/README.md
@@ -81,7 +81,8 @@ Supported config keys:
 | `compactionEnabled` | `true` | Enable LCM flush and checkpoint coordination |
 | `mcpToolsEnabled` | `true` | Register Remnic MCP tools as Pi tools |
 | `statusEnabled` | `true` | Set Pi UI status from daemon health |
-| `requestTimeoutMs` | `60000` | HTTP/MCP request timeout |
+| `requestTimeoutMs` | `60000` | HTTP/MCP request timeout for recall/observe/compaction/commands |
+| `startupRequestTimeoutMs` | `1000` | Shorter timeout for startup-sensitive probes (MCP `tools/list` registration and the `session_start` health/status check) so a slow or offline daemon can't stall Pi boot |
 
 Boolean-like strings such as `"false"`, `"0"`, `"no"`, and `"off"` are treated as false.
 
@@ -99,7 +100,8 @@ Example:
   "compactionEnabled": true,
   "mcpToolsEnabled": true,
   "statusEnabled": true,
-  "requestTimeoutMs": 60000
+  "requestTimeoutMs": 60000,
+  "startupRequestTimeoutMs": 1000
 }
 ```
 

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -22,6 +22,24 @@ test("RemnicClient reports request timeouts with actionable context", async (t) 
   );
 });
 
+test("RemnicClient allows startup callers to use a shorter timeout", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })));
+    });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const client = new RemnicClient({ ...baseConfig(), requestTimeoutMs: 60000 });
+
+  await assert.rejects(
+    () => client.health({ timeoutMs: 2 }),
+    /Remnic request timed out after 2ms/,
+  );
+});
+
 function baseConfig(): RemnicPiConfig {
   return {
     remnicDaemonUrl: "http://127.0.0.1:4318",
@@ -35,6 +53,7 @@ function baseConfig(): RemnicPiConfig {
     mcpToolsEnabled: true,
     statusEnabled: true,
     requestTimeoutMs: 60000,
+    startupRequestTimeoutMs: 1000,
   };
 }
 

--- a/packages/plugin-pi/src/client.test.ts
+++ b/packages/plugin-pi/src/client.test.ts
@@ -40,6 +40,26 @@ test("RemnicClient allows startup callers to use a shorter timeout", async (t) =
   );
 });
 
+test("RemnicClient ignores a non-positive timeout override and uses the general budget", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })));
+    });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const client = new RemnicClient({ ...baseConfig(), requestTimeoutMs: 7 });
+
+  // A 0/negative/NaN override would make setTimeout abort immediately; the client
+  // must reject it and fall back to requestTimeoutMs (reported as 7ms here).
+  await assert.rejects(
+    () => client.health({ timeoutMs: 0 }),
+    /Remnic request timed out after 7ms/,
+  );
+});
+
 function baseConfig(): RemnicPiConfig {
   return {
     remnicDaemonUrl: "http://127.0.0.1:4318",

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -138,7 +138,17 @@ export class RemnicClient {
     options: RequestOptions = {},
   ): Promise<T> {
     const controller = new AbortController();
-    const timeoutMs = options.timeoutMs ?? this.config.requestTimeoutMs;
+    // A per-request override is honored only when it is a finite positive number;
+    // 0, negative, NaN, or non-finite values would make setTimeout abort
+    // immediately (or behave erratically), so fall back to the general budget.
+    // In practice the override is always sourced from the validated
+    // `startupRequestTimeoutMs` config, but this keeps the client robust to any
+    // future caller (Copilot review).
+    const override = options.timeoutMs;
+    const timeoutMs =
+      typeof override === "number" && Number.isFinite(override) && override > 0
+        ? override
+        : this.config.requestTimeoutMs;
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetch(`${this.config.remnicDaemonUrl}${pathname}`, {

--- a/packages/plugin-pi/src/client.ts
+++ b/packages/plugin-pi/src/client.ts
@@ -43,8 +43,8 @@ export class RemnicClient {
 
   constructor(private readonly config: RemnicPiConfig) {}
 
-  async health(): Promise<Record<string, unknown>> {
-    return this.request("GET", "/engram/v1/health");
+  async health(options: RequestOptions = {}): Promise<Record<string, unknown>> {
+    return this.request("GET", "/engram/v1/health", undefined, options);
   }
 
   async recall(query: string, sessionKey: string, cwd: string): Promise<RecallResponse> {
@@ -118,8 +118,8 @@ export class RemnicClient {
     });
   }
 
-  async mcpListTools(): Promise<McpTool[]> {
-    const result = await this.mcpRequest("tools/list", {});
+  async mcpListTools(options: RequestOptions = {}): Promise<McpTool[]> {
+    const result = await this.mcpRequest("tools/list", {}, options);
     const tools = (result as { tools?: unknown }).tools;
     return Array.isArray(tools) ? tools.filter(isMcpTool) : [];
   }
@@ -131,9 +131,15 @@ export class RemnicClient {
     });
   }
 
-  private async request<T = Record<string, unknown>>(method: string, pathname: string, body?: unknown): Promise<T> {
+  private async request<T = Record<string, unknown>>(
+    method: string,
+    pathname: string,
+    body?: unknown,
+    options: RequestOptions = {},
+  ): Promise<T> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.config.requestTimeoutMs);
+    const timeoutMs = options.timeoutMs ?? this.config.requestTimeoutMs;
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
       const response = await fetch(`${this.config.remnicDaemonUrl}${pathname}`, {
         method,
@@ -165,7 +171,7 @@ export class RemnicClient {
       return payload as T;
     } catch (err) {
       if (isAbortError(err)) {
-        throw new Error(`Remnic request timed out after ${this.config.requestTimeoutMs}ms`);
+        throw new Error(`Remnic request timed out after ${timeoutMs}ms`);
       }
       throw err;
     } finally {
@@ -173,19 +179,27 @@ export class RemnicClient {
     }
   }
 
-  private async mcpRequest(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+  private async mcpRequest(
+    method: string,
+    params: Record<string, unknown>,
+    options: RequestOptions = {},
+  ): Promise<Record<string, unknown>> {
     this.requestId += 1;
     const payload = await this.request<Record<string, unknown>>("POST", "/mcp", {
       jsonrpc: "2.0",
       id: this.requestId,
       method,
       params,
-    });
+    }, options);
     if (payload.error) {
       throw new Error(JSON.stringify(payload.error));
     }
     return (payload.result && typeof payload.result === "object" ? payload.result : payload) as Record<string, unknown>;
   }
+}
+
+interface RequestOptions {
+  timeoutMs?: number;
 }
 
 function isMcpTool(value: unknown): value is McpTool {

--- a/packages/plugin-pi/src/config.test.ts
+++ b/packages/plugin-pi/src/config.test.ts
@@ -105,6 +105,7 @@ test("loadConfig defaults request timeout high enough for warmed-up recall", () 
     const config = loadConfig({ configPath, env: {} });
 
     assert.equal(config.requestTimeoutMs, 60000);
+    assert.equal(config.startupRequestTimeoutMs, 1000);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -125,6 +126,7 @@ test("loadConfig merges file values and coerces boolean-like strings", () => {
         mcpToolsEnabled: "0",
         recallTopK: "50",
         requestTimeoutMs: "10",
+        startupRequestTimeoutMs: "20",
       }),
     );
 
@@ -138,6 +140,7 @@ test("loadConfig merges file values and coerces boolean-like strings", () => {
     assert.equal(config.mcpToolsEnabled, false);
     assert.equal(config.recallTopK, 50);
     assert.equal(config.requestTimeoutMs, 10);
+    assert.equal(config.startupRequestTimeoutMs, 20);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -264,6 +267,12 @@ test("loadConfig fails closed on invalid numeric values", () => {
     assert.throws(
       () => loadConfig({ configPath, env: {} }),
       /Invalid numeric value for Remnic Pi config field requestTimeoutMs/,
+    );
+
+    fs.writeFileSync(configPath, JSON.stringify({ startupRequestTimeoutMs: "slow" }));
+    assert.throws(
+      () => loadConfig({ configPath, env: {} }),
+      /Invalid numeric value for Remnic Pi config field startupRequestTimeoutMs/,
     );
 
     fs.writeFileSync(configPath, JSON.stringify({ recallTopK: true }));

--- a/packages/plugin-pi/src/config.ts
+++ b/packages/plugin-pi/src/config.ts
@@ -19,6 +19,7 @@ export interface RemnicPiConfig {
   mcpToolsEnabled: boolean;
   statusEnabled: boolean;
   requestTimeoutMs: number;
+  startupRequestTimeoutMs: number;
 }
 
 export interface LoadConfigOptions {
@@ -38,6 +39,7 @@ const DEFAULT_CONFIG: RemnicPiConfig = {
   mcpToolsEnabled: true,
   statusEnabled: true,
   requestTimeoutMs: 60000,
+  startupRequestTimeoutMs: 1000,
 };
 
 function defaultConfigPath(env: NodeJS.ProcessEnv): string {
@@ -173,5 +175,11 @@ export function loadConfig(options: LoadConfigOptions = {}): RemnicPiConfig {
     mcpToolsEnabled: coerceBoolean(fileConfig.mcpToolsEnabled, DEFAULT_CONFIG.mcpToolsEnabled, "mcpToolsEnabled"),
     statusEnabled: coerceBoolean(fileConfig.statusEnabled, DEFAULT_CONFIG.statusEnabled, "statusEnabled"),
     requestTimeoutMs: coercePositiveInt(fileConfig.requestTimeoutMs, DEFAULT_CONFIG.requestTimeoutMs, 60_000, "requestTimeoutMs"),
+    startupRequestTimeoutMs: coercePositiveInt(
+      fileConfig.startupRequestTimeoutMs,
+      DEFAULT_CONFIG.startupRequestTimeoutMs,
+      60_000,
+      "startupRequestTimeoutMs",
+    ),
   };
 }

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -178,6 +178,81 @@ test("default Pi extension creates isolated state for each host invocation", asy
   assert.equal(recallBodies.length, 2);
 });
 
+test("MCP tool registration uses the startup timeout instead of the general request timeout", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })));
+    });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const registeredTools: Record<string, unknown>[] = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      statusEnabled: false,
+      mcpToolsEnabled: true,
+      requestTimeoutMs: 60000,
+      startupRequestTimeoutMs: 2,
+    },
+  });
+
+  await extension({
+    on: () => undefined,
+    registerCommand: () => undefined,
+    registerTool: (tool: Record<string, unknown>) => {
+      registeredTools.push(tool);
+    },
+    appendEntry: () => undefined,
+  });
+
+  assert.deepEqual(registeredTools, []);
+});
+
+test("session_start status probe uses the startup timeout", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(Object.assign(new Error("This operation was aborted"), { name: "AbortError" })));
+    });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const statuses: Array<[string, string]> = [];
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: true,
+      requestTimeoutMs: 60000,
+      startupRequestTimeoutMs: 2,
+    },
+  });
+  await extension(pi as any);
+
+  await emit("session_start", {}, {
+    cwd: "/tmp/remnic-pi",
+    ui: {
+      setStatus: (key: string, value: string) => statuses.push([key, value]),
+    },
+    sessionManager: { getSessionId: () => "startup-timeout-test", getEntries: () => [] },
+  });
+
+  assert.deepEqual(statuses, [["remnic", "Remnic offline"]]);
+});
+
 test("observeMessages only records dedupe hashes after a successful observe", async () => {
   const observedHashes = new Set<string>();
   const ctx = {
@@ -887,6 +962,7 @@ function baseConfig(): RemnicPiConfig {
     mcpToolsEnabled: true,
     statusEnabled: true,
     requestTimeoutMs: 60000,
+    startupRequestTimeoutMs: 1000,
   };
 }
 

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -235,7 +235,7 @@ function commandHandler(handler: (args: string, ctx: any) => Promise<void>): (ar
 async function registerMcpTools(pi: PiApi, client: RemnicClient, config: RemnicPiConfig): Promise<void> {
   let tools: McpTool[] = [];
   try {
-    tools = await client.mcpListTools();
+    tools = await client.mcpListTools({ timeoutMs: config.startupRequestTimeoutMs });
   } catch {
     return;
   }
@@ -498,7 +498,7 @@ function persistObservedState(pi: PiApi, observedHashes: Set<string>): void {
 
 async function setStatus(ctx: any, client: RemnicClient, config: RemnicPiConfig): Promise<void> {
   try {
-    await client.health();
+    await client.health({ timeoutMs: config.startupRequestTimeoutMs });
     ctx.ui?.setStatus?.("remnic", `Remnic ${config.namespace ? `(${config.namespace})` : "ready"}`);
   } catch {
     ctx.ui?.setStatus?.("remnic", "Remnic offline");

--- a/packages/plugin-pi/src/publisher.test.ts
+++ b/packages/plugin-pi/src/publisher.test.ts
@@ -246,6 +246,7 @@ test("Pi publisher preserves user-managed extension settings on reinstall", asyn
         mcpToolsEnabled: false,
         statusEnabled: false,
         requestTimeoutMs: 1234,
+        startupRequestTimeoutMs: 2345,
       },
       null,
       2
@@ -294,6 +295,7 @@ test("Pi publisher preserves user-managed extension settings on reinstall", asyn
   assert.equal(publishedConfig.mcpToolsEnabled, false);
   assert.equal(publishedConfig.statusEnabled, false);
   assert.equal(publishedConfig.requestTimeoutMs, 1234);
+  assert.equal(publishedConfig.startupRequestTimeoutMs, 2345);
 });
 
 test("Pi publisher preserves existing namespace when reinstall omits namespace", async (t) => {

--- a/packages/plugin-pi/src/publisher.ts
+++ b/packages/plugin-pi/src/publisher.ts
@@ -105,6 +105,7 @@ export class PiMemoryExtensionPublisher implements MemoryExtensionPublisher {
         mcpToolsEnabled: true,
         statusEnabled: true,
         requestTimeoutMs: 60000,
+        startupRequestTimeoutMs: 1000,
         ...priorConfig,
         remnicDaemonUrl: resolveDaemonUrl(ctx),
       };


### PR DESCRIPTION
## Summary

Fixes #1448.

Adds a startup-specific request timeout for Pi extension probes so slow Remnic status/MCP endpoints do not consume the general recall/observe timeout budget during startup.

## Changes

- Add `startupRequestTimeoutMs` to the Pi plugin config, defaulting to `1000`.
- Allow selected `RemnicClient` calls to override timeout per request.
- Use the startup timeout for:
  - MCP `tools/list` registration during extension initialization
  - `session_start` health/status probe
- Preserve the existing `requestTimeoutMs` behavior for recall, observe, compaction, and normal command calls.
- Preserve existing publisher config values on reinstall.

## Verification

- `C:/mise/installs/pnpm/10.33.2/pnpm.exe --filter @remnic/core build`
- `C:/mise/installs/pnpm/10.33.2/pnpm.exe --filter @remnic/plugin-pi exec tsx --test src/config.test.ts src/client.test.ts src/index.test.ts src/publisher.test.ts` — 56 passed
- `C:/mise/installs/pnpm/10.33.2/pnpm.exe --filter @remnic/plugin-pi exec tsc --noEmit`
- `C:/mise/installs/pnpm/10.33.2/pnpm.exe --filter @remnic/plugin-pi build`
- Packed local tarball and measured with temporary `PI_AGENT_HOME`; no live Pi config changes.

## Measurements

Real hosted Remnic config copied into temp Pi home:

| package | warm | timed runs | best | average |
|---|---:|---:|---:|---:|
| `@remnic/plugin-pi@9.3.591` | 6829.66ms | 5912.54, 6653.79, 10445.56ms | 5912.54ms | 7670.63ms |
| local patched `9.3.616` tarball | 9228.30ms | 7543.94, 5675.46, 6391.38ms | 5675.46ms | 6536.93ms |

Controlled slow `/mcp` endpoint, `requestTimeoutMs: 5000`, `mcpToolsEnabled: true`, `statusEnabled: false`:

| package | warm timed startup |
|---|---:|
| `@remnic/plugin-pi@9.3.591` | 12902.98ms |
| local patched `9.3.616` tarball with `startupRequestTimeoutMs: 1000` | 11264.23ms |

Note: `npm test --workspace @remnic/plugin-pi` expands to zero tests under Windows/cmd because the script uses a single-quoted glob, so I ran the concrete test files through `tsx` instead. The normal `check-types` pre-script also hits a Windows `spawnSync pnpm.cmd EINVAL` path issue in this shell, so I built `@remnic/core` and ran package-local `tsc --noEmit` directly.

🤖 *This content was generated with AI assistance using GPT-5 Codex.*