### PR TITLE
fix(ci): release step-summary backtick escaping executed package names as commands

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -597,7 +597,7 @@ jobs:
               echo "Provision npm trusted publishing for each name, then rerun this workflow:"
               echo ""
               for entry in "${UNPROVISIONED[@]}"; do
-                echo "- \\`$entry\\`"
+                echo "- \`$entry\`"
               done
             } >> "$GITHUB_STEP_SUMMARY"
             echo "::error::${#UNPROVISIONED[@]} package(s) require one-time trusted-publishing provisioning (see step summary). All other packages were published."


### PR DESCRIPTION
## Why

The unprovisioned first-publish summary in `release-and-publish.yml` never actually writes its package checklist. Line 600 used `\\\`` (escaped backslash + backtick) inside double quotes, so bash parsed the backtick as **command substitution and executed each package name as a command**:

```
/home/runner/work/_temp/….sh: line 68: @remnic/connector-bee@9.3.630\: No such file or directory
```

(run [27430613611](https://github.com/joshuaswarren/remnic/actions/runs/27430613611), the v9.3.630 release). The `::error` message tells operators to "see step summary" for which packages need trusted-publishing provisioning — but the summary list was empty.

## What

Single-backslash escape (`\``) prints the literal backtick. Verified the loop now emits:

```
- `@remnic/connector-bee@9.3.630`
```

One-line fix; `bash -n` parse check on the extracted step script passes. No behavior change to publishing itself — exit codes and warnings are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line bash quoting fix in CI; no runtime or publish logic changes.
> 
> **Overview**
> Fixes **bash backtick escaping** when the release workflow writes unprovisioned npm package names to the GitHub Actions step summary.
> 
> The loop that appends `UNPROVISIONED` entries used `\\\`` inside double-quoted `echo`, so bash treated the backtick as **command substitution** and tried to run each package name as a command. That produced shell errors and left the summary checklist empty even though the job still failed with “see step summary.”
> 
> The change uses a single escaped backtick (`\``) so each line is emitted as markdown like `` `@remnic/connector-bee@9.3.630` ``. **Publishing behavior, exit codes, and error messages are unchanged**—only the step summary output is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a3161ce40306899ab37ac0ac5d7481159b164a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->