### PR TITLE
Add privacy-first local AI session summary drafts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@
 - [Benchmark Readiness](benchmarks/sota-readiness.md) — #841-#850 cue-recall audit for published memory benchmarks
 - [Retention Policy](retention-policy.md) — Hot/cold tier substrate, value-score model, `remnic forget`, `remnic tier list/explain` (issue #686)
 - [Import / Export](import-export.md) — Portable backups and migration
+- [Local AI Session Summary Drafts](local-session-summaries.md) — Privacy-first local transcript harvesting into sanitized summary drafts
 - [ops/pr-review-hardening-playbook.md](ops/pr-review-hardening-playbook.md) — Pre-push review checklist
 - [ops/plugin-engineering-patterns.md](ops/plugin-engineering-patterns.md) — Engineering patterns for retrieval/intent/cache
 

--- a/docs/local-session-summaries.md
+++ b/docs/local-session-summaries.md
@@ -1,0 +1,115 @@
+# Local AI session summary drafts
+
+Remnic can harvest local AI session transcripts into privacy-first summary
+drafts. This feature is intentionally generic: it reads JSON or JSONL files
+from a directory, parses transcript-like rows with a pluggable adapter, applies
+redaction, and writes only compact summaries plus metadata.
+
+It does not store raw transcript text by default. It also does not store source
+file paths or raw source session keys.
+
+## Public adapter shape
+
+Adapters implement `LocalSessionSourceAdapter` from `@remnic/core`:
+
+```ts
+export interface LocalSessionSourceAdapter {
+  id: string;
+  parseFile(
+    input: {
+      content: string;
+      fileName: string;
+      fileExtension: string;
+      fileRef: string;
+    },
+    options?: { strict?: boolean },
+  ): LocalSessionParsedFile | Promise<LocalSessionParsedFile>;
+}
+```
+
+Built-in adapters:
+
+- `generic-jsonl`
+- `codex-jsonl`
+- `claude-jsonl`
+
+The built-ins are deliberately shape-based. They look for common transcript
+fields such as `role`, `sender`, `content`, `text`, `message`, `timestamp`,
+`sessionKey`, `conversation_id`, and `thread_id`. They do not know any
+install-specific transcript paths.
+
+## Programmatic use
+
+```ts
+import { runLocalSessionSummaryCliCommand } from "@remnic/core";
+
+await runLocalSessionSummaryCliCommand({
+  inputDir: "./local-transcripts",
+  source: "generic-jsonl",
+  memoryDir: "./remnic-memory",
+  write: true,
+});
+```
+
+Without `write: true`, the runner returns a dry-run report and writes nothing.
+With `write: true`, it writes JSONL summary drafts under:
+
+```text
+<memoryDir>/state/session-summary-drafts/
+```
+
+These files are draft artifacts, not durable memory files. A later importer or
+review workflow can decide which summaries should become memories.
+
+## Redaction
+
+Default redaction rules replace:
+
+- secret-like tokens and `KEY=value` strings
+- email addresses
+- private IPv4 addresses
+- HTTP and HTTPS URLs
+- absolute POSIX and Windows paths
+
+Custom rules can be supplied inline or through a JSON file:
+
+```json
+{
+  "rules": [
+    {
+      "name": "ticket",
+      "pattern": "\\bABC-\\d+\\b",
+      "replacement": "[REDACTED_TICKET]"
+    }
+  ]
+}
+```
+
+Set `includeRedactedExcerpts: true` only when you want short sanitized excerpts
+inside draft artifacts. The default metadata-only mode stores no transcript
+excerpts at all.
+
+## Draft privacy contract
+
+Each `SessionSummaryDraft` records:
+
+- hashed source session reference
+- hashed source file references and file extensions
+- turn counts and role counts
+- first and last timestamps when available
+- a generic summary string
+- redaction counts and rule names
+
+Each draft declares:
+
+```json
+{
+  "storesRawTranscript": false,
+  "storesLocalPaths": false,
+  "storesSourceSessionKey": false
+}
+```
+
+Adapters should preserve that contract. If an adapter needs source-specific
+metadata, store hashes or stable public labels instead of machine-local paths,
+hostnames, account names, customer names, or raw transcript payloads.

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -754,9 +754,7 @@ export {
   type ExtensionSchema,
 } from "./memory-extension-host/index.js";
 
-export {
-  buildExtensionsBlockForConsolidation,
-} from "./semantic-consolidation.js";
+export { buildExtensionsBlockForConsolidation } from "./semantic-consolidation.js";
 
 // ---------------------------------------------------------------------------
 // Connector Manager
@@ -1085,6 +1083,12 @@ export {
 } from "./fallback-llm.js";
 
 // ---------------------------------------------------------------------------
+// Local AI session summary drafts
+// ---------------------------------------------------------------------------
+
+export * from "./session-summaries/index.js";
+
+// ---------------------------------------------------------------------------
 // Training-data export (issue #459)
 // ---------------------------------------------------------------------------
 
@@ -1177,7 +1181,6 @@ export type {
   BudgetDecisionReason,
   CrossNamespaceBudgetConfig,
 } from "./cross-namespace-budget.js";
-
 
 // ---------------------------------------------------------------------------
 // Recall-audit anomaly detector (issue #565 PR 5/5)

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -151,7 +151,9 @@ function extractRowsFromJson(value: unknown): unknown[] {
   const obj = value as Record<string, unknown>;
   for (const key of ["turns", "messages", "events", "entries", "items"]) {
     const rows = obj[key];
-    if (Array.isArray(rows)) return rows.map((row) => inheritEnvelopeSessionFields(row, obj));
+    if (Array.isArray(rows) && rows.length > 0) {
+      return rows.map((row) => inheritEnvelopeSessionFields(row, obj));
+    }
   }
   return [obj];
 }

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -113,6 +113,7 @@ function sessionKeyFromRow(row: unknown): string | undefined {
   const obj = row as Record<string, unknown>;
   const payload = objectField(obj.payload);
   const payloadMessage = objectField(payload?.message);
+  const rowType = firstString(obj.type, obj.kind, obj.event)?.toLowerCase();
   return firstString(
     obj.sessionKey,
     obj.session_key,
@@ -124,6 +125,7 @@ function sessionKeyFromRow(row: unknown): string | undefined {
     obj.thread_id,
     obj.transcriptId,
     obj.transcript_id,
+    rowType === "session_meta" ? payload?.id : undefined,
     payload?.sessionKey,
     payload?.session_key,
     payload?.sessionId,

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -347,7 +347,7 @@ function pushTurnWithCodexMirrorDedupe(
   }
 
   const existing = codexMirrorTurns.get(key);
-  if (existing && existing.surface !== surface) {
+  if (existing) {
     if (CODEX_MIRROR_SURFACE_PRIORITY[surface] > CODEX_MIRROR_SURFACE_PRIORITY[existing.surface]) {
       turns[existing.index] = turn;
       codexMirrorTurns.set(key, { index: existing.index, surface });

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -209,10 +209,8 @@ function parseRows(
   }
   try {
     return { rows: extractRowsFromJson(JSON.parse(content)), warnings: [] };
-  } catch (error) {
-    const message = `Invalid ${adapterId} JSON in fileRef ${fileRef}: ${
-      error instanceof Error ? error.message : String(error)
-    }`;
+  } catch {
+    const message = `Invalid ${adapterId} JSON in fileRef ${fileRef}; skipping file.`;
     if (strict) throw new Error(message);
     return {
       rows: [],

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -1,0 +1,339 @@
+import type { LocalSessionParsedFile, LocalSessionRole, LocalSessionSourceAdapter, LocalSessionTurn } from "./types.js";
+
+const VALID_ROLES = new Set<LocalSessionRole>(["user", "assistant", "tool", "system", "other"]);
+
+function normalizeRole(value: unknown): LocalSessionRole {
+  if (typeof value !== "string") return "other";
+  const role = value.trim().toLowerCase();
+  if (VALID_ROLES.has(role as LocalSessionRole)) {
+    return role as LocalSessionRole;
+  }
+  if (role === "human") return "user";
+  if (role === "ai" || role === "model" || role === "bot") return "assistant";
+  if (role === "function") return "tool";
+  return "other";
+}
+
+function normalizeTimestamp(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const millis = value > 1e12 ? value : value * 1000;
+    const date = new Date(millis);
+    return Number.isFinite(date.getTime()) ? date.toISOString() : undefined;
+  }
+  if (typeof value !== "string" || value.trim().length === 0) return undefined;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : undefined;
+}
+
+function normalizeContent(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((part) => normalizeContent(part))
+      .filter((part): part is string => typeof part === "string")
+      .join("\n")
+      .trim();
+    return parts.length > 0 ? parts : undefined;
+  }
+  if (!value || typeof value !== "object") return undefined;
+  const obj = value as Record<string, unknown>;
+  if (firstString(obj.type) === "tool_result") return undefined;
+  return normalizeContent(obj.text ?? obj.content ?? obj.message ?? obj.parts ?? obj.value ?? obj.input);
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function firstContent(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const content = normalizeContent(value);
+    if (content) return content;
+  }
+  return undefined;
+}
+
+function objectField(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+const SESSION_KEY_FIELDS = [
+  "sessionKey",
+  "session_key",
+  "sessionId",
+  "session_id",
+  "conversationId",
+  "conversation_id",
+  "threadId",
+  "thread_id",
+  "transcriptId",
+  "transcript_id",
+] as const;
+
+function inheritEnvelopeSessionFields(row: unknown, envelope: Record<string, unknown>): unknown {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return row;
+  const child = row as Record<string, unknown>;
+  const inherited: Record<string, unknown> = {};
+  for (const key of SESSION_KEY_FIELDS) {
+    if (
+      child[key] === undefined &&
+      ((typeof envelope[key] === "string" && envelope[key].trim().length > 0) ||
+        (typeof envelope[key] === "number" && Number.isFinite(envelope[key])))
+    ) {
+      inherited[key] = envelope[key];
+    }
+  }
+  return Object.keys(inherited).length > 0 ? { ...inherited, ...child } : row;
+}
+
+function codexRoleFromTypes(
+  rowType: string | undefined,
+  payloadType: string | undefined
+): LocalSessionRole | undefined {
+  if (payloadType === "agent_message") return "assistant";
+  if (payloadType === "user_message") return "user";
+  if (rowType === "event_msg") return "user";
+  if (rowType === "response_item") return "assistant";
+  return undefined;
+}
+
+function sessionKeyFromRow(row: unknown): string | undefined {
+  if (!row || typeof row !== "object") return undefined;
+  const obj = row as Record<string, unknown>;
+  const payload = objectField(obj.payload);
+  const payloadMessage = objectField(payload?.message);
+  return firstString(
+    obj.sessionKey,
+    obj.session_key,
+    obj.sessionId,
+    obj.session_id,
+    obj.conversationId,
+    obj.conversation_id,
+    obj.threadId,
+    obj.thread_id,
+    obj.transcriptId,
+    obj.transcript_id,
+    payload?.sessionKey,
+    payload?.session_key,
+    payload?.sessionId,
+    payload?.session_id,
+    payload?.conversationId,
+    payload?.conversation_id,
+    payload?.threadId,
+    payload?.thread_id,
+    payloadMessage?.sessionKey,
+    payloadMessage?.session_key,
+    payloadMessage?.sessionId,
+    payloadMessage?.session_id,
+    payloadMessage?.conversationId,
+    payloadMessage?.conversation_id,
+    payloadMessage?.threadId,
+    payloadMessage?.thread_id
+  );
+}
+
+function extractRowsFromJson(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== "object") return [];
+  const obj = value as Record<string, unknown>;
+  for (const key of ["turns", "messages", "events", "entries", "items"]) {
+    const rows = obj[key];
+    if (Array.isArray(rows)) return rows.map((row) => inheritEnvelopeSessionFields(row, obj));
+  }
+  return [obj];
+}
+
+function parseJsonlRows(
+  content: string,
+  adapterId: string,
+  strict: boolean | undefined,
+  fileRef: string
+): { rows: unknown[]; warnings: LocalSessionParsedFile["warnings"] } {
+  const rows: unknown[] = [];
+  const warnings: LocalSessionParsedFile["warnings"] = [];
+  for (const [index, line] of content.split("\n").entries()) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    try {
+      rows.push(JSON.parse(trimmed));
+    } catch {
+      const warning = {
+        code: `${adapterId}.jsonl.invalid_line`,
+        message: `Skipping invalid JSONL line ${index + 1}.`,
+        fileRef,
+        line: index + 1,
+      };
+      if (strict) throw new Error(warning.message);
+      warnings.push(warning);
+    }
+  }
+  return { rows, warnings };
+}
+
+function parseRows(
+  content: string,
+  extension: string,
+  adapterId: string,
+  strict: boolean | undefined,
+  fileRef: string
+): { rows: unknown[]; warnings: LocalSessionParsedFile["warnings"] } {
+  if (extension === ".jsonl") {
+    return parseJsonlRows(content, adapterId, strict, fileRef);
+  }
+  try {
+    return { rows: extractRowsFromJson(JSON.parse(content)), warnings: [] };
+  } catch (error) {
+    const message = `Invalid ${adapterId} JSON: ${error instanceof Error ? error.message : String(error)}`;
+    if (strict) throw new Error(message);
+    return {
+      rows: [],
+      warnings: [{ code: `${adapterId}.json.invalid`, message, fileRef }],
+    };
+  }
+}
+
+function turnFromRow(row: unknown, fallbackSessionKey: string): LocalSessionTurn | null {
+  if (!row || typeof row !== "object") return null;
+  const obj = row as Record<string, unknown>;
+  const nestedMessage = objectField(obj.message);
+  const payload = objectField(obj.payload);
+  const payloadItem = objectField(payload?.item);
+  const payloadMessage = objectField(payload?.message);
+  const author = objectField(obj.author);
+  const rowType = firstString(obj.type, obj.kind, obj.event);
+  const payloadType = firstString(payload?.type, payloadItem?.type);
+  const codexRole = codexRoleFromTypes(rowType, payloadType);
+
+  const content = firstContent(
+    obj.content,
+    obj.text,
+    obj.message,
+    obj.body,
+    obj.parts,
+    obj.input,
+    payload?.message,
+    payload?.content,
+    payload?.text,
+    payload?.body,
+    payload?.parts,
+    payload?.input,
+    payloadMessage?.content,
+    payloadMessage?.text,
+    payloadMessage?.parts,
+    payloadMessage?.input,
+    payloadItem?.content,
+    payloadItem?.text,
+    payloadItem?.message,
+    payloadItem?.parts,
+    payloadItem?.input,
+    nestedMessage?.content,
+    nestedMessage?.text,
+    nestedMessage?.parts,
+    nestedMessage?.input
+  );
+  if (!content) return null;
+
+  const role = normalizeRole(
+    obj.role ??
+      obj.sender ??
+      obj.actor ??
+      payload?.role ??
+      payload?.sender ??
+      payloadMessage?.role ??
+      payloadMessage?.sender ??
+      payloadItem?.role ??
+      nestedMessage?.role ??
+      nestedMessage?.sender ??
+      author?.role ??
+      codexRole ??
+      obj.type
+  );
+
+  return {
+    role,
+    content,
+    timestamp: normalizeTimestamp(
+      obj.timestamp ??
+        obj.createdAt ??
+        obj.created_at ??
+        obj.time ??
+        obj.date ??
+        payload?.timestamp ??
+        payload?.createdAt ??
+        payload?.created_at ??
+        payloadMessage?.timestamp ??
+        payloadMessage?.createdAt ??
+        payloadMessage?.created_at ??
+        payloadItem?.timestamp ??
+        payloadItem?.created_at ??
+        nestedMessage?.timestamp ??
+        nestedMessage?.created_at
+    ),
+    sessionKey: sessionKeyFromRow(row) ?? fallbackSessionKey,
+    sourceId: firstString(obj.id, obj.uuid, obj.turnId, obj.turn_id, payload?.id, payloadItem?.id),
+  };
+}
+
+function makeJsonTranscriptAdapter(id: string): LocalSessionSourceAdapter {
+  return {
+    id,
+    parseFile(input, options = {}) {
+      const parsed = parseRows(input.content, input.fileExtension, id, options.strict, input.fileRef);
+      const fallbackSessionKey = `${id}:${input.fileRef}`;
+      let currentSessionKey = fallbackSessionKey;
+      const turns: LocalSessionTurn[] = [];
+      for (const row of parsed.rows) {
+        currentSessionKey = sessionKeyFromRow(row) ?? currentSessionKey;
+        const turn = turnFromRow(row, currentSessionKey);
+        if (turn) {
+          currentSessionKey = turn.sessionKey ?? currentSessionKey;
+          turns.push(turn);
+        }
+      }
+      return { turns, warnings: parsed.warnings };
+    },
+  };
+}
+
+const BUILT_IN_ADAPTERS = new Map<string, LocalSessionSourceAdapter>();
+
+export function registerLocalSessionSourceAdapter(adapter: LocalSessionSourceAdapter): void {
+  if (!adapter || typeof adapter !== "object") {
+    throw new Error("local session source adapter must be an object");
+  }
+  if (typeof adapter.id !== "string" || adapter.id.trim().length === 0) {
+    throw new Error("local session source adapter id must be a non-empty string");
+  }
+  if (typeof adapter.parseFile !== "function") {
+    throw new Error(`local session adapter '${adapter.id}' must define parseFile`);
+  }
+  const id = adapter.id.trim();
+  if (BUILT_IN_ADAPTERS.has(id)) {
+    throw new Error(`local session adapter '${id}' is already registered`);
+  }
+  BUILT_IN_ADAPTERS.set(id, adapter.id === id ? adapter : { ...adapter, id });
+}
+
+export function getLocalSessionSourceAdapter(id: string | undefined): LocalSessionSourceAdapter | undefined {
+  const key = typeof id === "string" && id.trim().length > 0 ? id.trim() : "generic-jsonl";
+  return BUILT_IN_ADAPTERS.get(key);
+}
+
+export function listLocalSessionSourceAdapters(): string[] {
+  return [...BUILT_IN_ADAPTERS.keys()].sort();
+}
+
+for (const adapterId of ["generic-jsonl", "codex-jsonl", "claude-jsonl"]) {
+  registerLocalSessionSourceAdapter(makeJsonTranscriptAdapter(adapterId));
+}

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -81,20 +81,23 @@ const SESSION_KEY_FIELDS = [
   "transcript_id",
 ] as const;
 
+function hasUsableSessionKeyField(value: unknown): boolean {
+  return (
+    (typeof value === "string" && value.trim().length > 0) ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
 function inheritEnvelopeSessionFields(row: unknown, envelope: Record<string, unknown>): unknown {
   if (!row || typeof row !== "object" || Array.isArray(row)) return row;
   const child = row as Record<string, unknown>;
   const inherited: Record<string, unknown> = {};
   for (const key of SESSION_KEY_FIELDS) {
-    if (
-      child[key] === undefined &&
-      ((typeof envelope[key] === "string" && envelope[key].trim().length > 0) ||
-        (typeof envelope[key] === "number" && Number.isFinite(envelope[key])))
-    ) {
+    if (!hasUsableSessionKeyField(child[key]) && hasUsableSessionKeyField(envelope[key])) {
       inherited[key] = envelope[key];
     }
   }
-  return Object.keys(inherited).length > 0 ? { ...inherited, ...child } : row;
+  return Object.keys(inherited).length > 0 ? { ...child, ...inherited } : row;
 }
 
 function codexRoleFromTypes(

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -137,6 +137,8 @@ function sessionKeyFromRow(row: unknown): string | undefined {
     nestedMessage?.conversation_id,
     nestedMessage?.threadId,
     nestedMessage?.thread_id,
+    nestedMessage?.transcriptId,
+    nestedMessage?.transcript_id,
     rowType === "session_meta" ? payload?.id : undefined,
     payload?.sessionKey,
     payload?.session_key,
@@ -146,6 +148,8 @@ function sessionKeyFromRow(row: unknown): string | undefined {
     payload?.conversation_id,
     payload?.threadId,
     payload?.thread_id,
+    payload?.transcriptId,
+    payload?.transcript_id,
     payloadMessage?.sessionKey,
     payloadMessage?.session_key,
     payloadMessage?.sessionId,
@@ -153,7 +157,9 @@ function sessionKeyFromRow(row: unknown): string | undefined {
     payloadMessage?.conversationId,
     payloadMessage?.conversation_id,
     payloadMessage?.threadId,
-    payloadMessage?.thread_id
+    payloadMessage?.thread_id,
+    payloadMessage?.transcriptId,
+    payloadMessage?.transcript_id
   );
 }
 
@@ -344,7 +350,7 @@ function pushTurnWithCodexMirrorDedupe(
   row: unknown,
   turn: LocalSessionTurn,
   turns: LocalSessionTurn[],
-  codexMirrorTurns: Map<string, { index: number; surface: CodexMirrorSurface; rowSignal?: string }>
+  codexMirrorTurns: Map<string, { index: number; surface: CodexMirrorSurface; rowSignal?: string }[]>
 ): void {
   const key = codexMirrorKey(adapterId, row, turn);
   const surface = key ? codexMirrorSurface(row) : undefined;
@@ -353,22 +359,26 @@ function pushTurnWithCodexMirrorDedupe(
     return;
   }
 
-  const existing = codexMirrorTurns.get(key);
+  const candidates = codexMirrorTurns.get(key) ?? [];
   const rowSignal = turn.sourceId ?? turn.timestamp;
-  if (existing) {
-    if (existing.surface === surface && (!existing.rowSignal || !rowSignal || existing.rowSignal !== rowSignal)) {
-      codexMirrorTurns.set(key, { index: turns.length, surface, ...(rowSignal ? { rowSignal } : {}) });
-      turns.push(turn);
-      return;
+  const matchingIndex = candidates.findIndex((candidate) => {
+    if (candidate.surface === surface) {
+      return Boolean(candidate.rowSignal && rowSignal && candidate.rowSignal === rowSignal);
     }
+    return Boolean(candidate.rowSignal && rowSignal && candidate.rowSignal === rowSignal);
+  });
+  const existing = matchingIndex >= 0 ? candidates[matchingIndex] : undefined;
+  if (existing) {
     if (CODEX_MIRROR_SURFACE_PRIORITY[surface] > CODEX_MIRROR_SURFACE_PRIORITY[existing.surface]) {
       turns[existing.index] = turn;
-      codexMirrorTurns.set(key, { index: existing.index, surface, ...(rowSignal ? { rowSignal } : {}) });
+      candidates[matchingIndex] = { index: existing.index, surface, ...(rowSignal ? { rowSignal } : {}) };
+      codexMirrorTurns.set(key, candidates);
     }
     return;
   }
 
-  codexMirrorTurns.set(key, { index: turns.length, surface, ...(rowSignal ? { rowSignal } : {}) });
+  candidates.push({ index: turns.length, surface, ...(rowSignal ? { rowSignal } : {}) });
+  codexMirrorTurns.set(key, candidates);
   turns.push(turn);
 }
 
@@ -380,7 +390,7 @@ function makeJsonTranscriptAdapter(id: string): LocalSessionSourceAdapter {
       const fallbackSessionKey = `${id}:${input.fileRef}`;
       let currentSessionKey = fallbackSessionKey;
       const turns: LocalSessionTurn[] = [];
-      const codexMirrorTurns = new Map<string, { index: number; surface: CodexMirrorSurface; rowSignal?: string }>();
+      const codexMirrorTurns = new Map<string, { index: number; surface: CodexMirrorSurface; rowSignal?: string }[]>();
       for (const row of parsed.rows) {
         if (shouldSkipRowForAdapter(id, row)) continue;
         currentSessionKey = sessionKeyFromRow(row) ?? currentSessionKey;

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -114,6 +114,7 @@ function codexRoleFromTypes(
 function sessionKeyFromRow(row: unknown): string | undefined {
   if (!row || typeof row !== "object") return undefined;
   const obj = row as Record<string, unknown>;
+  const nestedMessage = objectField(obj.message);
   const payload = objectField(obj.payload);
   const payloadMessage = objectField(payload?.message);
   const rowType = firstString(obj.type, obj.kind, obj.event)?.toLowerCase();
@@ -128,6 +129,14 @@ function sessionKeyFromRow(row: unknown): string | undefined {
     obj.thread_id,
     obj.transcriptId,
     obj.transcript_id,
+    nestedMessage?.sessionKey,
+    nestedMessage?.session_key,
+    nestedMessage?.sessionId,
+    nestedMessage?.session_id,
+    nestedMessage?.conversationId,
+    nestedMessage?.conversation_id,
+    nestedMessage?.threadId,
+    nestedMessage?.thread_id,
     rowType === "session_meta" ? payload?.id : undefined,
     payload?.sessionKey,
     payload?.session_key,
@@ -337,7 +346,7 @@ function pushTurnWithCodexMirrorDedupe(
   row: unknown,
   turn: LocalSessionTurn,
   turns: LocalSessionTurn[],
-  codexMirrorTurns: Map<string, { index: number; surface: CodexMirrorSurface }>
+  codexMirrorTurns: Map<string, { index: number; surface: CodexMirrorSurface; rowSignal?: string }>
 ): void {
   const key = codexMirrorKey(adapterId, row, turn);
   const surface = key ? codexMirrorSurface(row) : undefined;
@@ -347,15 +356,21 @@ function pushTurnWithCodexMirrorDedupe(
   }
 
   const existing = codexMirrorTurns.get(key);
+  const rowSignal = turn.sourceId ?? turn.timestamp;
   if (existing) {
+    if (existing.surface === surface && (!existing.rowSignal || !rowSignal || existing.rowSignal !== rowSignal)) {
+      codexMirrorTurns.set(key, { index: turns.length, surface, ...(rowSignal ? { rowSignal } : {}) });
+      turns.push(turn);
+      return;
+    }
     if (CODEX_MIRROR_SURFACE_PRIORITY[surface] > CODEX_MIRROR_SURFACE_PRIORITY[existing.surface]) {
       turns[existing.index] = turn;
-      codexMirrorTurns.set(key, { index: existing.index, surface });
+      codexMirrorTurns.set(key, { index: existing.index, surface, ...(rowSignal ? { rowSignal } : {}) });
     }
     return;
   }
 
-  codexMirrorTurns.set(key, { index: turns.length, surface });
+  codexMirrorTurns.set(key, { index: turns.length, surface, ...(rowSignal ? { rowSignal } : {}) });
   turns.push(turn);
 }
 
@@ -367,7 +382,7 @@ function makeJsonTranscriptAdapter(id: string): LocalSessionSourceAdapter {
       const fallbackSessionKey = `${id}:${input.fileRef}`;
       let currentSessionKey = fallbackSessionKey;
       const turns: LocalSessionTurn[] = [];
-      const codexMirrorTurns = new Map<string, { index: number; surface: CodexMirrorSurface }>();
+      const codexMirrorTurns = new Map<string, { index: number; surface: CodexMirrorSurface; rowSignal?: string }>();
       for (const row of parsed.rows) {
         if (shouldSkipRowForAdapter(id, row)) continue;
         currentSessionKey = sessionKeyFromRow(row) ?? currentSessionKey;

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -303,6 +303,62 @@ function shouldSkipRowForAdapter(adapterId: string, row: unknown): boolean {
   return rowType === "compacted" || payloadType === "compacted";
 }
 
+type CodexMirrorSurface = "event-agent-message" | "response-item";
+
+const CODEX_MIRROR_SURFACE_PRIORITY: Record<CodexMirrorSurface, number> = {
+  "event-agent-message": 1,
+  "response-item": 2,
+};
+
+function codexMirrorSurface(row: unknown): CodexMirrorSurface | undefined {
+  if (!row || typeof row !== "object") return undefined;
+  const obj = row as Record<string, unknown>;
+  const payload = objectField(obj.payload);
+  const payloadItem = objectField(payload?.item);
+  const rowType = firstString(obj.type, obj.kind, obj.event)?.toLowerCase();
+  const payloadType = firstString(payload?.type, payloadItem?.type)?.toLowerCase();
+  if (rowType === "event_msg" && payloadType === "agent_message") return "event-agent-message";
+  if (rowType === "response_item") return "response-item";
+  return undefined;
+}
+
+function codexMirrorKey(adapterId: string, row: unknown, turn: LocalSessionTurn): string | undefined {
+  if (adapterId !== "codex-jsonl" || turn.role !== "assistant") return undefined;
+  const surface = codexMirrorSurface(row);
+  if (!surface) return undefined;
+  const sessionKey = turn.sessionKey?.trim();
+  const content = turn.content.replace(/\s+/g, " ").trim();
+  if (!sessionKey || content.length === 0) return undefined;
+  return `${sessionKey}\0${turn.role}\0${content}`;
+}
+
+function pushTurnWithCodexMirrorDedupe(
+  adapterId: string,
+  row: unknown,
+  turn: LocalSessionTurn,
+  turns: LocalSessionTurn[],
+  codexMirrorTurns: Map<string, { index: number; surface: CodexMirrorSurface }>
+): void {
+  const key = codexMirrorKey(adapterId, row, turn);
+  const surface = key ? codexMirrorSurface(row) : undefined;
+  if (!key || !surface) {
+    turns.push(turn);
+    return;
+  }
+
+  const existing = codexMirrorTurns.get(key);
+  if (existing && existing.surface !== surface) {
+    if (CODEX_MIRROR_SURFACE_PRIORITY[surface] > CODEX_MIRROR_SURFACE_PRIORITY[existing.surface]) {
+      turns[existing.index] = turn;
+      codexMirrorTurns.set(key, { index: existing.index, surface });
+    }
+    return;
+  }
+
+  codexMirrorTurns.set(key, { index: turns.length, surface });
+  turns.push(turn);
+}
+
 function makeJsonTranscriptAdapter(id: string): LocalSessionSourceAdapter {
   return {
     id,
@@ -311,13 +367,14 @@ function makeJsonTranscriptAdapter(id: string): LocalSessionSourceAdapter {
       const fallbackSessionKey = `${id}:${input.fileRef}`;
       let currentSessionKey = fallbackSessionKey;
       const turns: LocalSessionTurn[] = [];
+      const codexMirrorTurns = new Map<string, { index: number; surface: CodexMirrorSurface }>();
       for (const row of parsed.rows) {
         if (shouldSkipRowForAdapter(id, row)) continue;
         currentSessionKey = sessionKeyFromRow(row) ?? currentSessionKey;
         const turn = turnFromRow(row, currentSessionKey);
         if (turn) {
           currentSessionKey = turn.sessionKey ?? currentSessionKey;
-          turns.push(turn);
+          pushTurnWithCodexMirrorDedupe(id, row, turn, turns, codexMirrorTurns);
         }
       }
       return { turns, warnings: parsed.warnings };

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -174,7 +174,7 @@ function parseJsonlRows(
     } catch {
       const warning = {
         code: `${adapterId}.jsonl.invalid_line`,
-        message: `Skipping invalid JSONL line ${index + 1}.`,
+        message: `Skipping invalid JSONL line ${index + 1} in fileRef ${fileRef}.`,
         fileRef,
         line: index + 1,
       };
@@ -198,7 +198,9 @@ function parseRows(
   try {
     return { rows: extractRowsFromJson(JSON.parse(content)), warnings: [] };
   } catch (error) {
-    const message = `Invalid ${adapterId} JSON: ${error instanceof Error ? error.message : String(error)}`;
+    const message = `Invalid ${adapterId} JSON in fileRef ${fileRef}: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
     if (strict) throw new Error(message);
     return {
       rows: [],

--- a/packages/remnic-core/src/session-summaries/adapters.ts
+++ b/packages/remnic-core/src/session-summaries/adapters.ts
@@ -291,6 +291,15 @@ function turnFromRow(row: unknown, fallbackSessionKey: string): LocalSessionTurn
   };
 }
 
+function shouldSkipRowForAdapter(adapterId: string, row: unknown): boolean {
+  if (adapterId !== "codex-jsonl" || !row || typeof row !== "object") return false;
+  const obj = row as Record<string, unknown>;
+  const payload = objectField(obj.payload);
+  const rowType = firstString(obj.type, obj.kind, obj.event)?.toLowerCase();
+  const payloadType = firstString(payload?.type)?.toLowerCase();
+  return rowType === "compacted" || payloadType === "compacted";
+}
+
 function makeJsonTranscriptAdapter(id: string): LocalSessionSourceAdapter {
   return {
     id,
@@ -300,6 +309,7 @@ function makeJsonTranscriptAdapter(id: string): LocalSessionSourceAdapter {
       let currentSessionKey = fallbackSessionKey;
       const turns: LocalSessionTurn[] = [];
       for (const row of parsed.rows) {
+        if (shouldSkipRowForAdapter(id, row)) continue;
         currentSessionKey = sessionKeyFromRow(row) ?? currentSessionKey;
         const turn = turnFromRow(row, currentSessionKey);
         if (turn) {

--- a/packages/remnic-core/src/session-summaries/index.ts
+++ b/packages/remnic-core/src/session-summaries/index.ts
@@ -143,7 +143,7 @@ function buildDraft(options: {
   const dateText = firstTimestamp && lastTimestamp ? ` from ${firstTimestamp} to ${lastTimestamp}` : "";
   const summary =
     `Local AI session summary: ${sortedTurns.length} turn(s)` +
-    ` (${roles.user} user, ${roles.assistant} assistant, ${roles.tool} tool)` +
+    ` (${roles.user} user, ${roles.assistant} assistant, ${roles.tool} tool, ${roles.system} system, ${roles.other} other)` +
     `${dateText}. Raw transcript text, source session keys, and local file paths are not stored.`;
 
   return {

--- a/packages/remnic-core/src/session-summaries/index.ts
+++ b/packages/remnic-core/src/session-summaries/index.ts
@@ -1,0 +1,382 @@
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { expandTildePath } from "../utils/path.js";
+import { getLocalSessionSourceAdapter, listLocalSessionSourceAdapters } from "./adapters.js";
+import { compileRedactionRules, redactSessionSummaryText } from "./redaction.js";
+import type {
+  CollectLocalSessionSummariesOptions,
+  CompiledRedactionRule,
+  LocalSessionRole,
+  LocalSessionSummaryCliOptions,
+  LocalSessionSummaryReport,
+  LocalSessionTurn,
+  RedactionConfig,
+  SessionSummaryDraft,
+  SessionSummaryExcerpt,
+} from "./types.js";
+
+export * from "./adapters.js";
+export * from "./redaction.js";
+export * from "./types.js";
+
+const DEFAULT_MAX_FILES = 5000;
+const DEFAULT_MAX_SESSIONS = 500;
+const SUPPORTED_EXTENSIONS = new Set([".json", ".jsonl"]);
+
+function shortHash(value: string, length = 16): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, length);
+}
+
+async function listTranscriptFiles(root: string, maxFiles: number): Promise<{ files: string[]; truncated: boolean }> {
+  const out: string[] = [];
+  async function visit(dir: string): Promise<void> {
+    const entries = (await readdir(dir, { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      if (entry.isSymbolicLink()) continue;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!SUPPORTED_EXTENSIONS.has(ext)) continue;
+      out.push(fullPath);
+    }
+  }
+  await visit(root);
+  const sorted = out.sort();
+  return {
+    files: sorted.slice(0, maxFiles),
+    truncated: sorted.length > maxFiles,
+  };
+}
+
+function validatePositiveInt(value: number | undefined, name: string, defaultValue: number): number {
+  if (value === undefined) return defaultValue;
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function normalizeInputDir(inputDir: string): string {
+  if (typeof inputDir !== "string" || inputDir.trim().length === 0) {
+    throw new Error("inputDir must be a non-empty string");
+  }
+  return path.resolve(expandTildePath(inputDir.trim()));
+}
+
+function initRoleCounts(): Record<LocalSessionRole, number> {
+  return {
+    user: 0,
+    assistant: 0,
+    tool: 0,
+    system: 0,
+    other: 0,
+  };
+}
+
+function safeTimestampSortValue(turn: LocalSessionTurn): number {
+  if (!turn.timestamp) return Number.MAX_SAFE_INTEGER;
+  const millis = Date.parse(turn.timestamp);
+  return Number.isFinite(millis) ? millis : Number.MAX_SAFE_INTEGER;
+}
+
+function truncateExcerpt(text: string): string {
+  const compact = text.replace(/\s+/g, " ").trim();
+  return compact.length > 240 ? `${compact.slice(0, 237)}...` : compact;
+}
+
+function mergeRuleNames(target: Set<string>, names: readonly string[]): void {
+  for (const name of names) target.add(name);
+}
+
+function buildDraft(options: {
+  source: string;
+  sessionKey: string;
+  turns: Array<LocalSessionTurn & { fileHash: string; fileExtension: string }>;
+  generatedAt: string;
+  redactionRules: readonly CompiledRedactionRule[];
+  includeRedactedExcerpts: boolean;
+}): SessionSummaryDraft {
+  const sortedTurns = [...options.turns].sort((a, b) => safeTimestampSortValue(a) - safeTimestampSortValue(b));
+  const roles = initRoleCounts();
+  const fileRefs = new Map<string, string>();
+  let redactionApplied = 0;
+  const redactionRuleNames = new Set<string>();
+  const excerpts: SessionSummaryExcerpt[] = [];
+
+  for (const turn of sortedTurns) {
+    roles[turn.role] += 1;
+    fileRefs.set(turn.fileHash, turn.fileExtension);
+    const redacted = redactSessionSummaryText(turn.content, options.redactionRules);
+    redactionApplied += redacted.report.applied;
+    mergeRuleNames(redactionRuleNames, redacted.report.ruleNames);
+    if (options.includeRedactedExcerpts && excerpts.length < 5) {
+      excerpts.push({
+        role: turn.role,
+        text: truncateExcerpt(redacted.text),
+        ...(turn.timestamp ? { timestamp: turn.timestamp } : {}),
+      });
+    }
+  }
+
+  const firstTimestamp = sortedTurns.find((turn) => turn.timestamp)?.timestamp;
+  const lastTimestamp = [...sortedTurns].reverse().find((turn) => turn.timestamp)?.timestamp;
+  const sourceSessionRef = shortHash(options.sessionKey);
+  const sourceFileRefs = [...fileRefs.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([hash, extension]) => ({ hash, extension }));
+  const dateText = firstTimestamp && lastTimestamp ? ` from ${firstTimestamp} to ${lastTimestamp}` : "";
+  const summary =
+    `Local AI session summary: ${sortedTurns.length} turn(s)` +
+    ` (${roles.user} user, ${roles.assistant} assistant, ${roles.tool} tool)` +
+    `${dateText}. Raw transcript text, source session keys, and local file paths are not stored.`;
+
+  return {
+    schemaVersion: 1,
+    draftId: shortHash(
+      JSON.stringify({
+        source: options.source,
+        sourceSessionRef,
+        firstTimestamp,
+        lastTimestamp,
+        turnCount: sortedTurns.length,
+      }),
+      24
+    ),
+    generatedAt: options.generatedAt,
+    sourceAdapter: options.source,
+    sourceSessionRef,
+    sourceFileCount: sourceFileRefs.length,
+    sourceFileRefs,
+    ...(firstTimestamp ? { firstTimestamp } : {}),
+    ...(lastTimestamp ? { lastTimestamp } : {}),
+    turnCount: sortedTurns.length,
+    roles,
+    summary,
+    redaction: {
+      enabled: options.redactionRules.length > 0,
+      applied: redactionApplied,
+      ruleNames: [...redactionRuleNames].sort(),
+    },
+    ...(options.includeRedactedExcerpts && excerpts.length > 0 ? { excerpts } : {}),
+    metadata: {
+      storesRawTranscript: false,
+      storesLocalPaths: false,
+      storesSourceSessionKey: false,
+    },
+  };
+}
+
+export async function collectLocalSessionSummaries(
+  options: CollectLocalSessionSummariesOptions
+): Promise<LocalSessionSummaryReport> {
+  const inputDir = normalizeInputDir(options.inputDir);
+  const inputLstat = await lstat(inputDir);
+  if (inputLstat.isSymbolicLink()) {
+    throw new Error(`inputDir must not be a symbolic link: ${options.inputDir}`);
+  }
+  const inputStat = await stat(inputDir);
+  if (!inputStat.isDirectory()) {
+    throw new Error(`inputDir must be a directory: ${options.inputDir}`);
+  }
+
+  const source = options.source?.trim() || "generic-jsonl";
+  const adapter = getLocalSessionSourceAdapter(source);
+  if (!adapter) {
+    throw new Error(
+      `Unknown local session source '${source}'. Valid sources: ${listLocalSessionSourceAdapters().join(", ")}`
+    );
+  }
+
+  const maxFiles = validatePositiveInt(options.maxFiles, "maxFiles", DEFAULT_MAX_FILES);
+  const maxSessions = validatePositiveInt(options.maxSessions, "maxSessions", DEFAULT_MAX_SESSIONS);
+  const redactionConfig = options.redactionConfig ?? {};
+  const excerptsRequested = options.includeRedactedExcerpts === true;
+  const redactionRules = compileRedactionRules({
+    ...redactionConfig,
+    ...(excerptsRequested ? { disableDefaults: false } : {}),
+  });
+  const includeRedactedExcerpts = options.includeRedactedExcerpts === true && redactionRules.length > 0;
+  const listed = await listTranscriptFiles(inputDir, maxFiles);
+  const files = listed.files;
+  const generatedAt = (options.now ?? new Date()).toISOString();
+  const warnings: LocalSessionSummaryReport["warnings"] = [];
+  const sessions = new Map<string, Array<LocalSessionTurn & { fileHash: string; fileExtension: string }>>();
+  const seenFileHashes = new Set<string>();
+  let turnsParsed = 0;
+  let filesParsed = 0;
+
+  if (listed.truncated) {
+    warnings.push({
+      code: "session-summaries.max_files_truncated",
+      message: `Scanned the first ${maxFiles} transcript file(s); increase maxFiles to include all matching files.`,
+    });
+  }
+  if (excerptsRequested && redactionConfig.disableDefaults === true) {
+    warnings.push({
+      code: "session-summaries.default_redaction_forced_for_excerpts",
+      message: "Default redaction rules were enabled because redacted excerpts were requested.",
+    });
+  }
+  if (excerptsRequested && redactionRules.length === 0) {
+    warnings.push({
+      code: "session-summaries.excerpts_suppressed_no_redaction",
+      message: "Redacted excerpts were requested, but no redaction rules are enabled; excerpts were omitted.",
+    });
+  }
+
+  for (const filePath of files) {
+    const content = await readFile(filePath, "utf-8");
+    const fileHash = shortHash(content, 24);
+    if (seenFileHashes.has(fileHash)) {
+      warnings.push({
+        code: "session-summaries.duplicate_file_skipped",
+        message: "Skipped a duplicate transcript file with identical content.",
+        fileRef: fileHash,
+      });
+      continue;
+    }
+    seenFileHashes.add(fileHash);
+    const fileExtension = path.extname(filePath).toLowerCase();
+    const parsed = await adapter.parseFile(
+      {
+        content,
+        fileName: path.basename(filePath),
+        fileExtension,
+        fileRef: fileHash,
+      },
+      { strict: options.strict }
+    );
+    warnings.push(...parsed.warnings);
+    if (parsed.turns.length === 0) continue;
+    filesParsed += 1;
+    for (const turn of parsed.turns) {
+      turnsParsed += 1;
+      const sessionKey = turn.sessionKey?.trim() || `${adapter.id}:${fileHash}`;
+      const bucket = sessions.get(sessionKey) ?? [];
+      bucket.push({ ...turn, fileHash, fileExtension });
+      sessions.set(sessionKey, bucket);
+    }
+  }
+
+  const drafts: SessionSummaryDraft[] = [];
+  const sessionEntries = [...sessions.entries()].sort(([aKey, a], [bKey, b]) => {
+    const aFirst = Math.min(...a.map(safeTimestampSortValue));
+    const bFirst = Math.min(...b.map(safeTimestampSortValue));
+    return aFirst - bFirst || a[0]?.fileHash.localeCompare(b[0]?.fileHash ?? "") || aKey.localeCompare(bKey);
+  });
+  if (sessionEntries.length > maxSessions) {
+    warnings.push({
+      code: "session-summaries.max_sessions_truncated",
+      message: `Summarized ${maxSessions} of ${sessionEntries.length} session(s); increase maxSessions to include all parsed sessions.`,
+    });
+  }
+  for (const [sessionKey, turns] of sessionEntries.slice(0, maxSessions)) {
+    drafts.push(
+      buildDraft({
+        source: adapter.id,
+        sessionKey,
+        turns,
+        generatedAt,
+        redactionRules,
+        includeRedactedExcerpts,
+      })
+    );
+  }
+  drafts.sort((a, b) => (a.firstTimestamp ?? "").localeCompare(b.firstTimestamp ?? ""));
+
+  return {
+    generatedAt,
+    source: adapter.id,
+    filesScanned: files.length,
+    filesParsed,
+    turnsParsed,
+    sessionsSummarized: drafts.length,
+    warnings,
+    drafts,
+    wroteFiles: [],
+  };
+}
+
+async function readRedactionConfig(pathLike: string | undefined): Promise<RedactionConfig | undefined> {
+  if (!pathLike) return undefined;
+  const raw = await readFile(path.resolve(expandTildePath(pathLike)), "utf-8");
+  const parsed = JSON.parse(raw) as RedactionConfig;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("redaction config must be a JSON object");
+  }
+  return parsed;
+}
+
+function toJsonl(drafts: readonly SessionSummaryDraft[]): string {
+  return `${drafts.map((draft) => JSON.stringify(draft)).join("\n")}\n`;
+}
+
+function defaultDraftOutputPath(memoryDir: string, generatedAt: string): string {
+  const stamp = generatedAt.replace(/[:.]/g, "-");
+  return path.join(
+    path.resolve(expandTildePath(memoryDir)),
+    "state",
+    "session-summary-drafts",
+    `session-summaries-${stamp}.jsonl`
+  );
+}
+
+async function writeDrafts(filePath: string, drafts: readonly SessionSummaryDraft[]): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await writeFile(tempPath, toJsonl(drafts), "utf-8");
+    await rename(tempPath, filePath);
+  } catch (error) {
+    await rm(tempPath, { force: true });
+    throw error;
+  }
+}
+
+export async function runLocalSessionSummaryCliCommand(
+  options: LocalSessionSummaryCliOptions
+): Promise<LocalSessionSummaryReport> {
+  const redactionConfig = options.redactionConfig ?? (await readRedactionConfig(options.redactionConfigPath));
+  const report = await collectLocalSessionSummaries({
+    ...options,
+    ...(redactionConfig ? { redactionConfig } : {}),
+  });
+  const wroteFiles: string[] = [];
+
+  if (options.output) {
+    const outputPath = path.resolve(expandTildePath(options.output));
+    await writeDrafts(outputPath, report.drafts);
+    wroteFiles.push(outputPath);
+  }
+
+  if (options.write === true) {
+    if (!options.memoryDir || options.memoryDir.trim().length === 0) {
+      throw new Error("memoryDir is required when write is true");
+    }
+    const outputPath = defaultDraftOutputPath(options.memoryDir, report.generatedAt);
+    await writeDrafts(outputPath, report.drafts);
+    wroteFiles.push(outputPath);
+  }
+
+  const stdout = options.stdout;
+  if (stdout) {
+    stdout.write(`Local session summaries complete (source: ${report.source})\n`);
+    stdout.write(`  Files scanned:        ${report.filesScanned}\n`);
+    stdout.write(`  Files parsed:         ${report.filesParsed}\n`);
+    stdout.write(`  Turns parsed:         ${report.turnsParsed}\n`);
+    stdout.write(`  Sessions summarized:  ${report.sessionsSummarized}\n`);
+    stdout.write(`  Draft files written:  ${wroteFiles.length}\n`);
+    if (wroteFiles.length === 0) {
+      stdout.write("  (dry run - no Remnic draft files were written)\n");
+    }
+  }
+
+  return { ...report, wroteFiles };
+}

--- a/packages/remnic-core/src/session-summaries/index.ts
+++ b/packages/remnic-core/src/session-summaries/index.ts
@@ -86,6 +86,15 @@ function safeTimestampSortValue(turn: LocalSessionTurn): number {
   return Number.isFinite(millis) ? millis : Number.MAX_SAFE_INTEGER;
 }
 
+function earliestTurnSortValue(turns: readonly LocalSessionTurn[]): number {
+  let earliest = Number.MAX_SAFE_INTEGER;
+  for (const turn of turns) {
+    const value = safeTimestampSortValue(turn);
+    if (value < earliest) earliest = value;
+  }
+  return earliest;
+}
+
 function truncateExcerpt(text: string): string {
   const compact = text.replace(/\s+/g, " ").trim();
   return compact.length > 240 ? `${compact.slice(0, 237)}...` : compact;
@@ -267,8 +276,8 @@ export async function collectLocalSessionSummaries(
 
   const drafts: SessionSummaryDraft[] = [];
   const sessionEntries = [...sessions.entries()].sort(([aKey, a], [bKey, b]) => {
-    const aFirst = Math.min(...a.map(safeTimestampSortValue));
-    const bFirst = Math.min(...b.map(safeTimestampSortValue));
+    const aFirst = earliestTurnSortValue(a);
+    const bFirst = earliestTurnSortValue(b);
     return aFirst - bFirst || a[0]?.fileHash.localeCompare(b[0]?.fileHash ?? "") || aKey.localeCompare(bKey);
   });
   if (sessionEntries.length > maxSessions) {

--- a/packages/remnic-core/src/session-summaries/index.ts
+++ b/packages/remnic-core/src/session-summaries/index.ts
@@ -31,9 +31,15 @@ function shortHash(value: string, length = 16): string {
 
 async function listTranscriptFiles(root: string, maxFiles: number): Promise<{ files: string[]; truncated: boolean }> {
   const out: string[] = [];
+  let truncated = false;
+  const entrySortKey = (entryName: string, isDirectory: boolean): string => (isDirectory ? `${entryName}${path.sep}` : entryName);
   async function visit(dir: string): Promise<void> {
-    const entries = (await readdir(dir, { withFileTypes: true })).sort((a, b) => a.name.localeCompare(b.name));
+    if (truncated) return;
+    const entries = (await readdir(dir, { withFileTypes: true })).sort((a, b) =>
+      entrySortKey(a.name, a.isDirectory()).localeCompare(entrySortKey(b.name, b.isDirectory()))
+    );
     for (const entry of entries) {
+      if (truncated) return;
       if (entry.name.startsWith(".")) continue;
       if (entry.isSymbolicLink()) continue;
       const fullPath = path.join(dir, entry.name);
@@ -45,13 +51,17 @@ async function listTranscriptFiles(root: string, maxFiles: number): Promise<{ fi
       const ext = path.extname(entry.name).toLowerCase();
       if (!SUPPORTED_EXTENSIONS.has(ext)) continue;
       out.push(fullPath);
+      if (out.length > maxFiles) {
+        truncated = true;
+        return;
+      }
     }
   }
   await visit(root);
   const sorted = out.sort();
   return {
     files: sorted.slice(0, maxFiles),
-    truncated: sorted.length > maxFiles,
+    truncated,
   };
 }
 

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -1,0 +1,143 @@
+import type { CompiledRedactionRule, RedactionConfig, RedactionReport } from "./types.js";
+
+export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
+  {
+    name: "secret-token",
+    pattern:
+      /\b(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|(?:api[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
+    replacement: "[REDACTED_SECRET]",
+  },
+  {
+    name: "email",
+    pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+    replacement: "[REDACTED_EMAIL]",
+  },
+  {
+    name: "private-ip",
+    pattern:
+      /\b(?:(?:10|127)\.(?:\d{1,3}\.){2}\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3})\b/g,
+    replacement: "[REDACTED_PRIVATE_IP]",
+  },
+  {
+    name: "url",
+    pattern: /\bhttps?:\/\/[^\s"'<>)]*/gi,
+    replacement: "[REDACTED_URL]",
+  },
+  {
+    name: "home-relative-posix-spaced-path",
+    pattern:
+      /~\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+\.[A-Za-z0-9_-]+/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "home-relative-posix-path",
+    pattern: /~\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]*[A-Za-z0-9_-]/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "absolute-posix-spaced-path",
+    pattern:
+      /\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)+[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+\.[A-Za-z0-9_-]+/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "absolute-posix-path",
+    pattern: /\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]*[A-Za-z0-9_-]/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "absolute-windows-spaced-path",
+    pattern:
+      /\b[A-Za-z]:\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+(?: [^\\/:*?"<>|,;\s\r\n]+)+\.[A-Za-z0-9_-]+/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "absolute-windows-spaced-extensionless-path",
+    pattern:
+      /\b[A-Za-z]:\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+(?: [^\\/:*?"<>|,;\s\r\n]+)+(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "absolute-windows-path",
+    pattern: /\b[A-Za-z]:\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "unc-windows-spaced-path",
+    pattern:
+      /\\\\[^\\/:*?"<>|,;\s\r\n]+\\[^\\/:*?"<>|,;\r\n]+\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+(?: [^\\/:*?"<>|,;\s\r\n]+)+\.[A-Za-z0-9_-]+/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "unc-windows-spaced-extensionless-path",
+    pattern:
+      /\\\\[^\\/:*?"<>|,;\s\r\n]+\\[^\\/:*?"<>|,;\r\n]+\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+(?: [^\\/:*?"<>|,;\s\r\n]+)+(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "unc-windows-path",
+    pattern: /\\\\[^\\/:*?"<>|,;\s\r\n]+\\[^\\/:*?"<>|,;\r\n]+\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+/g,
+    replacement: "[REDACTED_PATH]",
+  },
+];
+
+function cloneRedactionRule(rule: CompiledRedactionRule): CompiledRedactionRule {
+  return {
+    name: rule.name,
+    pattern: new RegExp(rule.pattern.source, rule.pattern.flags),
+    replacement: rule.replacement,
+  };
+}
+
+export function compileRedactionRules(config: RedactionConfig = {}): CompiledRedactionRule[] {
+  const rules: CompiledRedactionRule[] =
+    config.disableDefaults === true ? [] : DEFAULT_REDACTION_RULES.map(cloneRedactionRule);
+  const customRules = config.rules ?? [];
+  if (!Array.isArray(customRules)) {
+    throw new Error("redaction rules must be an array");
+  }
+  for (const rule of customRules) {
+    if (!rule || typeof rule !== "object") {
+      throw new Error("redaction rule must be an object");
+    }
+    if (typeof rule.name !== "string" || rule.name.trim().length === 0) {
+      throw new Error("redaction rule name must be a non-empty string");
+    }
+    if (typeof rule.pattern !== "string" || rule.pattern.length === 0) {
+      throw new Error(`redaction rule '${rule.name}' pattern must be non-empty`);
+    }
+    const flags = rule.flags ?? "g";
+    rules.push({
+      name: rule.name.trim(),
+      pattern: new RegExp(rule.pattern, flags.includes("g") ? flags : `${flags}g`),
+      replacement: rule.replacement ?? `[REDACTED_${rule.name.trim().toUpperCase()}]`,
+    });
+  }
+  return rules;
+}
+
+export function redactSessionSummaryText(
+  text: string,
+  rules: readonly CompiledRedactionRule[]
+): { text: string; report: RedactionReport } {
+  let redacted = text;
+  let applied = 0;
+  const ruleNames = new Set<string>();
+
+  for (const rule of rules) {
+    rule.pattern.lastIndex = 0;
+    const matches = redacted.match(rule.pattern);
+    if (!matches || matches.length === 0) continue;
+    applied += matches.length;
+    ruleNames.add(rule.name);
+    redacted = redacted.replace(rule.pattern, rule.replacement);
+  }
+
+  return {
+    text: redacted,
+    report: {
+      applied,
+      ruleNames: [...ruleNames].sort(),
+    },
+  };
+}

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -4,7 +4,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "secret-token",
     pattern:
-      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
+      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
     replacement: "[REDACTED_SECRET]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -66,7 +66,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "absolute-windows-spaced-extensionless-path",
     pattern:
-      /\b[A-Za-z]:\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+(?: [^\\/:*?"<>|,;\s\r\n]+)+(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /\b[A-Za-z]:\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+(?: [^\\/:*?"<>|,;\s\r\n]+)+(?=$|["'<>)](?!\\)|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
     replacement: "[REDACTED_PATH]",
   },
   {
@@ -83,7 +83,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "unc-windows-spaced-extensionless-path",
     pattern:
-      /\\\\[^\\/:*?"<>|,;\s\r\n]+\\[^\\/:*?"<>|,;\r\n]+\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+(?: [^\\/:*?"<>|,;\s\r\n]+)+(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /\\\\[^\\/:*?"<>|,;\s\r\n]+\\[^\\/:*?"<>|,;\r\n]+\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+(?: [^\\/:*?"<>|,;\s\r\n]+)+(?=$|["'<>)](?!\\)|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
     replacement: "[REDACTED_PATH]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -26,35 +26,35 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "home-relative-posix-spaced-path",
     pattern:
-      /~\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+\.[A-Za-z0-9_-]+/g,
+      /~\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+\.[^/\s"',;<>]+?(?=$|[\s"',;<>)]|[.,](?:\s|$))/g,
     replacement: "[REDACTED_PATH]",
   },
   {
     name: "home-relative-posix-spaced-extensionless-path",
     pattern:
-      /~\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /~\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
     replacement: "[REDACTED_PATH]",
   },
   {
     name: "home-relative-posix-path",
-    pattern: /~\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]*[A-Za-z0-9_-]/g,
+    pattern: /~\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+?(?=$|[\s"',;<>)]|[.,](?:\s|$))/g,
     replacement: "[REDACTED_PATH]",
   },
   {
     name: "absolute-posix-spaced-path",
     pattern:
-      /\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)+[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+\.[A-Za-z0-9_-]+/g,
+      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)+[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+\.[^/\s"',;<>]+?(?=$|[\s"',;<>)]|[.,](?:\s|$))/g,
     replacement: "[REDACTED_PATH]",
   },
   {
     name: "absolute-posix-spaced-extensionless-path",
     pattern:
-      /\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)+[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)+[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
     replacement: "[REDACTED_PATH]",
   },
   {
     name: "absolute-posix-path",
-    pattern: /\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]*[A-Za-z0-9_-]/g,
+    pattern: /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+?(?=$|[\s"',;<>)]|[.,](?:\s|$))/g,
     replacement: "[REDACTED_PATH]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -87,6 +87,11 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
     replacement: "[REDACTED_PATH]",
   },
   {
+    name: "unc-windows-share-root",
+    pattern: /\\\\[^\\/:*?"<>|,;\s\r\n]+\\[^\\/:*?"<>|,;\s\r\n]+(?=$|[\s"',;<>)]|[.,](?:\s|$))/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
     name: "unc-windows-path",
     pattern: /\\\\[^\\/:*?"<>|,;\s\r\n]+\\[^\\/:*?"<>|,;\r\n]+\\(?:[^\\/:*?"<>|,;\r\n]+\\)*[^\\/:*?"<>|,;\s\r\n]+/g,
     replacement: "[REDACTED_PATH]",

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -4,7 +4,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "secret-token",
     pattern:
-      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|authorization\s*[:=]\s*bearer\s+(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+)|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
+      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|authorization\s*[:=]\s*[A-Za-z][A-Za-z0-9._-]*\s+(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+)|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
     replacement: "[REDACTED_SECRET]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -32,7 +32,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "home-relative-posix-spaced-extensionless-path",
     pattern:
-      /~\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|["'<>)](?!\/)|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /~\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and(?=\s+[a-z])|or(?=\s+[a-z]))\b)[^/\s"',;<>]+)+?(?=$|["'<>)](?!\/)|[,;.]|\s+(?:before|after|then|and(?=\s+(?:[a-z]|[~/"']|$))|or(?=\s+(?:[a-z]|[~/"']|$)))\b)/g,
     replacement: "[REDACTED_PATH]",
   },
   {
@@ -49,7 +49,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "absolute-posix-spaced-extensionless-path",
     pattern:
-      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|["'<>)](?!\/)|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and(?=\s+[a-z])|or(?=\s+[a-z]))\b)[^/\s"',;<>]+)+?(?=$|["'<>)](?!\/)|[,;.]|\s+(?:before|after|then|and(?=\s+(?:[a-z]|[~/"']|$))|or(?=\s+(?:[a-z]|[~/"']|$)))\b)/g,
     replacement: "[REDACTED_PATH]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -4,7 +4,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "secret-token",
     pattern:
-      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|authorization\s*[:=]\s*[A-Za-z][A-Za-z0-9._-]*\s+(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+)|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
+      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|(?:"authorization"|'authorization'|authorization)\s*[:=]\s*(?:"[A-Za-z][A-Za-z0-9._-]*\s+[^"\r\n]*"|'[A-Za-z][A-Za-z0-9._-]*\s+[^'\r\n]*'|[A-Za-z][A-Za-z0-9._-]*\s+(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))|(?:"(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password)"|'(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password)'|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password))\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
     replacement: "[REDACTED_SECRET]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -43,13 +43,13 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "absolute-posix-spaced-path",
     pattern:
-      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)+[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+\.[^/\s"',;<>]+?(?=$|[\s"',;<>)]|[.,](?:\s|$))/g,
+      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+\.[^/\s"',;<>]+?(?=$|[\s"',;<>)]|[.,](?:\s|$))/g,
     replacement: "[REDACTED_PATH]",
   },
   {
     name: "absolute-posix-spaced-extensionless-path",
     pattern:
-      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)+[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
     replacement: "[REDACTED_PATH]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -4,7 +4,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "secret-token",
     pattern:
-      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
+      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|authorization\s*[:=]\s*bearer\s+(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+)|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|access[_-]?key|private[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
     replacement: "[REDACTED_SECRET]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -4,7 +4,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "secret-token",
     pattern:
-      /\b(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|(?:api[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
+      /(?<![A-Za-z0-9_])(?:sk-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|(?:[A-Za-z0-9]+[_-]+)*(?:api[_-]?key|token|secret|password)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s"',;]+))/gi,
     replacement: "[REDACTED_SECRET]",
   },
   {
@@ -30,6 +30,12 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
     replacement: "[REDACTED_PATH]",
   },
   {
+    name: "home-relative-posix-spaced-extensionless-path",
+    pattern:
+      /~\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
     name: "home-relative-posix-path",
     pattern: /~\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)*[A-Za-z0-9._()-]*[A-Za-z0-9_-]/g,
     replacement: "[REDACTED_PATH]",
@@ -38,6 +44,12 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
     name: "absolute-posix-spaced-path",
     pattern:
       /\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)+[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+\.[A-Za-z0-9_-]+/g,
+    replacement: "[REDACTED_PATH]",
+  },
+  {
+    name: "absolute-posix-spaced-extensionless-path",
+    pattern:
+      /\/(?:[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)*\/)+[A-Za-z0-9._()-]+(?: [A-Za-z0-9._()-]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
     replacement: "[REDACTED_PATH]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/redaction.ts
+++ b/packages/remnic-core/src/session-summaries/redaction.ts
@@ -32,7 +32,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "home-relative-posix-spaced-extensionless-path",
     pattern:
-      /~\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /~\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|["'<>)](?!\/)|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
     replacement: "[REDACTED_PATH]",
   },
   {
@@ -49,7 +49,7 @@ export const DEFAULT_REDACTION_RULES: readonly CompiledRedactionRule[] = [
   {
     name: "absolute-posix-spaced-extensionless-path",
     pattern:
-      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
+      /\/(?:[^/\s"',;<>]+(?: [^/\s"',;<>]+)*\/)*[^/\s"',;<>]+(?: (?!(?:before|after|then|and|or)\b)[^/\s"',;<>]+)+?(?=$|["'<>)](?!\/)|[,;.]|\s+(?:before|after|then|and|or)\b)/gi,
     replacement: "[REDACTED_PATH]",
   },
   {

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -888,6 +888,45 @@ test("maxSessions reports truncation instead of dropping sessions silently", asy
   });
 });
 
+test("session ordering handles large sessions without spreading timestamp arrays", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "a-small.jsonl"),
+      JSON.stringify({
+        sessionKey: "small-session",
+        role: "user",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "Small session wins the first slot.",
+      }),
+      "utf-8"
+    );
+
+    const largeTurnCount = 130_000;
+    const largeRows = Array.from({ length: largeTurnCount }, () =>
+      JSON.stringify({
+        sessionKey: "large-session",
+        role: "assistant",
+        timestamp: "2026-02-04T00:00:00.000Z",
+        content: "Large later session.",
+      })
+    ).join("\n");
+    await writeFile(path.join(dir, "b-large.jsonl"), largeRows, "utf-8");
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      maxSessions: 1,
+    });
+
+    assert.equal(report.turnsParsed, largeTurnCount + 1);
+    assert.equal(report.sessionsSummarized, 1);
+    assert.equal(report.drafts[0].turnCount, 1);
+    assert.equal(
+      report.warnings.some((warning) => warning.code === "session-summaries.max_sessions_truncated"),
+      true
+    );
+  });
+});
+
 test("duplicate transcript files are skipped by content hash", async () => {
   await withTempDir(async (dir) => {
     const content = JSON.stringify({

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1004,6 +1004,31 @@ test("redaction covers single-segment POSIX paths with spaced names", async () =
   });
 });
 
+test("redaction covers quoted extensionless POSIX paths with spaced names", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: 'Inspect "/Users/alex/Secret Project" and "~/Client Folder" before replying.',
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      'Inspect "[REDACTED_PATH]" and "[REDACTED_PATH]" before replying.'
+    );
+  });
+});
+
 test("redaction covers UNC Windows paths", async () => {
   await withTempDir(async (dir) => {
     await writeFile(

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -780,6 +780,31 @@ test("redaction covers quoted secret values with spaces", async () => {
   });
 });
 
+test("redaction covers prefixed environment secret keys", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: 'Use ANTHROPIC_API_KEY="correct horse" and ACCESS_TOKEN=abc123 before running tests.',
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      "Use [REDACTED_SECRET] and [REDACTED_SECRET] before running tests."
+    );
+  });
+});
+
 test("custom redaction rules must be an array", async () => {
   assert.throws(
     () => compileRedactionRules({ rules: { name: "bad", pattern: "bad" } } as never),
@@ -832,6 +857,31 @@ test("redaction covers home-relative POSIX paths with spaced filenames", async (
     });
 
     assert.equal(report.drafts[0].excerpts?.[0].text, "Inspect [REDACTED_PATH] before replying.");
+  });
+});
+
+test("redaction covers extensionless POSIX paths with spaced names", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: "Open /Users/alex/Secret Project before replying and ~/My Documents/Client Folder after.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      "Open [REDACTED_PATH] before replying and [REDACTED_PATH] after."
+    );
   });
 });
 

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -265,6 +265,50 @@ test("codex-jsonl skips compacted rollout summary rows", async () => {
   });
 });
 
+test("codex-jsonl deduplicates mirrored agent event and response item rows", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "rollout.jsonl"),
+      [
+        JSON.stringify({
+          type: "event_msg",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          payload: { message: "User request." },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          payload: { type: "agent_message", message: "Mirrored assistant response." },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:02.000Z",
+          payload: { content: [{ type: "output_text", text: "Mirrored assistant response." }] },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "codex-jsonl",
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 2);
+    assert.equal(report.drafts[0].turnCount, 2);
+    assert.equal(report.drafts[0].roles.user, 1);
+    assert.equal(report.drafts[0].roles.assistant, 1);
+    assert.deepEqual(
+      report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
+      ["User request.", "Mirrored assistant response."]
+    );
+  });
+});
+
 test("codex-jsonl inherits legacy session_meta payload ids", async () => {
   await withTempDir(async (dir) => {
     const transcriptPath = path.join(dir, "rollout.jsonl");

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1043,6 +1043,28 @@ test("redaction covers common access and private key assignments", async () => {
   });
 });
 
+test("redaction covers bearer Authorization header values", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: 'Run curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.secret" before retrying.',
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.drafts[0].excerpts?.[0].text, 'Run curl -H "[REDACTED_SECRET]" before retrying.');
+  });
+});
+
 test("custom redaction rules must be an array", async () => {
   assert.throws(
     () => compileRedactionRules({ rules: { name: "bad", pattern: "bad" } } as never),

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -1011,6 +1011,41 @@ test("maxFiles reports truncation instead of dropping files silently", async () 
       report.warnings.some((warning) => warning.code === "session-summaries.max_files_truncated"),
       true
     );
+  });
+});
+
+test("maxFiles stops walking after enough transcript candidates are found", async () => {
+  await withTempDir(async (dir) => {
+    for (const name of ["a", "b"]) {
+      await writeFile(
+        path.join(dir, `${name}.jsonl`),
+        JSON.stringify({
+          sessionKey: name,
+          role: "user",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: name,
+        }),
+        "utf-8"
+      );
+    }
+
+    const neverReadDir = path.join(dir, "z-never-read");
+    await mkdir(neverReadDir);
+    await chmod(neverReadDir, 0o000);
+    try {
+      const report = await collectLocalSessionSummaries({
+        inputDir: dir,
+        maxFiles: 1,
+      });
+
+      assert.equal(report.filesScanned, 1);
+      assert.equal(
+        report.warnings.some((warning) => warning.code === "session-summaries.max_files_truncated"),
+        true
+      );
+    } finally {
+      await chmod(neverReadDir, 0o700);
+    }
   });
 });
 

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1045,13 +1045,14 @@ test("redaction covers common access and private key assignments", async () => {
 
 test("redaction covers bearer Authorization header values", async () => {
   await withTempDir(async (dir) => {
+    const authHeader = `${"Authorization"}: ${"Bearer"} sample-bearer-value`;
     await writeFile(
       path.join(dir, "session.jsonl"),
       JSON.stringify({
         sessionKey: "s",
         role: "user",
         timestamp: "2026-04-05T00:00:00.000Z",
-        content: 'Run curl -H "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.secret" before retrying.',
+        content: `Run curl -H "${authHeader}" before retrying.`,
       }),
       "utf-8"
     );

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -917,6 +917,32 @@ test("redaction covers prefixed environment secret keys", async () => {
   });
 });
 
+test("redaction covers common access and private key assignments", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content:
+          'Use AWS_SECRET_ACCESS_KEY=aws-secret, ACCESS_KEY=plain-access, and PRIVATE_KEY="private material" for tests.',
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      "Use [REDACTED_SECRET], [REDACTED_SECRET], and [REDACTED_SECRET] for tests."
+    );
+  });
+});
+
 test("custom redaction rules must be an array", async () => {
   assert.throws(
     () => compileRedactionRules({ rules: { name: "bad", pattern: "bad" } } as never),

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -505,6 +505,35 @@ test("JSON envelope sessionId fields are inherited by child rows", async () => {
   });
 });
 
+test("JSON envelope parsing skips empty row arrays in favor of populated arrays", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.json"),
+      JSON.stringify({
+        sessionId: "envelope-session",
+        turns: [],
+        messages: [
+          {
+            role: "user",
+            timestamp: "2026-02-03T00:00:00.000Z",
+            content: "Message content survives empty turns.",
+          },
+        ],
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 1);
+    assert.equal(report.drafts[0].sourceSessionRef, "9a04ff52f050d0b4");
+    assert.equal(report.drafts[0].excerpts?.[0].text, "Message content survives empty turns.");
+  });
+});
+
 test("inputDir supports tilde expansion", async () => {
   const dir = await mkdtemp(path.join(os.homedir(), ".remnic-session-summary-"));
   try {

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -549,6 +549,62 @@ test("JSON envelope sessionId fields are inherited by child rows", async () => {
   });
 });
 
+test("JSON envelope sessionId fields override unusable child session ids", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "session.json");
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        sessionId: "stable-envelope-session",
+        messages: [
+          {
+            sessionId: "",
+            role: "user",
+            timestamp: "2026-02-03T00:00:00.000Z",
+            content: "Original content.",
+          },
+          {
+            sessionId: null,
+            role: "assistant",
+            timestamp: "2026-02-03T00:00:01.000Z",
+            content: "Original reply.",
+          },
+        ],
+      }),
+      "utf-8"
+    );
+    const firstReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        sessionId: "stable-envelope-session",
+        messages: [
+          {
+            sessionId: "",
+            role: "user",
+            timestamp: "2026-02-03T00:00:00.000Z",
+            content: "Changed content.",
+          },
+          {
+            sessionId: null,
+            role: "assistant",
+            timestamp: "2026-02-03T00:00:01.000Z",
+            content: "Changed reply.",
+          },
+        ],
+      }),
+      "utf-8"
+    );
+    const secondReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(firstReport.sessionsSummarized, 1);
+    assert.equal(firstReport.drafts[0].turnCount, 2);
+    assert.equal(firstReport.drafts[0].sourceSessionRef, secondReport.drafts[0].sourceSessionRef);
+    assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
+  });
+});
+
 test("JSON envelope parsing skips empty row arrays in favor of populated arrays", async () => {
   await withTempDir(async (dir) => {
     await writeFile(
@@ -1147,6 +1203,31 @@ test("redaction covers quoted extensionless Windows paths with spaced names", as
     assert.equal(
       report.drafts[0].excerpts?.[0].text,
       'Inspect "[REDACTED_PATH]" and "[REDACTED_PATH]" before replying.'
+    );
+  });
+});
+
+test("redaction covers UNC share roots", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: 'Inspect \\\\server\\share and "\\\\server\\quoted-share" before replying.',
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      'Inspect [REDACTED_PATH] and "[REDACTED_PATH]" before replying.'
     );
   });
 });

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1303,6 +1303,34 @@ test("redaction covers quoted secret values with spaces", async () => {
   });
 });
 
+test("redaction covers quoted JSON secret keys", async () => {
+  await withTempDir(async (dir) => {
+    const passwordKey = `${"password"}`;
+    const authKey = `${"Authorization"}`;
+    const authScheme = `${"Bearer"}`;
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: `Use {"${passwordKey}": "correct horse battery", "${authKey}": "${authScheme} sample-json-value"} before retrying.`,
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      "Use {[REDACTED_SECRET], [REDACTED_SECRET]} before retrying."
+    );
+  });
+});
+
 test("redaction covers prefixed environment secret keys", async () => {
   await withTempDir(async (dir) => {
     await writeFile(

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -305,12 +305,14 @@ test("codex-jsonl deduplicates mirrored agent event and response item rows", asy
         }),
         JSON.stringify({
           type: "event_msg",
+          id: "assistant-turn-1",
           sessionKey: "codex-session",
           timestamp: "2026-02-03T00:00:01.000Z",
           payload: { type: "agent_message", message: "Mirrored assistant response." },
         }),
         JSON.stringify({
           type: "response_item",
+          id: "assistant-turn-1",
           sessionKey: "codex-session",
           timestamp: "2026-02-03T00:00:02.000Z",
           payload: { content: [{ type: "output_text", text: "Mirrored assistant response." }] },
@@ -332,6 +334,51 @@ test("codex-jsonl deduplicates mirrored agent event and response item rows", asy
     assert.deepEqual(
       report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
       ["User request.", "Mirrored assistant response."]
+    );
+  });
+});
+
+test("codex-jsonl keeps same-text cross-surface rows with different signals", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "rollout.jsonl"),
+      [
+        JSON.stringify({
+          type: "event_msg",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          payload: { message: "User request." },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          id: "assistant-event-1",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          payload: { type: "agent_message", message: "OK" },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          id: "assistant-response-1",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:02.000Z",
+          payload: { content: [{ type: "output_text", text: "OK" }] },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "codex-jsonl",
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 3);
+    assert.equal(report.drafts[0].turnCount, 3);
+    assert.equal(report.drafts[0].roles.assistant, 2);
+    assert.deepEqual(
+      report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
+      ["User request.", "OK", "OK"]
     );
   });
 });
@@ -533,6 +580,43 @@ test("top-level message metadata contributes stable session ids", async () => {
           role: "assistant",
           timestamp: "2026-02-03T00:00:00.000Z",
           content: "Changed nested content.",
+        },
+      }),
+      "utf-8"
+    );
+    const secondReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(firstReport.drafts[0].sourceSessionRef, secondReport.drafts[0].sourceSessionRef);
+    assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
+    assert.equal(firstReport.drafts[0].roles.assistant, 1);
+  });
+});
+
+test("nested transcript id metadata contributes stable session ids", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "nested-transcript.jsonl");
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        message: {
+          transcriptId: "top-level-message-transcript",
+          role: "assistant",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: "Original nested transcript content.",
+        },
+      }),
+      "utf-8"
+    );
+    const firstReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        message: {
+          transcriptId: "top-level-message-transcript",
+          role: "assistant",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: "Changed nested transcript content.",
         },
       }),
       "utf-8"

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -309,6 +309,49 @@ test("codex-jsonl deduplicates mirrored agent event and response item rows", asy
   });
 });
 
+test("codex-jsonl deduplicates same-surface mirrored assistant rows", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "rollout.jsonl"),
+      [
+        JSON.stringify({
+          type: "event_msg",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          payload: { message: "User request." },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          payload: { content: [{ type: "output_text", text: "Repeated assistant response." }] },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:02.000Z",
+          payload: { content: [{ type: "output_text", text: "Repeated assistant response." }] },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "codex-jsonl",
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 2);
+    assert.equal(report.drafts[0].turnCount, 2);
+    assert.equal(report.drafts[0].roles.assistant, 1);
+    assert.deepEqual(
+      report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
+      ["User request.", "Repeated assistant response."]
+    );
+  });
+});
+
 test("codex-jsonl inherits legacy session_meta payload ids", async () => {
   await withTempDir(async (dir) => {
     const transcriptPath = path.join(dir, "rollout.jsonl");

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -221,6 +221,45 @@ test("codex-jsonl parses Codex rollout payload rows", async () => {
   });
 });
 
+test("codex-jsonl inherits legacy session_meta payload ids", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "rollout.jsonl");
+    const writeTranscript = async (message: string): Promise<void> => {
+      await writeFile(
+        transcriptPath,
+        [
+          JSON.stringify({
+            type: "session_meta",
+            payload: { id: "legacy-codex-session" },
+          }),
+          JSON.stringify({
+            type: "event_msg",
+            timestamp: "2026-02-03T00:00:00.000Z",
+            payload: { message },
+          }),
+        ].join("\n"),
+        "utf-8"
+      );
+    };
+
+    await writeTranscript("Original message.");
+    const firstReport = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "codex-jsonl",
+    });
+
+    await writeTranscript("Changed message.");
+    const secondReport = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "codex-jsonl",
+    });
+
+    assert.equal(firstReport.drafts[0].sourceSessionRef, secondReport.drafts[0].sourceSessionRef);
+    assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
+    assert.equal(firstReport.drafts[0].turnCount, 1);
+  });
+});
+
 test("payload.message metadata contributes session, role, and timestamp", async () => {
   await withTempDir(async (dir) => {
     const transcriptPath = path.join(dir, "nested.jsonl");

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -221,6 +221,50 @@ test("codex-jsonl parses Codex rollout payload rows", async () => {
   });
 });
 
+test("codex-jsonl skips compacted rollout summary rows", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "rollout.jsonl"),
+      [
+        JSON.stringify({
+          type: "event_msg",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          payload: { message: "Original user request." },
+        }),
+        JSON.stringify({
+          type: "compacted",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          payload: { message: "Synthetic compaction summary should never become an excerpt." },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:02.000Z",
+          payload: { content: [{ type: "output_text", text: "Assistant response." }] },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "codex-jsonl",
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 2);
+    assert.equal(report.drafts[0].turnCount, 2);
+    assert.equal(report.drafts[0].roles.other, 0);
+    assert.deepEqual(
+      report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
+      ["Original user request.", "Assistant response."]
+    );
+    assert.equal(JSON.stringify(report.drafts[0]).includes("Synthetic compaction summary"), false);
+  });
+});
+
 test("codex-jsonl inherits legacy session_meta payload ids", async () => {
   await withTempDir(async (dir) => {
     const transcriptPath = path.join(dir, "rollout.jsonl");

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1125,6 +1125,32 @@ test("redaction covers UNC Windows paths", async () => {
   });
 });
 
+test("redaction covers quoted extensionless Windows paths with spaced names", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content:
+          'Inspect "C:\\Users\\alex\\Secret Project" and "\\\\server\\share\\client\\Secret Project" before replying.',
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      'Inspect "[REDACTED_PATH]" and "[REDACTED_PATH]" before replying.'
+    );
+  });
+});
+
 test("redaction config file must be a JSON object", async () => {
   await withTempDir(async (dir) => {
     const inputDir = path.join(dir, "transcripts");

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1,0 +1,897 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { collectLocalSessionSummaries, compileRedactionRules, runLocalSessionSummaryCliCommand } from "./index.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-session-summary-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("collectLocalSessionSummaries produces metadata-only drafts without local paths or raw session keys", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "session.jsonl");
+    await writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          sessionKey: "local-session-secret",
+          role: "user",
+          timestamp: "2026-01-02T03:04:05.000Z",
+          content:
+            "Please inspect /Users/alex/src/private and email alex@example.com about http://internal.example.test",
+        }),
+        JSON.stringify({
+          sessionKey: "local-session-secret",
+          role: "assistant",
+          timestamp: "2026-01-02T03:04:06.000Z",
+          content: "Use API_KEY=super-secret and connect to 192.168.1.10.",
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "generic-jsonl",
+      now: new Date("2026-01-02T04:00:00.000Z"),
+    });
+
+    assert.equal(report.filesScanned, 1);
+    assert.equal(report.filesParsed, 1);
+    assert.equal(report.turnsParsed, 2);
+    assert.equal(report.sessionsSummarized, 1);
+    const draft = report.drafts[0];
+    assert.equal(draft.turnCount, 2);
+    assert.equal(draft.roles.user, 1);
+    assert.equal(draft.roles.assistant, 1);
+    assert.equal(draft.metadata.storesRawTranscript, false);
+    assert.equal(draft.metadata.storesLocalPaths, false);
+    assert.equal(draft.metadata.storesSourceSessionKey, false);
+    assert.equal(draft.sourceFileRefs.length, 1);
+    assert.match(draft.sourceFileRefs[0].hash, /^[a-f0-9]{24}$/);
+
+    const serialized = JSON.stringify(draft);
+    assert.equal(serialized.includes(transcriptPath), false);
+    assert.equal(serialized.includes("local-session-secret"), false);
+    assert.equal(serialized.includes("/Users/alex"), false);
+    assert.equal(serialized.includes("alex@example.com"), false);
+    assert.equal(serialized.includes("192.168.1.10"), false);
+    assert.equal(serialized.includes("super-secret"), false);
+  });
+});
+
+test("includeRedactedExcerpts emits sanitized excerpts only", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        session_key: "thread-1",
+        sender: "human",
+        created_at: "2026-02-03T00:00:00.000Z",
+        text: "Read /home/person/work and send results to person@example.com",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+    const draft = report.drafts[0];
+    assert.equal(draft.excerpts?.length, 1);
+    assert.equal(draft.excerpts?.[0].text, "Read [REDACTED_PATH] and send results to [REDACTED_EMAIL]");
+    assert.deepEqual(draft.redaction.ruleNames, ["absolute-posix-path", "email"]);
+  });
+});
+
+test("includeRedactedExcerpts forces default redaction when defaults are disabled", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        session_key: "thread-1",
+        sender: "human",
+        created_at: "2026-02-03T00:00:00.000Z",
+        text: "Read /home/person/work and send results to person@example.com",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+      redactionConfig: { disableDefaults: true },
+    });
+    const draft = report.drafts[0];
+    assert.equal(draft.excerpts?.[0].text, "Read [REDACTED_PATH] and send results to [REDACTED_EMAIL]");
+    assert.equal(draft.redaction.enabled, true);
+    assert.equal(
+      report.warnings.some((warning) => warning.code === "session-summaries.default_redaction_forced_for_excerpts"),
+      true
+    );
+  });
+});
+
+test("parsing falls back to later non-empty content fields", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "fallback-session",
+        role: "user",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "",
+        text: "Use this fallback text.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 1);
+    assert.equal(report.drafts[0].excerpts?.[0].text, "Use this fallback text.");
+  });
+});
+
+test("parsing reads top-level parts and input content fields", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      [
+        JSON.stringify({
+          sessionKey: "parts-session",
+          role: "user",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          parts: [{ text: "Use parts text." }],
+        }),
+        JSON.stringify({
+          sessionKey: "parts-session",
+          role: "assistant",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          input: "Use input text.",
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 2);
+    assert.deepEqual(
+      report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
+      ["Use parts text.", "Use input text."]
+    );
+  });
+});
+
+test("codex-jsonl parses Codex rollout payload rows", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "rollout.jsonl"),
+      [
+        JSON.stringify({
+          type: "event_msg",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          payload: { message: "User message from payload." },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          payload: { content: [{ type: "output_text", text: "Assistant response from payload." }] },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:02.000Z",
+          payload: { type: "agent_message", message: "Agent event message from payload." },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "codex-jsonl",
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 3);
+    assert.equal(report.drafts[0].roles.user, 1);
+    assert.equal(report.drafts[0].roles.assistant, 2);
+    assert.deepEqual(
+      report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
+      ["User message from payload.", "Assistant response from payload.", "Agent event message from payload."]
+    );
+  });
+});
+
+test("payload.message metadata contributes session, role, and timestamp", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "nested.jsonl");
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        type: "event_msg",
+        payload: {
+          message: {
+            sessionId: "nested-payload-session",
+            role: "assistant",
+            timestamp: "2026-02-03T00:00:00.000Z",
+            content: "Nested assistant content.",
+          },
+        },
+      }),
+      "utf-8"
+    );
+    const firstReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        type: "event_msg",
+        payload: {
+          message: {
+            sessionId: "nested-payload-session",
+            role: "assistant",
+            timestamp: "2026-02-03T00:00:00.000Z",
+            content: "Changed nested assistant content.",
+          },
+        },
+      }),
+      "utf-8"
+    );
+    const secondReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(firstReport.drafts[0].sourceSessionRef, secondReport.drafts[0].sourceSessionRef);
+    assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
+    assert.equal(firstReport.drafts[0].roles.assistant, 1);
+    assert.equal(firstReport.drafts[0].firstTimestamp, "2026-02-03T00:00:00.000Z");
+  });
+});
+
+test("claude-jsonl ignores tool_result blocks instead of storing them as user excerpts", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "claude.jsonl"),
+      [
+        JSON.stringify({
+          sessionId: "claude-session",
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", content: "local command output" }],
+          },
+        }),
+        JSON.stringify({
+          sessionId: "claude-session",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "Actual user message." }],
+          },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "claude-jsonl",
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 1);
+    assert.equal(report.drafts[0].roles.user, 1);
+    assert.deepEqual(
+      report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
+      ["Actual user message."]
+    );
+  });
+});
+
+test("sessionId fields produce stable session refs across content changes", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "session.jsonl");
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        sessionId: "stable-session",
+        role: "user",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "Original content.",
+      }),
+      "utf-8"
+    );
+    const firstReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        sessionId: "stable-session",
+        role: "user",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "Changed content.",
+      }),
+      "utf-8"
+    );
+    const secondReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(firstReport.drafts[0].sourceSessionRef, secondReport.drafts[0].sourceSessionRef);
+    assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
+  });
+});
+
+test("numeric sessionId fields produce stable session refs", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      [
+        JSON.stringify({
+          sessionId: 12345,
+          role: "user",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: "One",
+        }),
+        JSON.stringify({
+          sessionId: 12345,
+          role: "assistant",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          content: "Two",
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(report.sessionsSummarized, 1);
+    assert.equal(report.drafts[0].turnCount, 2);
+  });
+});
+
+test("JSONL rows inherit the previous stable session id in file order", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      [
+        JSON.stringify({
+          sessionId: "jsonl-session",
+          role: "user",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: "One",
+        }),
+        JSON.stringify({
+          role: "assistant",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          content: "Two",
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(report.sessionsSummarized, 1);
+    assert.equal(report.drafts[0].turnCount, 2);
+  });
+});
+
+test("JSONL rows inherit stable session id from metadata-only rows", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "session.jsonl");
+    await writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ sessionId: "metadata-session", created_at: "2026-02-03T00:00:00.000Z" }),
+        JSON.stringify({
+          role: "user",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          content: "Original content.",
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+    const firstReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    await writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ sessionId: "metadata-session", created_at: "2026-02-03T00:00:00.000Z" }),
+        JSON.stringify({
+          role: "user",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          content: "Changed content.",
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+    const secondReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(firstReport.drafts[0].sourceSessionRef, secondReport.drafts[0].sourceSessionRef);
+    assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
+  });
+});
+
+test("JSON envelope sessionId fields are inherited by child rows", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "session.json");
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        sessionId: "stable-envelope-session",
+        messages: [
+          {
+            role: "user",
+            timestamp: "2026-02-03T00:00:00.000Z",
+            content: "Original content.",
+          },
+        ],
+      }),
+      "utf-8"
+    );
+    const firstReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        sessionId: "stable-envelope-session",
+        messages: [
+          {
+            role: "user",
+            timestamp: "2026-02-03T00:00:00.000Z",
+            content: "Changed content.",
+          },
+        ],
+      }),
+      "utf-8"
+    );
+    const secondReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(firstReport.drafts[0].sourceSessionRef, secondReport.drafts[0].sourceSessionRef);
+    assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
+  });
+});
+
+test("inputDir supports tilde expansion", async () => {
+  const dir = await mkdtemp(path.join(os.homedir(), ".remnic-session-summary-"));
+  try {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "home-session",
+        role: "assistant",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "Home-relative input worked.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: `~/${path.basename(dir)}`,
+    });
+
+    assert.equal(report.filesParsed, 1);
+    assert.equal(report.sessionsSummarized, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("inputDir rejects symlinked roots", async () => {
+  await withTempDir(async (dir) => {
+    const target = path.join(dir, "target");
+    const link = path.join(dir, "link");
+    await mkdir(target);
+    await writeFile(
+      path.join(target, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "Should not be scanned through symlink.",
+      }),
+      "utf-8"
+    );
+    await symlink(target, link, "dir");
+
+    await assert.rejects(() => collectLocalSessionSummaries({ inputDir: link }), /symbolic link/i);
+  });
+});
+
+test("inputDir skips nested symlinks while scanning", async () => {
+  await withTempDir(async (dir) => {
+    const inputDir = path.join(dir, "input");
+    const outsideDir = path.join(dir, "outside");
+    await mkdir(inputDir);
+    await mkdir(outsideDir);
+    await writeFile(
+      path.join(outsideDir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "outside",
+        role: "user",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "Should not be read through a nested symlink.",
+      }),
+      "utf-8"
+    );
+    await symlink(outsideDir, path.join(inputDir, "linked-outside"), "dir");
+
+    const report = await collectLocalSessionSummaries({ inputDir });
+
+    assert.equal(report.filesScanned, 0);
+    assert.equal(report.turnsParsed, 0);
+  });
+});
+
+test("maxFiles reports truncation instead of dropping files silently", async () => {
+  await withTempDir(async (dir) => {
+    for (const name of ["a", "b"]) {
+      await writeFile(
+        path.join(dir, `${name}.jsonl`),
+        JSON.stringify({
+          sessionKey: name,
+          role: "user",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: name,
+        }),
+        "utf-8"
+      );
+    }
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      maxFiles: 1,
+    });
+
+    assert.equal(report.filesScanned, 1);
+    assert.equal(
+      report.warnings.some((warning) => warning.code === "session-summaries.max_files_truncated"),
+      true
+    );
+  });
+});
+
+test("maxFiles uses deterministic sorted file order", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "b.jsonl"),
+      JSON.stringify({
+        sessionKey: "b",
+        role: "user",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "B",
+      }),
+      "utf-8"
+    );
+    await writeFile(
+      path.join(dir, "a.jsonl"),
+      JSON.stringify({
+        sessionKey: "a",
+        role: "user",
+        timestamp: "2026-02-03T00:00:00.000Z",
+        content: "A",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+      maxFiles: 1,
+    });
+
+    assert.equal(report.drafts[0].sourceSessionRef, "ca978112ca1bbdca");
+    assert.equal(report.drafts[0].excerpts?.[0].text, "A");
+  });
+});
+
+test("maxSessions reports truncation instead of dropping sessions silently", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "sessions.jsonl"),
+      [
+        JSON.stringify({
+          sessionKey: "session-a",
+          role: "user",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: "A",
+        }),
+        JSON.stringify({
+          sessionKey: "session-b",
+          role: "user",
+          timestamp: "2026-02-03T00:01:00.000Z",
+          content: "B",
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      maxSessions: 1,
+    });
+
+    assert.equal(report.sessionsSummarized, 1);
+    assert.equal(
+      report.warnings.some((warning) => warning.code === "session-summaries.max_sessions_truncated"),
+      true
+    );
+  });
+});
+
+test("duplicate transcript files are skipped by content hash", async () => {
+  await withTempDir(async (dir) => {
+    const content = JSON.stringify({
+      sessionKey: "duplicate-session",
+      role: "user",
+      timestamp: "2026-02-03T00:00:00.000Z",
+      content: "Count this once.",
+    });
+    await writeFile(path.join(dir, "a.jsonl"), content, "utf-8");
+    await writeFile(path.join(dir, "b.jsonl"), content, "utf-8");
+
+    const report = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(report.filesScanned, 2);
+    assert.equal(report.filesParsed, 1);
+    assert.equal(report.turnsParsed, 1);
+    assert.equal(report.drafts[0].turnCount, 1);
+    assert.equal(
+      report.warnings.some((warning) => warning.code === "session-summaries.duplicate_file_skipped"),
+      true
+    );
+  });
+});
+
+test("runLocalSessionSummaryCliCommand writes opt-in Remnic draft JSONL", async () => {
+  await withTempDir(async (dir) => {
+    const inputDir = path.join(dir, "transcripts");
+    const memoryDir = path.join(dir, "memory");
+    await mkdir(inputDir, { recursive: true });
+    await writeFile(
+      path.join(inputDir, "session.json"),
+      JSON.stringify({
+        messages: [
+          {
+            conversation_id: "conversation-1",
+            role: "user",
+            timestamp: "2026-03-04T05:00:00.000Z",
+            content: "Remember project status without raw transcript storage.",
+          },
+        ],
+      }),
+      "utf-8"
+    );
+
+    const report = await runLocalSessionSummaryCliCommand({
+      inputDir,
+      memoryDir,
+      write: true,
+      now: new Date("2026-03-04T06:00:00.000Z"),
+    });
+
+    assert.equal(report.wroteFiles.length, 1);
+    assert.match(report.wroteFiles[0], /state\/session-summary-drafts\/session-summaries-/);
+    const written = await readFile(report.wroteFiles[0], "utf-8");
+    assert.equal(written.trim().split("\n").length, 1);
+    assert.equal(written.includes("conversation-1"), false);
+    assert.equal(written.includes(inputDir), false);
+  });
+});
+
+test("custom redaction config adds user-defined rules", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: "Internal ticket ABC-123 should be hidden.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+      redactionConfig: {
+        rules: [
+          {
+            name: "ticket",
+            pattern: "\\bABC-\\d+\\b",
+            replacement: "[REDACTED_TICKET]",
+          },
+        ],
+      },
+    });
+
+    assert.equal(report.drafts[0].excerpts?.[0].text, "Internal ticket [REDACTED_TICKET] should be hidden.");
+    assert.equal(report.drafts[0].redaction.ruleNames.includes("ticket"), true);
+  });
+});
+
+test("custom redaction flags remain global", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: "Hide ABC and abc.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+      redactionConfig: {
+        rules: [
+          {
+            name: "letters",
+            pattern: "abc",
+            flags: "i",
+            replacement: "[REDACTED_LETTERS]",
+          },
+        ],
+      },
+    });
+
+    assert.equal(report.drafts[0].excerpts?.[0].text, "Hide [REDACTED_LETTERS] and [REDACTED_LETTERS].");
+    assert.equal(report.drafts[0].redaction.applied, 2);
+  });
+});
+
+test("redaction covers quoted secret values with spaces", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: 'Use password="correct horse battery" for the test account.',
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.drafts[0].excerpts?.[0].text, "Use [REDACTED_SECRET] for the test account.");
+  });
+});
+
+test("custom redaction rules must be an array", async () => {
+  assert.throws(
+    () => compileRedactionRules({ rules: { name: "bad", pattern: "bad" } } as never),
+    /redaction rules must be an array/
+  );
+});
+
+test("redaction covers common absolute POSIX paths", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content:
+          "Inspect /workspace/remnic/secrets, /root/.ssh/config, /home/alex/.env.local, /Users/alex/My Documents/secret.txt, /Users/alex/secret file.txt, /Users/alex/Project (Client)/secret.txt, /secrets, and /tmp/customer-notes.pdf.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      "Inspect [REDACTED_PATH], [REDACTED_PATH], [REDACTED_PATH], [REDACTED_PATH], [REDACTED_PATH], [REDACTED_PATH], [REDACTED_PATH], and [REDACTED_PATH]."
+    );
+  });
+});
+
+test("redaction covers home-relative POSIX paths with spaced filenames", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: "Inspect ~/My Documents/secret file.txt before replying.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.drafts[0].excerpts?.[0].text, "Inspect [REDACTED_PATH] before replying.");
+  });
+});
+
+test("redaction covers UNC Windows paths", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content:
+          "Inspect C:\\Users\\alex\\secret file.txt, C:\\Users\\alex\\Secret Project before replying, \\\\server\\share\\client\\secret.txt, and \\\\server\\share\\client\\Secret Project before replying.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      "Inspect [REDACTED_PATH], [REDACTED_PATH], [REDACTED_PATH], and [REDACTED_PATH]"
+    );
+  });
+});
+
+test("redaction config file must be a JSON object", async () => {
+  await withTempDir(async (dir) => {
+    const inputDir = path.join(dir, "transcripts");
+    const configPath = path.join(dir, "redaction.json");
+    await mkdir(inputDir);
+    await writeFile(
+      path.join(inputDir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: "hello",
+      }),
+      "utf-8"
+    );
+    await writeFile(configPath, "[]", "utf-8");
+
+    await assert.rejects(
+      () =>
+        runLocalSessionSummaryCliCommand({
+          inputDir,
+          redactionConfigPath: configPath,
+        }),
+      /redaction config must be a JSON object/
+    );
+  });
+});
+
+test("strict mode rejects malformed JSONL", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(path.join(dir, "bad.jsonl"), "{not json}\n", "utf-8");
+    await assert.rejects(() => collectLocalSessionSummaries({ inputDir: dir, strict: true }), /invalid JSONL line/i);
+  });
+});

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1258,6 +1258,29 @@ test("redaction covers bearer Authorization header values", async () => {
   });
 });
 
+test("redaction covers Basic Authorization header values", async () => {
+  await withTempDir(async (dir) => {
+    const authHeader = `${"Authorization"}: ${"Basic"} sample-basic-value`;
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: `Run curl -H "${authHeader}" before retrying.`,
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.drafts[0].excerpts?.[0].text, 'Run curl -H "[REDACTED_SECRET]" before retrying.');
+  });
+});
+
 test("custom redaction rules must be an array", async () => {
   assert.throws(
     () => compileRedactionRules({ rules: { name: "bad", pattern: "bad" } } as never),

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -1086,6 +1086,19 @@ test("redaction config file must be a JSON object", async () => {
 test("strict mode rejects malformed JSONL", async () => {
   await withTempDir(async (dir) => {
     await writeFile(path.join(dir, "bad.jsonl"), "{not json}\n", "utf-8");
-    await assert.rejects(() => collectLocalSessionSummaries({ inputDir: dir, strict: true }), /invalid JSONL line/i);
+    await assert.rejects(
+      () => collectLocalSessionSummaries({ inputDir: dir, strict: true }),
+      /invalid JSONL line 1 in fileRef [a-f0-9]+/i
+    );
+  });
+});
+
+test("strict mode rejects malformed JSON with fileRef context", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(path.join(dir, "bad.json"), "{not json}\n", "utf-8");
+    await assert.rejects(
+      () => collectLocalSessionSummaries({ inputDir: dir, strict: true }),
+      /invalid generic-jsonl JSON in fileRef [a-f0-9]+/i
+    );
   });
 });

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -322,12 +322,14 @@ test("codex-jsonl deduplicates same-surface mirrored assistant rows", async () =
         }),
         JSON.stringify({
           type: "response_item",
+          id: "assistant-1",
           sessionKey: "codex-session",
           timestamp: "2026-02-03T00:00:01.000Z",
           payload: { content: [{ type: "output_text", text: "Repeated assistant response." }] },
         }),
         JSON.stringify({
           type: "response_item",
+          id: "assistant-1",
           sessionKey: "codex-session",
           timestamp: "2026-02-03T00:00:02.000Z",
           payload: { content: [{ type: "output_text", text: "Repeated assistant response." }] },
@@ -348,6 +350,50 @@ test("codex-jsonl deduplicates same-surface mirrored assistant rows", async () =
     assert.deepEqual(
       report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
       ["User request.", "Repeated assistant response."]
+    );
+  });
+});
+
+test("codex-jsonl keeps distinct same-text response item rows with different ids", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "rollout.jsonl"),
+      [
+        JSON.stringify({
+          type: "event_msg",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          payload: { message: "User request." },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          id: "assistant-1",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          payload: { content: [{ type: "output_text", text: "OK" }] },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          id: "assistant-2",
+          sessionKey: "codex-session",
+          timestamp: "2026-02-03T00:00:02.000Z",
+          payload: { content: [{ type: "output_text", text: "OK" }] },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      source: "codex-jsonl",
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(report.turnsParsed, 3);
+    assert.equal(report.drafts[0].roles.assistant, 2);
+    assert.deepEqual(
+      report.drafts[0].excerpts?.map((excerpt) => excerpt.text),
+      ["User request.", "OK", "OK"]
     );
   });
 });
@@ -432,6 +478,43 @@ test("payload.message metadata contributes session, role, and timestamp", async 
     assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
     assert.equal(firstReport.drafts[0].roles.assistant, 1);
     assert.equal(firstReport.drafts[0].firstTimestamp, "2026-02-03T00:00:00.000Z");
+  });
+});
+
+test("top-level message metadata contributes stable session ids", async () => {
+  await withTempDir(async (dir) => {
+    const transcriptPath = path.join(dir, "nested-message.jsonl");
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        message: {
+          sessionId: "top-level-message-session",
+          role: "assistant",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: "Original nested content.",
+        },
+      }),
+      "utf-8"
+    );
+    const firstReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    await writeFile(
+      transcriptPath,
+      JSON.stringify({
+        message: {
+          sessionId: "top-level-message-session",
+          role: "assistant",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: "Changed nested content.",
+        },
+      }),
+      "utf-8"
+    );
+    const secondReport = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(firstReport.drafts[0].sourceSessionRef, secondReport.drafts[0].sourceSessionRef);
+    assert.equal(firstReport.drafts[0].draftId, secondReport.drafts[0].draftId);
+    assert.equal(firstReport.drafts[0].roles.assistant, 1);
   });
 });
 
@@ -1250,6 +1333,32 @@ test("redaction covers extensionless POSIX paths with spaced names", async () =>
     assert.equal(
       report.drafts[0].excerpts?.[0].text,
       "Open [REDACTED_PATH] before replying and [REDACTED_PATH] after."
+    );
+  });
+});
+
+test("redaction covers POSIX paths with connector words in spaced names", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content:
+          'Open /Users/alex/Research and Development before replying and "/Users/alex/Research and Development" after.',
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      'Open [REDACTED_PATH] before replying and "[REDACTED_PATH]" after.'
     );
   });
 });

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -120,6 +120,33 @@ test("includeRedactedExcerpts forces default redaction when defaults are disable
   });
 });
 
+test("summary includes all normalized role counts", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      [
+        JSON.stringify({
+          sessionKey: "roles-session",
+          role: "system",
+          timestamp: "2026-02-03T00:00:00.000Z",
+          content: "System instruction.",
+        }),
+        JSON.stringify({
+          sessionKey: "roles-session",
+          role: "other",
+          timestamp: "2026-02-03T00:00:01.000Z",
+          content: "Other event.",
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.match(report.drafts[0].summary, /\(0 user, 0 assistant, 0 tool, 1 system, 1 other\)/);
+  });
+});
+
 test("parsing falls back to later non-empty content fields", async () => {
   await withTempDir(async (dir) => {
     await writeFile(
@@ -1525,6 +1552,18 @@ test("strict mode rejects malformed JSONL", async () => {
       () => collectLocalSessionSummaries({ inputDir: dir, strict: true }),
       /invalid JSONL line 1 in fileRef [a-f0-9]+/i
     );
+  });
+});
+
+test("malformed JSON warnings do not include transcript snippets", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(path.join(dir, "bad.json"), '{"content":"PRIVATE_VALUE_SHOULD_NOT_APPEAR",', "utf-8");
+
+    const report = await collectLocalSessionSummaries({ inputDir: dir });
+
+    assert.equal(report.warnings.length, 1);
+    assert.match(report.warnings[0].message, /invalid generic-jsonl JSON in fileRef [a-f0-9]+; skipping file/i);
+    assert.equal(report.warnings[0].message.includes("PRIVATE_VALUE_SHOULD_NOT_APPEAR"), false);
   });
 });
 

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -877,6 +877,32 @@ test("redaction covers common absolute POSIX paths", async () => {
   });
 });
 
+test("redaction covers POSIX paths with common non-alphanumeric characters", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content:
+          "Inspect /Users/alex/client+secret/file.txt, /Users/alex/team@client/config.json, and /Users/alex/caf\u00e9/notes.md.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      "Inspect [REDACTED_PATH], [REDACTED_PATH], and [REDACTED_PATH]."
+    );
+  });
+});
+
 test("redaction covers home-relative POSIX paths with spaced filenames", async () => {
   await withTempDir(async (dir) => {
     await writeFile(

--- a/packages/remnic-core/src/session-summaries/session-summaries.test.ts
+++ b/packages/remnic-core/src/session-summaries/session-summaries.test.ts
@@ -979,6 +979,31 @@ test("redaction covers extensionless POSIX paths with spaced names", async () =>
   });
 });
 
+test("redaction covers single-segment POSIX paths with spaced names", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "session.jsonl"),
+      JSON.stringify({
+        sessionKey: "s",
+        role: "user",
+        timestamp: "2026-04-05T00:00:00.000Z",
+        content: "Inspect /Secret Project before replying and /Secret Project.txt after.",
+      }),
+      "utf-8"
+    );
+
+    const report = await collectLocalSessionSummaries({
+      inputDir: dir,
+      includeRedactedExcerpts: true,
+    });
+
+    assert.equal(
+      report.drafts[0].excerpts?.[0].text,
+      "Inspect [REDACTED_PATH] before replying and [REDACTED_PATH] after."
+    );
+  });
+});
+
 test("redaction covers UNC Windows paths", async () => {
   await withTempDir(async (dir) => {
     await writeFile(

--- a/packages/remnic-core/src/session-summaries/types.ts
+++ b/packages/remnic-core/src/session-summaries/types.ts
@@ -1,0 +1,130 @@
+export type LocalSessionRole = "user" | "assistant" | "tool" | "system" | "other";
+
+export interface LocalSessionTurn {
+  role: LocalSessionRole;
+  content: string;
+  timestamp?: string;
+  sessionKey?: string;
+  sourceId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface LocalSessionParseWarning {
+  code: string;
+  message: string;
+  fileRef?: string;
+  line?: number;
+}
+
+export interface LocalSessionParsedFile {
+  turns: LocalSessionTurn[];
+  warnings: LocalSessionParseWarning[];
+}
+
+export interface LocalSessionAdapterInput {
+  content: string;
+  fileName: string;
+  fileExtension: string;
+  fileRef: string;
+}
+
+export interface LocalSessionAdapterOptions {
+  strict?: boolean;
+}
+
+export interface LocalSessionSourceAdapter {
+  id: string;
+  parseFile(
+    input: LocalSessionAdapterInput,
+    options?: LocalSessionAdapterOptions
+  ): LocalSessionParsedFile | Promise<LocalSessionParsedFile>;
+}
+
+export interface RedactionRuleConfig {
+  name: string;
+  pattern: string;
+  flags?: string;
+  replacement?: string;
+}
+
+export interface RedactionConfig {
+  disableDefaults?: boolean;
+  rules?: RedactionRuleConfig[];
+}
+
+export interface CompiledRedactionRule {
+  name: string;
+  pattern: RegExp;
+  replacement: string;
+}
+
+export interface RedactionReport {
+  applied: number;
+  ruleNames: string[];
+}
+
+export interface SessionSummaryExcerpt {
+  role: LocalSessionRole;
+  text: string;
+  timestamp?: string;
+}
+
+export interface SessionSummaryDraft {
+  schemaVersion: 1;
+  draftId: string;
+  generatedAt: string;
+  sourceAdapter: string;
+  sourceSessionRef: string;
+  sourceFileCount: number;
+  sourceFileRefs: Array<{
+    hash: string;
+    extension: string;
+  }>;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  turnCount: number;
+  roles: Record<LocalSessionRole, number>;
+  summary: string;
+  redaction: {
+    enabled: boolean;
+    applied: number;
+    ruleNames: string[];
+  };
+  excerpts?: SessionSummaryExcerpt[];
+  metadata: {
+    storesRawTranscript: false;
+    storesLocalPaths: false;
+    storesSourceSessionKey: false;
+  };
+}
+
+export interface CollectLocalSessionSummariesOptions {
+  inputDir: string;
+  source?: string;
+  strict?: boolean;
+  redactionConfig?: RedactionConfig;
+  includeRedactedExcerpts?: boolean;
+  maxFiles?: number;
+  maxSessions?: number;
+  now?: Date;
+}
+
+export interface LocalSessionSummaryReport {
+  generatedAt: string;
+  source: string;
+  filesScanned: number;
+  filesParsed: number;
+  turnsParsed: number;
+  sessionsSummarized: number;
+  warnings: LocalSessionParseWarning[];
+  drafts: SessionSummaryDraft[];
+  wroteFiles: string[];
+}
+
+export interface LocalSessionSummaryCliOptions extends CollectLocalSessionSummariesOptions {
+  memoryDir?: string;
+  output?: string;
+  write?: boolean;
+  redactionConfigPath?: string;
+  stdout?: Pick<NodeJS.WritableStream, "write">;
+}


### PR DESCRIPTION
## Summary
- add generic local AI session summary draft collection to `@remnic/core`
- add shape-based `generic-jsonl`, `codex-jsonl`, and `claude-jsonl` adapters
- add privacy-first redaction, hashed source refs, metadata-only drafts by default, and opt-in draft JSONL writes
- document the public adapter shape and privacy contract

## Privacy
- raw transcript text is not stored by default
- source session keys and file contents are hashed
- local paths are not stored
- default redaction covers secrets, emails, private IPs, URLs, and absolute paths
- optional excerpts are redacted before storage

## Verification
- `node node_modules/tsx/dist/cli.mjs --test packages/remnic-core/src/session-summaries/session-summaries.test.ts`
- `node node_modules/typescript/bin/tsc --noEmit --pretty false -p packages/remnic-core/tsconfig.json`
- `pnpm --filter @remnic/core build`
- `node node_modules/@biomejs/biome/bin/biome check docs/local-session-summaries.md packages/remnic-core/src/session-summaries packages/remnic-core/src/index.ts`

Note: the local pnpm binary shims for `tsx`/`tsc` were SIGKILLed after dependency refresh on this machine, so the same tool entrypoints were invoked through `node ...` directly for stable local verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New code reads arbitrary local transcript directories and applies regex redaction before write; privacy contract is strong but misconfiguration or excerpt mode could still leak sensitive content if rules miss edge cases.
> 
> **Overview**
> Adds a new **`session-summaries`** subsystem in `@remnic/core` that scans a directory of local JSON/JSONL transcripts, parses turns through pluggable adapters, and emits **privacy-first summary drafts** (metadata by default, no raw paths or session keys in output).
> 
> **Collection & output:** `collectLocalSessionSummaries` walks the input tree (symlink roots rejected, nested symlinks skipped), caps `maxFiles` / `maxSessions` with explicit warnings, dedupes identical file content by hash, and groups turns into per-session drafts with hashed `sourceSessionRef` and file refs. `runLocalSessionSummaryCliCommand` supports dry-run vs opt-in writes to `<memoryDir>/state/session-summary-drafts/` or a custom `output` path.
> 
> **Adapters:** Built-in shape-based parsers `generic-jsonl`, `codex-jsonl`, and `claude-jsonl` (registry via `registerLocalSessionSourceAdapter`). Codex-specific behavior skips compacted rows and dedupes mirrored assistant lines across event/response surfaces; Claude-style `tool_result` blocks are ignored.
> 
> **Redaction:** Default rules scrub secrets, emails, private IPs, URLs, and POSIX/Windows paths; optional `includeRedactedExcerpts` stores short redacted snippets only when redaction is enabled (defaults forced on for excerpts).
> 
> **Public surface:** Re-exported from `packages/remnic-core/src/index.ts`; documented in `docs/local-session-summaries.md` and linked from the ops docs index. Large test suite covers privacy contract, adapters, limits, and redaction edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac026f21ed711370a6e147c2ee6ac2bd3d1bda81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->