### PR TITLE
fix(briefing): route follow-ups through the configured LLM chain

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4933,6 +4933,12 @@ async function cmdBriefing(rest: string[]): Promise<void> {
     openaiApiKey: config.openaiApiKey,
     openaiBaseUrl: config.openaiBaseUrl,
     model: config.model,
+    // Without a direct OpenAI key, route follow-ups through the configured
+    // LLM chain (gateway model source or local LLM) — mirrors the access
+    // service so CLI and server briefings behave identically.
+    followupGenerator: config.openaiApiKey
+      ? undefined
+      : orchestrator.briefingChainFollowupGenerator,
   });
 
   const payload = format === "json" ? JSON.stringify(result.json, null, 2) : result.markdown;

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1814,6 +1814,13 @@ export class EngramAccessService {
       openaiApiKey: config.openaiApiKey,
       openaiBaseUrl: config.openaiBaseUrl,
       model: config.model,
+      // Without a direct OpenAI key, route follow-ups through the configured
+      // LLM chain (gateway model source or local LLM) — same fallback every
+      // other LLM feature uses. A configured key keeps its precedence so
+      // existing deployments are unchanged.
+      followupGenerator: config.openaiApiKey
+        ? undefined
+        : this.orchestrator.briefingChainFollowupGenerator,
     });
 
     return {

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -19,6 +19,7 @@ import { readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { log } from "./logger.js";
+import { extractJsonCandidates } from "./json-extract.js";
 import { normalizeEntityName, StorageManager } from "./storage.js";
 import { readEnvVar, resolveHomeDir } from "./runtime/env.js";
 import type {
@@ -865,7 +866,8 @@ export async function buildBriefing(options: BuildBriefingOptions): Promise<Brie
   if (maxFollowups === 0 || options.allowLlm === false) {
     followupsUnavailableReason = "LLM follow-ups disabled by configuration";
   } else if (!options.openaiApiKey && !options.followupGenerator) {
-    followupsUnavailableReason = "OPENAI_API_KEY not configured";
+    followupsUnavailableReason =
+      'no LLM configured for follow-ups (set OPENAI_API_KEY, enable a local LLM, or use modelSource "gateway")';
   } else {
     try {
       const generator = options.followupGenerator ?? buildOpenAiFollowupGenerator({
@@ -1197,6 +1199,70 @@ function buildOpenAiFollowupGenerator(cfg: {
 
     const text = typeof response.output_text === "string" ? response.output_text : "";
     return parseFollowupResponse(text, maxFollowups);
+  };
+}
+
+/**
+ * Minimal chat-completion surface shared by `FallbackLlmClient` (gateway
+ * model chain) and `LocalLlmClient` (Ollama / OpenAI-compatible local
+ * endpoints). Matches `Orchestrator.fastLlmForRerank` so briefing
+ * follow-ups can ride the same routing as other fast-tier operations.
+ */
+export interface BriefingChainLlmClient {
+  chatCompletion(
+    messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
+    options?: {
+      temperature?: number;
+      maxTokens?: number;
+      timeoutMs?: number;
+      operation?: string;
+      priority?: "background" | "recall-critical";
+    },
+  ): Promise<{ content: string } | null>;
+}
+
+/**
+ * Build a follow-up generator backed by the configured LLM chain
+ * (gateway model source or local LLM) instead of a direct OpenAI key.
+ *
+ * Local models frequently wrap JSON in code fences or prose, so the
+ * response is run through `extractJsonCandidates` and the first candidate
+ * that parses into a valid `{ followups: [...] }` shape wins. Throws when
+ * the chain returns nothing or no candidate parses — `buildBriefing`
+ * catches and surfaces the message via `followupsUnavailableReason`.
+ */
+export function buildChainFollowupGenerator(
+  client: BriefingChainLlmClient,
+): BriefingFollowupGenerator {
+  return async ({ sections, windowLabel, maxFollowups }) => {
+    const prompt = buildFollowupPrompt(sections, windowLabel, maxFollowups);
+    const response = await client.chatCompletion(
+      [
+        { role: "system", content: FOLLOWUP_INSTRUCTIONS },
+        { role: "user", content: prompt },
+      ],
+      {
+        temperature: 0.2,
+        maxTokens: 512,
+        operation: "briefing-followups",
+        priority: "background",
+      },
+    );
+    if (!response?.content) {
+      throw new Error("LLM chain returned no response");
+    }
+    const candidates = extractJsonCandidates(response.content);
+    let lastError: unknown;
+    for (const candidate of candidates) {
+      try {
+        return parseFollowupResponse(candidate, maxFollowups);
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    throw new Error(
+      `LLM chain response contained no valid followups JSON: ${stringifyError(lastError ?? "no JSON candidates found")}`,
+    );
   };
 }
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -507,6 +507,8 @@ export {
   briefingFilename,
   FileCalendarSource,
   BRIEFING_FORMAT_ALLOWED,
+  buildChainFollowupGenerator,
+  type BriefingChainLlmClient,
   type BuildBriefingOptions,
   type BriefingFollowupGenerator,
   type ParsedBriefingWindow,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1,4 +1,8 @@
 import { log } from "./logger.js";
+import {
+  buildChainFollowupGenerator,
+  type BriefingFollowupGenerator,
+} from "./briefing.js";
 import path from "node:path";
 import os from "node:os";
 import { createHash, randomBytes } from "node:crypto";
@@ -2514,6 +2518,25 @@ export class Orchestrator {
           forceDisableThinking: true,
         }),
     };
+  }
+
+  /**
+   * Build a briefing follow-up generator backed by the configured LLM chain
+   * (gateway model source or local LLM). Returns `undefined` when no chain
+   * is available so `buildBriefing` can surface a clear unavailable reason
+   * instead of failing at call time. Used by the access service and CLI as
+   * the fallback when no direct `openaiApiKey` is configured, so briefing
+   * follow-ups ride the same routing as every other fast-tier LLM feature.
+   */
+  get briefingChainFollowupGenerator(): BriefingFollowupGenerator | undefined {
+    const chainAvailable =
+      this.config.modelSource === "gateway"
+        ? this._fastGatewayLlm?.isAvailable(
+            this.config.fastGatewayAgentId || this.config.gatewayAgentId || undefined,
+          ) === true
+        : this.config.localLlmEnabled || this.config.localLlmFastEnabled;
+    if (!chainAvailable) return undefined;
+    return buildChainFollowupGenerator(this.fastLlmForRerank);
   }
 
   async initialize(): Promise<void> {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2529,12 +2529,15 @@ export class Orchestrator {
    * follow-ups ride the same routing as every other fast-tier LLM feature.
    */
   get briefingChainFollowupGenerator(): BriefingFollowupGenerator | undefined {
+    // Plugin mode gates on `localLlmEnabled` alone: `LocalLlmClient.chatCompletion`
+    // returns null when the master switch is off, so `localLlmFastEnabled` by
+    // itself cannot serve requests (Cursor review on PR #1463).
     const chainAvailable =
       this.config.modelSource === "gateway"
         ? this._fastGatewayLlm?.isAvailable(
             this.config.fastGatewayAgentId || this.config.gatewayAgentId || undefined,
           ) === true
-        : this.config.localLlmEnabled || this.config.localLlmFastEnabled;
+        : this.config.localLlmEnabled;
     if (!chainAvailable) return undefined;
     return buildChainFollowupGenerator(this.fastLlmForRerank);
   }

--- a/tests/briefing-chain-followups.test.ts
+++ b/tests/briefing-chain-followups.test.ts
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { StorageManager } from "../src/storage.js";
+import {
+  buildBriefing,
+  buildChainFollowupGenerator,
+  parseBriefingWindow,
+  type BriefingChainLlmClient,
+} from "../src/briefing.js";
+
+const NOW = new Date("2026-04-11T12:00:00.000Z");
+
+async function makeTempStorage(): Promise<{ dir: string; storage: StorageManager }> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-briefing-chain-"));
+  StorageManager.clearAllStaticCaches();
+  const storage = new StorageManager(dir);
+  await storage.ensureDirectories();
+  return { dir, storage };
+}
+
+function chainClient(content: string | null): BriefingChainLlmClient {
+  return {
+    async chatCompletion() {
+      return content === null ? null : { content };
+    },
+  };
+}
+
+test("buildChainFollowupGenerator parses plain JSON responses", async () => {
+  const generator = buildChainFollowupGenerator(
+    chainClient('{"followups": [{"text": "Review the deploy checklist", "rationale": "open commitment"}]}'),
+  );
+  const followups = await generator({
+    sections: {
+      activeThreads: [],
+      recentEntities: [],
+      openCommitments: [],
+      suggestedFollowups: [],
+    },
+    windowLabel: "yesterday",
+    maxFollowups: 5,
+  });
+  assert.equal(followups.length, 1);
+  assert.equal(followups[0].text, "Review the deploy checklist");
+  assert.equal(followups[0].rationale, "open commitment");
+});
+
+test("buildChainFollowupGenerator handles fenced JSON from local models", async () => {
+  const generator = buildChainFollowupGenerator(
+    chainClient(
+      'Here you go:\n```json\n{"followups": [{"text": "Ping the vendor about the renewal"}]}\n```\n',
+    ),
+  );
+  const followups = await generator({
+    sections: {
+      activeThreads: [],
+      recentEntities: [],
+      openCommitments: [],
+      suggestedFollowups: [],
+    },
+    windowLabel: "yesterday",
+    maxFollowups: 3,
+  });
+  assert.equal(followups.length, 1);
+  assert.equal(followups[0].text, "Ping the vendor about the renewal");
+});
+
+test("buildChainFollowupGenerator throws when the chain returns nothing", async () => {
+  const generator = buildChainFollowupGenerator(chainClient(null));
+  await assert.rejects(
+    generator({
+      sections: {
+        activeThreads: [],
+        recentEntities: [],
+        openCommitments: [],
+        suggestedFollowups: [],
+      },
+      windowLabel: "yesterday",
+      maxFollowups: 3,
+    }),
+    /LLM chain returned no response/,
+  );
+});
+
+test("buildChainFollowupGenerator throws when no candidate parses", async () => {
+  const generator = buildChainFollowupGenerator(
+    chainClient("Sorry, I cannot produce JSON right now."),
+  );
+  await assert.rejects(
+    generator({
+      sections: {
+        activeThreads: [],
+        recentEntities: [],
+        openCommitments: [],
+        suggestedFollowups: [],
+      },
+      windowLabel: "yesterday",
+      maxFollowups: 3,
+    }),
+    /no valid followups JSON/,
+  );
+});
+
+test("buildBriefing uses a chain generator without an OpenAI key", async () => {
+  const { dir, storage } = await makeTempStorage();
+  try {
+    const result = await buildBriefing({
+      storage,
+      window: parseBriefingWindow("yesterday", NOW)!,
+      maxFollowups: 5,
+      allowLlm: true,
+      // Intentionally no openaiApiKey — the chain generator must carry it.
+      followupGenerator: buildChainFollowupGenerator(
+        chainClient('{"followups": [{"text": "Follow up with the team"}]}'),
+      ),
+      now: NOW,
+    });
+
+    assert.equal(result.followupsUnavailableReason, undefined);
+    assert.equal(result.sections.suggestedFollowups.length, 1);
+    assert.equal(result.sections.suggestedFollowups[0].text, "Follow up with the team");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildBriefing surfaces chain failures via followupsUnavailableReason", async () => {
+  const { dir, storage } = await makeTempStorage();
+  try {
+    const result = await buildBriefing({
+      storage,
+      window: parseBriefingWindow("yesterday", NOW)!,
+      maxFollowups: 5,
+      allowLlm: true,
+      followupGenerator: buildChainFollowupGenerator(chainClient(null)),
+      now: NOW,
+    });
+
+    assert.equal(result.sections.suggestedFollowups.length, 0);
+    assert.match(result.followupsUnavailableReason ?? "", /LLM follow-ups failed/);
+    assert.match(result.followupsUnavailableReason ?? "", /LLM chain returned no response/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/briefing-llm-absent.test.ts
+++ b/tests/briefing-llm-absent.test.ts
@@ -16,7 +16,7 @@ async function makeTempStorage(): Promise<{ dir: string; storage: StorageManager
   return { dir, storage };
 }
 
-test("buildBriefing omits follow-ups cleanly when OPENAI_API_KEY is not set", async () => {
+test("buildBriefing omits follow-ups cleanly when no LLM is configured", async () => {
   const { dir, storage } = await makeTempStorage();
   try {
     const result = await buildBriefing({
@@ -29,9 +29,12 @@ test("buildBriefing omits follow-ups cleanly when OPENAI_API_KEY is not set", as
     });
 
     assert.equal(result.sections.suggestedFollowups.length, 0);
-    assert.equal(result.followupsUnavailableReason, "OPENAI_API_KEY not configured");
+    assert.equal(
+      result.followupsUnavailableReason,
+      'no LLM configured for follow-ups (set OPENAI_API_KEY, enable a local LLM, or use modelSource "gateway")',
+    );
     assert.match(result.markdown, /## Suggested follow-ups/);
-    assert.match(result.markdown, /_Unavailable: OPENAI_API_KEY not configured_/);
+    assert.match(result.markdown, /_Unavailable: no LLM configured for follow-ups/);
     // Other sections still render.
     assert.match(result.markdown, /## Active threads/);
     assert.match(result.markdown, /## Recent entities/);


### PR DESCRIPTION
## Problem

`engram_briefing` responses on chain-configured deployments (gateway model source or local LLM, `openaiApiKey: false`) always return:

```
"followupsUnavailableReason": "OPENAI_API_KEY not configured"
```

Follow-ups were the only LLM feature hard-wired to a direct OpenAI key. Extraction, the extraction judge, the summarizer, and semantic consolidation all already route through the gateway/local-LLM fallback chain.

## Fix

- **`briefing.ts`** — new exported `buildChainFollowupGenerator(client)` accepting the same chat-completion surface as `Orchestrator.fastLlmForRerank`. Local models often wrap JSON in code fences, so responses go through `extractJsonCandidates` and the first candidate that parses into a valid `{ followups: [...] }` wins. Failures throw so `buildBriefing` surfaces them via `followupsUnavailableReason` (existing contract).
- **`orchestrator.ts`** — new `briefingChainFollowupGenerator` getter: routes to the gateway fast chain when `modelSource: "gateway"` (gated on `isAvailable`), to the local fast LLM when `localLlmEnabled`/`localLlmFastEnabled`, otherwise `undefined` so the briefing reports a clear reason instead of failing at call time.
- **`access-service.ts` + CLI `briefing` command** — pass the chain generator as fallback when no `openaiApiKey` is configured. A configured key keeps precedence, so existing OpenAI-key deployments are byte-for-byte unchanged.
- Updated the unavailable reason to name all three options: `no LLM configured for follow-ups (set OPENAI_API_KEY, enable a local LLM, or use modelSource "gateway")`.

## Tests

- New `tests/briefing-chain-followups.test.ts`: plain JSON, fenced JSON from local models, null chain response, unparseable response, end-to-end `buildBriefing` with chain generator and failure surfacing.
- Updated `tests/briefing-llm-absent.test.ts` for the new reason string.
- `preflight:quick`: **Status: PASS**. Briefing suites 19/19. The `openclaw-registration-capture` / `openclaw-scenarios` failures are pre-existing and identical on a clean checkout (env-dependent, require `OLLAMA_API_KEY`); verified clean-vs-patched fail counts match exactly.

## PR Checklist
- [x] All briefing tests pass; preflight:quick PASS
- [x] New logic covered by tests
- [x] No secrets or creds committed
- [x] Diff ≤ 400 LOC (259 insertions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes briefing LLM routing and JSON parsing for follow-ups across CLI and access service, but preserves OpenAI-key behavior and surfaces failures via existing `followupsUnavailableReason`.
> 
> **Overview**
> **Briefing follow-ups** now use the same gateway/local LLM chain as other fast-tier features when no direct `OPENAI_API_KEY` is set. Access service and CLI pass `orchestrator.briefingChainFollowupGenerator` in that case; a configured key still uses the existing OpenAI Responses path unchanged.
> 
> Adds **`buildChainFollowupGenerator`**, which calls `chatCompletion` on the fast LLM client and parses follow-up JSON via **`extractJsonCandidates`** (handles fenced/local model output). **`Orchestrator.briefingChainFollowupGenerator`** gates on gateway `isAvailable` or `localLlmEnabled`, then wires `fastLlmForRerank`. The “no LLM” message now lists OpenAI key, local LLM, and `modelSource: "gateway"`. New tests cover chain parsing, failures, and end-to-end `buildBriefing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab1ea744972104075933531de5df1cf2352c927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->