### PR TITLE
feat(wearables): built-in auto-sync transcript refresh + uncapped days

### DIFF
--- a/docs/wearables.md
+++ b/docs/wearables.md
@@ -145,8 +145,10 @@ Deterministic gates still apply in every creating mode:
   importance scorer.
 - Content-hash dedup against existing memories and within the run
   (applied before the day cap so duplicates never consume cap slots).
-- `maxMemoriesPerDay` (default 50, `0` disables) — keeps the
-  highest-trust candidates in smart mode, highest-importance otherwise.
+- `maxMemoriesPerDay` (default `0` — uncapped) — optional ceiling for
+  operators who want one; when set, keeps the highest-trust candidates
+  in smart mode, highest-importance otherwise. The smart trust pipeline
+  is the quality gate, so busy days don't silently drop real memories.
 - `minConfidence` (default 0.6) applies in `review`/`auto` modes; in
   smart mode the trust bands subsume it so borderline facts can reach
   the review queue instead of vanishing.
@@ -181,6 +183,10 @@ is `off`.
     "redactionPatterns": ["internal-codename-\\w+"],
     "offTheRecordEnabled": true,          // default true
     "digestEnabled": true,                 // default true
+    "autoSyncEnabled": true,               // default true (long-lived hosts)
+    "autoSyncIntervalMinutes": 15,         // tick cadence
+    "autoSyncDays": 2,                     // window per tick (today + yesterday)
+    "autoSyncDeepDays": 7,                 // daily deep pass; 0 disables
     "corrections": [
       { "match": "remnick", "replace": "Remnic" },
       { "match": "acme corp", "replace": "ACME Corp", "sources": ["limitless"] }
@@ -193,7 +199,7 @@ is `off`.
         "autoApproveTrust": 0.7,             // trust >= this -> written active
         "reviewTrust": 0.45,                 // trust >= this -> review queue
         "minImportance": "low",              // trivial|low|normal|high|critical
-        "maxMemoriesPerDay": 50               // 0 disables the cap
+        "maxMemoriesPerDay": 0                // 0 (default) = uncapped
       },
       "bee": {
         "enabled": true,
@@ -243,9 +249,22 @@ remnic wearables corrections add "remnick" "Remnic"
 remnic wearables corrections list
 ```
 
-For continuous syncing, run `remnic wearables sync` from cron or a
-heartbeat task; the sync is incremental and idempotent (re-running is
-cheap — unchanged days are skipped by content hash).
+Continuous syncing is built in: long-lived hosts (the gateway, the
+HTTP daemon) start an in-process **auto-sync** scheduler by default
+(`wearables.autoSyncEnabled`, on). Every `autoSyncIntervalMinutes`
+(default 15) it re-syncs the last `autoSyncDays` (default 2) for all
+enabled sources — existing day files included, so today's transcript
+keeps growing while the wearable records. Once per local day the
+window deepens to `autoSyncDeepDays` (default 7) to pick up late
+uploads and provider re-processing (phones syncing hours later,
+re-diarized transcripts). Syncs are incremental and idempotent —
+unchanged days are skipped by content hash, so a quiet tick is
+read-only. Day fetches are never page-capped: a long recorded day
+paginates to completion (runaway providers are stopped by
+cursor-cycle detection, not by truncating real data).
+
+The manual CLI stays useful for one-shot contexts, instant refreshes
+(`remnic wearables sync`), and deep backfills (`--days 90`).
 
 ## MCP tools
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -813,6 +813,32 @@
             "default": true,
             "description": "Write one compact daily-digest memory per synced source/day."
           },
+          "autoSyncEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Periodically refresh transcripts in-process on long-lived hosts. Every tick re-syncs a rolling window ending today (existing day files included)."
+          },
+          "autoSyncIntervalMinutes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1440,
+            "default": 15,
+            "description": "Minutes between auto-sync ticks."
+          },
+          "autoSyncDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 90,
+            "default": 2,
+            "description": "Rolling window (days ending today) refreshed on each auto-sync tick."
+          },
+          "autoSyncDeepDays": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 90,
+            "default": 7,
+            "description": "Once-per-local-day deep refresh window (days) for late uploads and provider re-processing. 0 disables; otherwise must be >= autoSyncDays."
+          },
           "corrections": {
             "type": "array",
             "default": [],
@@ -936,9 +962,8 @@
                 "maxMemoriesPerDay": {
                   "type": "integer",
                   "minimum": 0,
-                  "maximum": 500,
-                  "default": 50,
-                  "description": "Cap on memories created per source per day. Set to 0 to disable the cap."
+                  "default": 0,
+                  "description": "Cap on memories created per source per day. 0 (the default) disables the cap."
                 },
                 "importNativeMemories": {
                   "type": "string",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -813,6 +813,32 @@
             "default": true,
             "description": "Write one compact daily-digest memory per synced source/day."
           },
+          "autoSyncEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Periodically refresh transcripts in-process on long-lived hosts. Every tick re-syncs a rolling window ending today (existing day files included)."
+          },
+          "autoSyncIntervalMinutes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1440,
+            "default": 15,
+            "description": "Minutes between auto-sync ticks."
+          },
+          "autoSyncDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 90,
+            "default": 2,
+            "description": "Rolling window (days ending today) refreshed on each auto-sync tick."
+          },
+          "autoSyncDeepDays": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 90,
+            "default": 7,
+            "description": "Once-per-local-day deep refresh window (days) for late uploads and provider re-processing. 0 disables; otherwise must be >= autoSyncDays."
+          },
           "corrections": {
             "type": "array",
             "default": [],
@@ -936,9 +962,8 @@
                 "maxMemoriesPerDay": {
                   "type": "integer",
                   "minimum": 0,
-                  "maximum": 500,
-                  "default": 50,
-                  "description": "Cap on memories created per source per day. Set to 0 to disable the cap."
+                  "default": 0,
+                  "description": "Cap on memories created per source per day. 0 (the default) disables the cap."
                 },
                 "importNativeMemories": {
                   "type": "string",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1700,6 +1700,7 @@ export class Orchestrator {
   >();
   private qmdMaintenanceTimer: NodeJS.Timeout | null = null;
   private wearablesServiceInstance: WearablesService | null = null;
+  private wearablesAutoSyncHandle: { stop(): void } | null = null;
   private qmdMaintenancePending = false;
   private qmdMaintenanceInFlight = false;
   private lastQmdEmbedAtMs = 0;
@@ -1781,6 +1782,10 @@ export class Orchestrator {
    */
   async destroy(): Promise<void> {
     this.abortDeferredInit();
+    if (this.wearablesAutoSyncHandle) {
+      this.wearablesAutoSyncHandle.stop();
+      this.wearablesAutoSyncHandle = null;
+    }
     if (this.qmdMaintenanceTimer) {
       clearTimeout(this.qmdMaintenanceTimer);
       this.qmdMaintenanceTimer = null;
@@ -2954,6 +2959,48 @@ export class Orchestrator {
         }
       } catch (err) {
         log.warn(`first-start lifecycle migration failed (non-fatal): ${err}`);
+      }
+    }
+
+    // Wearables auto-sync: in-process periodic transcript refresh for
+    // long-lived hosts (default on). Today's transcript keeps growing
+    // while the wearable records; a once-per-local-day deep pass picks
+    // up late uploads and provider re-processing. Static config gate —
+    // sources can't appear at runtime, so checking once here is safe.
+    // The timer is unref'd, so one-shot CLI runs exit naturally without
+    // ever ticking; idempotent across stop/start cycles via the handle
+    // guard. Non-fatal: a failure to start must not break init.
+    if (signal.aborted) return;
+    if (
+      !this.wearablesAutoSyncHandle &&
+      this.config.wearables.enabled &&
+      this.config.wearables.autoSyncEnabled &&
+      Object.values(this.config.wearables.sources).some((source) => source.enabled)
+    ) {
+      try {
+        const { startWearablesAutoSync } = await import("./wearables/auto-sync.js");
+        this.wearablesAutoSyncHandle = startWearablesAutoSync(
+          {
+            intervalMinutes: this.config.wearables.autoSyncIntervalMinutes,
+            days: this.config.wearables.autoSyncDays,
+            deepDays: this.config.wearables.autoSyncDeepDays,
+            ...(this.config.wearables.timezone !== undefined
+              ? { timezone: this.config.wearables.timezone }
+              : {}),
+          },
+          {
+            sync: (options) => this.getWearablesService().sync(options),
+            log: {
+              info: (message) => log.info(message),
+              warn: (message) => log.warn(message),
+            },
+          },
+        );
+        log.info(
+          `wearables auto-sync started: every ${this.config.wearables.autoSyncIntervalMinutes}m over ${this.config.wearables.autoSyncDays}d (deep ${this.config.wearables.autoSyncDeepDays}d daily)`,
+        );
+      } catch (err) {
+        log.warn(`wearables auto-sync failed to start (non-fatal): ${err}`);
       }
     }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3000,7 +3000,10 @@ export class Orchestrator {
           `wearables auto-sync started: every ${this.config.wearables.autoSyncIntervalMinutes}m over ${this.config.wearables.autoSyncDays}d (deep ${this.config.wearables.autoSyncDeepDays}d daily)`,
         );
       } catch (err) {
-        log.warn(`wearables auto-sync failed to start (non-fatal): ${err}`);
+        const { displayErrorDetail } = await import("./runtime/better-sqlite.js");
+        log.warn(
+          `wearables auto-sync failed to start (non-fatal): ${displayErrorDetail(err)}`,
+        );
       }
     }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1700,7 +1700,7 @@ export class Orchestrator {
   >();
   private qmdMaintenanceTimer: NodeJS.Timeout | null = null;
   private wearablesServiceInstance: WearablesService | null = null;
-  private wearablesAutoSyncHandle: { stop(): void } | null = null;
+  private wearablesAutoSyncHandle: { stop(): Promise<void> } | null = null;
   private qmdMaintenancePending = false;
   private qmdMaintenanceInFlight = false;
   private lastQmdEmbedAtMs = 0;
@@ -1783,7 +1783,9 @@ export class Orchestrator {
   async destroy(): Promise<void> {
     this.abortDeferredInit();
     if (this.wearablesAutoSyncHandle) {
-      this.wearablesAutoSyncHandle.stop();
+      // Aborts in-flight provider fetches and waits for the tick to
+      // settle, so nothing is writing or reindexing past destroy().
+      await this.wearablesAutoSyncHandle.stop();
       this.wearablesAutoSyncHandle = null;
     }
     if (this.qmdMaintenanceTimer) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2981,6 +2981,12 @@ export class Orchestrator {
     ) {
       try {
         const { startWearablesAutoSync } = await import("./wearables/auto-sync.js");
+        // Re-check after the await: destroy() may have aborted while
+        // the import was in flight, having found no handle to stop —
+        // starting now would leave a live interval on a destroyed
+        // orchestrator (Cursor review on PR #1464). Handle creation
+        // below is synchronous, so no further window exists.
+        if (signal.aborted) return;
         this.wearablesAutoSyncHandle = startWearablesAutoSync(
           {
             intervalMinutes: this.config.wearables.autoSyncIntervalMinutes,

--- a/packages/remnic-core/src/wearables/auto-sync.test.ts
+++ b/packages/remnic-core/src/wearables/auto-sync.test.ts
@@ -139,7 +139,43 @@ test("overlapping ticks are skipped, not stacked", async () => {
 test("stop() prevents any further ticks", async () => {
   const { calls, deps } = makeDeps();
   const handle = startWearablesAutoSync(SETTINGS, deps);
-  handle.stop();
+  await handle.stop();
   await handle.tick();
   assert.equal(calls.length, 0);
+});
+
+test("stop() aborts the in-flight sync and awaits its settlement", async () => {
+  const warnings: string[] = [];
+  let sawSignal: AbortSignal | undefined;
+  let syncSettled = false;
+  const handle = startWearablesAutoSync(SETTINGS, {
+    sync: async (options) => {
+      sawSignal = options.signal;
+      // Hang until the shutdown abort arrives, like a slow provider.
+      await new Promise<void>((_resolve, reject) => {
+        options.signal!.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      }).finally(() => {
+        syncSettled = true;
+      });
+    },
+    log: {
+      info: () => {},
+      warn: (message: string) => {
+        warnings.push(message);
+      },
+    },
+    now: () => new Date("2026-06-12T10:00:00.000Z"),
+  });
+  const inFlight = handle.tick();
+  assert.ok(sawSignal instanceof AbortSignal, "sync receives the abort signal");
+  await handle.stop();
+  assert.equal(syncSettled, true, "stop() resolves only after the tick settled");
+  assert.equal(
+    warnings.length,
+    0,
+    "an abort raised by shutdown is intentional, never warned",
+  );
+  await inFlight;
 });

--- a/packages/remnic-core/src/wearables/auto-sync.test.ts
+++ b/packages/remnic-core/src/wearables/auto-sync.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { startWearablesAutoSync } from "./auto-sync.js";
+
+function makeDeps(overrides: { failTimes?: number } = {}) {
+  const calls: Array<{ days: number }> = [];
+  const warnings: string[] = [];
+  let remainingFailures = overrides.failTimes ?? 0;
+  let nowIso = "2026-06-12T10:00:00.000Z";
+  return {
+    calls,
+    warnings,
+    setNow(iso: string) {
+      nowIso = iso;
+    },
+    deps: {
+      sync: async (options: { days: number }) => {
+        if (remainingFailures > 0) {
+          remainingFailures -= 1;
+          throw new Error("provider down");
+        }
+        calls.push(options);
+        return [];
+      },
+      log: {
+        info: () => {},
+        warn: (message: string) => {
+          warnings.push(message);
+        },
+      },
+      now: () => new Date(nowIso),
+    },
+  };
+}
+
+const SETTINGS = {
+  intervalMinutes: 15,
+  days: 2,
+  deepDays: 7,
+  timezone: "UTC",
+};
+
+test("first tick runs the deep window, same-day ticks run the shallow window", async () => {
+  const { calls, deps } = makeDeps();
+  const handle = startWearablesAutoSync(SETTINGS, deps);
+  try {
+    await handle.tick();
+    await handle.tick();
+    await handle.tick();
+    assert.deepEqual(
+      calls.map((call) => call.days),
+      [7, 2, 2],
+      "deep once, then shallow for the rest of the day",
+    );
+  } finally {
+    handle.stop();
+  }
+});
+
+test("a new local day triggers the deep pass again", async () => {
+  const { calls, deps, setNow } = makeDeps();
+  const handle = startWearablesAutoSync(SETTINGS, deps);
+  try {
+    await handle.tick();
+    await handle.tick();
+    setNow("2026-06-13T00:05:00.000Z");
+    await handle.tick();
+    await handle.tick();
+    assert.deepEqual(
+      calls.map((call) => call.days),
+      [7, 2, 7, 2],
+    );
+  } finally {
+    handle.stop();
+  }
+});
+
+test("a failed deep pass retries deep on the next tick, never throws", async () => {
+  const { calls, warnings, deps } = makeDeps({ failTimes: 1 });
+  const handle = startWearablesAutoSync(SETTINGS, deps);
+  try {
+    await handle.tick();
+    assert.equal(calls.length, 0, "first tick failed");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /retrying on the next tick/);
+    await handle.tick();
+    assert.deepEqual(
+      calls.map((call) => call.days),
+      [7],
+      "deep window retries — a failure must not consume the daily deep slot",
+    );
+  } finally {
+    handle.stop();
+  }
+});
+
+test("deepDays 0 disables the deep pass entirely", async () => {
+  const { calls, deps } = makeDeps();
+  const handle = startWearablesAutoSync({ ...SETTINGS, deepDays: 0 }, deps);
+  try {
+    await handle.tick();
+    await handle.tick();
+    assert.deepEqual(
+      calls.map((call) => call.days),
+      [2, 2],
+    );
+  } finally {
+    handle.stop();
+  }
+});
+
+test("overlapping ticks are skipped, not stacked", async () => {
+  const calls: Array<{ days: number }> = [];
+  let release: (() => void) | null = null;
+  const handle = startWearablesAutoSync(SETTINGS, {
+    sync: async (options) => {
+      calls.push(options);
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return [];
+    },
+    log: { info: () => {}, warn: () => {} },
+    now: () => new Date("2026-06-12T10:00:00.000Z"),
+  });
+  try {
+    const first = handle.tick();
+    const second = handle.tick();
+    await second;
+    assert.equal(calls.length, 1, "second tick is a no-op while the first runs");
+    release!();
+    await first;
+  } finally {
+    handle.stop();
+  }
+});
+
+test("stop() prevents any further ticks", async () => {
+  const { calls, deps } = makeDeps();
+  const handle = startWearablesAutoSync(SETTINGS, deps);
+  handle.stop();
+  await handle.tick();
+  assert.equal(calls.length, 0);
+});

--- a/packages/remnic-core/src/wearables/auto-sync.ts
+++ b/packages/remnic-core/src/wearables/auto-sync.ts
@@ -1,0 +1,104 @@
+/**
+ * Wearables auto-sync — in-process periodic transcript refresh.
+ *
+ * Every tick re-syncs a short rolling window ending today for ALL
+ * enabled sources, so the current day's transcript keeps growing while
+ * the wearable records and provider-side revisions of recent days flow
+ * in without operator action. Once per local day the window deepens to
+ * `autoSyncDeepDays` to pick up late uploads and provider reprocessing
+ * further back (phones syncing hours later, re-diarized transcripts).
+ *
+ * Day fetches are unconditional within the window — existing day files
+ * are always re-fetched and re-composed; the content-hash skip in the
+ * pipeline keeps unchanged days write-free, so a tick on a quiet day
+ * is read-only. The timer is unref'd: it never keeps a one-shot CLI
+ * process alive, and long-lived hosts stop it via the returned handle.
+ */
+
+import { describeErrorForOperator } from "./errors.js";
+import { dateInTimezone, defaultTimezone } from "./pipeline.js";
+
+export interface WearablesAutoSyncSettings {
+  /** Minutes between ticks. */
+  intervalMinutes: number;
+  /** Rolling window (days ending today) refreshed on a normal tick. */
+  days: number;
+  /**
+   * Window for the once-per-local-day deep pass. 0 disables the deep
+   * pass; otherwise must be >= `days` (validated at config parse).
+   */
+  deepDays: number;
+  /** IANA timezone used to detect the local-day rollover. */
+  timezone?: string;
+}
+
+export interface WearablesAutoSyncDeps {
+  /** Run a sync across all enabled sources (WearablesService.sync). */
+  sync(options: { days: number }): Promise<unknown>;
+  log: { info(message: string): void; warn(message: string): void };
+  /** Clock injection for tests. */
+  now?: () => Date;
+}
+
+export interface WearablesAutoSyncHandle {
+  /** Run one scheduler tick now (first-run hook and test seam). */
+  tick(): Promise<void>;
+  stop(): void;
+}
+
+/**
+ * Start the periodic refresh. The first tick fires after one full
+ * interval rather than at start — gateways on low-power hardware can
+ * restart-loop during setup (issue #462), and an immediate fetch on
+ * every restart would hammer provider APIs. Operators who want an
+ * instant refresh run `wearables sync` (or call `tick()`).
+ */
+export function startWearablesAutoSync(
+  settings: WearablesAutoSyncSettings,
+  deps: WearablesAutoSyncDeps,
+): WearablesAutoSyncHandle {
+  let inFlight = false;
+  let stopped = false;
+  let lastDeepDate: string | null = null;
+
+  const tick = async (): Promise<void> => {
+    // Overlap guard: a slow provider or large deep window must never
+    // stack a second sync on top of a running one.
+    if (inFlight || stopped) return;
+    inFlight = true;
+    try {
+      const now = deps.now ? deps.now() : new Date();
+      const today = dateInTimezone(now, settings.timezone ?? defaultTimezone());
+      const deep = settings.deepDays > 0 && lastDeepDate !== today;
+      const days = deep ? settings.deepDays : settings.days;
+      await deps.sync({ days });
+      // Mark the deep pass done only AFTER it succeeded — a failed
+      // deep pass retries on the next tick instead of silently waiting
+      // for tomorrow (CLAUDE.md rule 25's "confirm before consuming
+      // the one-shot" shape).
+      if (deep) lastDeepDate = today;
+      deps.log.info(
+        `wearables auto-sync: refreshed ${days}-day window${deep ? " (daily deep pass)" : ""}`,
+      );
+    } catch (err) {
+      deps.log.warn(
+        `wearables auto-sync failed: ${describeErrorForOperator(err)} — retrying on the next tick`,
+      );
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void tick();
+  }, settings.intervalMinutes * 60_000);
+  timer.unref?.();
+
+  return {
+    tick,
+    stop: () => {
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}

--- a/packages/remnic-core/src/wearables/auto-sync.ts
+++ b/packages/remnic-core/src/wearables/auto-sync.ts
@@ -34,7 +34,7 @@ export interface WearablesAutoSyncSettings {
 
 export interface WearablesAutoSyncDeps {
   /** Run a sync across all enabled sources (WearablesService.sync). */
-  sync(options: { days: number }): Promise<unknown>;
+  sync(options: { days: number; signal?: AbortSignal }): Promise<unknown>;
   log: { info(message: string): void; warn(message: string): void };
   /** Clock injection for tests. */
   now?: () => Date;
@@ -43,7 +43,14 @@ export interface WearablesAutoSyncDeps {
 export interface WearablesAutoSyncHandle {
   /** Run one scheduler tick now (first-run hook and test seam). */
   tick(): Promise<void>;
-  stop(): void;
+  /**
+   * Stop the scheduler: clears the timer, aborts the in-flight sync's
+   * provider fetches via AbortSignal, and resolves once the in-flight
+   * tick has fully settled — after `await stop()` nothing is writing
+   * or reindexing anymore. The handle is single-use; a restarted host
+   * starts a fresh one.
+   */
+  stop(): Promise<void>;
 }
 
 /**
@@ -57,36 +64,51 @@ export function startWearablesAutoSync(
   settings: WearablesAutoSyncSettings,
   deps: WearablesAutoSyncDeps,
 ): WearablesAutoSyncHandle {
-  let inFlight = false;
+  let inFlight: Promise<void> | null = null;
   let stopped = false;
   let lastDeepDate: string | null = null;
+  // Aborting cancels the in-flight sync's provider fetches promptly on
+  // shutdown — without it, a slow tick would keep writing/reindexing
+  // after orchestrator.destroy() while a restarted host starts a
+  // second scheduler (Kilo review on PR #1464).
+  const abortController = new AbortController();
 
   const tick = async (): Promise<void> => {
     // Overlap guard: a slow provider or large deep window must never
-    // stack a second sync on top of a running one.
+    // stack a second sync on top of a running one. The skipped call
+    // resolves immediately — it must NOT await the running tick, or a
+    // caller holding both promises could deadlock itself.
     if (inFlight || stopped) return;
-    inFlight = true;
-    try {
-      const now = deps.now ? deps.now() : new Date();
-      const today = dateInTimezone(now, settings.timezone ?? defaultTimezone());
-      const deep = settings.deepDays > 0 && lastDeepDate !== today;
-      const days = deep ? settings.deepDays : settings.days;
-      await deps.sync({ days });
-      // Mark the deep pass done only AFTER it succeeded — a failed
-      // deep pass retries on the next tick instead of silently waiting
-      // for tomorrow (CLAUDE.md rule 25's "confirm before consuming
-      // the one-shot" shape).
-      if (deep) lastDeepDate = today;
-      deps.log.info(
-        `wearables auto-sync: refreshed ${days}-day window${deep ? " (daily deep pass)" : ""}`,
-      );
-    } catch (err) {
-      deps.log.warn(
-        `wearables auto-sync failed: ${describeErrorForOperator(err)} — retrying on the next tick`,
-      );
-    } finally {
-      inFlight = false;
-    }
+    const run = (async () => {
+      try {
+        const now = deps.now ? deps.now() : new Date();
+        const today = dateInTimezone(now, settings.timezone ?? defaultTimezone());
+        const deep = settings.deepDays > 0 && lastDeepDate !== today;
+        const days = deep ? settings.deepDays : settings.days;
+        await deps.sync({ days, signal: abortController.signal });
+        // Mark the deep pass done only AFTER it succeeded — a failed
+        // deep pass retries on the next tick instead of silently
+        // waiting for tomorrow (CLAUDE.md rule 25's "confirm before
+        // consuming the one-shot" shape).
+        if (deep) lastDeepDate = today;
+        deps.log.info(
+          `wearables auto-sync: refreshed ${days}-day window${deep ? " (daily deep pass)" : ""}`,
+        );
+      } catch (err) {
+        // An abort raised by stop() is intentional shutdown, not a
+        // failure — warning about it would be noise in every clean
+        // shutdown log.
+        if (!stopped) {
+          deps.log.warn(
+            `wearables auto-sync failed: ${describeErrorForOperator(err)} — retrying on the next tick`,
+          );
+        }
+      } finally {
+        inFlight = null;
+      }
+    })();
+    inFlight = run;
+    await run;
   };
 
   const timer = setInterval(() => {
@@ -96,9 +118,12 @@ export function startWearablesAutoSync(
 
   return {
     tick,
-    stop: () => {
+    stop: async () => {
       stopped = true;
       clearInterval(timer);
+      abortController.abort();
+      // tick() never rejects (all paths caught), so this only waits.
+      if (inFlight) await inFlight;
     },
   };
 }

--- a/packages/remnic-core/src/wearables/config.test.ts
+++ b/packages/remnic-core/src/wearables/config.test.ts
@@ -37,7 +37,7 @@ test("source settings default to the fully-automated smart pipeline", () => {
   assert.equal(source.reviewTrust, 0.45);
   assert.equal(source.minConfidence, 0.6);
   assert.equal(source.minImportance, "low");
-  assert.equal(source.maxMemoriesPerDay, 50);
+  assert.equal(source.maxMemoriesPerDay, 0, "uncapped by default");
   assert.equal(source.importNativeMemories, "smart");
   assert.deepEqual(source.cleanup, {
     mergeSameSpeaker: true,
@@ -95,15 +95,15 @@ test("maxMemoriesPerDay honors the documented 0-disables value and bounds", () =
     sources: { limitless: { maxMemoriesPerDay: 0 } },
   });
   assert.equal(parsed.sources.limitless.maxMemoriesPerDay, 0);
-  // Over-ceiling values reject instead of silently clamping to 500.
-  assert.throws(
-    () => parseWearablesConfig({ sources: { limitless: { maxMemoriesPerDay: 99999 } } }),
-    /maxMemoriesPerDay must be an integer between 0 and 500/,
-  );
+  // No ceiling: any non-negative integer cap is the operator's call.
   assert.equal(
-    parseWearablesConfig({ sources: { limitless: { maxMemoriesPerDay: 500 } } })
+    parseWearablesConfig({ sources: { limitless: { maxMemoriesPerDay: 99999 } } })
       .sources.limitless.maxMemoriesPerDay,
-    500,
+    99999,
+  );
+  assert.throws(
+    () => parseWearablesConfig({ sources: { limitless: { maxMemoriesPerDay: -1 } } }),
+    /maxMemoriesPerDay must be a non-negative integer/,
   );
   assert.throws(
     () => parseWearablesConfig({ sources: { limitless: { maxMemoriesPerDay: "lots" } } }),
@@ -168,5 +168,55 @@ test("minConfidence rejects out-of-range values instead of clamping", () => {
   assert.equal(
     parseWearablesConfig({ sources: { bee: { minConfidence: 0.85 } } }).sources.bee.minConfidence,
     0.85,
+  );
+});
+
+test("auto-sync defaults to enabled with sane window settings", () => {
+  const parsed = parseWearablesConfig({});
+  assert.equal(parsed.autoSyncEnabled, true);
+  assert.equal(parsed.autoSyncIntervalMinutes, 15);
+  assert.equal(parsed.autoSyncDays, 2);
+  assert.equal(parsed.autoSyncDeepDays, 7);
+});
+
+test("auto-sync knobs parse, coerce, and loud-reject invalid values", () => {
+  const parsed = parseWearablesConfig({
+    autoSyncEnabled: "false",
+    autoSyncIntervalMinutes: "30",
+    autoSyncDays: 3,
+    autoSyncDeepDays: 14,
+  });
+  assert.equal(parsed.autoSyncEnabled, false, "boolean-ish strings coerce");
+  assert.equal(parsed.autoSyncIntervalMinutes, 30, "numeric strings coerce");
+  assert.equal(parsed.autoSyncDays, 3);
+  assert.equal(parsed.autoSyncDeepDays, 14);
+
+  assert.throws(
+    () => parseWearablesConfig({ autoSyncIntervalMinutes: 0 }),
+    /autoSyncIntervalMinutes must be an integer between 1 and 1440/,
+  );
+  assert.throws(
+    () => parseWearablesConfig({ autoSyncIntervalMinutes: 2.5 }),
+    /autoSyncIntervalMinutes/,
+  );
+  assert.throws(
+    () => parseWearablesConfig({ autoSyncDays: 0 }),
+    /autoSyncDays must be an integer between 1 and 90/,
+  );
+  assert.throws(
+    () => parseWearablesConfig({ autoSyncDeepDays: 91 }),
+    /autoSyncDeepDays must be an integer between 0 and 90/,
+  );
+});
+
+test("a deep window narrower than the tick window is rejected, 0 disables", () => {
+  assert.throws(
+    () => parseWearablesConfig({ autoSyncDays: 5, autoSyncDeepDays: 3 }),
+    /autoSyncDeepDays must be 0 \(disabled\) or >= wearables.autoSyncDays/,
+  );
+  assert.equal(parseWearablesConfig({ autoSyncDeepDays: 0 }).autoSyncDeepDays, 0);
+  assert.equal(
+    parseWearablesConfig({ autoSyncDays: 5, autoSyncDeepDays: 5 }).autoSyncDeepDays,
+    5,
   );
 });

--- a/packages/remnic-core/src/wearables/config.ts
+++ b/packages/remnic-core/src/wearables/config.ts
@@ -34,8 +34,16 @@ const NATIVE_IMPORT_MODES = ["off", "review", "smart"] as const;
 
 const DEFAULT_MIN_CONFIDENCE = 0.6;
 const DEFAULT_MIN_IMPORTANCE: ImportanceLevel = "low";
-const DEFAULT_MAX_MEMORIES_PER_DAY = 50;
-const MAX_MEMORIES_PER_DAY_CEILING = 500;
+// Uncapped by default — wearables capture full days and the smart trust
+// pipeline is the quality gate; a count cap would drop real memories on
+// busy days. Operators who want a ceiling set any positive integer.
+const DEFAULT_MAX_MEMORIES_PER_DAY = 0;
+const DEFAULT_AUTO_SYNC_ENABLED = true;
+const DEFAULT_AUTO_SYNC_INTERVAL_MINUTES = 15;
+const MAX_AUTO_SYNC_INTERVAL_MINUTES = 1440;
+const DEFAULT_AUTO_SYNC_DAYS = 2;
+const DEFAULT_AUTO_SYNC_DEEP_DAYS = 7;
+const MAX_AUTO_SYNC_WINDOW_DAYS = 90;
 const DEFAULT_SOURCE_TRUST = 0.8;
 const DEFAULT_AUTO_APPROVE_TRUST = 0.7;
 const DEFAULT_REVIEW_TRUST = 0.45;
@@ -71,6 +79,10 @@ export function defaultWearablesConfig(): WearablesConfig {
     redactionPatterns: [],
     offTheRecordEnabled: true,
     digestEnabled: true,
+    autoSyncEnabled: DEFAULT_AUTO_SYNC_ENABLED,
+    autoSyncIntervalMinutes: DEFAULT_AUTO_SYNC_INTERVAL_MINUTES,
+    autoSyncDays: DEFAULT_AUTO_SYNC_DAYS,
+    autoSyncDeepDays: DEFAULT_AUTO_SYNC_DEEP_DAYS,
     corrections: [],
     sources: {},
   };
@@ -198,11 +210,10 @@ function parseSourceSettings(
     raw.maxMemoriesPerDay !== undefined &&
     (maxPerDayRaw === undefined ||
       !Number.isInteger(maxPerDayRaw) ||
-      maxPerDayRaw < 0 ||
-      maxPerDayRaw > MAX_MEMORIES_PER_DAY_CEILING)
+      maxPerDayRaw < 0)
   ) {
     throw new Error(
-      `${keyPath}.maxMemoriesPerDay must be an integer between 0 and ${MAX_MEMORIES_PER_DAY_CEILING} (0 disables the cap); got ${JSON.stringify(raw.maxMemoriesPerDay)}`,
+      `${keyPath}.maxMemoriesPerDay must be a non-negative integer (0, the default, disables the cap); got ${JSON.stringify(raw.maxMemoriesPerDay)}`,
     );
   }
   // 0 is the documented "disable the cap" value — honored here AND in
@@ -323,6 +334,57 @@ export function parseWearablesConfig(value: unknown): WearablesConfig {
     compileRedactionPatterns(redactionPatterns);
   }
 
+  const parseBoundedInt = (
+    value: unknown,
+    name: string,
+    fallback: number,
+    min: number,
+    max: number,
+  ): number => {
+    if (value === undefined) return fallback;
+    const coerced = coerceNumber(value);
+    if (
+      coerced === undefined ||
+      !Number.isInteger(coerced) ||
+      coerced < min ||
+      coerced > max
+    ) {
+      throw new Error(
+        `${name} must be an integer between ${min} and ${max}; got ${JSON.stringify(value)}`,
+      );
+    }
+    return coerced;
+  };
+  const autoSyncIntervalMinutes = parseBoundedInt(
+    raw.autoSyncIntervalMinutes,
+    "wearables.autoSyncIntervalMinutes",
+    defaults.autoSyncIntervalMinutes,
+    1,
+    MAX_AUTO_SYNC_INTERVAL_MINUTES,
+  );
+  const autoSyncDays = parseBoundedInt(
+    raw.autoSyncDays,
+    "wearables.autoSyncDays",
+    defaults.autoSyncDays,
+    1,
+    MAX_AUTO_SYNC_WINDOW_DAYS,
+  );
+  const autoSyncDeepDays = parseBoundedInt(
+    raw.autoSyncDeepDays,
+    "wearables.autoSyncDeepDays",
+    defaults.autoSyncDeepDays,
+    0,
+    MAX_AUTO_SYNC_WINDOW_DAYS,
+  );
+  // A deep window narrower than the every-tick window would make the
+  // "deep" pass fetch LESS than a normal tick — reject the confusion
+  // instead of silently honoring it (0 disables the deep pass).
+  if (autoSyncDeepDays !== 0 && autoSyncDeepDays < autoSyncDays) {
+    throw new Error(
+      `wearables.autoSyncDeepDays must be 0 (disabled) or >= wearables.autoSyncDays (${autoSyncDays}); got ${autoSyncDeepDays}`,
+    );
+  }
+
   const sources: Record<string, WearableSourceSettings> = {};
   if (raw.sources !== undefined) {
     const rawSources = requireObject(raw.sources, "wearables.sources");
@@ -358,6 +420,14 @@ export function parseWearablesConfig(value: unknown): WearablesConfig {
       "wearables.digestEnabled",
       defaults.digestEnabled,
     ),
+    autoSyncEnabled: parseBool(
+      raw.autoSyncEnabled,
+      "wearables.autoSyncEnabled",
+      defaults.autoSyncEnabled,
+    ),
+    autoSyncIntervalMinutes,
+    autoSyncDays,
+    autoSyncDeepDays,
     corrections: parseCorrectionRules(raw.corrections, "wearables.corrections"),
     sources,
   };

--- a/packages/remnic-core/src/wearables/pipeline.test.ts
+++ b/packages/remnic-core/src/wearables/pipeline.test.ts
@@ -544,14 +544,15 @@ test("zero provider conversations never clobber an existing transcript", async (
   }
 });
 
-test("page-capped days carry a visible partial marker and keep warning", async () => {
+test("looping pagination cursors stop with a partial marker and keep warning", async () => {
   const memoryDir = mkdtempSync(path.join(tmpdir(), "remnic-pipeline-"));
   try {
     const conversation = makeConversation("c1", "2026-06-11", [
       { speaker: "user", isWearer: true, text: "First chunk of a very long recorded day of conversations." },
       { speaker: "Speaker 2", text: "Indeed, the recordings just keep going on and on today." },
     ]);
-    // A connector that always reports another page (pathological).
+    // A connector whose cursor loops forever (pathological) — cycle
+    // detection must stop it; no page-count cap truncates real data.
     const endlessConnector = {
       id: "testsource",
       displayName: "Test Source",
@@ -567,14 +568,60 @@ test("page-capped days carry a visible partial marker and keep warning", async (
     };
     const { deps, written } = makeDeps(memoryDir);
     const first = await syncWearableSource(endlessConnector, settings(), config(), { days: 1 }, deps);
-    assert.ok(first.warnings.some((warning) => warning.includes("stopped paginating")));
+    assert.ok(first.warnings.some((warning) => warning.includes("repeated cursor")));
     assert.equal(written.length, 1);
     assert.match(written[0].serialized, /pagination safety cap reached/);
 
     // Identical second sync: file unchanged (no rewrite), warning persists.
     const second = await syncWearableSource(endlessConnector, settings(), config(), { days: 1 }, deps);
     assert.equal(second.transcriptsWritten.length, 0);
-    assert.ok(second.warnings.some((warning) => warning.includes("stopped paginating")));
+    assert.ok(second.warnings.some((warning) => warning.includes("repeated cursor")));
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("long provider days paginate fully — no page-count truncation", async () => {
+  const memoryDir = mkdtempSync(path.join(tmpdir(), "remnic-pipeline-"));
+  try {
+    // 60 pages (beyond the old 50-page cap), each with one conversation.
+    const PAGES = 60;
+    const longDayConnector = {
+      id: "testsource",
+      displayName: "Test Source",
+      async verifyAuth() {
+        return { ok: true };
+      },
+      async fetchConversations(opts: { cursor?: string | null }) {
+        const page = opts.cursor ? Number(opts.cursor) : 0;
+        return {
+          conversations: [
+            makeConversation(`c${page + 1}`, "2026-06-11", [
+              { speaker: "user", isWearer: true, text: `Recorded conversation segment number ${page + 1} from the long day.` },
+              { speaker: "Speaker 2", text: "Acknowledged, that part of the day was captured as well." },
+            ]),
+          ],
+          nextCursor: page + 1 < PAGES ? String(page + 1) : null,
+        };
+      },
+    };
+    const { deps } = makeDeps(memoryDir);
+    const summary = await syncWearableSource(
+      longDayConnector,
+      settings(),
+      config(),
+      { days: 1 },
+      deps,
+    );
+    assert.equal(summary.conversations, PAGES, "every page's conversation synced");
+    assert.equal(
+      summary.warnings.filter(
+        (warning) =>
+          warning.includes("stopped paginating") || warning.includes("repeated cursor"),
+      ).length,
+      0,
+      "a real long day is never truncated or warned",
+    );
   } finally {
     rmSync(memoryDir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/wearables/pipeline.test.ts
+++ b/packages/remnic-core/src/wearables/pipeline.test.ts
@@ -581,6 +581,42 @@ test("looping pagination cursors stop with a partial marker and keep warning", a
   }
 });
 
+test("looping providers that re-serve rows never duplicate conversations", async () => {
+  const memoryDir = mkdtempSync(path.join(tmpdir(), "remnic-pipeline-"));
+  try {
+    const conversation = makeConversation("c1", "2026-06-11", [
+      { speaker: "user", isWearer: true, text: "A conversation the provider keeps re-serving on every page." },
+      { speaker: "Speaker 2", text: "The looping pagination should still store this exactly once." },
+    ]);
+    // Pathological: every page returns the SAME row and loops the cursor.
+    const reServingConnector = {
+      id: "testsource",
+      displayName: "Test Source",
+      async verifyAuth() {
+        return { ok: true };
+      },
+      async fetchConversations() {
+        return { conversations: [conversation], nextCursor: "loop" };
+      },
+    };
+    const { deps, written } = makeDeps(memoryDir);
+    const summary = await syncWearableSource(
+      reServingConnector,
+      settings(),
+      config(),
+      { days: 1 },
+      deps,
+    );
+    assert.equal(summary.conversations, 1, "re-served rows collapse by conversation id");
+    assert.ok(summary.warnings.some((warning) => warning.includes("repeated cursor")));
+    assert.equal(written.length, 1);
+    const occurrences = written[0].serialized.split("conversation c1").length - 1;
+    assert.equal(occurrences, 1, "day file stores the conversation exactly once");
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("long provider days paginate fully — no page-count truncation", async () => {
   const memoryDir = mkdtempSync(path.join(tmpdir(), "remnic-pipeline-"));
   try {

--- a/packages/remnic-core/src/wearables/pipeline.ts
+++ b/packages/remnic-core/src/wearables/pipeline.ts
@@ -189,9 +189,16 @@ async function fetchAllConversationsForDate(
   signal: AbortSignal | undefined,
   warnings: string[],
 ): Promise<{ conversations: WearableConversation[]; partial: boolean }> {
-  const conversations: WearableConversation[] = [];
+  // Keyed by conversation id: a looping or overlapping provider can
+  // re-serve rows it already returned, and appending blindly would
+  // store the same conversation twice in the day file (Cursor review
+  // on PR #1464). Map keeps first-seen order; a re-served id replaces
+  // its entry in place, so the provider's LATEST version of a
+  // conversation wins — exactly what the current-day refresh wants.
+  const byId = new Map<string, WearableConversation>();
   let cursor: string | null | undefined = undefined;
   const seenCursors = new Set<string>();
+  const collect = () => [...byId.values()];
   for (let page = 0; page < PAGE_SAFETY_CEILING; page++) {
     const result = await connector.fetchConversations({
       date,
@@ -199,15 +206,17 @@ async function fetchAllConversationsForDate(
       cursor,
       signal,
     });
-    conversations.push(...result.conversations);
-    if (!result.nextCursor) return { conversations, partial: false };
+    for (const conversation of result.conversations) {
+      byId.set(conversation.id, conversation);
+    }
+    if (!result.nextCursor) return { conversations: collect(), partial: false };
     // A repeated cursor means the provider's pagination is looping —
     // following it again would refetch the same page forever.
     if (seenCursors.has(result.nextCursor)) {
       warnings.push(
         `${connector.id}: provider pagination repeated cursor on ${date} — stopped to avoid an infinite loop; day may be partially synced (every sync refetches and re-warns while the provider misbehaves)`,
       );
-      return { conversations, partial: true };
+      return { conversations: collect(), partial: true };
     }
     seenCursors.add(result.nextCursor);
     cursor = result.nextCursor;
@@ -215,7 +224,7 @@ async function fetchAllConversationsForDate(
   warnings.push(
     `${connector.id}: stopped paginating ${date} after the ${PAGE_SAFETY_CEILING}-page safety ceiling — day may be partially synced (every sync refetches and re-warns while this persists)`,
   );
-  return { conversations, partial: true };
+  return { conversations: collect(), partial: true };
 }
 
 /** Visible marker appended to day files whose fetch hit the page cap. */

--- a/packages/remnic-core/src/wearables/pipeline.ts
+++ b/packages/remnic-core/src/wearables/pipeline.ts
@@ -52,10 +52,13 @@ import type {
   WearablesConfig,
 } from "./types.js";
 
-/** Safety cap on pages fetched per day window. */
-const MAX_PAGES_PER_DAY = 50;
-/** Safety cap on native-memory pages per sync. */
-const MAX_NATIVE_PAGES = 20;
+/**
+ * Pathological-provider backstop on pagination loops. Day fetches are
+ * intentionally UNLIMITED for real data — a full day must never be
+ * truncated — so runaway protection comes from cursor-cycle detection
+ * plus this far-out-of-band ceiling, not from a content-sized cap.
+ */
+const PAGE_SAFETY_CEILING = 10_000;
 /** Default lookback window (today + yesterday) for unscoped syncs. */
 const DEFAULT_SYNC_DAYS = 2;
 const MAX_SYNC_DAYS = 90;
@@ -188,7 +191,8 @@ async function fetchAllConversationsForDate(
 ): Promise<{ conversations: WearableConversation[]; partial: boolean }> {
   const conversations: WearableConversation[] = [];
   let cursor: string | null | undefined = undefined;
-  for (let page = 0; page < MAX_PAGES_PER_DAY; page++) {
+  const seenCursors = new Set<string>();
+  for (let page = 0; page < PAGE_SAFETY_CEILING; page++) {
     const result = await connector.fetchConversations({
       date,
       timezone,
@@ -197,10 +201,19 @@ async function fetchAllConversationsForDate(
     });
     conversations.push(...result.conversations);
     if (!result.nextCursor) return { conversations, partial: false };
+    // A repeated cursor means the provider's pagination is looping —
+    // following it again would refetch the same page forever.
+    if (seenCursors.has(result.nextCursor)) {
+      warnings.push(
+        `${connector.id}: provider pagination repeated cursor on ${date} — stopped to avoid an infinite loop; day may be partially synced (every sync refetches and re-warns while the provider misbehaves)`,
+      );
+      return { conversations, partial: true };
+    }
+    seenCursors.add(result.nextCursor);
     cursor = result.nextCursor;
   }
   warnings.push(
-    `${connector.id}: stopped paginating ${date} after ${MAX_PAGES_PER_DAY} pages — day may be partially synced (every sync refetches and re-warns until the provider day fits the cap)`,
+    `${connector.id}: stopped paginating ${date} after the ${PAGE_SAFETY_CEILING}-page safety ceiling — day may be partially synced (every sync refetches and re-warns while this persists)`,
   );
   return { conversations, partial: true };
 }
@@ -521,7 +534,8 @@ export async function syncWearableSource(
           : {}),
       };
       let cursor: string | null | undefined = undefined;
-      for (let page = 0; page < MAX_NATIVE_PAGES; page++) {
+      const seenNativeCursors = new Set<string>();
+      for (let page = 0; page < PAGE_SAFETY_CEILING; page++) {
         const result = await connector.fetchNativeMemories({
           cursor,
           signal: options.signal,
@@ -538,10 +552,17 @@ export async function syncWearableSource(
         importedNativeIds.push(...imported.importedIds);
         for (const id of imported.importedIds) alreadyImported.add(id);
         if (!result.nextCursor) break;
-        cursor = result.nextCursor;
-        if (page === MAX_NATIVE_PAGES - 1) {
+        if (seenNativeCursors.has(result.nextCursor)) {
           summary.warnings.push(
-            `${connector.id}: stopped native-memory import after ${MAX_NATIVE_PAGES} pages — remaining items import on the next sync`,
+            `${connector.id}: provider pagination repeated cursor during native-memory import — stopped to avoid an infinite loop; remaining items import on the next sync`,
+          );
+          break;
+        }
+        seenNativeCursors.add(result.nextCursor);
+        cursor = result.nextCursor;
+        if (page === PAGE_SAFETY_CEILING - 1) {
+          summary.warnings.push(
+            `${connector.id}: stopped native-memory import at the ${PAGE_SAFETY_CEILING}-page safety ceiling — remaining items import on the next sync`,
           );
         }
       }

--- a/packages/remnic-core/src/wearables/types.ts
+++ b/packages/remnic-core/src/wearables/types.ts
@@ -176,7 +176,9 @@ export interface WearableSourceSettings {
   /** Drop extracted facts scored below this importance level. */
   minImportance: ImportanceLevel;
   /**
-   * Cap on memories created per source per day. 0 disables the cap.
+   * Cap on memories created per source per day. 0 (the default)
+   * disables the cap — the smart trust pipeline is the quality gate,
+   * and a count cap would drop real memories on busy days.
    */
   maxMemoriesPerDay: number;
   /**
@@ -250,6 +252,23 @@ export interface WearablesConfig {
    * Default false.
    */
   digestEnabled: boolean;
+  /**
+   * Periodically refresh transcripts in-process (long-lived hosts).
+   * Every tick re-syncs `autoSyncDays` ending today — existing day
+   * files included, so the current day keeps growing while the
+   * wearable records. Default true.
+   */
+  autoSyncEnabled: boolean;
+  /** Minutes between auto-sync ticks (1-1440). Default 15. */
+  autoSyncIntervalMinutes: number;
+  /** Rolling window (days ending today) per tick (1-90). Default 2. */
+  autoSyncDays: number;
+  /**
+   * Once-per-local-day deep pass window (days, 0-90) picking up late
+   * uploads and provider re-processing. 0 disables; otherwise must be
+   * >= autoSyncDays. Default 7.
+   */
+  autoSyncDeepDays: number;
   /** Correction rules from config (merged with CLI-managed rules). */
   corrections: WearableCorrectionRule[];
   /** Per-source settings, keyed by connector id. */


### PR DESCRIPTION
## Why

Wearables record all day, but transcripts only refreshed when an operator ran `wearables sync` — the current day's file went stale within minutes of a sync, and provider-side revisions (late phone uploads, re-diarization) never arrived unless someone remembered to re-run with `--days`. Separately, two per-day limits could silently truncate real data: the 50-page pagination cap could cut off a long recorded day, and `maxMemoriesPerDay: 50` could drop genuine memories on busy days.

## What

**Built-in periodic refresh (default on).** Long-lived hosts start an in-process auto-sync scheduler from the orchestrator's deferred init:

- Every `autoSyncIntervalMinutes` (default 15), re-sync the last `autoSyncDays` (default 2 — today + yesterday) for all enabled sources. Day fetches are unconditional within the window, so **existing day files are re-fetched and re-composed every tick** — the current day's transcript keeps growing while the wearable records. The content-hash skip keeps unchanged days write-free, so quiet ticks are read-only.
- Once per local day, the window deepens to `autoSyncDeepDays` (default 7) to pick up late uploads and provider re-processing further back. A failed deep pass retries on the next tick instead of waiting for tomorrow.
- Overlap-guarded (a slow sync never stacks), warn-and-retry on failure, `unref()`'d timer (one-shot CLI commands exit naturally without ever ticking), stopped via `orchestrator.destroy()`, idempotent across stop/start cycles.
- `autoSyncDeepDays` must be 0 (disabled) or >= `autoSyncDays` — a deep pass narrower than a normal tick is rejected at config parse.

**No per-day limits.**

- Transcript pagination: the 50-page cap is gone. Days paginate to completion; runaway providers are stopped by **cursor-cycle detection** (repeated cursor → stop + warn + partial marker) plus a far-out-of-band 10,000-page backstop — never by truncating real data. Native-memory import gets the same treatment (was 20 pages).
- `maxMemoriesPerDay` now defaults to **0 (uncapped)** and the 500 ceiling is dropped (any non-negative integer; negatives/non-integers still loud-reject). The smart trust pipeline is the quality gate — a count cap would drop real memories on busy days.

## Tests

10 new: auto-sync scheduler (deep-then-shallow cadence, local-day rollover, failed-deep retry, deepDays=0, overlap guard, stop), long-day full pagination past the old cap with zero warnings, cursor-loop detection with persistent warning, config validation (defaults, coercion, bounds, deepDays>=days invariant). 150/150 wearables tests, preflight:quick and test:entity-hardening (orchestrator touched) green.

## Config

```jsonc
"wearables": {
  "autoSyncEnabled": true,        // default
  "autoSyncIntervalMinutes": 15,  // default
  "autoSyncDays": 2,              // default
  "autoSyncDeepDays": 7           // default; 0 disables the deep pass
}
```

Schema (`openclaw.plugin.json`), docs/wearables.md, and JSDoc updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Long-lived hosts will hit provider APIs on a schedule by default and may create more memories without a daily cap; pagination changes affect transcript completeness and disk/API load on busy days.
> 
> **Overview**
> Adds **in-process wearables auto-sync** (default on) for long-lived hosts: a new `auto-sync` scheduler runs periodic `WearablesService.sync` with a shallow rolling window (`autoSyncDays`, default 2) and a once-per-local-day deep window (`autoSyncDeepDays`, default 7), with overlap protection, warn-and-retry failures, `unref()`’d timers, and clean shutdown via `orchestrator.destroy()`. Config/schema/docs gain `autoSyncEnabled`, interval, and window knobs.
> 
> **Removes silent truncation of real wearable data:** transcript and native-memory pagination no longer stop at low page caps; days paginate until complete, with **cursor-cycle detection** and a far-out safety ceiling instead. Conversation fetches **dedupe by conversation id** so looping providers don’t duplicate rows. **`maxMemoriesPerDay` defaults to 0 (uncapped)** and the 500 cap is removed—operators may set any non-negative integer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8044fb38439e87a04247564b3e563e7a1d6562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->