### PR TITLE
fix: resolve OAuth providers, route LCM through taskModelChain, reconcile day summary cron

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3361,6 +3361,11 @@
         "default": true,
         "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
       },
+      "daySummaryTimezone": {
+        "type": "string",
+        "default": "",
+        "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
+      },
       "summaryRecallHours": {
         "type": "number",
         "default": 24,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3361,6 +3361,11 @@
         "default": true,
         "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
       },
+      "daySummaryTimezone": {
+        "type": "string",
+        "default": "",
+        "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
+      },
       "summaryRecallHours": {
         "type": "number",
         "default": 24,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -108,6 +108,8 @@ const STRICT_MCP_SCHEMA_KEYS: Partial<Record<SchemaName, readonly string[]>> = {
     "sessionKey",
     "namespace",
     "timeZone",
+    "cwd",
+    "projectTag",
   ],
   memoryStore: [
     "schemaVersion",
@@ -773,6 +775,7 @@ export class EngramMcpServer {
             sessionKey: { type: "string" },
             namespace: { type: "string" },
             timeZone: { type: "string" },
+            ...MCP_GIT_CONTEXT_SCHEMA_PROPS_IGNORED,
           },
           required: [],
           additionalProperties: false,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -8,6 +8,7 @@ import {
   type CapsuleExportRequest,
   type CapsuleImportRequest,
   type CapsuleListRequest,
+  type DaySummaryRequest,
   type MemoryStoreRequest,
   type SchemaName,
   type SchemaTypeFor,
@@ -102,6 +103,12 @@ function resolveChatGptInspectorRecallSessionKey(
 }
 
 const STRICT_MCP_SCHEMA_KEYS: Partial<Record<SchemaName, readonly string[]>> = {
+  daySummary: [
+    "memories",
+    "sessionKey",
+    "namespace",
+    "timeZone",
+  ],
   memoryStore: [
     "schemaVersion",
     "idempotencyKey",
@@ -765,6 +772,7 @@ export class EngramMcpServer {
             memories: { type: "string" },
             sessionKey: { type: "string" },
             namespace: { type: "string" },
+            timeZone: { type: "string" },
           },
           required: [],
           additionalProperties: false,
@@ -2638,12 +2646,10 @@ export class EngramMcpServer {
           actionConfidence,
         );
       }
-      case "engram.day_summary":
-        return this.service.daySummary({
-          memories: typeof args.memories === "string" ? args.memories : "",
-          sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
-          namespace: typeof args.namespace === "string" ? args.namespace : undefined,
-        });
+      case "engram.day_summary": {
+        const body: DaySummaryRequest = parseMcpRequest("daySummary", args);
+        return this.service.daySummary(body);
+      }
       case "engram.capsule_export": {
         const body: CapsuleExportRequest = parseMcpRequest("capsuleExport", args);
         return this.service.capsuleExport({

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -46,6 +46,19 @@ const sessionKeySchema = z.string().trim().min(1).max(512).optional();
 const idempotencyKeySchema = z.string().trim().min(1).max(256).optional();
 const dryRunSchema = z.boolean().optional();
 const schemaVersionSchema = z.number().int().optional();
+const timeZoneSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .refine((value) => {
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: value });
+      return true;
+    } catch {
+      return false;
+    }
+  }, "must be a valid IANA timezone");
 
 // ---------------------------------------------------------------------------
 // Recall
@@ -330,6 +343,7 @@ export const daySummaryRequestSchema = z.object({
   memories: z.string().max(100000).optional(),
   sessionKey: sessionKeySchema,
   namespace: namespaceSchema,
+  timeZone: timeZoneSchema.optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -376,6 +376,7 @@ export interface EngramAccessDaySummaryRequest {
   memories?: string;
   sessionKey?: string;
   namespace?: string;
+  timeZone?: string;
 }
 
 /** Inputs accepted by the `remnic_briefing` MCP tool. */
@@ -1802,7 +1803,9 @@ export class EngramAccessService {
 
     if (memories.length === 0) {
       // Auto-gather today's facts from the resolved namespace
-      return this.orchestrator.generateDaySummaryAuto(namespace);
+      return this.orchestrator.generateDaySummaryAuto(namespace, {
+        timeZone: request.timeZone,
+      });
     }
     return this.orchestrator.generateDaySummary(memories);
   }

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2062,8 +2062,15 @@ export function parseConfig(raw: unknown): PluginConfig {
     // Day summary timezone override (issue #1475). When unset, the plugin
     // falls back to the server's local timezone.
     daySummaryTimezone:
-      typeof cfg.daySummaryTimezone === "string" && cfg.daySummaryTimezone.length > 0
-        ? cfg.daySummaryTimezone
+      typeof cfg.daySummaryTimezone === "string" && cfg.daySummaryTimezone.trim().length > 0
+        ? (() => {
+            try {
+              Intl.DateTimeFormat(undefined, { timeZone: cfg.daySummaryTimezone });
+              return cfg.daySummaryTimezone;
+            } catch {
+              return undefined;
+            }
+          })()
         : undefined,
     // Codex P1 on PR 763 round 2: gate the nightly-governance cron
     // (deep-sleep's primary scheduled execution path) on

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2064,10 +2064,14 @@ export function parseConfig(raw: unknown): PluginConfig {
     daySummaryTimezone:
       typeof cfg.daySummaryTimezone === "string" && cfg.daySummaryTimezone.trim().length > 0
         ? (() => {
+            const tz = cfg.daySummaryTimezone as string;
             try {
-              Intl.DateTimeFormat(undefined, { timeZone: cfg.daySummaryTimezone });
-              return cfg.daySummaryTimezone;
+              Intl.DateTimeFormat(undefined, { timeZone: tz });
+              return tz;
             } catch {
+              log.warn(
+                `daySummaryTimezone: invalid IANA timezone "${tz}", falling back to server timezone`,
+              );
               return undefined;
             }
           })()

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2069,10 +2069,7 @@ export function parseConfig(raw: unknown): PluginConfig {
               Intl.DateTimeFormat(undefined, { timeZone: tz });
               return tz;
             } catch {
-              log.warn(
-                `daySummaryTimezone: invalid IANA timezone "${tz}", falling back to server timezone`,
-              );
-              return undefined;
+              throw new Error(`daySummaryTimezone must be a valid IANA timezone: ${tz}`);
             }
           })()
         : undefined,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2064,7 +2064,7 @@ export function parseConfig(raw: unknown): PluginConfig {
     daySummaryTimezone:
       typeof cfg.daySummaryTimezone === "string" && cfg.daySummaryTimezone.trim().length > 0
         ? (() => {
-            const tz = cfg.daySummaryTimezone as string;
+            const tz = (cfg.daySummaryTimezone as string).trim();
             try {
               Intl.DateTimeFormat(undefined, { timeZone: tz });
               return tz;

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2059,6 +2059,12 @@ export function parseConfig(raw: unknown): PluginConfig {
     hourlySummariesEnabled: cfg.hourlySummariesEnabled !== false, // default: true
     daySummaryEnabled: cfg.daySummaryEnabled !== false, // default: true
     hourlySummaryCronAutoRegister: cfg.hourlySummaryCronAutoRegister === true,
+    // Day summary timezone override (issue #1475). When unset, the plugin
+    // falls back to the server's local timezone.
+    daySummaryTimezone:
+      typeof cfg.daySummaryTimezone === "string" && cfg.daySummaryTimezone.length > 0
+        ? cfg.daySummaryTimezone
+        : undefined,
     // Codex P1 on PR 763 round 2: gate the nightly-governance cron
     // (deep-sleep's primary scheduled execution path) on
     // dreams.phases.deepSleep.enabled. When the phase is disabled the

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -128,7 +128,7 @@ const BUILT_IN_PROVIDER_FALLBACKS: Record<string, ModelProviderConfig> = {
   },
   openai: {
     baseUrl: "https://api.openai.com/v1",
-    api: "openai-completions",
+    api: "openai-responses",
     models: [],
     [PROVIDER_API_KEY_FIELD]: MANAGED_SECRETREF_MARKER,
   },

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -109,10 +109,26 @@ const LEGACY_PROVIDER_IDS = new Set(["openai-codex", "claude-cli"]);
 const MANAGED_SECRETREF_MARKER = ["secretref", "managed"].join("-");
 const PROVIDER_API_KEY_FIELD = ["api", "Key"].join("") as keyof ModelProviderConfig;
 
+/**
+ * Built-in provider fallbacks for providers that are commonly configured via
+ * OAuth or gateway-managed auth rather than an explicit apiKey in
+ * openclaw.json. These entries let resolveProviderConfig() succeed so the
+ * chain proceeds to tryModel() → resolveRuntimeAuth(), which is where the
+ * gateway's native OAuth token exchange happens.
+ *
+ * Without these, OAuth-only providers like `openai` are rejected with
+ * "provider not found" before runtime auth is ever attempted.
+ */
 const BUILT_IN_PROVIDER_FALLBACKS: Record<string, ModelProviderConfig> = {
   anthropic: {
     baseUrl: "https://api.anthropic.com/v1",
     api: "anthropic-messages",
+    models: [],
+    [PROVIDER_API_KEY_FIELD]: MANAGED_SECRETREF_MARKER,
+  },
+  openai: {
+    baseUrl: "https://api.openai.com/v1",
+    api: "openai-completions",
     models: [],
     [PROVIDER_API_KEY_FIELD]: MANAGED_SECRETREF_MARKER,
   },

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -195,13 +195,14 @@ export async function ensureDaySummaryCron(
     typeof options.agentId === "string" && options.agentId.trim().length > 0
       ? options.agentId.trim()
       : "main";
+  const daySummaryParams = JSON.stringify({ timeZone: options.timezone });
 
   const payload: Record<string, unknown> = {
     kind: "agentTurn",
     timeoutSeconds: 900,
     thinking: "off",
     message:
-      "You are OpenClaw automation. Call tool engram.day_summary with empty params (it will auto-gather today's facts). If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
+      `You are OpenClaw automation. Call tool engram.day_summary with params ${daySummaryParams} (it will auto-gather today's facts for that timezone). If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.`,
   };
   if (options.model) {
     payload.model = options.model;

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -146,34 +146,56 @@ export async function ensureDaySummaryCron(
   options: {
     timezone: string;
     agentId?: string;
+    /** Optional model override (e.g. from summaryModel or taskModelChain.primary). */
+    model?: string;
+    /** Optional fallbacks to include alongside the model. */
+    fallbacks?: string[];
   },
-): Promise<{ created: boolean; jobId: string }> {
+): Promise<{ created: boolean; updated: boolean; jobId: string }> {
   const agentId =
     typeof options.agentId === "string" && options.agentId.trim().length > 0
       ? options.agentId.trim()
       : "main";
 
-  return ensureCronJob(jobsPath, DAY_SUMMARY_CRON_ID, () => ({
-    id: DAY_SUMMARY_CRON_ID,
-    agentId,
-    name: "Remnic Day Summary (auto)",
-    enabled: true,
-    schedule: {
-      kind: "cron",
-      expr: "47 23 * * *",
-      tz: options.timezone,
+  const payload: Record<string, unknown> = {
+    kind: "agentTurn",
+    timeoutSeconds: 900,
+    thinking: "off",
+    message:
+      "You are OpenClaw automation. Call tool engram.day_summary with empty params (it will auto-gather today's facts). If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
+  };
+  if (options.model) {
+    payload.model = options.model;
+  }
+  if (options.fallbacks && options.fallbacks.length > 0) {
+    payload.fallbacks = options.fallbacks;
+  }
+
+  return ensureCronJob(
+    jobsPath,
+    DAY_SUMMARY_CRON_ID,
+    () => ({
+      id: DAY_SUMMARY_CRON_ID,
+      agentId,
+      name: "Remnic Day Summary (auto)",
+      enabled: true,
+      schedule: {
+        kind: "cron",
+        expr: "47 23 * * *",
+        tz: options.timezone,
+      },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload,
+      delivery: { mode: "none" },
+    }),
+    // Reconcile on every startup so model/timezone changes propagate.
+    // Issue #1474 (model reconcile) + #1475 (timezone reconcile).
+    {
+      updateExisting: true,
+      updateFields: ["schedule", "payload", "agentId"],
     },
-    sessionTarget: "isolated",
-    wakeMode: "now",
-    payload: {
-      kind: "agentTurn",
-      timeoutSeconds: 900,
-      thinking: "off",
-      message:
-        "You are OpenClaw automation. Call tool engram.day_summary with empty params (it will auto-gather today's facts). If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
-    },
-    delivery: { mode: "none" },
-  }));
+  );
 }
 
 export async function ensureNightlyGovernanceCron(

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -117,7 +117,10 @@ function deepMergeObjects(
 ): Record<string, unknown> {
   const result = { ...target };
   for (const [key, value] of Object.entries(source)) {
-    if (
+    if (value === null) {
+      // null means "remove this key"
+      delete result[key];
+    } else if (
       value && typeof value === "object" && !Array.isArray(value) &&
       result[key] && typeof result[key] === "object" && !Array.isArray(result[key])
     ) {
@@ -232,11 +235,13 @@ export async function ensureDaySummaryCron(
       updateFields: ["agentId"],
       deepMerge: {
         schedule: { tz: options.timezone },
+        // Always write model/fallbacks so stale values are cleared when
+        // an operator removes summaryModel or taskModelChain from config.
         payload: {
-          ...(options.model ? { model: options.model } : {}),
-          ...(options.fallbacks && options.fallbacks.length > 0
-            ? { fallbacks: options.fallbacks }
-            : {}),
+          model: options.model ?? null,
+          fallbacks: (options.fallbacks && options.fallbacks.length > 0)
+            ? options.fallbacks
+            : null,
         },
       },
     },

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -183,6 +183,8 @@ export async function ensureDaySummaryCron(
   options: {
     timezone: string;
     agentId?: string;
+    /** Whether agentId was explicitly provided (vs defaulted to "main"). */
+    hasExplicitAgentId?: boolean;
     /** Optional model override (e.g. from summaryModel or taskModelChain.primary). */
     model?: string;
     /** Optional fallbacks to include alongside the model. */
@@ -230,9 +232,11 @@ export async function ensureDaySummaryCron(
     // Issue #1474 (model reconcile) + #1475 (timezone reconcile).
     // Only update managed leaves to avoid clobbering user edits to
     // schedule.expr, payload.message, payload.timeoutSeconds, etc.
+    // Only reconcile agentId when explicitly provided, so manually-set
+    // cron personas are preserved.
     {
       updateExisting: true,
-      updateFields: ["agentId"],
+      updateFields: options.hasExplicitAgentId ? ["agentId"] : [],
       deepMerge: {
         schedule: { tz: options.timezone },
         // Always write model/fallbacks so stale values are cleared when

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -225,6 +225,9 @@ export async function ensureDaySummaryCron(
       },
       sessionTarget: "isolated",
       wakeMode: "now",
+      // Mirror model at job root for backward compat with older OpenClaw
+      // builds that read root model instead of payload.model.
+      ...(options.model ? { model: options.model } : {}),
       payload,
       delivery: { mode: "none" },
     }),
@@ -239,6 +242,9 @@ export async function ensureDaySummaryCron(
       updateFields: options.hasExplicitAgentId ? ["agentId"] : [],
       deepMerge: {
         schedule: { tz: options.timezone },
+        // Mirror model at job root for backward compat with older OpenClaw
+        // builds that read root model instead of payload.model.
+        model: options.model ?? null,
         // Always write model/fallbacks so stale values are cleared when
         // an operator removes summaryModel or taskModelChain from config.
         payload: {

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -72,7 +72,11 @@ export async function ensureCronJob(
   jobsPath: string,
   jobId: string,
   buildJob: () => Record<string, unknown>,
-  options: { updateExisting?: boolean; updateFields?: string[] } = {},
+  options: {
+    updateExisting?: boolean;
+    updateFields?: string[];
+    deepMerge?: Record<string, unknown>;
+  } = {},
 ): Promise<{ created: boolean; updated: boolean; jobId: string }> {
   const releaseLock = await acquireCronJobsLock(jobsPath);
   try {
@@ -87,7 +91,7 @@ export async function ensureCronJob(
 
       const desired = buildJob();
       const existing = jobs[existingIndex];
-      const next = mergeCronJobUpdate(existing, desired, options.updateFields);
+      const next = mergeCronJobUpdate(existing, desired, options.updateFields, options.deepMerge);
       if (stableJson(existing) === stableJson(next)) {
         return { created: false, updated: false, jobId };
       }
@@ -107,23 +111,53 @@ export async function ensureCronJob(
   }
 }
 
+function deepMergeObjects(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = { ...target };
+  for (const [key, value] of Object.entries(source)) {
+    if (
+      value && typeof value === "object" && !Array.isArray(value) &&
+      result[key] && typeof result[key] === "object" && !Array.isArray(result[key])
+    ) {
+      result[key] = deepMergeObjects(
+        result[key] as Record<string, unknown>,
+        value as Record<string, unknown>,
+      );
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 function mergeCronJobUpdate(
   existing: Record<string, unknown>,
   desired: Record<string, unknown>,
   updateFields?: string[],
+  deepMerge?: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (!updateFields) {
+  let next = { ...existing };
+
+  if (!updateFields && !deepMerge) {
     return desired;
   }
 
-  const next = { ...existing };
-  for (const field of updateFields) {
-    if (Object.prototype.hasOwnProperty.call(desired, field)) {
-      next[field] = desired[field];
-    } else {
-      delete next[field];
+  if (updateFields) {
+    for (const field of updateFields) {
+      if (Object.prototype.hasOwnProperty.call(desired, field)) {
+        next[field] = desired[field];
+      } else {
+        delete next[field];
+      }
     }
   }
+
+  if (deepMerge) {
+    next = deepMergeObjects(next, deepMerge);
+  }
+
   return next;
 }
 
@@ -191,9 +225,20 @@ export async function ensureDaySummaryCron(
     }),
     // Reconcile on every startup so model/timezone changes propagate.
     // Issue #1474 (model reconcile) + #1475 (timezone reconcile).
+    // Only update managed leaves to avoid clobbering user edits to
+    // schedule.expr, payload.message, payload.timeoutSeconds, etc.
     {
       updateExisting: true,
-      updateFields: ["schedule", "payload", "agentId"],
+      updateFields: ["agentId"],
+      deepMerge: {
+        schedule: { tz: options.timezone },
+        payload: {
+          ...(options.model ? { model: options.model } : {}),
+          ...(options.fallbacks && options.fallbacks.length > 0
+            ? { fallbacks: options.fallbacks }
+            : {}),
+        },
+      },
     },
   );
 }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -778,6 +778,42 @@ function parseFiniteDate(value: unknown): Date | null {
   return Number.isFinite(parsed.getTime()) ? parsed : null;
 }
 
+function filterHourlySummaryMarkdownForLocalDay(
+  raw: string,
+  utcDate: string,
+  timeZone: string,
+  targetLocalDate: string,
+): string | null {
+  const hourHeaderPattern = /^## ([01]\d|2[0-3]):00[ \t]*$/gm;
+  const matches = Array.from(raw.matchAll(hourHeaderPattern));
+  if (matches.length === 0) return null;
+
+  const firstSectionStart = matches[0]?.index ?? 0;
+  const preamble = raw.slice(0, firstSectionStart).trim();
+  const sections: string[] = [];
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index];
+    const hour = match[1];
+    if (!hour) continue;
+    const sectionTimestamp = parseFiniteDate(`${utcDate}T${hour}:00:00.000Z`);
+    if (
+      !sectionTimestamp ||
+      formatDateInTimeZone(sectionTimestamp, timeZone) !== targetLocalDate
+    ) {
+      continue;
+    }
+    const sectionStart = match.index ?? 0;
+    const sectionEnd = matches[index + 1]?.index ?? raw.length;
+    const section = raw.slice(sectionStart, sectionEnd).trim();
+    if (section.length > 0) sections.push(section);
+  }
+
+  if (sections.length === 0) return null;
+  return [preamble, ...sections]
+    .filter((section) => section.length > 0)
+    .join("\n\n");
+}
+
 type SearchCollectionState = "present" | "missing" | "unknown" | "skipped";
 
 function qmdStartupCollectionCheckTimeoutMs(): number {
@@ -4317,8 +4353,14 @@ export class Orchestrator {
           const summaryFile = path.join(hourlyBaseDir, sk.name, `${date}.md`);
           try {
             const raw = await readFile(summaryFile, "utf-8");
-            if (raw.trim().length > 0) {
-              hourlySummaries.push(raw.trim());
+            const filtered = filterHourlySummaryMarkdownForLocalDay(
+              raw,
+              date,
+              timeZone,
+              targetLocalDate,
+            );
+            if (filtered) {
+              hourlySummaries.push(filtered);
             }
           } catch {
             // No summary file for this session/date

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3180,11 +3180,22 @@ export class Orchestrator {
       }
 
       // Resolve model from config: explicit summaryModel, then taskModelChain.primary
-      const model = this.config.summaryModel || this.config.taskModelChain?.primary || undefined;
+      // In plugin mode, summaryModel may default to DEFAULT_REASONING_MODEL even
+      // when the operator didn't configure one. Only inject model into the cron
+      // when there's a gateway route, a task chain, or a non-default override.
+      const rawSummaryModel = this.config.summaryModel;
+      const taskPrimary = this.config.taskModelChain?.primary;
+      const isGateway = this.config.modelSource === "gateway";
+      const hasTaskChain = !!this.config.taskModelChain;
+      // Skip model injection when it's just the bare default (plugin mode, no
+      // task chain, no explicit override) — let the gateway use its own default.
+      const isBareDefault = !isGateway && !hasTaskChain && rawSummaryModel === "gpt-5.5";
+      const model = isBareDefault
+        ? undefined
+        : (rawSummaryModel || taskPrimary || undefined);
       // Attach task-chain fallbacks only when the model matches the task-chain
       // primary. If summaryModel is a distinct override, its fallbacks would
       // be unrelated to the task chain.
-      const taskPrimary = this.config.taskModelChain?.primary;
       const fallbacks = (model && taskPrimary && model === taskPrimary && this.config.taskModelChain?.fallbacks)
         ? this.config.taskModelChain.fallbacks
         : [];

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2249,6 +2249,11 @@ export class Orchestrator {
                 // the gateway default chain (which may be expensive).
                 // Issue #1473.
                 ...gatewayTaskChainOptions(this.config),
+                // Preserve fastGatewayAgentId preference if set, so LCM
+                // summarization can still use a distinct fast persona.
+                ...(this.config.fastGatewayAgentId
+                  ? { agentId: this.config.fastGatewayAgentId }
+                  : {}),
               })
             : await this.localLlm.chatCompletion(messages, {
                 maxTokens: targetTokens * 2,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3195,10 +3195,27 @@ export class Orchestrator {
         : (rawSummaryModel || taskPrimary || undefined);
       // Attach task-chain fallbacks only when the model matches the task-chain
       // primary. If summaryModel is a distinct override, its fallbacks would
-      // be unrelated to the task chain.
-      const fallbacks = (model && taskPrimary && model === taskPrimary && this.config.taskModelChain?.fallbacks)
-        ? this.config.taskModelChain.fallbacks
-        : [];
+      // be unrelated to the task chain. Also append gateway default models as
+      // tail fallbacks (de-duped) so a task-chain outage doesn't stop the cron
+      // before reaching the gateway default chain. Mirrors hourly cron pattern.
+      const fallbacks: string[] = [];
+      if (model && taskPrimary && model === taskPrimary) {
+        const seen = new Set<string>(model ? [model] : []);
+        const addUnique = (value: string | undefined) => {
+          if (typeof value !== "string") return;
+          const trimmed = value.trim();
+          if (trimmed.length > 0 && !seen.has(trimmed)) {
+            seen.add(trimmed);
+            fallbacks.push(trimmed);
+          }
+        };
+        for (const fb of this.config.taskModelChain?.fallbacks ?? []) addUnique(fb);
+        const gwDefaults = this.config.gatewayConfig?.agents?.defaults?.model;
+        addUnique(gwDefaults?.primary);
+        if (Array.isArray(gwDefaults?.fallbacks)) {
+          for (const fb of gwDefaults.fallbacks) addUnique(fb);
+        }
+      }
 
       // Resolve timezone: configurable override, then server default
       const timezone = this.config.daySummaryTimezone

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -715,6 +715,69 @@ async function raceRecallAbort<T>(
 const COMPACTION_SIGNAL_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 const DEFAULT_QMD_STARTUP_COLLECTION_CHECK_TIMEOUT_MS = 10_000;
 
+type DaySummaryGatherOptions = {
+  timeZone?: string;
+  now?: Date;
+};
+
+function normalizeIanaTimeZone(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: trimmed });
+    return trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatDateInTimeZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const get = (type: string): string => parts.find((part) => part.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+function utcDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function utcDateKeysAround(date: Date): string[] {
+  const dayMs = 86_400_000;
+  const keys = [
+    utcDateKey(new Date(date.getTime() - dayMs)),
+    utcDateKey(date),
+    utcDateKey(new Date(date.getTime() + dayMs)),
+  ];
+  return keys.filter((value, index, array) => array.indexOf(value) === index);
+}
+
+function utcDateKeysForLocalDay(date: Date, timeZone: string): string[] {
+  const targetLocalDate = formatDateInTimeZone(date, timeZone);
+  const keys = new Set<string>();
+  const hourMs = 3_600_000;
+  const scanStart = date.getTime() - 48 * hourMs;
+  const scanEnd = date.getTime() + 48 * hourMs;
+  for (let ms = scanStart; ms <= scanEnd; ms += hourMs) {
+    const candidate = new Date(ms);
+    if (formatDateInTimeZone(candidate, timeZone) === targetLocalDate) {
+      keys.add(utcDateKey(candidate));
+    }
+  }
+  return keys.size > 0 ? [...keys].sort() : utcDateKeysAround(date);
+}
+
+function parseFiniteDate(value: unknown): Date | null {
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
 type SearchCollectionState = "present" | "missing" | "unknown" | "skipped";
 
 function qmdStartupCollectionCheckTimeoutMs(): number {
@@ -3175,20 +3238,13 @@ export class Orchestrator {
         return;
       }
 
-      // Resolve model from config: explicit summaryModel, then taskModelChain.primary
-      // In plugin mode, summaryModel may default to DEFAULT_REASONING_MODEL even
-      // when the operator didn't configure one. Only inject model into the cron
-      // when there's a gateway route, a task chain, or a non-default override.
+      // Resolve an OpenClaw cron-routing model only in gateway mode. In plugin
+      // mode, summaryModel is a direct-client model id for Remnic's own LLM
+      // calls and may be unroutable as an OpenClaw agentTurn model.
       const rawSummaryModel = this.config.summaryModel;
       const taskPrimary = this.config.taskModelChain?.primary;
       const isGateway = this.config.modelSource === "gateway";
-      const hasTaskChain = !!this.config.taskModelChain;
-      // Skip model injection when it's just the bare default (plugin mode, no
-      // task chain, no explicit override) — let the gateway use its own default.
-      const isBareDefault = !isGateway && !hasTaskChain && rawSummaryModel === "gpt-5.5";
-      const model = isBareDefault
-        ? undefined
-        : (rawSummaryModel || taskPrimary || undefined);
+      const model = isGateway ? (rawSummaryModel || taskPrimary || undefined) : undefined;
       // Attach task-chain fallbacks only when the model matches the task-chain
       // primary. If summaryModel is a distinct override, its fallbacks would
       // be unrelated to the task chain. Also append gateway default models as
@@ -4152,8 +4208,9 @@ export class Orchestrator {
    */
   async generateDaySummaryAuto(
     namespace?: string,
+    options: DaySummaryGatherOptions = {},
   ): Promise<DaySummaryResult | null> {
-    const gathered = await this.gatherTodayFacts(namespace);
+    const gathered = await this.gatherTodayFacts(namespace, options);
     if (!gathered || !gathered.trim()) {
       log.warn("generateDaySummaryAuto: no facts found for today, skipping");
       return null;
@@ -4165,24 +4222,27 @@ export class Orchestrator {
    * Read today's facts and hourly summaries from storage, returning them
    * as a formatted string suitable for generateDaySummary().
    */
-  async gatherTodayFacts(namespace?: string): Promise<string> {
+  async gatherTodayFacts(
+    namespace?: string,
+    options: DaySummaryGatherOptions = {},
+  ): Promise<string> {
     const ns =
       namespace && namespace.length > 0
         ? namespace
         : this.config.defaultNamespace;
     const storage = await this.storageRouter.storageFor(ns);
-    // Facts are stored under UTC dates, but a local calendar day can span
-    // two UTC dates (e.g. 23:47 local in UTC-6 is 05:47 UTC the next day). To capture
-    // all facts for the local day, read from both the current UTC date and
-    // yesterday's UTC date (which covers the local day's morning hours).
-    const now = new Date();
-    const utcToday = now.toISOString().slice(0, 10);
-    const yesterday = new Date(now.getTime() - 86_400_000)
-      .toISOString()
-      .slice(0, 10);
-    const datesToScan = [yesterday, utcToday].filter(
-      (v, i, a) => a.indexOf(v) === i,
-    );
+    const configuredTimeZone = normalizeIanaTimeZone(options.timeZone)
+      ?? normalizeIanaTimeZone(this.config.daySummaryTimezone);
+    const timeZone =
+      configuredTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const now = options.now instanceof Date && Number.isFinite(options.now.getTime())
+      ? options.now
+      : new Date();
+    const targetLocalDate = formatDateInTimeZone(now, timeZone);
+    // Facts are stored under UTC date directories, while the summary target is
+    // a local calendar day. Scan the UTC-date envelope that overlaps the local
+    // day, then filter parseable fact timestamps to that configured local day.
+    const datesToScan = utcDateKeysForLocalDay(now, timeZone);
     const factsBaseDir = path.join(storage.dir, "facts");
     const MAX_CHARS = 100_000;
 
@@ -4209,13 +4269,21 @@ export class Orchestrator {
                 .slice(colonIdx + 1)
                 .trim();
             }
+            const created = fm.created || "unknown";
+            const createdAt = parseFiniteDate(created);
+            if (
+              createdAt &&
+              formatDateInTimeZone(createdAt, timeZone) !== targetLocalDate
+            ) {
+              continue;
+            }
             facts.push({
               path: fullPath,
               frontmatter: {
                 id: fm.id || path.basename(entry.name, ".md"),
                 category: (fm.category as any) || "fact",
-                created: fm.created || "unknown",
-                updated: fm.updated || fm.created || "unknown",
+                created,
+                updated: fm.updated || created,
                 source: fm.source || "unknown",
                 confidence: parseFloat(fm.confidence || "0.8"),
                 confidenceTier: (fm.confidenceTier as any) || "implied",
@@ -4233,9 +4301,10 @@ export class Orchestrator {
     }
 
     // Sort facts by created timestamp (most recent last) so truncation keeps newest
-    facts.sort((a, b) =>
-      a.frontmatter.created < b.frontmatter.created ? -1 : 1,
-    );
+    facts.sort((a, b) => {
+      if (a.frontmatter.created === b.frontmatter.created) return 0;
+      return a.frontmatter.created < b.frontmatter.created ? -1 : 1;
+    });
 
     // --- Read hourly summaries for the scanned dates ---
     const hourlySummaries: string[] = [];
@@ -4287,7 +4356,7 @@ export class Orchestrator {
     }
 
     log.info(
-      `gatherTodayFacts: collected ${facts.length} facts, ${hourlySummaries.length} hourly summaries (${formatted.length} chars)`,
+      `gatherTodayFacts: collected ${facts.length} facts, ${hourlySummaries.length} hourly summaries for ${targetLocalDate} (${timeZone}, ${formatted.length} chars)`,
     );
 
     return formatted;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2244,16 +2244,12 @@ export class Orchestrator {
             ? await this._fastGatewayLlm.chatCompletion(messages, {
                 maxTokens: targetTokens * 2,
                 timeoutMs: this.config.localLlmFastTimeoutMs,
-                // Route through taskModelChain so LCM uses the same cheap/fast
-                // model tier as other background tasks instead of falling to
-                // the gateway default chain (which may be expensive).
-                // Issue #1473.
-                ...gatewayTaskChainOptions(this.config),
-                // Preserve fastGatewayAgentId preference if set, so LCM
-                // summarization can still use a distinct fast persona.
+                // LCM is latency-sensitive. A configured fast persona is the
+                // explicit fast-tier route; otherwise use taskModelChain so LCM
+                // avoids falling to an expensive gateway default. Issue #1473.
                 ...(this.config.fastGatewayAgentId
                   ? { agentId: this.config.fastGatewayAgentId }
-                  : {}),
+                  : gatewayTaskChainOptions(this.config)),
               })
             : await this.localLlm.chatCompletion(messages, {
                 maxTokens: targetTokens * 2,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3181,7 +3181,11 @@ export class Orchestrator {
 
       // Resolve model from config: explicit summaryModel, then taskModelChain.primary
       const model = this.config.summaryModel || this.config.taskModelChain?.primary || undefined;
-      const fallbacks = this.config.taskModelChain?.fallbacks ?? [];
+      // Only attach task-chain fallbacks when the model is the task-chain primary.
+      // If summaryModel overrides the model, its fallbacks would be unrelated.
+      const fallbacks = (!this.config.summaryModel && this.config.taskModelChain?.fallbacks)
+        ? this.config.taskModelChain.fallbacks
+        : [];
 
       // Resolve timezone: configurable override, then server default
       const timezone = this.config.daySummaryTimezone

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3181,9 +3181,11 @@ export class Orchestrator {
 
       // Resolve model from config: explicit summaryModel, then taskModelChain.primary
       const model = this.config.summaryModel || this.config.taskModelChain?.primary || undefined;
-      // Only attach task-chain fallbacks when the model is the task-chain primary.
-      // If summaryModel overrides the model, its fallbacks would be unrelated.
-      const fallbacks = (!this.config.summaryModel && this.config.taskModelChain?.fallbacks)
+      // Attach task-chain fallbacks only when the model matches the task-chain
+      // primary. If summaryModel is a distinct override, its fallbacks would
+      // be unrelated to the task chain.
+      const taskPrimary = this.config.taskModelChain?.primary;
+      const fallbacks = (model && taskPrimary && model === taskPrimary && this.config.taskModelChain?.fallbacks)
         ? this.config.taskModelChain.fallbacks
         : [];
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -78,6 +78,7 @@ import { LocalLlmClient } from "./local-llm.js";
 import {
   FallbackLlmClient,
   fallbackLlmRuntimeContextFromConfig,
+  gatewayTaskChainOptions,
 } from "./fallback-llm.js";
 import {
   ensureDaySummaryCron,
@@ -2243,10 +2244,11 @@ export class Orchestrator {
             ? await this._fastGatewayLlm.chatCompletion(messages, {
                 maxTokens: targetTokens * 2,
                 timeoutMs: this.config.localLlmFastTimeoutMs,
-                agentId:
-                  this.config.fastGatewayAgentId ||
-                  this.config.gatewayAgentId ||
-                  undefined,
+                // Route through taskModelChain so LCM uses the same cheap/fast
+                // model tier as other background tasks instead of falling to
+                // the gateway default chain (which may be expensive).
+                // Issue #1473.
+                ...gatewayTaskChainOptions(this.config),
               })
             : await this.localLlm.chatCompletion(messages, {
                 maxTokens: targetTokens * 2,
@@ -3155,8 +3157,10 @@ export class Orchestrator {
   }
 
   /**
-   * Auto-register the engram-day-summary cron job in OpenClaw if it doesn't exist.
+   * Auto-register the engram-day-summary cron job in OpenClaw.
+   * Reconciles model and timezone on every startup so config changes propagate.
    * Fire-and-forget — never blocks init or crashes on failure.
+   * Issues #1474, #1475.
    */
   private async autoRegisterDaySummaryCron(): Promise<void> {
     const home = resolveHomeDir();
@@ -3169,15 +3173,30 @@ export class Orchestrator {
         );
         return;
       }
-      const created = await ensureDaySummaryCron(jobsPath, {
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+
+      // Resolve model from config: explicit summaryModel, then taskModelChain.primary
+      const model = this.config.summaryModel || this.config.taskModelChain?.primary || undefined;
+      const fallbacks = this.config.taskModelChain?.fallbacks ?? [];
+
+      // Resolve timezone: configurable override, then server default
+      const timezone = this.config.daySummaryTimezone
+        || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+      const result = await ensureDaySummaryCron(jobsPath, {
+        timezone,
+        ...(model ? { model } : {}),
+        ...(fallbacks.length > 0 ? { fallbacks } : {}),
       });
-      if (created.created) {
+      if (result.created) {
         log.info(
-          `day-summary cron auto-registered (${created.jobId}, 23:47 ${Intl.DateTimeFormat().resolvedOptions().timeZone})`,
+          `day-summary cron auto-registered (${result.jobId}, 23:47 ${timezone}${model ? `, model: ${model}` : ""})`,
+        );
+      } else if (result.updated) {
+        log.info(
+          `day-summary cron reconciled (${result.jobId}, timezone: ${timezone}${model ? `, model: ${model}` : ""})`,
         );
       } else {
-        log.debug("day-summary cron already exists, skipping auto-register");
+        log.debug("day-summary cron already up to date");
       }
     } catch (err) {
       log.debug(`day-summary cron auto-register error: ${err}`);

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1282,6 +1282,8 @@ export interface PluginConfig {
    * consolidation. When set, this chain is resolved through gateway providers
    * instead of using gatewayAgentId or agents.defaults.model. All task paths
    * route through the shared `gatewayTaskChainOptions` helper.
+   * LCM summarization is the one fast-tier exception: if `fastGatewayAgentId`
+   * is configured, LCM uses that persona before falling back to this chain.
    *
    * Only takes effect when `modelSource: "gateway"`; ignored (with a startup
    * warning) under `modelSource: "plugin"`. See issue #1365 / PR #1370.

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -945,6 +945,8 @@ export interface PluginConfig {
   // Hourly summaries
   hourlySummariesEnabled: boolean;
   daySummaryEnabled: boolean;
+  /** Timezone override for the day summary cron (issue #1475). */
+  daySummaryTimezone?: string;
   /** If true, Engram may attempt to auto-register an hourly summary cron job (default off). */
   hourlySummaryCronAutoRegister: boolean;
   /** If true, Engram may attempt to auto-register the nightly governance cron job (default off). */

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3361,6 +3361,11 @@
         "default": true,
         "description": "Enable end-of-day summary generation via engram.day_summary MCP tool"
       },
+      "daySummaryTimezone": {
+        "type": "string",
+        "default": "",
+        "description": "Timezone for the day summary cron (e.g. 'America/Lima'). When empty, uses the server timezone."
+      },
       "summaryRecallHours": {
         "type": "number",
         "default": 24,

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -642,6 +642,45 @@ test("MCP capsule tools reject invalid arguments before calling service", async 
   assert.equal(listCalls, 0);
 });
 
+test("MCP day_summary tolerates injected git context keys", async () => {
+  let request: unknown;
+  const service = {
+    ...createFakeService(),
+    daySummary: async (body: unknown) => {
+      request = body;
+      return {
+        summary: "done",
+        bullets: [],
+        next_actions: [],
+        risks_or_open_loops: [],
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "engram.day_summary",
+      arguments: {
+        namespace: "global",
+        timeZone: "America/Chicago",
+        cwd: "/tmp/project",
+        projectTag: "blend-supply",
+      },
+    },
+  });
+
+  const result = response?.result as { isError?: boolean };
+  assert.equal(result?.isError, false);
+  assert.deepEqual(request, {
+    namespace: "global",
+    timeZone: "America/Chicago",
+  });
+});
+
 test("engram.dreams_status rejects invalid windowHours without calling service", async () => {
   let capturedWindowHours: number | undefined;
   let calls = 0;

--- a/tests/day-summary-cron-routing.test.ts
+++ b/tests/day-summary-cron-routing.test.ts
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { validateRequest } from "../src/access-schema.js";
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+
+function resetGlobals(): void {
+  const globals = globalThis as Record<string, unknown>;
+  for (const key of [
+    "__openclawEngramOrchestrator",
+    "__openclawEngramCliRegistered",
+    "__openclawEngramCliActiveServiceCount",
+    "__openclawEngramSessionCommandsRegistered",
+    "__openclawEngramMigrationPromise",
+  ]) {
+    delete globals[key];
+  }
+}
+
+test.afterEach(() => {
+  resetGlobals();
+});
+
+async function withHome<T>(prefix: string, fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const previousHome = process.env.HOME;
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    process.env.HOME = homeDir;
+    return await fn(homeDir);
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writeFact(
+  memoryDir: string,
+  utcDate: string,
+  id: string,
+  created: string,
+  content: string
+): Promise<void> {
+  const dir = path.join(memoryDir, "facts", utcDate);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    path.join(dir, `${id}.md`),
+    [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      `created: ${created}`,
+      `updated: ${created}`,
+      "source: test",
+      "confidence: 0.9",
+      "---",
+      content,
+      "",
+    ].join("\n"),
+    "utf-8"
+  );
+}
+
+test("day-summary cron omits direct plugin summary models from OpenClaw routing", async () => {
+  await withHome("remnic-day-summary-home-", async (homeDir) => {
+    const cronDir = path.join(homeDir, ".openclaw", "cron");
+    const jobsPath = path.join(cronDir, "jobs.json");
+    await mkdir(cronDir, { recursive: true });
+    await writeFile(jobsPath, JSON.stringify({ version: 1, jobs: [] }, null, 2) + "\n", "utf-8");
+
+    const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-day-summary-memory-"));
+    try {
+      const config = parseConfig({
+        openaiApiKey: "sk-test",
+        memoryDir,
+        workspaceDir: path.join(memoryDir, "workspace"),
+        modelSource: "plugin",
+        summaryModel: "gpt-4.1",
+        daySummaryTimezone: "America/Chicago",
+      });
+      const orchestrator = new Orchestrator(config) as any;
+
+      await orchestrator.autoRegisterDaySummaryCron();
+
+      const parsed = JSON.parse(await readFile(jobsPath, "utf-8")) as {
+        jobs: Array<{
+          id: string;
+          model?: string;
+          schedule: { tz: string };
+          payload: { message: string; model?: string };
+        }>;
+      };
+      const job = parsed.jobs.find((candidate) => candidate.id === "engram-day-summary");
+      assert.ok(job);
+      assert.equal(job.model, undefined);
+      assert.equal(job.payload.model, undefined);
+      assert.equal(job.schedule.tz, "America/Chicago");
+      assert.match(job.payload.message, /"timeZone":"America\/Chicago"/);
+    } finally {
+      await rm(memoryDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test("day-summary request rejects invalid timeZone values", () => {
+  const result = validateRequest("daySummary", {
+    timeZone: "Mars/Olympus",
+  });
+
+  assert.equal(result.success, false);
+  if (result.success) assert.fail("invalid timeZone should not validate");
+  assert.deepEqual(result.error.details, [{ field: "timeZone", message: "must be a valid IANA timezone" }]);
+});
+
+test("day-summary auto-gather filters facts by configured local day", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-day-summary-gather-"));
+  try {
+    await writeFact(
+      memoryDir,
+      "2026-06-23",
+      "same-local-day-afternoon",
+      "2026-06-23T19:00:00Z",
+      "Afternoon Chicago fact"
+    );
+    await writeFact(memoryDir, "2026-06-24", "same-local-day-late", "2026-06-24T04:20:00Z", "Late Chicago fact");
+    await writeFact(memoryDir, "2026-06-24", "next-local-day", "2026-06-24T05:20:00Z", "Next Chicago day fact");
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      daySummaryTimezone: "America/Chicago",
+    });
+    const orchestrator = new Orchestrator(config);
+
+    const gathered = await orchestrator.gatherTodayFacts(undefined, {
+      now: new Date("2026-06-24T04:30:00Z"),
+    });
+
+    assert.match(gathered, /Afternoon Chicago fact/);
+    assert.match(gathered, /Late Chicago fact/);
+    assert.doesNotMatch(gathered, /Next Chicago day fact/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/tests/day-summary-cron-routing.test.ts
+++ b/tests/day-summary-cron-routing.test.ts
@@ -115,6 +115,13 @@ test("day-summary request rejects invalid timeZone values", () => {
   assert.deepEqual(result.error.details, [{ field: "timeZone", message: "must be a valid IANA timezone" }]);
 });
 
+test("parseConfig rejects invalid daySummaryTimezone values", () => {
+  assert.throws(
+    () => parseConfig({ openaiApiKey: "sk-test", daySummaryTimezone: "Mars/Olympus" }),
+    /daySummaryTimezone must be a valid IANA timezone: Mars\/Olympus/,
+  );
+});
+
 test("day-summary auto-gather filters facts by configured local day", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-day-summary-gather-"));
   try {

--- a/tests/day-summary-cron-routing.test.ts
+++ b/tests/day-summary-cron-routing.test.ts
@@ -64,6 +64,32 @@ async function writeFact(
   );
 }
 
+async function writeHourlySummary(
+  memoryDir: string,
+  sessionKey: string,
+  utcDate: string,
+  sections: Array<{ hour: string; text: string }>,
+): Promise<void> {
+  const dir = path.join(memoryDir, "summaries", "hourly", sessionKey);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    path.join(dir, `${utcDate}.md`),
+    [
+      `# Hourly Summaries — ${utcDate}`,
+      "",
+      `*Session: ${sessionKey}*`,
+      "",
+      ...sections.flatMap((section) => [
+        `## ${section.hour}:00`,
+        "",
+        `- ${section.text}`,
+        "",
+      ]),
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
 test("day-summary cron omits direct plugin summary models from OpenClaw routing", async () => {
   await withHome("remnic-day-summary-home-", async (homeDir) => {
     const cronDir = path.join(homeDir, ".openclaw", "cron");
@@ -150,6 +176,39 @@ test("day-summary auto-gather filters facts by configured local day", async () =
     assert.match(gathered, /Afternoon Chicago fact/);
     assert.match(gathered, /Late Chicago fact/);
     assert.doesNotMatch(gathered, /Next Chicago day fact/);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("day-summary auto-gather filters hourly summary sections by configured local day", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-day-summary-hourly-gather-"));
+  try {
+    await writeHourlySummary(memoryDir, "session-a", "2026-06-23", [
+      { hour: "03", text: "Previous Chicago day hourly" },
+      { hour: "19", text: "Target Chicago afternoon hourly" },
+    ]);
+    await writeHourlySummary(memoryDir, "session-a", "2026-06-24", [
+      { hour: "04", text: "Target Chicago late hourly" },
+      { hour: "05", text: "Next Chicago day hourly" },
+    ]);
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir: path.join(memoryDir, "workspace"),
+      daySummaryTimezone: "America/Chicago",
+    });
+    const orchestrator = new Orchestrator(config);
+
+    const gathered = await orchestrator.gatherTodayFacts(undefined, {
+      now: new Date("2026-06-24T04:30:00Z"),
+    });
+
+    assert.match(gathered, /Target Chicago afternoon hourly/);
+    assert.match(gathered, /Target Chicago late hourly/);
+    assert.doesNotMatch(gathered, /Previous Chicago day hourly/);
+    assert.doesNotMatch(gathered, /Next Chicago day hourly/);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }

--- a/tests/lcm-gateway-summarizer.test.ts
+++ b/tests/lcm-gateway-summarizer.test.ts
@@ -9,9 +9,63 @@ import { setCodexCliFallbackRunnerForProcess } from "@remnic/core";
 import { Orchestrator } from "../src/orchestrator.js";
 import { parseConfig } from "../src/config.js";
 
-test("LCM summarization uses gateway internal LLM when modelSource is gateway", async () => {
+type CapturedGatewayCall = {
+  modelId: string;
+  agentPrompt: string;
+  timeoutMs?: number;
+};
+
+function makeGatewayConfig() {
+  return {
+    agents: {
+      defaults: {
+        model: { primary: "default-provider/default-model" },
+      },
+      list: [
+        {
+          id: "main-agent",
+          name: "Main Remnic provider",
+          model: { primary: "main-provider/main-model" },
+        },
+        {
+          id: "fast-agent",
+          name: "Fast Remnic provider",
+          model: { primary: "fast-provider/fast-model" },
+        },
+      ],
+    },
+    models: {
+      providers: {
+        "default-provider": {
+          baseUrl: "codex-cli://local",
+          api: "codex-cli",
+          models: [{ id: "default-model", name: "default-model" }],
+        },
+        "main-provider": {
+          baseUrl: "codex-cli://local",
+          api: "codex-cli",
+          models: [{ id: "main-model", name: "main-model" }],
+        },
+        "fast-provider": {
+          baseUrl: "codex-cli://local",
+          api: "codex-cli",
+          models: [{ id: "fast-model", name: "fast-model" }],
+        },
+        "task-provider": {
+          baseUrl: "codex-cli://local",
+          api: "codex-cli",
+          models: [{ id: "task-model", name: "task-model" }],
+        },
+      },
+    },
+  };
+}
+
+async function captureLcmGatewaySummary(
+  overrides: Record<string, unknown> = {},
+): Promise<CapturedGatewayCall[]> {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-lcm-gateway-"));
-  const calls: Array<{ modelId: string; agentPrompt: string; timeoutMs?: number }> = [];
+  const calls: CapturedGatewayCall[] = [];
   const restoreRunner = setCodexCliFallbackRunnerForProcess(
     async (request) => {
       calls.push({
@@ -34,32 +88,9 @@ test("LCM summarization uses gateway internal LLM when modelSource is gateway", 
       localLlmEnabled: false,
       localLlmFastTimeoutMs: 1234,
       modelSource: "gateway",
-      gatewayAgentId: "remnic-bench-internal",
-      fastGatewayAgentId: "remnic-bench-internal",
-      gatewayConfig: {
-        agents: {
-          defaults: {
-            model: { primary: "remnic-bench-internal/gpt-5.5" },
-          },
-          list: [
-            {
-              id: "remnic-bench-internal",
-              name: "Remnic bench internal provider",
-              model: { primary: "remnic-bench-internal/gpt-5.5" },
-            },
-          ],
-        },
-        models: {
-          providers: {
-            "remnic-bench-internal": {
-              baseUrl: "codex-cli://local",
-              api: "codex-cli",
-              codexCliReasoningEffort: "xhigh",
-              models: [{ id: "gpt-5.5", name: "gpt-5.5" }],
-            },
-          },
-        },
-      },
+      gatewayAgentId: "main-agent",
+      gatewayConfig: makeGatewayConfig(),
+      ...overrides,
     }),
   );
 
@@ -81,10 +112,7 @@ test("LCM summarization uses gateway internal LLM when modelSource is gateway", 
 
     const stats = await orchestrator.lcmEngine!.getStats("session-1");
     assert.equal(stats.totalSummaryNodes, 1);
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0]?.modelId, "gpt-5.5");
-    assert.equal(calls[0]?.timeoutMs, 1234);
-    assert.match(calls[0]?.agentPrompt ?? "", /gateway too/);
+    return [...calls];
   } finally {
     restoreRunner();
     const teardown = orchestrator as unknown as {
@@ -106,4 +134,32 @@ test("LCM summarization uses gateway internal LLM when modelSource is gateway", 
     orchestrator.lcmEngine?.close();
     await rm(memoryDir, { recursive: true, force: true });
   }
+}
+
+test("LCM summarization uses gateway internal LLM when modelSource is gateway", async () => {
+  const calls = await captureLcmGatewaySummary();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.modelId, "main-model");
+  assert.equal(calls[0]?.timeoutMs, 1234);
+  assert.match(calls[0]?.agentPrompt ?? "", /gateway too/);
+});
+
+test("LCM summarization uses taskModelChain when no fast gateway persona is configured", async () => {
+  const calls = await captureLcmGatewaySummary({
+    taskModelChain: { primary: "task-provider/task-model" },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.modelId, "task-model");
+});
+
+test("LCM summarization preserves fastGatewayAgentId over taskModelChain", async () => {
+  const calls = await captureLcmGatewaySummary({
+    fastGatewayAgentId: "fast-agent",
+    taskModelChain: { primary: "task-provider/task-model" },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.modelId, "fast-model");
 });


### PR DESCRIPTION
## Summary

Four related fixes that prevent Remnic background tasks from using unintended models:

### #1478 — OAuth provider resolution
Add `openai` to `BUILT_IN_PROVIDER_FALLBACKS` so `FallbackLlmClient` can resolve OAuth-only providers. Without this, `openai/gpt-5.4` in the gateway fallback chain is rejected with `provider not found` before runtime auth (OAuth token exchange) is ever attempted.

### #1473 — LCM summarizer uses taskModelChain
Route the LCM `summarizeFn` through `gatewayTaskChainOptions()` so compression/summary calls use the configured `taskModelChain` (e.g. `deepseek-v4-flash`) instead of silently falling to the gateway default chain (which may use expensive models like `deepseek-v4-pro`).

### #1474 — Day summary cron reconciles model on startup
`ensureDaySummaryCron` now uses `updateExisting: true` with `updateFields: ["schedule", "payload", "agentId"]`. The model is resolved from `summaryModel || taskModelChain.primary`. When config changes, the cron job is updated on the next plugin startup.

### #1475 — Day summary cron timezone is configurable
New `daySummaryTimezone` config option (IANA timezone string). When set, the day summary cron uses it instead of `Intl.DateTimeFormat().resolvedOptions().timeZone`.

## Changes

| File | Change |
|------|--------|
| `fallback-llm.ts` | Add `openai` to `BUILT_IN_PROVIDER_FALLBACKS` |
| `orchestrator.ts` | Import `gatewayTaskChainOptions`; spread it into LCM `summarizeFn` call; reconcile day summary cron with model + timezone |
| `memory-governance-cron.ts` | `ensureDaySummaryCron` accepts `model`/`fallbacks`; uses `updateExisting: true` |
| `config.ts` | Add `daySummaryTimezone` config field |
| `types.ts` | Add `daySummaryTimezone?: string` to `PluginConfig` |
| `openclaw.plugin.json` | Add `daySummaryTimezone` to schema |

## Test Results

- TypeScript: clean (`tsc --noEmit`)
- Core tests: **2995 pass, 0 fail**
- Plugin: no test script (no regression)

## Closes

- #1473
- #1474
- #1475
- #1478