### PR TITLE
fix: harden Pi context handling and append recall

### DIFF
--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -848,6 +848,73 @@ test("context recall does not load full session history", async (t) => {
   assert.equal(result.messages?.at(-1)?.remnicInjected, true);
 });
 
+test("context recall skips stale Pi ctx before snapshot", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response(JSON.stringify({ context: "should not be used" }), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  const stale = makeStaleCtx({ sessionId: "stale-before-snapshot" });
+  stale.markStale();
+
+  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, stale.ctx);
+
+  assert.equal(result, undefined);
+  assert.equal(calls, 0);
+  assert.deepEqual(stale.notifications, []);
+});
+
+test("context recall keeps pi:default fallback when session manager is missing", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const recallBodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = async (_input, init) => {
+    recallBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+    return new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, {
+    cwd: "/tmp/remnic-pi",
+  }) as { messages?: Array<Record<string, unknown>> };
+
+  assert.equal(result.messages?.at(-1)?.remnicInjected, true);
+  assert.equal(recallBodies[0]?.sessionKey, "pi:default");
+  assert.equal(recallBodies[0]?.cwd, "/tmp/remnic-pi");
+});
+
 test("recall context truncation stays within the configured budget", async (t) => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () =>

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -809,6 +809,45 @@ test("context recall appends injected context after stable conversation history"
   assert.equal(result.messages?.[2]?.remnicInjected, true);
 });
 
+test("context recall does not load full session history", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  const sessionManager = {
+    getSessionId: () => "history-free-context",
+    getEntries: () => {
+      throw new Error("getEntries should not be called");
+    },
+    getBranch: () => {
+      throw new Error("getBranch should not be called");
+    },
+  };
+
+  const result = await emit("context", { messages: [{ role: "user", content: "same prompt" }] }, {
+    cwd: "/tmp/remnic-pi",
+    sessionManager,
+  }) as { messages?: Array<Record<string, unknown>> };
+
+  assert.equal(result.messages?.at(-1)?.remnicInjected, true);
+});
+
 test("recall context truncation stays within the configured budget", async (t) => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () =>

--- a/packages/plugin-pi/src/index.test.ts
+++ b/packages/plugin-pi/src/index.test.ts
@@ -764,15 +764,49 @@ test("empty recall responses do not suppress retry for same query", async (t) =>
   const result = await emit("context", event, ctx) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
 
   assert.equal(calls, 2);
-  assert.ok(result.messages?.[0]?.content?.[0]?.text?.includes("remembered context"));
+  const injected = result.messages?.at(-1);
+  assert.ok(injected?.content?.[0]?.text?.includes("remembered context"));
   assert.equal(
-    (result.messages?.[0] as { excludeFromContext?: unknown } | undefined)?.excludeFromContext,
+    (injected as { excludeFromContext?: unknown } | undefined)?.excludeFromContext,
     undefined,
   );
   assert.equal(
-    (result.messages?.[0] as { remnicInjected?: unknown } | undefined)?.remnicInjected,
+    (injected as { remnicInjected?: unknown } | undefined)?.remnicInjected,
     true,
   );
+});
+
+test("context recall appends injected context after stable conversation history", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ context: "remembered context" }), { status: 200 });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  const firstMessage = { role: "system", content: "stable prefix" };
+  const userMessage = { role: "user", content: "same prompt" };
+  const result = await emit("context", { messages: [firstMessage, userMessage] }, {
+    cwd: "/tmp/remnic-pi",
+    sessionManager: { getSessionId: () => "append-recall-test" },
+  }) as { messages?: Array<Record<string, unknown>> };
+
+  assert.equal(result.messages?.[0], firstMessage);
+  assert.equal(result.messages?.[1], userMessage);
+  assert.equal(result.messages?.[2]?.remnicInjected, true);
 });
 
 test("recall context truncation stays within the configured budget", async (t) => {
@@ -802,7 +836,7 @@ test("recall context truncation stays within the configured budget", async (t) =
     sessionManager: { getSessionId: () => "recall-budget-test" },
   }) as { messages?: Array<{ content?: Array<{ text?: string }> }> };
 
-  const text = result.messages?.[0]?.content?.[0]?.text ?? "";
+  const text = result.messages?.at(-1)?.content?.[0]?.text ?? "";
   const context = text.split("Remnic recalled context for this turn:\n\n")[1] ?? "";
   assert.equal(context.length, 40);
   assert.ok(context.endsWith("[Remnic context truncated]"));
@@ -844,6 +878,134 @@ test("failed recall does not suppress retry for same query", async (t) => {
   await emit("context", event, ctx);
 
   assert.equal(calls, 2);
+});
+
+test("context recall failure notification survives stale Pi ctx after await", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const stale = makeStaleCtx({ sessionId: "stale-context-recall" });
+  globalThis.fetch = async () => {
+    stale.markStale();
+    throw new Error("offline");
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  await assert.doesNotReject(() =>
+    emit("context", { messages: [{ role: "user", content: "same prompt" }] }, stale.ctx)
+  );
+  assert.deepEqual(stale.notifications, [
+    { message: "Remnic recall unavailable: offline", level: "warning" },
+  ]);
+});
+
+test("observe failure notification survives stale Pi ctx after await", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const stale = makeStaleCtx({ sessionId: "stale-observe" });
+  globalThis.fetch = async () => {
+    stale.markStale();
+    throw new Error("observe offline");
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  await assert.doesNotReject(() =>
+    emit("message_end", { message: { id: "m1", role: "user", content: "remember this" } }, stale.ctx)
+  );
+  assert.deepEqual(stale.notifications, [
+    { message: "Remnic observe failed: observe offline", level: "warning" },
+  ]);
+});
+
+test("compaction failure notification survives stale Pi ctx after await", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const stale = makeStaleCtx({ sessionId: "stale-compaction" });
+  globalThis.fetch = async () => {
+    stale.markStale();
+    throw new Error("flush offline");
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, emit } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      recallEnabled: false,
+      observeEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  await assert.doesNotReject(() => emit("session_before_compact", { preparation: {} }, stale.ctx));
+  assert.deepEqual(stale.notifications, [
+    { message: "Remnic LCM flush failed: flush offline", level: "warning" },
+  ]);
+});
+
+test("command handlers notify with captured context after stale Pi ctx", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const stale = makeStaleCtx({ sessionId: "stale-command" });
+  const recallBodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = async (_input, init) => {
+    recallBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+    stale.markStale();
+    return new Response(JSON.stringify({ context: "remembered command context" }), { status: 200 });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const { pi, runCommand } = makePiHarness();
+  const extension = createRemnicPiExtension({
+    config: {
+      ...baseConfig(),
+      authToken: "test-token",
+      observeEnabled: false,
+      compactionEnabled: false,
+      mcpToolsEnabled: false,
+      statusEnabled: false,
+    },
+  });
+  await extension(pi as any);
+
+  await assert.doesNotReject(() => runCommand("remnic-recall", "same prompt", stale.ctx));
+  assert.equal(recallBodies[0].sessionKey, "pi:stale-command");
+  assert.equal(recallBodies[0].cwd, "/tmp/remnic-pi");
+  assert.deepEqual(stale.notifications, [
+    { message: "remembered command context", level: "info" },
+  ]);
 });
 
 test("registered MCP tools strip nested session-owned params before forwarding", async (t) => {
@@ -969,13 +1131,17 @@ function baseConfig(): RemnicPiConfig {
 function makePiHarness(): {
   pi: Record<string, unknown>;
   emit: (event: string, payload: unknown, ctx: unknown) => Promise<unknown>;
+  runCommand: (name: string, args: string, ctx: unknown) => Promise<void>;
 } {
   const handlers = new Map<string, Array<(event: unknown, ctx: unknown) => unknown | Promise<unknown>>>();
+  const commands = new Map<string, (args: string, ctx: unknown) => Promise<void>>();
   const pi = {
     on: (event: string, handler: (event: unknown, ctx: unknown) => unknown | Promise<unknown>) => {
       handlers.set(event, [...(handlers.get(event) ?? []), handler]);
     },
-    registerCommand: () => undefined,
+    registerCommand: (name: string, options: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+      commands.set(name, options.handler);
+    },
     registerTool: () => undefined,
     appendEntry: () => undefined,
   };
@@ -988,5 +1154,73 @@ function makePiHarness(): {
       }
       return result;
     },
+    runCommand: async (name, args, ctx) => {
+      const handler = commands.get(name);
+      assert.ok(handler, `missing command ${name}`);
+      await handler(args, ctx);
+    },
+  };
+}
+
+function makeStaleCtx(options: {
+  sessionId: string;
+  cwd?: string;
+  entries?: unknown[];
+  branch?: unknown[];
+}): {
+  ctx: unknown;
+  markStale: () => void;
+  notifications: Array<{ message: string; level: string }>;
+  statuses: Array<{ key: string; value: string }>;
+} {
+  let stale = false;
+  const notifications: Array<{ message: string; level: string }> = [];
+  const statuses: Array<{ key: string; value: string }> = [];
+  const assertActive = () => {
+    if (stale) {
+      throw new Error("This extension ctx is stale after session replacement or reload.");
+    }
+  };
+  const sessionManager = {
+    getSessionId: () => options.sessionId,
+    getEntries: () => options.entries ?? [],
+    getBranch: () => options.branch ?? [],
+  };
+  const ui = {
+    notify(message: string, level: string) {
+      notifications.push({ message, level });
+    },
+    setStatus(key: string, value: string) {
+      statuses.push({ key, value });
+    },
+  };
+
+  return {
+    ctx: {
+      get cwd() {
+        assertActive();
+        return options.cwd ?? "/tmp/remnic-pi";
+      },
+      get hasUI() {
+        assertActive();
+        return true;
+      },
+      get ui() {
+        assertActive();
+        return ui;
+      },
+      get sessionManager() {
+        assertActive();
+        return sessionManager;
+      },
+      compact() {
+        assertActive();
+      },
+    },
+    markStale: () => {
+      stale = true;
+    },
+    notifications,
+    statuses,
   };
 }

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -60,6 +60,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
   return async function remnicPiExtension(pi: PiApi): Promise<void> {
     pi.on("session_start", async (_event, ctx) => {
       const session = snapshotPiContext(ctx, { includeSessionHistory: true });
+      if (!session) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
       restoreObservedState(session, state.observedHashes);
       if (!config.statusEnabled) return;
@@ -68,6 +69,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
 
     pi.on("context", async (event, ctx) => {
       const session = snapshotPiContext(ctx);
+      if (!session) return;
       if (!config.recallEnabled || !config.authToken) return;
       const recallTarget = latestUserRecallTarget(Array.isArray(event.messages) ? event.messages : []);
       if (!recallTarget) return;
@@ -98,6 +100,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
 
     pi.on("message_end", async (event, ctx) => {
       const session = snapshotPiContext(ctx);
+      if (!session) return;
       if (!config.observeEnabled || !isUserMessage(event.message)) return;
       const { state } = getSessionState(session.sessionKey, sessionStates);
       await observeMessagesForSession(session, client, [event.message], state.observedHashes, state.liveObservedReplayKeys);
@@ -105,6 +108,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
 
     pi.on("turn_end", async (event, ctx) => {
       const session = snapshotPiContext(ctx);
+      if (!session) return;
       if (!config.observeEnabled) return;
       const messages = [event.message, ...(Array.isArray(event.toolResults) ? event.toolResults : [])];
       const { state } = getSessionState(session.sessionKey, sessionStates);
@@ -113,6 +117,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
 
     pi.on("session_shutdown", async (_event, ctx) => {
       const session = snapshotPiContext(ctx, { includeSessionHistory: true });
+      if (!session) return;
       const { sessionKey, state } = getSessionState(session.sessionKey, sessionStates);
       if (config.observeEnabled) {
         const branchMessages = branchMessagesWithEntryIdentity(session.branch);
@@ -127,6 +132,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
 
     pi.on("session_before_compact", async (event, ctx) => {
       const session = snapshotPiContext(ctx);
+      if (!session) return;
       if (!config.compactionEnabled || !config.authToken) return;
       const preparation = event.preparation ?? {};
       try {
@@ -248,6 +254,7 @@ function commandHandler(
 ): (args: string, ctx: any) => Promise<void> {
   return async (args, ctx) => {
     const session = snapshotPiContext(ctx);
+    if (!session) return;
     try {
       await handler(args, ctx, session);
     } catch (err) {
@@ -273,6 +280,12 @@ async function registerMcpTools(pi: PiApi, client: RemnicClient, config: RemnicP
       parameters: toPiToolParametersSchema(tool.inputSchema),
       async execute(_toolCallId: string, params: Record<string, unknown>, _signal: AbortSignal | undefined, _onUpdate: unknown, ctx: any) {
         const session = snapshotPiContext(ctx);
+        if (!session) {
+          return {
+            content: [{ type: "text", text: "Remnic tool skipped because the Pi context is no longer active." }],
+            details: { skipped: true, reason: "stale_context" },
+          };
+        }
         const safeParams = stripSessionOwnedRuntimeFields(params ?? {}) as Record<string, unknown>;
         const result = await client.mcpTool(tool.name, {
           ...safeParams,
@@ -387,6 +400,7 @@ export async function observeMessages(
   liveObservedReplayKeys?: Map<string, number>,
 ): Promise<void> {
   const session = snapshotPiContext(ctx);
+  if (!session) return;
   await observeMessagesForSession(session, client, rawMessages, observedHashes, liveObservedReplayKeys);
 }
 
@@ -537,8 +551,9 @@ async function setStatus(session: PiContextSnapshot, client: RemnicClient, confi
   }
 }
 
-function snapshotPiContext(ctx: any, options: PiContextSnapshotOptions = {}): PiContextSnapshot {
+function snapshotPiContext(ctx: any, options: PiContextSnapshotOptions = {}): PiContextSnapshot | null {
   const sessionKey = safeSessionKeyFromContext(ctx);
+  if (!sessionKey) return null;
   const cwd = safeStringRead(() => ctx?.cwd, "");
   const hasUI = safeRead(() => ctx?.hasUI, undefined) === false;
   const ui = hasUI ? undefined : safeRead(() => ctx?.ui, undefined);
@@ -555,11 +570,11 @@ function snapshotPiContext(ctx: any, options: PiContextSnapshotOptions = {}): Pi
   };
 }
 
-function safeSessionKeyFromContext(ctx: any): string {
+function safeSessionKeyFromContext(ctx: any): string | null {
   try {
     return sessionKeyFromContext(ctx);
   } catch {
-    return "pi:default";
+    return null;
   }
 }
 

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -48,6 +48,9 @@ type PiContextSnapshot = {
   setStatus: (key: string, value: string) => void;
   compact?: () => unknown;
 };
+type PiContextSnapshotOptions = {
+  includeSessionHistory?: boolean;
+};
 
 export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) {
   const config = options.config ?? loadConfig(options);
@@ -56,7 +59,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
 
   return async function remnicPiExtension(pi: PiApi): Promise<void> {
     pi.on("session_start", async (_event, ctx) => {
-      const session = snapshotPiContext(ctx);
+      const session = snapshotPiContext(ctx, { includeSessionHistory: true });
       const { state } = getSessionState(session.sessionKey, sessionStates);
       restoreObservedState(session, state.observedHashes);
       if (!config.statusEnabled) return;
@@ -109,7 +112,7 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
     });
 
     pi.on("session_shutdown", async (_event, ctx) => {
-      const session = snapshotPiContext(ctx);
+      const session = snapshotPiContext(ctx, { includeSessionHistory: true });
       const { sessionKey, state } = getSessionState(session.sessionKey, sessionStates);
       if (config.observeEnabled) {
         const branchMessages = branchMessagesWithEntryIdentity(session.branch);
@@ -534,17 +537,18 @@ async function setStatus(session: PiContextSnapshot, client: RemnicClient, confi
   }
 }
 
-function snapshotPiContext(ctx: any): PiContextSnapshot {
+function snapshotPiContext(ctx: any, options: PiContextSnapshotOptions = {}): PiContextSnapshot {
   const sessionKey = safeSessionKeyFromContext(ctx);
   const cwd = safeStringRead(() => ctx?.cwd, "");
   const hasUI = safeRead(() => ctx?.hasUI, undefined) === false;
   const ui = hasUI ? undefined : safeRead(() => ctx?.ui, undefined);
   const compact = safeRead(() => ctx?.compact, undefined);
+  const includeSessionHistory = options.includeSessionHistory === true;
   return {
     sessionKey,
     cwd,
-    entries: safeEntries(ctx),
-    branch: safeBranch(ctx),
+    entries: includeSessionHistory ? safeEntries(ctx) : [],
+    branch: includeSessionHistory ? safeBranch(ctx) : [],
     notify: makeNotifier(ui, hasUI),
     setStatus: makeStatusSetter(ui, hasUI),
     compact: typeof compact === "function" ? () => compact.call(ctx) : undefined,

--- a/packages/plugin-pi/src/index.ts
+++ b/packages/plugin-pi/src/index.ts
@@ -36,6 +36,19 @@ type PiSessionState = {
   lastInjectedRecallKey: string;
 };
 
+type NotifyLevel = "info" | "success" | "warning" | "error";
+type NotifyFn = (message: string, level: NotifyLevel) => void;
+
+type PiContextSnapshot = {
+  sessionKey: string;
+  cwd: string;
+  entries: any[];
+  branch: any[];
+  notify: NotifyFn;
+  setStatus: (key: string, value: string) => void;
+  compact?: () => unknown;
+};
+
 export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) {
   const config = options.config ?? loadConfig(options);
   const client = new RemnicClient(config);
@@ -43,75 +56,80 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
 
   return async function remnicPiExtension(pi: PiApi): Promise<void> {
     pi.on("session_start", async (_event, ctx) => {
-      const { state } = getSessionState(ctx, sessionStates);
-      restoreObservedState(ctx, state.observedHashes);
+      const session = snapshotPiContext(ctx);
+      const { state } = getSessionState(session.sessionKey, sessionStates);
+      restoreObservedState(session, state.observedHashes);
       if (!config.statusEnabled) return;
-      await setStatus(ctx, client, config);
+      await setStatus(session, client, config);
     });
 
     pi.on("context", async (event, ctx) => {
+      const session = snapshotPiContext(ctx);
       if (!config.recallEnabled || !config.authToken) return;
       const recallTarget = latestUserRecallTarget(Array.isArray(event.messages) ? event.messages : []);
       if (!recallTarget) return;
       const { query } = recallTarget;
-      const sessionKey = sessionKeyFromContext(ctx);
-      const { state } = getSessionState(ctx, sessionStates);
+      const { state } = getSessionState(session.sessionKey, sessionStates);
       if (recallTarget.dedupeKey === state.lastInjectedRecallKey) return;
 
       try {
-        const recalled = await client.recall(query, sessionKey, ctx.cwd);
+        const recalled = await client.recall(query, session.sessionKey, session.cwd);
         const context = trimContext(recalled.context ?? "", config.recallBudgetChars);
         if (!context) return;
         state.lastInjectedRecallKey = recallTarget.dedupeKey;
         return {
           messages: [
+            ...event.messages,
             {
               role: "user",
               content: [{ type: "text", text: `Remnic recalled context for this turn:\n\n${context}` }],
               remnicInjected: true,
               timestamp: Date.now(),
             },
-            ...event.messages,
           ],
         };
       } catch (err) {
-        notify(ctx, `Remnic recall unavailable: ${errorMessage(err)}`, "warning");
+        session.notify(`Remnic recall unavailable: ${errorMessage(err)}`, "warning");
       }
     });
 
     pi.on("message_end", async (event, ctx) => {
+      const session = snapshotPiContext(ctx);
       if (!config.observeEnabled || !isUserMessage(event.message)) return;
-      const { state } = getSessionState(ctx, sessionStates);
-      await observeMessages(ctx, client, [event.message], state.observedHashes, state.liveObservedReplayKeys);
+      const { state } = getSessionState(session.sessionKey, sessionStates);
+      await observeMessagesForSession(session, client, [event.message], state.observedHashes, state.liveObservedReplayKeys);
     });
 
     pi.on("turn_end", async (event, ctx) => {
+      const session = snapshotPiContext(ctx);
       if (!config.observeEnabled) return;
       const messages = [event.message, ...(Array.isArray(event.toolResults) ? event.toolResults : [])];
-      const { state } = getSessionState(ctx, sessionStates);
-      await observeMessages(ctx, client, messages, state.observedHashes, state.liveObservedReplayKeys);
+      const { state } = getSessionState(session.sessionKey, sessionStates);
+      await observeMessagesForSession(session, client, messages, state.observedHashes, state.liveObservedReplayKeys);
     });
 
     pi.on("session_shutdown", async (_event, ctx) => {
-      const { sessionKey, state } = getSessionState(ctx, sessionStates);
+      const session = snapshotPiContext(ctx);
+      const { sessionKey, state } = getSessionState(session.sessionKey, sessionStates);
       if (config.observeEnabled) {
-        const branch = safeBranch(ctx);
-        const branchMessages = branchMessagesWithEntryIdentity(branch);
-        const unobservedBranchMessages = skipLiveObservedReplayMessages(ctx, branchMessages, state.liveObservedReplayKeys);
-        if (unobservedBranchMessages.length > 0) await observeMessages(ctx, client, unobservedBranchMessages, state.observedHashes);
+        const branchMessages = branchMessagesWithEntryIdentity(session.branch);
+        const unobservedBranchMessages = skipLiveObservedReplayMessages(session.sessionKey, branchMessages, state.liveObservedReplayKeys);
+        if (unobservedBranchMessages.length > 0) {
+          await observeMessagesForSession(session, client, unobservedBranchMessages, state.observedHashes);
+        }
       }
       persistObservedState(pi, state.observedHashes);
       sessionStates.delete(sessionKey);
     });
 
     pi.on("session_before_compact", async (event, ctx) => {
+      const session = snapshotPiContext(ctx);
       if (!config.compactionEnabled || !config.authToken) return;
-      const sessionKey = sessionKeyFromContext(ctx);
       const preparation = event.preparation ?? {};
       try {
-        await client.lcmCompactionFlush(sessionKey);
+        await client.lcmCompactionFlush(session.sessionKey);
       } catch (err) {
-        notify(ctx, `Remnic LCM flush failed: ${errorMessage(err)}`, "warning");
+        session.notify(`Remnic LCM flush failed: ${errorMessage(err)}`, "warning");
         return;
       }
 
@@ -119,18 +137,18 @@ export function createRemnicPiExtension(options: RemnicPiExtensionOptions = {}) 
       const tokensAfter = finiteTokenCount(preparation.tokensAfter);
       if (tokensBefore !== null && tokensAfter !== null) {
         try {
-          await client.lcmCompactionRecord(sessionKey, tokensBefore, tokensAfter);
+          await client.lcmCompactionRecord(session.sessionKey, tokensBefore, tokensAfter);
         } catch (err) {
-          notify(ctx, `Remnic LCM compaction token record failed: ${errorMessage(err)}`, "warning");
+          session.notify(`Remnic LCM compaction token record failed: ${errorMessage(err)}`, "warning");
         }
       }
 
       const summary = buildCompactionSummary(preparation);
       if (!summary.trim()) return;
       try {
-        await client.contextCheckpoint(sessionKey, summary);
+        await client.contextCheckpoint(session.sessionKey, summary);
       } catch (err) {
-        notify(ctx, `Remnic context checkpoint failed: ${errorMessage(err)}`, "warning");
+        session.notify(`Remnic context checkpoint failed: ${errorMessage(err)}`, "warning");
       }
       const details = fileDetailsFromPreparation(preparation);
       return {
@@ -160,74 +178,77 @@ export default async function remnicPiExtension(pi: PiApi): Promise<void> {
 function registerCommands(pi: PiApi, client: RemnicClient, config: RemnicPiConfig): void {
   pi.registerCommand("remnic-status", {
     description: "Check Remnic daemon status",
-    handler: commandHandler(async (_args, ctx) => {
+    handler: commandHandler(async (_args, _ctx, session) => {
       const health = await client.health();
-      notify(ctx, `Remnic ${health.ok ? "healthy" : "unhealthy"} at ${config.remnicDaemonUrl}`, health.ok ? "success" : "warning");
+      session.notify(`Remnic ${health.ok ? "healthy" : "unhealthy"} at ${config.remnicDaemonUrl}`, health.ok ? "success" : "warning");
     }),
   });
 
   pi.registerCommand("remnic-recall", {
     description: "Recall Remnic context for a query",
-    handler: commandHandler(async (args, ctx) => {
+    handler: commandHandler(async (args, _ctx, session) => {
       const query = args.trim();
       if (!query) {
-        notify(ctx, "Usage: /remnic-recall <query>", "warning");
+        session.notify("Usage: /remnic-recall <query>", "warning");
         return;
       }
-      const result = await client.recall(query, sessionKeyFromContext(ctx), ctx.cwd);
-      notify(ctx, trimContext(result.context ?? "(no Remnic context)", MAX_CONTEXT_CHARS), "info");
+      const result = await client.recall(query, session.sessionKey, session.cwd);
+      session.notify(trimContext(result.context ?? "(no Remnic context)", MAX_CONTEXT_CHARS), "info");
     }),
   });
 
   pi.registerCommand("remnic-remember", {
     description: "Store a Remnic memory",
-    handler: commandHandler(async (args, ctx) => {
+    handler: commandHandler(async (args, _ctx, session) => {
       const content = args.trim();
       if (!content) {
-        notify(ctx, "Usage: /remnic-remember <memory>", "warning");
+        session.notify("Usage: /remnic-remember <memory>", "warning");
         return;
       }
-      await client.storeMemory(content, sessionKeyFromContext(ctx));
-      notify(ctx, "Stored Remnic memory", "success");
+      await client.storeMemory(content, session.sessionKey);
+      session.notify("Stored Remnic memory", "success");
     }),
   });
 
   pi.registerCommand("remnic-lcm-search", {
     description: "Search Remnic LCM archived Pi context",
-    handler: commandHandler(async (args, ctx) => {
+    handler: commandHandler(async (args, _ctx, session) => {
       const query = args.trim();
       if (!query) {
-        notify(ctx, "Usage: /remnic-lcm-search <query>", "warning");
+        session.notify("Usage: /remnic-lcm-search <query>", "warning");
         return;
       }
-      const result = await client.lcmSearch(query, sessionKeyFromContext(ctx));
-      notify(ctx, JSON.stringify(result, null, 2), "info");
+      const result = await client.lcmSearch(query, session.sessionKey);
+      session.notify(JSON.stringify(result, null, 2), "info");
     }),
   });
 
   pi.registerCommand("remnic-why", {
     description: "Explain the last Remnic recall",
-    handler: commandHandler(async (_args, ctx) => {
-      const result = await client.recallExplain(sessionKeyFromContext(ctx));
-      notify(ctx, JSON.stringify(result, null, 2), "info");
+    handler: commandHandler(async (_args, _ctx, session) => {
+      const result = await client.recallExplain(session.sessionKey);
+      session.notify(JSON.stringify(result, null, 2), "info");
     }),
   });
 
   pi.registerCommand("remnic-compact", {
     description: "Trigger Pi compaction with Remnic LCM coordination",
-    handler: commandHandler(async (_args, ctx) => {
-      ctx.compact?.();
-      notify(ctx, "Compaction requested", "info");
+    handler: commandHandler(async (_args, _ctx, session) => {
+      session.compact?.();
+      session.notify("Compaction requested", "info");
     }),
   });
 }
 
-function commandHandler(handler: (args: string, ctx: any) => Promise<void>): (args: string, ctx: any) => Promise<void> {
+function commandHandler(
+  handler: (args: string, ctx: any, session: PiContextSnapshot) => Promise<void>,
+): (args: string, ctx: any) => Promise<void> {
   return async (args, ctx) => {
+    const session = snapshotPiContext(ctx);
     try {
-      await handler(args, ctx);
+      await handler(args, ctx, session);
     } catch (err) {
-      notify(ctx, `Remnic command failed: ${errorMessage(err)}`, "warning");
+      session.notify(`Remnic command failed: ${errorMessage(err)}`, "warning");
     }
   };
 }
@@ -248,13 +269,13 @@ async function registerMcpTools(pi: PiApi, client: RemnicClient, config: RemnicP
       description: tool.description ?? `Call ${tool.name}`,
       parameters: toPiToolParametersSchema(tool.inputSchema),
       async execute(_toolCallId: string, params: Record<string, unknown>, _signal: AbortSignal | undefined, _onUpdate: unknown, ctx: any) {
-        const sessionKey = sessionKeyFromContext(ctx);
+        const session = snapshotPiContext(ctx);
         const safeParams = stripSessionOwnedRuntimeFields(params ?? {}) as Record<string, unknown>;
         const result = await client.mcpTool(tool.name, {
           ...safeParams,
-          sessionKey,
+          sessionKey: session.sessionKey,
           namespace: config.namespace,
-          cwd: ctx.cwd,
+          cwd: session.cwd,
         });
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -333,8 +354,7 @@ function isUserMessage(message: unknown): boolean {
   return isRecord(message) && message.role === "user";
 }
 
-function getSessionState(ctx: any, states: Map<string, PiSessionState>): { sessionKey: string; state: PiSessionState } {
-  const sessionKey = sessionKeyFromContext(ctx);
+function getSessionState(sessionKey: string, states: Map<string, PiSessionState>): { sessionKey: string; state: PiSessionState } {
   let state = states.get(sessionKey);
   if (!state) {
     state = {
@@ -363,28 +383,38 @@ export async function observeMessages(
   observedHashes: Set<string>,
   liveObservedReplayKeys?: Map<string, number>,
 ): Promise<void> {
-  const sessionKey = sessionKeyFromContext(ctx);
+  const session = snapshotPiContext(ctx);
+  await observeMessagesForSession(session, client, rawMessages, observedHashes, liveObservedReplayKeys);
+}
+
+async function observeMessagesForSession(
+  session: PiContextSnapshot,
+  client: RemnicClient,
+  rawMessages: unknown[],
+  observedHashes: Set<string>,
+  liveObservedReplayKeys?: Map<string, number>,
+): Promise<void> {
   const messages: ObserveMessage[] = [];
   const pendingHashes = new Set<string>();
   for (const raw of rawMessages) {
     const message = toObserveMessage(raw);
     if (!message) continue;
-    const hash = observedMessageDedupeKey(message, sessionKey);
+    const hash = observedMessageDedupeKey(message, session.sessionKey);
     if (hash && (observedHashes.has(hash) || pendingHashes.has(hash))) continue;
     if (hash) pendingHashes.add(hash);
     messages.push(message);
   }
   if (messages.length === 0) return;
   try {
-    await client.observe(sessionKey, ctx.cwd, messages);
+    await client.observe(session.sessionKey, session.cwd, messages);
     for (const hash of pendingHashes) rememberObservedHash(observedHashes, hash);
     if (liveObservedReplayKeys) {
       for (const message of messages) {
-        rememberLiveObservedReplayKey(liveObservedReplayKeys, liveReplayKey(message, sessionKey));
+        rememberLiveObservedReplayKey(liveObservedReplayKeys, liveReplayKey(message, session.sessionKey));
       }
     }
   } catch (err) {
-    notify(ctx, `Remnic observe failed: ${errorMessage(err)}`, "warning");
+    session.notify(`Remnic observe failed: ${errorMessage(err)}`, "warning");
   }
 }
 
@@ -432,8 +462,8 @@ function fileDetailsFromPreparation(preparation: any): { readFiles: string[]; mo
   };
 }
 
-function restoreObservedState(ctx: any, observedHashes: Set<string>): void {
-  for (const entry of safeEntries(ctx)) {
+function restoreObservedState(session: PiContextSnapshot, observedHashes: Set<string>): void {
+  for (const entry of session.entries) {
     if (entry?.type !== "custom" || entry.customType !== STATE_CUSTOM_TYPE) continue;
     const hashes = entry.data?.observedHashes;
     if (Array.isArray(hashes)) {
@@ -467,12 +497,11 @@ function consumeLiveObservedReplayKey(liveObservedReplayKeys: Map<string, number
 }
 
 function skipLiveObservedReplayMessages(
-  ctx: any,
+  sessionKey: string,
   rawMessages: unknown[],
   liveObservedReplayKeys: Map<string, number>,
 ): unknown[] {
   if (liveObservedReplayKeys.size === 0) return rawMessages;
-  const sessionKey = sessionKeyFromContext(ctx);
   const unobserved: unknown[] = [];
   for (const raw of rawMessages) {
     const message = toObserveMessage(raw);
@@ -496,13 +525,80 @@ function persistObservedState(pi: PiApi, observedHashes: Set<string>): void {
   });
 }
 
-async function setStatus(ctx: any, client: RemnicClient, config: RemnicPiConfig): Promise<void> {
+async function setStatus(session: PiContextSnapshot, client: RemnicClient, config: RemnicPiConfig): Promise<void> {
   try {
     await client.health({ timeoutMs: config.startupRequestTimeoutMs });
-    ctx.ui?.setStatus?.("remnic", `Remnic ${config.namespace ? `(${config.namespace})` : "ready"}`);
+    session.setStatus("remnic", `Remnic ${config.namespace ? `(${config.namespace})` : "ready"}`);
   } catch {
-    ctx.ui?.setStatus?.("remnic", "Remnic offline");
+    session.setStatus("remnic", "Remnic offline");
   }
+}
+
+function snapshotPiContext(ctx: any): PiContextSnapshot {
+  const sessionKey = safeSessionKeyFromContext(ctx);
+  const cwd = safeStringRead(() => ctx?.cwd, "");
+  const hasUI = safeRead(() => ctx?.hasUI, undefined) === false;
+  const ui = hasUI ? undefined : safeRead(() => ctx?.ui, undefined);
+  const compact = safeRead(() => ctx?.compact, undefined);
+  return {
+    sessionKey,
+    cwd,
+    entries: safeEntries(ctx),
+    branch: safeBranch(ctx),
+    notify: makeNotifier(ui, hasUI),
+    setStatus: makeStatusSetter(ui, hasUI),
+    compact: typeof compact === "function" ? () => compact.call(ctx) : undefined,
+  };
+}
+
+function safeSessionKeyFromContext(ctx: any): string {
+  try {
+    return sessionKeyFromContext(ctx);
+  } catch {
+    return "pi:default";
+  }
+}
+
+function makeNotifier(ui: unknown, hasUI: boolean): NotifyFn {
+  if (hasUI || !isRecord(ui) || typeof ui.notify !== "function") {
+    return () => undefined;
+  }
+  const notifyFn = ui.notify;
+  return (message, level) => {
+    try {
+      notifyFn.call(ui, message, level);
+    } catch {
+      // Pi invalidates session-bound UI objects during reload/replacement. A
+      // notification failure must not tear down Remnic's hooks.
+    }
+  };
+}
+
+function makeStatusSetter(ui: unknown, hasUI: boolean): PiContextSnapshot["setStatus"] {
+  if (hasUI || !isRecord(ui) || typeof ui.setStatus !== "function") {
+    return () => undefined;
+  }
+  const setStatusFn = ui.setStatus;
+  return (key, value) => {
+    try {
+      setStatusFn.call(ui, key, value);
+    } catch {
+      // See makeNotifier: stale UI should not make extension startup fail.
+    }
+  };
+}
+
+function safeRead<T>(read: () => T, fallback: T): T {
+  try {
+    return read();
+  } catch {
+    return fallback;
+  }
+}
+
+function safeStringRead(read: () => unknown, fallback: string): string {
+  const value = safeRead(read, fallback);
+  return typeof value === "string" ? value : fallback;
 }
 
 function safeEntries(ctx: any): any[] {
@@ -559,11 +655,6 @@ function trimContext(value: string, budget: number): string {
   if (value.length <= budget) return value;
   if (budget <= TRUNCATION_NOTICE.length) return TRUNCATION_NOTICE.slice(0, budget);
   return `${value.slice(0, budget - TRUNCATION_NOTICE.length)}${TRUNCATION_NOTICE}`;
-}
-
-function notify(ctx: any, message: string, level: "info" | "success" | "warning" | "error"): void {
-  if (ctx?.hasUI === false) return;
-  ctx?.ui?.notify?.(message, level);
 }
 
 function errorMessage(err: unknown): string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core Pi hook paths (context injection, observe, compaction, commands) where ordering and session routing affect model input and Remnic API calls; behavior change on recall message order is user-visible.
> 
> **Overview**
> Hardens the Remnic Pi extension against **stale or invalidated Pi session contexts** (reload/replacement) by snapshotting `sessionKey`, `cwd`, UI hooks, and optional history up front via **`snapshotPiContext`**, then routing recall/observe/compaction/commands/MCP through that snapshot instead of touching `ctx` after `await`.
> 
> **Recall behavior** changes: injected Remnic context is **appended** after the existing `event.messages` (not prepended), and the normal `context` hook avoids loading full session history unless `includeSessionHistory` is set (e.g. `session_start` / `session_shutdown`). Stale contexts are skipped before network calls; post-await warnings use captured notifiers that swallow UI errors so hooks do not throw. MCP execution returns a explicit skip when the context is no longer active.
> 
> Tests add **`makeStaleCtx`**, command harness support, and coverage for append order, history-free recall, stale pre-snapshot skip, `pi:default` fallback, and notifications after async failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62dbcb66a4fbb911312405fb52f399f958964fc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->