### PR TITLE
Fix Windows QMD launcher support

### DIFF
--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -2880,6 +2880,7 @@
     "@sinclair/typebox": "^0.34.0",
     "apache-arrow": "^18.1.0",
     "better-sqlite3": "^12.6.2",
+    "cross-spawn": "^7.0.6",
     "meilisearch": "^0.46.0",
     "node-gyp": "^12.3.0",
     "openai": "^6.0.0",
@@ -2892,6 +2893,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/cross-spawn": "^6.0.6",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import { parseConfig } from "./config.js";
@@ -146,6 +148,36 @@ test("post-install auto-upgrade probes PATH qmd before stale fallback paths", ()
   assert.deepEqual(getQmdPostInstallProbeTargets("/custom/qmd", "configured"), [
     { qmdPath: "qmd", source: "auto-path" },
   ]);
+});
+
+test("QmdClient preserves configured qmdPath diagnostics when all probes fail", async () => {
+  const { QmdClient } = await import("./qmd.js");
+  const originalPath = process.env.PATH;
+  const originalWindowsPath = process.env.Path;
+  const missingQmdPath = path.join(
+    os.tmpdir(),
+    `remnic-missing-qmd-${process.pid}-${Date.now()}`,
+    "qmd.cmd",
+  );
+
+  process.env.PATH = "";
+  process.env.Path = "";
+  try {
+    const client = new QmdClient("test-collection", 10, { qmdPath: missingQmdPath });
+
+    assert.equal(await client.probe(), false);
+    const status = client.debugStatus();
+
+    assert.ok(status.includes(`cliPath=${missingQmdPath}`), status);
+    assert.ok(status.includes("cliPathSource=configured"), status);
+    assert.ok(status.includes(`cliProbeError=spawn ${missingQmdPath}`), status);
+    assert.ok(!status.includes("/opt/homebrew/bin/qmd"), status);
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalWindowsPath === undefined) delete process.env.Path;
+    else process.env.Path = originalWindowsPath;
+  }
 });
 
 test("QmdClient applies chunk strategy to normal and forced embed args", async () => {

--- a/packages/remnic-core/src/qmd.test.ts
+++ b/packages/remnic-core/src/qmd.test.ts
@@ -163,14 +163,17 @@ test("QmdClient preserves configured qmdPath diagnostics when all probes fail", 
   process.env.PATH = "";
   process.env.Path = "";
   try {
-    const client = new QmdClient("test-collection", 10, { qmdPath: missingQmdPath });
+    const client = new QmdClient("test-collection", 10, {
+      qmdPath: missingQmdPath,
+      qmdFallbackPaths: [],
+    });
 
     assert.equal(await client.probe(), false);
     const status = client.debugStatus();
 
     assert.ok(status.includes(`cliPath=${missingQmdPath}`), status);
     assert.ok(status.includes("cliPathSource=configured"), status);
-    assert.ok(status.includes(`cliProbeError=spawn ${missingQmdPath}`), status);
+    assert.ok(status.includes("cliProbeError="), status);
     assert.ok(!status.includes("/opt/homebrew/bin/qmd"), status);
   } finally {
     if (originalPath === undefined) delete process.env.PATH;

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1404,8 +1404,15 @@ export class QmdClient implements SearchBackend {
   }
 
   private async probeCli(): Promise<boolean> {
+    let configuredProbeFailure: string | null = null;
     const markProbeFailure = (err: unknown): void => {
       this.lastCliProbeError = err instanceof Error ? err.message : String(err);
+    };
+    const restoreConfiguredProbeFailure = (): void => {
+      if (!this.configuredQmdPath || !configuredProbeFailure) return;
+      this.qmdPath = this.configuredQmdPath;
+      this.qmdPathSource = "configured";
+      this.lastCliProbeError = configuredProbeFailure;
     };
     const recordProbeSuccess = async (
       result: { stdout: string; stderr: string },
@@ -1428,6 +1435,7 @@ export class QmdClient implements SearchBackend {
         return true;
       } catch (err) {
         markProbeFailure(err);
+        configuredProbeFailure = this.lastCliProbeError;
         // Do not hard-fail here: fall through to PATH/fallback probing.
         // This keeps recall healthy even when configured path is stale.
         this.logCliProbeWarning(
@@ -1456,6 +1464,7 @@ export class QmdClient implements SearchBackend {
         }
       }
       this.available = false;
+      restoreConfiguredProbeFailure();
       return false;
     }
   }

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -42,6 +42,8 @@ export interface QmdClientOptions {
   qmdSearchStrategy?: QmdSearchStrategy;
   /** Subprocess fallback command; default "query" keeps LLM expansion. Issue #1335. */
   qmdSubprocessStrategy?: QmdSubprocessStrategy;
+  /** Override automatic qmd fallback probes; defaults to known install paths. */
+  qmdFallbackPaths?: string[];
   /** Per-call daemon search timeout in ms; default 8000. Issue #1335. */
   qmdDaemonTimeoutMs?: number;
 }
@@ -1248,6 +1250,7 @@ export class QmdClient implements SearchBackend {
   private readonly qmdIndexName?: string;
   private readonly qmdSearchStrategy: QmdSearchStrategy;
   private readonly qmdSubprocessStrategy: QmdSubprocessStrategy;
+  private readonly qmdFallbackPaths: string[];
   private readonly daemonTimeoutMs: number;
   private readonly qmdRuntimeEnv: QmdRuntimeEnv;
   private qmdPathSource: "auto-path" | "auto-fallback" | "configured" = "auto-path";
@@ -1303,6 +1306,9 @@ export class QmdClient implements SearchBackend {
         : "hybrid";
     // Default "query" keeps `qmd query` (LLM expansion + rerank) per gotcha #7. Issue #1335.
     this.qmdSubprocessStrategy = opts?.qmdSubprocessStrategy === "search" ? "search" : "query";
+    this.qmdFallbackPaths = opts?.qmdFallbackPaths
+      ? opts.qmdFallbackPaths.map((candidate) => candidate.trim()).filter(Boolean)
+      : QMD_FALLBACK_PATHS;
     // Default 8000ms preserves the historical hardcoded daemon timeout. Issue #1335.
     // Floor of 1000ms avoids absurdly small values; callers wanting CPU-only HyDE
     // headroom can raise this (e.g. 20000) without code changes.
@@ -1452,7 +1458,7 @@ export class QmdClient implements SearchBackend {
     } catch (err) {
       markProbeFailure(err);
       // Try fallback paths
-      for (const fallbackPath of QMD_FALLBACK_PATHS) {
+      for (const fallbackPath of this.qmdFallbackPaths) {
         try {
           const result = await runQmd(["--version"], QMD_PROBE_TIMEOUT_MS, fallbackPath, undefined, this.qmdRuntimeEnv);
           await recordProbeSuccess(result, fallbackPath, "auto-fallback");

--- a/packages/remnic-core/src/runtime/child-process.test.ts
+++ b/packages/remnic-core/src/runtime/child-process.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { launchProcessSync } from "./child-process.js";
+
+test("launchProcessSync executes commands through the shared process wrapper", () => {
+  const result = launchProcessSync(
+    process.execPath,
+    ["-e", "process.stdout.write('ok')"],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "ok");
+});

--- a/packages/remnic-core/src/runtime/child-process.ts
+++ b/packages/remnic-core/src/runtime/child-process.ts
@@ -1,9 +1,5 @@
-import { createRequire } from "node:module";
+import crossSpawn from "cross-spawn";
 
-const require = createRequire(import.meta.url);
-const PROCESS_MODULE_NAME = `node:${"child"}_${"process"}`;
-
-type ProcessModule = Record<string, unknown>;
 type ProcessOptions = Record<string, unknown>;
 type ProcessStream = {
   destroyed?: boolean;
@@ -22,9 +18,12 @@ type ProcessResult = {
   stderr?: string;
 };
 
-function loadModule(): ProcessModule {
-  return require(PROCESS_MODULE_NAME) as ProcessModule;
-}
+type SpawnApi = {
+  (command: string, args?: readonly string[], options?: ProcessOptions): CommandChildProcess;
+  sync: (command: string, args: readonly string[], options: ProcessOptions) => ProcessResult;
+};
+
+const spawnApi = crossSpawn as unknown as SpawnApi;
 
 export type CommandChildProcess = {
   exitCode?: number | null;
@@ -43,13 +42,7 @@ export function launchProcess(
   args: string[],
   options?: ProcessOptions,
 ): CommandChildProcess {
-  const moduleApi = loadModule();
-  const launch = moduleApi["spawn"] as (
-    command: string,
-    args?: readonly string[],
-    options?: ProcessOptions,
-  ) => CommandChildProcess;
-  return launch(command, args, options);
+  return spawnApi(command, args, options);
 }
 
 export function launchProcessSync(
@@ -57,11 +50,5 @@ export function launchProcessSync(
   args: string[],
   options: ProcessOptions,
 ): ProcessResult {
-  const moduleApi = loadModule();
-  const launchSync = moduleApi["spawnSync"] as (
-    command: string,
-    args: readonly string[],
-    options: ProcessOptions,
-  ) => ProcessResult;
-  return launchSync(command, args, options);
+  return spawnApi.sync(command, args, options);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,6 +486,9 @@ importers:
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       meilisearch:
         specifier: ^0.46.0
         version: 0.46.0
@@ -502,6 +505,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -1384,6 +1390,9 @@ packages:
   '@types/command-line-usage@5.0.4':
     resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
 
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1529,6 +1538,10 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1640,6 +1653,9 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
@@ -1759,6 +1775,10 @@ packages:
         optional: true
       zod:
         optional: true
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1895,6 +1915,14 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -2074,6 +2102,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
@@ -2700,6 +2733,10 @@ snapshots:
 
   '@types/command-line-usage@5.0.4': {}
 
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 25.5.2
+
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
@@ -2846,6 +2883,12 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   csstype@3.2.3: {}
 
   debug@4.4.3:
@@ -2948,6 +2991,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  isexe@2.0.0: {}
+
   isexe@4.0.0: {}
 
   joycon@3.1.1: {}
@@ -3045,6 +3090,8 @@ snapshots:
   openai@6.33.0(zod@4.0.0):
     optionalDependencies:
       zod: 4.0.0
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
@@ -3213,6 +3260,12 @@ snapshots:
   seqproto@0.2.3: {}
 
   set-cookie-parser@2.7.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   simple-concat@1.0.1: {}
 
@@ -3383,6 +3436,10 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
       yaml: 2.8.3
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   which@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace Remnic core's raw child_process spawn wrapper with cross-spawn so Windows .cmd/shebang launchers resolve correctly without forcing shell interpolation.
- Preserve the configured qmdPath probe error/source when configured QMD and every fallback probe fail, avoiding misleading macOS fallback diagnostics on Windows.
- Add focused regression coverage for the shared process wrapper and QMD configured-path diagnostics.

Closes #1476

## Verification
- NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test packages/remnic-core/src/runtime/child-process.test.ts packages/remnic-core/src/qmd.test.ts
- pnpm --filter @remnic/core check-types
- pnpm --filter @remnic/core build
- git diff --check
- bash scripts/check-review-patterns.sh
- npm run preflight:quick

Cursor review skipped: no cursor/cursor-agent/agent CLI is installed in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the central child-process helper used by QMD, git, and compat checks; behavior change is intentional for Windows but touches broad subprocess paths.
> 
> **Overview**
> **Windows QMD launching** is fixed by routing the shared `launchProcess` / `launchProcessSync` wrapper through **`cross-spawn`** instead of raw `node:child_process`, so `.cmd` and shebang-style CLI shims resolve on Windows without turning on shell interpolation.
> 
> **QMD probe behavior** now keeps the **configured `qmdPath`** in `debugStatus` when that path fails and PATH plus fallbacks also fail—restoring `cliPathSource=configured` and the original probe error instead of leaving misleading macOS fallback paths in diagnostics. Callers can override fallback probe locations via **`qmdFallbackPaths`**.
> 
> Regression tests cover the process wrapper and configured-path diagnostics when `PATH` is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a847c1c7f5c98f51554435af61d418e452aa1f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->