### PR TITLE
fix(security): don't leak stack traces via better-sqlite error messages (CodeQL #138)

### DIFF
--- a/packages/remnic-core/src/runtime/better-sqlite.test.ts
+++ b/packages/remnic-core/src/runtime/better-sqlite.test.ts
@@ -22,36 +22,32 @@ test("isLikelyBetterSqlite3NativeBindingError recognizes missing and mismatched 
   assert.equal(isLikelyBetterSqlite3NativeBindingError(new Error("SQLITE_BUSY: database is locked")), false);
 });
 
-test("displayErrorDetail strips require stacks and redacts paths without leaking server internals (CodeQL js/stack-trace-exposure)", () => {
-  // MODULE_NOT_FOUND: Node appends a "Require stack:" block of absolute paths.
-  const moduleNotFound = new Error(
-    "Cannot find module 'better-sqlite3'\nRequire stack:\n- /home/app/node_modules/x/index.js\n- /home/app/server.js",
+test("displayErrorDetail surfaces only error class + code, never the raw message (CodeQL js/stack-trace-exposure)", () => {
+  // MODULE_NOT_FOUND messages embed an absolute "Require stack:" path block.
+  const moduleNotFound = Object.assign(
+    new Error("Cannot find module 'better-sqlite3'\nRequire stack:\n- /home/app/node_modules/x/index.js"),
+    { code: "MODULE_NOT_FOUND" },
   );
   const d1 = displayErrorDetail(moduleNotFound);
-  assert.equal(d1, "Cannot find module 'better-sqlite3'");
-  assert.ok(!d1.includes("Require stack"));
-  assert.ok(!d1.includes("/home/app"));
+  assert.equal(d1, "Error (MODULE_NOT_FOUND)");
+  assert.ok(!d1.includes("/home/app") && !d1.includes("Require stack"));
 
-  // Native version mismatch: the path is on the first line (possibly with
-  // spaces), the useful NODE_MODULE_VERSION markers are on later lines. The
-  // path must be redacted but the markers preserved.
-  const nativeMismatch = new Error(
-    "The module '/Users/Jane Doe/app/node_modules/better-sqlite3/build/Release/better_sqlite3.node'\n" +
-      "was compiled against a different Node.js version using\nNODE_MODULE_VERSION 108. This version of Node.js requires\nNODE_MODULE_VERSION 115.",
+  // Native loader failures can embed an absolute path (even with spaces) in the
+  // message; we never surface it.
+  const dlopen = Object.assign(
+    new Error("/Users/Jane Doe/app/node_modules/better-sqlite3/build/Release/better_sqlite3.node: file too short"),
+    { code: "ERR_DLOPEN_FAILED" },
   );
-  const d2 = displayErrorDetail(nativeMismatch);
-  assert.ok(!d2.includes("/Users/Jane Doe"), "absolute path (with spaces) must be redacted");
-  assert.ok(d2.includes("<path>"));
-  assert.ok(d2.includes("NODE_MODULE_VERSION 108"), "diagnostic markers must be preserved");
-  assert.ok(d2.includes("was compiled against a different Node.js version"));
+  const d2 = displayErrorDetail(dlopen);
+  assert.equal(d2, "Error (ERR_DLOPEN_FAILED)");
+  assert.ok(!d2.includes("/Users/Jane Doe") && !d2.includes(".node"));
 
-  // error.stack is never surfaced.
-  const withStack = new Error("boom");
-  withStack.stack = "boom\n    at /home/app/secret.js:1:1";
-  assert.equal(displayErrorDetail(withStack), "boom");
+  // No code → class name only. error.stack is never read.
+  const noCode = new Error("boom");
+  noCode.stack = "boom\n    at /home/app/secret.js:1:1";
+  assert.equal(displayErrorDetail(noCode), "Error");
 
-  // Innocuous slashes are not over-redacted.
-  assert.equal(displayErrorDetail(new Error("input was invalid and/or empty")), "input was invalid and/or empty");
+  assert.equal(displayErrorDetail("not an error"), "");
 });
 
 test("openBetterSqlite3 can open an in-memory database after install verification", () => {

--- a/packages/remnic-core/src/runtime/better-sqlite.test.ts
+++ b/packages/remnic-core/src/runtime/better-sqlite.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  displayErrorDetail,
   isLikelyBetterSqlite3NativeBindingError,
   openBetterSqlite3,
 } from "./better-sqlite.js";
@@ -19,6 +20,38 @@ test("isLikelyBetterSqlite3NativeBindingError recognizes missing and mismatched 
     true,
   );
   assert.equal(isLikelyBetterSqlite3NativeBindingError(new Error("SQLITE_BUSY: database is locked")), false);
+});
+
+test("displayErrorDetail strips require stacks and redacts paths without leaking server internals (CodeQL js/stack-trace-exposure)", () => {
+  // MODULE_NOT_FOUND: Node appends a "Require stack:" block of absolute paths.
+  const moduleNotFound = new Error(
+    "Cannot find module 'better-sqlite3'\nRequire stack:\n- /home/app/node_modules/x/index.js\n- /home/app/server.js",
+  );
+  const d1 = displayErrorDetail(moduleNotFound);
+  assert.equal(d1, "Cannot find module 'better-sqlite3'");
+  assert.ok(!d1.includes("Require stack"));
+  assert.ok(!d1.includes("/home/app"));
+
+  // Native version mismatch: the path is on the first line (possibly with
+  // spaces), the useful NODE_MODULE_VERSION markers are on later lines. The
+  // path must be redacted but the markers preserved.
+  const nativeMismatch = new Error(
+    "The module '/Users/Jane Doe/app/node_modules/better-sqlite3/build/Release/better_sqlite3.node'\n" +
+      "was compiled against a different Node.js version using\nNODE_MODULE_VERSION 108. This version of Node.js requires\nNODE_MODULE_VERSION 115.",
+  );
+  const d2 = displayErrorDetail(nativeMismatch);
+  assert.ok(!d2.includes("/Users/Jane Doe"), "absolute path (with spaces) must be redacted");
+  assert.ok(d2.includes("<path>"));
+  assert.ok(d2.includes("NODE_MODULE_VERSION 108"), "diagnostic markers must be preserved");
+  assert.ok(d2.includes("was compiled against a different Node.js version"));
+
+  // error.stack is never surfaced.
+  const withStack = new Error("boom");
+  withStack.stack = "boom\n    at /home/app/secret.js:1:1";
+  assert.equal(displayErrorDetail(withStack), "boom");
+
+  // Innocuous slashes are not over-redacted.
+  assert.equal(displayErrorDetail(new Error("input was invalid and/or empty")), "input was invalid and/or empty");
 });
 
 test("openBetterSqlite3 can open an in-memory database after install verification", () => {

--- a/packages/remnic-core/src/runtime/better-sqlite.ts
+++ b/packages/remnic-core/src/runtime/better-sqlite.ts
@@ -41,8 +41,19 @@ function requireBetterSqlite3Ctor(require: RuntimeRequire): BetterSqlite3Ctor {
   return ctor;
 }
 
+// Raw, unredacted message — used ONLY for internal classification (detecting a
+// native-binding mismatch). Never returned to a user-facing surface, because it
+// can contain absolute paths. Native-binding markers (better_sqlite3.node,
+// NODE_MODULE_VERSION, "was compiled against a different Node.js version") live
+// in error.message, so message text is sufficient and we never read .stack.
+function rawErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error ?? "");
+}
+
 export function isLikelyBetterSqlite3NativeBindingError(error: unknown): boolean {
-  const detail = errorDetail(error);
+  // Classify on the RAW message so redaction can't strip detection markers
+  // (e.g. the path containing "better_sqlite3.node").
+  const detail = rawErrorMessage(error);
   return (
     detail.includes("Could not locate the bindings file") ||
     detail.includes("better_sqlite3.node") ||
@@ -53,7 +64,7 @@ export function isLikelyBetterSqlite3NativeBindingError(error: unknown): boolean
 }
 
 function unavailableError(error: unknown): Error {
-  const detail = errorDetail(error);
+  const detail = displayErrorDetail(error);
   const nativeBindingHint = isLikelyBetterSqlite3NativeBindingError(error)
     ? " This usually means the better-sqlite3 native binding was not compiled for this Node.js/platform combination. " +
       "Run `node scripts/ensure-better-sqlite3.mjs` from the Remnic install directory, or run " +
@@ -67,28 +78,31 @@ function unavailableError(error: unknown): Error {
   );
 }
 
-function errorDetail(error: unknown): string {
-  // This string becomes the message of the Error thrown by unavailableError(),
-  // which propagates to user-facing surfaces (HTTP error bodies, MCP tool
-  // errors — see access-http.ts / access-mcp.ts, which return err.message).
-  // We must not leak server internals (CodeQL js/stack-trace-exposure):
-  //   - error.stack is excluded entirely.
-  //   - Node module-load errors embed absolute server paths directly in
-  //     error.message: a "Require stack:" block (MODULE_NOT_FOUND) and native
-  //     loader paths. We keep only the first line and redact filesystem paths.
-  // The full original error is still preserved via the `cause` chain on
-  // unavailableError() and logged with its stack elsewhere.
-  if (error instanceof Error) {
-    const firstLine = error.message.split("\n", 1)[0] ?? "";
-    return redactFilesystemPaths(firstLine);
-  }
-  return redactFilesystemPaths(String(error ?? ""));
+// Sanitized, user-facing error detail. This string becomes the message of the
+// Error thrown by unavailableError(), which propagates to user-facing surfaces
+// (HTTP error bodies, MCP tool errors — access-http.ts / access-mcp.ts return
+// err.message). We must not leak server internals (CodeQL js/stack-trace-exposure):
+//   - error.stack is never read.
+//   - The "Require stack:" block Node appends to MODULE_NOT_FOUND messages
+//     (a list of absolute paths) is stripped.
+//   - Any remaining absolute filesystem path is redacted.
+// The rest of the message is preserved, so useful diagnostics (e.g. the
+// NODE_MODULE_VERSION mismatch text) still reach the user. The full original
+// error remains on the `cause` chain and is logged with its stack elsewhere.
+export function displayErrorDetail(error: unknown): string {
+  const withoutRequireStack = rawErrorMessage(error).split(/\n\s*Require stack:/i)[0] ?? "";
+  return redactFilesystemPaths(withoutRequireStack).trim();
 }
 
 // Replace absolute filesystem paths (POSIX, UNC, or Windows drive form) with a
-// placeholder so loader error text cannot expose server directory layout.
-// Requires at least two path segments to avoid mangling innocuous tokens like
-// "and/or". The single bounded quantifier keeps this linear (no ReDoS).
+// placeholder so loader error text cannot expose server directory layout. Two
+// passes: quoted paths first (these may legitimately contain spaces, e.g.
+// '/Users/Jane Doe/...'), then unquoted no-space runs. Requiring ≥2 path
+// segments avoids mangling innocuous tokens like "and/or". Both patterns use a
+// single bounded character-class quantifier per segment, so matching is linear
+// (no ReDoS).
 function redactFilesystemPaths(text: string): string {
-  return text.replace(/(?:[A-Za-z]:)?(?:[/\\][^\s/\\'"]+){2,}/g, "<path>");
+  return text
+    .replace(/(['"`])(?:[A-Za-z]:)?[/\\][^'"`\n]*\1/g, "$1<path>$1")
+    .replace(/(?:[A-Za-z]:)?(?:[/\\][^\s/\\'"`\n]+){2,}/g, "<path>");
 }

--- a/packages/remnic-core/src/runtime/better-sqlite.ts
+++ b/packages/remnic-core/src/runtime/better-sqlite.ts
@@ -83,26 +83,16 @@ function unavailableError(error: unknown): Error {
 // (HTTP error bodies, MCP tool errors — access-http.ts / access-mcp.ts return
 // err.message). We must not leak server internals (CodeQL js/stack-trace-exposure):
 //   - error.stack is never read.
-//   - The "Require stack:" block Node appends to MODULE_NOT_FOUND messages
-//     (a list of absolute paths) is stripped.
-//   - Any remaining absolute filesystem path is redacted.
-// The rest of the message is preserved, so useful diagnostics (e.g. the
-// NODE_MODULE_VERSION mismatch text) still reach the user. The full original
-// error remains on the `cause` chain and is logged with its stack elsewhere.
+// We deliberately surface only the error's class name and Node error code —
+// never the raw message. Node module-load failures embed absolute server paths
+// directly in error.message (the "Require stack:" block, and unquoted native
+// loader paths that may even contain spaces), which no regex can redact
+// reliably. The error code (MODULE_NOT_FOUND, ERR_DLOPEN_FAILED, …) is a stable,
+// path-free identifier that, together with the native-binding hint, is enough
+// for a user to act on. The full original error stays on the `cause` chain and
+// is logged with its stack elsewhere.
 export function displayErrorDetail(error: unknown): string {
-  const withoutRequireStack = rawErrorMessage(error).split(/\n\s*Require stack:/i)[0] ?? "";
-  return redactFilesystemPaths(withoutRequireStack).trim();
-}
-
-// Replace absolute filesystem paths (POSIX, UNC, or Windows drive form) with a
-// placeholder so loader error text cannot expose server directory layout. Two
-// passes: quoted paths first (these may legitimately contain spaces, e.g.
-// '/Users/Jane Doe/...'), then unquoted no-space runs. Requiring ≥2 path
-// segments avoids mangling innocuous tokens like "and/or". Both patterns use a
-// single bounded character-class quantifier per segment, so matching is linear
-// (no ReDoS).
-function redactFilesystemPaths(text: string): string {
-  return text
-    .replace(/(['"`])(?:[A-Za-z]:)?[/\\][^'"`\n]*\1/g, "$1<path>$1")
-    .replace(/(?:[A-Za-z]:)?(?:[/\\][^\s/\\'"`\n]+){2,}/g, "<path>");
+  if (!(error instanceof Error)) return "";
+  const code = (error as NodeJS.ErrnoException).code;
+  return typeof code === "string" && code.length > 0 ? `${error.name} (${code})` : error.name;
 }

--- a/packages/remnic-core/src/runtime/better-sqlite.ts
+++ b/packages/remnic-core/src/runtime/better-sqlite.ts
@@ -68,9 +68,13 @@ function unavailableError(error: unknown): Error {
 }
 
 function errorDetail(error: unknown): string {
+  // Intentionally exclude error.stack: this string becomes the message of the
+  // Error thrown by unavailableError(), which can propagate to user-facing
+  // surfaces (e.g. HTTP error bodies) and would leak a stack trace
+  // (CodeQL js/stack-trace-exposure). The original error is preserved via the
+  // `cause` chain on unavailableError() and logged with its stack elsewhere.
   if (error instanceof Error) {
-    const stack = error.stack && error.stack !== error.message ? `\n${error.stack}` : "";
-    return `${error.message}${stack}`;
+    return error.message;
   }
   return String(error ?? "");
 }

--- a/packages/remnic-core/src/runtime/better-sqlite.ts
+++ b/packages/remnic-core/src/runtime/better-sqlite.ts
@@ -68,13 +68,27 @@ function unavailableError(error: unknown): Error {
 }
 
 function errorDetail(error: unknown): string {
-  // Intentionally exclude error.stack: this string becomes the message of the
-  // Error thrown by unavailableError(), which can propagate to user-facing
-  // surfaces (e.g. HTTP error bodies) and would leak a stack trace
-  // (CodeQL js/stack-trace-exposure). The original error is preserved via the
-  // `cause` chain on unavailableError() and logged with its stack elsewhere.
+  // This string becomes the message of the Error thrown by unavailableError(),
+  // which propagates to user-facing surfaces (HTTP error bodies, MCP tool
+  // errors — see access-http.ts / access-mcp.ts, which return err.message).
+  // We must not leak server internals (CodeQL js/stack-trace-exposure):
+  //   - error.stack is excluded entirely.
+  //   - Node module-load errors embed absolute server paths directly in
+  //     error.message: a "Require stack:" block (MODULE_NOT_FOUND) and native
+  //     loader paths. We keep only the first line and redact filesystem paths.
+  // The full original error is still preserved via the `cause` chain on
+  // unavailableError() and logged with its stack elsewhere.
   if (error instanceof Error) {
-    return error.message;
+    const firstLine = error.message.split("\n", 1)[0] ?? "";
+    return redactFilesystemPaths(firstLine);
   }
-  return String(error ?? "");
+  return redactFilesystemPaths(String(error ?? ""));
+}
+
+// Replace absolute filesystem paths (POSIX, UNC, or Windows drive form) with a
+// placeholder so loader error text cannot expose server directory layout.
+// Requires at least two path segments to avoid mangling innocuous tokens like
+// "and/or". The single bounded quantifier keeps this linear (no ReDoS).
+function redactFilesystemPaths(text: string): string {
+  return text.replace(/(?:[A-Za-z]:)?(?:[/\\][^\s/\\'"]+){2,}/g, "<path>");
 }


### PR DESCRIPTION
## What

Fixes CodeQL **`js/stack-trace-exposure`** (alert #138).

`errorDetail()` in `runtime/better-sqlite.ts` appended `error.stack` to the string that becomes the **message** of the `Error` thrown by `unavailableError()`. When better-sqlite3 fails to load, that error propagates up and its `.message` can be returned in an HTTP error body (via `access-http.ts` → `respondJson` → `res.end`), exposing a server-side stack trace to the client.

This was the **only `Error.stack` read in non-test code**, so removing it severs the dataflow to the HTTP response at the source.

## Why it's safe

The original error is still preserved via the `{ cause }` chain on `unavailableError()` and logged with its full stack elsewhere — diagnosability is unchanged. No tests reference the stack-in-message behavior.

## Scope

One file, one helper. Verified no test asserts the stack appears in the error message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Security-hardening of error strings only; behavior for successful SQLite use is unchanged and full errors remain on the cause chain for server-side logging.
> 
> **Overview**
> Addresses **CodeQL `js/stack-trace-exposure`** by changing how better-sqlite3 load failures are described when they reach HTTP/MCP clients.
> 
> `errorDetail()` used to append **`error.stack`** (and the full **`error.message`**) into the thrown `unavailableError()` message. That string can flow to **`err.message`** on user-facing surfaces. The PR replaces that with **`displayErrorDetail()`**, which returns only the error **class name** and optional **Node `code`** (e.g. `Error (MODULE_NOT_FOUND)`), never the raw message or stack.
> 
> **Native-binding detection** still uses the full message via a new internal **`rawErrorMessage()`** helper so markers like `better_sqlite3.node` are not lost by redaction. The original error remains on **`{ cause }`** for logging.
> 
> Tests lock in that paths, require stacks, and `.node` paths never appear in `displayErrorDetail` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b30164134b5431336e00b2e750a6716443da9179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->