### PR TITLE
feat(wearables): Bee connector (@remnic/connector-bee)

### DIFF
--- a/packages/connector-bee/README.md
+++ b/packages/connector-bee/README.md
@@ -1,0 +1,88 @@
+# @remnic/connector-bee
+
+Bee wearable connector for [Remnic](https://github.com/joshuaswarren/remnic).
+Pulls your Bee bracelet conversations into Remnic's wearable-transcript
+pipeline: cleaned, speaker-labeled, redacted, searchable day
+transcripts — and, under per-source trust gates, memories. Optionally
+imports Bee's own extracted "facts" into the review queue.
+
+This is an **à-la-carte optional companion** of `@remnic/core`:
+
+```bash
+npm install -g @remnic/connector-bee
+```
+
+Remnic discovers it at runtime. No further registration is needed.
+
+## Setup
+
+> **Heads up:** Bee's original public API (`api.bee.computer` with
+> `x-api-key`) was retired after the Amazon acquisition. This connector
+> targets the current developer surface.
+
+### Option A — local proxy (recommended, zero config)
+
+1. Enable Developer Mode in the Bee app (Settings → tap **Version**
+   5 times), then pair the CLI:
+   ```bash
+   npm install -g @beeai/cli
+   bee login
+   bee proxy        # serves the developer API on http://127.0.0.1:8787
+   ```
+2. Enable the source — no token needed:
+
+```jsonc
+{
+  "wearables": {
+    "enabled": true,
+    "sources": {
+      "bee": {
+        "enabled": true,
+        "memoryMode": "review",
+        "importNativeMemories": "review"   // optional: queue Bee facts for review
+      }
+    }
+  }
+}
+```
+
+### Option B — direct API access
+
+Set `baseUrl` to the direct host and provide the bearer token from
+`bee login` (`~/.bee/token-prod`) via `BEE_API_TOKEN` (or
+`REMNIC_BEE_API_TOKEN`, or `apiKey` in config). The direct host uses
+Bee's private CA — export `NODE_EXTRA_CA_CERTS` pointing at it.
+
+## Usage
+
+```bash
+remnic wearables check bee
+remnic wearables sync --source bee --days 7
+remnic wearables transcript --date 2026-06-10 --source bee
+```
+
+## Speaker labels
+
+Bee exposes opaque diarization labels ("0", "1", ...) with no wearer
+marker. Map them once and every stored transcript uses the names:
+
+```bash
+remnic wearables speakers set bee 0 "Your Name" --self
+remnic wearables speakers set bee 1 "Jane Doe"
+```
+
+## Notes
+
+- Bee's list API has no date filter; the connector paginates
+  newest-first and filters to the requested local day, so backfills
+  stay bounded.
+- Conversations still in the `CAPTURING` state are skipped until they
+  settle; the next sync picks them up.
+- Default `memoryMode: "review"`: nothing enters active recall without
+  approval. Bee-native facts (when imported) are always review-queued.
+
+Full documentation: [docs/wearables.md](https://github.com/joshuaswarren/remnic/blob/main/docs/wearables.md).
+
+## License
+
+MIT

--- a/packages/connector-bee/package.json
+++ b/packages/connector-bee/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@remnic/connector-bee",
+  "version": "9.3.624",
+  "description": "Bee wearable connector for Remnic — pull, clean, and remember bracelet transcripts via the Bee developer API",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/client.test.ts src/normalize.test.ts src/index.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.3.624"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/connector-bee"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "bee",
+    "bee.computer",
+    "wearable",
+    "transcript"
+  ]
+}

--- a/packages/connector-bee/package.json
+++ b/packages/connector-bee/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/client.test.ts src/normalize.test.ts src/index.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/connector-bee/src/client.test.ts
+++ b/packages/connector-bee/src/client.test.ts
@@ -179,5 +179,5 @@ test("verifyAuth reports proxy reachability problems distinctly", async () => {
   ]);
   const result = await client.verifyAuth();
   assert.equal(result.ok, false);
-  assert.match(result.detail ?? "", /start it with `bee proxy`/);
+  assert.match(result.detail ?? "", /is `bee proxy` running\?/);
 });

--- a/packages/connector-bee/src/client.test.ts
+++ b/packages/connector-bee/src/client.test.ts
@@ -103,6 +103,19 @@ test("getConversation accepts both bare and wrapped detail shapes", async () => 
   }
 });
 
+test("a 404 detail fetch returns null instead of aborting the day", async () => {
+  const { client } = makeClient([jsonResponse({ error: "not found" }, 404)]);
+  assert.equal(await client.getConversation(404404), null);
+  // Non-404 failures still throw (after retries for 5xx).
+  const { client: failing } = makeClient([
+    jsonResponse({}, 500),
+    jsonResponse({}, 502),
+    jsonResponse({}, 503),
+    jsonResponse({}, 504),
+  ]);
+  await assert.rejects(failing.getConversation(1), /responded 504/);
+});
+
 test("listFacts requests confirmed facts and validates the envelope", async () => {
   const { client, calls } = makeClient([
     jsonResponse({ facts: [{ id: 1, text: "User likes tea." }], next_cursor: null }),

--- a/packages/connector-bee/src/client.test.ts
+++ b/packages/connector-bee/src/client.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { BeeApiError, BeeClient, BEE_DEFAULT_BASE_URL } from "./client.js";
+
+type FetchCall = { url: string; headers: Record<string, string> };
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient(
+  responses: Array<Response | Error>,
+  options: { token?: string; baseUrl?: string } = {},
+): { client: BeeClient; calls: FetchCall[]; sleeps: number[] } {
+  const calls: FetchCall[] = [];
+  const sleeps: number[] = [];
+  const client = new BeeClient({
+    ...options,
+    fetchImpl: (async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ) => {
+      calls.push({
+        url: String(input),
+        headers: Object.fromEntries(
+          Object.entries((init?.headers ?? {}) as Record<string, string>),
+        ),
+      });
+      const next = responses.shift();
+      if (next === undefined) throw new Error("unexpected extra fetch call");
+      if (next instanceof Error) throw next;
+      return next;
+    }) as typeof fetch,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  return { client, calls, sleeps };
+}
+
+test("proxy mode is the default and sends no Authorization header", async () => {
+  const { client, calls } = makeClient([
+    jsonResponse({ conversations: [], next_cursor: null }),
+  ]);
+  await client.listConversations();
+  assert.ok(calls[0].url.startsWith(BEE_DEFAULT_BASE_URL));
+  assert.equal(calls[0].headers.Authorization, undefined);
+  assert.equal(client.usingLocalProxy, true);
+});
+
+test("direct mode sends the Bearer token", async () => {
+  const { client, calls } = makeClient(
+    [jsonResponse({ conversations: [], next_cursor: null })],
+    { token: "synthetic-token", baseUrl: "https://bee.example.test" },
+  );
+  await client.listConversations();
+  assert.equal(calls[0].headers.Authorization, "Bearer synthetic-token");
+  assert.equal(client.usingLocalProxy, false);
+});
+
+test("listConversations forwards cursor and surfaces next_cursor (string or number)", async () => {
+  const { client, calls } = makeClient([
+    jsonResponse({
+      conversations: [{ id: 1, start_time: 1_780_000_000_000 }],
+      next_cursor: "abc",
+    }),
+    jsonResponse({
+      conversations: [{ id: 2, start_time: 1_779_900_000_000 }],
+      next_cursor: 17799,
+    }),
+  ]);
+  const first = await client.listConversations();
+  assert.equal(first.nextCursor, "abc");
+  const second = await client.listConversations({ cursor: first.nextCursor });
+  assert.equal(second.nextCursor, "17799");
+  const url = new URL(calls[1].url);
+  assert.equal(url.searchParams.get("cursor"), "abc");
+});
+
+test("getConversation accepts both bare and wrapped detail shapes", async () => {
+  const detail = {
+    id: 5,
+    start_time: 1_780_000_000_000,
+    transcriptions: [{ utterances: [{ text: "hi", speaker: "0", spoken_at: 1_780_000_000_500 }] }],
+  };
+  {
+    const { client } = makeClient([jsonResponse(detail)]);
+    const result = await client.getConversation(5);
+    assert.equal(result?.id, 5);
+  }
+  {
+    const { client } = makeClient([jsonResponse({ conversation: detail })]);
+    const result = await client.getConversation(5);
+    assert.equal(result?.id, 5);
+  }
+  {
+    const { client } = makeClient([jsonResponse({ nonsense: true })]);
+    assert.equal(await client.getConversation(5), null);
+  }
+});
+
+test("listFacts requests confirmed facts and validates the envelope", async () => {
+  const { client, calls } = makeClient([
+    jsonResponse({ facts: [{ id: 1, text: "User likes tea." }], next_cursor: null }),
+  ]);
+  const page = await client.listFacts();
+  assert.equal(page.facts.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.searchParams.get("confirmed"), "true");
+
+  const { client: badClient } = makeClient([jsonResponse({})]);
+  await assert.rejects(badClient.listFacts(), /unexpected \/v1\/facts shape/);
+});
+
+test("retries 5xx with backoff and eventually throws", async () => {
+  const { client, sleeps } = makeClient([
+    jsonResponse({}, 502),
+    jsonResponse({}, 503),
+    jsonResponse({ conversations: [], next_cursor: null }),
+  ]);
+  const page = await client.listConversations();
+  assert.equal(page.conversations.length, 0);
+  assert.equal(sleeps.length, 2);
+});
+
+test("network failure in proxy mode points at `bee proxy`", async () => {
+  const { client } = makeClient([
+    new Error("ECONNREFUSED"),
+    new Error("ECONNREFUSED"),
+    new Error("ECONNREFUSED"),
+    new Error("ECONNREFUSED"),
+  ]);
+  await assert.rejects(
+    client.listConversations(),
+    (err: unknown) =>
+      err instanceof BeeApiError && /is `bee proxy` running\?/.test(err.message),
+  );
+});
+
+test("verifyAuth maps 401 to actionable guidance and never leaks the token", async () => {
+  const { client } = makeClient([jsonResponse({ error: "unauthorized" }, 401)], {
+    token: "synthetic-token",
+    baseUrl: "https://bee.example.test",
+  });
+  const result = await client.verifyAuth();
+  assert.equal(result.ok, false);
+  assert.match(result.detail ?? "", /bee login/);
+  assert.ok(!(result.detail ?? "").includes("synthetic-token"));
+});
+
+test("verifyAuth reports proxy reachability problems distinctly", async () => {
+  const { client } = makeClient([
+    new Error("ECONNREFUSED"),
+    new Error("ECONNREFUSED"),
+    new Error("ECONNREFUSED"),
+    new Error("ECONNREFUSED"),
+  ]);
+  const result = await client.verifyAuth();
+  assert.equal(result.ok, false);
+  assert.match(result.detail ?? "", /start it with `bee proxy`/);
+});

--- a/packages/connector-bee/src/client.test.ts
+++ b/packages/connector-bee/src/client.test.ts
@@ -152,6 +152,24 @@ test("verifyAuth maps 401 to actionable guidance and never leaks the token", asy
   assert.ok(!(result.detail ?? "").includes("synthetic-token"));
 });
 
+test("isLocalProxyUrl compares hostnames exactly, not by prefix", async () => {
+  const { isLocalProxyUrl } = await import("./client.js");
+  assert.equal(isLocalProxyUrl("http://127.0.0.1:8787"), true);
+  assert.equal(isLocalProxyUrl("http://localhost:8787"), true);
+  assert.equal(isLocalProxyUrl("http://[::1]:8787"), true);
+  assert.equal(isLocalProxyUrl("http://127.0.0.1.evil.example"), false);
+  assert.equal(isLocalProxyUrl("https://bee.example.test"), false);
+  assert.equal(isLocalProxyUrl("not a url"), false);
+});
+
+test("verifyAuth keeps actionable Bee API status detail for non-auth errors", async () => {
+  const { client } = makeClient([jsonResponse({}, 500), jsonResponse({}, 502), jsonResponse({}, 503), jsonResponse({}, 504)]);
+  const result = await client.verifyAuth();
+  assert.equal(result.ok, false);
+  assert.match(result.detail ?? "", /Bee API responded 504/);
+  assert.ok(!(result.detail ?? "").includes("bee proxy ("), "API errors are not proxy-reachability guidance");
+});
+
 test("verifyAuth reports proxy reachability problems distinctly", async () => {
   const { client } = makeClient([
     new Error("ECONNREFUSED"),

--- a/packages/connector-bee/src/client.ts
+++ b/packages/connector-bee/src/client.ts
@@ -211,16 +211,12 @@ export class BeeClient {
         };
       }
       // BeeApiError messages are our own constructed strings (status
-      // codes + endpoint role) — keep them actionable; only foreign
-      // network/timeout errors are reduced to name + code.
-      const detail =
-        err instanceof BeeApiError ? err.message : describeNetworkError(err);
+      // codes + endpoint role; network failures already carry the
+      // `bee proxy` hint from requestJson) — keep them actionable.
+      // Only foreign errors are reduced to name + code.
       return {
         ok: false,
-        detail:
-          this.usingLocalProxy && !(err instanceof BeeApiError)
-            ? `could not reach the local bee proxy at ${this.baseUrl} — start it with \`bee proxy\` (${detail})`
-            : detail,
+        detail: err instanceof BeeApiError ? err.message : describeNetworkError(err),
       };
     }
   }

--- a/packages/connector-bee/src/client.ts
+++ b/packages/connector-bee/src/client.ts
@@ -118,7 +118,7 @@ export class BeeClient {
   }
 
   get usingLocalProxy(): boolean {
-    return this.baseUrl.startsWith("http://127.0.0.1") || this.baseUrl.startsWith("http://localhost");
+    return isLocalProxyUrl(this.baseUrl);
   }
 
   async listConversations(params: {
@@ -210,12 +210,17 @@ export class BeeClient {
             : "Bee rejected the token (401/403) — re-run `bee login` and update BEE_API_TOKEN",
         };
       }
-      const detail = describeNetworkError(err);
+      // BeeApiError messages are our own constructed strings (status
+      // codes + endpoint role) — keep them actionable; only foreign
+      // network/timeout errors are reduced to name + code.
+      const detail =
+        err instanceof BeeApiError ? err.message : describeNetworkError(err);
       return {
         ok: false,
-        detail: this.usingLocalProxy
-          ? `could not reach the local bee proxy at ${this.baseUrl} — start it with \`bee proxy\` (${detail})`
-          : detail,
+        detail:
+          this.usingLocalProxy && !(err instanceof BeeApiError)
+            ? `could not reach the local bee proxy at ${this.baseUrl} — start it with \`bee proxy\` (${detail})`
+            : detail,
       };
     }
   }
@@ -294,6 +299,25 @@ function readNextCursor(payload: unknown): string | null {
   if (typeof cursor === "string" && cursor.length > 0) return cursor;
   if (typeof cursor === "number") return String(cursor);
   return null;
+}
+
+/**
+ * True when the URL points at the local `bee proxy`. Hostname is
+ * compared exactly after parsing — a prefix match would also treat
+ * hosts like 127.0.0.1.evil.example as local.
+ */
+export function isLocalProxyUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "localhost" ||
+      parsed.hostname === "[::1]" ||
+      parsed.hostname === "::1"
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/connector-bee/src/client.ts
+++ b/packages/connector-bee/src/client.ts
@@ -110,7 +110,7 @@ export class BeeClient {
       typeof options.token === "string" && options.token.trim().length > 0
         ? options.token.trim()
         : undefined;
-    this.baseUrl = (options.baseUrl ?? BEE_DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.baseUrl = stripTrailingSlashes(options.baseUrl ?? BEE_DEFAULT_BASE_URL);
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.sleep =
@@ -295,6 +295,13 @@ function readNextCursor(payload: unknown): string | null {
   if (typeof cursor === "string" && cursor.length > 0) return cursor;
   if (typeof cursor === "number") return String(cursor);
   return null;
+}
+
+/** Loop instead of `/\/+$/` — CodeQL js/polynomial-redos on user-set URLs. */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 0x2f) end--;
+  return value.slice(0, end);
 }
 
 function backoffMs(attempt: number): number {

--- a/packages/connector-bee/src/client.ts
+++ b/packages/connector-bee/src/client.ts
@@ -210,12 +210,12 @@ export class BeeClient {
             : "Bee rejected the token (401/403) — re-run `bee login` and update BEE_API_TOKEN",
         };
       }
-      const message = err instanceof Error ? err.message : String(err);
+      const detail = describeNetworkError(err);
       return {
         ok: false,
         detail: this.usingLocalProxy
-          ? `could not reach the local bee proxy at ${this.baseUrl} — start it with \`bee proxy\` (${message})`
-          : message,
+          ? `could not reach the local bee proxy at ${this.baseUrl} — start it with \`bee proxy\` (${detail})`
+          : detail,
       };
     }
   }
@@ -246,9 +246,8 @@ export class BeeClient {
           continue;
         }
         throw new BeeApiError(
-          `Bee API request failed after ${MAX_RETRIES + 1} attempts: ${
-            err instanceof Error ? err.message : String(err)
-          }` + (this.usingLocalProxy ? " — is `bee proxy` running?" : ""),
+          `Bee API request failed after ${MAX_RETRIES + 1} attempts: ${describeNetworkError(err)}` +
+            (this.usingLocalProxy ? " — is `bee proxy` running?" : ""),
         );
       }
 
@@ -295,6 +294,17 @@ function readNextCursor(payload: unknown): string | null {
   if (typeof cursor === "string" && cursor.length > 0) return cursor;
   if (typeof cursor === "number") return String(cursor);
   return null;
+}
+
+/**
+ * Network/timeout failures wrap Node error text that can carry loader
+ * paths or stack fragments; sync errors reach MCP clients verbatim, so
+ * only the error name + code survive.
+ */
+function describeNetworkError(err: unknown): string {
+  if (!(err instanceof Error)) return "unexpected non-Error failure";
+  const code = (err as NodeJS.ErrnoException).code;
+  return typeof code === "string" && code.length > 0 ? `${err.name} (${code})` : err.name;
 }
 
 /** Loop instead of `/\/+$/` — CodeQL js/polynomial-redos on user-set URLs. */

--- a/packages/connector-bee/src/client.ts
+++ b/packages/connector-bee/src/client.ts
@@ -152,7 +152,18 @@ export class BeeClient {
     id: number,
     signal?: AbortSignal,
   ): Promise<BeeConversationDetail | null> {
-    const payload = await this.requestJson(`/v1/conversations/${id}`, signal);
+    let payload: unknown;
+    try {
+      payload = await this.requestJson(`/v1/conversations/${id}`, signal);
+    } catch (err) {
+      // A conversation can be deleted between the list and the detail
+      // fetch — a 404 skips that conversation instead of aborting the
+      // whole day sync. Other failures (auth, 5xx after retries) still
+      // throw so transient outages retry the sync rather than silently
+      // dropping data.
+      if (err instanceof BeeApiError && err.status === 404) return null;
+      throw err;
+    }
     // Current API returns the detail at the top level; the legacy shape
     // wrapped it as {conversation: {...}}. Accept both.
     const detail =

--- a/packages/connector-bee/src/client.ts
+++ b/packages/connector-bee/src/client.ts
@@ -1,0 +1,313 @@
+/**
+ * Minimal Bee developer API client (raw fetch, no SDK).
+ *
+ * Contract verified against the official `@beeai/cli` source and
+ * docs.bee.computer (2026-06). Two access modes:
+ *
+ *  - **Proxy mode (default):** the official `bee proxy` command serves
+ *    the full developer API unauthenticated on `http://127.0.0.1:8787`.
+ *    No token required.
+ *  - **Direct mode:** `https://app-api-developer.ce.bee.amazon.dev`
+ *    with `Authorization: Bearer <token>` (token from `bee login`,
+ *    stored at `~/.bee/token-prod`). The direct host uses Bee's private
+ *    CA — point `NODE_EXTRA_CA_CERTS` at it when going direct.
+ *
+ * The legacy pre-acquisition API (`api.bee.computer`, `x-api-key`,
+ * page/totalPages) no longer resolves and is intentionally not
+ * supported.
+ *
+ * List endpoints use `limit` + `cursor` pagination with a `next_cursor`
+ * in the envelope; timestamps are epoch milliseconds. Tokens are never
+ * logged and never appear in thrown error messages.
+ */
+
+export const BEE_DEFAULT_BASE_URL = "http://127.0.0.1:8787";
+export const BEE_DIRECT_BASE_URL = "https://app-api-developer.ce.bee.amazon.dev";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const MAX_RETRY_DELAY_MS = 30_000;
+const LIST_PAGE_SIZE = 50;
+
+export interface BeeConversationListItem {
+  id: number;
+  start_time: number;
+  end_time?: number | null;
+  device_type?: string;
+  short_summary?: string | null;
+  summary?: string | null;
+  state?: string;
+}
+
+export interface BeeUtterance {
+  id?: number;
+  start?: number | null;
+  end?: number | null;
+  spoken_at?: number;
+  text?: string;
+  speaker?: string;
+}
+
+export interface BeeConversationDetail extends BeeConversationListItem {
+  transcriptions?: Array<{
+    id?: number;
+    utterances?: BeeUtterance[];
+  }>;
+  primary_location?: {
+    address?: string | null;
+    latitude?: number;
+    longitude?: number;
+  } | null;
+}
+
+export interface BeeFact {
+  id: number;
+  text: string;
+  tags?: string[];
+  created_at?: number;
+  confirmed?: boolean;
+}
+
+export interface BeeConversationsPage {
+  conversations: BeeConversationListItem[];
+  nextCursor: string | null;
+}
+
+export interface BeeFactsPage {
+  facts: BeeFact[];
+  nextCursor: string | null;
+}
+
+export interface BeeClientOptions {
+  /** Bearer token for direct mode. Omit entirely for proxy mode. */
+  token?: string;
+  /** Defaults to the local `bee proxy` address. */
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class BeeApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "BeeApiError";
+  }
+}
+
+export class BeeClient {
+  private readonly token: string | undefined;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: BeeClientOptions = {}) {
+    this.token =
+      typeof options.token === "string" && options.token.trim().length > 0
+        ? options.token.trim()
+        : undefined;
+    this.baseUrl = (options.baseUrl ?? BEE_DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.sleep =
+      options.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  get usingLocalProxy(): boolean {
+    return this.baseUrl.startsWith("http://127.0.0.1") || this.baseUrl.startsWith("http://localhost");
+  }
+
+  async listConversations(params: {
+    cursor?: string | null;
+    limit?: number;
+    signal?: AbortSignal;
+  } = {}): Promise<BeeConversationsPage> {
+    const search = new URLSearchParams({
+      limit: String(params.limit ?? LIST_PAGE_SIZE),
+    });
+    if (typeof params.cursor === "string" && params.cursor.length > 0) {
+      search.set("cursor", params.cursor);
+    }
+    const payload = await this.requestJson(
+      `/v1/conversations?${search.toString()}`,
+      params.signal,
+    );
+    const conversations = (payload as { conversations?: unknown }).conversations;
+    if (!Array.isArray(conversations)) {
+      throw new BeeApiError(
+        "Bee API returned an unexpected /v1/conversations shape (missing conversations array)",
+      );
+    }
+    return {
+      conversations: conversations.filter(isConversationListItem),
+      nextCursor: readNextCursor(payload),
+    };
+  }
+
+  async getConversation(
+    id: number,
+    signal?: AbortSignal,
+  ): Promise<BeeConversationDetail | null> {
+    const payload = await this.requestJson(`/v1/conversations/${id}`, signal);
+    // Current API returns the detail at the top level; the legacy shape
+    // wrapped it as {conversation: {...}}. Accept both.
+    const detail =
+      payload !== null &&
+      typeof payload === "object" &&
+      "conversation" in (payload as Record<string, unknown>)
+        ? (payload as { conversation: unknown }).conversation
+        : payload;
+    return isConversationListItem(detail) ? (detail as BeeConversationDetail) : null;
+  }
+
+  async listFacts(params: {
+    cursor?: string | null;
+    signal?: AbortSignal;
+  } = {}): Promise<BeeFactsPage> {
+    const search = new URLSearchParams({
+      limit: String(LIST_PAGE_SIZE),
+      confirmed: "true",
+    });
+    if (typeof params.cursor === "string" && params.cursor.length > 0) {
+      search.set("cursor", params.cursor);
+    }
+    const payload = await this.requestJson(`/v1/facts?${search.toString()}`, params.signal);
+    const facts = (payload as { facts?: unknown }).facts;
+    if (!Array.isArray(facts)) {
+      throw new BeeApiError(
+        "Bee API returned an unexpected /v1/facts shape (missing facts array)",
+      );
+    }
+    return {
+      facts: facts.filter(
+        (entry): entry is BeeFact =>
+          entry !== null &&
+          typeof entry === "object" &&
+          typeof (entry as { id?: unknown }).id === "number" &&
+          typeof (entry as { text?: unknown }).text === "string",
+      ),
+      nextCursor: readNextCursor(payload),
+    };
+  }
+
+  async verifyAuth(signal?: AbortSignal): Promise<{ ok: boolean; detail?: string }> {
+    try {
+      await this.requestJson("/v1/me", signal);
+      return {
+        ok: true,
+        detail: this.usingLocalProxy ? "via local bee proxy" : "direct API access",
+      };
+    } catch (err) {
+      if (err instanceof BeeApiError && (err.status === 401 || err.status === 403)) {
+        return {
+          ok: false,
+          detail: this.usingLocalProxy
+            ? "the bee proxy rejected the request — re-run `bee login` then restart `bee proxy`"
+            : "Bee rejected the token (401/403) — re-run `bee login` and update BEE_API_TOKEN",
+        };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        detail: this.usingLocalProxy
+          ? `could not reach the local bee proxy at ${this.baseUrl} — start it with \`bee proxy\` (${message})`
+          : message,
+      };
+    }
+  }
+
+  private async requestJson(pathAndQuery: string, signal?: AbortSignal): Promise<unknown> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      signal?.throwIfAborted();
+      const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+      const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+      let response: Response;
+      try {
+        response = await this.fetchImpl(`${this.baseUrl}${pathAndQuery}`, {
+          method: "GET",
+          headers: {
+            Accept: "application/json",
+            ...(this.token !== undefined
+              ? { Authorization: `Bearer ${this.token}` }
+              : {}),
+          },
+          signal: combined,
+        });
+      } catch (err) {
+        if (signal?.aborted) throw err;
+        lastError = err;
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(backoffMs(attempt));
+          continue;
+        }
+        throw new BeeApiError(
+          `Bee API request failed after ${MAX_RETRIES + 1} attempts: ${
+            err instanceof Error ? err.message : String(err)
+          }` + (this.usingLocalProxy ? " — is `bee proxy` running?" : ""),
+        );
+      }
+
+      if (response.status === 429 || response.status >= 500) {
+        lastError = new BeeApiError(
+          `Bee API responded ${response.status}`,
+          response.status,
+        );
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(retryDelayMs(response, attempt));
+          continue;
+        }
+        throw lastError;
+      }
+      if (!response.ok) {
+        throw new BeeApiError(
+          `Bee API responded ${response.status} for ${pathAndQuery.split("?")[0]}`,
+          response.status,
+        );
+      }
+      try {
+        return await response.json();
+      } catch {
+        throw new BeeApiError("Bee API returned a non-JSON body");
+      }
+    }
+    throw lastError instanceof Error
+      ? lastError
+      : new BeeApiError("Bee API request failed");
+  }
+}
+
+function isConversationListItem(entry: unknown): entry is BeeConversationListItem {
+  return (
+    entry !== null &&
+    typeof entry === "object" &&
+    typeof (entry as { id?: unknown }).id === "number" &&
+    typeof (entry as { start_time?: unknown }).start_time === "number"
+  );
+}
+
+function readNextCursor(payload: unknown): string | null {
+  const cursor = (payload as { next_cursor?: unknown }).next_cursor;
+  if (typeof cursor === "string" && cursor.length > 0) return cursor;
+  if (typeof cursor === "number") return String(cursor);
+  return null;
+}
+
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_RETRY_DELAY_MS, 1_000 * 2 ** attempt);
+}
+
+function retryDelayMs(response: Response, attempt: number): number {
+  const headerValue = response.headers.get("retry-after");
+  if (headerValue !== null) {
+    const parsed = Number(headerValue);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.min(MAX_RETRY_DELAY_MS, Math.ceil(parsed * 1_000));
+    }
+  }
+  return backoffMs(attempt);
+}

--- a/packages/connector-bee/src/index.test.ts
+++ b/packages/connector-bee/src/index.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { getWearableConnector } from "@remnic/core";
+import type { WearableSourceSettings } from "@remnic/core";
+
+import {
+  createBeeConnector,
+  ensureBeeConnectorRegistered,
+  resolveBeeToken,
+  wearableConnectorRegistration,
+} from "./index.js";
+
+function settings(overrides: Partial<WearableSourceSettings> = {}): WearableSourceSettings {
+  return {
+    enabled: true,
+    memoryMode: "review",
+    minConfidence: 0.6,
+    minImportance: "low",
+    maxMemoriesPerDay: 20,
+    importNativeMemories: "off",
+    cleanup: {
+      mergeSameSpeaker: true,
+      stripFillers: true,
+      collapseRepeats: true,
+      dropLowQuality: true,
+    },
+    ...overrides,
+  };
+}
+
+/** Route-based global-fetch stub for connector-level tests. */
+function stubFetch(routes: Record<string, unknown>): {
+  restore: () => void;
+  calls: string[];
+} {
+  const original = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    const url = new URL(String(input));
+    calls.push(`${url.pathname}${url.search}`);
+    for (const [prefix, payload] of Object.entries(routes)) {
+      if (url.pathname === prefix || url.pathname.startsWith(`${prefix}/`)) {
+        const body = typeof payload === "function" ? payload(url) : payload;
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+    return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+  }) as typeof fetch;
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    calls,
+  };
+}
+
+test("importing the module registers the connector exactly once", () => {
+  assert.ok(getWearableConnector("bee"));
+  assert.equal(ensureBeeConnectorRegistered(), false);
+  assert.equal(wearableConnectorRegistration.id, "bee");
+});
+
+test("resolveBeeToken prefers config, then REMNIC_*, then provider env, else proxy mode", () => {
+  assert.equal(resolveBeeToken("from-config", {}), "from-config");
+  assert.equal(
+    resolveBeeToken(undefined, {
+      REMNIC_BEE_API_TOKEN: "remnic-env",
+      BEE_API_TOKEN: "provider-env",
+    }),
+    "remnic-env",
+  );
+  assert.equal(resolveBeeToken(undefined, { BEE_API_TOKEN: "provider-env" }), "provider-env");
+  assert.equal(resolveBeeToken(undefined, {}), undefined);
+});
+
+test("fetchConversations filters to the requested local day and fetches details", async () => {
+  // 2026-06-10 in America/Chicago spans 05:00Z (Jun 10) to 05:00Z (Jun 11).
+  const inDayMs = Date.UTC(2026, 5, 10, 20, 0, 0); // 15:00 Chicago, Jun 10
+  const utcNextDayMs = Date.UTC(2026, 5, 11, 1, 0, 0); // 20:00 Chicago, Jun 10 — still in day!
+  const olderMs = Date.UTC(2026, 5, 9, 12, 0, 0); // Jun 9 — older day
+  const stub = stubFetch({
+    "/v1/conversations": (url: URL) => {
+      if (/^\/v1\/conversations\/\d+$/.test(url.pathname)) {
+        const id = Number(url.pathname.split("/").pop());
+        const startTime = id === 1 ? inDayMs : id === 2 ? utcNextDayMs : olderMs;
+        return {
+          id,
+          start_time: startTime,
+          transcriptions: [
+            { utterances: [{ text: `utterance for ${id}`, speaker: "0", spoken_at: startTime }] },
+          ],
+        };
+      }
+      return {
+        conversations: [
+          { id: 1, start_time: inDayMs, state: "COMPLETED" },
+          { id: 2, start_time: utcNextDayMs, state: "COMPLETED" },
+          { id: 3, start_time: olderMs, state: "COMPLETED" },
+          { id: 4, start_time: inDayMs, state: "CAPTURING" },
+        ],
+        next_cursor: "deeper",
+      };
+    },
+  });
+  try {
+    const connector = createBeeConnector({ settings: settings(), timezone: "America/Chicago" });
+    const page = await connector.fetchConversations({
+      date: "2026-06-10",
+      timezone: "America/Chicago",
+    });
+    // ids 1 and 2 are both Jun 10 in Chicago (2 crosses the UTC date
+    // line); 3 is an older day; 4 is still capturing.
+    assert.deepEqual(page.conversations.map((c) => c.id), ["1", "2"]);
+    assert.equal(
+      page.nextCursor,
+      "deeper",
+      "page still contained the target day — keep paginating",
+    );
+  } finally {
+    stub.restore();
+  }
+});
+
+test("pagination stops when an entire page predates the requested day", async () => {
+  const olderMs = Date.UTC(2026, 5, 1, 12, 0, 0);
+  const stub = stubFetch({
+    "/v1/conversations": {
+      conversations: [
+        { id: 9, start_time: olderMs, state: "COMPLETED" },
+        { id: 10, start_time: olderMs - 86_400_000, state: "COMPLETED" },
+      ],
+      next_cursor: "even-deeper",
+    },
+  });
+  try {
+    const connector = createBeeConnector({ settings: settings(), timezone: "UTC" });
+    const page = await connector.fetchConversations({ date: "2026-06-10", timezone: "UTC" });
+    assert.equal(page.conversations.length, 0);
+    assert.equal(page.nextCursor, null, "all-older page must stop pagination");
+  } finally {
+    stub.restore();
+  }
+});
+
+test("fetchNativeMemories maps Bee facts", async () => {
+  const stub = stubFetch({
+    "/v1/facts": {
+      facts: [{ id: 5, text: "User likes tea.", created_at: Date.UTC(2026, 5, 1) }],
+      next_cursor: null,
+    },
+  });
+  try {
+    const connector = createBeeConnector({ settings: settings(), timezone: "UTC" });
+    assert.ok(connector.fetchNativeMemories, "bee connector must support native memories");
+    const page = await connector.fetchNativeMemories({});
+    assert.equal(page.memories.length, 1);
+    assert.equal(page.memories[0].id, "5");
+    assert.equal(page.nextCursor, null);
+  } finally {
+    stub.restore();
+  }
+});

--- a/packages/connector-bee/src/index.test.ts
+++ b/packages/connector-bee/src/index.test.ts
@@ -146,6 +146,43 @@ test("pagination stops when an entire page predates the requested day", async ()
   }
 });
 
+test("the proxy path never attaches an environment token", async () => {
+  const previousRemnic = process.env.REMNIC_BEE_API_TOKEN;
+  const previousProvider = process.env.BEE_API_TOKEN;
+  process.env.BEE_API_TOKEN = "direct-mode-token";
+  const original = globalThis.fetch;
+  const headersSeen: Array<Record<string, string>> = [];
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    headersSeen.push(
+      Object.fromEntries(Object.entries((init?.headers ?? {}) as Record<string, string>)),
+    );
+    return new Response(JSON.stringify({ conversations: [], next_cursor: null }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  try {
+    // Default base URL (the local proxy): token must be omitted.
+    const proxyConnector = createBeeConnector({ settings: settings({ apiKey: undefined }), timezone: "UTC" });
+    await proxyConnector.fetchConversations({ date: "2026-06-10", timezone: "UTC" });
+    assert.equal(headersSeen[0].Authorization, undefined);
+
+    // Direct base URL: the env token applies.
+    const directConnector = createBeeConnector({
+      settings: settings({ apiKey: undefined, baseUrl: "https://bee.example.test" }),
+      timezone: "UTC",
+    });
+    await directConnector.fetchConversations({ date: "2026-06-10", timezone: "UTC" });
+    assert.equal(headersSeen[1].Authorization, "Bearer direct-mode-token");
+  } finally {
+    globalThis.fetch = original;
+    if (previousProvider !== undefined) process.env.BEE_API_TOKEN = previousProvider;
+    else delete process.env.BEE_API_TOKEN;
+    if (previousRemnic !== undefined) process.env.REMNIC_BEE_API_TOKEN = previousRemnic;
+    else delete process.env.REMNIC_BEE_API_TOKEN;
+  }
+});
+
 test("fetchNativeMemories maps Bee facts", async () => {
   const stub = stubFetch({
     "/v1/facts": {

--- a/packages/connector-bee/src/index.ts
+++ b/packages/connector-bee/src/index.ts
@@ -27,7 +27,7 @@ import {
   type WearableSourceConnector,
 } from "@remnic/core";
 
-import { BeeClient, type BeeConversationListItem } from "./client.js";
+import { BeeClient, isLocalProxyUrl, BEE_DEFAULT_BASE_URL, type BeeConversationListItem } from "./client.js";
 import { BEE_SOURCE_ID, conversationToWearable, factToNativeMemory } from "./normalize.js";
 
 export {
@@ -35,6 +35,7 @@ export {
   BeeClient,
   BEE_DEFAULT_BASE_URL,
   BEE_DIRECT_BASE_URL,
+  isLocalProxyUrl,
 } from "./client.js";
 export type {
   BeeClientOptions,
@@ -74,10 +75,15 @@ export function createBeeConnector(
   let client: BeeClient | null = null;
   const getClient = (): BeeClient => {
     if (!client) {
-      client = new BeeClient({
-        token: resolveBeeToken(options.settings.apiKey),
-        baseUrl: options.settings.baseUrl,
-      });
+      const baseUrl = options.settings.baseUrl ?? BEE_DEFAULT_BASE_URL;
+      // The local proxy is unauthenticated by design — never attach a
+      // Bearer header there, even when a direct-mode token sits in the
+      // environment (it would 401 proxy requests for users who keep
+      // BEE_API_TOKEN exported for occasional direct use).
+      const token = isLocalProxyUrl(baseUrl)
+        ? undefined
+        : resolveBeeToken(options.settings.apiKey);
+      client = new BeeClient({ token, baseUrl });
     }
     return client;
   };

--- a/packages/connector-bee/src/index.ts
+++ b/packages/connector-bee/src/index.ts
@@ -1,0 +1,156 @@
+/**
+ * @remnic/connector-bee — Bee wearable connector.
+ *
+ * À-la-carte optional companion of @remnic/core (computed-specifier
+ * discovery; importing this module self-registers idempotently).
+ *
+ * Access modes:
+ *  - default: the local `bee proxy` (http://127.0.0.1:8787, no token)
+ *  - direct:  set `wearables.sources.bee.baseUrl` to the direct host
+ *             and provide a token via `REMNIC_BEE_API_TOKEN` /
+ *             `BEE_API_TOKEN` (or `apiKey` in config)
+ *
+ * Bee's list API has no date filter, so the connector paginates
+ * newest-first and filters conversations to the requested local day,
+ * stopping once a whole page predates it.
+ */
+
+import {
+  dateInTimezone,
+  registerWearableConnector,
+  getWearableConnector,
+  type WearableConnectorFactoryOptions,
+  type WearableConnectorRegistration,
+  type WearableFetchOptions,
+  type WearableFetchPage,
+  type WearableNativeMemoryPage,
+  type WearableSourceConnector,
+} from "@remnic/core";
+
+import { BeeClient, type BeeConversationListItem } from "./client.js";
+import { BEE_SOURCE_ID, conversationToWearable, factToNativeMemory } from "./normalize.js";
+
+export {
+  BeeApiError,
+  BeeClient,
+  BEE_DEFAULT_BASE_URL,
+  BEE_DIRECT_BASE_URL,
+} from "./client.js";
+export type {
+  BeeClientOptions,
+  BeeConversationDetail,
+  BeeConversationListItem,
+  BeeConversationsPage,
+  BeeFact,
+  BeeFactsPage,
+  BeeUtterance,
+} from "./client.js";
+export { BEE_SOURCE_ID, conversationToWearable, factToNativeMemory } from "./normalize.js";
+
+export function resolveBeeToken(
+  configuredToken: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (typeof configuredToken === "string" && configuredToken.trim().length > 0) {
+    return configuredToken.trim();
+  }
+  for (const name of ["REMNIC_BEE_API_TOKEN", "BEE_API_TOKEN"]) {
+    const value = env[name];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+/** Conversations still being recorded are skipped until they settle. */
+function isSyncableState(item: BeeConversationListItem): boolean {
+  return typeof item.state !== "string" || item.state.toUpperCase() !== "CAPTURING";
+}
+
+export function createBeeConnector(
+  options: WearableConnectorFactoryOptions,
+): WearableSourceConnector {
+  let client: BeeClient | null = null;
+  const getClient = (): BeeClient => {
+    if (!client) {
+      client = new BeeClient({
+        token: resolveBeeToken(options.settings.apiKey),
+        baseUrl: options.settings.baseUrl,
+      });
+    }
+    return client;
+  };
+
+  return {
+    id: BEE_SOURCE_ID,
+    displayName: "Bee",
+    async verifyAuth(signal?: AbortSignal) {
+      return getClient().verifyAuth(signal);
+    },
+    async fetchConversations(opts: WearableFetchOptions): Promise<WearableFetchPage> {
+      const page = await getClient().listConversations({
+        cursor: opts.cursor,
+        signal: opts.signal,
+      });
+
+      const matching: BeeConversationListItem[] = [];
+      let sawOnlyOlder = page.conversations.length > 0;
+      for (const item of page.conversations) {
+        const localDate = dateInTimezone(new Date(item.start_time), opts.timezone);
+        if (localDate === opts.date && isSyncableState(item)) {
+          matching.push(item);
+        }
+        if (localDate >= opts.date) {
+          sawOnlyOlder = false;
+        }
+      }
+
+      const conversations = [];
+      for (const item of matching) {
+        const detail = await getClient().getConversation(item.id, opts.signal);
+        if (detail === null) continue;
+        conversations.push(conversationToWearable(detail));
+      }
+
+      // Stop paginating once an entire (newest-first) page predates the
+      // requested day; anything deeper is older still.
+      const nextCursor = sawOnlyOlder ? null : page.nextCursor;
+      return { conversations, nextCursor };
+    },
+    async fetchNativeMemories(opts: {
+      cursor?: string | null;
+      signal?: AbortSignal;
+    }): Promise<WearableNativeMemoryPage> {
+      const page = await getClient().listFacts({
+        cursor: opts.cursor,
+        signal: opts.signal,
+      });
+      return {
+        memories: page.facts.map(factToNativeMemory),
+        nextCursor: page.nextCursor,
+      };
+    },
+  };
+}
+
+export const wearableConnectorRegistration: WearableConnectorRegistration = {
+  id: BEE_SOURCE_ID,
+  displayName: "Bee",
+  factory: createBeeConnector,
+};
+
+/**
+ * Idempotently register the connector with the core registry. Importing
+ * this module registers it as a side effect; calling this again is safe
+ * (returns false when already registered).
+ */
+export function ensureBeeConnectorRegistered(): boolean {
+  if (getWearableConnector(BEE_SOURCE_ID) !== undefined) {
+    return false;
+  }
+  registerWearableConnector(wearableConnectorRegistration);
+  return true;
+}
+
+ensureBeeConnectorRegistered();

--- a/packages/connector-bee/src/normalize.test.ts
+++ b/packages/connector-bee/src/normalize.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { conversationToWearable, factToNativeMemory } from "./normalize.js";
+
+const BASE_MS = Date.UTC(2026, 5, 10, 14, 0, 0);
+
+test("maps conversation metadata, epoch-ms timestamps, and location", () => {
+  const conversation = conversationToWearable({
+    id: 42,
+    start_time: BASE_MS,
+    end_time: BASE_MS + 30 * 60_000,
+    state: "COMPLETED",
+    short_summary: "Coffee catch-up\n",
+    summary: "### Summary\nTalked about hiking.",
+    primary_location: { address: "123 Example Ave", latitude: 0, longitude: 0 },
+    transcriptions: [
+      {
+        utterances: [
+          { text: "Try the east loop.", speaker: "1", spoken_at: BASE_MS + 60_000 },
+          { text: "I will this weekend.", speaker: "0", spoken_at: BASE_MS + 90_000 },
+        ],
+      },
+    ],
+  });
+  assert.equal(conversation.id, "42");
+  assert.equal(conversation.source, "bee");
+  assert.equal(conversation.title, "Coffee catch-up");
+  assert.equal(conversation.startIso, new Date(BASE_MS).toISOString());
+  assert.equal(conversation.endIso, new Date(BASE_MS + 30 * 60_000).toISOString());
+  assert.equal(conversation.location, "123 Example Ave");
+  assert.equal(conversation.segments.length, 2);
+  assert.equal(conversation.segments[0].speakerKey, "1");
+  assert.equal(conversation.segments[0].isWearer, undefined);
+});
+
+test("flattens and time-sorts utterances across transcription blocks", () => {
+  const conversation = conversationToWearable({
+    id: 7,
+    start_time: BASE_MS,
+    transcriptions: [
+      { utterances: [{ text: "second", speaker: "0", spoken_at: BASE_MS + 2_000 }] },
+      { utterances: [{ text: "first", speaker: "1", spoken_at: BASE_MS + 1_000 }] },
+    ],
+  });
+  assert.deepEqual(
+    conversation.segments.map((segment) => segment.text),
+    ["first", "second"],
+  );
+});
+
+test("skips empty utterances and tolerates missing fields", () => {
+  const conversation = conversationToWearable({
+    id: 8,
+    start_time: BASE_MS,
+    transcriptions: [
+      { utterances: [{ text: "   ", speaker: "0" }, { text: "kept", speaker: "" }, {}] },
+    ],
+  });
+  assert.equal(conversation.segments.length, 1);
+  assert.equal(conversation.segments[0].text, "kept");
+  assert.equal(conversation.segments[0].speakerKey, "unknown");
+});
+
+test("maps Bee facts to native memories", () => {
+  const memory = factToNativeMemory({
+    id: 99,
+    text: "User volunteers monthly.",
+    tags: ["habit"],
+    created_at: BASE_MS,
+    confirmed: true,
+  });
+  assert.deepEqual(memory, {
+    id: "99",
+    content: "User volunteers monthly.",
+    createdIso: new Date(BASE_MS).toISOString(),
+    tags: ["habit"],
+  });
+});

--- a/packages/connector-bee/src/normalize.ts
+++ b/packages/connector-bee/src/normalize.ts
@@ -1,0 +1,92 @@
+/**
+ * Normalize Bee conversations into Remnic's provider-agnostic
+ * `WearableConversation` shape.
+ *
+ * Bee timestamps are epoch milliseconds; utterance `speaker` values are
+ * opaque diarization labels ("0", "1", ...) with no wearer marker — the
+ * Remnic speaker registry is how labels become names
+ * (`remnic wearables speakers set bee 0 "You" --self`).
+ */
+
+import type {
+  WearableConversation,
+  WearableNativeMemory,
+  WearableTranscriptSegment,
+} from "@remnic/core";
+
+import type { BeeConversationDetail, BeeFact } from "./client.js";
+
+export const BEE_SOURCE_ID = "bee";
+
+function msToIso(ms: number | null | undefined): string | undefined {
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) return undefined;
+  return new Date(ms).toISOString();
+}
+
+export function conversationToWearable(
+  detail: BeeConversationDetail,
+): WearableConversation {
+  const segments: WearableTranscriptSegment[] = [];
+  for (const transcription of detail.transcriptions ?? []) {
+    for (const utterance of transcription.utterances ?? []) {
+      const text = typeof utterance.text === "string" ? utterance.text.trim() : "";
+      if (text.length === 0) continue;
+      const speaker =
+        typeof utterance.speaker === "string" && utterance.speaker.trim().length > 0
+          ? utterance.speaker.trim()
+          : "unknown";
+      segments.push({
+        text,
+        speakerKey: speaker,
+        ...(msToIso(utterance.spoken_at) !== undefined
+          ? { startIso: msToIso(utterance.spoken_at) }
+          : {}),
+      });
+    }
+  }
+  // Bee nests utterances per transcription block; order within a block
+  // is chronological but blocks can interleave — sort stably by time
+  // when timestamps exist.
+  segments.sort((a, b) => {
+    const aMs = a.startIso ? Date.parse(a.startIso) : Number.NaN;
+    const bMs = b.startIso ? Date.parse(b.startIso) : Number.NaN;
+    if (Number.isNaN(aMs) || Number.isNaN(bMs)) return 0;
+    if (aMs < bMs) return -1;
+    if (aMs > bMs) return 1;
+    return 0;
+  });
+
+  const title =
+    typeof detail.short_summary === "string" && detail.short_summary.trim().length > 0
+      ? detail.short_summary.trim().split("\n")[0]
+      : undefined;
+
+  return {
+    id: String(detail.id),
+    source: BEE_SOURCE_ID,
+    ...(title !== undefined ? { title } : {}),
+    ...(typeof detail.summary === "string" && detail.summary.trim().length > 0
+      ? { summary: detail.summary.trim() }
+      : {}),
+    startIso: msToIso(detail.start_time) ?? "",
+    ...(msToIso(detail.end_time ?? undefined) !== undefined
+      ? { endIso: msToIso(detail.end_time ?? undefined) }
+      : {}),
+    ...(typeof detail.primary_location?.address === "string" &&
+    detail.primary_location.address.length > 0
+      ? { location: detail.primary_location.address }
+      : {}),
+    segments,
+  };
+}
+
+export function factToNativeMemory(fact: BeeFact): WearableNativeMemory {
+  return {
+    id: String(fact.id),
+    content: fact.text,
+    ...(msToIso(fact.created_at) !== undefined
+      ? { createdIso: msToIso(fact.created_at) }
+      : {}),
+    ...(Array.isArray(fact.tags) && fact.tags.length > 0 ? { tags: fact.tags } : {}),
+  };
+}

--- a/packages/connector-bee/tsconfig.json
+++ b/packages/connector-bee/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -48,7 +48,8 @@
     "@remnic/import-lossless-claw": "^9.3.625",
     "@remnic/import-mem0": "^9.3.625",
     "@remnic/import-supermemory": "^9.3.625",
-    "@remnic/connector-limitless": "^9.3.625"
+    "@remnic/connector-limitless": "^9.3.625",
+    "@remnic/connector-bee": "^9.3.625"
   },
   "peerDependenciesMeta": {
     "@remnic/bench": {
@@ -80,6 +81,9 @@
     },
     "@remnic/connector-limitless": {
       "optional": true
+    },
+    "@remnic/connector-bee": {
+      "optional": true
     }
   },
   "devDependencies": {
@@ -94,7 +98,8 @@
     "@remnic/import-supermemory": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "@remnic/connector-limitless": "workspace:*"
+    "@remnic/connector-limitless": "workspace:*",
+    "@remnic/connector-bee": "workspace:*"
   },
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,21 @@ importers:
         specifier: ^7.1.12
         version: 7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/connector-bee:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/connector-limitless:
     devDependencies:
       '@remnic/core':
@@ -390,6 +405,9 @@ importers:
       '@remnic/bench':
         specifier: workspace:*
         version: link:../bench
+      '@remnic/connector-bee':
+        specifier: workspace:*
+        version: link:../connector-bee
       '@remnic/connector-limitless':
         specifier: workspace:*
         version: link:../connector-limitless

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -542,7 +542,7 @@ tests/recall-hardening.test.ts(754,3): TS2349
 tests/recall-hardening.test.ts(812,3): TS2349
 tests/recall-hardening.test.ts(814,3): TS2349
 tests/recall-no-recall-short-circuit.test.ts(14,3): TS2740
-tests/release-workflow-public-packages.test.ts(149,41): TS7016
+tests/release-workflow-public-packages.test.ts(150,41): TS7016
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006
 tests/remnic-plugin-register-migration.test.ts(66,12): TS2352
 tests/remnic-server-cli.test.ts(9,30): TS7016

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -21,6 +21,7 @@ const expectedPublishDirs = [
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/connector-limitless",
+  "packages/connector-bee",
   "packages/hermes-provider",
   "packages/belief-ledger",
   "packages/remnic-server",


### PR DESCRIPTION
## Summary

Second of three wearable-integration PRs (follows #1458, which shipped the shared wearables subsystem + Limitless). This is a **pure additive package**: `@remnic/connector-bee`, implementing the `WearableSourceConnector` contract for the Bee bracelet against the **current (post-Amazon) developer API** — the registry in core already discovers it via computed-specifier dynamic import.

### What it does

- **Two access modes**: the local `bee proxy` (default `http://127.0.0.1:8787`, no token — the officially supported path) and direct Bearer-token access to the Amazon-hosted developer API. The retired legacy `api.bee.computer` (`x-api-key`, page/totalPages) surface is intentionally unsupported; the README documents the `bee login` pairing flow and the private-CA caveat for direct mode.
- **Day-windowed sync without a provider date filter**: Bee's list API has no date params, so the connector paginates newest-first (cursor + epoch-ms timestamps) and filters to the requested **local** day via core's `dateInTimezone`, stopping once an entire page predates the target day (bounded backfills; regression test crosses the UTC date line).
- **Detail fetch + normalization**: per-conversation utterances flattened across transcription blocks and time-sorted; opaque diarization labels ("0", "1") flow into the core speaker registry (`remnic wearables speakers set bee 0 "You" --self`); `CAPTURING` (in-progress) conversations are skipped until they settle; `short_summary` becomes the title, `primary_location.address` the location.
- **Native memory import**: `fetchNativeMemories` maps Bee's confirmed **facts** for the review-queue import path (`importNativeMemories: "review"` — always `pending_review`).
- **Hardening parity with everything #1458's seven review rounds produced**: loop-based trailing-slash trim (CodeQL polynomial-redos), network errors surfaced as error name + errno code only (never raw Node text), tokens never logged or embedded in errors, retry with backoff on 429/5xx, proxy-reachability failures point at `bee proxy`, strict envelope validation with loud failures, standard `precheck-types` script, publish-order + root-typecheck contract tests updated.

### Tests

18 connector tests: proxy-default/no-auth-header, Bearer direct mode, cursor pagination (string + numeric `next_cursor`), wrapped/bare detail shapes, confirmed-facts param + envelope validation, 5xx retry, proxy-hint on network failure, 401 guidance without token leakage, error-text scrubbing, normalization (epoch-ms→ISO, cross-block time sort, empty-utterance skipping), local-day filtering across the UTC boundary, pagination stop semantics, native-memory mapping, registration idempotency.

### Gates

`preflight:quick` ✅ · connector check-types + tests ✅ · publish-order/root-typecheck contract tests ✅ · docs already landed in #1458 (`docs/wearables.md` Bee section, README mention); the package README covers setup end-to-end.

Remaining follow-up: PR 3 (`@remnic/connector-omi`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional package with isolated HTTP client logic; no changes to core auth or storage paths beyond runtime connector discovery and optional CLI peer dependency.
> 
> **Overview**
> Adds **`@remnic/connector-bee`**, an optional Bee bracelet source that self-registers with core’s wearable registry and plugs into the existing transcript/memory pipeline.
> 
> The connector talks to the **current Bee developer API** (not legacy `api.bee.computer`): default **local `bee proxy`** on `127.0.0.1:8787` with no Bearer token, or **direct** access with config/env tokens and a custom `baseUrl`. A small **`BeeClient`** handles cursor pagination, retries on 429/5xx, strict response validation, 404-tolerant detail fetches, and auth/error messaging that avoids leaking tokens.
> 
> **Sync behavior:** because the list API has no date filter, it pages newest-first, filters to the requested **local calendar day** (via core `dateInTimezone`), stops when a full page is older than that day, skips `CAPTURING` conversations, and maps details into `WearableConversation` (flattened, time-sorted utterances; opaque speaker keys). **`fetchNativeMemories`** maps confirmed Bee **facts** for optional review-queue import.
> 
> **Wiring:** `@remnic/cli` gains an optional peer on `@remnic/connector-bee`; release publish-order tests include the new package. Package README documents setup, speakers, and CLI usage. Broad unit test coverage for client, normalization, and connector behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f755c3fffea6145c1d6475c5f92fd8fbe3f30751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->