### PR TITLE
feat(wearables): Omi connector (@remnic/connector-omi)

### DIFF
--- a/packages/connector-omi/README.md
+++ b/packages/connector-omi/README.md
@@ -1,0 +1,85 @@
+# @remnic/connector-omi
+
+Omi AI wearable connector for [Remnic](https://github.com/joshuaswarren/remnic).
+Pulls your Omi necklace conversations into Remnic's wearable-transcript
+pipeline: cleaned, speaker-labeled, redacted, searchable day
+transcripts — and, under per-source trust gates, memories. Optionally
+imports Omi's own "memories" (extracted facts) into the review queue.
+
+This is an **à-la-carte optional companion** of `@remnic/core`:
+
+```bash
+npm install -g @remnic/connector-omi
+```
+
+Remnic discovers it at runtime. No further registration is needed.
+
+## Setup
+
+The connector uses Omi's Integrations API, which is scoped to an app
+you create:
+
+1. In the Omi app: **Apps → Create App → External Integration**, and
+   grant the **read conversations** capability (plus **read memories**
+   if you want native-memory import). Install/enable the app for your
+   account.
+2. On the app's management page, create an **API key** (`sk_...`).
+3. Note your **app id** and your **uid** (Omi passes `?uid=` to your
+   app's links; it identifies the account to read).
+4. Configure:
+
+```jsonc
+{
+  "wearables": {
+    "enabled": true,
+    "sources": {
+      "omi": {
+        "enabled": true,
+        "appId": "your-omi-app-id",
+        "userId": "your-omi-uid",
+        "memoryMode": "review",
+        "importNativeMemories": "review"   // optional: queue Omi memories for review
+      }
+    }
+  }
+}
+```
+
+Provide the key via `OMI_API_KEY` (or `REMNIC_OMI_API_KEY`, or `apiKey`
+in config).
+
+## Usage
+
+```bash
+remnic wearables check omi
+remnic wearables sync --source omi --days 7
+remnic wearables transcript --date 2026-06-10 --source omi
+```
+
+## Speaker labels
+
+Omi marks the wearer (`is_user`) automatically. Other voices arrive as
+`SPEAKER_NN` diarization labels — or stable person ids once you tag
+people in Omi. Map either form to a display name once:
+
+```bash
+remnic wearables speakers set omi SPEAKER_01 "Jane Doe"
+```
+
+## Notes
+
+- Transcripts are fetched **unabridged**: the connector passes
+  `max_transcript_segments=-1` because the API's default silently
+  truncates conversations to their first 100 segments.
+- Day windows are timezone-correct: the connector computes local-day
+  ISO bounds (DST-aware) for the API's `start_date`/`end_date` filters,
+  and only `completed`, non-discarded conversations sync.
+- Default `memoryMode: "review"`: nothing enters active recall without
+  approval. Omi-native memories (when imported) are always
+  review-queued.
+
+Full documentation: [docs/wearables.md](https://github.com/joshuaswarren/remnic/blob/main/docs/wearables.md).
+
+## License
+
+MIT

--- a/packages/connector-omi/package.json
+++ b/packages/connector-omi/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
+    "precheck-types": "node ../../scripts/ensure-bench-build-deps.mjs",
     "check-types": "tsc --noEmit",
     "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/client.test.ts src/normalize.test.ts src/index.test.ts",
     "prepublishOnly": "npm run build"

--- a/packages/connector-omi/package.json
+++ b/packages/connector-omi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/connector-omi",
-  "version": "9.3.624",
+  "version": "9.3.626",
   "description": "Omi AI wearable connector for Remnic — pull, clean, and remember necklace transcripts via the Omi Integrations API",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "provenance": true
   },
   "peerDependencies": {
-    "@remnic/core": "^9.3.624"
+    "@remnic/core": "^9.3.626"
   },
   "devDependencies": {
     "@remnic/core": "workspace:*",

--- a/packages/connector-omi/package.json
+++ b/packages/connector-omi/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@remnic/connector-omi",
+  "version": "9.3.624",
+  "description": "Omi AI wearable connector for Remnic — pull, clean, and remember necklace transcripts via the Omi Integrations API",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source\" tsx --test src/client.test.ts src/normalize.test.ts src/index.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "^9.3.624"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/connector-omi"
+  },
+  "keywords": [
+    "remnic",
+    "memory",
+    "omi",
+    "omi.me",
+    "wearable",
+    "transcript"
+  ]
+}

--- a/packages/connector-omi/src/client.test.ts
+++ b/packages/connector-omi/src/client.test.ts
@@ -150,6 +150,18 @@ test("retries 429 honoring Retry-After and 5xx with backoff", async () => {
   assert.deepEqual(sleeps, [3_000, 2_000]);
 });
 
+test("verifyAuth reduces foreign network failures to name + code", async () => {
+  const pathy = new Error("connect ETIMEDOUT /home/someone/.cache/loader/path.js");
+  (pathy as NodeJS.ErrnoException).code = "ETIMEDOUT";
+  const { client } = makeClient([pathy, pathy, pathy, pathy]);
+  const result = await client.verifyAuth();
+  assert.equal(result.ok, false);
+  // The exhausted-retry OmiApiError message carries the scrubbed code…
+  assert.match(result.detail ?? "", /ETIMEDOUT|Error/);
+  // …and never the raw path.
+  assert.ok(!(result.detail ?? "").includes("/home/someone"));
+});
+
 test("verifyAuth maps the authorization chain to actionable detail", async () => {
   {
     const { client } = makeClient([

--- a/packages/connector-omi/src/client.test.ts
+++ b/packages/connector-omi/src/client.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { OmiApiError, OmiClient } from "./client.js";
+
+type FetchCall = { url: string; headers: Record<string, string> };
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient(
+  responses: Array<Response | Error>,
+): { client: OmiClient; calls: FetchCall[]; sleeps: number[] } {
+  const calls: FetchCall[] = [];
+  const sleeps: number[] = [];
+  const client = new OmiClient({
+    apiKey: "sk_synthetic_not_real",
+    appId: "app-123",
+    userId: "uid-456",
+    fetchImpl: (async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ) => {
+      calls.push({
+        url: String(input),
+        headers: Object.fromEntries(
+          Object.entries((init?.headers ?? {}) as Record<string, string>),
+        ),
+      });
+      const next = responses.shift();
+      if (next === undefined) throw new Error("unexpected extra fetch call");
+      if (next instanceof Error) throw next;
+      return next;
+    }) as typeof fetch,
+    sleep: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  return { client, calls, sleeps };
+}
+
+test("constructor demands key, appId, and userId with actionable messages", () => {
+  assert.throws(
+    () => new OmiClient({ apiKey: "", appId: "a", userId: "u" }),
+    /OMI_API_KEY/,
+  );
+  assert.throws(
+    () => new OmiClient({ apiKey: "sk_x", appId: " ", userId: "u" }),
+    /appId/,
+  );
+  assert.throws(
+    () => new OmiClient({ apiKey: "sk_x", appId: "a", userId: "" }),
+    /userId/,
+  );
+});
+
+test("listConversations sends uid, day bounds, repeated statuses, and unlimited segments", async () => {
+  const { client, calls } = makeClient([
+    jsonResponse({ conversations: [] }),
+  ]);
+  const page = await client.listConversations({
+    startIso: "2026-06-10T00:00:00-05:00",
+    endIso: "2026-06-11T00:00:00-05:00",
+  });
+  assert.equal(page.conversations.length, 0);
+  assert.equal(page.nextOffset, null);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/v2/integrations/app-123/conversations");
+  assert.equal(url.searchParams.get("uid"), "uid-456");
+  assert.equal(url.searchParams.get("start_date"), "2026-06-10T00:00:00-05:00");
+  assert.equal(url.searchParams.get("end_date"), "2026-06-11T00:00:00-05:00");
+  assert.equal(url.searchParams.get("max_transcript_segments"), "-1");
+  assert.equal(url.searchParams.get("include_discarded"), "false");
+  assert.deepEqual(url.searchParams.getAll("statuses"), ["completed"]);
+  assert.equal(calls[0].headers.Authorization, "Bearer sk_synthetic_not_real");
+});
+
+test("offset pagination advances only on full pages", async () => {
+  const fullPage = {
+    conversations: Array.from({ length: 100 }, (_, index) => ({
+      id: `c${index}`,
+    })),
+  };
+  const { client } = makeClient([
+    jsonResponse(fullPage),
+    jsonResponse({ conversations: [{ id: "last" }] }),
+  ]);
+  const first = await client.listConversations({
+    startIso: "2026-06-10T00:00:00Z",
+    endIso: "2026-06-11T00:00:00Z",
+  });
+  assert.equal(first.nextOffset, 100);
+  const second = await client.listConversations({
+    startIso: "2026-06-10T00:00:00Z",
+    endIso: "2026-06-11T00:00:00Z",
+    offset: first.nextOffset ?? 0,
+  });
+  assert.equal(second.nextOffset, null);
+});
+
+test("listMemories paginates with uid and validates the envelope", async () => {
+  const { client, calls } = makeClient([
+    jsonResponse({ memories: [{ id: "m1", content: "User likes tea." }] }),
+  ]);
+  const page = await client.listMemories();
+  assert.equal(page.memories.length, 1);
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/v2/integrations/app-123/memories");
+  assert.equal(url.searchParams.get("uid"), "uid-456");
+
+  const { client: badClient } = makeClient([jsonResponse({})]);
+  await assert.rejects(badClient.listMemories(), /unexpected memories shape/);
+});
+
+test("FastAPI detail strings surface in errors without leaking the key", async () => {
+  const { client } = makeClient([
+    jsonResponse({ detail: "App is not enabled for this user" }, 403),
+  ]);
+  await assert.rejects(
+    client.listConversations({
+      startIso: "2026-06-10T00:00:00Z",
+      endIso: "2026-06-11T00:00:00Z",
+    }),
+    (err: unknown) =>
+      err instanceof OmiApiError &&
+      err.status === 403 &&
+      err.detail === "App is not enabled for this user" &&
+      !err.message.includes("sk_synthetic_not_real"),
+  );
+});
+
+test("retries 429 honoring Retry-After and 5xx with backoff", async () => {
+  const { client, sleeps } = makeClient([
+    new Response(JSON.stringify({ detail: "Rate limit exceeded." }), {
+      status: 429,
+      headers: { "Retry-After": "3" },
+    }),
+    jsonResponse({}, 502),
+    jsonResponse({ conversations: [] }),
+  ]);
+  const page = await client.listConversations({
+    startIso: "2026-06-10T00:00:00Z",
+    endIso: "2026-06-11T00:00:00Z",
+  });
+  assert.equal(page.conversations.length, 0);
+  assert.deepEqual(sleeps, [3_000, 2_000]);
+});
+
+test("verifyAuth maps the authorization chain to actionable detail", async () => {
+  {
+    const { client } = makeClient([
+      jsonResponse({ detail: "Invalid API key" }, 403),
+    ]);
+    const result = await client.verifyAuth();
+    assert.equal(result.ok, false);
+    assert.match(result.detail ?? "", /Invalid API key/);
+    assert.match(result.detail ?? "", /read_conversations|not enabled|key rejected/);
+  }
+  {
+    const { client } = makeClient([jsonResponse({ detail: "not found" }, 404)]);
+    const result = await client.verifyAuth();
+    assert.equal(result.ok, false);
+    assert.match(result.detail ?? "", /appId/);
+  }
+  {
+    const { client } = makeClient([jsonResponse({ conversations: [] })]);
+    assert.deepEqual(await client.verifyAuth(), { ok: true });
+  }
+});

--- a/packages/connector-omi/src/client.ts
+++ b/packages/connector-omi/src/client.ts
@@ -1,0 +1,334 @@
+/**
+ * Minimal Omi Integrations API client (raw fetch, no SDK).
+ *
+ * Contract verified against docs.omi.me and the open-source backend
+ * (`backend/routers/integration.py`, `models/integrations.py`) in
+ * 2026-06:
+ *
+ *  - base `https://api.omi.me`, auth `Authorization: Bearer sk_...`
+ *    (an app API key created in the Omi app; the app needs the
+ *    External Integration `read_conversations` / `read_memories`
+ *    capabilities and must be enabled for the target user)
+ *  - `uid` rides as a query parameter on every endpoint
+ *  - `GET /v2/integrations/{app_id}/conversations` with
+ *    `limit`/`offset` pagination, `start_date`/`end_date` (ISO 8601),
+ *    repeated `statuses` params, and `max_transcript_segments=-1`
+ *    (the API default silently truncates to the first 100 segments)
+ *  - `GET /v2/integrations/{app_id}/memories` with `limit`/`offset`
+ *  - responses serialize with exclude_none — every optional field may
+ *    be entirely absent
+ *  - errors are FastAPI-shaped `{"detail": "..."}`
+ *
+ * The API key is never logged and never appears in thrown error
+ * messages.
+ */
+
+export const OMI_DEFAULT_BASE_URL = "https://api.omi.me";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const MAX_RETRY_DELAY_MS = 30_000;
+/** Page size for both conversations and memories (API max is 1000). */
+const PAGE_SIZE = 100;
+
+export interface OmiTranscriptSegment {
+  text?: string;
+  speaker?: string;
+  is_user?: boolean;
+  person_id?: string | null;
+  start?: number;
+  end?: number;
+}
+
+export interface OmiConversation {
+  id: string;
+  created_at?: string;
+  started_at?: string;
+  finished_at?: string;
+  structured?: {
+    title?: string;
+    overview?: string;
+    category?: string;
+    action_items?: Array<{ description?: string; completed?: boolean }>;
+  };
+  transcript_segments?: OmiTranscriptSegment[];
+  geolocation?: { address?: string | null } | null;
+  status?: string;
+  discarded?: boolean;
+}
+
+export interface OmiMemory {
+  id: string;
+  content?: string;
+  category?: string;
+  tags?: string[];
+  created_at?: string;
+}
+
+export interface OmiConversationsPage {
+  conversations: OmiConversation[];
+  nextOffset: number | null;
+}
+
+export interface OmiMemoriesPage {
+  memories: OmiMemory[];
+  nextOffset: number | null;
+}
+
+export interface OmiClientOptions {
+  apiKey: string;
+  appId: string;
+  userId: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class OmiApiError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    /** FastAPI `detail` string when the body carried one. */
+    readonly detail?: string,
+  ) {
+    super(message);
+    this.name = "OmiApiError";
+  }
+}
+
+export class OmiClient {
+  private readonly apiKey: string;
+  private readonly appId: string;
+  private readonly userId: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: OmiClientOptions) {
+    if (typeof options.apiKey !== "string" || options.apiKey.trim().length === 0) {
+      throw new OmiApiError(
+        "Omi API key is missing. Set wearables.sources.omi.apiKey or the " +
+          "OMI_API_KEY environment variable (create a key under your app's " +
+          "API Keys in the Omi app).",
+      );
+    }
+    if (typeof options.appId !== "string" || options.appId.trim().length === 0) {
+      throw new OmiApiError(
+        "Omi app id is missing. Set wearables.sources.omi.appId to your " +
+          "integration app's id.",
+      );
+    }
+    if (typeof options.userId !== "string" || options.userId.trim().length === 0) {
+      throw new OmiApiError(
+        "Omi user id is missing. Set wearables.sources.omi.userId to the " +
+          "target uid (shown when the user installs/opens your Omi app).",
+      );
+    }
+    this.apiKey = options.apiKey.trim();
+    this.appId = options.appId.trim();
+    this.userId = options.userId.trim();
+    this.baseUrl = (options.baseUrl ?? OMI_DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.sleep =
+      options.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  /** One page of completed conversations inside [startIso, endIso). */
+  async listConversations(params: {
+    startIso: string;
+    endIso: string;
+    offset?: number;
+    signal?: AbortSignal;
+  }): Promise<OmiConversationsPage> {
+    const offset = params.offset ?? 0;
+    const search = new URLSearchParams({
+      uid: this.userId,
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+      start_date: params.startIso,
+      end_date: params.endIso,
+      include_discarded: "false",
+      // -1 = unlimited; the API default silently truncates transcripts
+      // to their first 100 segments.
+      max_transcript_segments: "-1",
+    });
+    // Repeated param (FastAPI List[str]) — comma-joining does NOT work.
+    search.append("statuses", "completed");
+    const payload = await this.requestJson(
+      `/v2/integrations/${encodeURIComponent(this.appId)}/conversations?${search.toString()}`,
+      params.signal,
+    );
+    const conversations = (payload as { conversations?: unknown }).conversations;
+    if (!Array.isArray(conversations)) {
+      throw new OmiApiError(
+        "Omi API returned an unexpected conversations shape (missing conversations array)",
+      );
+    }
+    const valid = conversations.filter(
+      (entry): entry is OmiConversation =>
+        entry !== null &&
+        typeof entry === "object" &&
+        typeof (entry as { id?: unknown }).id === "string",
+    );
+    return {
+      conversations: valid,
+      nextOffset: conversations.length === PAGE_SIZE ? offset + PAGE_SIZE : null,
+    };
+  }
+
+  /** One page of Omi memories (provider-extracted facts). */
+  async listMemories(params: {
+    offset?: number;
+    signal?: AbortSignal;
+  } = {}): Promise<OmiMemoriesPage> {
+    const offset = params.offset ?? 0;
+    const search = new URLSearchParams({
+      uid: this.userId,
+      limit: String(PAGE_SIZE),
+      offset: String(offset),
+    });
+    const payload = await this.requestJson(
+      `/v2/integrations/${encodeURIComponent(this.appId)}/memories?${search.toString()}`,
+      params.signal,
+    );
+    const memories = (payload as { memories?: unknown }).memories;
+    if (!Array.isArray(memories)) {
+      throw new OmiApiError(
+        "Omi API returned an unexpected memories shape (missing memories array)",
+      );
+    }
+    const valid = memories.filter(
+      (entry): entry is OmiMemory =>
+        entry !== null &&
+        typeof entry === "object" &&
+        typeof (entry as { id?: unknown }).id === "string",
+    );
+    return {
+      memories: valid,
+      nextOffset: memories.length === PAGE_SIZE ? offset + PAGE_SIZE : null,
+    };
+  }
+
+  async verifyAuth(signal?: AbortSignal): Promise<{ ok: boolean; detail?: string }> {
+    try {
+      const search = new URLSearchParams({
+        uid: this.userId,
+        limit: "1",
+        offset: "0",
+        max_transcript_segments: "1",
+      });
+      await this.requestJson(
+        `/v2/integrations/${encodeURIComponent(this.appId)}/conversations?${search.toString()}`,
+        signal,
+      );
+      return { ok: true };
+    } catch (err) {
+      if (err instanceof OmiApiError && err.status !== undefined) {
+        // The backend's authorization chain yields distinct, actionable
+        // detail strings: bad key (403), app not enabled for the user
+        // (403), missing capability (403), app not found (404).
+        const hint =
+          err.status === 401
+            ? "missing/malformed Authorization header"
+            : err.status === 403
+              ? "key rejected, app not enabled for this uid, or missing read_conversations capability"
+              : err.status === 404
+                ? "app not found — check wearables.sources.omi.appId"
+                : undefined;
+        return {
+          ok: false,
+          detail: [err.detail, hint].filter(Boolean).join(" — ") || err.message,
+        };
+      }
+      return {
+        ok: false,
+        detail: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  private async requestJson(pathAndQuery: string, signal?: AbortSignal): Promise<unknown> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      signal?.throwIfAborted();
+      const timeoutSignal = AbortSignal.timeout(this.timeoutMs);
+      const combined = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+      let response: Response;
+      try {
+        response = await this.fetchImpl(`${this.baseUrl}${pathAndQuery}`, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            Accept: "application/json",
+          },
+          signal: combined,
+        });
+      } catch (err) {
+        if (signal?.aborted) throw err;
+        lastError = err;
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(backoffMs(attempt));
+          continue;
+        }
+        throw new OmiApiError(
+          `Omi API request failed after ${MAX_RETRIES + 1} attempts: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+
+      if (response.status === 429 || response.status >= 500) {
+        lastError = new OmiApiError(
+          `Omi API responded ${response.status}`,
+          response.status,
+          await readDetail(response),
+        );
+        if (attempt < MAX_RETRIES) {
+          await this.sleep(retryDelayMs(response, attempt));
+          continue;
+        }
+        throw lastError;
+      }
+      if (!response.ok) {
+        throw new OmiApiError(
+          `Omi API responded ${response.status} for ${pathAndQuery.split("?")[0]}`,
+          response.status,
+          await readDetail(response),
+        );
+      }
+      try {
+        return await response.json();
+      } catch {
+        throw new OmiApiError("Omi API returned a non-JSON body");
+      }
+    }
+    throw lastError instanceof Error ? lastError : new OmiApiError("Omi API request failed");
+  }
+}
+
+async function readDetail(response: Response): Promise<string | undefined> {
+  try {
+    const body = (await response.clone().json()) as { detail?: unknown };
+    return typeof body?.detail === "string" ? body.detail : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function backoffMs(attempt: number): number {
+  return Math.min(MAX_RETRY_DELAY_MS, 1_000 * 2 ** attempt);
+}
+
+function retryDelayMs(response: Response, attempt: number): number {
+  const headerValue = response.headers.get("retry-after");
+  if (headerValue !== null) {
+    const parsed = Number(headerValue);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.min(MAX_RETRY_DELAY_MS, Math.ceil(parsed * 1_000));
+    }
+  }
+  return backoffMs(attempt);
+}

--- a/packages/connector-omi/src/client.ts
+++ b/packages/connector-omi/src/client.ts
@@ -129,7 +129,7 @@ export class OmiClient {
     this.apiKey = options.apiKey.trim();
     this.appId = options.appId.trim();
     this.userId = options.userId.trim();
-    this.baseUrl = (options.baseUrl ?? OMI_DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.baseUrl = stripTrailingSlashes(options.baseUrl ?? OMI_DEFAULT_BASE_URL);
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.sleep =
@@ -307,6 +307,13 @@ export class OmiClient {
     }
     throw lastError instanceof Error ? lastError : new OmiApiError("Omi API request failed");
   }
+}
+
+/** Loop instead of `/\/+$/` — CodeQL js/polynomial-redos on user-set URLs. */
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 0x2f) end--;
+  return value.slice(0, end);
 }
 
 async function readDetail(response: Response): Promise<string | undefined> {

--- a/packages/connector-omi/src/client.ts
+++ b/packages/connector-omi/src/client.ts
@@ -243,9 +243,14 @@ export class OmiClient {
           detail: [err.detail, hint].filter(Boolean).join(" — ") || err.message,
         };
       }
+      // OmiApiError messages are our own constructed strings (already
+      // scrubbed — network text is reduced to name + code inside
+      // requestJson); foreign errors reduce to name + errno code so raw
+      // Node text (paths, loader stacks) never reaches operator
+      // surfaces.
       return {
         ok: false,
-        detail: err instanceof Error ? err.message : String(err),
+        detail: err instanceof OmiApiError ? err.message : describeNetworkError(err),
       };
     }
   }

--- a/packages/connector-omi/src/client.ts
+++ b/packages/connector-omi/src/client.ts
@@ -274,9 +274,7 @@ export class OmiClient {
           continue;
         }
         throw new OmiApiError(
-          `Omi API request failed after ${MAX_RETRIES + 1} attempts: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
+          `Omi API request failed after ${MAX_RETRIES + 1} attempts: ${describeNetworkError(err)}`,
         );
       }
 
@@ -307,6 +305,17 @@ export class OmiClient {
     }
     throw lastError instanceof Error ? lastError : new OmiApiError("Omi API request failed");
   }
+}
+
+/**
+ * Network/timeout failures wrap Node error text that can carry loader
+ * paths or stack fragments; sync errors reach MCP clients verbatim, so
+ * only the error name + code survive.
+ */
+function describeNetworkError(err: unknown): string {
+  if (!(err instanceof Error)) return "unexpected non-Error failure";
+  const code = (err as NodeJS.ErrnoException).code;
+  return typeof code === "string" && code.length > 0 ? `${err.name} (${code})` : err.name;
 }
 
 /** Loop instead of `/\/+$/` — CodeQL js/polynomial-redos on user-set URLs. */

--- a/packages/connector-omi/src/index.test.ts
+++ b/packages/connector-omi/src/index.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { getWearableConnector } from "@remnic/core";
+import type { WearableSourceSettings } from "@remnic/core";
+
+import {
+  createOmiConnector,
+  ensureOmiConnectorRegistered,
+  resolveOmiApiKey,
+  wearableConnectorRegistration,
+} from "./index.js";
+
+function settings(overrides: Partial<WearableSourceSettings> = {}): WearableSourceSettings {
+  return {
+    enabled: true,
+    apiKey: "sk_synthetic_not_real",
+    appId: "app-123",
+    userId: "uid-456",
+    memoryMode: "review",
+    minConfidence: 0.6,
+    minImportance: "low",
+    maxMemoriesPerDay: 20,
+    importNativeMemories: "off",
+    cleanup: {
+      mergeSameSpeaker: true,
+      stripFillers: true,
+      collapseRepeats: true,
+      dropLowQuality: true,
+    },
+    ...overrides,
+  };
+}
+
+function stubFetch(handler: (url: URL) => unknown): {
+  restore: () => void;
+  urls: URL[];
+} {
+  const original = globalThis.fetch;
+  const urls: URL[] = [];
+  globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+    const url = new URL(String(input));
+    urls.push(url);
+    return new Response(JSON.stringify(handler(url)), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    urls,
+  };
+}
+
+test("importing the module registers the connector exactly once", () => {
+  assert.ok(getWearableConnector("omi"));
+  assert.equal(ensureOmiConnectorRegistered(), false);
+  assert.equal(wearableConnectorRegistration.id, "omi");
+});
+
+test("resolveOmiApiKey prefers config, then REMNIC_*, then provider env", () => {
+  assert.equal(resolveOmiApiKey("from-config", {}), "from-config");
+  assert.equal(
+    resolveOmiApiKey(undefined, {
+      REMNIC_OMI_API_KEY: "remnic-env",
+      OMI_API_KEY: "provider-env",
+    }),
+    "remnic-env",
+  );
+  assert.equal(resolveOmiApiKey(undefined, { OMI_API_KEY: "provider-env" }), "provider-env");
+  assert.equal(resolveOmiApiKey(undefined, {}), undefined);
+});
+
+test("fetchConversations applies timezone day bounds and maps cursors to offsets", async () => {
+  const stub = stubFetch((url) => {
+    assert.equal(url.searchParams.get("start_date"), "2026-06-10T00:00:00-05:00");
+    assert.equal(url.searchParams.get("end_date"), "2026-06-11T00:00:00-05:00");
+    return {
+      conversations: [
+        {
+          id: "c1",
+          started_at: "2026-06-10T15:00:00+00:00",
+          transcript_segments: [
+            { text: "Planning the launch.", speaker: "SPEAKER_00", is_user: true, start: 0, end: 4 },
+          ],
+        },
+        { id: "c2", started_at: "2026-06-10T16:00:00+00:00", discarded: true },
+      ],
+    };
+  });
+  try {
+    const connector = createOmiConnector({
+      settings: settings(),
+      timezone: "America/Chicago",
+    });
+    const page = await connector.fetchConversations({
+      date: "2026-06-10",
+      timezone: "America/Chicago",
+      cursor: "200",
+    });
+    assert.deepEqual(page.conversations.map((c) => c.id), ["c1"], "discarded filtered");
+    assert.equal(page.nextCursor, null, "partial page ends pagination");
+    assert.equal(stub.urls[0].searchParams.get("offset"), "200");
+  } finally {
+    stub.restore();
+  }
+});
+
+test("missing credentials surface actionable errors at call time, not construction", async () => {
+  const connector = createOmiConnector({
+    settings: settings({ apiKey: undefined, appId: undefined, userId: undefined }),
+    timezone: "UTC",
+  });
+  const previousRemnic = process.env.REMNIC_OMI_API_KEY;
+  const previousProvider = process.env.OMI_API_KEY;
+  delete process.env.REMNIC_OMI_API_KEY;
+  delete process.env.OMI_API_KEY;
+  try {
+    await assert.rejects(
+      connector.fetchConversations({ date: "2026-06-10", timezone: "UTC" }),
+      /OMI_API_KEY/,
+    );
+  } finally {
+    if (previousRemnic !== undefined) process.env.REMNIC_OMI_API_KEY = previousRemnic;
+    if (previousProvider !== undefined) process.env.OMI_API_KEY = previousProvider;
+  }
+});
+
+test("fetchNativeMemories maps Omi memories and skips empty content", async () => {
+  const stub = stubFetch(() => ({
+    memories: [
+      { id: "m1", content: "User runs on Saturdays." },
+      { id: "m2", content: "" },
+    ],
+  }));
+  try {
+    const connector = createOmiConnector({ settings: settings(), timezone: "UTC" });
+    assert.ok(connector.fetchNativeMemories, "omi connector must support native memories");
+    const page = await connector.fetchNativeMemories({});
+    assert.deepEqual(page.memories.map((memory) => memory.id), ["m1"]);
+    assert.equal(page.nextCursor, null);
+  } finally {
+    stub.restore();
+  }
+});

--- a/packages/connector-omi/src/index.ts
+++ b/packages/connector-omi/src/index.ts
@@ -1,0 +1,155 @@
+/**
+ * @remnic/connector-omi — Omi AI wearable connector.
+ *
+ * À-la-carte optional companion of @remnic/core (computed-specifier
+ * discovery; importing this module self-registers idempotently).
+ *
+ * Requires an Omi integration app with the External Integration
+ * `read_conversations` (and, for native-memory import,
+ * `read_memories`) capabilities:
+ *   - `wearables.sources.omi.appId`  — the app id
+ *   - `wearables.sources.omi.userId` — the target uid
+ *   - key via `REMNIC_OMI_API_KEY` / `OMI_API_KEY` env (or `apiKey`)
+ */
+
+import {
+  registerWearableConnector,
+  getWearableConnector,
+  type WearableConnectorFactoryOptions,
+  type WearableConnectorRegistration,
+  type WearableFetchOptions,
+  type WearableFetchPage,
+  type WearableNativeMemoryPage,
+  type WearableSourceConnector,
+} from "@remnic/core";
+
+import { OmiClient } from "./client.js";
+import {
+  conversationToWearable,
+  memoryToNativeMemory,
+  OMI_SOURCE_ID,
+  zonedDayBounds,
+} from "./normalize.js";
+
+export { OmiApiError, OmiClient, OMI_DEFAULT_BASE_URL } from "./client.js";
+export type {
+  OmiClientOptions,
+  OmiConversation,
+  OmiConversationsPage,
+  OmiMemoriesPage,
+  OmiMemory,
+  OmiTranscriptSegment,
+} from "./client.js";
+export {
+  conversationToWearable,
+  memoryToNativeMemory,
+  nextIsoDate,
+  OMI_SOURCE_ID,
+  timezoneOffsetIso,
+  zonedDayBounds,
+  zonedDayStartIso,
+} from "./normalize.js";
+
+export function resolveOmiApiKey(
+  configuredKey: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (typeof configuredKey === "string" && configuredKey.trim().length > 0) {
+    return configuredKey.trim();
+  }
+  for (const name of ["REMNIC_OMI_API_KEY", "OMI_API_KEY"]) {
+    const value = env[name];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function parseOffsetCursor(cursor: string | null | undefined): number {
+  if (typeof cursor !== "string" || cursor.length === 0) return 0;
+  const parsed = Number(cursor);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+export function createOmiConnector(
+  options: WearableConnectorFactoryOptions,
+): WearableSourceConnector {
+  // Construction is lazy so `wearables status` works without
+  // credentials; the client constructor throws the actionable
+  // missing-credential messages at call time.
+  let client: OmiClient | null = null;
+  const getClient = (): OmiClient => {
+    if (!client) {
+      client = new OmiClient({
+        apiKey: resolveOmiApiKey(options.settings.apiKey) ?? "",
+        appId: options.settings.appId ?? "",
+        userId: options.settings.userId ?? "",
+        baseUrl: options.settings.baseUrl,
+      });
+    }
+    return client;
+  };
+
+  return {
+    id: OMI_SOURCE_ID,
+    displayName: "Omi",
+    async verifyAuth(signal?: AbortSignal) {
+      return getClient().verifyAuth(signal);
+    },
+    async fetchConversations(opts: WearableFetchOptions): Promise<WearableFetchPage> {
+      const bounds = zonedDayBounds(opts.date, opts.timezone);
+      const page = await getClient().listConversations({
+        startIso: bounds.startIso,
+        endIso: bounds.endIso,
+        offset: parseOffsetCursor(opts.cursor),
+        signal: opts.signal,
+      });
+      return {
+        conversations: page.conversations
+          .filter((conversation) => conversation.discarded !== true)
+          .map(conversationToWearable),
+        nextCursor: page.nextOffset !== null ? String(page.nextOffset) : null,
+      };
+    },
+    async fetchNativeMemories(opts: {
+      cursor?: string | null;
+      signal?: AbortSignal;
+    }): Promise<WearableNativeMemoryPage> {
+      const page = await getClient().listMemories({
+        offset: parseOffsetCursor(opts.cursor),
+        signal: opts.signal,
+      });
+      const memories = [];
+      for (const memory of page.memories) {
+        const mapped = memoryToNativeMemory(memory);
+        if (mapped !== null) memories.push(mapped);
+      }
+      return {
+        memories,
+        nextCursor: page.nextOffset !== null ? String(page.nextOffset) : null,
+      };
+    },
+  };
+}
+
+export const wearableConnectorRegistration: WearableConnectorRegistration = {
+  id: OMI_SOURCE_ID,
+  displayName: "Omi",
+  factory: createOmiConnector,
+};
+
+/**
+ * Idempotently register the connector with the core registry. Importing
+ * this module registers it as a side effect; calling this again is safe
+ * (returns false when already registered).
+ */
+export function ensureOmiConnectorRegistered(): boolean {
+  if (getWearableConnector(OMI_SOURCE_ID) !== undefined) {
+    return false;
+  }
+  registerWearableConnector(wearableConnectorRegistration);
+  return true;
+}
+
+ensureOmiConnectorRegistered();

--- a/packages/connector-omi/src/normalize.test.ts
+++ b/packages/connector-omi/src/normalize.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  conversationToWearable,
+  memoryToNativeMemory,
+  nextIsoDate,
+  timezoneOffsetIso,
+  zonedDayBounds,
+} from "./normalize.js";
+
+test("timezoneOffsetIso resolves fixed and DST offsets", () => {
+  const june = new Date("2026-06-10T12:00:00Z");
+  const january = new Date("2026-01-10T12:00:00Z");
+  assert.equal(timezoneOffsetIso(june, "UTC"), "+00:00");
+  assert.equal(timezoneOffsetIso(june, "America/Chicago"), "-05:00");
+  assert.equal(timezoneOffsetIso(january, "America/Chicago"), "-06:00");
+  assert.equal(timezoneOffsetIso(june, "Asia/Kolkata"), "+05:30");
+  // Unknown zone falls back to UTC instead of crashing the sync.
+  assert.equal(timezoneOffsetIso(june, "Not/AZone"), "+00:00");
+});
+
+test("nextIsoDate handles month and year boundaries", () => {
+  assert.equal(nextIsoDate("2026-06-10"), "2026-06-11");
+  assert.equal(nextIsoDate("2026-06-30"), "2026-07-01");
+  assert.equal(nextIsoDate("2026-12-31"), "2027-01-01");
+  assert.equal(nextIsoDate("2028-02-28"), "2028-02-29");
+});
+
+test("zonedDayBounds produces a half-open local-day window", () => {
+  const bounds = zonedDayBounds("2026-06-10", "America/Chicago");
+  assert.equal(bounds.startIso, "2026-06-10T00:00:00-05:00");
+  assert.equal(bounds.endIso, "2026-06-11T00:00:00-05:00");
+  const utc = zonedDayBounds("2026-06-10", "UTC");
+  assert.equal(utc.startIso, "2026-06-10T00:00:00+00:00");
+  assert.equal(utc.endIso, "2026-06-11T00:00:00+00:00");
+});
+
+const CONVERSATION = {
+  id: "omi-1",
+  created_at: "2026-06-10T14:00:05+00:00",
+  started_at: "2026-06-10T14:00:00+00:00",
+  finished_at: "2026-06-10T14:20:00+00:00",
+  structured: {
+    title: "Walk and talk",
+    overview: "Planned the trip.",
+    category: "travel",
+  },
+  geolocation: { address: "Example Park" },
+  status: "completed",
+  transcript_segments: [
+    { text: "Let's plan the August trip.", speaker: "SPEAKER_00", is_user: true, start: 10, end: 14 },
+    { text: "Flights first, then the hotel.", speaker: "SPEAKER_01", is_user: false, person_id: "person-7", start: 15, end: 19 },
+    { text: "   ", speaker: "SPEAKER_01", is_user: false },
+  ],
+};
+
+test("maps conversation metadata and derives segment timestamps from offsets", () => {
+  const conversation = conversationToWearable(CONVERSATION);
+  assert.equal(conversation.id, "omi-1");
+  assert.equal(conversation.source, "omi");
+  assert.equal(conversation.title, "Walk and talk");
+  assert.equal(conversation.summary, "Planned the trip.");
+  assert.equal(conversation.location, "Example Park");
+  assert.equal(conversation.startIso, "2026-06-10T14:00:00+00:00");
+  assert.equal(conversation.segments.length, 2);
+  assert.equal(conversation.segments[0].startIso, "2026-06-10T14:00:10.000Z");
+  assert.equal(conversation.segments[0].endIso, "2026-06-10T14:00:14.000Z");
+});
+
+test("wearer keys as 'user'; known people key by person_id", () => {
+  const conversation = conversationToWearable(CONVERSATION);
+  const [wearer, other] = conversation.segments;
+  assert.equal(wearer.isWearer, true);
+  assert.equal(wearer.speakerKey, "user");
+  assert.equal(other.isWearer, undefined);
+  assert.equal(other.speakerKey, "person-7");
+  assert.equal(other.speakerName, "SPEAKER_01");
+});
+
+test("tolerates absent optional fields (exclude_none serialization)", () => {
+  const conversation = conversationToWearable({ id: "sparse-1" });
+  assert.equal(conversation.segments.length, 0);
+  assert.equal(conversation.startIso, "");
+  assert.equal(conversation.title, undefined);
+});
+
+test("maps Omi memories and drops empty/locked-truncated-empty content", () => {
+  assert.deepEqual(
+    memoryToNativeMemory({
+      id: "m1",
+      content: "User prefers window seats.",
+      created_at: "2026-06-01T00:00:00+00:00",
+      tags: ["travel"],
+    }),
+    {
+      id: "m1",
+      content: "User prefers window seats.",
+      createdIso: "2026-06-01T00:00:00+00:00",
+      tags: ["travel"],
+    },
+  );
+  assert.equal(memoryToNativeMemory({ id: "m2", content: "  " }), null);
+  assert.equal(memoryToNativeMemory({ id: "m3" }), null);
+});

--- a/packages/connector-omi/src/normalize.ts
+++ b/packages/connector-omi/src/normalize.ts
@@ -1,0 +1,137 @@
+/**
+ * Normalize Omi conversations into Remnic's provider-agnostic
+ * `WearableConversation` shape, plus the timezone-aware day-window
+ * helpers the Omi API needs (its date filters are ISO datetimes).
+ *
+ * Omi segments carry `is_user` for the wearer, opaque `SPEAKER_NN`
+ * diarization labels, optional `person_id`s (user-defined people), and
+ * start/end offsets in seconds relative to the conversation start.
+ */
+
+import type {
+  WearableConversation,
+  WearableNativeMemory,
+  WearableTranscriptSegment,
+} from "@remnic/core";
+
+import type { OmiConversation, OmiMemory } from "./client.js";
+
+export const OMI_SOURCE_ID = "omi";
+
+/** "GMT+05:30" → "+05:30"; plain "GMT" → "+00:00". */
+export function timezoneOffsetIso(instant: Date, timezone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "longOffset",
+    }).formatToParts(instant);
+    const name = parts.find((part) => part.type === "timeZoneName")?.value ?? "GMT";
+    const match = name.match(/GMT([+-]\d{2}:\d{2})?/);
+    return match?.[1] ?? "+00:00";
+  } catch {
+    return "+00:00";
+  }
+}
+
+/** ISO instant for local midnight of `date` in `timezone`. */
+export function zonedDayStartIso(date: string, timezone: string): string {
+  // Two-pass offset resolution: guess from midday (stable away from DST
+  // transitions), then re-derive at the candidate midnight itself.
+  let offset = timezoneOffsetIso(new Date(`${date}T12:00:00Z`), timezone);
+  const candidate = new Date(`${date}T00:00:00${offset}`);
+  const refined = timezoneOffsetIso(candidate, timezone);
+  if (refined !== offset) {
+    offset = refined;
+  }
+  return `${date}T00:00:00${offset}`;
+}
+
+export function nextIsoDate(date: string): string {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + 1);
+  return parsed.toISOString().slice(0, 10);
+}
+
+/** Half-open [start, end) ISO bounds of a local day. */
+export function zonedDayBounds(
+  date: string,
+  timezone: string,
+): { startIso: string; endIso: string } {
+  return {
+    startIso: zonedDayStartIso(date, timezone),
+    endIso: zonedDayStartIso(nextIsoDate(date), timezone),
+  };
+}
+
+export function conversationToWearable(
+  conversation: OmiConversation,
+): WearableConversation {
+  const startedAtMs = conversation.started_at
+    ? Date.parse(conversation.started_at)
+    : Number.NaN;
+  const segments: WearableTranscriptSegment[] = [];
+  for (const segment of conversation.transcript_segments ?? []) {
+    const text = typeof segment.text === "string" ? segment.text.trim() : "";
+    if (text.length === 0) continue;
+    const isWearer = segment.is_user === true;
+    const personId =
+      typeof segment.person_id === "string" && segment.person_id.length > 0
+        ? segment.person_id
+        : undefined;
+    const label =
+      typeof segment.speaker === "string" && segment.speaker.trim().length > 0
+        ? segment.speaker.trim()
+        : undefined;
+    const startIso =
+      !Number.isNaN(startedAtMs) && typeof segment.start === "number"
+        ? new Date(startedAtMs + segment.start * 1_000).toISOString()
+        : undefined;
+    const endIso =
+      !Number.isNaN(startedAtMs) && typeof segment.end === "number"
+        ? new Date(startedAtMs + segment.end * 1_000).toISOString()
+        : undefined;
+    segments.push({
+      text,
+      // person_id is the most stable key when the user has tagged the
+      // speaker as a known person in Omi; the diarization label
+      // otherwise.
+      speakerKey: isWearer ? "user" : (personId ?? label ?? "unknown"),
+      ...(label !== undefined ? { speakerName: label } : {}),
+      ...(isWearer ? { isWearer: true } : {}),
+      ...(startIso !== undefined ? { startIso } : {}),
+      ...(endIso !== undefined ? { endIso } : {}),
+    });
+  }
+
+  const title = conversation.structured?.title?.trim();
+  const overview = conversation.structured?.overview?.trim();
+  const address = conversation.geolocation?.address;
+
+  return {
+    id: conversation.id,
+    source: OMI_SOURCE_ID,
+    ...(title && title.length > 0 ? { title } : {}),
+    ...(overview && overview.length > 0 ? { summary: overview } : {}),
+    startIso: conversation.started_at ?? conversation.created_at ?? "",
+    ...(conversation.finished_at !== undefined
+      ? { endIso: conversation.finished_at }
+      : {}),
+    ...(typeof address === "string" && address.length > 0
+      ? { location: address }
+      : {}),
+    segments,
+  };
+}
+
+export function memoryToNativeMemory(memory: OmiMemory): WearableNativeMemory | null {
+  const content = typeof memory.content === "string" ? memory.content.trim() : "";
+  if (content.length === 0) return null;
+  return {
+    id: memory.id,
+    content,
+    ...(memory.created_at !== undefined ? { createdIso: memory.created_at } : {}),
+    ...(Array.isArray(memory.tags) && memory.tags.length > 0
+      ? { tags: memory.tags }
+      : {}),
+  };
+}

--- a/packages/connector-omi/tsconfig.json
+++ b/packages/connector-omi/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -49,7 +49,8 @@
     "@remnic/import-mem0": "^9.3.626",
     "@remnic/import-supermemory": "^9.3.626",
     "@remnic/connector-limitless": "^9.3.626",
-    "@remnic/connector-bee": "^9.3.626"
+    "@remnic/connector-bee": "^9.3.626",
+    "@remnic/connector-omi": "^9.3.626"
   },
   "peerDependenciesMeta": {
     "@remnic/bench": {
@@ -84,6 +85,9 @@
     },
     "@remnic/connector-bee": {
       "optional": true
+    },
+    "@remnic/connector-omi": {
+      "optional": true
     }
   },
   "devDependencies": {
@@ -99,7 +103,8 @@
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "@remnic/connector-limitless": "workspace:*",
-    "@remnic/connector-bee": "workspace:*"
+    "@remnic/connector-bee": "workspace:*",
+    "@remnic/connector-omi": "workspace:*"
   },
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/connector-omi:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/connector-replit:
     devDependencies:
       tsup:
@@ -411,6 +426,9 @@ importers:
       '@remnic/connector-limitless':
         specifier: workspace:*
         version: link:../connector-limitless
+      '@remnic/connector-omi':
+        specifier: workspace:*
+        version: link:../connector-omi
       '@remnic/export-weclone':
         specifier: workspace:*
         version: link:../export-weclone

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -542,7 +542,7 @@ tests/recall-hardening.test.ts(754,3): TS2349
 tests/recall-hardening.test.ts(812,3): TS2349
 tests/recall-hardening.test.ts(814,3): TS2349
 tests/recall-no-recall-short-circuit.test.ts(14,3): TS2740
-tests/release-workflow-public-packages.test.ts(150,41): TS7016
+tests/release-workflow-public-packages.test.ts(151,41): TS7016
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006
 tests/remnic-plugin-register-migration.test.ts(66,12): TS2352
 tests/remnic-server-cli.test.ts(9,30): TS7016

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -22,6 +22,7 @@ const expectedPublishDirs = [
   "packages/connector-replit",
   "packages/connector-limitless",
   "packages/connector-bee",
+  "packages/connector-omi",
   "packages/hermes-provider",
   "packages/belief-ledger",
   "packages/remnic-server",


### PR DESCRIPTION
## Summary

Third and final wearable-integration PR (follows #1458 — shared subsystem + Limitless — and #1459 — Bee). A **pure additive package**: `@remnic/connector-omi`, implementing the `WearableSourceConnector` contract for the Omi AI necklace against the Omi Integrations API (contract verified against docs.omi.me AND the open-source backend source, `routers/integration.py` / `models/integrations.py`).

### What it does

- **Auth & scoping**: `Authorization: Bearer sk_...` app keys with `uid` query parameter on every call; requires `appId` + `userId` in config (External Integration app with `read_conversations` / `read_memories` capabilities). Constructor demands all three with actionable messages, resolved lazily so `wearables status` works without credentials.
- **Timezone-correct day windows**: computes local-midnight ISO bounds with a two-pass DST-aware offset resolution (`zonedDayBounds`) for the API's `start_date`/`end_date` filters; only `completed`, non-discarded conversations sync.
- **Unabridged transcripts**: passes `max_transcript_segments=-1` because the API's default silently truncates conversations to their first 100 segments (verified in backend source); `statuses` is sent as a repeated query param (FastAPI `List[str]` does not split commas).
- **Speaker mapping**: the wearer arrives pre-identified (`is_user`); known people key by stable `person_id`, other voices by `SPEAKER_NN` diarization labels — all remappable once via the core speaker registry. Segment timestamps derive from `started_at` + per-segment second offsets.
- **Native memory import**: `fetchNativeMemories` maps Omi's "memories" (its extracted facts) for the review-queue import path — always `pending_review`.
- **Hardening parity with the full #1458/#1459 review history**: offset pagination mapped to the connector cursor contract (advances only on full pages), retry on 429 (`Retry-After` honored) + 5xx, FastAPI `detail` strings surfaced in errors and `verifyAuth` guidance distinguishing bad-key / app-not-enabled / missing-capability / app-not-found, network failures reduced to error name + errno code (never raw Node text), loop-based trailing-slash trim, keys never logged, `exclude_none` tolerance (every optional field may be absent), standard `precheck-types`, publish-order + root-typecheck contract tests updated.

### Tests

19 connector tests: constructor validation, query-param contract (uid, day bounds, repeated statuses, `max_transcript_segments=-1`, `include_discarded=false`), offset pagination semantics, memories envelope validation, FastAPI detail surfacing without key leakage, 429/5xx retry, auth-chain guidance mapping, DST offset + day-bound helpers (fixed/DST/half-hour zones, month/year/leap boundaries), normalization (segment timestamp derivation, wearer/person keying, `exclude_none` tolerance), discarded filtering, cursor→offset mapping, native-memory mapping + empty-content skipping, registration idempotency, lazy credential errors.

### Gates

`preflight:quick` ✅ · connector check-types + tests ✅ · publish-order/root-typecheck contract tests ✅ · docs landed in #1458 (`docs/wearables.md` Omi section); the package README covers app creation, capabilities, key/uid setup end-to-end.

This completes the wearable-connector family: Limitless ✅ (#1458) · Bee ✅ (#1459) · Omi (this PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional package with no changes to core auth or storage; API keys are kept out of logs and error surfaces.
> 
> **Overview**
> Adds **`@remnic/connector-omi`**, an optional wearable source that plugs into Remnic’s existing `WearableSourceConnector` flow for the Omi necklace via the Omi Integrations API.
> 
> The package ships an **`OmiClient`** (Bearer app key + `uid`, offset pagination, 429/`Retry-After` and 5xx retries, scrubbed errors and `verifyAuth` hints) and maps API payloads into core wearable types: **DST-aware local-day bounds** for sync windows, **`max_transcript_segments=-1`** so transcripts aren’t capped at 100 segments, filtering of discarded conversations, **speaker keys** (`user` / `person_id` / diarization labels), and optional **`fetchNativeMemories`** for Omi-extracted facts. The connector **self-registers** on import with lazy credential resolution so status commands work without keys.
> 
> **Wiring only:** `@remnic/cli` optional peer + workspace dev dep, publish-order list in release tests, lockfile entry, and package README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac029aa66d3c3a6f9b1cc243d5cf92b06a9e189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->