### PR TITLE
fix(deps): bump react-router-dom 7.14.1 → 7.17.0 (RCE + DoS advisories)

### DIFF
--- a/packages/bench-ui/package.json
+++ b/packages/bench-ui/package.json
@@ -11,7 +11,7 @@
     "build": "pnpm run check-types && vite build"
   },
   "dependencies": {
-    "react-router-dom": "^7.9.4",
+    "react-router-dom": "^7.15.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^19.2.0
         version: 19.2.5(react@19.2.5)
       react-router-dom:
-        specifier: ^7.9.4
-        version: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^7.15.0
+        version: 7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -1630,15 +1630,15 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@7.14.1:
-    resolution: {integrity: sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==}
+  react-router-dom@7.17.0:
+    resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.14.1:
-    resolution: {integrity: sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==}
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -2829,13 +2829,13 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router-dom@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router-dom@7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      react-router: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-router: 7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  react-router@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router@7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       cookie: 1.1.1
       react: 19.2.5


### PR DESCRIPTION
## What

Bumps the `react-router` / `react-router-dom` transitive dependency (pulled in by `@remnic/bench-ui`) from **7.14.1 → 7.17.0**, clearing two GitHub Dependabot advisories:

| Advisory | Affected | Patched |
|---|---|---|
| Prototype-pollution-assisted **RCE** (Framework Mode) | `>= 7.0.0, <= 7.14.1` | 7.14.2 |
| Resource-exhaustion **DoS** (Framework Mode) | `>= 7.0.0, < 7.15.0` | 7.15.0 |

## Exploitability here

**Not actually exploitable in this repo.** `bench-ui` is a `private: true`, client-only Vite SPA that uses `<HashRouter>` (Declarative Mode) — and `MemoryRouter` in tests. Both advisories explicitly state they do **not** impact Declarative Mode, and there is no server component for the RCE/DoS to target. This bump is purely to remove the flagged version from the tree and clear the alerts.

## Changes

- `packages/bench-ui/package.json`: `react-router-dom` floor `^7.9.4` → `^7.15.0` (the patch boundary, so a future resolution can't fall back to a vulnerable 7.14.x).
- `pnpm-lock.yaml`: resolved version 7.14.1 → 7.17.0 (latest stable 7.x, satisfies the range). Integrity hashes taken directly from the npm registry; transitive deps (`cookie`, `set-cookie-parser`) are unchanged.

## Verification

- Lockfile and manifest parse cleanly; no stale 7.14.1 references remain.
- CI `quality` job runs `pnpm install --frozen-lockfile`, which validates lockfile↔manifest consistency and integrity end-to-end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and version floor only; no application logic changes, and the flagged issues do not apply to this app’s declarative routing usage.
> 
> **Overview**
> Bumps **`react-router-dom`** in `@remnic/bench-ui` from **7.14.1** to **7.17.0** and raises the declared range from **`^7.9.4`** to **`^7.15.0`** so resolutions cannot land on vulnerable 7.14.x. The lockfile updates the matching **`react-router`** transitive to 7.17.0.
> 
> This is a **dependency-only** change to address Dependabot advisories (Framework Mode RCE and DoS); **`bench-ui`** still uses **`HashRouter`** / **`MemoryRouter`** with no routing code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bcc9ccc3a4d0ea7236bb2b867870ad7732939f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->