### PR TITLE
fix: constrain OpenClaw flush-plan prompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3780,9 +3780,9 @@ const pluginDefinition = {
           reserveTokensFloor: 2_000,
           ...(flushModel ? { model: flushModel } : {}),
           prompt:
-            "Flush the recent OpenClaw transcript into Remnic memory. Preserve durable user preferences, project facts, decisions, corrections, and commitments. Ignore runtime metadata, credentials, and transient command noise.",
+            "Flush the recent OpenClaw transcript into Remnic memory by appending to the allowed flush-plan file only. Preserve durable user preferences, project facts, decisions, corrections, and commitments. Ignore runtime metadata, credentials, and transient command noise.",
           systemPrompt:
-            "You are Remnic's memory flush planner. Produce concise durable memory candidates only when the transcript contains information worth remembering.",
+            "You are Remnic's memory flush planner. Read the transcript and append concise durable memory notes to the file the write tool allows. Do not create files, directories, or dated paths; use only the allowed flush-plan file. Ignore runtime metadata, credentials, transient command noise, and content that is not worth remembering.",
           relativePath: ["state", "plugins", serviceId, "flush-plan.md"].join("/"),
         };
       };

--- a/tests/openclaw-registration-capture.test.ts
+++ b/tests/openclaw-registration-capture.test.ts
@@ -135,6 +135,26 @@ test("flush plan pins configured gateway task model", async () => {
   });
 });
 
+test("flush plan prompt constrains writes to the allowed flush-plan file", async () => {
+  await withCapturedRegistration((plugin) => {
+    const capture = captureOpenClawRegistrationApi();
+
+    plugin.register(capture.api);
+
+    const [flushPlanResolver] = capture.registrations("registerMemoryFlushPlan")[0] as [
+      () => Record<string, unknown>,
+    ];
+    const plan = flushPlanResolver();
+    const prompt = `${String(plan.prompt)}\n${String(plan.systemPrompt)}`;
+
+    assert.equal(plan.relativePath, "state/plugins/openclaw-remnic/flush-plan.md");
+    assert.match(prompt, /allowed flush-plan file/i);
+    assert.match(prompt, /Do not create files, directories, or dated paths/i);
+    assert.doesNotMatch(prompt, /memory-candidates/i);
+    assert.doesNotMatch(prompt, /memory candidates/i);
+  });
+});
+
 test("split-only SDKs receive runtime and flush-plan registrations without unified capability", async () => {
   await withCapturedRegistration((plugin) => {
     const capture = captureOpenClawRegistrationApi({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Prompt-only change to memory flush behavior with no auth, data schema, or runtime logic changes beyond what the model is told to do.
> 
> **Overview**
> Tightens the **OpenClaw memory flush-plan** `prompt` and `systemPrompt` so the flush planner appends durable notes **only** to the configured flush-plan file (`state/plugins/.../flush-plan.md`), instead of behaving like a free-form “memory candidates” writer.
> 
> The user-facing prompt now says to flush into Remnic memory via that allowed file only; the system prompt instructs the model to use the write tool’s permitted path, **not** create files, directories, or dated paths, and to skip noise and low-value content.
> 
> Adds a registration test that asserts `relativePath`, checks the new wording, and confirms references to “memory candidates” are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb916dd261f0f58915d29266777ff80050492f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->