### PR TITLE
Scope MCP memory search collections by namespace

### DIFF
--- a/.changeset/namespace-search-collection-contract.md
+++ b/.changeset/namespace-search-collection-contract.md
@@ -1,0 +1,5 @@
+---
+"@remnic/core": patch
+---
+
+Make MCP memory search collection handling namespace-aware. Namespace-enabled searches now scope omitted, base, and global collection requests to the caller's readable recall namespaces, accept namespace-derived collection names only for readable requested namespaces, and reject arbitrary custom collections instead of silently ignoring them.

--- a/docs/api.md
+++ b/docs/api.md
@@ -384,6 +384,9 @@ Search memories by semantic similarity.
 - `limit` (number, optional, default: 10) — Max results to return.
 - `category` (string, optional) — Filter by memory category.
 - `namespace` (string, optional) — Filter by namespace.
+- `collection` (string, optional) — QMD collection override for direct MCP/access calls.
+
+When namespaces are enabled, unqualified searches use the authenticated principal's readable recall namespaces. Passing `collection: "global"` remains ACL-scoped to those readable namespaces; it does not bypass namespace isolation. Namespace-derived collection names are accepted only when they match a readable requested namespace. Arbitrary custom collections are rejected in namespace mode because Remnic cannot prove they are namespace-safe. Deployments without namespaces may still search a named custom QMD collection directly.
 
 **Returns:** Array of matching memories with scores, paths, and content snippets.
 

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1433,7 +1433,7 @@ export class EngramMcpServer {
             query: { type: "string" },
             namespace: { type: "string" },
             maxResults: { type: "number" },
-            collection: { type: "string", description: "QMD collection (omit for memory, 'global' for all)" },
+            collection: { type: "string", description: "QMD collection. With namespaces enabled, omitted, base, and 'global' searches stay scoped to readable namespaces; namespace-derived collections require matching namespace access." },
           },
           required: ["query"],
           additionalProperties: false,

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { EngramAccessInputError, EngramAccessService } from "./access-service.js";
+import { namespaceCollectionName } from "./namespaces/search.js";
 import type { StorageManager } from "./storage.js";
 import type { PluginConfig } from "./types.js";
 
@@ -25,6 +26,8 @@ function makeConfig(): PluginConfig {
     daySum: { enabled: false },
     searchBackend: "orama",
     qmd: { enabled: false },
+    qmdCollection: "test-memory",
+    qmdMaxResults: 10,
     nativeKnowledge: { enabled: false },
     recall: { budget: {} },
     consolidation: { enabled: false },
@@ -50,13 +53,34 @@ function makeService(): {
   (service as unknown as {
     orchestrator: {
       config: PluginConfig;
+      qmd: {
+        search(query: string, collection?: string, maxResults?: number): Promise<unknown[]>;
+        searchGlobal(query: string, maxResults?: number): Promise<unknown[]>;
+      };
       getStorage(namespace: string): Promise<StorageManager>;
+      searchAcrossNamespaces(params: {
+        query: string;
+        namespaces?: string[];
+        maxResults?: number;
+        mode?: string;
+      }): Promise<unknown[]>;
     };
   }).orchestrator = {
     config: makeConfig(),
+    qmd: {
+      async search() {
+        throw new Error("qmd.search should not run in namespace mode");
+      },
+      async searchGlobal() {
+        throw new Error("qmd.searchGlobal should not run in namespace mode");
+      },
+    },
     async getStorage(namespace: string): Promise<StorageManager> {
       getStorageCalls.push(namespace);
       return storage;
+    },
+    async searchAcrossNamespaces() {
+      return [];
     },
   };
 
@@ -124,6 +148,294 @@ test("memoryBrowse resolves namespace storage for read principals", async () => 
   assert.equal(result.namespace, "team");
   assert.equal(result.count, 0);
   assert.deepEqual(getStorageCalls, ["team"]);
+});
+
+test("memorySearch without an explicit namespace uses readable recall namespaces", async () => {
+  const { service } = makeService();
+  let searchParams: unknown;
+  (service as unknown as {
+    orchestrator: {
+      searchAcrossNamespaces(params: unknown): Promise<Array<{ path: string; score: number; snippet: string }>>;
+    };
+  }).orchestrator.searchAcrossNamespaces = async (params) => {
+    searchParams = params;
+    return [{ path: "default/facts/a.md", score: 0.7, snippet: "matched" }];
+  };
+
+  const result = await service.memorySearch({
+    query: "deployment notes",
+    maxResults: 3,
+    principal: "reader",
+  });
+
+  assert.deepEqual(searchParams, {
+    query: "deployment notes",
+    namespaces: ["default", "shared"],
+    maxResults: 3,
+    mode: "search",
+  });
+  assert.equal(result.count, 1);
+});
+
+test("memorySearch with an explicit namespace searches only that readable namespace", async () => {
+  const { service } = makeService();
+  let searchParams: unknown;
+  (service as unknown as {
+    orchestrator: {
+      searchAcrossNamespaces(params: unknown): Promise<unknown[]>;
+    };
+  }).orchestrator.searchAcrossNamespaces = async (params) => {
+    searchParams = params;
+    return [];
+  };
+
+  await service.memorySearch({
+    query: "release note",
+    namespace: "team",
+    maxResults: 2,
+    principal: "reader",
+  });
+
+  assert.deepEqual(searchParams, {
+    query: "release note",
+    namespaces: ["team"],
+    maxResults: 2,
+    mode: "search",
+  });
+});
+
+test("memorySearch rejects unreadable namespaces before collection routing", async () => {
+  const { service } = makeService();
+  let searchCalls = 0;
+  (service as unknown as {
+    orchestrator: {
+      searchAcrossNamespaces(params: unknown): Promise<unknown[]>;
+    };
+  }).orchestrator.searchAcrossNamespaces = async () => {
+    searchCalls += 1;
+    return [];
+  };
+
+  await assert.rejects(
+    () =>
+      service.memorySearch({
+        query: "release note",
+        namespace: "team",
+        collection: namespaceCollectionName("test-memory", "team", {
+          defaultNamespace: "default",
+          useLegacyDefaultCollection: false,
+        }),
+        principal: "stranger",
+      }),
+    /namespace is not readable: team/,
+  );
+  assert.equal(searchCalls, 0);
+});
+
+test("memorySearch rejects empty collection names", async () => {
+  const { service } = makeService();
+  let searchCalls = 0;
+  (service as unknown as {
+    orchestrator: {
+      searchAcrossNamespaces(params: unknown): Promise<unknown[]>;
+    };
+  }).orchestrator.searchAcrossNamespaces = async () => {
+    searchCalls += 1;
+    return [];
+  };
+
+  await assert.rejects(
+    () =>
+      service.memorySearch({
+        query: "deployment notes",
+        collection: "   ",
+        principal: "reader",
+      }),
+    /collection must be a non-empty string/,
+  );
+  assert.equal(searchCalls, 0);
+});
+
+test("memorySearch treats global collection as ACL-scoped when namespaces are enabled", async () => {
+  const { service } = makeService();
+  let globalSearchCalls = 0;
+  let searchParams: unknown;
+  (service as unknown as {
+    orchestrator: {
+      qmd: {
+        searchGlobal(query: string, maxResults?: number): Promise<unknown[]>;
+      };
+      searchAcrossNamespaces(params: unknown): Promise<unknown[]>;
+    };
+  }).orchestrator.qmd.searchGlobal = async () => {
+    globalSearchCalls += 1;
+    return [];
+  };
+  (service as unknown as {
+    orchestrator: {
+      searchAcrossNamespaces(params: unknown): Promise<unknown[]>;
+    };
+  }).orchestrator.searchAcrossNamespaces = async (params) => {
+    searchParams = params;
+    return [];
+  };
+
+  await service.memorySearch({
+    query: "runbook",
+    collection: "global",
+    principal: "reader",
+  });
+
+  assert.equal(globalSearchCalls, 0);
+  assert.deepEqual(searchParams, {
+    query: "runbook",
+    namespaces: ["default", "shared"],
+    maxResults: undefined,
+    mode: "search",
+  });
+});
+
+test("memorySearch accepts a namespace-scoped collection for the requested namespace", async () => {
+  const { service } = makeService();
+  let searchParams: unknown;
+  (service as unknown as {
+    orchestrator: {
+      searchAcrossNamespaces(params: unknown): Promise<unknown[]>;
+    };
+  }).orchestrator.searchAcrossNamespaces = async (params) => {
+    searchParams = params;
+    return [];
+  };
+
+  await service.memorySearch({
+    query: "release note",
+    namespace: "team",
+    collection: namespaceCollectionName("test-memory", "team", {
+      defaultNamespace: "default",
+      useLegacyDefaultCollection: false,
+    }),
+    principal: "reader",
+  });
+
+  assert.deepEqual(searchParams, {
+    query: "release note",
+    namespaces: ["team"],
+    maxResults: undefined,
+    mode: "search",
+  });
+});
+
+test("memorySearch accepts a readable namespace-scoped collection without duplicate namespace", async () => {
+  const { service } = makeService();
+  let searchParams: unknown;
+  (service as unknown as {
+    orchestrator: {
+      searchAcrossNamespaces(params: unknown): Promise<unknown[]>;
+    };
+  }).orchestrator.searchAcrossNamespaces = async (params) => {
+    searchParams = params;
+    return [];
+  };
+
+  await service.memorySearch({
+    query: "release note",
+    collection: namespaceCollectionName("test-memory", "team", {
+      defaultNamespace: "default",
+      useLegacyDefaultCollection: false,
+    }),
+    principal: "reader",
+  });
+
+  assert.deepEqual(searchParams, {
+    query: "release note",
+    namespaces: ["team"],
+    maxResults: undefined,
+    mode: "search",
+  });
+});
+
+test("memorySearch rejects arbitrary custom collections when namespaces are enabled", async () => {
+  const { service } = makeService();
+  let qmdSearchCalls = 0;
+  (service as unknown as {
+    orchestrator: {
+      qmd: {
+        search(query: string, collection?: string, maxResults?: number): Promise<unknown[]>;
+      };
+    };
+  }).orchestrator.qmd.search = async () => {
+    qmdSearchCalls += 1;
+    return [];
+  };
+
+  await assert.rejects(
+    () =>
+      service.memorySearch({
+        query: "deployment notes",
+        collection: "custom-collection",
+        principal: "reader",
+      }),
+    /collection is not namespace-scoped for the requested principal/,
+  );
+  assert.equal(qmdSearchCalls, 0);
+});
+
+test("memorySearch honors custom collections when namespaces are disabled", async () => {
+  const { service } = makeService();
+  (service as unknown as { orchestrator: { config: PluginConfig } }).orchestrator.config = {
+    ...makeConfig(),
+    namespacesEnabled: false,
+  };
+  let qmdSearchArgs: unknown[] | undefined;
+  (service as unknown as {
+    orchestrator: {
+      qmd: {
+        search(query: string, collection?: string, maxResults?: number): Promise<unknown[]>;
+      };
+    };
+  }).orchestrator.qmd.search = async (...args) => {
+    qmdSearchArgs = args;
+    return [{ path: "facts/a.md", score: 0.5, snippet: "matched" }];
+  };
+
+  const result = await service.memorySearch({
+    query: "deployment notes",
+    collection: "custom-collection",
+    maxResults: 4,
+  });
+
+  assert.deepEqual(qmdSearchArgs, ["deployment notes", "custom-collection", 4]);
+  assert.equal(result.count, 1);
+});
+
+test("memorySearch rejects unsupported namespaces when namespaces are disabled", async () => {
+  const { service } = makeService();
+  (service as unknown as { orchestrator: { config: PluginConfig } }).orchestrator.config = {
+    ...makeConfig(),
+    namespacesEnabled: false,
+  };
+  let qmdSearchCalls = 0;
+  (service as unknown as {
+    orchestrator: {
+      qmd: {
+        search(query: string, collection?: string, maxResults?: number): Promise<unknown[]>;
+      };
+    };
+  }).orchestrator.qmd.search = async () => {
+    qmdSearchCalls += 1;
+    return [];
+  };
+
+  await assert.rejects(
+    () =>
+      service.memorySearch({
+        query: "deployment notes",
+        namespace: "team",
+        collection: "custom-collection",
+      }),
+    /unsupported namespace: team/,
+  );
+  assert.equal(qmdSearchCalls, 0);
 });
 
 test("offlineSyncFiles reports invalid requested paths as input errors", async () => {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -54,6 +54,7 @@ import {
 } from "./memory-lifecycle-ledger-utils.js";
 import { getMemoryProjectionPath } from "./memory-projection-store.js";
 import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal, resolvePrincipal } from "./namespaces/principal.js";
+import { namespaceCollectionName } from "./namespaces/search.js";
 import type { LastRecallSnapshot } from "./recall-state.js";
 import type {
   GraphRecallSnapshot,
@@ -1320,6 +1321,75 @@ export class EngramAccessService {
       throw new EngramAccessInputError(`namespace is not readable: ${resolved}`);
     }
     return resolved;
+  }
+
+  private resolveReadableNamespacesForSearch(namespace: string | undefined, principal?: string): string[] {
+    const requested = namespace?.trim();
+    if (requested) {
+      return [this.resolveReadableNamespace(requested, principal)];
+    }
+
+    if (!this.orchestrator.config.namespacesEnabled) {
+      return [this.resolveNamespace(undefined)];
+    }
+
+    if (!principal) {
+      throw new EngramAccessInputError(
+        "authentication required: namespaces are enabled and no principal was supplied",
+      );
+    }
+
+    return recallNamespacesForPrincipal(principal, this.orchestrator.config)
+      .filter((ns) => canReadNamespace(principal, ns, this.orchestrator.config));
+  }
+
+  private resolveAllReadableConfiguredNamespaces(principal: string): string[] {
+    const config = this.orchestrator.config;
+    const candidates = [
+      config.defaultNamespace,
+      config.sharedNamespace,
+      ...config.namespacePolicies.map((policy) => policy.name),
+    ];
+    return [...new Set(candidates)]
+      .filter((namespace) => canReadNamespace(principal, namespace, config));
+  }
+
+  private resolveMemorySearchNamespacesForCollection(
+    collection: string | undefined,
+    namespaces: string[],
+    collectionPrincipal?: string,
+  ): string[] {
+    if (!this.orchestrator.config.namespacesEnabled) {
+      return namespaces;
+    }
+
+    const baseCollection = this.orchestrator.config.qmdCollection;
+    if (!collection || collection === "global" || collection === baseCollection) {
+      return namespaces;
+    }
+
+    const candidates = collectionPrincipal
+      ? this.resolveAllReadableConfiguredNamespaces(collectionPrincipal)
+      : namespaces;
+    const matchedNamespaces = candidates.filter((namespace) => {
+      const canonical = namespaceCollectionName(baseCollection, namespace, {
+        defaultNamespace: this.orchestrator.config.defaultNamespace,
+        useLegacyDefaultCollection: false,
+      });
+      const legacyDefault = namespaceCollectionName(baseCollection, namespace, {
+        defaultNamespace: this.orchestrator.config.defaultNamespace,
+        useLegacyDefaultCollection: true,
+      });
+      return collection === canonical || collection === legacyDefault;
+    });
+
+    if (matchedNamespaces.length > 0) {
+      return matchedNamespaces;
+    }
+
+    throw new EngramAccessInputError(
+      "collection is not namespace-scoped for the requested principal",
+    );
   }
 
   private async buildRecallDebug(
@@ -4864,18 +4934,34 @@ export class EngramAccessService {
     collection?: string;
     principal?: string;
   }): Promise<{ query: string; results: Array<{ path: string; score: number; snippet: string }>; count: number }> {
-    const { query, namespace, maxResults, collection, principal } = request;
-    const resolvedNs = this.resolveReadableNamespace(namespace, principal);
-    const namespaceFilter = resolvedNs !== this.orchestrator.config.defaultNamespace ? resolvedNs : undefined;
+    const { query, namespace, maxResults, principal } = request;
+    const collection = request.collection?.trim();
+    if (request.collection !== undefined && !collection) {
+      throw new EngramAccessInputError("collection must be a non-empty string");
+    }
 
-    const results = collection === "global" && !namespaceFilter
-      ? await this.orchestrator.qmd.searchGlobal(query, maxResults)
-      : await this.orchestrator.searchAcrossNamespaces({
-          query,
-          namespaces: namespaceFilter ? [namespaceFilter] : undefined,
-          maxResults,
-          mode: "search",
-        });
+    let results: Array<{ path: string; score: number; snippet?: string }>;
+    if (!this.orchestrator.config.namespacesEnabled) {
+      this.resolveReadableNamespace(namespace, principal);
+      results = collection === "global"
+        ? await this.orchestrator.qmd.searchGlobal(query, maxResults)
+        : await this.orchestrator.qmd.search(query, collection, maxResults);
+    } else {
+      const readableNamespaces = this.resolveReadableNamespacesForSearch(namespace, principal);
+      const namespaces = this.resolveMemorySearchNamespacesForCollection(
+        collection,
+        readableNamespaces,
+        namespace?.trim() ? undefined : principal,
+      );
+      results = namespaces.length === 0
+        ? []
+        : await this.orchestrator.searchAcrossNamespaces({
+            query,
+            namespaces,
+            maxResults,
+            mode: "search",
+          });
+    }
 
     return {
       query,


### PR DESCRIPTION
## Summary
- make access-service memory search resolve explicit and default namespace sets before searching
- keep `collection: global` ACL-scoped when namespaces are enabled
- reject arbitrary custom collections in namespace mode unless they match a readable namespace-derived collection
- document the MCP/access collection contract and add a patch changeset

## Verification
- pnpm --filter @remnic/core exec tsx --test src/access-service-namespace.test.ts
- pnpm --filter @remnic/core run check-types
- npm run preflight:quick

## Notes
- `pnpm rebuild better-sqlite3` was required in this fresh worktree before quick preflight because the native binding was not linked yet.
- `npm run review:cursor` was attempted but skipped because the local Cursor agent is not authenticated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes access-layer search routing and rejects previously tolerated custom collections in namespace mode, which can break MCP clients that relied on unscoped QMD collections; the ACL tightening is intentional but behavior-changing for multi-tenant deployments.
> 
> **Overview**
> **Makes `memorySearch` enforce namespace isolation for QMD `collection` overrides** instead of routing some requests through unscoped `qmd.searchGlobal` / direct QMD collection search.
> 
> When namespaces are enabled, searches resolve to the caller’s **readable recall namespaces** (or a single explicit `namespace` after ACL checks). Omitted collection, the configured base collection, and `collection: "global"` all go through `searchAcrossNamespaces` with that ACL-scoped namespace set—**`global` no longer bypasses namespace boundaries**. Namespace-derived collection names are accepted only when they map to a namespace the principal may read; **arbitrary custom collections are rejected** with an input error rather than ignored. Whitespace-only `collection` values are rejected up front.
> 
> When namespaces are disabled, behavior stays on direct QMD paths (`search` / `searchGlobal`) with custom collections still allowed.
> 
> Docs and the `engram.memory_search` MCP schema describe this contract; namespace routing is covered by new tests in `access-service-namespace.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 954ede28f750a6a2dcdbb8b300dd480e1f264f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->