### PR TITLE
fix(cli): include results in query explain fallback

### DIFF
--- a/.changeset/query-explain-fallback-results.md
+++ b/.changeset/query-explain-fallback-results.md
@@ -1,0 +1,5 @@
+---
+"@remnic/cli": patch
+---
+
+Include per-result summaries in `remnic query --explain` fallback output when the optional `@remnic/bench` explainer is not installed.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3923,6 +3923,21 @@ interface QueryRenderableResult {
   content?: string;
   preview?: string;
   context?: string;
+  id?: string;
+  memoryId?: string;
+  path?: string;
+  file?: string;
+  source?: string;
+  score?: number;
+}
+
+function queryResultText(memory: QueryRenderableResult): string {
+  return (
+    memory.content?.trim()
+    || memory.preview?.trim()
+    || memory.context?.trim()
+    || "(no preview available)"
+  );
 }
 
 export function renderQueryTextLines(result: {
@@ -3933,12 +3948,43 @@ export function renderQueryTextLines(result: {
   if (results.length === 0) return ["No results."];
 
   return results.map((memory) => {
-    const text =
-      memory.content?.trim()
-      || memory.preview?.trim()
-      || memory.context?.trim()
-      || "(no preview available)";
-    return `- ${text}`;
+    return `- ${queryResultText(memory)}`;
+  });
+}
+
+export interface QueryExplainFallbackResultSummary {
+  index: number;
+  text: string;
+  id?: string;
+  source?: string;
+  score?: number;
+}
+
+function firstNonEmptyString(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+export function summarizeQueryExplainFallbackResults(result: {
+  results?: QueryRenderableResult[];
+}): QueryExplainFallbackResultSummary[] {
+  const results = Array.isArray(result.results) ? result.results : [];
+  return results.map((memory, index) => {
+    const summary: QueryExplainFallbackResultSummary = {
+      index: index + 1,
+      text: queryResultText(memory),
+    };
+    const id = firstNonEmptyString(memory.id, memory.memoryId);
+    if (id) summary.id = id;
+    const source = firstNonEmptyString(memory.source, memory.path, memory.file);
+    if (source) summary.source = source;
+    if (typeof memory.score === "number" && Number.isFinite(memory.score)) {
+      summary.score = memory.score;
+    }
+    return summary;
   });
 }
 
@@ -4014,6 +4060,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
         query: queryText,
         totalDurationMs,
         resultsCount,
+        results: summarizeQueryExplainFallbackResults(recallResult),
         note: "Install @remnic/bench for a full tier-level explain breakdown.",
       };
       if (json) {
@@ -4022,6 +4069,10 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
         console.log(`Query: ${minimalExplain.query}`);
         console.log(`Total duration: ${minimalExplain.totalDurationMs}ms`);
         console.log(`Results: ${minimalExplain.resultsCount}`);
+        for (const result of minimalExplain.results) {
+          const suffix = result.source ? ` (${result.source})` : "";
+          console.log(`  ${result.index}. ${result.text}${suffix}`);
+        }
         console.log(`Note: ${minimalExplain.note}`);
       }
       return;

--- a/packages/remnic-cli/src/query-render.test.ts
+++ b/packages/remnic-cli/src/query-render.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { buildQueryRecallRequest, renderQueryTextLines } from "./index.js";
+import {
+  buildQueryRecallRequest,
+  renderQueryTextLines,
+  summarizeQueryExplainFallbackResults,
+} from "./index.js";
 
 test("query recall requests include a one-shot CLI session key", () => {
   const request = buildQueryRecallRequest("known fact");
@@ -46,5 +50,68 @@ test("plain text query output does not use aggregate recall context as item text
       results: [{}],
     }),
     ["- (no preview available)"],
+  );
+});
+
+test("query explain fallback summaries include per-result bodies", () => {
+  assert.deepEqual(
+    summarizeQueryExplainFallbackResults({
+      results: [
+        {
+          id: "memory-a",
+          content: "Canonical project root is /example/project.",
+          source: "facts/project-root.md",
+          score: 0.91,
+        },
+        {
+          memoryId: "memory-b",
+          preview: "Daily notes live under notes/daily.",
+          path: "facts/daily-notes.md",
+        },
+      ],
+    }),
+    [
+      {
+        index: 1,
+        id: "memory-a",
+        text: "Canonical project root is /example/project.",
+        source: "facts/project-root.md",
+        score: 0.91,
+      },
+      {
+        index: 2,
+        id: "memory-b",
+        text: "Daily notes live under notes/daily.",
+        source: "facts/daily-notes.md",
+      },
+    ],
+  );
+});
+
+test("query explain fallback summaries ignore blank metadata and non-finite scores", () => {
+  assert.deepEqual(
+    summarizeQueryExplainFallbackResults({
+      results: [
+        {
+          id: " ",
+          context: "memory context",
+          source: "",
+          file: "facts/context.md",
+          score: Number.NaN,
+        },
+        {},
+      ],
+    }),
+    [
+      {
+        index: 1,
+        text: "memory context",
+        source: "facts/context.md",
+      },
+      {
+        index: 2,
+        text: "(no preview available)",
+      },
+    ],
   );
 });


### PR DESCRIPTION
## Summary
- include per-result summaries in the fallback output for `remnic query --explain` when `@remnic/bench` is not installed
- reuse the same result text precedence as normal query output
- add CLI renderer tests and a patch changeset

## Verification
- `pnpm exec tsx --test packages/remnic-cli/src/query-render.test.ts`
- `pnpm --filter @remnic/cli run check-types`
- `pnpm --filter @remnic/cli test`
- `npm run preflight:quick`

Note: `npm run review:cursor` was attempted but skipped because the local Cursor agent requires authentication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only presentation of existing recall data; no auth or server behavior changes.
> 
> **Overview**
> Improves the **minimal explain path** for `remnic query --explain` when the optional `@remnic/bench` explainer is not installed.
> 
> Recall hits are summarized with the same text precedence as normal query output (`content` → `preview` → `context`), plus optional **id** (`id` / `memoryId`), **source** (`source` / `path` / `file`), and **score** when present and finite. Plain-text fallback prints numbered lines with an optional source suffix; JSON fallback adds a `results` array alongside the existing query, duration, and count fields.
> 
> Adds unit tests for the summarizer and a patch changeset for `@remnic/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be2dbcf5f7f94e106d59801414948bc674c39fa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->