### PR TITLE
fix(release): unprovisioned first-publish packages no longer strand the release train

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -543,6 +543,13 @@ jobs:
           # plugins) must ship so end users can install only what they need
           # — see the à-la-carte invariant in CLAUDE.md / AGENTS.md.
           mapfile -t PUBLISH_ORDER < "${RUNNER_TEMP}/remnic-publish-order.txt"
+          # New packages that npm rejects with E404 on their FIRST publish
+          # (trusted publishing not yet provisioned for the name) must not
+          # strand every package after them in topological order — that
+          # left @remnic/cli and friends lagging whole release trains.
+          # They are collected, surfaced loudly, and skipped; everything
+          # else still publishes. Any other publish failure remains fatal.
+          UNPROVISIONED=()
           for pkg_dir in "${PUBLISH_ORDER[@]}"; do
             pkg_json="$pkg_dir/package.json"
             if [ ! -f "$pkg_json" ]; then
@@ -574,14 +581,28 @@ jobs:
               publish_status=$?
               cat "$publish_log"
               if [ "$pkg_exists" != "true" ] && grep -q "npm error code E404" "$publish_log"; then
-                echo "::error::${pkg_name}@${pkg_version} is not provisioned for first-time npm publish from this automation. Set up trusted publishing for this package, then rerun the release workflow."
+                echo "::warning::${pkg_name}@${pkg_version} is not provisioned for first-time npm publish from this automation. Set up trusted publishing for this package name, then rerun the release workflow (already-published packages are skipped automatically). Continuing with the remaining packages."
+                UNPROVISIONED+=("${pkg_name}@${pkg_version}")
                 rm -f "$publish_log"
-                exit $publish_status
+                continue
               fi
               rm -f "$publish_log"
               exit $publish_status
             fi
           done
+          if [ "${#UNPROVISIONED[@]}" -gt 0 ]; then
+            {
+              echo "## Unprovisioned first-time packages (not published)"
+              echo ""
+              echo "Provision npm trusted publishing for each name, then rerun this workflow:"
+              echo ""
+              for entry in "${UNPROVISIONED[@]}"; do
+                echo "- \\`$entry\\`"
+              done
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::${#UNPROVISIONED[@]} package(s) require one-time trusted-publishing provisioning (see step summary). All other packages were published."
+            exit 1
+          fi
 
       - name: Publish root package to npm
         run: |


### PR DESCRIPTION
## Summary

The release workflow publishes via OIDC trusted publishing. A brand-new package name that npm rejects with **E404 on its first publish** (trusted publishing not yet provisioned for that name) aborted the whole publish loop — every package after it in topological order was stranded. That is why `@remnic/cli`, `@remnic/plugin-openclaw`, and the `import-*` family sat at 9.3.624 while `@remnic/core` advanced to 9.3.626+ after the wearable-connector merges (#1458–#1460) introduced three new package names.

## Change

In the publish step only:
- E404-on-first-publish packages are **warned, collected, and skipped** — all remaining packages still publish.
- The run ends with a `$GITHUB_STEP_SUMMARY` checklist of the names needing one-time trusted-publishing provisioning, and **still exits 1** so the condition stays loud (CI never silences a partial deploy).
- Every other publish failure remains immediately fatal, unchanged.

After the three connector names are provisioned on npmjs.com, the next run's already-published-skip logic catches everything up in one pass.

No behavior change for fully-provisioned releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to error handling in the npm publish loop; no runtime or auth logic changes, with non-E404 failures still fatal.
> 
> **Overview**
> **Release npm publish** no longer aborts the whole topological publish loop when a **brand-new package name** fails with **E404** because trusted publishing is not yet set up for that name.
> 
> Those first-publish failures are **warned, recorded in `UNPROVISIONED`, and skipped** so later packages (e.g. `@remnic/cli`) still publish. After the loop, any skipped names are listed in **`$GITHUB_STEP_SUMMARY`** and the job **still exits 1** so partial deploys stay visible. **All other publish errors remain immediately fatal**; fully provisioned releases behave the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7548240ffb679e50528b96c3cd8af0d0f1f729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->