### PR TITLE
fix(ci): make CodeQL default-branch scan pass (timeout + on.push)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+name: "Remnic CodeQL config"
+
+# Scope the JavaScript/TypeScript database to shipped source code.
+# Tests, evals, benchmarks, docs and build output are excluded so the
+# full default-branch scan stays well under the workflow timeout and
+# does not exhaust the runner's disk during database extraction.
+paths-ignore:
+  - '**/*.test.ts'
+  - '**/*.test.tsx'
+  - '**/*.spec.ts'
+  - '**/*.spec.tsx'
+  - '**/*.d.ts'
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - tests/**
+  - '**/tests/**'
+  - evals/**
+  - benchmarks/**
+  - docs/**
+  - examples/**
+  - '**/dist/**'
+  - '**/build/**'
+  - '**/.turbo/**'
+  - '**/node_modules/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -15,7 +15,9 @@ paths-ignore:
   - tests/**
   - '**/tests/**'
   - evals/**
+  - '**/evals/**'
   - benchmarks/**
+  - '**/benchmarks/**'
   - docs/**
   - examples/**
   - '**/dist/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,10 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [main]
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened]
   schedule:
     - cron: '22 8 * * 1'
@@ -14,7 +17,7 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,9 +26,8 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: javascript-typescript
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Analyze
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Problem

The CodeQL code scanning configuration is failing on the default branch:

- The scheduled run on `main` is **cancelled at the 30-minute timeout** (`The job has exceeded the maximum execution time of 30m0s`). PR runs finish in ~4m only because they are diff-informed; the full-repo scan is the real workload.
- Improved incremental analysis **failed due to disk space constraints**.
- GitHub flags: *"Please specify an on.push hook to analyze and see code scanning alerts from the default branch on the Security tab."* — there was no `push` trigger, so default-branch alerts never populated and the configuration reads as failing.

## Fix

- **Add `push: branches: [main]`** so default-branch alerts populate and the on.push warning clears.
- **Raise `timeout-minutes` 30 → 120** so the full scan has headroom.
- **Add `.github/codeql/codeql-config.yml`** with `paths-ignore` excluding tests / evals / benchmarks / docs / build output — roughly halves the ~1,800 JS/TS files extracted, cutting scan time and the disk pressure that broke incremental analysis.
- **`build-mode: none`** for `javascript-typescript` and drop the no-op `autobuild` step (modern, faster extraction path).

## Verification

YAML validated locally. The push/PR triggers will exercise this workflow on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and CodeQL configuration only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Fixes failing **default-branch CodeQL** runs by widening when scans run, giving them more time, and shrinking what gets indexed.
> 
> The workflow now runs on **`push` to `main`** (in addition to PRs and the weekly schedule) so Security tab alerts from the default branch can populate. Job **`timeout-minutes` increases from 30 to 120** to avoid full-repo scans being cancelled while PR-only runs stayed fast.
> 
> A new **`.github/codeql/codeql-config.yml`** scopes extraction with **`paths-ignore`** (tests, evals, benchmarks, docs, build artifacts, etc.) to cut scan time and disk use. **Init** uses **`build-mode: none`** and points at that config; the separate **autobuild** step is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6f3e29ec07af9de56b94b05c01c03971e1f9b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->