### PR TITLE
Fix post-retrieval assembly deadline handling

### DIFF
--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { EngramAccessInputError, EngramAccessService } from "./access-service.js";
+import { namespaceIdentityToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
 import type { StorageManager } from "./storage.js";
 import type { PluginConfig } from "./types.js";
@@ -148,6 +149,97 @@ test("memoryBrowse resolves namespace storage for read principals", async () => 
   assert.equal(result.namespace, "team");
   assert.equal(result.count, 0);
   assert.deepEqual(getStorageCalls, ["team"]);
+});
+
+test("last recall serialization resolves namespace collection-prefixed result paths", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-ns-"));
+  const teamDir = path.join(
+    memoryRoot,
+    "namespaces",
+    namespaceIdentityToken("team"),
+  );
+  const memoryPath = path.join(teamDir, "facts", "2026-06-16", "fact-001.md");
+  const teamMemory = {
+    path: memoryPath,
+    frontmatter: {
+      id: "fact-001",
+      created: "2026-06-16T12:00:00.000Z",
+      updated: "2026-06-16T12:00:00.000Z",
+      category: "fact",
+      status: "active",
+      tags: ["discord"],
+    },
+    content: "Agent-authored status update from the channel.",
+  };
+  const readCalls: Array<{ namespace: string; path: string }> = [];
+  const storages: Record<string, StorageManager> = {
+    default: {
+      dir: memoryRoot,
+      async readMemoryByPath(filePath: string) {
+        readCalls.push({ namespace: "default", path: filePath });
+        return null;
+      },
+      async getMemoryById() {
+        return null;
+      },
+    } as unknown as StorageManager,
+    team: {
+      dir: teamDir,
+      async readMemoryByPath(filePath: string) {
+        readCalls.push({ namespace: "team", path: filePath });
+        return filePath === memoryPath ? teamMemory : null;
+      },
+      async getMemoryById() {
+        return null;
+      },
+    } as unknown as StorageManager,
+  };
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: makeConfig(),
+    async getStorage(namespace: string) {
+      return storages[namespace] ?? storages.default;
+    },
+  };
+
+  const collection = namespaceCollectionName("test-memory", "team", {
+    defaultNamespace: "default",
+    useLegacyDefaultCollection: false,
+  });
+  const result = await (service as unknown as {
+    serializeRecallResults(
+      snapshot: unknown,
+      disclosure: "summary",
+    ): Promise<Array<{ id: string; path: string; preview: string }>>;
+  }).serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-06-16T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 4,
+      memoryIds: [],
+      namespace: "default",
+      resultPaths: [`${collection}/2026-06-16/fact-001.md`],
+    },
+    "summary",
+  );
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, "fact-001");
+  assert.equal(result[0].path, memoryPath);
+  assert.ok(result[0].preview.includes("Agent-authored status update"));
+  assert.ok(
+    readCalls.some(
+      (call) => call.namespace === "team" && call.path === memoryPath,
+    ),
+    "expected collection-prefixed result path to resolve through team storage",
+  );
 });
 
 test("memorySearch without an explicit namespace uses readable recall namespaces", async () => {

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -340,6 +340,83 @@ test("last recall serialization does not fall back after namespace collection mi
   );
 });
 
+test("last recall serialization resolves cold collection paths through snapshot storage", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-cold-"));
+  const coldMemoryPath = path.join(
+    memoryRoot,
+    "cold",
+    "facts",
+    "2026-06-16",
+    "fact-001.md",
+  );
+  const coldMemory = {
+    path: coldMemoryPath,
+    frontmatter: {
+      id: "fact-001",
+      created: "2026-06-16T12:00:00.000Z",
+      updated: "2026-06-16T12:00:00.000Z",
+      category: "fact",
+      status: "active",
+    },
+    content: "Cold namespace recall content.",
+  };
+  const readCalls: string[] = [];
+  const storage = {
+    dir: memoryRoot,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push(filePath);
+      return filePath === coldMemoryPath ? coldMemory : null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: {
+      ...makeConfig(),
+      qmdColdCollection: "test-memory-cold",
+    },
+    async getStorage() {
+      return storage;
+    },
+  };
+
+  const result = await (service as unknown as {
+    serializeRecallResults(
+      snapshot: unknown,
+      disclosure: "summary",
+    ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
+  }).serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-06-16T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 4,
+      memoryIds: [],
+      namespace: "default",
+      resultPaths: ["test-memory-cold/facts/2026-06-16/fact-001.md"],
+    },
+    "summary",
+  );
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, "fact-001");
+  assert.equal(result[0].path, coldMemoryPath);
+  assert.ok(result[0].preview.includes("Cold namespace recall content"));
+  assert.ok(readCalls.includes(coldMemoryPath));
+  assert.ok(
+    !readCalls.includes(path.join(memoryRoot, "test-memory-cold", "facts", "2026-06-16", "fact-001.md")),
+    "expected cold collection path to resolve under cold/ rather than a collection-named subdirectory",
+  );
+});
+
 test("last recall serialization propagates locked namespace collection errors", async () => {
   const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
   const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-lock-"));

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -249,6 +249,96 @@ test("last recall serialization resolves namespace collection-prefixed result pa
   );
 });
 
+test("last recall serialization does not fall back after namespace collection misses", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-ns-miss-"));
+  const defaultMemoryPath = path.join(
+    memoryRoot,
+    "facts",
+    "2026-06-16",
+    "fact-001.md",
+  );
+  const defaultMemory = {
+    path: defaultMemoryPath,
+    frontmatter: {
+      id: "fact-001",
+      created: "2026-06-16T12:00:00.000Z",
+      updated: "2026-06-16T12:00:00.000Z",
+      category: "fact",
+      status: "active",
+    },
+    content: "Default namespace content should not be reused.",
+  };
+  const teamDir = path.join(
+    memoryRoot,
+    "namespaces",
+    namespaceIdentityToken("team"),
+  );
+  const readCalls: Array<{ namespace: string; path: string }> = [];
+  const storages: Record<string, StorageManager> = {
+    default: {
+      dir: memoryRoot,
+      async readMemoryByPath(filePath: string) {
+        readCalls.push({ namespace: "default", path: filePath });
+        return filePath === defaultMemoryPath ? defaultMemory : null;
+      },
+      async getMemoryById() {
+        return null;
+      },
+    } as unknown as StorageManager,
+    team: {
+      dir: teamDir,
+      async readMemoryByPath(filePath: string) {
+        readCalls.push({ namespace: "team", path: filePath });
+        return null;
+      },
+      async getMemoryById() {
+        return null;
+      },
+    } as unknown as StorageManager,
+  };
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: makeConfig(),
+    async getStorage(namespace: string) {
+      return storages[namespace] ?? storages.default;
+    },
+  };
+
+  const collection = namespaceCollectionName("test-memory", "team", {
+    defaultNamespace: "default",
+    useLegacyDefaultCollection: false,
+  });
+  const result = await (service as unknown as {
+    serializeRecallResults(
+      snapshot: unknown,
+      disclosure: "summary",
+    ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
+  }).serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-06-16T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 4,
+      memoryIds: [],
+      namespace: "default",
+      resultPaths: [`${collection}/2026-06-16/fact-001.md`],
+    },
+    "summary",
+  );
+
+  assert.deepEqual(result, []);
+  assert.ok(
+    readCalls.every((call) => call.namespace === "team"),
+    "expected recognized collection-prefixed miss not to probe default storage",
+  );
+});
+
 test("memorySearch without an explicit namespace uses readable recall namespaces", async () => {
   const { service } = makeService();
   let searchParams: unknown;

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -540,6 +540,94 @@ test("last recall serialization does not strip invalid collection prefixes", asy
   );
 });
 
+test("last recall serialization rejects traversing collection paths", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-traversal-"));
+  const defaultMemoryPath = path.join(
+    memoryRoot,
+    "facts",
+    "2026-06-16",
+    "fact-001.md",
+  );
+  const defaultMemory = {
+    path: defaultMemoryPath,
+    frontmatter: {
+      id: "fact-001",
+      created: "2026-06-16T12:00:00.000Z",
+      updated: "2026-06-16T12:00:00.000Z",
+      category: "fact",
+      status: "active",
+    },
+    content: "Default namespace content should not be reused.",
+  };
+  const teamDir = path.join(
+    memoryRoot,
+    "namespaces",
+    namespaceIdentityToken("team"),
+  );
+  const readCalls: Array<{ namespace: string; path: string }> = [];
+  const storage = {
+    dir: memoryRoot,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push({ namespace: "default", path: filePath });
+      return filePath === defaultMemoryPath ? defaultMemory : null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+  const teamStorage = {
+    dir: teamDir,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push({ namespace: "team", path: filePath });
+      return filePath === defaultMemoryPath ? defaultMemory : null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: makeConfig(),
+    async getStorage(namespace: string) {
+      return namespace === "team" ? teamStorage : storage;
+    },
+  };
+
+  const collection = namespaceCollectionName("test-memory", "team", {
+    defaultNamespace: "default",
+    useLegacyDefaultCollection: false,
+  });
+  const result = await (service as unknown as {
+    serializeRecallResults(
+      snapshot: unknown,
+      disclosure: "summary",
+    ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
+  }).serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-06-16T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 4,
+      memoryIds: [],
+      namespace: "default",
+      resultPaths: [`${collection}/../../facts/2026-06-16/fact-001.md`],
+    },
+    "summary",
+  );
+
+  assert.deepEqual(result, []);
+  assert.ok(
+    !readCalls.some((call) => call.path === defaultMemoryPath),
+    "expected traversing collection path not to probe escaped default path",
+  );
+});
+
 test("memorySearch without an explicit namespace uses readable recall namespaces", async () => {
   const { service } = makeService();
   let searchParams: unknown;

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -159,7 +159,13 @@ test("last recall serialization resolves namespace collection-prefixed result pa
     "namespaces",
     namespaceIdentityToken("team"),
   );
-  const memoryPath = path.join(teamDir, "facts", "2026-06-16", "fact-001.md");
+  const memoryPath = path.join(
+    teamDir,
+    "archive",
+    "facts",
+    "2026-06-16",
+    "fact-001.md",
+  );
   const teamMemory = {
     path: memoryPath,
     frontmatter: {
@@ -216,7 +222,7 @@ test("last recall serialization resolves namespace collection-prefixed result pa
     serializeRecallResults(
       snapshot: unknown,
       disclosure: "summary",
-    ): Promise<Array<{ id: string; path: string; preview: string }>>;
+    ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
   }).serializeRecallResults(
     {
       sessionKey: "session-1",
@@ -225,7 +231,7 @@ test("last recall serialization resolves namespace collection-prefixed result pa
       queryLen: 4,
       memoryIds: [],
       namespace: "default",
-      resultPaths: [`${collection}/2026-06-16/fact-001.md`],
+      resultPaths: [`${collection}/archive/facts/2026-06-16/fact-001.md`],
     },
     "summary",
   );
@@ -233,6 +239,7 @@ test("last recall serialization resolves namespace collection-prefixed result pa
   assert.equal(result.length, 1);
   assert.equal(result[0].id, "fact-001");
   assert.equal(result[0].path, memoryPath);
+  assert.equal(result[0].status, "archived");
   assert.ok(result[0].preview.includes("Agent-authored status update"));
   assert.ok(
     readCalls.some(

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -640,6 +640,91 @@ test("last recall serialization preserves absolute paths from readable namespace
   assert.deepEqual(readCalls, [{ namespace: "shared", path: sharedMemoryPath }]);
 });
 
+test("last recall serialization preserves absolute paths from dynamic namespace storage", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-dynamic-ns-"));
+  const dynamicNamespace = "team-project-alpha";
+  const dynamicDir = path.join(
+    memoryRoot,
+    "namespaces",
+    namespaceIdentityToken(dynamicNamespace),
+  );
+  const dynamicMemoryPath = path.join(
+    dynamicDir,
+    "facts",
+    "2026-06-16",
+    "fact-dynamic.md",
+  );
+  const dynamicMemory = {
+    path: dynamicMemoryPath,
+    frontmatter: {
+      id: "fact-dynamic",
+      created: "2026-06-16T12:00:00.000Z",
+      updated: "2026-06-16T12:00:00.000Z",
+      category: "fact",
+      status: "active",
+    },
+    content: "Dynamic namespace content should survive serialization.",
+  };
+  const readCalls: Array<{ namespace: string; path: string }> = [];
+  const defaultStorage = {
+    dir: memoryRoot,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push({ namespace: "default", path: filePath });
+      return null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+  const dynamicStorage = {
+    dir: dynamicDir,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push({ namespace: dynamicNamespace, path: filePath });
+      return filePath === dynamicMemoryPath ? dynamicMemory : null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: { ...makeConfig(), memoryDir: memoryRoot },
+    async getStorage(namespace: string) {
+      return namespace === dynamicNamespace ? dynamicStorage : defaultStorage;
+    },
+  };
+
+  const result = await (service as unknown as {
+    serializeRecallResults(
+      snapshot: unknown,
+      disclosure: "summary",
+    ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
+  }).serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-06-16T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 4,
+      memoryIds: [],
+      namespace: "team",
+      resultPaths: [dynamicMemoryPath],
+    },
+    "summary",
+  );
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, "fact-dynamic");
+  assert.deepEqual(readCalls, [
+    { namespace: dynamicNamespace, path: dynamicMemoryPath },
+  ]);
+});
+
 test("last recall serialization rejects traversing collection paths", async () => {
   const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
   const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-traversal-"));

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -403,6 +403,75 @@ test("last recall serialization does not treat date paths as collection prefixes
   );
 });
 
+test("last recall serialization does not strip invalid collection prefixes", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-invalid-prefix-"));
+  const defaultMemoryPath = path.join(
+    memoryRoot,
+    "facts",
+    "2026-06-16",
+    "fact-001.md",
+  );
+  const defaultMemory = {
+    path: defaultMemoryPath,
+    frontmatter: {
+      id: "fact-001",
+      created: "2026-06-16T12:00:00.000Z",
+      updated: "2026-06-16T12:00:00.000Z",
+      category: "fact",
+      status: "active",
+    },
+    content: "Default namespace content should not be reused.",
+  };
+  const readCalls: string[] = [];
+  const storage = {
+    dir: memoryRoot,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push(filePath);
+      return filePath === defaultMemoryPath ? defaultMemory : null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: makeConfig(),
+    async getStorage() {
+      return storage;
+    },
+  };
+
+  const result = await (service as unknown as {
+    serializeRecallResults(
+      snapshot: unknown,
+      disclosure: "summary",
+    ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
+  }).serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-06-16T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 4,
+      memoryIds: [],
+      namespace: "default",
+      resultPaths: ["test-memory--not-a-token/2026-06-16/fact-001.md"],
+    },
+    "summary",
+  );
+
+  assert.deepEqual(result, []);
+  assert.ok(
+    !readCalls.includes(defaultMemoryPath),
+    "expected invalid collection prefix not to probe stripped default path",
+  );
+});
+
 test("memorySearch without an explicit namespace uses readable recall namespaces", async () => {
   const { service } = makeService();
   let searchParams: unknown;

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { EngramAccessInputError, EngramAccessService } from "./access-service.js";
 import { namespaceIdentityToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
+import { SecureStoreLockedError } from "./secure-store/index.js";
 import type { StorageManager } from "./storage.js";
 import type { PluginConfig } from "./types.js";
 
@@ -336,6 +337,73 @@ test("last recall serialization does not fall back after namespace collection mi
   assert.ok(
     readCalls.every((call) => call.namespace === "team"),
     "expected recognized collection-prefixed miss not to probe default storage",
+  );
+});
+
+test("last recall serialization propagates locked namespace collection errors", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-lock-"));
+  const teamDir = path.join(
+    memoryRoot,
+    "namespaces",
+    namespaceIdentityToken("team"),
+  );
+  const storage = {
+    dir: memoryRoot,
+    async readMemoryByPath() {
+      return null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+  const teamStorage = {
+    dir: teamDir,
+    async readMemoryByPath() {
+      throw new SecureStoreLockedError("locked namespace store");
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: makeConfig(),
+    async getStorage(namespace: string) {
+      return namespace === "team" ? teamStorage : storage;
+    },
+  };
+
+  const collection = namespaceCollectionName("test-memory", "team", {
+    defaultNamespace: "default",
+    useLegacyDefaultCollection: false,
+  });
+
+  await assert.rejects(
+    async () =>
+      await (service as unknown as {
+        serializeRecallResults(
+          snapshot: unknown,
+          disclosure: "summary",
+        ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
+      }).serializeRecallResults(
+        {
+          sessionKey: "session-1",
+          recordedAt: "2026-06-16T12:00:00.000Z",
+          queryHash: "hash",
+          queryLen: 4,
+          memoryIds: [],
+          namespace: "default",
+          resultPaths: [`${collection}/2026-06-16/fact-001.md`],
+        },
+        "summary",
+      ),
+    SecureStoreLockedError,
   );
 });
 

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -339,6 +339,70 @@ test("last recall serialization does not fall back after namespace collection mi
   );
 });
 
+test("last recall serialization does not treat date paths as collection prefixes", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-date-miss-"));
+  const rootMemoryPath = path.join(memoryRoot, "fact-001.md");
+  const rootMemory = {
+    path: rootMemoryPath,
+    frontmatter: {
+      id: "fact-001",
+      created: "2026-06-16T12:00:00.000Z",
+      updated: "2026-06-16T12:00:00.000Z",
+      category: "fact",
+      status: "active",
+    },
+    content: "Root basename content should not be reused.",
+  };
+  const readCalls: string[] = [];
+  const storage = {
+    dir: memoryRoot,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push(filePath);
+      return filePath === rootMemoryPath ? rootMemory : null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: makeConfig(),
+    async getStorage() {
+      return storage;
+    },
+  };
+
+  const result = await (service as unknown as {
+    serializeRecallResults(
+      snapshot: unknown,
+      disclosure: "summary",
+    ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
+  }).serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-06-16T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 4,
+      memoryIds: [],
+      namespace: "default",
+      resultPaths: ["2026-06-16/fact-001.md"],
+    },
+    "summary",
+  );
+
+  assert.deepEqual(result, []);
+  assert.ok(
+    !readCalls.includes(rootMemoryPath),
+    "expected date-relative miss not to probe storage root basename",
+  );
+});
+
 test("memorySearch without an explicit namespace uses readable recall namespaces", async () => {
   const { service } = makeService();
   let searchParams: unknown;

--- a/packages/remnic-core/src/access-service-namespace.test.ts
+++ b/packages/remnic-core/src/access-service-namespace.test.ts
@@ -540,6 +540,106 @@ test("last recall serialization does not strip invalid collection prefixes", asy
   );
 });
 
+test("last recall serialization preserves absolute paths from readable namespace storage", async () => {
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-cross-ns-"));
+  const teamDir = path.join(
+    memoryRoot,
+    "namespaces",
+    namespaceIdentityToken("team"),
+  );
+  const sharedDir = path.join(
+    memoryRoot,
+    "namespaces",
+    namespaceIdentityToken("shared"),
+  );
+  const sharedMemoryPath = path.join(
+    sharedDir,
+    "facts",
+    "2026-06-16",
+    "fact-shared.md",
+  );
+  const sharedMemory = {
+    path: sharedMemoryPath,
+    frontmatter: {
+      id: "fact-shared",
+      created: "2026-06-16T12:00:00.000Z",
+      updated: "2026-06-16T12:00:00.000Z",
+      category: "fact",
+      status: "active",
+    },
+    content: "Shared namespace content should survive serialization.",
+  };
+  const readCalls: Array<{ namespace: string; path: string }> = [];
+  const defaultStorage = {
+    dir: memoryRoot,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push({ namespace: "default", path: filePath });
+      return null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+  const teamStorage = {
+    dir: teamDir,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push({ namespace: "team", path: filePath });
+      return null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+  const sharedStorage = {
+    dir: sharedDir,
+    async readMemoryByPath(filePath: string) {
+      readCalls.push({ namespace: "shared", path: filePath });
+      return filePath === sharedMemoryPath ? sharedMemory : null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+
+  (service as unknown as {
+    orchestrator: {
+      config: PluginConfig;
+      getStorage(namespace: string): Promise<StorageManager>;
+    };
+  }).orchestrator = {
+    config: makeConfig(),
+    async getStorage(namespace: string) {
+      if (namespace === "team") return teamStorage;
+      if (namespace === "shared") return sharedStorage;
+      return defaultStorage;
+    },
+  };
+
+  const result = await (service as unknown as {
+    serializeRecallResults(
+      snapshot: unknown,
+      disclosure: "summary",
+    ): Promise<Array<{ id: string; path: string; preview: string; status: string }>>;
+  }).serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-06-16T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 4,
+      memoryIds: [],
+      namespace: "team",
+      resultPaths: [sharedMemoryPath],
+    },
+    "summary",
+  );
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, "fact-shared");
+  assert.equal(result[0].path, sharedMemoryPath);
+  assert.deepEqual(readCalls, [{ namespace: "shared", path: sharedMemoryPath }]);
+});
+
 test("last recall serialization rejects traversing collection paths", async () => {
   const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
   const memoryRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-access-qmd-traversal-"));

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1571,6 +1571,24 @@ export class EngramAccessService {
       memoryPath: string,
     ): Promise<{ memory: MemoryFile; baseDir: string } | null> => {
       const parts = qmdCollectionPathParts(memoryPath);
+      const coldCollection = this.orchestrator.config.qmdColdCollection;
+      if (parts && parts.collection === coldCollection) {
+        try {
+          const coldRoot = nodePath.join(storageDir, "cold");
+          for (const candidate of qmdResultPathCandidates(
+            coldRoot,
+            parts.relativePath,
+          )) {
+            const memory = await storage.readMemoryByPath(candidate);
+            if (memory) return { memory, baseDir: storageDir };
+          }
+          return null;
+        } catch (err) {
+          if (err instanceof SecureStoreLockedError) throw err;
+          return null;
+        }
+      }
+
       const collectionNamespace = parts
         ? collectionNamespaceFromPrefix(parts.collection)
         : null;

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1585,7 +1585,8 @@ export class EngramAccessService {
       memoryPath: string,
     ): Promise<{ memory: MemoryFile; baseDir: string } | null> => {
       const parts = qmdCollectionPathParts(memoryPath);
-      const coldCollection = this.orchestrator.config.qmdColdCollection;
+      const coldCollection =
+        this.orchestrator.config.qmdColdCollection ?? "openclaw-engram-cold";
       if (parts && parts.collection === coldCollection) {
         const storages: Array<{ storage: StorageManager; dir: string }> = [];
         const seenStorageDirs = new Set<string>();

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1671,20 +1671,34 @@ export class EngramAccessService {
     primaryNamespace: string,
   ): Promise<{ storage: StorageManager; dir: string } | null> {
     const resolvedPath = nodePath.resolve(memoryPath);
+    const memoryRoot = nodePath.resolve(this.orchestrator.config.memoryDir);
+    const namespacesRoot = nodePath.join(memoryRoot, "namespaces");
     const configuredNamespaces = new Set<string>();
     configuredNamespaces.add(primaryNamespace);
     configuredNamespaces.add(this.orchestrator.config.defaultNamespace);
     configuredNamespaces.add(this.orchestrator.config.sharedNamespace);
+    if (isPathInsideStorageRoot(namespacesRoot, resolvedPath)) {
+      const relativeToNamespaces = nodePath.relative(namespacesRoot, resolvedPath);
+      const [namespaceSegment] = relativeToNamespaces.split(/[\\/]/);
+      if (namespaceSegment) {
+        configuredNamespaces.add(
+          namespaceIdentityFromToken(namespaceSegment) ?? namespaceSegment,
+        );
+      }
+    }
     for (const policy of this.orchestrator.config.namespacePolicies ?? []) {
       configuredNamespaces.add(policy.name);
     }
 
-    const memoryRoot = nodePath.resolve(this.orchestrator.config.memoryDir);
-    const namespacesRoot = nodePath.join(memoryRoot, "namespaces");
     const matches: Array<{ storage: StorageManager; dir: string }> = [];
     for (const ns of configuredNamespaces) {
       if (!ns) continue;
-      const candidateStorage = await this.orchestrator.getStorage(ns);
+      let candidateStorage: StorageManager;
+      try {
+        candidateStorage = await this.orchestrator.getStorage(ns);
+      } catch {
+        continue;
+      }
       const candidateRoot = nodePath.resolve(candidateStorage.dir);
       if (!isPathInsideStorageRoot(candidateRoot, resolvedPath)) continue;
       if (

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1486,6 +1486,7 @@ export class EngramAccessService {
       queryLen: options.query.length,
       memoryIds,
       namespace,
+      recallNamespaces: [namespace],
       traceId: options.snapshot.traceId,
       plannerMode: options.normalizedMode,
       requestedMode:
@@ -1549,6 +1550,19 @@ export class EngramAccessService {
     const namespace = snapshot.namespace ? this.resolveNamespace(snapshot.namespace) : this.orchestrator.config.defaultNamespace;
     const storage = await this.orchestrator.getStorage(namespace);
     const storageDir = storage.dir;
+    const recallNamespaces = Array.from(
+      new Set(
+        [
+          namespace,
+          ...(Array.isArray(snapshot.recallNamespaces)
+            ? snapshot.recallNamespaces.map((ns) => this.resolveNamespace(ns))
+            : []),
+          this.orchestrator.config.defaultNamespace,
+          this.orchestrator.config.sharedNamespace,
+          ...(this.orchestrator.config.namespacePolicies ?? []).map((p) => p.name),
+        ].filter((ns): ns is string => typeof ns === "string" && ns.length > 0),
+      ),
+    );
     const results: EngramAccessMemorySummary[] = [];
     const seen = new Set<string>();
     const collectionNamespaceFromPrefix = (collectionPrefix: string): string | null => {
@@ -1573,20 +1587,39 @@ export class EngramAccessService {
       const parts = qmdCollectionPathParts(memoryPath);
       const coldCollection = this.orchestrator.config.qmdColdCollection;
       if (parts && parts.collection === coldCollection) {
-        try {
-          const coldRoot = nodePath.join(storageDir, "cold");
-          for (const candidate of qmdResultPathCandidates(
-            coldRoot,
-            parts.relativePath,
-          )) {
-            const memory = await storage.readMemoryByPath(candidate);
-            if (memory) return { memory, baseDir: storageDir };
+        const storages: Array<{ storage: StorageManager; dir: string }> = [];
+        const seenStorageDirs = new Set<string>();
+        const addStorage = (candidateStorage: StorageManager): void => {
+          const candidateDir = nodePath.resolve(candidateStorage.dir);
+          if (seenStorageDirs.has(candidateDir)) return;
+          seenStorageDirs.add(candidateDir);
+          storages.push({ storage: candidateStorage, dir: candidateDir });
+        };
+        addStorage(storage);
+        for (const recallNamespace of recallNamespaces) {
+          try {
+            addStorage(await this.orchestrator.getStorage(recallNamespace));
+          } catch {
+            continue;
           }
-          return null;
-        } catch (err) {
-          if (err instanceof SecureStoreLockedError) throw err;
-          return null;
         }
+        for (const candidateStorage of storages) {
+          try {
+            const coldRoot = nodePath.join(candidateStorage.dir, "cold");
+            for (const candidatePath of qmdResultPathCandidates(
+              coldRoot,
+              parts.relativePath,
+            )) {
+              const memory =
+                await candidateStorage.storage.readMemoryByPath(candidatePath);
+              if (memory) return { memory, baseDir: candidateStorage.dir };
+            }
+          } catch (err) {
+            if (err instanceof SecureStoreLockedError) throw err;
+            continue;
+          }
+        }
+        return null;
       }
 
       const collectionNamespace = parts
@@ -1615,6 +1648,7 @@ export class EngramAccessService {
         const ownerStorage = await this.storageForAbsoluteRecallPath(
           memoryPath,
           namespace,
+          recallNamespaces,
         );
         if (!ownerStorage) return null;
         for (const candidate of qmdResultPathCandidates(
@@ -1687,12 +1721,16 @@ export class EngramAccessService {
   private async storageForAbsoluteRecallPath(
     memoryPath: string,
     primaryNamespace: string,
+    recallNamespaces: readonly string[] = [],
   ): Promise<{ storage: StorageManager; dir: string } | null> {
     const resolvedPath = nodePath.resolve(memoryPath);
     const memoryRoot = nodePath.resolve(this.orchestrator.config.memoryDir);
     const namespacesRoot = nodePath.join(memoryRoot, "namespaces");
     const configuredNamespaces = new Set<string>();
     configuredNamespaces.add(primaryNamespace);
+    for (const namespace of recallNamespaces) {
+      configuredNamespaces.add(namespace);
+    }
     configuredNamespaces.add(this.orchestrator.config.defaultNamespace);
     configuredNamespaces.add(this.orchestrator.config.sharedNamespace);
     if (isPathInsideStorageRoot(namespacesRoot, resolvedPath)) {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -177,8 +177,10 @@ function qmdCollectionPathParts(resultPath: string): {
   const normalized = resultPath.replace(/\\/g, "/").replace(/^\/+/, "");
   const slashIndex = normalized.indexOf("/");
   if (slashIndex <= 0 || slashIndex >= normalized.length - 1) return null;
+  const collection = normalized.slice(0, slashIndex);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(collection)) return null;
   return {
-    collection: normalized.slice(0, slashIndex),
+    collection,
     relativePath: normalized.slice(slashIndex + 1),
   };
 }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -54,6 +54,7 @@ import {
 } from "./memory-lifecycle-ledger-utils.js";
 import { getMemoryProjectionPath } from "./memory-projection-store.js";
 import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal, resolvePrincipal } from "./namespaces/principal.js";
+import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
 import type { LastRecallSnapshot } from "./recall-state.js";
 import type {
@@ -167,6 +168,46 @@ import {
 import { formatProfileTraceAscii } from "./profiling.js";
 
 export class EngramAccessInputError extends Error {}
+
+function qmdCollectionPathParts(resultPath: string): {
+  collection: string;
+  relativePath: string;
+} | null {
+  if (!resultPath || nodePath.isAbsolute(resultPath)) return null;
+  const normalized = resultPath.replace(/\\/g, "/").replace(/^\/+/, "");
+  const slashIndex = normalized.indexOf("/");
+  if (slashIndex <= 0 || slashIndex >= normalized.length - 1) return null;
+  return {
+    collection: normalized.slice(0, slashIndex),
+    relativePath: normalized.slice(slashIndex + 1),
+  };
+}
+
+function qmdResultPathCandidates(
+  storageDir: string,
+  resultPath: string,
+): string[] {
+  const candidates = new Set<string>();
+  const addRelativeCandidates = (relativePath: string) => {
+    const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+    if (!normalized) return;
+    candidates.add(nodePath.join(storageDir, normalized));
+    if (/^\d{4}-\d{2}-\d{2}\//.test(normalized)) {
+      candidates.add(nodePath.join(storageDir, "facts", normalized));
+    }
+  };
+
+  if (nodePath.isAbsolute(resultPath)) {
+    candidates.add(resultPath);
+  } else {
+    addRelativeCandidates(resultPath);
+  }
+
+  const parts = qmdCollectionPathParts(resultPath);
+  if (parts) addRelativeCandidates(parts.relativePath);
+
+  return [...candidates];
+}
 
 type AccessProfilingReportRequest = {
   format?: string;
@@ -1502,6 +1543,50 @@ export class EngramAccessService {
     const storageDir = storage.dir;
     const results: EngramAccessMemorySummary[] = [];
     const seen = new Set<string>();
+    const collectionNamespaceFromPrefix = (collectionPrefix: string): string | null => {
+      const baseCollection = this.orchestrator.config.qmdCollection;
+      if (collectionPrefix === baseCollection) return this.orchestrator.config.defaultNamespace;
+      const namespaceSuffix = collectionPrefix.startsWith(`${baseCollection}--`)
+        ? collectionPrefix.slice(baseCollection.length + 2)
+        : "";
+      if (!namespaceSuffix) return null;
+
+      const decoded = namespaceIdentityFromToken(namespaceSuffix);
+      if (decoded !== null) return decoded || this.orchestrator.config.defaultNamespace;
+      if (namespaceSuffix.startsWith("ns--")) {
+        const legacyNamespace = namespaceSuffix.slice("ns--".length).trim();
+        return legacyNamespace || null;
+      }
+      return null;
+    };
+    const readResultPath = async (memoryPath: string): Promise<MemoryFile | null> => {
+      const parts = qmdCollectionPathParts(memoryPath);
+      const collectionNamespace = parts
+        ? collectionNamespaceFromPrefix(parts.collection)
+        : null;
+
+      if (parts && collectionNamespace) {
+        try {
+          const collectionStorage =
+            await this.orchestrator.getStorage(collectionNamespace);
+          for (const candidate of qmdResultPathCandidates(
+            collectionStorage.dir,
+            parts.relativePath,
+          )) {
+            const memory = await collectionStorage.readMemoryByPath(candidate);
+            if (memory) return memory;
+          }
+        } catch {
+          // Fall through to the snapshot namespace candidates.
+        }
+      }
+
+      for (const candidate of qmdResultPathCandidates(storageDir, memoryPath)) {
+        const memory = await storage.readMemoryByPath(candidate);
+        if (memory) return memory;
+      }
+      return null;
+    };
 
     // Pre-fetch raw excerpts once when `disclosure === "raw"` so we don't
     // hit the LCM archive per-result (issue #677 PR 2/4).  Excerpts are
@@ -1519,7 +1604,7 @@ export class EngramAccessService {
 
     for (const memoryPath of snapshot.resultPaths ?? []) {
       if (!memoryPath || seen.has(memoryPath)) continue;
-      const memory = await storage.readMemoryByPath(memoryPath);
+      const memory = await readResultPath(memoryPath);
       if (!memory) continue;
       seen.add(memoryPath);
       results.push(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -205,9 +205,6 @@ function qmdResultPathCandidates(
     addRelativeCandidates(resultPath);
   }
 
-  const parts = qmdCollectionPathParts(resultPath);
-  if (parts) addRelativeCandidates(parts.relativePath);
-
   return [...candidates];
 }
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -56,6 +56,7 @@ import { getMemoryProjectionPath } from "./memory-projection-store.js";
 import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal, resolvePrincipal } from "./namespaces/principal.js";
 import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
+import { SecureStoreLockedError } from "./secure-store/index.js";
 import type { LastRecallSnapshot } from "./recall-state.js";
 import type {
   GraphRecallSnapshot,
@@ -1578,7 +1579,8 @@ export class EngramAccessService {
             if (memory) return { memory, baseDir: collectionStorage.dir };
           }
           return null;
-        } catch {
+        } catch (err) {
+          if (err instanceof SecureStoreLockedError) throw err;
           return null;
         }
       }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -57,6 +57,7 @@ import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal, reca
 import { namespaceIdentityFromToken } from "./namespaces/identity.js";
 import { namespaceCollectionName } from "./namespaces/search.js";
 import { SecureStoreLockedError } from "./secure-store/index.js";
+import { isPathInsideStorageRoot } from "./storage-paths.js";
 import type { LastRecallSnapshot } from "./recall-state.js";
 import type {
   GraphRecallSnapshot,
@@ -191,17 +192,24 @@ function qmdResultPathCandidates(
   resultPath: string,
 ): string[] {
   const candidates = new Set<string>();
+  const storageRoot = nodePath.resolve(storageDir);
+  const addCandidate = (candidate: string) => {
+    const resolved = nodePath.resolve(candidate);
+    if (isPathInsideStorageRoot(storageRoot, resolved)) {
+      candidates.add(resolved);
+    }
+  };
   const addRelativeCandidates = (relativePath: string) => {
     const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
     if (!normalized) return;
-    candidates.add(nodePath.join(storageDir, normalized));
+    addCandidate(nodePath.join(storageRoot, normalized));
     if (/^\d{4}-\d{2}-\d{2}\//.test(normalized)) {
-      candidates.add(nodePath.join(storageDir, "facts", normalized));
+      addCandidate(nodePath.join(storageRoot, "facts", normalized));
     }
   };
 
   if (nodePath.isAbsolute(resultPath)) {
-    candidates.add(resultPath);
+    addCandidate(resultPath);
   } else {
     addRelativeCandidates(resultPath);
   }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1578,8 +1578,9 @@ export class EngramAccessService {
             const memory = await collectionStorage.readMemoryByPath(candidate);
             if (memory) return { memory, baseDir: collectionStorage.dir };
           }
+          return null;
         } catch {
-          // Fall through to the snapshot namespace candidates.
+          return null;
         }
       }
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1559,7 +1559,9 @@ export class EngramAccessService {
       }
       return null;
     };
-    const readResultPath = async (memoryPath: string): Promise<MemoryFile | null> => {
+    const readResultPath = async (
+      memoryPath: string,
+    ): Promise<{ memory: MemoryFile; baseDir: string } | null> => {
       const parts = qmdCollectionPathParts(memoryPath);
       const collectionNamespace = parts
         ? collectionNamespaceFromPrefix(parts.collection)
@@ -1574,7 +1576,7 @@ export class EngramAccessService {
             parts.relativePath,
           )) {
             const memory = await collectionStorage.readMemoryByPath(candidate);
-            if (memory) return memory;
+            if (memory) return { memory, baseDir: collectionStorage.dir };
           }
         } catch {
           // Fall through to the snapshot namespace candidates.
@@ -1583,7 +1585,7 @@ export class EngramAccessService {
 
       for (const candidate of qmdResultPathCandidates(storageDir, memoryPath)) {
         const memory = await storage.readMemoryByPath(candidate);
-        if (memory) return memory;
+        if (memory) return { memory, baseDir: storageDir };
       }
       return null;
     };
@@ -1604,13 +1606,14 @@ export class EngramAccessService {
 
     for (const memoryPath of snapshot.resultPaths ?? []) {
       if (!memoryPath || seen.has(memoryPath)) continue;
-      const memory = await readResultPath(memoryPath);
-      if (!memory) continue;
+      const resolved = await readResultPath(memoryPath);
+      if (!resolved) continue;
+      const { memory, baseDir } = resolved;
       seen.add(memoryPath);
       results.push(
         this.serializeMemorySummary(
           memory,
-          storageDir,
+          baseDir,
           disclosure,
           // Attach the (possibly empty) raw excerpts to the first raw
           // result; subsequent results do not duplicate the array.

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1593,6 +1593,22 @@ export class EngramAccessService {
         }
       }
 
+      if (nodePath.isAbsolute(memoryPath)) {
+        const ownerStorage = await this.storageForAbsoluteRecallPath(
+          memoryPath,
+          namespace,
+        );
+        if (!ownerStorage) return null;
+        for (const candidate of qmdResultPathCandidates(
+          ownerStorage.dir,
+          memoryPath,
+        )) {
+          const memory = await ownerStorage.storage.readMemoryByPath(candidate);
+          if (memory) return { memory, baseDir: ownerStorage.dir };
+        }
+        return null;
+      }
+
       for (const candidate of qmdResultPathCandidates(storageDir, memoryPath)) {
         const memory = await storage.readMemoryByPath(candidate);
         if (memory) return { memory, baseDir: storageDir };
@@ -1648,6 +1664,40 @@ export class EngramAccessService {
       );
     }
     return results;
+  }
+
+  private async storageForAbsoluteRecallPath(
+    memoryPath: string,
+    primaryNamespace: string,
+  ): Promise<{ storage: StorageManager; dir: string } | null> {
+    const resolvedPath = nodePath.resolve(memoryPath);
+    const configuredNamespaces = new Set<string>();
+    configuredNamespaces.add(primaryNamespace);
+    configuredNamespaces.add(this.orchestrator.config.defaultNamespace);
+    configuredNamespaces.add(this.orchestrator.config.sharedNamespace);
+    for (const policy of this.orchestrator.config.namespacePolicies ?? []) {
+      configuredNamespaces.add(policy.name);
+    }
+
+    const memoryRoot = nodePath.resolve(this.orchestrator.config.memoryDir);
+    const namespacesRoot = nodePath.join(memoryRoot, "namespaces");
+    const matches: Array<{ storage: StorageManager; dir: string }> = [];
+    for (const ns of configuredNamespaces) {
+      if (!ns) continue;
+      const candidateStorage = await this.orchestrator.getStorage(ns);
+      const candidateRoot = nodePath.resolve(candidateStorage.dir);
+      if (!isPathInsideStorageRoot(candidateRoot, resolvedPath)) continue;
+      if (
+        candidateRoot === memoryRoot &&
+        isPathInsideStorageRoot(namespacesRoot, resolvedPath)
+      ) {
+        continue;
+      }
+      matches.push({ storage: candidateStorage, dir: candidateRoot });
+    }
+
+    matches.sort((a, b) => b.dir.length - a.dir.length);
+    return matches[0] ?? null;
   }
 
   /**

--- a/packages/remnic-core/src/graph.ts
+++ b/packages/remnic-core/src/graph.ts
@@ -517,6 +517,8 @@ export class GraphIndex {
        * Default `false` (floor from config is applied).
        */
       includeLowConfidence?: boolean;
+      /** Absolute deadline in ms-since-epoch for post-retrieval assembly. */
+      deadlineAtMs?: number;
     }
   ): Promise<
     Array<{
@@ -545,15 +547,21 @@ export class GraphIndex {
     const floor =
       opts?.includeLowConfidence === true ? 0 : clampConfidenceFloor(this.cfg.graphTraversalConfidenceFloor);
     const iterations = clampPageRankIterations(this.cfg.graphTraversalPageRankIterations);
+    const deadlineAtMs = opts?.deadlineAtMs;
+    const deadlineExpired = (): boolean =>
+      typeof deadlineAtMs === "number" && Date.now() >= deadlineAtMs;
 
     try {
       const allEdges = await this.loadEdgesCached();
+      if (deadlineExpired()) return [];
 
       // Build adjacency index: from → edges, to → edges (bidirectional for entity/time, directional for causal).
       // Edges below the confidence floor are pruned at index time so neither
       // direct activation nor downstream BFS expansion can re-introduce them.
       const adj = new Map<string, GraphEdge[]>();
-      for (const edge of allEdges) {
+      for (let i = 0; i < allEdges.length; i += 1) {
+        if ((i & 1023) === 0 && deadlineExpired()) return [];
+        const edge = allEdges[i];
         const conf = readEdgeConfidence(edge);
         if (conf < floor) continue;
         if (!adj.has(edge.from)) adj.set(edge.from, []);
@@ -585,11 +593,14 @@ export class GraphIndex {
       }
 
       for (let hop = 0; hop < steps && frontier.size > 0; hop++) {
+        if (deadlineExpired()) return [];
         const nextFrontier = new Map<string, { node: string; seed: string; activation: number }>();
 
         for (const { node, seed: sourceSeed, activation } of frontier.values()) {
           const edges = adj.get(node) ?? [];
-          for (const edge of edges) {
+          for (let i = 0; i < edges.length; i += 1) {
+            if ((i & 1023) === 0 && deadlineExpired()) return [];
+            const edge = edges[i];
             const neighbor = edge.to === node ? edge.from : edge.to;
             const conf = readEdgeConfidence(edge);
             // Defense in depth: the adjacency build already drops sub-floor
@@ -645,15 +656,17 @@ export class GraphIndex {
       // edges, weighted by edge confidence. Damping is fixed at the
       // canonical 0.85 so the ranking stays comparable across queries;
       // the `iterations` knob bounds compute, not behavior shape.
-      if (iterations > 0 && scores.size > 1) {
+      if (!deadlineExpired() && iterations > 0 && scores.size > 1) {
         applyPageRankRefinement(scores, adj, {
           iterations,
           floor,
           damping: 0.85,
+          deadlineAtMs,
         });
       }
 
       // Apply lateral inhibition if enabled (Synapse-inspired competitive suppression)
+      if (deadlineExpired()) return [];
       if (this.cfg.graphLateralInhibitionEnabled && scores.size > 1) {
         const inhibited = applyLateralInhibition(scores, {
           beta: this.cfg.graphLateralInhibitionBeta,
@@ -725,11 +738,13 @@ export function clampPageRankIterations(raw: unknown): number {
 export function applyPageRankRefinement(
   scores: Map<string, number>,
   adj: Map<string, GraphEdge[]>,
-  opts: { iterations: number; floor: number; damping: number }
+  opts: { iterations: number; floor: number; damping: number; deadlineAtMs?: number }
 ): void {
-  const { iterations, floor, damping } = opts;
+  const { iterations, floor, damping, deadlineAtMs } = opts;
   if (iterations <= 0 || scores.size === 0) return;
   const safeDamping = Math.min(1, Math.max(0, damping));
+  const deadlineExpired = (): boolean =>
+    typeof deadlineAtMs === "number" && Date.now() >= deadlineAtMs;
 
   // Pre-compute confidence-weighted out-edge totals for normalization.
   // Done once per refinement, not per iteration, since adjacency is
@@ -748,6 +763,7 @@ export function applyPageRankRefinement(
   };
   const outboundTotal = new Map<string, number>();
   for (const [node, edges] of adj.entries()) {
+    if (deadlineExpired()) return;
     if (!scores.has(node)) continue; // only candidate nodes redistribute
     let sum = 0;
     for (const edge of edges) {
@@ -758,6 +774,7 @@ export function applyPageRankRefinement(
   }
 
   for (let i = 0; i < iterations; i += 1) {
+    if (deadlineExpired()) return;
     const next = new Map<string, number>();
     // Teleport / damping floor: every node retains `(1 - damping) * score`
     // of its current activation so dangling nodes do not bleed to zero.
@@ -776,7 +793,9 @@ export function applyPageRankRefinement(
         next.set(node, (next.get(node) ?? 0) + safeDamping * score);
         continue;
       }
-      for (const edge of outEdges) {
+      for (let edgeIndex = 0; edgeIndex < outEdges.length; edgeIndex += 1) {
+        if ((edgeIndex & 1023) === 0 && deadlineExpired()) return;
+        const edge = outEdges[edgeIndex];
         if (!eligible(edge, node)) continue;
         const conf = readEdgeConfidence(edge);
         const neighbor = edge.to === node ? edge.from : edge.to;

--- a/packages/remnic-core/src/graph.ts
+++ b/packages/remnic-core/src/graph.ts
@@ -591,15 +591,27 @@ export class GraphIndex {
         frontier.set(`${seed}\0${seed}`, { node: seed, seed, activation: 1 });
         reachedBySeed.set(seed, new Set([seed]));
       }
+      const finalizeScores = () =>
+        Array.from(scores.entries())
+          .map(([p, score]) => ({
+            path: p,
+            score,
+            seed: provenance.get(p)?.seed ?? "",
+            hopDepth: provenance.get(p)?.hopDepth ?? 0,
+            decayedWeight: provenance.get(p)?.decayedWeight ?? 0,
+            graphType: provenance.get(p)?.graphType ?? "entity",
+            edgeConfidence: provenance.get(p)?.edgeConfidence ?? 1,
+          }))
+          .sort((a, b) => b.score - a.score);
 
       for (let hop = 0; hop < steps && frontier.size > 0; hop++) {
-        if (deadlineExpired()) return [];
+        if (deadlineExpired()) return finalizeScores();
         const nextFrontier = new Map<string, { node: string; seed: string; activation: number }>();
 
         for (const { node, seed: sourceSeed, activation } of frontier.values()) {
           const edges = adj.get(node) ?? [];
           for (let i = 0; i < edges.length; i += 1) {
-            if ((i & 1023) === 0 && deadlineExpired()) return [];
+            if ((i & 1023) === 0 && deadlineExpired()) return finalizeScores();
             const edge = edges[i];
             const neighbor = edge.to === node ? edge.from : edge.to;
             const conf = readEdgeConfidence(edge);
@@ -666,7 +678,7 @@ export class GraphIndex {
       }
 
       // Apply lateral inhibition if enabled (Synapse-inspired competitive suppression)
-      if (deadlineExpired()) return [];
+      if (deadlineExpired()) return finalizeScores();
       if (this.cfg.graphLateralInhibitionEnabled && scores.size > 1) {
         const inhibited = applyLateralInhibition(scores, {
           beta: this.cfg.graphLateralInhibitionBeta,
@@ -677,17 +689,7 @@ export class GraphIndex {
         }
       }
 
-      return Array.from(scores.entries())
-        .map(([p, score]) => ({
-          path: p,
-          score,
-          seed: provenance.get(p)?.seed ?? "",
-          hopDepth: provenance.get(p)?.hopDepth ?? 0,
-          decayedWeight: provenance.get(p)?.decayedWeight ?? 0,
-          graphType: provenance.get(p)?.graphType ?? "entity",
-          edgeConfidence: provenance.get(p)?.edgeConfidence ?? 1,
-        }))
-        .sort((a, b) => b.score - a.score);
+      return finalizeScores();
     } catch (err) {
       const { log } = await import("./logger.js");
       log.warn(`[graph] spreadingActivation error: ${err}`);

--- a/packages/remnic-core/src/graph.ts
+++ b/packages/remnic-core/src/graph.ts
@@ -552,6 +552,7 @@ export class GraphIndex {
       typeof deadlineAtMs === "number" && Date.now() >= deadlineAtMs;
 
     try {
+      if (deadlineExpired()) return [];
       const allEdges = await this.loadEdgesCached();
       if (deadlineExpired()) return [];
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9742,6 +9742,7 @@ export class Orchestrator {
             : enrichmentAssemblyDeadlineAtMs,
           abortSignal: options.abortSignal,
           dropUnresolved: true,
+          recallNamespaces,
         },
       );
 
@@ -15705,6 +15706,7 @@ export class Orchestrator {
   private async readQmdResultMemory(
     resultPath: string,
     fallbackStorage: StorageManager,
+    recallNamespaces: readonly string[] = [],
   ): Promise<MemoryFile | null> {
     const parts = qmdCollectionPathParts(resultPath);
     const fallbackStorageDir =
@@ -15771,6 +15773,7 @@ export class Orchestrator {
       const ownerStorage = await this.storageForAbsoluteQmdResultPath(
         resultPath,
         fallbackStorage,
+        recallNamespaces,
       );
       if (!ownerStorage) return null;
       for (const candidate of qmdResultPathCandidates(
@@ -15799,6 +15802,7 @@ export class Orchestrator {
   private async storageForAbsoluteQmdResultPath(
     resultPath: string,
     fallbackStorage: StorageManager,
+    recallNamespaces: readonly string[] = [],
   ): Promise<{ storage: StorageManager; dir: string } | null> {
     const resolvedPath = path.resolve(resultPath);
     const memoryRoot = path.resolve(this.config.memoryDir);
@@ -15831,6 +15835,9 @@ export class Orchestrator {
     const candidateNamespaces = new Set<string>();
     candidateNamespaces.add(this.config.defaultNamespace);
     candidateNamespaces.add(this.config.sharedNamespace);
+    for (const ns of recallNamespaces) {
+      candidateNamespaces.add(ns);
+    }
     if (isPathInsideStorageRoot(namespacesRoot, resolvedPath)) {
       const relativeToNamespaces = path.relative(namespacesRoot, resolvedPath);
       const [namespaceSegment] = relativeToNamespaces.split(/[\\/]/);
@@ -15932,7 +15939,7 @@ export class Orchestrator {
       if (reader) {
         for (const r of missing) {
           try {
-            const memory = await this.readQmdResultMemory(r.path, reader);
+            const memory = await this.readQmdResultMemory(r.path, reader, namespaces);
             if (!memory) continue;
             const fm = memory.frontmatter;
             if (fm.mw_success === undefined && fm.mw_fail === undefined) continue;
@@ -16504,6 +16511,7 @@ export class Orchestrator {
         deadlineAtMs: options.deadlineAtMs,
         abortSignal: options.abortSignal,
         dropUnresolved: true,
+        recallNamespaces: options.recallNamespaces,
       },
     );
     results = boostInput.results;
@@ -16710,6 +16718,7 @@ export class Orchestrator {
     options?: {
       deadlineAtMs?: number | null;
       abortSignal?: AbortSignal;
+      recallNamespaces?: readonly string[];
     },
   ): Promise<{
     memoryByPath: Map<string, MemoryFile>;
@@ -16748,7 +16757,11 @@ export class Orchestrator {
             return;
           }
           try {
-            const mem = await this.readQmdResultMemory(r.path, this.storage);
+            const mem = await this.readQmdResultMemory(
+              r.path,
+              this.storage,
+              options?.recallNamespaces,
+            );
             markChecked(r);
             if (mem) memoryByPath.set(r.path, mem);
           } catch (err) {
@@ -16774,7 +16787,11 @@ export class Orchestrator {
         return { memoryByPath, checkedPaths, unreadablePaths, completed: false };
       }
       try {
-        const mem = await this.readQmdResultMemory(result.path, this.storage);
+        const mem = await this.readQmdResultMemory(
+          result.path,
+          this.storage,
+          options?.recallNamespaces,
+        );
         markChecked(result);
         if (mem) memoryByPath.set(result.path, mem);
       } catch (err) {
@@ -16913,6 +16930,7 @@ export class Orchestrator {
       deadlineAtMs?: number | null;
       abortSignal?: AbortSignal;
       dropUnresolved?: boolean;
+      recallNamespaces?: readonly string[];
     },
   ): Promise<{ results: QmdSearchResult[]; memoryByPath: Map<string, MemoryFile> }> {
     if (results.length === 0) {
@@ -16979,7 +16997,7 @@ export class Orchestrator {
     const safety = await this.filterSearchResultsForRecall(
       results,
       preloadedMemoryMap,
-      options,
+      { ...options, recallNamespaces: _recallNamespaces },
     );
     const safeResults = safety.results;
     const memoryByPath = safety.memoryByPath;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9590,9 +9590,9 @@ export class Orchestrator {
     }
 
     // 2. QMD results — post-process and format
-    const qmdResult = await awaitEnrichmentSection("qmd", qmdPromise);
-    const qmdWasSettledBeforeSafetyFilter =
+    const qmdWasSettledBeforeAssemblyWait =
       qmdPromise.getSettledOutcome() !== undefined;
+    const qmdResult = await awaitEnrichmentSection("qmd", qmdPromise);
     if (qmdResult) {
       const t0 = Date.now();
       const {
@@ -9761,11 +9761,11 @@ export class Orchestrator {
         undefined,
         {
           asOfMs,
-          // If QMD itself has settled before safety filtering starts, do not
-          // let unrelated slow enrichment turn those known results into
-          // unchecked misses. Mandatory safety still runs; optional scoring
-          // below remains bounded by awaitAssemblyStep.
-          deadlineAtMs: qmdWasSettledBeforeSafetyFilter
+          // If QMD had already settled before the ordered assembly reached it,
+          // do not let unrelated slow enrichment turn those known results into
+          // unchecked misses. QMD that only settles during its own wait remains
+          // bounded by the shared post-retrieval assembly deadline.
+          deadlineAtMs: qmdWasSettledBeforeAssemblyWait
             ? null
             : enrichmentAssemblyDeadlineAtMs,
           abortSignal: options.abortSignal,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9611,8 +9611,9 @@ export class Orchestrator {
             if (!graphExpansion) {
               graphSnapshotStatus = "aborted";
               graphDecisionStatus = "aborted";
-              graphDecisionReason =
-                "graph expansion skipped because shared post-retrieval assembly budget expired";
+              graphDecisionReason = options.abortSignal?.aborted
+                ? "graph expansion skipped because recall assembly was aborted"
+                : "graph expansion skipped because shared post-retrieval assembly budget expired";
               graphSnapshotReason = graphDecisionReason;
               graphSnapshotSeedPaths = baselineMemoryResults
                 .slice(0, Math.max(1, recallResultLimit))
@@ -9700,7 +9701,11 @@ export class Orchestrator {
       const qmdBoostInput = await this.filterSearchResultsForRecall(
         memoryResults,
         undefined,
-        { asOfMs },
+        {
+          asOfMs,
+          deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
+          abortSignal: options.abortSignal,
+        },
       );
 
       // Apply recency and access count boosting
@@ -16286,7 +16291,12 @@ export class Orchestrator {
     const boostInput = await this.filterSearchResultsForRecall(
       results,
       undefined,
-      { allowLifecycleFiltered: true, asOfMs: options.asOfMs },
+      {
+        allowLifecycleFiltered: true,
+        asOfMs: options.asOfMs,
+        deadlineAtMs: options.deadlineAtMs,
+        abortSignal: options.abortSignal,
+      },
     );
     results = boostInput.results;
     const boostTimeoutMs =
@@ -16489,20 +16499,59 @@ export class Orchestrator {
   private async loadSearchResultMemoryMap(
     results: QmdSearchResult[],
     preloadedMemoryMap?: Map<string, MemoryFile>,
-  ): Promise<Map<string, MemoryFile>> {
+    options?: {
+      deadlineAtMs?: number | null;
+      abortSignal?: AbortSignal;
+    },
+  ): Promise<{
+    memoryByPath: Map<string, MemoryFile>;
+    checkedPaths: Set<string>;
+    completed: boolean;
+  }> {
     const memoryByPath: Map<string, MemoryFile> = preloadedMemoryMap
       ? new Map(preloadedMemoryMap)
       : new Map();
+    const checkedPaths = new Set<string>();
 
-    await Promise.all(
-      results.map(async (r) => {
-        if (!r.path || memoryByPath.has(r.path)) return;
-        const mem = await this.readQmdResultMemory(r.path, this.storage);
-        if (mem) memoryByPath.set(r.path, mem);
-      }),
-    );
+    const markChecked = (result: QmdSearchResult): void => {
+      if (result.path) checkedPaths.add(result.path);
+    };
+    const deadlineExpired = (): boolean =>
+      typeof options?.deadlineAtMs === "number" &&
+      Date.now() >= options.deadlineAtMs;
 
-    return memoryByPath;
+    if (!options?.abortSignal && options?.deadlineAtMs == null) {
+      await Promise.all(
+        results.map(async (r) => {
+          if (!r.path) return;
+          if (memoryByPath.has(r.path)) {
+            markChecked(r);
+            return;
+          }
+          const mem = await this.readQmdResultMemory(r.path, this.storage);
+          markChecked(r);
+          if (mem) memoryByPath.set(r.path, mem);
+        }),
+      );
+
+      return { memoryByPath, checkedPaths, completed: true };
+    }
+
+    for (const result of results) {
+      if (!result.path) continue;
+      if (memoryByPath.has(result.path)) {
+        markChecked(result);
+        continue;
+      }
+      if (options?.abortSignal?.aborted || deadlineExpired()) {
+        return { memoryByPath, checkedPaths, completed: false };
+      }
+      const mem = await this.readQmdResultMemory(result.path, this.storage);
+      markChecked(result);
+      if (mem) memoryByPath.set(result.path, mem);
+    }
+
+    return { memoryByPath, checkedPaths, completed: true };
   }
 
   private filterSearchResultsByRecallSafety(
@@ -16615,6 +16664,8 @@ export class Orchestrator {
       allowLifecycleFiltered?: boolean;
       allowDedicatedSurface?: boolean;
       asOfMs?: number;
+      deadlineAtMs?: number | null;
+      abortSignal?: AbortSignal;
     },
   ): Promise<{ results: QmdSearchResult[]; memoryByPath: Map<string, MemoryFile> }> {
     if (results.length === 0) {
@@ -16623,17 +16674,26 @@ export class Orchestrator {
         memoryByPath: preloadedMemoryMap ? new Map(preloadedMemoryMap) : new Map(),
       };
     }
-    const memoryByPath = await this.loadSearchResultMemoryMap(
+    const loaded = await this.loadSearchResultMemoryMap(
       results,
       preloadedMemoryMap,
+      options,
     );
+    const candidateResults = loaded.completed
+      ? results
+      : results.filter((result) => !result.path || loaded.checkedPaths.has(result.path));
+    if (!loaded.completed) {
+      log.debug(
+        `recall safety filter stopped before validating all candidates (${candidateResults.length}/${results.length} eligible)`,
+      );
+    }
     return {
       results: this.filterSearchResultsByRecallSafety(
-        results,
-        memoryByPath,
+        candidateResults,
+        loaded.memoryByPath,
         options,
       ),
-      memoryByPath,
+      memoryByPath: loaded.memoryByPath,
     };
   }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -16516,9 +16516,41 @@ export class Orchestrator {
 
     let results = longTerm;
     if (this.config.namespacesEnabled) {
+      const coldRoots: string[] = [];
+      const seenColdRoots = new Set<string>();
+      for (const namespace of options.recallNamespaces) {
+        try {
+          const storage = await this.storageRouter.storageFor(namespace);
+          const storageDir =
+            typeof (storage as { dir?: unknown }).dir === "string" &&
+            (storage as { dir?: string }).dir
+              ? (storage as { dir: string }).dir
+              : null;
+          if (!storageDir) continue;
+          const coldRoot = path.resolve(storageDir, "cold");
+          if (seenColdRoots.has(coldRoot)) continue;
+          seenColdRoots.add(coldRoot);
+          coldRoots.push(coldRoot);
+        } catch (err) {
+          log.debug("cold-tier recall namespace root lookup skipped", {
+            namespace,
+            error: (err as Error).message,
+          });
+        }
+      }
       results = results.filter((r) => {
         const parts = qmdCollectionPathParts(r.path);
         if (parts?.collection === coldCollection) return true;
+        if (path.isAbsolute(r.path)) {
+          const resolvedPath = path.resolve(r.path);
+          if (
+            coldRoots.some((coldRoot) =>
+              isPathInsideStorageRoot(coldRoot, resolvedPath),
+            )
+          ) {
+            return true;
+          }
+        }
         return options.recallNamespaces.includes(this.namespaceFromPath(r.path));
       });
     }
@@ -16793,31 +16825,42 @@ export class Orchestrator {
       typeof options?.deadlineAtMs === "number" &&
       Date.now() >= options.deadlineAtMs;
 
-    if (!options?.abortSignal && options?.deadlineAtMs == null) {
-      await Promise.all(
-        results.map(async (r) => {
-          if (!r.path) return;
-          if (memoryByPath.has(r.path)) {
-            markChecked(r);
-            return;
-          }
-          try {
-            const mem = await this.readQmdResultMemory(
-              r.path,
-              this.storage,
-              options?.recallNamespaces,
-            );
-            markChecked(r);
-            if (mem) memoryByPath.set(r.path, mem);
-          } catch (err) {
-            if (err instanceof SecureStoreLockedError) {
-              markUnreadable(r, err);
+    if (options?.deadlineAtMs == null) {
+      const batchSize = options?.abortSignal ? 16 : results.length;
+      for (let offset = 0; offset < results.length; offset += batchSize) {
+        if (options?.abortSignal?.aborted) {
+          return {
+            memoryByPath,
+            checkedPaths,
+            unreadablePaths,
+            completed: false,
+          };
+        }
+        await Promise.all(
+          results.slice(offset, offset + batchSize).map(async (r) => {
+            if (!r.path) return;
+            if (memoryByPath.has(r.path)) {
+              markChecked(r);
               return;
             }
-            throw err;
-          }
-        }),
-      );
+            try {
+              const mem = await this.readQmdResultMemory(
+                r.path,
+                this.storage,
+                options?.recallNamespaces,
+              );
+              markChecked(r);
+              if (mem) memoryByPath.set(r.path, mem);
+            } catch (err) {
+              if (err instanceof SecureStoreLockedError) {
+                markUnreadable(r, err);
+                return;
+              }
+              throw err;
+            }
+          }),
+        );
+      }
 
       return { memoryByPath, checkedPaths, unreadablePaths, completed: true };
     }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6017,23 +6017,33 @@ export class Orchestrator {
     const seedResults: QmdSearchResult[] = [];
     const expandedPaths: GraphRecallExpandedEntry[] = [];
     const expandedResults: QmdSearchResult[] = [];
+    const deadlineExpired = (): boolean =>
+      typeof options.deadlineAtMs === "number" &&
+      Date.now() >= options.deadlineAtMs;
 
     for (const [namespace, nsResults] of byNamespace.entries()) {
-      if (
-        typeof options.deadlineAtMs === "number" &&
-        Date.now() >= options.deadlineAtMs
-      ) {
-        break;
-      }
+      if (deadlineExpired()) break;
       const storage = await this.storageRouter.storageFor(namespace);
       const seedCandidates = nsResults.slice(0, perNamespaceSeedCap);
       seedResults.push(...seedCandidates);
-      const seedRelativePaths = seedCandidates
-        .map((result) => graphPathRelativeToStorage(storage.dir, result.path))
-        .filter(
-          (value): value is string =>
-            typeof value === "string" && value.length > 0,
-        );
+      const seedRelativePaths =
+        typeof options.deadlineAtMs === "number"
+          ? await this.graphSeedPathsWithinDeadline(
+              storage,
+              seedCandidates,
+              options.deadlineAtMs,
+            )
+          : (
+              await Promise.all(
+                seedCandidates.map((result) =>
+                  this.graphSeedPathRelativeToStorage(storage, result),
+                ),
+              )
+            ).filter(
+              (value): value is string =>
+                typeof value === "string" && value.length > 0,
+            );
+      if (deadlineExpired()) break;
       if (seedRelativePaths.length === 0) continue;
 
       const seedRecallScore = seedCandidates.reduce(
@@ -6055,11 +6065,14 @@ export class Orchestrator {
         },
       );
       if (expanded.length === 0) continue;
+      if (deadlineExpired()) break;
 
       for (const candidate of expanded.slice(0, perNamespaceExpandedCap)) {
+        if (deadlineExpired()) break;
         if (seedSet.has(candidate.path)) continue;
         const memoryPath = path.resolve(storage.dir, candidate.path);
         const memory = await storage.readMemoryByPath(memoryPath);
+        if (deadlineExpired()) break;
         if (!memory) continue;
         if (isArtifactMemoryPath(memory.path)) continue;
         if (memory.frontmatter.status && memory.frontmatter.status !== "active")
@@ -15694,6 +15707,28 @@ export class Orchestrator {
     fallbackStorage: StorageManager,
   ): Promise<MemoryFile | null> {
     const parts = qmdCollectionPathParts(resultPath);
+    const coldCollection = this.config.qmdColdCollection;
+    if (parts && parts.collection === coldCollection) {
+      try {
+        const coldStorage = new StorageManager(path.join(fallbackStorage.dir, "cold"));
+        for (const candidate of qmdResultPathCandidates(
+          coldStorage.dir,
+          parts.relativePath,
+        )) {
+          const memory = await coldStorage.readMemoryByPath(candidate);
+          if (memory) return memory;
+        }
+        return null;
+      } catch (err) {
+        if (err instanceof SecureStoreLockedError) throw err;
+        log.debug("qmd cold result path lookup failed open", {
+          path: resultPath,
+          collection: coldCollection,
+          error: (err as Error).message,
+        });
+        return null;
+      }
+    }
     const collectionNamespace = parts
       ? this.qmdCollectionNamespaceFromPrefix(parts.collection)
       : null;
@@ -17357,6 +17392,35 @@ export class Orchestrator {
       strength: link.strength,
       reason: link.reason || undefined,
     }));
+  }
+
+  private async graphSeedPathRelativeToStorage(
+    storage: StorageManager,
+    result: QmdSearchResult,
+  ): Promise<string | null> {
+    const parts = qmdCollectionPathParts(result.path);
+    if (parts) {
+      const memory = await this.readQmdResultMemory(result.path, storage);
+      return memory
+        ? graphPathRelativeToStorage(storage.dir, memory.path)
+        : null;
+    }
+    return graphPathRelativeToStorage(storage.dir, result.path);
+  }
+
+  private async graphSeedPathsWithinDeadline(
+    storage: StorageManager,
+    results: QmdSearchResult[],
+    deadlineAtMs: number,
+  ): Promise<string[]> {
+    const resolved: string[] = [];
+    for (const result of results) {
+      if (Date.now() >= deadlineAtMs) break;
+      const seedPath = await this.graphSeedPathRelativeToStorage(storage, result);
+      if (Date.now() >= deadlineAtMs) break;
+      if (seedPath) resolved.push(seedPath);
+    }
+    return resolved;
   }
 
   private namespaceFromPath(p: string): string {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15713,14 +15713,17 @@ export class Orchestrator {
         ? (fallbackStorage as { dir: string }).dir
         : null;
     const coldCollection = this.config.qmdColdCollection;
-    if (parts && parts.collection === coldCollection && fallbackStorageDir) {
+    if (parts && parts.collection === coldCollection) {
+      if (!fallbackStorageDir) {
+        return await fallbackStorage.readMemoryByPath(resultPath);
+      }
       try {
-        const coldStorage = new StorageManager(path.join(fallbackStorageDir, "cold"));
+        const coldRoot = path.join(fallbackStorageDir, "cold");
         for (const candidate of qmdResultPathCandidates(
-          coldStorage.dir,
+          coldRoot,
           parts.relativePath,
         )) {
-          const memory = await coldStorage.readMemoryByPath(candidate);
+          const memory = await fallbackStorage.readMemoryByPath(candidate);
           if (memory) return memory;
         }
         return null;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15709,35 +15709,78 @@ export class Orchestrator {
     recallNamespaces: readonly string[] = [],
   ): Promise<MemoryFile | null> {
     const parts = qmdCollectionPathParts(resultPath);
-    const fallbackStorageDir =
-      typeof (fallbackStorage as { dir?: unknown }).dir === "string" &&
-      (fallbackStorage as { dir?: string }).dir
-        ? (fallbackStorage as { dir: string }).dir
+    const storageDirFor = (storage: StorageManager): string | null =>
+      typeof (storage as { dir?: unknown }).dir === "string" &&
+      (storage as { dir?: string }).dir
+        ? (storage as { dir: string }).dir
         : null;
+    const fallbackStorageDir = storageDirFor(fallbackStorage);
     const coldCollection = this.config.qmdColdCollection;
     if (parts && parts.collection === coldCollection) {
-      if (!fallbackStorageDir) {
-        return await fallbackStorage.readMemoryByPath(resultPath);
+      const storages: StorageManager[] = [];
+      const seenStorageDirs = new Set<string>();
+      const addStorage = (storage: StorageManager): void => {
+        const storageDir = storageDirFor(storage);
+        const storageKey = storageDir
+          ? path.resolve(storageDir)
+          : `storage-without-dir-${storages.length}`;
+        if (seenStorageDirs.has(storageKey)) return;
+        seenStorageDirs.add(storageKey);
+        storages.push(storage);
+      };
+
+      const fallbackNamespace =
+        fallbackStorageDir !== null
+          ? this.namespaceFromStorageDir(fallbackStorageDir)
+          : this.config.defaultNamespace;
+      if (
+        recallNamespaces.length === 0 ||
+        !this.config.namespacesEnabled ||
+        recallNamespaces.includes(fallbackNamespace)
+      ) {
+        addStorage(fallbackStorage);
       }
-      try {
-        const coldRoot = path.join(fallbackStorageDir, "cold");
-        for (const candidate of qmdResultPathCandidates(
-          coldRoot,
-          parts.relativePath,
-        )) {
-          const memory = await fallbackStorage.readMemoryByPath(candidate);
-          if (memory) return memory;
+
+      if (recallNamespaces.length > 0) {
+        for (const namespace of recallNamespaces) {
+          try {
+            addStorage(await this.storageRouter.storageFor(namespace));
+          } catch (err) {
+            log.debug("qmd cold result namespace storage lookup skipped", {
+              path: resultPath,
+              namespace,
+              error: (err as Error).message,
+            });
+          }
         }
-        return null;
-      } catch (err) {
-        if (err instanceof SecureStoreLockedError) throw err;
-        log.debug("qmd cold result path lookup failed open", {
-          path: resultPath,
-          collection: coldCollection,
-          error: (err as Error).message,
-        });
-        return null;
       }
+
+      for (const storage of storages) {
+        const storageDir = storageDirFor(storage);
+        if (!storageDir) {
+          const memory = await storage.readMemoryByPath(resultPath);
+          if (memory) return memory;
+          continue;
+        }
+        try {
+          const coldRoot = path.join(storageDir, "cold");
+          for (const candidate of qmdResultPathCandidates(
+            coldRoot,
+            parts.relativePath,
+          )) {
+            const memory = await storage.readMemoryByPath(candidate);
+            if (memory) return memory;
+          }
+        } catch (err) {
+          if (err instanceof SecureStoreLockedError) throw err;
+          log.debug("qmd cold result path lookup failed open", {
+            path: resultPath,
+            collection: coldCollection,
+            error: (err as Error).message,
+          });
+        }
+      }
+      return null;
     }
     const collectionNamespace = parts
       ? this.qmdCollectionNamespaceFromPrefix(parts.collection)
@@ -16473,9 +16516,11 @@ export class Orchestrator {
 
     let results = longTerm;
     if (this.config.namespacesEnabled) {
-      results = results.filter((r) =>
-        options.recallNamespaces.includes(this.namespaceFromPath(r.path)),
-      );
+      results = results.filter((r) => {
+        const parts = qmdCollectionPathParts(r.path);
+        if (parts?.collection === coldCollection) return true;
+        return options.recallNamespaces.includes(this.namespaceFromPath(r.path));
+      });
     }
     // Artifact isolation contract: generic recall paths must exclude artifacts.
     results = results.filter((r) => !isArtifactMemoryPath(r.path));

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -10013,41 +10013,47 @@ export class Orchestrator {
         // low-relevance results from polluting context.
         const queryAwarePrefilter = await queryAwarePrefilterPromise;
         if (queryAwarePrefilter.candidatePaths?.size !== 0) {
-        const embeddingResults = await this.searchEmbeddingFallback(
-          retrievalQuery,
-          embeddingFetchLimit,
-        );
-        const prefilteredEmbeddingResults = applyQueryAwareCandidateFilter(
-          embeddingResults,
-          queryAwarePrefilter.candidatePaths,
-        );
-        const scopedCandidates = filterRecallCandidates(
-          prefilteredEmbeddingResults,
-          {
-            namespacesEnabled: this.config.namespacesEnabled,
-            recallNamespaces,
-            resolveNamespace: (p) => this.namespaceFromPath(p),
-            limit: embeddingFetchLimit,
+        const scoped = await awaitAssemblyStep(
+          "embedding-fallback",
+          async () => {
+            const embeddingResults = await this.searchEmbeddingFallback(
+              retrievalQuery,
+              embeddingFetchLimit,
+            );
+            const prefilteredEmbeddingResults = applyQueryAwareCandidateFilter(
+              embeddingResults,
+              queryAwarePrefilter.candidatePaths,
+            );
+            const scopedCandidates = filterRecallCandidates(
+              prefilteredEmbeddingResults,
+              {
+                namespacesEnabled: this.config.namespacesEnabled,
+                recallNamespaces,
+                resolveNamespace: (p) => this.namespaceFromPath(p),
+                limit: embeddingFetchLimit,
+              },
+            );
+            const boostedScoped = await this.boostSearchResults(
+              scopedCandidates,
+              recallNamespaces,
+              retrievalQuery,
+              undefined,
+              { asOfMs },
+            );
+            // MMR runs on the pre-truncation pool so diverse candidates just
+            // below the cutoff can be promoted into the injected set.
+            xrayBranchPoolSize.hot_embedding = Math.max(
+              xrayBranchPoolSize.hot_embedding,
+              boostedScoped.length,
+            );
+            return this.diversifyAndLimitRecallResults(
+              "memories",
+              boostedScoped,
+              recallResultLimit,
+              retrievalQuery,
+            );
           },
-        );
-        const boostedScoped = await this.boostSearchResults(
-          scopedCandidates,
-          recallNamespaces,
-          retrievalQuery,
-          undefined,
-          { asOfMs },
-        );
-        // MMR runs on the pre-truncation pool so diverse candidates just
-        // below the cutoff can be promoted into the injected set.
-        xrayBranchPoolSize.hot_embedding = Math.max(
-          xrayBranchPoolSize.hot_embedding,
-          boostedScoped.length,
-        );
-        const scoped = this.diversifyAndLimitRecallResults(
-          "memories",
-          boostedScoped,
-          recallResultLimit,
-          retrievalQuery,
+          [] as QmdSearchResult[],
         );
         if (scoped.length > 0) {
           if (shouldPersistGraphSnapshot) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9692,18 +9692,29 @@ export class Orchestrator {
         }
       }
 
+      // Apply mandatory recall safety filters before deadline-bound scoring
+      // enrichment. If scoring times out, we must fall back to this filtered
+      // list rather than raw QMD hits; boostSearchResults also removes
+      // forgotten, lifecycle-filtered, superseded/as_of-invalid, and
+      // dream/procedural memories.
+      const qmdBoostInput = await this.filterSearchResultsForRecall(
+        memoryResults,
+        undefined,
+        { asOfMs },
+      );
+
       // Apply recency and access count boosting
       memoryResults = await awaitAssemblyStep(
         "qmd-boost",
         () =>
           this.boostSearchResults(
-            memoryResults,
+            qmdBoostInput.results,
             recallNamespaces,
             retrievalQuery,
-            undefined,
+            qmdBoostInput.memoryByPath,
             { asOfMs },
           ),
-        memoryResults,
+        qmdBoostInput.results,
       );
 
       // Optional LLM reranking (default off). Fail-open if rerank fails/slow.
@@ -16272,13 +16283,62 @@ export class Orchestrator {
       results = merged;
     }
 
-    results = await this.boostSearchResults(
+    const boostInput = await this.filterSearchResultsForRecall(
       results,
-      options.recallNamespaces,
-      options.prompt,
       undefined,
       { allowLifecycleFiltered: true, asOfMs: options.asOfMs },
     );
+    results = boostInput.results;
+    const boostTimeoutMs =
+      typeof options.deadlineAtMs === "number"
+        ? Math.max(0, options.deadlineAtMs - Date.now())
+        : null;
+    if (boostTimeoutMs !== 0) {
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      try {
+        const boosted = await (boostTimeoutMs !== null
+          ? Promise.race<QmdSearchResult[] | { status: "timed_out" }>([
+              this.boostSearchResults(
+                boostInput.results,
+                options.recallNamespaces,
+                options.prompt,
+                boostInput.memoryByPath,
+                { allowLifecycleFiltered: true, asOfMs: options.asOfMs },
+              ),
+              new Promise<{ status: "timed_out" }>((resolve) => {
+                timeoutHandle = setTimeout(
+                  () => resolve({ status: "timed_out" }),
+                  boostTimeoutMs,
+                );
+              }),
+            ])
+          : this.boostSearchResults(
+              boostInput.results,
+              options.recallNamespaces,
+              options.prompt,
+              boostInput.memoryByPath,
+              { allowLifecycleFiltered: true, asOfMs: options.asOfMs },
+            ));
+        if (
+          typeof boosted === "object" &&
+          boosted !== null &&
+          "status" in boosted &&
+          boosted.status === "timed_out"
+        ) {
+          log.debug("cold-tier recall boost skipped: shared assembly deadline expired");
+        } else if (Array.isArray(boosted)) {
+          results = boosted;
+        } else {
+          results = boostInput.results;
+        }
+      } catch (err) {
+        log.debug(`cold-tier recall boost failed open: ${err}`);
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+      }
+    } else {
+      log.debug("cold-tier recall boost skipped: shared assembly deadline already expired");
+    }
 
     if (this.config.rerankEnabled && this.config.rerankProvider === "local") {
       const ranked = await rerankLocalOrNoop({
@@ -16426,104 +16486,41 @@ export class Orchestrator {
     log.debug(`flushed ${entries.length} access tracking entries`);
   }
 
-  /**
-   * Apply recency, access count, and importance boosting to QMD search results.
-   * Returns re-ranked results.
-   */
-  private async boostSearchResults(
+  private async loadSearchResultMemoryMap(
     results: QmdSearchResult[],
-    _recallNamespaces: string[],
-    prompt?: string,
     preloadedMemoryMap?: Map<string, MemoryFile>,
-    options?: {
-      allowLifecycleFiltered?: boolean;
-      allowDedicatedSurface?: boolean;
-      /**
-       * Historical recall point in ms-since-epoch (issue #680).  When
-       * set, drops candidates that were not authoritative at this
-       * instant per `temporal-validity.isValidAsOf`.  Caller is
-       * responsible for parsing/validating the user-supplied ISO
-       * string at the input boundary (CLI / HTTP / MCP).
-       */
-      asOfMs?: number;
-    },
-  ): Promise<QmdSearchResult[]> {
-    if (results.length === 0) return results;
-
-    const now = Date.now();
-    // Seed with any pre-loaded memories (e.g. from the recency fallback path)
-    // to avoid redundant disk reads for files already in memory.
+  ): Promise<Map<string, MemoryFile>> {
     const memoryByPath: Map<string, MemoryFile> = preloadedMemoryMap
       ? new Map(preloadedMemoryMap)
       : new Map();
 
-    // Determine temporal/tag query params before I/O (pure computation).
-    const resultPaths = new Set(
-      results.map((r) => r.path).filter(Boolean) as string[],
+    await Promise.all(
+      results.map(async (r) => {
+        if (!r.path || memoryByPath.has(r.path)) return;
+        const mem = await this.readQmdResultMemory(r.path, this.storage);
+        if (mem) memoryByPath.set(r.path, mem);
+      }),
     );
-    let temporalFromDate: string | null = null;
-    let promptTags: string[] = [];
-    if (this.config.queryAwareIndexingEnabled && prompt) {
-      if (isTemporalQuery(prompt)) {
-        temporalFromDate = recencyWindowFromPrompt(prompt, now);
-      }
-      promptTags = extractTagsFromPrompt(prompt);
-    }
 
-    // Run all file I/O in parallel: memory files not yet preloaded + index files.
-    const [, rawTemporal, rawTags] = await Promise.all([
-      Promise.all(
-        results.map(async (r) => {
-          if (!r.path || memoryByPath.has(r.path)) return;
-          const mem = await this.readQmdResultMemory(r.path, this.storage);
-          if (mem) memoryByPath.set(r.path, mem);
-        }),
-      ),
-      temporalFromDate !== null
-        ? queryByDateRangeAsync(this.config.memoryDir, temporalFromDate)
-        : Promise.resolve<Set<string> | null>(null),
-      promptTags.length > 0
-        ? queryByTagsAsync(this.config.memoryDir, promptTags)
-        : Promise.resolve<Set<string> | null>(null),
-    ]);
+    return memoryByPath;
+  }
 
-    const queryIntent =
-      this.config.intentRoutingEnabled && prompt
-        ? inferIntentFromText(prompt)
-        : null;
-
-    // v8.1: Temporal + Tag prefilter candidate set
-    // Scope to result paths first so cross-namespace paths don't consume the cap.
-    let temporalCandidates: Set<string> | null = null;
-    let tagCandidates: Set<string> | null = null;
-    if (this.config.queryAwareIndexingEnabled && prompt) {
-      const maxCandidates = this.config.queryAwareIndexingMaxCandidates;
-      const capSet = (s: Set<string> | null): Set<string> | null => {
-        if (!s) return null;
-        // Intersect with result paths first so out-of-scope paths don't exhaust the budget
-        const scoped = new Set(Array.from(s).filter((p) => resultPaths.has(p)));
-        if (maxCandidates === 0 || scoped.size <= maxCandidates)
-          return scoped;
-        return new Set(Array.from(scoped).slice(0, maxCandidates));
-      };
-      if (temporalFromDate !== null) {
-        temporalCandidates = capSet(rawTemporal);
-      }
-      if (promptTags.length > 0) {
-        tagCandidates = capSet(rawTags);
-      }
-    }
-
+  private filterSearchResultsByRecallSafety(
+    results: QmdSearchResult[],
+    memoryByPath: Map<string, MemoryFile>,
+    options?: {
+      allowLifecycleFiltered?: boolean;
+      allowDedicatedSurface?: boolean;
+      asOfMs?: number;
+    },
+  ): QmdSearchResult[] {
     let lifecycleFilteredCount = 0;
     let temporalSupersededFilteredCount = 0;
     let dedicatedSurfaceFilteredCount = 0;
     let forgottenFilteredCount = 0;
-    const boosted: QmdSearchResult[] = [];
-    const recencyWeight = this.effectiveRecencyWeight();
+    const filtered: QmdSearchResult[] = [];
     for (const r of results) {
       const memory = memoryByPath.get(r.path);
-      let score = r.score;
-
       if (memory) {
         if (memory.frontmatter.status === "forgotten") {
           forgottenFilteredCount += 1;
@@ -16585,7 +16582,152 @@ export class Orchestrator {
           dedicatedSurfaceFilteredCount += 1;
           continue;
         }
+      }
+      filtered.push(r);
+    }
+    if (lifecycleFilteredCount > 0) {
+      log.debug(
+        `lifecycle retrieval filter removed ${lifecycleFilteredCount} stale/archived candidates`,
+      );
+    }
+    if (temporalSupersededFilteredCount > 0) {
+      log.debug(
+        `temporal supersession filter removed ${temporalSupersededFilteredCount} superseded candidates`,
+      );
+    }
+    if (dedicatedSurfaceFilteredCount > 0) {
+      log.debug(
+        `dedicated surface filter removed ${dedicatedSurfaceFilteredCount} dream/procedural candidates from generic recall`,
+      );
+    }
+    if (forgottenFilteredCount > 0) {
+      log.debug(
+        `forgotten status filter removed ${forgottenFilteredCount} candidates from recall`,
+      );
+    }
+    return filtered;
+  }
 
+  private async filterSearchResultsForRecall(
+    results: QmdSearchResult[],
+    preloadedMemoryMap?: Map<string, MemoryFile>,
+    options?: {
+      allowLifecycleFiltered?: boolean;
+      allowDedicatedSurface?: boolean;
+      asOfMs?: number;
+    },
+  ): Promise<{ results: QmdSearchResult[]; memoryByPath: Map<string, MemoryFile> }> {
+    if (results.length === 0) {
+      return {
+        results,
+        memoryByPath: preloadedMemoryMap ? new Map(preloadedMemoryMap) : new Map(),
+      };
+    }
+    const memoryByPath = await this.loadSearchResultMemoryMap(
+      results,
+      preloadedMemoryMap,
+    );
+    return {
+      results: this.filterSearchResultsByRecallSafety(
+        results,
+        memoryByPath,
+        options,
+      ),
+      memoryByPath,
+    };
+  }
+
+  /**
+   * Apply recency, access count, and importance boosting to QMD search results.
+   * Returns re-ranked results.
+   */
+  private async boostSearchResults(
+    results: QmdSearchResult[],
+    _recallNamespaces: string[],
+    prompt?: string,
+    preloadedMemoryMap?: Map<string, MemoryFile>,
+    options?: {
+      allowLifecycleFiltered?: boolean;
+      allowDedicatedSurface?: boolean;
+      /**
+       * Historical recall point in ms-since-epoch (issue #680).  When
+       * set, drops candidates that were not authoritative at this
+       * instant per `temporal-validity.isValidAsOf`.  Caller is
+       * responsible for parsing/validating the user-supplied ISO
+       * string at the input boundary (CLI / HTTP / MCP).
+       */
+      asOfMs?: number;
+    },
+  ): Promise<QmdSearchResult[]> {
+    if (results.length === 0) return results;
+
+    const safety = await this.filterSearchResultsForRecall(
+      results,
+      preloadedMemoryMap,
+      options,
+    );
+    const safeResults = safety.results;
+    const memoryByPath = safety.memoryByPath;
+    if (safeResults.length === 0) return safeResults;
+
+    const now = Date.now();
+
+    // Determine temporal/tag query params before index I/O (pure computation).
+    const resultPaths = new Set(
+      safeResults.map((r) => r.path).filter(Boolean) as string[],
+    );
+    let temporalFromDate: string | null = null;
+    let promptTags: string[] = [];
+    if (this.config.queryAwareIndexingEnabled && prompt) {
+      if (isTemporalQuery(prompt)) {
+        temporalFromDate = recencyWindowFromPrompt(prompt, now);
+      }
+      promptTags = extractTagsFromPrompt(prompt);
+    }
+
+    const [rawTemporal, rawTags] = await Promise.all([
+      temporalFromDate !== null
+        ? queryByDateRangeAsync(this.config.memoryDir, temporalFromDate)
+        : Promise.resolve<Set<string> | null>(null),
+      promptTags.length > 0
+        ? queryByTagsAsync(this.config.memoryDir, promptTags)
+        : Promise.resolve<Set<string> | null>(null),
+    ]);
+
+    const queryIntent =
+      this.config.intentRoutingEnabled && prompt
+        ? inferIntentFromText(prompt)
+        : null;
+
+    // v8.1: Temporal + Tag prefilter candidate set
+    // Scope to result paths first so cross-namespace paths don't consume the cap.
+    let temporalCandidates: Set<string> | null = null;
+    let tagCandidates: Set<string> | null = null;
+    if (this.config.queryAwareIndexingEnabled && prompt) {
+      const maxCandidates = this.config.queryAwareIndexingMaxCandidates;
+      const capSet = (s: Set<string> | null): Set<string> | null => {
+        if (!s) return null;
+        // Intersect with result paths first so out-of-scope paths don't exhaust the budget
+        const scoped = new Set(Array.from(s).filter((p) => resultPaths.has(p)));
+        if (maxCandidates === 0 || scoped.size <= maxCandidates)
+          return scoped;
+        return new Set(Array.from(scoped).slice(0, maxCandidates));
+      };
+      if (temporalFromDate !== null) {
+        temporalCandidates = capSet(rawTemporal);
+      }
+      if (promptTags.length > 0) {
+        tagCandidates = capSet(rawTags);
+      }
+    }
+
+    const boosted: QmdSearchResult[] = [];
+    const recencyWeight = this.effectiveRecencyWeight();
+    for (const r of safeResults) {
+      const memory = memoryByPath.get(r.path);
+      let score = r.score;
+
+      if (memory) {
         // Recency boost: exponential decay over 7 days
         if (recencyWeight > 0) {
           const createdAt = new Date(memory.frontmatter.created).getTime();
@@ -16729,26 +16871,6 @@ export class Orchestrator {
       }
 
       boosted.push({ ...r, score });
-    }
-    if (lifecycleFilteredCount > 0) {
-      log.debug(
-        `lifecycle retrieval filter removed ${lifecycleFilteredCount} stale/archived candidates`,
-      );
-    }
-    if (temporalSupersededFilteredCount > 0) {
-      log.debug(
-        `temporal supersession filter removed ${temporalSupersededFilteredCount} superseded candidates`,
-      );
-    }
-    if (dedicatedSurfaceFilteredCount > 0) {
-      log.debug(
-        `dedicated surface filter removed ${dedicatedSurfaceFilteredCount} dream/procedural candidates from generic recall`,
-      );
-    }
-    if (forgottenFilteredCount > 0) {
-      log.debug(
-        `forgotten status filter removed ${forgottenFilteredCount} candidates from recall`,
-      );
     }
 
     // Re-sort by boosted score

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6032,22 +6032,17 @@ export class Orchestrator {
       let resolvedPath = result.path;
       let resolvedResult = result;
       if (parts) {
-        const memory = await this.readQmdResultMemory(
-          result.path,
+        const resolvedCold = await this.resolveColdQmdResultForRecall(
+          result,
           this.storage,
           options.recallNamespaces,
         );
-        if (!memory || deadlineExpired()) {
+        if (!resolvedCold || deadlineExpired()) {
           resolvedAmbiguousSeeds.set(result.path, null);
           return null;
         }
-        resolvedPath = memory.path;
-        resolvedResult = {
-          ...result,
-          docid: result.docid || memory.frontmatter.id,
-          path: memory.path,
-          snippet: result.snippet || memory.content.slice(0, 400),
-        };
+        resolvedPath = resolvedCold.result.path;
+        resolvedResult = resolvedCold.result;
       }
 
       if (!path.isAbsolute(resolvedPath)) {
@@ -15922,6 +15917,47 @@ export class Orchestrator {
     return null;
   }
 
+  private async resolveColdQmdResultForRecall(
+    result: QmdSearchResult,
+    fallbackStorage: StorageManager,
+    recallNamespaces: readonly string[] = [],
+  ): Promise<{ namespace: string; result: QmdSearchResult } | null> {
+    const memory = await this.readQmdResultMemory(
+      result.path,
+      fallbackStorage,
+      recallNamespaces,
+    );
+    if (!memory) return null;
+
+    let ownerNamespace: string | null = null;
+    if (path.isAbsolute(memory.path)) {
+      const ownerStorage = await this.storageForAbsoluteQmdResultPath(
+        memory.path,
+        fallbackStorage,
+        recallNamespaces,
+      );
+      ownerNamespace = ownerStorage?.namespace ?? null;
+      if (!ownerNamespace && this.config.namespacesEnabled) return null;
+    }
+    ownerNamespace ??= this.namespaceFromPath(memory.path);
+    if (
+      recallNamespaces.length > 0 &&
+      !recallNamespaces.includes(ownerNamespace)
+    ) {
+      return null;
+    }
+
+    return {
+      namespace: ownerNamespace,
+      result: {
+        ...result,
+        docid: result.docid || memory.frontmatter.id,
+        path: memory.path,
+        snippet: result.snippet || memory.content.slice(0, 400),
+      },
+    };
+  }
+
   private async storageForAbsoluteQmdResultPath(
     resultPath: string,
     fallbackStorage: StorageManager,
@@ -16627,21 +16663,35 @@ export class Orchestrator {
           });
         }
       }
-      results = results.filter((r) => {
-        const parts = qmdCollectionPathParts(r.path);
-        if (parts?.collection === coldCollection) return true;
-        if (path.isAbsolute(r.path)) {
-          const resolvedPath = path.resolve(r.path);
+      const scopedResults: QmdSearchResult[] = [];
+      for (const result of results) {
+        if (options.abortSignal?.aborted || deadlineRemainingMs() === 0) break;
+        const parts = qmdCollectionPathParts(result.path);
+        if (parts?.collection === coldCollection) {
+          const resolvedCold = await this.resolveColdQmdResultForRecall(
+            result,
+            this.storage,
+            options.recallNamespaces,
+          );
+          if (resolvedCold) scopedResults.push(resolvedCold.result);
+          continue;
+        }
+        if (path.isAbsolute(result.path)) {
+          const resolvedPath = path.resolve(result.path);
           if (
             recallRoots.some((recallRoot) =>
               isPathInsideStorageRoot(recallRoot, resolvedPath),
             )
           ) {
-            return true;
+            scopedResults.push(result);
           }
+          continue;
         }
-        return options.recallNamespaces.includes(this.namespaceFromPath(r.path));
-      });
+        if (options.recallNamespaces.includes(this.namespaceFromPath(result.path))) {
+          scopedResults.push(result);
+        }
+      }
+      results = scopedResults;
     }
     // Artifact isolation contract: generic recall paths must exclude artifacts.
     results = results.filter((r) => !isArtifactMemoryPath(r.path));

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15720,6 +15720,22 @@ export class Orchestrator {
       }
     }
 
+    if (path.isAbsolute(resultPath)) {
+      const ownerStorage = await this.storageForAbsoluteQmdResultPath(
+        resultPath,
+        fallbackStorage,
+      );
+      if (!ownerStorage) return null;
+      for (const candidate of qmdResultPathCandidates(
+        ownerStorage.dir,
+        resultPath,
+      )) {
+        const memory = await ownerStorage.storage.readMemoryByPath(candidate);
+        if (memory) return memory;
+      }
+      return null;
+    }
+
     for (const candidate of qmdResultPathCandidates(
       fallbackStorage.dir,
       resultPath,
@@ -15728,6 +15744,61 @@ export class Orchestrator {
       if (memory) return memory;
     }
     return null;
+  }
+
+  private async storageForAbsoluteQmdResultPath(
+    resultPath: string,
+    fallbackStorage: StorageManager,
+  ): Promise<{ storage: StorageManager; dir: string } | null> {
+    const resolvedPath = path.resolve(resultPath);
+    const memoryRoot = path.resolve(this.config.memoryDir);
+    const namespacesRoot = path.join(memoryRoot, "namespaces");
+    const matches: Array<{ storage: StorageManager; dir: string }> = [];
+    const seenDirs = new Set<string>();
+
+    const maybeAddStorage = (storage: StorageManager) => {
+      const candidateRoot = path.resolve(storage.dir);
+      if (seenDirs.has(candidateRoot)) return;
+      if (!isPathInsideStorageRoot(candidateRoot, resolvedPath)) return;
+      if (
+        candidateRoot === memoryRoot &&
+        isPathInsideStorageRoot(namespacesRoot, resolvedPath)
+      ) {
+        return;
+      }
+      seenDirs.add(candidateRoot);
+      matches.push({ storage, dir: candidateRoot });
+    };
+
+    maybeAddStorage(fallbackStorage);
+
+    const candidateNamespaces = new Set<string>();
+    candidateNamespaces.add(this.config.defaultNamespace);
+    candidateNamespaces.add(this.config.sharedNamespace);
+    if (isPathInsideStorageRoot(namespacesRoot, resolvedPath)) {
+      const relativeToNamespaces = path.relative(namespacesRoot, resolvedPath);
+      const [namespaceSegment] = relativeToNamespaces.split(/[\\/]/);
+      if (namespaceSegment) {
+        candidateNamespaces.add(
+          namespaceIdentityFromToken(namespaceSegment) ?? namespaceSegment,
+        );
+      }
+    }
+    for (const policy of this.config.namespacePolicies ?? []) {
+      candidateNamespaces.add(policy.name);
+    }
+
+    for (const ns of candidateNamespaces) {
+      if (!ns) continue;
+      try {
+        maybeAddStorage(await this.storageRouter.storageFor(ns));
+      } catch {
+        continue;
+      }
+    }
+
+    matches.sort((a, b) => b.dir.length - a.dir.length);
+    return matches[0] ?? null;
   }
 
   private async applyMemoryWorthRerank(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -341,7 +341,11 @@ import {
   dedupeBehaviorSignalsByMemoryAndHash,
 } from "./behavior-signals.js";
 import { ProfilingCollector } from "./profiling.js";
-import { keyring, secureStoreDir } from "./secure-store/index.js";
+import {
+  keyring,
+  secureStoreDir,
+  SecureStoreLockedError,
+} from "./secure-store/index.js";
 import type {
   AccessTrackingEntry,
   BehaviorLoopPolicyState,
@@ -745,9 +749,6 @@ function qmdResultPathCandidates(
   } else {
     addRelativeCandidates(resultPath);
   }
-
-  const parts = qmdCollectionPathParts(resultPath);
-  if (parts) addRelativeCandidates(parts.relativePath);
 
   return [...candidates];
 }
@@ -8791,17 +8792,18 @@ export class Orchestrator {
     // several seconds on large box directories due to sequential I/O). We kick it
     // off here so it overlaps with QMD and other concurrent work rather than
     // running sequentially in phase-2 and blocking assembly.
-    const recentBoxesPromise: Promise<BoxFrontmatter[]> =
+    const recentBoxesPromise = observeEnrichmentPromise(
       this.isRecallSectionEnabled(
         "memory-boxes",
         this.config.memoryBoxesEnabled === true,
       ) &&
-      this.config.memoryBoxesEnabled &&
-      this.config.boxRecallDays > 0
+        this.config.memoryBoxesEnabled &&
+        this.config.boxRecallDays > 0
         ? this.boxBuilderFor(profileStorage)
             .readRecentBoxes(this.config.boxRecallDays)
             .catch(() => [] as BoxFrontmatter[])
-        : Promise.resolve([] as BoxFrontmatter[]);
+        : Promise.resolve([] as BoxFrontmatter[]),
+    );
 
     // --- Wait for core sections first, then bounded enrichment ---
     this.profiler.startSpan("phase-1-parallel", profileTraceId);
@@ -9381,8 +9383,11 @@ export class Orchestrator {
     // 1d. Memory Boxes (topic continuity windows, v8.0 Phase 2A)
     // recentBoxesPromise was kicked off before phase-1 so it ran concurrently.
     {
-      const recentBoxes = await recentBoxesPromise;
-      if (recentBoxes.length > 0) {
+      const recentBoxes = await awaitEnrichmentSection(
+        "memory-boxes",
+        recentBoxesPromise,
+      );
+      if (recentBoxes && recentBoxes.length > 0) {
         const boxLines = recentBoxes.slice(0, 5).map((b: BoxFrontmatter) => {
           const sealedDate = b.sealedAt
             ? b.sealedAt.slice(0, 16).replace("T", " ")
@@ -9536,6 +9541,8 @@ export class Orchestrator {
     }
 
     // 2. QMD results — post-process and format
+    const qmdWasSettledBeforeFormatting =
+      qmdPromise.getSettledOutcome() !== undefined;
     const qmdResult = await awaitEnrichmentSection("qmd", qmdPromise);
     if (qmdResult) {
       const t0 = Date.now();
@@ -9705,7 +9712,13 @@ export class Orchestrator {
         undefined,
         {
           asOfMs,
-          deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
+          // If QMD itself already settled before formatting starts, do not let
+          // an unrelated slow enrichment section turn those known results into
+          // unchecked misses. Mandatory safety still runs; optional scoring
+          // below remains bounded by awaitAssemblyStep.
+          deadlineAtMs: qmdWasSettledBeforeFormatting
+            ? null
+            : enrichmentAssemblyDeadlineAtMs,
           abortSignal: options.abortSignal,
         },
       );
@@ -15689,6 +15702,7 @@ export class Orchestrator {
         }
         return null;
       } catch (err) {
+        if (err instanceof SecureStoreLockedError) throw err;
         log.debug("qmd result namespace path lookup failed open", {
           path: resultPath,
           namespace: collectionNamespace,
@@ -16510,15 +16524,26 @@ export class Orchestrator {
   ): Promise<{
     memoryByPath: Map<string, MemoryFile>;
     checkedPaths: Set<string>;
+    unreadablePaths: Set<string>;
     completed: boolean;
   }> {
     const memoryByPath: Map<string, MemoryFile> = preloadedMemoryMap
       ? new Map(preloadedMemoryMap)
       : new Map();
     const checkedPaths = new Set<string>();
+    const unreadablePaths = new Set<string>();
 
     const markChecked = (result: QmdSearchResult): void => {
       if (result.path) checkedPaths.add(result.path);
+    };
+    const markUnreadable = (result: QmdSearchResult, err: unknown): void => {
+      if (!result.path) return;
+      checkedPaths.add(result.path);
+      unreadablePaths.add(result.path);
+      log.warn("recall safety filter dropped unreadable secure-store candidate", {
+        path: result.path,
+        error: (err as Error).message,
+      });
     };
     const deadlineExpired = (): boolean =>
       typeof options?.deadlineAtMs === "number" &&
@@ -16532,13 +16557,21 @@ export class Orchestrator {
             markChecked(r);
             return;
           }
-          const mem = await this.readQmdResultMemory(r.path, this.storage);
-          markChecked(r);
-          if (mem) memoryByPath.set(r.path, mem);
+          try {
+            const mem = await this.readQmdResultMemory(r.path, this.storage);
+            markChecked(r);
+            if (mem) memoryByPath.set(r.path, mem);
+          } catch (err) {
+            if (err instanceof SecureStoreLockedError) {
+              markUnreadable(r, err);
+              return;
+            }
+            throw err;
+          }
         }),
       );
 
-      return { memoryByPath, checkedPaths, completed: true };
+      return { memoryByPath, checkedPaths, unreadablePaths, completed: true };
     }
 
     for (const result of results) {
@@ -16548,14 +16581,22 @@ export class Orchestrator {
         continue;
       }
       if (options?.abortSignal?.aborted || deadlineExpired()) {
-        return { memoryByPath, checkedPaths, completed: false };
+        return { memoryByPath, checkedPaths, unreadablePaths, completed: false };
       }
-      const mem = await this.readQmdResultMemory(result.path, this.storage);
-      markChecked(result);
-      if (mem) memoryByPath.set(result.path, mem);
+      try {
+        const mem = await this.readQmdResultMemory(result.path, this.storage);
+        markChecked(result);
+        if (mem) memoryByPath.set(result.path, mem);
+      } catch (err) {
+        if (err instanceof SecureStoreLockedError) {
+          markUnreadable(result, err);
+          continue;
+        }
+        throw err;
+      }
     }
 
-    return { memoryByPath, checkedPaths, completed: true };
+    return { memoryByPath, checkedPaths, unreadablePaths, completed: true };
   }
 
   private filterSearchResultsByRecallSafety(
@@ -16686,14 +16727,20 @@ export class Orchestrator {
     const candidateResults = loaded.completed
       ? results
       : results.filter((result) => !result.path || loaded.checkedPaths.has(result.path));
+    const readableCandidateResults =
+      loaded.unreadablePaths.size === 0
+        ? candidateResults
+        : candidateResults.filter(
+            (result) => !result.path || !loaded.unreadablePaths.has(result.path),
+          );
     if (!loaded.completed) {
       log.debug(
-        `recall safety filter stopped before validating all candidates (${candidateResults.length}/${results.length} eligible)`,
+        `recall safety filter stopped before validating all candidates (${readableCandidateResults.length}/${results.length} eligible)`,
       );
     }
     return {
       results: this.filterSearchResultsByRecallSafety(
-        candidateResults,
+        readableCandidateResults,
         loaded.memoryByPath,
         options,
       ),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9549,9 +9549,9 @@ export class Orchestrator {
     }
 
     // 2. QMD results — post-process and format
-    const qmdWasSettledBeforeFormatting =
-      qmdPromise.getSettledOutcome() !== undefined;
     const qmdResult = await awaitEnrichmentSection("qmd", qmdPromise);
+    const qmdWasSettledBeforeSafetyFilter =
+      qmdPromise.getSettledOutcome() !== undefined;
     if (qmdResult) {
       const t0 = Date.now();
       const {
@@ -9720,11 +9720,11 @@ export class Orchestrator {
         undefined,
         {
           asOfMs,
-          // If QMD itself already settled before formatting starts, do not let
-          // an unrelated slow enrichment section turn those known results into
+          // If QMD itself has settled before safety filtering starts, do not
+          // let unrelated slow enrichment turn those known results into
           // unchecked misses. Mandatory safety still runs; optional scoring
           // below remains bounded by awaitAssemblyStep.
-          deadlineAtMs: qmdWasSettledBeforeFormatting
+          deadlineAtMs: qmdWasSettledBeforeSafetyFilter
             ? null
             : enrichmentAssemblyDeadlineAtMs,
           abortSignal: options.abortSignal,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -16614,14 +16614,20 @@ export class Orchestrator {
       allowLifecycleFiltered?: boolean;
       allowDedicatedSurface?: boolean;
       asOfMs?: number;
+      blockedPaths?: Set<string>;
     },
   ): QmdSearchResult[] {
     let lifecycleFilteredCount = 0;
     let temporalSupersededFilteredCount = 0;
     let dedicatedSurfaceFilteredCount = 0;
     let forgottenFilteredCount = 0;
+    let blockedPathFilteredCount = 0;
     const filtered: QmdSearchResult[] = [];
     for (const r of results) {
+      if (r.path && options?.blockedPaths?.has(r.path)) {
+        blockedPathFilteredCount += 1;
+        continue;
+      }
       const memory = memoryByPath.get(r.path);
       if (memory) {
         if (memory.frontmatter.status === "forgotten") {
@@ -16707,6 +16713,11 @@ export class Orchestrator {
         `forgotten status filter removed ${forgottenFilteredCount} candidates from recall`,
       );
     }
+    if (blockedPathFilteredCount > 0) {
+      log.debug(
+        `unreadable-path filter removed ${blockedPathFilteredCount} candidates from recall`,
+      );
+    }
     return filtered;
   }
 
@@ -16735,22 +16746,16 @@ export class Orchestrator {
     const candidateResults = loaded.completed
       ? results
       : results.filter((result) => !result.path || loaded.checkedPaths.has(result.path));
-    const readableCandidateResults =
-      loaded.unreadablePaths.size === 0
-        ? candidateResults
-        : candidateResults.filter(
-            (result) => !result.path || !loaded.unreadablePaths.has(result.path),
-          );
     if (!loaded.completed) {
       log.debug(
-        `recall safety filter stopped before validating all candidates (${readableCandidateResults.length}/${results.length} eligible)`,
+        `recall safety filter stopped before validating all candidates (${candidateResults.length}/${results.length} eligible)`,
       );
     }
     return {
       results: this.filterSearchResultsByRecallSafety(
-        readableCandidateResults,
+        candidateResults,
         loaded.memoryByPath,
-        options,
+        { ...options, blockedPaths: loaded.unreadablePaths },
       ),
       memoryByPath: loaded.memoryByPath,
     };

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -718,8 +718,10 @@ function qmdCollectionPathParts(resultPath: string): {
   const normalized = resultPath.replace(/\\/g, "/").replace(/^\/+/, "");
   const slashIndex = normalized.indexOf("/");
   if (slashIndex <= 0 || slashIndex >= normalized.length - 1) return null;
+  const collection = normalized.slice(0, slashIndex);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(collection)) return null;
   return {
-    collection: normalized.slice(0, slashIndex),
+    collection,
     relativePath: normalized.slice(slashIndex + 1),
   };
 }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6011,7 +6011,7 @@ export class Orchestrator {
         byNamespace.set(namespace, [result]);
       }
     };
-    const coldCollection = this.config.qmdColdCollection;
+    const coldCollection = this.config.qmdColdCollection ?? "openclaw-engram-cold";
     for (const result of options.memoryResults) {
       const parts = qmdCollectionPathParts(result.path);
       if (parts?.collection === coldCollection) {
@@ -15744,7 +15744,7 @@ export class Orchestrator {
         ? (storage as { dir: string }).dir
         : null;
     const fallbackStorageDir = storageDirFor(fallbackStorage);
-    const coldCollection = this.config.qmdColdCollection;
+    const coldCollection = this.config.qmdColdCollection ?? "openclaw-engram-cold";
     if (parts && parts.collection === coldCollection) {
       const storages: StorageManager[] = [];
       const seenStorageDirs = new Set<string>();
@@ -16545,8 +16545,8 @@ export class Orchestrator {
 
     let results = longTerm;
     if (this.config.namespacesEnabled) {
-      const coldRoots: string[] = [];
-      const seenColdRoots = new Set<string>();
+      const recallRoots: string[] = [];
+      const seenRecallRoots = new Set<string>();
       for (const namespace of options.recallNamespaces) {
         try {
           const storage = await this.storageRouter.storageFor(namespace);
@@ -16556,10 +16556,10 @@ export class Orchestrator {
               ? (storage as { dir: string }).dir
               : null;
           if (!storageDir) continue;
-          const coldRoot = path.resolve(storageDir, "cold");
-          if (seenColdRoots.has(coldRoot)) continue;
-          seenColdRoots.add(coldRoot);
-          coldRoots.push(coldRoot);
+          const recallRoot = path.resolve(storageDir);
+          if (seenRecallRoots.has(recallRoot)) continue;
+          seenRecallRoots.add(recallRoot);
+          recallRoots.push(recallRoot);
         } catch (err) {
           log.debug("cold-tier recall namespace root lookup skipped", {
             namespace,
@@ -16573,8 +16573,8 @@ export class Orchestrator {
         if (path.isAbsolute(r.path)) {
           const resolvedPath = path.resolve(r.path);
           if (
-            coldRoots.some((coldRoot) =>
-              isPathInsideStorageRoot(coldRoot, resolvedPath),
+            recallRoots.some((recallRoot) =>
+              isPathInsideStorageRoot(recallRoot, resolvedPath),
             )
           ) {
             return true;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5999,6 +5999,9 @@ export class Orchestrator {
     expandedPaths: GraphRecallExpandedEntry[];
     seedResults: QmdSearchResult[];
   }> {
+    const deadlineExpired = (): boolean =>
+      typeof options.deadlineAtMs === "number" &&
+      Date.now() >= options.deadlineAtMs;
     const byNamespace = new Map<string, QmdSearchResult[]>();
     const addResultForNamespace = (
       namespace: string,
@@ -6011,23 +6014,74 @@ export class Orchestrator {
         byNamespace.set(namespace, [result]);
       }
     };
+    const resolvedAmbiguousSeeds = new Map<
+      string,
+      { namespace: string; result: QmdSearchResult } | null
+    >();
+    const resolveAmbiguousSeedOwner = async (
+      result: QmdSearchResult,
+      parts: { collection: string; relativePath: string } | null,
+    ): Promise<{ namespace: string; result: QmdSearchResult } | null> => {
+      const cached = resolvedAmbiguousSeeds.get(result.path);
+      if (cached !== undefined) return cached;
+      if (deadlineExpired()) {
+        resolvedAmbiguousSeeds.set(result.path, null);
+        return null;
+      }
+
+      let resolvedPath = result.path;
+      let resolvedResult = result;
+      if (parts) {
+        const memory = await this.readQmdResultMemory(
+          result.path,
+          this.storage,
+          options.recallNamespaces,
+        );
+        if (!memory || deadlineExpired()) {
+          resolvedAmbiguousSeeds.set(result.path, null);
+          return null;
+        }
+        resolvedPath = memory.path;
+        resolvedResult = {
+          ...result,
+          docid: result.docid || memory.frontmatter.id,
+          path: memory.path,
+          snippet: result.snippet || memory.content.slice(0, 400),
+        };
+      }
+
+      if (!path.isAbsolute(resolvedPath)) {
+        resolvedAmbiguousSeeds.set(result.path, null);
+        return null;
+      }
+      const ownerStorage = await this.storageForAbsoluteQmdResultPath(
+        resolvedPath,
+        this.storage,
+        options.recallNamespaces,
+      );
+      const ownerNamespace = ownerStorage?.namespace ?? null;
+      const resolved =
+        ownerNamespace && options.recallNamespaces.includes(ownerNamespace)
+          ? { namespace: ownerNamespace, result: resolvedResult }
+          : null;
+      resolvedAmbiguousSeeds.set(result.path, resolved);
+      return resolved;
+    };
     const coldCollection = this.config.qmdColdCollection ?? "openclaw-engram-cold";
     for (const result of options.memoryResults) {
+      if (deadlineExpired()) break;
       const parts = qmdCollectionPathParts(result.path);
       if (parts?.collection === coldCollection) {
-        for (const namespace of options.recallNamespaces) {
-          addResultForNamespace(namespace, result);
+        const resolved = await resolveAmbiguousSeedOwner(result, parts);
+        if (resolved) {
+          addResultForNamespace(resolved.namespace, resolved.result);
         }
         continue;
       }
       if (path.isAbsolute(result.path)) {
-        const ns = this.namespaceFromPath(result.path);
-        if (options.recallNamespaces.includes(ns)) {
-          addResultForNamespace(ns, result);
-        } else {
-          for (const namespace of options.recallNamespaces) {
-            addResultForNamespace(namespace, result);
-          }
+        const resolved = await resolveAmbiguousSeedOwner(result, null);
+        if (resolved) {
+          addResultForNamespace(resolved.namespace, resolved.result);
         }
         continue;
       }
@@ -6042,9 +6096,6 @@ export class Orchestrator {
     const seedResults: QmdSearchResult[] = [];
     const expandedPaths: GraphRecallExpandedEntry[] = [];
     const expandedResults: QmdSearchResult[] = [];
-    const deadlineExpired = (): boolean =>
-      typeof options.deadlineAtMs === "number" &&
-      Date.now() >= options.deadlineAtMs;
 
     for (const [namespace, nsResults] of byNamespace.entries()) {
       if (deadlineExpired()) break;
@@ -15875,14 +15926,19 @@ export class Orchestrator {
     resultPath: string,
     fallbackStorage: StorageManager,
     recallNamespaces: readonly string[] = [],
-  ): Promise<{ storage: StorageManager; dir: string } | null> {
+  ): Promise<{ storage: StorageManager; dir: string; namespace: string } | null> {
     const resolvedPath = path.resolve(resultPath);
     const memoryRoot = path.resolve(this.config.memoryDir);
     const namespacesRoot = path.join(memoryRoot, "namespaces");
-    const matches: Array<{ storage: StorageManager; dir: string }> = [];
+    const fallbackStorageDir =
+      typeof (fallbackStorage as { dir?: unknown }).dir === "string" &&
+      (fallbackStorage as { dir?: string }).dir
+        ? (fallbackStorage as { dir: string }).dir
+        : null;
+    const matches: Array<{ storage: StorageManager; dir: string; namespace: string }> = [];
     const seenDirs = new Set<string>();
 
-    const maybeAddStorage = (storage: StorageManager) => {
+    const maybeAddStorage = (storage: StorageManager, namespace: string) => {
       const storageDir =
         typeof (storage as { dir?: unknown }).dir === "string" &&
         (storage as { dir?: string }).dir
@@ -15899,10 +15955,14 @@ export class Orchestrator {
         return;
       }
       seenDirs.add(candidateRoot);
-      matches.push({ storage, dir: candidateRoot });
+      matches.push({ storage, dir: candidateRoot, namespace });
     };
 
-    maybeAddStorage(fallbackStorage);
+    const fallbackNamespace =
+      fallbackStorageDir !== null
+        ? this.namespaceFromStorageDir(fallbackStorageDir)
+        : this.config.defaultNamespace;
+    maybeAddStorage(fallbackStorage, fallbackNamespace);
 
     const candidateNamespaces = new Set<string>();
     candidateNamespaces.add(this.config.defaultNamespace);
@@ -15926,7 +15986,7 @@ export class Orchestrator {
     for (const ns of candidateNamespaces) {
       if (!ns) continue;
       try {
-        maybeAddStorage(await this.storageRouter.storageFor(ns));
+        maybeAddStorage(await this.storageRouter.storageFor(ns), ns);
       } catch {
         continue;
       }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -710,6 +710,46 @@ async function raceRecallAbort<T>(
   }
 }
 
+function qmdCollectionPathParts(resultPath: string): {
+  collection: string;
+  relativePath: string;
+} | null {
+  if (!resultPath || path.isAbsolute(resultPath)) return null;
+  const normalized = resultPath.replace(/\\/g, "/").replace(/^\/+/, "");
+  const slashIndex = normalized.indexOf("/");
+  if (slashIndex <= 0 || slashIndex >= normalized.length - 1) return null;
+  return {
+    collection: normalized.slice(0, slashIndex),
+    relativePath: normalized.slice(slashIndex + 1),
+  };
+}
+
+function qmdResultPathCandidates(
+  storageDir: string,
+  resultPath: string,
+): string[] {
+  const candidates = new Set<string>();
+  const addRelativeCandidates = (relativePath: string) => {
+    const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+    if (!normalized) return;
+    candidates.add(path.join(storageDir, normalized));
+    if (/^\d{4}-\d{2}-\d{2}\//.test(normalized)) {
+      candidates.add(path.join(storageDir, "facts", normalized));
+    }
+  };
+
+  if (path.isAbsolute(resultPath)) {
+    candidates.add(resultPath);
+  } else {
+    addRelativeCandidates(resultPath);
+  }
+
+  const parts = qmdCollectionPathParts(resultPath);
+  if (parts) addRelativeCandidates(parts.relativePath);
+
+  return [...candidates];
+}
+
 /** Maximum age (ms) before a compaction-reset signal file is considered stale and removed. */
 const COMPACTION_SIGNAL_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 const DEFAULT_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS = 10_000;
@@ -5939,6 +5979,7 @@ export class Orchestrator {
     memoryResults: QmdSearchResult[];
     recallNamespaces: string[];
     recallResultLimit: number;
+    deadlineAtMs?: number | null;
     /** Issue #681 — when true, bypass graphTraversalConfidenceFloor. */
     includeLowConfidence?: boolean;
   }): Promise<{
@@ -5967,6 +6008,12 @@ export class Orchestrator {
     const expandedResults: QmdSearchResult[] = [];
 
     for (const [namespace, nsResults] of byNamespace.entries()) {
+      if (
+        typeof options.deadlineAtMs === "number" &&
+        Date.now() >= options.deadlineAtMs
+      ) {
+        break;
+      }
       const storage = await this.storageRouter.storageFor(namespace);
       const seedCandidates = nsResults.slice(0, perNamespaceSeedCap);
       seedResults.push(...seedCandidates);
@@ -5989,7 +6036,12 @@ export class Orchestrator {
       const expanded = await this.graphIndexFor(storage).spreadingActivation(
         seedRelativePaths,
         this.config.maxGraphTraversalSteps,
-        options.includeLowConfidence === true ? { includeLowConfidence: true } : undefined,
+        {
+          ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
+          ...(typeof options.deadlineAtMs === "number"
+            ? { deadlineAtMs: options.deadlineAtMs }
+            : {}),
+        },
       );
       if (expanded.length === 0) continue;
 
@@ -8931,6 +8983,70 @@ export class Orchestrator {
       return finalizeEnrichmentOutcome(outcome);
     };
 
+    const remainingEnrichmentAssemblyMs = (): number | null =>
+      enrichmentAssemblyDeadlineAtMs === null
+        ? null
+        : Math.max(0, enrichmentAssemblyDeadlineAtMs - Date.now());
+
+    const awaitAssemblyStep = async <T>(
+      name: string,
+      task: () => Promise<T>,
+      fallback: T,
+    ): Promise<T> => {
+      if (options.abortSignal?.aborted) {
+        log.debug(
+          `recall phase-1 assembly [${name}]: skipped after abort at +${Date.now() - phase1Start}ms`,
+        );
+        return fallback;
+      }
+
+      const timeoutMs = remainingEnrichmentAssemblyMs();
+      if (timeoutMs === 0) {
+        log.debug(
+          `recall phase-1 assembly [${name}]: skipped after shared ${enrichmentSectionDeadlineMs}ms budget expired ` +
+            `at +${Date.now() - phase1Start}ms`,
+        );
+        return fallback;
+      }
+
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      try {
+        const result = await (timeoutMs !== null
+          ? Promise.race<T | { status: "timed_out" }>([
+              task(),
+              new Promise<{ status: "timed_out" }>((resolve) => {
+                timeoutHandle = setTimeout(
+                  () => resolve({ status: "timed_out" }),
+                  timeoutMs,
+                );
+              }),
+            ])
+          : task());
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        if (
+          typeof result === "object" &&
+          result !== null &&
+          "status" in result &&
+          (result as { status?: unknown }).status === "timed_out"
+        ) {
+          log.debug(
+            `recall phase-1 assembly [${name}]: timed out within shared ${enrichmentSectionDeadlineMs}ms budget ` +
+              `at +${Date.now() - phase1Start}ms`,
+          );
+          return fallback;
+        }
+        return result as T;
+      } catch (err) {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        log.warn(
+          `recall phase-1 assembly [${name}] failed open: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        return fallback;
+      }
+    };
+
     // --- Phase 2: Assemble sections in correct order ---
     this.profiler.startSpan("assembly", profileTraceId);
 
@@ -9480,56 +9596,81 @@ export class Orchestrator {
           graphExpandedResultPaths.clear();
         } else {
           try {
-            const {
-              merged,
-              seedPaths,
-              expandedPaths,
-              seedResults = baselineMemoryResults,
-            } = await this.expandResultsViaGraph({
-              memoryResults,
-              recallNamespaces,
-              recallResultLimit,
-              ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
-            });
-            graphSnapshotStatus = "completed";
-            graphDecisionStatus = "completed";
-            graphDecisionReason = graphShadowEvalEnabled
-              ? "graph shadow evaluation completed without altering injected context"
-              : "graph expansion merged into recall ranking";
-            graphSnapshotReason = graphDecisionReason;
-            graphSnapshotSeedPaths = seedPaths;
-            graphSnapshotExpandedPaths = expandedPaths;
-            graphSnapshotSeedResults = this.buildGraphRecallRankedResults(
-              seedResults,
-              () => ["baseline"],
+            const graphExpansion = await awaitAssemblyStep(
+              "graph-expansion",
+              () =>
+                this.expandResultsViaGraph({
+                  memoryResults,
+                  recallNamespaces,
+                  recallResultLimit,
+                  deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
+                  ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
+                }),
+              null as Awaited<ReturnType<typeof this.expandResultsViaGraph>> | null,
             );
-            graphExpandedResultPaths.clear();
-            expandedPaths.forEach((entry) =>
-              graphExpandedResultPaths.add(entry.path),
-            );
-            memoryResults = graphShadowEvalEnabled
-              ? baselineMemoryResults
-              : merged;
-
-            if (graphShadowEvalEnabled) {
-              const comparison = summarizeGraphShadowComparison(
+            if (!graphExpansion) {
+              graphSnapshotStatus = "aborted";
+              graphDecisionStatus = "aborted";
+              graphDecisionReason =
+                "graph expansion skipped because shared post-retrieval assembly budget expired";
+              graphSnapshotReason = graphDecisionReason;
+              graphSnapshotSeedPaths = baselineMemoryResults
+                .slice(0, Math.max(1, recallResultLimit))
+                .map((result) => result.path);
+              graphSnapshotSeedResults = this.buildGraphRecallRankedResults(
                 baselineMemoryResults,
-                merged,
-                recallResultLimit,
+                () => ["baseline"],
               );
-              graphSnapshotShadowComparison = comparison;
-              recordRecallSectionMetric({
-                section: "graphShadow",
-                priority: "enrichment",
-                durationMs: Date.now() - t0,
-                deadlineMs: enrichmentSectionDeadlineMs,
-                source: "fresh",
-                success: true,
-                timing:
-                  `on b=${comparison.baselineCount} g=${comparison.graphCount} ` +
-                  `ov=${comparison.overlapCount} (${comparison.overlapRatio.toFixed(2)}) ` +
-                  `avgDelta=${comparison.averageOverlapDelta.toFixed(3)}`,
-              });
+              graphSnapshotExpandedPaths = [];
+              graphExpandedResultPaths.clear();
+              memoryResults = baselineMemoryResults;
+            } else {
+              const {
+                merged,
+                seedPaths,
+                expandedPaths,
+                seedResults = baselineMemoryResults,
+              } = graphExpansion;
+              graphSnapshotStatus = "completed";
+              graphDecisionStatus = "completed";
+              graphDecisionReason = graphShadowEvalEnabled
+                ? "graph shadow evaluation completed without altering injected context"
+                : "graph expansion merged into recall ranking";
+              graphSnapshotReason = graphDecisionReason;
+              graphSnapshotSeedPaths = seedPaths;
+              graphSnapshotExpandedPaths = expandedPaths;
+              graphSnapshotSeedResults = this.buildGraphRecallRankedResults(
+                seedResults,
+                () => ["baseline"],
+              );
+              graphExpandedResultPaths.clear();
+              expandedPaths.forEach((entry) =>
+                graphExpandedResultPaths.add(entry.path),
+              );
+              memoryResults = graphShadowEvalEnabled
+                ? baselineMemoryResults
+                : merged;
+
+              if (graphShadowEvalEnabled) {
+                const comparison = summarizeGraphShadowComparison(
+                  baselineMemoryResults,
+                  merged,
+                  recallResultLimit,
+                );
+                graphSnapshotShadowComparison = comparison;
+                recordRecallSectionMetric({
+                  section: "graphShadow",
+                  priority: "enrichment",
+                  durationMs: Date.now() - t0,
+                  deadlineMs: enrichmentSectionDeadlineMs,
+                  source: "fresh",
+                  success: true,
+                  timing:
+                    `on b=${comparison.baselineCount} g=${comparison.graphCount} ` +
+                    `ov=${comparison.overlapCount} (${comparison.overlapRatio.toFixed(2)}) ` +
+                    `avgDelta=${comparison.averageOverlapDelta.toFixed(3)}`,
+                });
+              }
             }
           } catch (err) {
             graphSnapshotStatus = "aborted";
@@ -9552,12 +9693,17 @@ export class Orchestrator {
       }
 
       // Apply recency and access count boosting
-      memoryResults = await this.boostSearchResults(
+      memoryResults = await awaitAssemblyStep(
+        "qmd-boost",
+        () =>
+          this.boostSearchResults(
+            memoryResults,
+            recallNamespaces,
+            retrievalQuery,
+            undefined,
+            { asOfMs },
+          ),
         memoryResults,
-        recallNamespaces,
-        retrievalQuery,
-        undefined,
-        { asOfMs },
       );
 
       // Optional LLM reranking (default off). Fail-open if rerank fails/slow.
@@ -9811,6 +9957,7 @@ export class Orchestrator {
             queryAwarePrefilter,
             abortSignal: options.abortSignal,
             xrayPoolSizeSink: xrayColdPoolSink,
+            deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
             asOfMs,
             ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
@@ -10023,6 +10170,7 @@ export class Orchestrator {
               queryAwarePrefilter,
               abortSignal: options.abortSignal,
               xrayPoolSizeSink: xrayColdPoolSink,
+              deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
               asOfMs,
               ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
             });
@@ -10125,6 +10273,7 @@ export class Orchestrator {
                 queryAwarePrefilter,
                 abortSignal: options.abortSignal,
                 xrayPoolSizeSink: xrayColdPoolSink,
+                deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
                 asOfMs,
                 ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
               });
@@ -10168,6 +10317,7 @@ export class Orchestrator {
             queryAwarePrefilter,
             abortSignal: options.abortSignal,
             xrayPoolSizeSink: xrayColdPoolSink,
+            deadlineAtMs: enrichmentAssemblyDeadlineAtMs,
             asOfMs,
             ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
@@ -15482,6 +15632,62 @@ export class Orchestrator {
    *
    * Callers must pass the full candidate pool (post-rerank, pre-slice).
    */
+  private qmdCollectionNamespaceFromPrefix(collectionPrefix: string): string | null {
+    const baseCollection = this.config.qmdCollection;
+    if (collectionPrefix === baseCollection) return this.config.defaultNamespace;
+    const namespaceSuffix = collectionPrefix.startsWith(`${baseCollection}--`)
+      ? collectionPrefix.slice(baseCollection.length + 2)
+      : "";
+    if (!namespaceSuffix) return null;
+
+    const decoded = namespaceIdentityFromToken(namespaceSuffix);
+    if (decoded !== null) return decoded || this.config.defaultNamespace;
+    if (namespaceSuffix.startsWith("ns--")) {
+      const legacyNamespace = namespaceSuffix.slice("ns--".length).trim();
+      return legacyNamespace || null;
+    }
+    return null;
+  }
+
+  private async readQmdResultMemory(
+    resultPath: string,
+    fallbackStorage: StorageManager,
+  ): Promise<MemoryFile | null> {
+    const parts = qmdCollectionPathParts(resultPath);
+    const collectionNamespace = parts
+      ? this.qmdCollectionNamespaceFromPrefix(parts.collection)
+      : null;
+
+    if (parts && collectionNamespace) {
+      try {
+        const collectionStorage =
+          await this.storageRouter.storageFor(collectionNamespace);
+        for (const candidate of qmdResultPathCandidates(
+          collectionStorage.dir,
+          parts.relativePath,
+        )) {
+          const memory = await collectionStorage.readMemoryByPath(candidate);
+          if (memory) return memory;
+        }
+      } catch (err) {
+        log.debug("qmd result namespace path lookup failed open", {
+          path: resultPath,
+          namespace: collectionNamespace,
+          error: (err as Error).message,
+        });
+      }
+    }
+
+    for (const candidate of qmdResultPathCandidates(
+      fallbackStorage.dir,
+      resultPath,
+    )) {
+      const memory = await fallbackStorage.readMemoryByPath(candidate);
+      if (memory) return memory;
+    }
+    return null;
+  }
+
   private async applyMemoryWorthRerank(
     results: QmdSearchResult[],
     namespaces: string[],
@@ -15557,7 +15763,7 @@ export class Orchestrator {
       if (reader) {
         for (const r of missing) {
           try {
-            const memory = await reader.readMemoryByPath(r.path);
+            const memory = await this.readQmdResultMemory(r.path, reader);
             if (!memory) continue;
             const fm = memory.frontmatter;
             if (fm.mw_success === undefined && fm.mw_fail === undefined) continue;
@@ -15973,6 +16179,7 @@ export class Orchestrator {
      * Unset by default so existing call sites are unaffected.
      */
     xrayPoolSizeSink?: { size: number };
+    deadlineAtMs?: number | null;
     /** Issue #681 — when true, bypass graphTraversalConfidenceFloor. */
     includeLowConfidence?: boolean;
   }): Promise<QmdSearchResult[]> {
@@ -16059,6 +16266,7 @@ export class Orchestrator {
         memoryResults: results,
         recallNamespaces: options.recallNamespaces,
         recallResultLimit: options.recallResultLimit,
+        deadlineAtMs: options.deadlineAtMs,
         ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
       });
       results = merged;
@@ -16267,7 +16475,7 @@ export class Orchestrator {
       Promise.all(
         results.map(async (r) => {
           if (!r.path || memoryByPath.has(r.path)) return;
-          const mem = await this.storage.readMemoryByPath(r.path);
+          const mem = await this.readQmdResultMemory(r.path, this.storage);
           if (mem) memoryByPath.set(r.path, mem);
         }),
       ),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -10167,42 +10167,48 @@ export class Orchestrator {
       // Fallback: embeddings first, then recency-only.
       const queryAwarePrefilter = await queryAwarePrefilterPromise;
       if (queryAwarePrefilter.candidatePaths?.size !== 0) {
-      const embeddingResults = await this.searchEmbeddingFallback(
-        retrievalQuery,
-        embeddingFetchLimit,
-      );
-      const prefilteredEmbeddingResults = applyQueryAwareCandidateFilter(
-        embeddingResults,
-        queryAwarePrefilter.candidatePaths,
-      );
-      const scopedCandidates = filterRecallCandidates(
-        prefilteredEmbeddingResults,
-        {
-          namespacesEnabled: this.config.namespacesEnabled,
-          recallNamespaces,
-          resolveNamespace: (p) => this.namespaceFromPath(p),
-          limit: embeddingFetchLimit,
-        },
-      );
-      const boostedScoped = await this.boostSearchResults(
-        scopedCandidates,
-        recallNamespaces,
-        retrievalQuery,
-        undefined,
-        { asOfMs },
-      );
-      // MMR runs on the pre-truncation pool so diverse candidates just
-      // below the cutoff can be promoted into the injected set.
-      xrayBranchPoolSize.hot_embedding = Math.max(
-        xrayBranchPoolSize.hot_embedding,
-        boostedScoped.length,
-      );
-      const scoped = this.diversifyAndLimitRecallResults(
-        "memories",
-        boostedScoped,
-        recallResultLimit,
-        retrievalQuery,
-      );
+        const scoped = await awaitAssemblyStep(
+          "embedding-fallback",
+          async () => {
+            const embeddingResults = await this.searchEmbeddingFallback(
+              retrievalQuery,
+              embeddingFetchLimit,
+            );
+            const prefilteredEmbeddingResults = applyQueryAwareCandidateFilter(
+              embeddingResults,
+              queryAwarePrefilter.candidatePaths,
+            );
+            const scopedCandidates = filterRecallCandidates(
+              prefilteredEmbeddingResults,
+              {
+                namespacesEnabled: this.config.namespacesEnabled,
+                recallNamespaces,
+                resolveNamespace: (p) => this.namespaceFromPath(p),
+                limit: embeddingFetchLimit,
+              },
+            );
+            const boostedScoped = await this.boostSearchResults(
+              scopedCandidates,
+              recallNamespaces,
+              retrievalQuery,
+              undefined,
+              { asOfMs },
+            );
+            // MMR runs on the pre-truncation pool so diverse candidates just
+            // below the cutoff can be promoted into the injected set.
+            xrayBranchPoolSize.hot_embedding = Math.max(
+              xrayBranchPoolSize.hot_embedding,
+              boostedScoped.length,
+            );
+            return this.diversifyAndLimitRecallResults(
+              "memories",
+              boostedScoped,
+              recallResultLimit,
+              retrievalQuery,
+            );
+          },
+          [] as QmdSearchResult[],
+        );
       if (scoped.length > 0) {
         if (shouldPersistGraphSnapshot) {
           graphSnapshotFinalResults = this.buildGraphRecallRankedResults(
@@ -10231,8 +10237,11 @@ export class Orchestrator {
         xrayRecalledResults = scoped;
         impressionRecorded = true;
       } else {
-        const memories =
-          await this.readAllMemoriesForNamespaces(recallNamespaces);
+        const memories = await awaitAssemblyStep(
+          "recent-memory-read",
+          () => this.readAllMemoriesForNamespaces(recallNamespaces),
+          [] as MemoryFile[],
+        );
         if (memories.length > 0) {
           // Filter out non-active memories.  Delegate to
           // shouldFilterSupersededFromRecall for superseded-status logic so
@@ -10331,44 +10340,50 @@ export class Orchestrator {
               impressionRecorded = true;
             }
           } else {
-            const recentSorted = queryAwareScopedMemories.sort(
-              (a, b) =>
-                new Date(b.frontmatter.updated).getTime() -
-                new Date(a.frontmatter.updated).getTime(),
-            );
-            const preloadedMap = new Map<string, MemoryFile>(
-              queryAwareScopedMemories
-                .filter((m) => m.path)
-                .map((m) => [m.path, m]),
-            );
-            const recentAsResults: QmdSearchResult[] = recentSorted.map(
-              (m, i) => ({
-                docid: m.frontmatter.id,
-                path: m.path,
-                snippet: m.content,
-                score: 1.0 - i / Math.max(recentSorted.length, 1),
-              }),
-            );
-            const boostedRecent = (
-              await this.boostSearchResults(
-                recentAsResults,
-                recallNamespaces,
-                retrievalQuery,
-                preloadedMap,
-                { asOfMs },
-              )
-            ).sort((a, b) => b.score - a.score);
-            // MMR runs on the pre-truncation pool so diverse candidates just
-            // below the cutoff can be promoted into the injected set.
-            xrayBranchPoolSize.recent_scan = Math.max(
-              xrayBranchPoolSize.recent_scan,
-              boostedRecent.length,
-            );
-            const recent = this.diversifyAndLimitRecallResults(
-              "memories",
-              boostedRecent,
-              recallResultLimit,
-              retrievalQuery,
+            const recent = await awaitAssemblyStep(
+              "recent-memory-scan",
+              async () => {
+                const recentSorted = queryAwareScopedMemories.sort(
+                  (a, b) =>
+                    new Date(b.frontmatter.updated).getTime() -
+                    new Date(a.frontmatter.updated).getTime(),
+                );
+                const preloadedMap = new Map<string, MemoryFile>(
+                  queryAwareScopedMemories
+                    .filter((m) => m.path)
+                    .map((m) => [m.path, m]),
+                );
+                const recentAsResults: QmdSearchResult[] = recentSorted.map(
+                  (m, i) => ({
+                    docid: m.frontmatter.id,
+                    path: m.path,
+                    snippet: m.content,
+                    score: 1.0 - i / Math.max(recentSorted.length, 1),
+                  }),
+                );
+                const boostedRecent = (
+                  await this.boostSearchResults(
+                    recentAsResults,
+                    recallNamespaces,
+                    retrievalQuery,
+                    preloadedMap,
+                    { asOfMs },
+                  )
+                ).sort((a, b) => b.score - a.score);
+                // MMR runs on the pre-truncation pool so diverse candidates just
+                // below the cutoff can be promoted into the injected set.
+                xrayBranchPoolSize.recent_scan = Math.max(
+                  xrayBranchPoolSize.recent_scan,
+                  boostedRecent.length,
+                );
+                return this.diversifyAndLimitRecallResults(
+                  "memories",
+                  boostedRecent,
+                  recallResultLimit,
+                  retrievalQuery,
+                );
+              },
+              [] as QmdSearchResult[],
             );
 
             if (recent.length > 0) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6000,15 +6000,40 @@ export class Orchestrator {
     seedResults: QmdSearchResult[];
   }> {
     const byNamespace = new Map<string, QmdSearchResult[]>();
-    for (const result of options.memoryResults) {
-      const ns = this.namespaceFromPath(result.path);
-      if (!options.recallNamespaces.includes(ns)) continue;
-      const existing = byNamespace.get(ns);
+    const addResultForNamespace = (
+      namespace: string,
+      result: QmdSearchResult,
+    ): void => {
+      const existing = byNamespace.get(namespace);
       if (existing) {
         existing.push(result);
       } else {
-        byNamespace.set(ns, [result]);
+        byNamespace.set(namespace, [result]);
       }
+    };
+    const coldCollection = this.config.qmdColdCollection;
+    for (const result of options.memoryResults) {
+      const parts = qmdCollectionPathParts(result.path);
+      if (parts?.collection === coldCollection) {
+        for (const namespace of options.recallNamespaces) {
+          addResultForNamespace(namespace, result);
+        }
+        continue;
+      }
+      if (path.isAbsolute(result.path)) {
+        const ns = this.namespaceFromPath(result.path);
+        if (options.recallNamespaces.includes(ns)) {
+          addResultForNamespace(ns, result);
+        } else {
+          for (const namespace of options.recallNamespaces) {
+            addResultForNamespace(namespace, result);
+          }
+        }
+        continue;
+      }
+      const ns = this.namespaceFromPath(result.path);
+      if (!options.recallNamespaces.includes(ns)) continue;
+      addResultForNamespace(ns, result);
     }
 
     const perNamespaceSeedCap = Math.max(3, options.recallResultLimit);
@@ -6032,11 +6057,14 @@ export class Orchestrator {
               storage,
               seedCandidates,
               options.deadlineAtMs,
+              [namespace],
             )
           : (
               await Promise.all(
                 seedCandidates.map((result) =>
-                  this.graphSeedPathRelativeToStorage(storage, result),
+                  this.graphSeedPathRelativeToStorage(storage, result, [
+                    namespace,
+                  ]),
                 ),
               )
             ).filter(
@@ -10751,6 +10779,7 @@ export class Orchestrator {
           query: retrievalQuery,
           memoryIds: recalledMemoryIds,
           namespace: selfNamespace,
+          recallNamespaces,
           traceId,
           plannerMode: recallMode,
           requestedMode,
@@ -17523,10 +17552,15 @@ export class Orchestrator {
   private async graphSeedPathRelativeToStorage(
     storage: StorageManager,
     result: QmdSearchResult,
+    recallNamespaces: readonly string[] = [],
   ): Promise<string | null> {
     const parts = qmdCollectionPathParts(result.path);
     if (parts) {
-      const memory = await this.readQmdResultMemory(result.path, storage);
+      const memory = await this.readQmdResultMemory(
+        result.path,
+        storage,
+        recallNamespaces,
+      );
       return memory
         ? graphPathRelativeToStorage(storage.dir, memory.path)
         : null;
@@ -17538,11 +17572,16 @@ export class Orchestrator {
     storage: StorageManager,
     results: QmdSearchResult[],
     deadlineAtMs: number,
+    recallNamespaces: readonly string[] = [],
   ): Promise<string[]> {
     const resolved: string[] = [];
     for (const result of results) {
       if (Date.now() >= deadlineAtMs) break;
-      const seedPath = await this.graphSeedPathRelativeToStorage(storage, result);
+      const seedPath = await this.graphSeedPathRelativeToStorage(
+        storage,
+        result,
+        recallNamespaces,
+      );
       if (Date.now() >= deadlineAtMs) break;
       if (seedPath) resolved.push(seedPath);
     }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15707,10 +15707,15 @@ export class Orchestrator {
     fallbackStorage: StorageManager,
   ): Promise<MemoryFile | null> {
     const parts = qmdCollectionPathParts(resultPath);
+    const fallbackStorageDir =
+      typeof (fallbackStorage as { dir?: unknown }).dir === "string" &&
+      (fallbackStorage as { dir?: string }).dir
+        ? (fallbackStorage as { dir: string }).dir
+        : null;
     const coldCollection = this.config.qmdColdCollection;
-    if (parts && parts.collection === coldCollection) {
+    if (parts && parts.collection === coldCollection && fallbackStorageDir) {
       try {
-        const coldStorage = new StorageManager(path.join(fallbackStorage.dir, "cold"));
+        const coldStorage = new StorageManager(path.join(fallbackStorageDir, "cold"));
         for (const candidate of qmdResultPathCandidates(
           coldStorage.dir,
           parts.relativePath,
@@ -15757,6 +15762,9 @@ export class Orchestrator {
     }
 
     if (path.isAbsolute(resultPath)) {
+      if (!fallbackStorageDir) {
+        return await fallbackStorage.readMemoryByPath(resultPath);
+      }
       const ownerStorage = await this.storageForAbsoluteQmdResultPath(
         resultPath,
         fallbackStorage,
@@ -15772,8 +15780,11 @@ export class Orchestrator {
       return null;
     }
 
+    if (!fallbackStorageDir) {
+      return await fallbackStorage.readMemoryByPath(resultPath);
+    }
     for (const candidate of qmdResultPathCandidates(
-      fallbackStorage.dir,
+      fallbackStorageDir,
       resultPath,
     )) {
       const memory = await fallbackStorage.readMemoryByPath(candidate);
@@ -15793,7 +15804,13 @@ export class Orchestrator {
     const seenDirs = new Set<string>();
 
     const maybeAddStorage = (storage: StorageManager) => {
-      const candidateRoot = path.resolve(storage.dir);
+      const storageDir =
+        typeof (storage as { dir?: unknown }).dir === "string" &&
+        (storage as { dir?: string }).dir
+          ? (storage as { dir: string }).dir
+          : null;
+      if (!storageDir) return;
+      const candidateRoot = path.resolve(storageDir);
       if (seenDirs.has(candidateRoot)) return;
       if (!isPathInsideStorageRoot(candidateRoot, resolvedPath)) return;
       if (

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -15685,12 +15685,14 @@ export class Orchestrator {
           const memory = await collectionStorage.readMemoryByPath(candidate);
           if (memory) return memory;
         }
+        return null;
       } catch (err) {
         log.debug("qmd result namespace path lookup failed open", {
           path: resultPath,
           namespace: collectionNamespace,
           error: (err as Error).message,
         });
+        return null;
       }
     }
 
@@ -17161,6 +17163,11 @@ export class Orchestrator {
 
   private namespaceFromPath(p: string): string {
     if (!this.config.namespacesEnabled) return this.config.defaultNamespace;
+    const parts = qmdCollectionPathParts(p);
+    const collectionNamespace = parts
+      ? this.qmdCollectionNamespaceFromPrefix(parts.collection)
+      : null;
+    if (collectionNamespace) return collectionNamespace;
     const m = p.match(/[\\/]+namespaces[\\/]+([^\\/]+)(?:[\\/]|$)/);
     if (!m?.[1]) return this.config.defaultNamespace;
     return namespaceIdentityFromToken(m[1]) ?? m[1];

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9728,6 +9728,7 @@ export class Orchestrator {
             ? null
             : enrichmentAssemblyDeadlineAtMs,
           abortSignal: options.abortSignal,
+          dropUnresolved: true,
         },
       );
 
@@ -16300,6 +16301,50 @@ export class Orchestrator {
       if (options.xrayPoolSizeSink) options.xrayPoolSizeSink.size = 0;
       return [];
     }
+    const deadlineRemainingMs = (): number | null =>
+      typeof options.deadlineAtMs === "number"
+        ? Math.max(0, options.deadlineAtMs - Date.now())
+        : null;
+    const runColdStepWithinDeadline = async <T>(
+      label: string,
+      fallback: T,
+      task: () => Promise<T>,
+    ): Promise<T> => {
+      throwIfRecallAborted(options.abortSignal);
+      const remainingMs = deadlineRemainingMs();
+      if (remainingMs === 0) {
+        log.debug(`cold-tier recall ${label} skipped: shared assembly deadline expired`);
+        return fallback;
+      }
+      if (remainingMs === null) return task();
+
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      let timedOut = false;
+      const taskPromise = task().catch((err) => {
+        if (timedOut) {
+          log.debug(`cold-tier recall ${label} failed after deadline: ${err}`);
+          return fallback;
+        }
+        throw err;
+      });
+
+      try {
+        return await Promise.race<T>([
+          taskPromise,
+          new Promise<T>((resolve) => {
+            timeoutHandle = setTimeout(() => {
+              timedOut = true;
+              log.debug(
+                `cold-tier recall ${label} skipped: shared assembly deadline expired`,
+              );
+              resolve(fallback);
+            }, remainingMs);
+          }),
+        ]);
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+      }
+    };
 
     const coldQmdEnabled = this.config.qmdColdTierEnabled === true;
     const coldCollection =
@@ -16319,19 +16364,24 @@ export class Orchestrator {
           false,
           0,
         );
-        longTerm = await this.fetchQmdMemoryResultsWithArtifactTopUp(
-          options.prompt,
-          coldFetchLimit,
-          coldHybridLimit,
-          {
-            namespacesEnabled: this.config.namespacesEnabled,
-            recallNamespaces: options.recallNamespaces,
-            resolveNamespace: (p) => this.namespaceFromPath(p),
-            collection: coldCollection,
-            queryAwarePrefilter: options.queryAwarePrefilter,
-            searchOptions: this.buildConfiguredQmdSearchOptions(options.prompt),
-            abortSignal: options.abortSignal,
-          },
+        longTerm = await runColdStepWithinDeadline(
+          "qmd lookup",
+          [],
+          () =>
+            this.fetchQmdMemoryResultsWithArtifactTopUp(
+              options.prompt,
+              coldFetchLimit,
+              coldHybridLimit,
+              {
+                namespacesEnabled: this.config.namespacesEnabled,
+                recallNamespaces: options.recallNamespaces,
+                resolveNamespace: (p) => this.namespaceFromPath(p),
+                collection: coldCollection,
+                queryAwarePrefilter: options.queryAwarePrefilter,
+                searchOptions: this.buildConfiguredQmdSearchOptions(options.prompt),
+                abortSignal: options.abortSignal,
+              },
+            ),
         );
         if (longTerm.length > 0) {
           log.debug(
@@ -16341,12 +16391,17 @@ export class Orchestrator {
       }
     }
     if (longTerm.length === 0) {
-      longTerm = await this.searchLongTermArchiveFallback(
-        options.prompt,
-        options.recallNamespaces,
-        options.recallResultLimit,
-        options.queryAwarePrefilter,
-        options.abortSignal,
+      longTerm = await runColdStepWithinDeadline(
+        "archive scan",
+        [],
+        () =>
+          this.searchLongTermArchiveFallback(
+            options.prompt,
+            options.recallNamespaces,
+            options.recallResultLimit,
+            options.queryAwarePrefilter,
+            options.abortSignal,
+          ),
       );
       if (longTerm.length > 0) {
         log.debug("cold-tier recall source=archive-scan");
@@ -16393,6 +16448,7 @@ export class Orchestrator {
         asOfMs: options.asOfMs,
         deadlineAtMs: options.deadlineAtMs,
         abortSignal: options.abortSignal,
+        dropUnresolved: true,
       },
     );
     results = boostInput.results;
@@ -16801,6 +16857,7 @@ export class Orchestrator {
       asOfMs?: number;
       deadlineAtMs?: number | null;
       abortSignal?: AbortSignal;
+      dropUnresolved?: boolean;
     },
   ): Promise<{ results: QmdSearchResult[]; memoryByPath: Map<string, MemoryFile> }> {
     if (results.length === 0) {
@@ -16822,11 +16879,19 @@ export class Orchestrator {
         `recall safety filter stopped before validating all candidates (${candidateResults.length}/${results.length} eligible)`,
       );
     }
+    const blockedPaths = new Set(loaded.unreadablePaths);
+    if (options?.dropUnresolved === true) {
+      for (const resultPath of loaded.checkedPaths) {
+        if (!loaded.memoryByPath.has(resultPath)) {
+          blockedPaths.add(resultPath);
+        }
+      }
+    }
     return {
       results: this.filterSearchResultsByRecallSafety(
         candidateResults,
         loaded.memoryByPath,
-        { ...options, blockedPaths: loaded.unreadablePaths },
+        { ...options, blockedPaths },
       ),
       memoryByPath: loaded.memoryByPath,
     };

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -153,6 +153,7 @@ import {
 import { CODEX_THREAD_KEY_PREFIX } from "./codex-thread-key.js";
 import { isDisagreementPrompt } from "./signal.js";
 import { lintWorkspaceFiles, rotateMarkdownFileToArchive } from "./hygiene.js";
+import { isPathInsideStorageRoot } from "./storage-paths.js";
 import { EmbeddingFallback } from "./embedding-fallback.js";
 import {
   decideSemanticDedup,
@@ -735,17 +736,24 @@ function qmdResultPathCandidates(
   resultPath: string,
 ): string[] {
   const candidates = new Set<string>();
+  const storageRoot = path.resolve(storageDir);
+  const addCandidate = (candidate: string) => {
+    const resolved = path.resolve(candidate);
+    if (isPathInsideStorageRoot(storageRoot, resolved)) {
+      candidates.add(resolved);
+    }
+  };
   const addRelativeCandidates = (relativePath: string) => {
     const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
     if (!normalized) return;
-    candidates.add(path.join(storageDir, normalized));
+    addCandidate(path.join(storageRoot, normalized));
     if (/^\d{4}-\d{2}-\d{2}\//.test(normalized)) {
-      candidates.add(path.join(storageDir, "facts", normalized));
+      addCandidate(path.join(storageRoot, "facts", normalized));
     }
   };
 
   if (path.isAbsolute(resultPath)) {
-    candidates.add(resultPath);
+    addCandidate(resultPath);
   } else {
     addRelativeCandidates(resultPath);
   }

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -29,6 +29,7 @@ export interface LastRecallSnapshot {
   queryLen: number;
   memoryIds: string[];
   namespace?: string;
+  recallNamespaces?: string[];
   traceId?: string;
   plannerMode?: RecallPlanMode;
   requestedMode?: RecallPlanMode;
@@ -247,6 +248,7 @@ export class LastRecallStore {
     query: string;
     memoryIds: string[];
     namespace?: string;
+    recallNamespaces?: string[];
     traceId?: string;
     plannerMode?: RecallPlanMode;
     requestedMode?: RecallPlanMode;
@@ -285,6 +287,7 @@ export class LastRecallStore {
       queryLen: opts.query.length,
       memoryIds: opts.memoryIds,
       namespace: opts.namespace,
+      recallNamespaces: opts.recallNamespaces,
       traceId: opts.traceId,
       plannerMode: opts.plannerMode,
       requestedMode: opts.requestedMode,

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -536,11 +536,11 @@ tests/recall-hardening.test.ts(183,14): TS2304
 tests/recall-hardening.test.ts(253,14): TS2304
 tests/recall-hardening.test.ts(358,3): TS2349
 tests/recall-hardening.test.ts(433,3): TS2349
-tests/recall-hardening.test.ts(632,3): TS2349
-tests/recall-hardening.test.ts(679,3): TS2349
-tests/recall-hardening.test.ts(754,3): TS2349
-tests/recall-hardening.test.ts(812,3): TS2349
-tests/recall-hardening.test.ts(814,3): TS2349
+tests/recall-hardening.test.ts(627,3): TS2349
+tests/recall-hardening.test.ts(674,3): TS2349
+tests/recall-hardening.test.ts(749,3): TS2349
+tests/recall-hardening.test.ts(807,3): TS2349
+tests/recall-hardening.test.ts(809,3): TS2349
 tests/recall-no-recall-short-circuit.test.ts(14,3): TS2740
 tests/release-workflow-public-packages.test.ts(151,41): TS7016
 tests/remnic-cli-service-candidates.test.ts(17,82): TS7006

--- a/tests/access-service-recall-xray-tags.test.ts
+++ b/tests/access-service-recall-xray-tags.test.ts
@@ -151,6 +151,88 @@ test("buildXraySnapshot: tags field is preserved on RecallXrayResult", () => {
   assert.deepEqual(snapshot.results[0].tags, ["alice", "location"]);
 });
 
+test("serializeRecallResults resolves cold collection paths through recorded recall namespaces", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-cold-recall-"));
+  const defaultDir = path.join(memoryDir, "default");
+  const projectDir = path.join(memoryDir, "project-cold");
+  const coldPath = path.join(
+    projectDir,
+    "cold",
+    "facts",
+    "2026-03-11",
+    "fact-cold.md",
+  );
+  const memory = {
+    path: coldPath,
+    content: "project cold recall memory",
+    frontmatter: {
+      id: "fact-cold",
+      category: "fact",
+      created: "2026-03-11T12:00:00.000Z",
+      updated: "2026-03-11T12:00:00.000Z",
+      source: "extraction",
+      confidence: 0.8,
+      confidenceTier: "confident",
+    },
+  };
+  const storageFor = (dir: string, readablePath?: string) => ({
+    dir,
+    readMemoryByPath: async (candidatePath: string) =>
+      readablePath && path.resolve(candidatePath) === path.resolve(readablePath)
+        ? memory
+        : null,
+    getMemoryById: async () => null,
+    getMemoryTimeline: async () => [],
+  });
+  const storages = new Map<string, ReturnType<typeof storageFor>>([
+    ["default", storageFor(defaultDir)],
+    ["shared", storageFor(path.join(memoryDir, "shared"))],
+    ["project-cold", storageFor(projectDir, coldPath)],
+  ]);
+  const orchestrator = {
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      sharedNamespace: "shared",
+      namespacePolicies: [],
+      defaultRecallNamespaces: ["default"],
+      qmdCollection: "openclaw-engram",
+      qmdColdCollection: "openclaw-engram-cold",
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 20,
+      recallAuditAnomalyDetectionEnabled: false,
+    },
+    getStorage: async (namespace: string) => {
+      const storage = storages.get(namespace);
+      if (!storage) throw new Error(`missing storage: ${namespace}`);
+      return storage;
+    },
+    lcmEngine: null,
+  };
+  const service = new EngramAccessService(orchestrator as never) as any;
+
+  const results = await service.serializeRecallResults(
+    {
+      sessionKey: "session-1",
+      recordedAt: "2026-03-11T12:00:00.000Z",
+      queryHash: "hash",
+      queryLen: 5,
+      memoryIds: ["fact-cold"],
+      namespace: "default",
+      recallNamespaces: ["project-cold"],
+      resultPaths: ["openclaw-engram-cold/facts/2026-03-11/fact-cold.md"],
+    },
+    "chunk",
+  );
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].id, "fact-cold");
+  assert.equal(results[0].path, coldPath);
+});
+
 test("buildXraySnapshot: tags field is absent when not provided", () => {
   const result = fakeXrayResult({
     memoryId: "fact-2",

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -696,4 +696,43 @@ describe("GraphIndex.spreadingActivation — assembly deadlines", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("keeps completed BFS results when the deadline expires before inhibition", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "engram-sa-deadline-partial-"));
+    const originalNow = Date.now;
+    try {
+      const gi = new GraphIndex(dir, {
+        ...cfg,
+        graphTraversalPageRankIterations: 0,
+        graphLateralInhibitionEnabled: true,
+      } as unknown as GraphConfig);
+      await appendEdge(dir, {
+        from: "A.md",
+        to: "B.md",
+        type: "entity",
+        weight: 1.0,
+        label: "deadline",
+        ts: new Date().toISOString(),
+      });
+
+      let calls = 0;
+      Date.now = () => {
+        calls += 1;
+        return calls < 6 ? 1_000 : 2_000;
+      };
+
+      const results = await gi.spreadingActivation(["A.md"], 1, {
+        deadlineAtMs: 1_500,
+      });
+      assert.equal(results.length, 1);
+      assert.equal(results[0].path, "B.md");
+      assert.ok(
+        Math.abs(results[0].score - 0.7) < 0.001,
+        `expected BFS score 0.7 got ${results[0].score}`,
+      );
+    } finally {
+      Date.now = originalNow;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -686,11 +686,18 @@ describe("GraphIndex.spreadingActivation — assembly deadlines", () => {
         label: "deadline",
         ts: new Date().toISOString(),
       });
+      let edgeCacheLoaded = false;
+      (gi as unknown as { loadEdgesCached(): Promise<unknown[]> }).loadEdgesCached =
+        async () => {
+          edgeCacheLoaded = true;
+          return [];
+        };
       const startedAt = Date.now();
       const results = await gi.spreadingActivation(["A.md"], 3, {
         deadlineAtMs: startedAt - 1,
       });
       assert.deepEqual(results, []);
+      assert.equal(edgeCacheLoaded, false);
       assert.ok(Date.now() - startedAt < 100, "expired deadline should fail open quickly");
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -718,7 +725,7 @@ describe("GraphIndex.spreadingActivation — assembly deadlines", () => {
       let calls = 0;
       Date.now = () => {
         calls += 1;
-        return calls < 6 ? 1_000 : 2_000;
+        return calls < 7 ? 1_000 : 2_000;
       };
 
       const results = await gi.spreadingActivation(["A.md"], 1, {

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -662,3 +662,38 @@ describe("Integration: corrupt JSONL fail-open", () => {
     }
   });
 });
+
+describe("GraphIndex.spreadingActivation — assembly deadlines", () => {
+  const cfg = {
+    multiGraphMemoryEnabled: true,
+    entityGraphEnabled: true,
+    timeGraphEnabled: true,
+    causalGraphEnabled: false,
+    maxGraphTraversalSteps: 3,
+    graphActivationDecay: 0.7,
+    maxEntityGraphEdgesPerMemory: 10,
+  } as unknown as GraphConfig;
+
+  it("returns [] immediately when the traversal deadline is already expired", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "engram-sa-deadline-"));
+    try {
+      const gi = new GraphIndex(dir, cfg);
+      await appendEdge(dir, {
+        from: "A.md",
+        to: "B.md",
+        type: "entity",
+        weight: 1.0,
+        label: "deadline",
+        ts: new Date().toISOString(),
+      });
+      const startedAt = Date.now();
+      const results = await gi.spreadingActivation(["A.md"], 3, {
+        deadlineAtMs: startedAt - 1,
+      });
+      assert.deepEqual(results, []);
+      assert.ok(Date.now() - startedAt < 100, "expired deadline should fail open quickly");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/orchestrator-graph-activation.test.ts
+++ b/tests/orchestrator-graph-activation.test.ts
@@ -6,6 +6,12 @@ import { mkdtemp } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { Orchestrator } from "../src/orchestrator.js";
 
+function namespaceIdentityToken(namespace: string): string {
+  const bytes = new TextEncoder().encode(namespace.trim());
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `ns-${hex || "default"}`;
+}
+
 test("buildGraphEdge writes fallback session adjacency when enabled", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-graph-adj-enabled-"));
   const cfg = parseConfig({
@@ -74,4 +80,137 @@ test("buildGraphEdge skips fallback session adjacency when disabled", async () =
 
   assert.ok(captured);
   assert.deepEqual(captured.recentInThread, []);
+});
+
+test("graph expansion resolves namespace QMD collection paths before seeding", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-graph-qmd-seed-"));
+  const namespace = "team-project-alpha";
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      {
+        name: namespace,
+        readPrincipals: ["reader"],
+        writePrincipals: ["writer"],
+      },
+    ],
+    qmdCollection: "openclaw-engram",
+    multiGraphMemoryEnabled: true,
+  });
+  const orchestrator = new Orchestrator(cfg);
+  const storage = await (orchestrator as any).storageRouter.storageFor(namespace);
+  const memoryId = await storage.writeMemory(
+    "fact",
+    "Graph seed memory for namespace collection paths.",
+  );
+  const memory = await storage.getMemoryById(memoryId);
+  assert.ok(memory);
+
+  const relativeMemoryPath = path
+    .relative(storage.dir, memory.path)
+    .split(path.sep)
+    .join("/");
+  const collectionPath = [
+    `openclaw-engram--${namespaceIdentityToken(namespace)}`,
+    relativeMemoryPath,
+  ].join("/");
+  let observedSeeds: string[] = [];
+  (orchestrator as any).graphIndexFor = () => ({
+    spreadingActivation: async (seeds: string[]) => {
+      observedSeeds = seeds;
+      return [];
+    },
+  });
+
+  await (orchestrator as any).expandResultsViaGraph({
+    memoryResults: [
+      {
+        docid: memory.frontmatter.id,
+        path: collectionPath,
+        snippet: memory.content,
+        score: 0.8,
+      },
+    ],
+    recallNamespaces: [namespace],
+    recallResultLimit: 5,
+  });
+
+  assert.deepEqual(observedSeeds, [relativeMemoryPath]);
+});
+
+test("graph expansion stops expanded memory reads after assembly deadline", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-graph-read-deadline-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    multiGraphMemoryEnabled: true,
+  });
+  const orchestrator = new Orchestrator(cfg);
+  const storage = await (orchestrator as any).storageRouter.storageFor("default");
+  const seedId = await storage.writeMemory("fact", "Graph seed memory.");
+  const expandedId = await storage.writeMemory("fact", "Expanded graph memory.");
+  const seed = await storage.getMemoryById(seedId);
+  const expanded = await storage.getMemoryById(expandedId);
+  assert.ok(seed);
+  assert.ok(expanded);
+
+  const seedRelativePath = path.relative(storage.dir, seed.path).split(path.sep).join("/");
+  const expandedRelativePath = path
+    .relative(storage.dir, expanded.path)
+    .split(path.sep)
+    .join("/");
+  const deadlineAtMs = 1_100;
+  const originalDateNow = Date.now;
+  let nowMs = 1_000;
+  let expandedReads = 0;
+  const originalReadMemoryByPath = storage.readMemoryByPath.bind(storage);
+  (storage as any).readMemoryByPath = async (...args: unknown[]) => {
+    expandedReads += 1;
+    return originalReadMemoryByPath(...(args as [string]));
+  };
+  (orchestrator as any).graphIndexFor = () => ({
+    spreadingActivation: async () => {
+      nowMs = deadlineAtMs + 1;
+      return [
+        {
+          path: expandedRelativePath,
+          score: 0.7,
+          seed: seedRelativePath,
+          hopDepth: 1,
+          decayedWeight: 0.7,
+          graphType: "semantic",
+          edgeConfidence: 0.9,
+        },
+      ];
+    },
+  });
+
+  try {
+    Date.now = () => nowMs;
+    const result = await (orchestrator as any).expandResultsViaGraph({
+      memoryResults: [
+        {
+          docid: seed.frontmatter.id,
+          path: seed.path,
+          snippet: seed.content,
+          score: 0.8,
+        },
+      ],
+      recallNamespaces: ["default"],
+      recallResultLimit: 5,
+      deadlineAtMs,
+    });
+
+    assert.equal(expandedReads, 0);
+    assert.deepEqual(result.expandedPaths, []);
+  } finally {
+    Date.now = originalDateNow;
+    (storage as any).readMemoryByPath = originalReadMemoryByPath;
+  }
 });

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -312,6 +312,13 @@ test("cold-tier recall forwards explain traces even when intent hints are disabl
     qmdIntentHintsEnabled: false,
   });
   const orchestrator = new Orchestrator(cfg) as any;
+  const memoryId = await orchestrator.storage.writeMemory(
+    "fact",
+    "cold explain trace memory",
+  );
+  const memory = await orchestrator.storage.getMemoryById(memoryId);
+  assert.ok(memory);
+  const migrated = await orchestrator.storage.migrateMemoryToTier(memory, "cold");
 
   let capturedOptions: Record<string, unknown> | undefined;
   orchestrator.qmd = {
@@ -326,9 +333,9 @@ test("cold-tier recall forwards explain traces even when intent hints are disabl
     capturedOptions = options.searchOptions;
     return [
       {
-        docid: "fact-1",
-        path: "facts/2026-03-11/fact-1.md",
-        snippet: "fact one",
+        docid: memory.frontmatter.id,
+        path: migrated.targetPath,
+        snippet: "cold explain trace memory",
         score: 0.9,
       },
     ];

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -402,6 +402,60 @@ test("cold-tier recall reads encrypted cold collection paths through primary sto
   assert.equal(results[0].path, `openclaw-engram-cold/${coldRelativePath}`);
 });
 
+test("recall safety resolves absolute QMD paths from runtime recall namespaces", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-runtime-ns-"));
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-runtime-root-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    namespacesEnabled: true,
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  const StorageManagerCtor = orchestrator.storage.constructor as new (
+    dir: string,
+  ) => typeof orchestrator.storage;
+  const runtimeStorage = new StorageManagerCtor(runtimeDir);
+  const memoryId = await runtimeStorage.writeMemory(
+    "fact",
+    "runtime namespace absolute QMD memory",
+  );
+  const memory = await runtimeStorage.getMemoryById(memoryId);
+  assert.ok(memory);
+
+  const originalStorageFor = orchestrator.storageRouter.storageFor.bind(
+    orchestrator.storageRouter,
+  );
+  orchestrator.storageRouter.storageFor = async (namespace: string) =>
+    namespace === "runtime-overlay"
+      ? runtimeStorage
+      : originalStorageFor(namespace);
+
+  const result = {
+    docid: memory.frontmatter.id,
+    path: memory.path,
+    snippet: "runtime namespace absolute QMD memory",
+    score: 0.9,
+  };
+  const withoutRuntimeNamespace = await orchestrator.filterSearchResultsForRecall(
+    [result],
+    undefined,
+    { dropUnresolved: true },
+  );
+  assert.equal(withoutRuntimeNamespace.results.length, 0);
+
+  const withRuntimeNamespace = await orchestrator.filterSearchResultsForRecall(
+    [result],
+    undefined,
+    { dropUnresolved: true, recallNamespaces: ["runtime-overlay"] },
+  );
+  assert.equal(withRuntimeNamespace.results.length, 1);
+  assert.equal(
+    withRuntimeNamespace.memoryByPath.get(memory.path)?.frontmatter.id,
+    memory.frontmatter.id,
+  );
+});
+
 test("QMD recall snapshot helpers read persisted snapshots and memory_qmd_debug is registered", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-debug-"));
   const cfg = parseConfig({

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -494,7 +494,54 @@ test("cold-tier recall resolves collection-prefixed paths from active recall nam
 
   assert.equal(results.length, 1);
   assert.equal(results[0].docid, memory.frontmatter.id);
-  assert.equal(results[0].path, `openclaw-engram-cold/${coldRelativePath}`);
+  assert.equal(results[0].path, migrated.targetPath);
+});
+
+test("cold-tier recall drops collection-prefixed paths outside active recall namespaces", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-ns-drop-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    namespacesEnabled: true,
+    qmdColdTierEnabled: true,
+    qmdColdCollection: "openclaw-engram-cold",
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  const otherStorage = await orchestrator.getStorage("other-cold");
+  const memoryId = await otherStorage.writeMemory(
+    "fact",
+    "other namespace cold memory",
+  );
+  const memory = await otherStorage.getMemoryById(memoryId);
+  assert.ok(memory);
+  const migrated = await otherStorage.migrateMemoryToTier(memory, "cold");
+  const coldRelativePath = path
+    .relative(path.join(otherStorage.dir, "cold"), migrated.targetPath)
+    .split(path.sep)
+    .join("/");
+
+  orchestrator.qmd = {
+    isAvailable: () => true,
+  };
+  orchestrator.fetchQmdMemoryResultsWithArtifactTopUp = async () => [
+    {
+      docid: memory.frontmatter.id,
+      path: `openclaw-engram-cold/${coldRelativePath}`,
+      snippet: "other namespace cold memory",
+      score: 0.9,
+    },
+  ];
+
+  const results = await orchestrator.applyColdFallbackPipeline({
+    prompt: "review project cold namespace",
+    recallNamespaces: ["project-cold"],
+    recallResultLimit: 2,
+    recallMode: "full",
+    queryAwarePrefilter: EMPTY_PREFILTER,
+  });
+
+  assert.deepEqual(results, []);
 });
 
 test("cold-tier recall resolves absolute cold paths from runtime recall namespaces", async () => {

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -402,6 +402,52 @@ test("cold-tier recall reads encrypted cold collection paths through primary sto
   assert.equal(results[0].path, `openclaw-engram-cold/${coldRelativePath}`);
 });
 
+test("cold-tier recall resolves the default cold collection when config omits it", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-default-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdColdTierEnabled: true,
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  orchestrator.config.qmdColdCollection = undefined;
+  const memoryId = await orchestrator.storage.writeMemory(
+    "fact",
+    "default cold collection memory",
+  );
+  const memory = await orchestrator.storage.getMemoryById(memoryId);
+  assert.ok(memory);
+  const migrated = await orchestrator.storage.migrateMemoryToTier(memory, "cold");
+  const coldRelativePath = path
+    .relative(path.join(orchestrator.storage.dir, "cold"), migrated.targetPath)
+    .split(path.sep)
+    .join("/");
+
+  orchestrator.qmd = {
+    isAvailable: () => true,
+  };
+  orchestrator.fetchQmdMemoryResultsWithArtifactTopUp = async () => [
+    {
+      docid: memory.frontmatter.id,
+      path: `openclaw-engram-cold/${coldRelativePath}`,
+      snippet: "default cold collection memory",
+      score: 0.9,
+    },
+  ];
+
+  const results = await orchestrator.applyColdFallbackPipeline({
+    prompt: "review default cold collection",
+    recallNamespaces: ["default"],
+    recallResultLimit: 2,
+    recallMode: "full",
+    queryAwarePrefilter: EMPTY_PREFILTER,
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].docid, memory.frontmatter.id);
+});
+
 test("cold-tier recall resolves collection-prefixed paths from active recall namespaces", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-ns-"));
   const cfg = parseConfig({
@@ -506,6 +552,61 @@ test("cold-tier recall resolves absolute cold paths from runtime recall namespac
   assert.equal(results.length, 1);
   assert.equal(results[0].docid, memory.frontmatter.id);
   assert.equal(results[0].path, migrated.targetPath);
+});
+
+test("cold fallback keeps absolute fallback hits under active runtime recall roots", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-archive-abs-ns-"));
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-archive-runtime-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    namespacesEnabled: true,
+    qmdColdTierEnabled: false,
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  const StorageManagerCtor = orchestrator.storage.constructor as new (
+    dir: string,
+  ) => typeof orchestrator.storage;
+  const runtimeStorage = new StorageManagerCtor(runtimeDir);
+  const memoryId = await runtimeStorage.writeMemory(
+    "fact",
+    "runtime archive fallback absolute memory",
+  );
+  const memory = await runtimeStorage.getMemoryById(memoryId);
+  assert.ok(memory);
+
+  const originalStorageFor = orchestrator.storageRouter.storageFor.bind(
+    orchestrator.storageRouter,
+  );
+  orchestrator.storageRouter.storageFor = async (namespace: string) =>
+    namespace === "runtime-archive"
+      ? runtimeStorage
+      : originalStorageFor(namespace);
+
+  orchestrator.qmd = {
+    isAvailable: () => false,
+  };
+  orchestrator.searchLongTermArchiveFallback = async () => [
+    {
+      docid: memory.frontmatter.id,
+      path: memory.path,
+      snippet: "runtime archive fallback absolute memory",
+      score: 0.9,
+    },
+  ];
+
+  const results = await orchestrator.applyColdFallbackPipeline({
+    prompt: "review runtime archive fallback",
+    recallNamespaces: ["runtime-archive"],
+    recallResultLimit: 2,
+    recallMode: "full",
+    queryAwarePrefilter: EMPTY_PREFILTER,
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].docid, memory.frontmatter.id);
+  assert.equal(results[0].path, memory.path);
 });
 
 test("graph expansion resolves cold collection seeds from active recall namespaces", async () => {

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -402,6 +402,55 @@ test("cold-tier recall reads encrypted cold collection paths through primary sto
   assert.equal(results[0].path, `openclaw-engram-cold/${coldRelativePath}`);
 });
 
+test("cold-tier recall resolves collection-prefixed paths from active recall namespaces", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-ns-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    namespacesEnabled: true,
+    qmdColdTierEnabled: true,
+    qmdColdCollection: "openclaw-engram-cold",
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  const namespaceStorage = await orchestrator.getStorage("project-cold");
+  const memoryId = await namespaceStorage.writeMemory(
+    "fact",
+    "project cold namespace memory",
+  );
+  const memory = await namespaceStorage.getMemoryById(memoryId);
+  assert.ok(memory);
+  const migrated = await namespaceStorage.migrateMemoryToTier(memory, "cold");
+  const coldRelativePath = path
+    .relative(path.join(namespaceStorage.dir, "cold"), migrated.targetPath)
+    .split(path.sep)
+    .join("/");
+
+  orchestrator.qmd = {
+    isAvailable: () => true,
+  };
+  orchestrator.fetchQmdMemoryResultsWithArtifactTopUp = async () => [
+    {
+      docid: memory.frontmatter.id,
+      path: `openclaw-engram-cold/${coldRelativePath}`,
+      snippet: "project cold namespace memory",
+      score: 0.9,
+    },
+  ];
+
+  const results = await orchestrator.applyColdFallbackPipeline({
+    prompt: "review project cold namespace",
+    recallNamespaces: ["project-cold"],
+    recallResultLimit: 2,
+    recallMode: "full",
+    queryAwarePrefilter: EMPTY_PREFILTER,
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].docid, memory.frontmatter.id);
+  assert.equal(results[0].path, `openclaw-engram-cold/${coldRelativePath}`);
+});
+
 test("recall safety resolves absolute QMD paths from runtime recall namespaces", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-runtime-ns-"));
   const runtimeDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-runtime-root-"));

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -508,6 +508,69 @@ test("cold-tier recall resolves absolute cold paths from runtime recall namespac
   assert.equal(results[0].path, migrated.targetPath);
 });
 
+test("graph expansion resolves cold collection seeds from active recall namespaces", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-graph-"));
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-graph-runtime-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    namespacesEnabled: true,
+    qmdColdTierEnabled: true,
+    qmdColdCollection: "openclaw-engram-cold",
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  const StorageManagerCtor = orchestrator.storage.constructor as new (
+    dir: string,
+  ) => typeof orchestrator.storage;
+  const runtimeStorage = new StorageManagerCtor(runtimeDir);
+  const memoryId = await runtimeStorage.writeMemory(
+    "fact",
+    "runtime cold graph seed memory",
+  );
+  const memory = await runtimeStorage.getMemoryById(memoryId);
+  assert.ok(memory);
+  const migrated = await runtimeStorage.migrateMemoryToTier(memory, "cold");
+  const coldRelativePath = path
+    .relative(path.join(runtimeStorage.dir, "cold"), migrated.targetPath)
+    .split(path.sep)
+    .join("/");
+
+  const originalStorageFor = orchestrator.storageRouter.storageFor.bind(
+    orchestrator.storageRouter,
+  );
+  orchestrator.storageRouter.storageFor = async (namespace: string) =>
+    namespace === "runtime-cold"
+      ? runtimeStorage
+      : originalStorageFor(namespace);
+
+  let graphSeedPaths: string[] = [];
+  orchestrator.graphIndexFor = () => ({
+    spreadingActivation: async (seedPaths: string[]) => {
+      graphSeedPaths = seedPaths;
+      return [];
+    },
+  });
+
+  const expanded = await orchestrator.expandResultsViaGraph({
+    memoryResults: [
+      {
+        docid: memory.frontmatter.id,
+        path: `openclaw-engram-cold/${coldRelativePath}`,
+        snippet: "runtime cold graph seed memory",
+        score: 0.9,
+      },
+    ],
+    recallNamespaces: ["runtime-cold"],
+    recallResultLimit: 2,
+  });
+
+  assert.deepEqual(expanded.seedPaths, [migrated.targetPath]);
+  assert.deepEqual(graphSeedPaths, [
+    path.relative(runtimeStorage.dir, migrated.targetPath).split(path.sep).join("/"),
+  ]);
+});
+
 test("recall safety resolves absolute QMD paths from runtime recall namespaces", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-runtime-ns-"));
   const runtimeDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-runtime-root-"));

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -451,6 +451,63 @@ test("cold-tier recall resolves collection-prefixed paths from active recall nam
   assert.equal(results[0].path, `openclaw-engram-cold/${coldRelativePath}`);
 });
 
+test("cold-tier recall resolves absolute cold paths from runtime recall namespaces", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-abs-ns-"));
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-runtime-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    namespacesEnabled: true,
+    qmdColdTierEnabled: true,
+    qmdColdCollection: "openclaw-engram-cold",
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  const StorageManagerCtor = orchestrator.storage.constructor as new (
+    dir: string,
+  ) => typeof orchestrator.storage;
+  const runtimeStorage = new StorageManagerCtor(runtimeDir);
+  const memoryId = await runtimeStorage.writeMemory(
+    "fact",
+    "runtime cold namespace absolute memory",
+  );
+  const memory = await runtimeStorage.getMemoryById(memoryId);
+  assert.ok(memory);
+  const migrated = await runtimeStorage.migrateMemoryToTier(memory, "cold");
+
+  const originalStorageFor = orchestrator.storageRouter.storageFor.bind(
+    orchestrator.storageRouter,
+  );
+  orchestrator.storageRouter.storageFor = async (namespace: string) =>
+    namespace === "runtime-cold"
+      ? runtimeStorage
+      : originalStorageFor(namespace);
+
+  orchestrator.qmd = {
+    isAvailable: () => true,
+  };
+  orchestrator.fetchQmdMemoryResultsWithArtifactTopUp = async () => [
+    {
+      docid: memory.frontmatter.id,
+      path: migrated.targetPath,
+      snippet: "runtime cold namespace absolute memory",
+      score: 0.9,
+    },
+  ];
+
+  const results = await orchestrator.applyColdFallbackPipeline({
+    prompt: "review runtime cold namespace",
+    recallNamespaces: ["runtime-cold"],
+    recallResultLimit: 2,
+    recallMode: "full",
+    queryAwarePrefilter: EMPTY_PREFILTER,
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].docid, memory.frontmatter.id);
+  assert.equal(results[0].path, migrated.targetPath);
+});
+
 test("recall safety resolves absolute QMD paths from runtime recall namespaces", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-runtime-ns-"));
   const runtimeDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-runtime-root-"));
@@ -503,6 +560,50 @@ test("recall safety resolves absolute QMD paths from runtime recall namespaces",
     withRuntimeNamespace.memoryByPath.get(memory.path)?.frontmatter.id,
     memory.frontmatter.id,
   );
+});
+
+test("recall safety keeps signal-only memory reads concurrent", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-signal-concurrency-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  let activeReads = 0;
+  let maxActiveReads = 0;
+  orchestrator.readQmdResultMemory = async (resultPath: string) => {
+    activeReads += 1;
+    maxActiveReads = Math.max(maxActiveReads, activeReads);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    activeReads -= 1;
+    return {
+      path: resultPath,
+      content: "memory",
+      frontmatter: {
+        id: resultPath,
+        category: "fact",
+        created: "2026-03-11T12:00:00.000Z",
+        updated: "2026-03-11T12:00:00.000Z",
+      },
+    };
+  };
+
+  const controller = new AbortController();
+  const loaded = await orchestrator.loadSearchResultMemoryMap(
+    Array.from({ length: 8 }, (_, index) => ({
+      docid: `fact-${index}`,
+      path: `facts/2026-03-11/fact-${index}.md`,
+      snippet: "memory",
+      score: 0.9,
+    })),
+    undefined,
+    { abortSignal: controller.signal },
+  );
+
+  assert.equal(loaded.completed, true);
+  assert.equal(loaded.memoryByPath.size, 8);
+  assert.ok(maxActiveReads > 1);
 });
 
 test("QMD recall snapshot helpers read persisted snapshots and memory_qmd_debug is registered", async () => {

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -353,6 +353,55 @@ test("cold-tier recall forwards explain traces even when intent hints are disabl
   assert.deepEqual(capturedOptions, { explain: true });
 });
 
+test("cold-tier recall reads encrypted cold collection paths through primary storage", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-review-cold-secure-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdColdTierEnabled: true,
+    qmdColdCollection: "openclaw-engram-cold",
+    secureStoreEnabled: true,
+  });
+  const orchestrator = new Orchestrator(cfg) as any;
+  orchestrator.storage.setSecureStoreKey(Buffer.alloc(32, 9), true);
+  const memoryId = await orchestrator.storage.writeMemory(
+    "fact",
+    "encrypted cold collection memory",
+  );
+  const memory = await orchestrator.storage.getMemoryById(memoryId);
+  assert.ok(memory);
+  const migrated = await orchestrator.storage.migrateMemoryToTier(memory, "cold");
+  const coldRelativePath = path
+    .relative(path.join(orchestrator.storage.dir, "cold"), migrated.targetPath)
+    .split(path.sep)
+    .join("/");
+
+  orchestrator.qmd = {
+    isAvailable: () => true,
+  };
+  orchestrator.fetchQmdMemoryResultsWithArtifactTopUp = async () => [
+    {
+      docid: memory.frontmatter.id,
+      path: `openclaw-engram-cold/${coldRelativePath}`,
+      snippet: "encrypted cold collection memory",
+      score: 0.9,
+    },
+  ];
+
+  const results = await orchestrator.applyColdFallbackPipeline({
+    prompt: "review encrypted archive",
+    recallNamespaces: ["default"],
+    recallResultLimit: 2,
+    recallMode: "full",
+    queryAwarePrefilter: EMPTY_PREFILTER,
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].docid, memory.frontmatter.id);
+  assert.equal(results[0].path, `openclaw-engram-cold/${coldRelativePath}`);
+});
+
 test("QMD recall snapshot helpers read persisted snapshots and memory_qmd_debug is registered", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-qmd-debug-"));
   const cfg = parseConfig({

--- a/tests/orchestrator-qmd-review.test.ts
+++ b/tests/orchestrator-qmd-review.test.ts
@@ -645,6 +645,14 @@ test("graph expansion resolves cold collection seeds from active recall namespac
       ? runtimeStorage
       : originalStorageFor(namespace);
 
+  const originalReadQmdResultMemory =
+    orchestrator.readQmdResultMemory.bind(orchestrator);
+  let qmdMemoryReads = 0;
+  orchestrator.readQmdResultMemory = async (...args: unknown[]) => {
+    qmdMemoryReads += 1;
+    return originalReadQmdResultMemory(...args);
+  };
+
   let graphSeedPaths: string[] = [];
   orchestrator.graphIndexFor = () => ({
     spreadingActivation: async (seedPaths: string[]) => {
@@ -662,10 +670,11 @@ test("graph expansion resolves cold collection seeds from active recall namespac
         score: 0.9,
       },
     ],
-    recallNamespaces: ["runtime-cold"],
+    recallNamespaces: ["missing-cold", "runtime-cold", "other-cold"],
     recallResultLimit: 2,
   });
 
+  assert.equal(qmdMemoryReads, 1);
   assert.deepEqual(expanded.seedPaths, [migrated.targetPath]);
   assert.deepEqual(graphSeedPaths, [
     path.relative(runtimeStorage.dir, migrated.targetPath).split(path.sep).join("/"),

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -825,7 +825,7 @@ test("recallInternal shares one enrichment timeout budget across sequential enri
   );
 });
 
-test("recallInternal treats qmd settling during the qmd wait as settled before safety filtering", async () => {
+test("recallInternal keeps qmd safety reads deadline-bound when qmd settles during the qmd wait", async () => {
   clearQmdRecallCache();
   const orchestrator = await makeOrchestrator(
     "engram-recall-qmd-settles-during-wait-",
@@ -887,7 +887,8 @@ test("recallInternal treats qmd settling during the qmd wait as settled before s
   );
 
   assert.match(context, /qmd settled during wait memory/);
-  assert.deepEqual(observedSafetyDeadlines, [null]);
+  assert.equal(observedSafetyDeadlines.length, 1);
+  assert.equal(typeof observedSafetyDeadlines[0], "number");
 });
 
 test("cold fallback deadline stops before cold QMD and archive scanning", async () => {

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -920,3 +920,51 @@ test("cold fallback deadline stops before cold QMD and archive scanning", async 
   assert.equal(coldQmdReads, 0);
   assert.equal(archiveReads, 0);
 });
+
+test("cold fallback resolves QMD cold collection-prefixed result paths", async () => {
+  const orchestrator = await makeOrchestrator("engram-cold-fallback-qmd-prefix-", {
+    qmdColdTierEnabled: true,
+    qmdEnabled: true,
+    qmdColdCollection: "openclaw-engram-cold",
+  });
+  const storage = (orchestrator as any).storage;
+  const memoryId = await storage.writeMemory(
+    "fact",
+    "cold collection-prefixed memory",
+  );
+  const hotMemory = await storage.getMemoryById(memoryId);
+  assert.ok(hotMemory);
+  const migrated = await storage.migrateMemoryToTier(hotMemory, "cold");
+  const coldRelativePath = path
+    .relative(path.join(storage.dir, "cold"), migrated.targetPath)
+    .split(path.sep)
+    .join("/");
+  const coldCollectionPath = `openclaw-engram-cold/${coldRelativePath}`;
+
+  let archiveReads = 0;
+  (orchestrator as any).qmd = { isAvailable: () => true };
+  (orchestrator as any).fetchQmdMemoryResultsWithArtifactTopUp = async () => [
+    {
+      docid: hotMemory.frontmatter.id,
+      path: coldCollectionPath,
+      snippet: "cold collection-prefixed memory",
+      score: 0.91,
+    },
+  ];
+  (orchestrator as any).readArchivedMemoriesForNamespaces = async () => {
+    archiveReads += 1;
+    return [];
+  };
+
+  const results = await (orchestrator as any).applyColdFallbackPipeline({
+    prompt: "cold collection prefix test",
+    recallNamespaces: ["default"],
+    recallResultLimit: 5,
+    recallMode: "minimal",
+  });
+
+  assert.equal(archiveReads, 0);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].docid, hotMemory.frontmatter.id);
+  assert.equal(results[0].path, coldCollectionPath);
+});

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -519,12 +519,9 @@ test("recallInternal uses already-settled qmd results after the enrichment budge
   const memory = await (orchestrator as any).storage.getMemoryById(memoryId);
   assert.ok(memory);
 
-  let releaseBoxes: (() => void) | null = null;
   (orchestrator as any).boxBuilderFor = () => ({
     readRecentBoxes: async () => {
-      await new Promise<void>((resolve) => {
-        releaseBoxes = resolve;
-      });
+      await new Promise<never>(() => {});
       return [];
     },
   });
@@ -542,8 +539,6 @@ test("recallInternal uses already-settled qmd results after the enrichment budge
       score: 0.91,
     },
   ];
-
-  setTimeout(() => releaseBoxes?.(), 15);
 
   const context = await (orchestrator as any).recallInternal(
     "Summarize the current project state.",
@@ -985,12 +980,9 @@ test("recallInternal skips embedding fallback after assembly budget expires", as
     },
   );
 
-  let releaseBoxes: (() => void) | null = null;
   (orchestrator as any).boxBuilderFor = () => ({
     readRecentBoxes: async () => {
-      await new Promise<void>((resolve) => {
-        releaseBoxes = resolve;
-      });
+      await new Promise<never>(() => {});
       return [];
     },
   });
@@ -1012,8 +1004,6 @@ test("recallInternal skips embedding fallback after assembly budget expires", as
       },
     ];
   };
-
-  setTimeout(() => releaseBoxes?.(), 15);
 
   const context = await (orchestrator as any).recallInternal(
     "Summarize the current project state.",

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -824,3 +824,68 @@ test("recallInternal shares one enrichment timeout budget across sequential enri
     `expected compounding to share the remaining enrichment budget, saw ${elapsedMs}ms`,
   );
 });
+
+test("recallInternal treats qmd settling during the qmd wait as settled before safety filtering", async () => {
+  clearQmdRecallCache();
+  const orchestrator = await makeOrchestrator(
+    "engram-recall-qmd-settles-during-wait-",
+    {
+      qmdEnabled: true,
+      recallEnrichmentDeadlineMs: 1000,
+    },
+  );
+
+  const memoryId = await (orchestrator as any).storage.writeMemory(
+    "fact",
+    "qmd settled during wait memory",
+  );
+  const memory = await (orchestrator as any).storage.getMemoryById(memoryId);
+  assert.ok(memory);
+
+  const observedSafetyDeadlines: Array<number | null> = [];
+  const originalFilterSearchResultsForRecall =
+    (orchestrator as any).filterSearchResultsForRecall.bind(orchestrator);
+  (orchestrator as any).filterSearchResultsForRecall = async (
+    results: unknown[],
+    preloadedMemoryMap?: unknown,
+    options?: { deadlineAtMs?: number | null },
+  ) => {
+    if (
+      options &&
+      Object.prototype.hasOwnProperty.call(options, "deadlineAtMs")
+    ) {
+      observedSafetyDeadlines.push(options.deadlineAtMs ?? null);
+    }
+    return originalFilterSearchResultsForRecall(
+      results,
+      preloadedMemoryMap,
+      options,
+    );
+  };
+
+  (orchestrator as any).qmd = {
+    isAvailable: () => true,
+    probe: async () => true,
+    debugStatus: () => "qmd ready",
+  };
+  (orchestrator as any).fetchQmdMemoryResultsWithArtifactTopUp = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return [
+      {
+        docid: memory.frontmatter.id,
+        path: memory.path,
+        snippet: "qmd settled during wait memory",
+        score: 0.91,
+      },
+    ];
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "Summarize the current project state.",
+    "agent:test:qmd-settles-during-wait",
+    { mode: "full" },
+  );
+
+  assert.match(context, /qmd settled during wait memory/);
+  assert.deepEqual(observedSafetyDeadlines, [null]);
+});

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -889,3 +889,34 @@ test("recallInternal treats qmd settling during the qmd wait as settled before s
   assert.match(context, /qmd settled during wait memory/);
   assert.deepEqual(observedSafetyDeadlines, [null]);
 });
+
+test("cold fallback deadline stops before cold QMD and archive scanning", async () => {
+  const orchestrator = await makeOrchestrator("engram-cold-fallback-deadline-", {
+    qmdColdTierEnabled: true,
+    qmdEnabled: true,
+  });
+
+  let coldQmdReads = 0;
+  let archiveReads = 0;
+  (orchestrator as any).qmd = { isAvailable: () => true };
+  (orchestrator as any).fetchQmdMemoryResultsWithArtifactTopUp = async () => {
+    coldQmdReads += 1;
+    return [];
+  };
+  (orchestrator as any).readArchivedMemoriesForNamespaces = async () => {
+    archiveReads += 1;
+    return [];
+  };
+
+  const results = await (orchestrator as any).applyColdFallbackPipeline({
+    prompt: "archive deadline test",
+    recallNamespaces: ["default"],
+    recallResultLimit: 5,
+    recallMode: "minimal",
+    deadlineAtMs: Date.now() - 1,
+  });
+
+  assert.deepEqual(results, []);
+  assert.equal(coldQmdReads, 0);
+  assert.equal(archiveReads, 0);
+});

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -969,3 +969,58 @@ test("cold fallback resolves QMD cold collection-prefixed result paths", async (
   assert.equal(results[0].docid, hotMemory.frontmatter.id);
   assert.equal(results[0].path, coldCollectionPath);
 });
+
+test("recallInternal skips embedding fallback after assembly budget expires", async () => {
+  clearQmdRecallCache();
+  const orchestrator = await makeOrchestrator(
+    "engram-recall-embedding-fallback-deadline-",
+    {
+      qmdEnabled: true,
+      embeddingFallbackEnabled: true,
+      memoryBoxesEnabled: true,
+      boxRecallDays: 1,
+      recallEnrichmentDeadlineMs: 5,
+      queryAwareIndexingEnabled: false,
+      parallelRetrievalEnabled: false,
+    },
+  );
+
+  let releaseBoxes: (() => void) | null = null;
+  (orchestrator as any).boxBuilderFor = () => ({
+    readRecentBoxes: async () => {
+      await new Promise<void>((resolve) => {
+        releaseBoxes = resolve;
+      });
+      return [];
+    },
+  });
+  (orchestrator as any).qmd = {
+    isAvailable: () => true,
+    probe: async () => true,
+    debugStatus: () => "qmd ready",
+  };
+  (orchestrator as any).fetchQmdMemoryResultsWithArtifactTopUp = async () => [];
+  let embeddingCalls = 0;
+  (orchestrator as any).searchEmbeddingFallback = async () => {
+    embeddingCalls += 1;
+    return [
+      {
+        docid: "late-embedding",
+        path: "facts/2026-03-11/late-embedding.md",
+        snippet: "late embedding memory",
+        score: 0.9,
+      },
+    ];
+  };
+
+  setTimeout(() => releaseBoxes?.(), 15);
+
+  const context = await (orchestrator as any).recallInternal(
+    "Summarize the current project state.",
+    "agent:test:embedding-fallback-deadline",
+    { mode: "full" },
+  );
+
+  assert.equal(embeddingCalls, 0);
+  assert.doesNotMatch(context, /late embedding memory/);
+});

--- a/tests/recall-hardening.test.ts
+++ b/tests/recall-hardening.test.ts
@@ -1014,3 +1014,58 @@ test("recallInternal skips embedding fallback after assembly budget expires", as
   assert.equal(embeddingCalls, 0);
   assert.doesNotMatch(context, /late embedding memory/);
 });
+
+test("recallInternal skips no-QMD hot fallback after assembly budget expires", async () => {
+  clearQmdRecallCache();
+  const orchestrator = await makeOrchestrator(
+    "engram-recall-no-qmd-fallback-deadline-",
+    {
+      qmdEnabled: true,
+      embeddingFallbackEnabled: true,
+      memoryBoxesEnabled: true,
+      boxRecallDays: 1,
+      recallEnrichmentDeadlineMs: 5,
+      queryAwareIndexingEnabled: false,
+      parallelRetrievalEnabled: false,
+    },
+  );
+
+  (orchestrator as any).boxBuilderFor = () => ({
+    readRecentBoxes: async () => {
+      await new Promise<never>(() => {});
+      return [];
+    },
+  });
+  (orchestrator as any).qmd = {
+    isAvailable: () => false,
+    probe: async () => false,
+    debugStatus: () => "qmd unavailable",
+  };
+  let embeddingCalls = 0;
+  (orchestrator as any).searchEmbeddingFallback = async () => {
+    embeddingCalls += 1;
+    return [
+      {
+        docid: "late-no-qmd-embedding",
+        path: "facts/2026-03-11/late-no-qmd-embedding.md",
+        snippet: "late no-qmd embedding memory",
+        score: 0.9,
+      },
+    ];
+  };
+  let recentScanReads = 0;
+  (orchestrator as any).readAllMemoriesForNamespaces = async () => {
+    recentScanReads += 1;
+    return [];
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "Summarize the current project state.",
+    "agent:test:no-qmd-fallback-deadline",
+    { mode: "full" },
+  );
+
+  assert.equal(embeddingCalls, 0);
+  assert.equal(recentScanReads, 0);
+  assert.doesNotMatch(context, /late no-qmd embedding memory/);
+});

--- a/tests/recall-no-recall-short-circuit.test.ts
+++ b/tests/recall-no-recall-short-circuit.test.ts
@@ -838,7 +838,28 @@ test("recall accepts readable namespace overrides even when they are excluded fr
 
 test("cold fallback uses configured cold QMD collection before archive scan", async () => {
   const memoryDir = tmpDir("engram-cold-qmd");
-  await mkdir(memoryDir, { recursive: true });
+  const factsDir = path.join(memoryDir, "facts");
+  await mkdir(factsDir, { recursive: true });
+  const coldMemoryPath = path.join(factsDir, "fact-cold-qmd-1.md");
+  await writeFile(
+    coldMemoryPath,
+    [
+      "---",
+      "id: fact-cold-qmd-1",
+      "category: fact",
+      "created: 2026-01-01T00:00:00.000Z",
+      "updated: 2026-01-01T00:00:00.000Z",
+      "source: extraction",
+      "confidence: 0.9",
+      "confidenceTier: explicit",
+      "status: active",
+      "---",
+      "",
+      "Cold collection memory about shard migration edge cases.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
 
   const cfg = baseConfig(memoryDir);
   cfg.recallPlannerEnabled = false;
@@ -857,7 +878,7 @@ test("cold fallback uses configured cold QMD collection before archive scan", as
         return [
           {
             docid: "fact-cold-qmd-1",
-            path: "/tmp/memory/default/facts/fact-cold-qmd-1.md",
+            path: coldMemoryPath,
             snippet: "Cold collection memory about shard migration edge cases",
             score: 0.91,
           },

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -20,6 +20,7 @@ import {
   buildXraySnapshot,
   type RecallXrayResult,
 } from "../src/recall-xray.js";
+import { SecureStoreLockedError } from "../src/secure-store/index.js";
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -360,6 +361,42 @@ test("namespace collection misses do not fall back to default storage", async ()
   assert.strictEqual(result[0].explain?.reinforcementBoost, undefined);
 });
 
+test("invalid QMD collection prefixes do not strip into default storage", async () => {
+  const memoryDir = await makeTmpDir("engram-reinforce-qmd-invalid-prefix-");
+  const defaultDayDir = path.join(memoryDir, "facts", "2026-06-16");
+  await mkdir(defaultDayDir, { recursive: true });
+  await writeMemory(defaultDayDir, "fact-invalid-prefix", {
+    reinforcement_count: 9,
+  });
+
+  const orchestrator = await makeOrchestrator(memoryDir, {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    qmdCollection: "openclaw-engram",
+    reinforcementRecallBoostEnabled: true,
+    reinforcementRecallBoostWeight: 0.1,
+    reinforcementRecallBoostMax: 1.0,
+  });
+  (orchestrator as any).initPromise = null;
+
+  const result = await (orchestrator as any).boostSearchResults(
+    [
+      {
+        docid: "fact-invalid-prefix",
+        path: "openclaw-engram--not-a-token/2026-06-16/fact-invalid-prefix.md",
+        snippet: "invalid collection prefix",
+        score: 0.5,
+      },
+    ],
+    ["default"],
+  );
+
+  assert.equal(result.length, 1);
+  assert.strictEqual(result[0].score, 0.5);
+  assert.strictEqual(result[0].explain?.reinforcementBoost, undefined);
+});
+
 test("date-relative QMD misses do not fall back to storage root basename", async () => {
   const memoryDir = await makeTmpDir("engram-reinforce-qmd-date-miss-");
   await writeMemory(memoryDir, "fact-001", {
@@ -486,6 +523,30 @@ test("recall safety filtering keeps checked candidates when deadline expires mid
   } finally {
     Date.now = realDateNow;
   }
+});
+
+test("recall safety filtering drops locked secure-store candidates", async () => {
+  const memoryDir = await makeTmpDir("engram-recall-safety-secure-lock-");
+  const factsDir = path.join(memoryDir, "facts");
+  await mkdir(factsDir, { recursive: true });
+  const locked = await writeMemory(factsDir, "fact-locked");
+
+  const orchestrator = await makeOrchestrator(memoryDir);
+  (orchestrator as any).initPromise = null;
+  let readAttempts = 0;
+  (orchestrator as any).readQmdResultMemory = async () => {
+    readAttempts += 1;
+    throw new SecureStoreLockedError("locked namespace store");
+  };
+
+  const filtered = await (orchestrator as any).filterSearchResultsForRecall(
+    [{ docid: "locked", path: locked, snippet: "locked candidate", score: 0.9 }],
+    undefined,
+    {},
+  );
+
+  assert.equal(readAttempts, 1);
+  assert.deepEqual(filtered.results, []);
 });
 
 test("boost capped at reinforcementRecallBoostMax", async () => {

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -288,6 +288,78 @@ test("boost resolves QMD collection-prefixed namespace result paths", async () =
   );
 });
 
+test("namespace detection decodes QMD collection-prefixed result paths", async () => {
+  const memoryDir = await makeTmpDir("engram-reinforce-qmd-ns-detect-");
+  const namespace = "team";
+  const orchestrator = await makeOrchestrator(memoryDir, {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      {
+        name: namespace,
+        readPrincipals: ["reader"],
+        writePrincipals: ["writer"],
+      },
+    ],
+    qmdCollection: "openclaw-engram",
+  });
+
+  const collection = `openclaw-engram--${namespaceIdentityToken(namespace)}`;
+
+  assert.equal(
+    (orchestrator as any).namespaceFromPath(
+      `${collection}/2026-06-16/fact-ns-001.md`,
+    ),
+    namespace,
+  );
+});
+
+test("namespace collection misses do not fall back to default storage", async () => {
+  const memoryDir = await makeTmpDir("engram-reinforce-qmd-ns-miss-");
+  const namespace = "team";
+  const defaultDayDir = path.join(memoryDir, "facts", "2026-06-16");
+  await mkdir(defaultDayDir, { recursive: true });
+  await writeMemory(defaultDayDir, "fact-ns-001", {
+    reinforcement_count: 9,
+  });
+
+  const orchestrator = await makeOrchestrator(memoryDir, {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      {
+        name: namespace,
+        readPrincipals: ["reader"],
+        writePrincipals: ["writer"],
+      },
+    ],
+    qmdCollection: "openclaw-engram",
+    reinforcementRecallBoostEnabled: true,
+    reinforcementRecallBoostWeight: 0.1,
+    reinforcementRecallBoostMax: 1.0,
+  });
+  (orchestrator as any).initPromise = null;
+
+  const collection = `openclaw-engram--${namespaceIdentityToken(namespace)}`;
+  const result = await (orchestrator as any).boostSearchResults(
+    [
+      {
+        docid: "fact-ns-001",
+        path: `${collection}/2026-06-16/fact-ns-001.md`,
+        snippet: "stale namespace hit",
+        score: 0.5,
+      },
+    ],
+    ["default", namespace],
+  );
+
+  assert.equal(result.length, 1);
+  assert.strictEqual(result[0].score, 0.5);
+  assert.strictEqual(result[0].explain?.reinforcementBoost, undefined);
+});
+
 test("recall safety filtering is available without running score boosts", async () => {
   const memoryDir = await makeTmpDir("engram-recall-safety-filter-");
   const factsDir = path.join(memoryDir, "facts");

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -501,7 +501,7 @@ test("recall safety filtering is available without running score boosts", async 
       { docid: "dream", path: dream, snippet: "dream", score: 0.7 },
     ],
     undefined,
-    {},
+    { dropUnresolved: true },
   );
 
   assert.deepEqual(
@@ -547,6 +547,36 @@ test("absolute QMD result paths read through dynamic namespace owner storage", a
   assert.equal(fallbackReads, 0);
   assert.equal(memory?.path, ownedPath);
   assert.equal(memory?.frontmatter.id, "fact-owned");
+});
+
+test("recall safety filtering drops QMD paths that fail resolution", async () => {
+  const memoryDir = await makeTmpDir("engram-recall-safety-unresolved-qmd-");
+  const factsDir = path.join(memoryDir, "facts");
+  await mkdir(factsDir, { recursive: true });
+  const active = await writeMemory(factsDir, "fact-active");
+
+  const orchestrator = await makeOrchestrator(memoryDir);
+  (orchestrator as any).initPromise = null;
+  const qmdCollection = (orchestrator as any).config.qmdCollection;
+
+  const filtered = await (orchestrator as any).filterSearchResultsForRecall(
+    [
+      { docid: "active", path: active, snippet: "active", score: 0.4 },
+      {
+        docid: "escape",
+        path: `${qmdCollection}/../other/fact.md`,
+        snippet: "unchecked traversal hit",
+        score: 0.9,
+      },
+    ],
+    undefined,
+    { dropUnresolved: true },
+  );
+
+  assert.deepEqual(
+    filtered.results.map((result: { path: string }) => path.basename(result.path)),
+    ["fact-active.md"],
+  );
 });
 
 test("recall safety filtering does not return unchecked results after deadline", async () => {

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -27,6 +27,12 @@ async function makeTmpDir(prefix: string): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
+function namespaceIdentityToken(namespace: string): string {
+  const bytes = new TextEncoder().encode(namespace.trim());
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `ns-${hex || "default"}`;
+}
+
 async function makeOrchestrator(
   memoryDir: string,
   overrides: Record<string, unknown> = {},
@@ -223,6 +229,62 @@ test("boost applied when feature on and memory has reinforcement_count", async (
   assert.ok(
     Math.abs((result[0].explain?.reinforcementBoost ?? 0) - 0.3) < 1e-9,
     `expected reinforcementBoost ≈ 0.3 but got ${result[0].explain?.reinforcementBoost}`,
+  );
+});
+
+test("boost resolves QMD collection-prefixed namespace result paths", async () => {
+  const memoryDir = await makeTmpDir("engram-reinforce-qmd-ns-");
+  const namespace = "team";
+  const namespaceDir = path.join(
+    memoryDir,
+    "namespaces",
+    namespaceIdentityToken(namespace),
+  );
+  const dayDir = path.join(namespaceDir, "facts", "2026-06-16");
+  await mkdir(dayDir, { recursive: true });
+  await writeMemory(dayDir, "fact-ns-001", {
+    reinforcement_count: 2,
+  });
+
+  const orchestrator = await makeOrchestrator(memoryDir, {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      {
+        name: namespace,
+        readPrincipals: ["reader"],
+        writePrincipals: ["writer"],
+      },
+    ],
+    qmdCollection: "openclaw-engram",
+    reinforcementRecallBoostEnabled: true,
+    reinforcementRecallBoostWeight: 0.1,
+    reinforcementRecallBoostMax: 1.0,
+  });
+  (orchestrator as any).initPromise = null;
+
+  const collection = `openclaw-engram--${namespaceIdentityToken(namespace)}`;
+  const result = await (orchestrator as any).boostSearchResults(
+    [
+      {
+        docid: "fact-ns-001",
+        path: `${collection}/2026-06-16/fact-ns-001.md`,
+        snippet: "test",
+        score: 0.5,
+      },
+    ],
+    ["default", namespace],
+  );
+
+  assert.equal(result.length, 1);
+  assert.ok(
+    Math.abs(result[0].score - 0.7) < 1e-9,
+    `expected score ≈ 0.7 but got ${result[0].score}`,
+  );
+  assert.ok(
+    Math.abs((result[0].explain?.reinforcementBoost ?? 0) - 0.2) < 1e-9,
+    `expected reinforcementBoost ≈ 0.2 but got ${result[0].explain?.reinforcementBoost}`,
   );
 });
 

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -326,6 +326,66 @@ test("recall safety filtering is available without running score boosts", async 
   );
 });
 
+test("recall safety filtering does not return unchecked results after deadline", async () => {
+  const memoryDir = await makeTmpDir("engram-recall-safety-deadline-");
+  const factsDir = path.join(memoryDir, "facts");
+  await mkdir(factsDir, { recursive: true });
+  const active = await writeMemory(factsDir, "fact-active");
+
+  const orchestrator = await makeOrchestrator(memoryDir);
+  (orchestrator as any).initPromise = null;
+  let readAttempts = 0;
+  (orchestrator as any).readQmdResultMemory = async () => {
+    readAttempts += 1;
+    return null;
+  };
+
+  const filtered = await (orchestrator as any).filterSearchResultsForRecall(
+    [{ docid: "active", path: active, snippet: "active", score: 0.4 }],
+    undefined,
+    { deadlineAtMs: Date.now() - 1 },
+  );
+
+  assert.equal(readAttempts, 0);
+  assert.deepEqual(filtered.results, []);
+});
+
+test("recall safety filtering keeps checked candidates when deadline expires mid-scan", async () => {
+  const memoryDir = await makeTmpDir("engram-recall-safety-partial-deadline-");
+  const factsDir = path.join(memoryDir, "facts");
+  await mkdir(factsDir, { recursive: true });
+  const active = await writeMemory(factsDir, "fact-active");
+  const unchecked = await writeMemory(factsDir, "fact-unchecked");
+
+  const orchestrator = await makeOrchestrator(memoryDir);
+  (orchestrator as any).initPromise = null;
+
+  const realDateNow = Date.now;
+  let nowCalls = 0;
+  Date.now = () => {
+    nowCalls += 1;
+    return nowCalls === 1 ? 1_000 : 2_000;
+  };
+
+  try {
+    const filtered = await (orchestrator as any).filterSearchResultsForRecall(
+      [
+        { docid: "active", path: active, snippet: "active", score: 0.4 },
+        { docid: "unchecked", path: unchecked, snippet: "unchecked", score: 0.9 },
+      ],
+      undefined,
+      { deadlineAtMs: 1_500 },
+    );
+
+    assert.deepEqual(
+      filtered.results.map((result: { path: string }) => path.basename(result.path)),
+      ["fact-active.md"],
+    );
+  } finally {
+    Date.now = realDateNow;
+  }
+});
+
 test("boost capped at reinforcementRecallBoostMax", async () => {
   const memoryDir = await makeTmpDir("engram-reinforce-cap-");
   await mkdir(path.join(memoryDir, "facts"), { recursive: true });

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -288,6 +288,44 @@ test("boost resolves QMD collection-prefixed namespace result paths", async () =
   );
 });
 
+test("recall safety filtering is available without running score boosts", async () => {
+  const memoryDir = await makeTmpDir("engram-recall-safety-filter-");
+  const factsDir = path.join(memoryDir, "facts");
+  await mkdir(factsDir, { recursive: true });
+  const active = await writeMemory(factsDir, "fact-active");
+  const forgotten = await writeMemory(factsDir, "fact-forgotten", {
+    status: "forgotten",
+  });
+  const superseded = await writeMemory(factsDir, "fact-superseded", {
+    status: "superseded",
+  });
+  const dream = await writeMemory(factsDir, "fact-dream", {
+    memoryKind: "dream",
+  });
+
+  const orchestrator = await makeOrchestrator(memoryDir, {
+    temporalSupersessionEnabled: true,
+    temporalSupersessionIncludeInRecall: false,
+  });
+  (orchestrator as any).initPromise = null;
+
+  const filtered = await (orchestrator as any).filterSearchResultsForRecall(
+    [
+      { docid: "active", path: active, snippet: "active", score: 0.4 },
+      { docid: "forgotten", path: forgotten, snippet: "forgotten", score: 0.9 },
+      { docid: "superseded", path: superseded, snippet: "superseded", score: 0.8 },
+      { docid: "dream", path: dream, snippet: "dream", score: 0.7 },
+    ],
+    undefined,
+    {},
+  );
+
+  assert.deepEqual(
+    filtered.results.map((result: { path: string }) => path.basename(result.path)),
+    ["fact-active.md"],
+  );
+});
+
 test("boost capped at reinforcementRecallBoostMax", async () => {
   const memoryDir = await makeTmpDir("engram-reinforce-cap-");
   await mkdir(path.join(memoryDir, "facts"), { recursive: true });

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -397,6 +397,51 @@ test("invalid QMD collection prefixes do not strip into default storage", async 
   assert.strictEqual(result[0].explain?.reinforcementBoost, undefined);
 });
 
+test("namespace collection traversal paths do not escape storage root", async () => {
+  const memoryDir = await makeTmpDir("engram-reinforce-qmd-traversal-");
+  const namespace = "team";
+  const defaultDayDir = path.join(memoryDir, "facts", "2026-06-16");
+  await mkdir(defaultDayDir, { recursive: true });
+  await writeMemory(defaultDayDir, "fact-traversal", {
+    reinforcement_count: 9,
+  });
+
+  const orchestrator = await makeOrchestrator(memoryDir, {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [
+      {
+        name: namespace,
+        readPrincipals: ["reader"],
+        writePrincipals: ["writer"],
+      },
+    ],
+    qmdCollection: "openclaw-engram",
+    reinforcementRecallBoostEnabled: true,
+    reinforcementRecallBoostWeight: 0.1,
+    reinforcementRecallBoostMax: 1.0,
+  });
+  (orchestrator as any).initPromise = null;
+
+  const collection = `openclaw-engram--${namespaceIdentityToken(namespace)}`;
+  const result = await (orchestrator as any).boostSearchResults(
+    [
+      {
+        docid: "fact-traversal",
+        path: `${collection}/../../facts/2026-06-16/fact-traversal.md`,
+        snippet: "traversal hit",
+        score: 0.5,
+      },
+    ],
+    ["default", namespace],
+  );
+
+  assert.equal(result.length, 1);
+  assert.strictEqual(result[0].score, 0.5);
+  assert.strictEqual(result[0].explain?.reinforcementBoost, undefined);
+});
+
 test("date-relative QMD misses do not fall back to storage root basename", async () => {
   const memoryDir = await makeTmpDir("engram-reinforce-qmd-date-miss-");
   await writeMemory(memoryDir, "fact-001", {

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -510,6 +510,45 @@ test("recall safety filtering is available without running score boosts", async 
   );
 });
 
+test("absolute QMD result paths read through dynamic namespace owner storage", async () => {
+  const memoryDir = await makeTmpDir("engram-recall-absolute-dynamic-ns-");
+  const dynamicNamespace = "team-project-alpha";
+  const dynamicFactsDir = path.join(
+    memoryDir,
+    "namespaces",
+    namespaceIdentityToken(dynamicNamespace),
+    "facts",
+  );
+  await mkdir(dynamicFactsDir, { recursive: true });
+  const ownedPath = await writeMemory(dynamicFactsDir, "fact-owned");
+
+  const orchestrator = await makeOrchestrator(memoryDir, {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+  });
+  (orchestrator as any).initPromise = null;
+
+  const fallbackStorage = await (orchestrator as any).storageRouter.storageFor(
+    "default",
+  );
+  let fallbackReads = 0;
+  fallbackStorage.readMemoryByPath = async () => {
+    fallbackReads += 1;
+    return null;
+  };
+
+  const memory = await (orchestrator as any).readQmdResultMemory(
+    ownedPath,
+    fallbackStorage,
+  );
+
+  assert.equal(fallbackReads, 0);
+  assert.equal(memory?.path, ownedPath);
+  assert.equal(memory?.frontmatter.id, "fact-owned");
+});
+
 test("recall safety filtering does not return unchecked results after deadline", async () => {
   const memoryDir = await makeTmpDir("engram-recall-safety-deadline-");
   const factsDir = path.join(memoryDir, "facts");

--- a/tests/retrieval-reinforcement-boost.test.ts
+++ b/tests/retrieval-reinforcement-boost.test.ts
@@ -360,6 +360,36 @@ test("namespace collection misses do not fall back to default storage", async ()
   assert.strictEqual(result[0].explain?.reinforcementBoost, undefined);
 });
 
+test("date-relative QMD misses do not fall back to storage root basename", async () => {
+  const memoryDir = await makeTmpDir("engram-reinforce-qmd-date-miss-");
+  await writeMemory(memoryDir, "fact-001", {
+    reinforcement_count: 9,
+  });
+
+  const orchestrator = await makeOrchestrator(memoryDir, {
+    reinforcementRecallBoostEnabled: true,
+    reinforcementRecallBoostWeight: 0.1,
+    reinforcementRecallBoostMax: 1.0,
+  });
+  (orchestrator as any).initPromise = null;
+
+  const result = await (orchestrator as any).boostSearchResults(
+    [
+      {
+        docid: "fact-001",
+        path: "2026-06-16/fact-001.md",
+        snippet: "missing dated hit",
+        score: 0.5,
+      },
+    ],
+    ["default"],
+  );
+
+  assert.equal(result.length, 1);
+  assert.strictEqual(result[0].score, 0.5);
+  assert.strictEqual(result[0].explain?.reinforcementBoost, undefined);
+});
+
 test("recall safety filtering is available without running score boosts", async () => {
   const memoryDir = await makeTmpDir("engram-recall-safety-filter-");
   const factsDir = path.join(memoryDir, "facts");


### PR DESCRIPTION
## Summary
- Bound graph expansion and QMD boost work to the shared post-retrieval assembly deadline, with graceful fallback to baseline recall when time expires.
- Resolve QMD collection-prefixed namespace result paths before reading files for reinforcement boosts and last-recall serialization.
- Propagate the assembly deadline through graph traversal and PageRank so graph assist cannot overrun the recall assembly budget.

## Validation
- `pnpm exec tsc --noEmit --pretty false -p packages/remnic-core/tsconfig.json`
- `pnpm exec tsx --test tests/graph.test.ts tests/retrieval-reinforcement-boost.test.ts packages/remnic-core/src/access-service-namespace.test.ts`
- `node scripts/check-test-types.mjs`
- `OPENCLAW_CONFIG_PATH=/tmp/remnic-preflight-no-openclaw.json npm run preflight:quick`

Note: an unisolated local preflight reads this host's active OpenClaw config and fails an unrelated registration expectation by seeing the locally configured `minimax-portal/MiniMax-M3`; the isolated command above matches CI-style behavior and passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core recall pipeline and multi-namespace path resolution; incorrect resolution could leak or drop memories, though extensive tests and fail-open deadlines limit blast radius.
> 
> **Overview**
> Recall **post-retrieval assembly** now shares a single deadline across graph expansion, QMD safety filtering, boosting, embedding/recent-scan fallbacks, and cold-tier work. When time runs out, those steps **fail open** to baseline or pre-filtered results instead of blocking assembly.
> 
> **QMD result paths** are resolved consistently before reads: namespace **collection prefixes**, **cold** collections, **absolute** paths (including dynamic namespace storage), with guards against date-shaped false prefixes, invalid tokens, `..` traversal, and wrong-namespace fallback. **`SecureStoreLockedError`** propagates or drops candidates as appropriate. Last-recall serialization and graph seeding use the same resolution model; snapshots can carry **`recallNamespaces`**.
> 
> Graph **spreading activation** and **PageRank** honor **`deadlineAtMs`** during BFS and refinement so graph assist cannot overrun the assembly budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef6900efe09e92eeb18bf3f559d45687141d566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->