### PR TITLE
fix(security): don't return String(err) of arbitrary throws in HTTP errors (CodeQL #138)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -984,17 +984,21 @@ export class EngramAccessHttpServer {
           ...(disclosure !== undefined ? { disclosure } : {}),
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (message.startsWith("recallXray:")) {
+        // Only surface the message for the deliberately-prefixed recallXray
+        // input-validation errors, and only when it is a real Error.message —
+        // never String(err) of an arbitrary throw, which CodeQL flags as
+        // stack-trace exposure (js/stack-trace-exposure). Validation errors are
+        // always thrown as Error instances (see access-service.ts), so this is
+        // behavior-preserving; anything else is a server-side fault and is
+        // rethrown so the outer `handle()` catch returns 500 + logs it.
+        if (err instanceof Error && err.message.startsWith("recallXray:")) {
           this.respondJson(res, 400, {
             error: "invalid_request",
             code: "invalid_request",
-            message,
+            message: err.message,
           });
           return;
         }
-        // Anything else is a server-side fault; rethrow so the
-        // outer `handle()` catch returns 500 + logs the error.
         throw err;
       }
       this.respondJson(res, 200, payload);
@@ -1558,12 +1562,15 @@ export class EngramAccessHttpServer {
         );
         this.respondJson(res, 200, snapshot);
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        if (message.startsWith("graphSnapshot:")) {
+        // As with recallXray above: surface only the deliberately-prefixed
+        // graphSnapshot validation Error.message, never String(err) of an
+        // arbitrary throw (CodeQL js/stack-trace-exposure). Validation errors are
+        // always Error instances; anything else is rethrown as a 500.
+        if (err instanceof Error && err.message.startsWith("graphSnapshot:")) {
           this.respondJson(res, 400, {
             error: "invalid_request",
             code: "invalid_request",
-            message,
+            message: err.message,
           });
           return;
         }


### PR DESCRIPTION
## What

Fixes the last open CodeQL **`js/stack-trace-exposure`** alert (#138).

The SARIF dataflow for #138 runs through `access-http.ts:987` and `:1561` — the `recallXray` and `graphSnapshot` handlers — **not** the better-sqlite path that #1454 hardened (that was a separate, real leak). Both handlers built their 400 response via:

```ts
const message = err instanceof Error ? err.message : String(err);
if (message.startsWith("recallXray:")) { respondJson(400, { ..., message }); }
```

CodeQL taints `String(err)` of a caught exception and tracks it into the response body. The flagged values are actually **developer-authored input-validation messages** (`recallXray: query is required and must be non-empty`, `graphSnapshot: limit must be a positive integer`, …) — a false positive — but the `String(err)` fallback is genuinely undesirable in a client response.

## Fix

Return only `err.message`, guarded by `instanceof Error`, for the deliberately-prefixed validation errors; rethrow everything else as a generic 500. Those validation errors are **always** thrown as `Error` instances (verified in `access-service.ts` / `graph-snapshot.ts`), so this is behavior-preserving while removing the exact `String(err)` taint source CodeQL flagged.

## Verification

Behavior-preserving (all `recallXray:`/`graphSnapshot:` throws are `Error` instances; a non-Error throw could never carry a real validation prefix). CI `quality` runs the full suite + `check-types`; the post-merge `main` CodeQL scan will confirm #138 clears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to two catch blocks; validation 400s stay the same because those errors are always `Error` instances.
> 
> **Overview**
> Tightens **400** error handling on **`GET /engram/v1/recall/xray`** and **`GET /engram/v1/graph/snapshot`** so client JSON never includes `String(err)` from arbitrary caught values—addressing CodeQL **`js/stack-trace-exposure`** (#138).
> 
> Both handlers now map only **`Error`** instances whose **`message`** starts with **`recallXray:`** or **`graphSnapshot:`** to **`invalid_request`** responses; all other failures are rethrown for the outer handler’s **500** path. Prefixed validation messages are unchanged for real **`Error`** throws; non-**`Error`** throws no longer get their string form echoed in **400** bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e01b300fe1e17e6b834fea99e55b8183eb4087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->