### PR TITLE
Fix optional unverified previews in Remnic memory inspector

### DIFF
--- a/docs/chatgpt-apps-demo.md
+++ b/docs/chatgpt-apps-demo.md
@@ -18,6 +18,12 @@ provenance, evaluates action confidence, and renders the result in a widget.
 Correction, forget, and scoping controls send follow-up prompts only; persistent
 changes still require a separate Remnic tool call and user confirmation.
 
+By default, the inspector withholds preview text when Recall X-ray provenance is
+missing or unavailable. For local audit workflows, pass
+`allowUnverifiedPreview: true` to show those unverified previews with a
+requires-review warning. Memories that X-ray explicitly marks blocked remain
+redacted either way.
+
 ## Why This Shape
 
 OpenAI's Apps SDK quickstart says ChatGPT apps use an MCP server to expose
@@ -60,7 +66,8 @@ Then call:
     "name": "remnic.chatgpt_memory_inspector",
     "arguments": {
       "query": "What preferences matter for this answer?",
-      "currentContextScopes": ["work", "repo"]
+      "currentContextScopes": ["work", "repo"],
+      "allowUnverifiedPreview": true
     }
   }
 }

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -715,6 +715,11 @@ export class EngramMcpServer {
               description:
                 "Optional current user-context scopes, such as repo, work, personal, client, or private.",
             },
+            allowUnverifiedPreview: {
+              type: "boolean",
+              description:
+                "If true, the inspector may show recalled preview text when X-ray provenance is missing or unavailable. Explicitly blocked memories remain redacted.",
+            },
           },
           required: ["query"],
           additionalProperties: false,
@@ -2607,6 +2612,17 @@ export class EngramMcpServer {
         }
         if (currentContextScopes !== undefined) {
           input.currentContextScopes = currentContextScopes;
+        }
+        if (
+          args.allowUnverifiedPreview !== undefined &&
+          args.allowUnverifiedPreview !== null
+        ) {
+          if (typeof args.allowUnverifiedPreview !== "boolean") {
+            throw new EngramAccessInputError(
+              "allowUnverifiedPreview must be a boolean",
+            );
+          }
+          input.allowUnverifiedPreview = args.allowUnverifiedPreview;
         }
         const recallSessionKey = resolveChatGptInspectorRecallSessionKey(
           input.sessionKey,

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -119,28 +119,38 @@ export function buildChatGptMemoryInspectorResult(
   const allowUnverifiedPreview = input.allowUnverifiedPreview === true;
   const matchXrayResult = buildXrayResultMatcher(xray, recall.results);
   const matchedXrayResults = recall.results.map(matchXrayResult);
+  const hasBlockedSameId = buildBlockedSameIdMatcher(xray);
 
   const memories = recall.results.slice(0, 8).map((summary) => {
     const xrayResult = matchXrayResult(summary);
     const provenance = xrayResult?.provenance;
-    const unverified = !xrayUnavailable && provenance === undefined;
-    const blocked = provenance?.safety === "blocked";
+    const blockedByAmbiguousSameId = !xrayUnavailable
+      && provenance === undefined
+      && hasBlockedSameId(summary.id);
+    const blocked = provenance?.safety === "blocked" || blockedByAmbiguousSameId;
+    const unverified = !xrayUnavailable && provenance === undefined && !blockedByAmbiguousSameId;
     const preview = xrayUnavailable
       ? allowUnverifiedPreview
         ? summary.preview
         : "Preview withheld: X-ray provenance was unavailable for this recall."
-      : unverified
-        ? allowUnverifiedPreview
-          ? summary.preview
-          : "Preview withheld: X-ray provenance was missing for this memory."
       : blocked
         ? "Preview withheld: this memory is blocked in the current context."
-        : summary.preview;
-    const fallbackSafety = xrayUnavailable || unverified
-      ? allowUnverifiedPreview ? "requires-review" : "blocked"
-      : undefined;
+        : unverified
+          ? allowUnverifiedPreview
+            ? summary.preview
+            : "Preview withheld: X-ray provenance was missing for this memory."
+          : summary.preview;
+    const fallbackSafety = blockedByAmbiguousSameId
+      ? "blocked"
+      : xrayUnavailable || unverified
+        ? allowUnverifiedPreview
+          ? "requires-review"
+          : "blocked"
+        : undefined;
     const fallbackSafetyReason = xrayUnavailable
       ? "X-ray provenance was unavailable for this recall."
+      : blockedByAmbiguousSameId
+        ? "An unmatched X-ray row with this memory id was blocked."
       : "X-ray provenance was missing for this memory.";
     return {
       id: summary.id,
@@ -156,28 +166,41 @@ export function buildChatGptMemoryInspectorResult(
       confidence: provenance?.confidence,
       stale: provenance?.stale,
       corrected: provenance?.corrected,
-      safeToUse: provenance?.safeToUse ?? (xrayUnavailable || unverified ? false : undefined),
+      safeToUse: provenance?.safeToUse
+        ?? (xrayUnavailable || unverified || blockedByAmbiguousSameId ? false : undefined),
       safety: provenance?.safety ?? fallbackSafety,
       safetyReasons: provenance?.safetyReasons
-        ?? (xrayUnavailable || unverified ? [fallbackSafetyReason] : []),
+        ?? (
+          xrayUnavailable || unverified || blockedByAmbiguousSameId
+            ? [fallbackSafetyReason]
+            : []
+        ),
       userContextScopes: provenance?.userContextScopes ?? [],
     };
   });
   const blockedCount = matchedXrayResults
     .filter((result) => result?.provenance?.safety === "blocked")
     .length;
+  const ambiguousBlockedCount = recall.results
+    .filter((summary, index) =>
+      matchedXrayResults[index]?.provenance === undefined && hasBlockedSameId(summary.id)
+    )
+    .length;
   const missingProvenanceCount = xrayUnavailable
     ? 0
     : matchedXrayResults
-      .filter((result) => result?.provenance === undefined)
+      .filter((result, index) =>
+        result?.provenance === undefined && !hasBlockedSameId(recall.results[index]?.id ?? "")
+      )
     .length;
+  const totalBlockedCount = blockedCount + ambiguousBlockedCount;
   const safeRecallPreview = xrayUnavailable
     ? allowUnverifiedPreview
       ? `Unverified recall preview: X-ray provenance was unavailable, so memory safety could not be verified.\n\n${truncate(recall.context, 1_500)}`
       : "Recall preview withheld: X-ray provenance was unavailable, so memory safety could not be verified."
-    : blockedCount > 0 || missingProvenanceCount > 0
-      ? blockedCount > 0 || !allowUnverifiedPreview
-        ? formatUnsafeRecallPreview(blockedCount, missingProvenanceCount)
+    : totalBlockedCount > 0 || missingProvenanceCount > 0
+      ? totalBlockedCount > 0 || !allowUnverifiedPreview
+        ? formatUnsafeRecallPreview(totalBlockedCount, missingProvenanceCount)
         : `Unverified recall preview: ${missingProvenanceCount} retrieved ${memoryNoun(missingProvenanceCount)} ${isAre(missingProvenanceCount)} missing X-ray provenance.\n\n${truncate(recall.context, 1_500)}`
       : truncate(recall.context, 1_500);
 
@@ -423,6 +446,18 @@ function buildXrayResultMatcher(
       ? xrayById.get(summary.id)
       : undefined;
   };
+}
+
+function buildBlockedSameIdMatcher(
+  xray: RecallXraySnapshot | null,
+): (memoryId: string) => boolean {
+  const blockedIds = new Set<string>();
+  for (const result of xray?.results ?? []) {
+    if (result.provenance?.safety === "blocked") {
+      blockedIds.add(result.memoryId);
+    }
+  }
+  return (memoryId) => blockedIds.has(memoryId);
 }
 
 function missingProvenance(result: RecallXrayResult): RetrievedMemoryProvenance {

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -125,7 +125,7 @@ export function buildChatGptMemoryInspectorResult(
     const xrayResult = matchXrayResult(summary);
     const provenance = xrayResult?.provenance;
     const blockedByAmbiguousSameId = !xrayUnavailable
-      && provenance === undefined
+      && xrayResult === undefined
       && hasBlockedSameId(summary.id);
     const blocked = provenance?.safety === "blocked" || blockedByAmbiguousSameId;
     const unverified = !xrayUnavailable && provenance === undefined && !blockedByAmbiguousSameId;
@@ -183,14 +183,15 @@ export function buildChatGptMemoryInspectorResult(
     .length;
   const ambiguousBlockedCount = recall.results
     .filter((summary, index) =>
-      matchedXrayResults[index]?.provenance === undefined && hasBlockedSameId(summary.id)
+      matchedXrayResults[index] === undefined && hasBlockedSameId(summary.id)
     )
     .length;
   const missingProvenanceCount = xrayUnavailable
     ? 0
     : matchedXrayResults
       .filter((result, index) =>
-        result?.provenance === undefined && !hasBlockedSameId(recall.results[index]?.id ?? "")
+        result?.provenance === undefined
+        && !(result === undefined && hasBlockedSameId(recall.results[index]?.id ?? ""))
       )
     .length;
   const totalBlockedCount = blockedCount + ambiguousBlockedCount;

--- a/packages/remnic-core/src/mcp-memory-inspector-app.ts
+++ b/packages/remnic-core/src/mcp-memory-inspector-app.ts
@@ -18,6 +18,7 @@ export interface RemnicChatGptMemoryInspectorInput {
   sessionKey?: string;
   namespace?: string;
   currentContextScopes?: string[];
+  allowUnverifiedPreview?: boolean;
 }
 
 export interface RemnicChatGptMemoryCard {
@@ -115,7 +116,8 @@ export function buildChatGptMemoryInspectorResult(
   actionConfidence: ActionConfidenceResult,
 ): RemnicChatGptMemoryInspectorResult {
   const xrayUnavailable = xray === null;
-  const matchXrayResult = buildXrayResultMatcher(xray);
+  const allowUnverifiedPreview = input.allowUnverifiedPreview === true;
+  const matchXrayResult = buildXrayResultMatcher(xray, recall.results);
   const matchedXrayResults = recall.results.map(matchXrayResult);
 
   const memories = recall.results.slice(0, 8).map((summary) => {
@@ -124,12 +126,22 @@ export function buildChatGptMemoryInspectorResult(
     const unverified = !xrayUnavailable && provenance === undefined;
     const blocked = provenance?.safety === "blocked";
     const preview = xrayUnavailable
-      ? "Preview withheld: X-ray provenance was unavailable for this recall."
+      ? allowUnverifiedPreview
+        ? summary.preview
+        : "Preview withheld: X-ray provenance was unavailable for this recall."
       : unverified
-        ? "Preview withheld: X-ray provenance was missing for this memory."
+        ? allowUnverifiedPreview
+          ? summary.preview
+          : "Preview withheld: X-ray provenance was missing for this memory."
       : blocked
         ? "Preview withheld: this memory is blocked in the current context."
         : summary.preview;
+    const fallbackSafety = xrayUnavailable || unverified
+      ? allowUnverifiedPreview ? "requires-review" : "blocked"
+      : undefined;
+    const fallbackSafetyReason = xrayUnavailable
+      ? "X-ray provenance was unavailable for this recall."
+      : "X-ray provenance was missing for this memory.";
     return {
       id: summary.id,
       path: summary.path,
@@ -144,10 +156,10 @@ export function buildChatGptMemoryInspectorResult(
       confidence: provenance?.confidence,
       stale: provenance?.stale,
       corrected: provenance?.corrected,
-      safeToUse: provenance?.safeToUse ?? (unverified ? false : undefined),
-      safety: provenance?.safety ?? (unverified ? "blocked" : undefined),
+      safeToUse: provenance?.safeToUse ?? (xrayUnavailable || unverified ? false : undefined),
+      safety: provenance?.safety ?? fallbackSafety,
       safetyReasons: provenance?.safetyReasons
-        ?? (unverified ? ["X-ray provenance was missing for this memory."] : []),
+        ?? (xrayUnavailable || unverified ? [fallbackSafetyReason] : []),
       userContextScopes: provenance?.userContextScopes ?? [],
     };
   });
@@ -160,9 +172,13 @@ export function buildChatGptMemoryInspectorResult(
       .filter((result) => result?.provenance === undefined)
     .length;
   const safeRecallPreview = xrayUnavailable
-    ? "Recall preview withheld: X-ray provenance was unavailable, so memory safety could not be verified."
+    ? allowUnverifiedPreview
+      ? `Unverified recall preview: X-ray provenance was unavailable, so memory safety could not be verified.\n\n${truncate(recall.context, 1_500)}`
+      : "Recall preview withheld: X-ray provenance was unavailable, so memory safety could not be verified."
     : blockedCount > 0 || missingProvenanceCount > 0
-      ? formatUnsafeRecallPreview(blockedCount, missingProvenanceCount)
+      ? blockedCount > 0 || !allowUnverifiedPreview
+        ? formatUnsafeRecallPreview(blockedCount, missingProvenanceCount)
+        : `Unverified recall preview: ${missingProvenanceCount} retrieved ${memoryNoun(missingProvenanceCount)} ${isAre(missingProvenanceCount)} missing X-ray provenance.\n\n${truncate(recall.context, 1_500)}`
       : truncate(recall.context, 1_500);
 
   const primaryMemoryId = memories[0]?.id ?? "<memory-id>";
@@ -372,7 +388,7 @@ function buildRecallProvenances(
   if (xray === null) {
     return recall.results.map(missingRecallProvenance);
   }
-  const matchXrayResult = buildXrayResultMatcher(xray);
+  const matchXrayResult = buildXrayResultMatcher(xray, recall.results);
   return recall.results.map((summary) => {
     const result = matchXrayResult(summary);
     if (result === undefined) {
@@ -384,18 +400,28 @@ function buildRecallProvenances(
 
 function buildXrayResultMatcher(
   xray: RecallXraySnapshot | null,
+  recallResults: EngramAccessRecallResponse["results"],
 ): (summary: EngramAccessRecallResponse["results"][number]) => RecallXrayResult | undefined {
   const xrayById = new Map<string, RecallXrayResult>();
+  const xrayIdCounts = new Map<string, number>();
+  const recallIdCounts = new Map<string, number>();
   const xrayByPath = new Map<string, RecallXrayResult>();
+  for (const summary of recallResults) {
+    recallIdCounts.set(summary.id, (recallIdCounts.get(summary.id) ?? 0) + 1);
+  }
   for (const result of xray?.results ?? []) {
     xrayById.set(result.memoryId, result);
+    xrayIdCounts.set(result.memoryId, (xrayIdCounts.get(result.memoryId) ?? 0) + 1);
     xrayByPath.set(result.path, result);
   }
   return (summary) => {
     if (summary.path) {
-      return xrayByPath.get(summary.path);
+      const pathMatch = xrayByPath.get(summary.path);
+      if (pathMatch) return pathMatch;
     }
-    return xrayById.get(summary.id);
+    return xrayIdCounts.get(summary.id) === 1 && recallIdCounts.get(summary.id) === 1
+      ? xrayById.get(summary.id)
+      : undefined;
   };
 }
 

--- a/scripts/test-typecheck-baseline.txt
+++ b/scripts/test-typecheck-baseline.txt
@@ -137,16 +137,6 @@ tests/access-idempotency.test.ts(225,7): TS2349
 tests/access-idempotency.test.ts(294,7): TS2349
 tests/access-idempotency.test.ts(302,7): TS2349
 tests/access-idempotency.test.ts(397,7): TS2349
-tests/access-mcp-chatgpt-app.test.ts(377,5): TS2322
-tests/access-mcp-chatgpt-app.test.ts(391,7): TS2322
-tests/access-mcp-chatgpt-app.test.ts(429,7): TS2741
-tests/access-mcp-chatgpt-app.test.ts(509,7): TS2741
-tests/access-mcp-chatgpt-app.test.ts(516,7): TS2741
-tests/access-mcp-chatgpt-app.test.ts(616,7): TS2741
-tests/access-mcp-chatgpt-app.test.ts(623,7): TS2741
-tests/access-mcp-chatgpt-app.test.ts(664,7): TS2322
-tests/access-mcp-chatgpt-app.test.ts(701,7): TS2741
-tests/access-mcp-chatgpt-app.test.ts(764,7): TS2741
 tests/access-mcp.test.ts(9,22): TS7031
 tests/access-mcp.test.ts(31,26): TS7031
 tests/access-mcp.test.ts(44,23): TS7006

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -1128,6 +1128,96 @@ test("ChatGPT Apps inspector can show unverified previews when explicitly reques
   assert.match(result.memories[0]?.safetyReasons[0] ?? "", /provenance was missing/);
 });
 
+test("ChatGPT Apps inspector keeps path-matched missing-provenance rows unverified", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "unverified work detail",
+    count: 1,
+    memoryIds: ["mem-shared"],
+    results: [
+      {
+        id: "mem-shared",
+        path: "work/mem-shared.md",
+        category: "preference",
+        status: "active",
+        tags: [],
+        preview: "unverified work detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work", allowUnverifiedPreview: true },
+    recall,
+    {
+      schemaVersion: "1",
+      query: "show preferences",
+      snapshotId: "snap-path-matched-missing-provenance",
+      capturedAt: 1_779_000_000_000,
+      tierExplain: null,
+      results: [
+        {
+          memoryId: "mem-shared",
+          path: "work/mem-shared.md",
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.8 },
+          admittedBy: ["test"],
+        },
+        {
+          memoryId: "mem-shared",
+          path: "private/mem-shared.md",
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.9 },
+          admittedBy: ["test"],
+          provenance: {
+            source: "conversation",
+            scope: "namespace:private",
+            userContextScopes: ["work"],
+            retrievalReason: "test",
+            confidence: 0.9,
+            stale: false,
+            corrected: false,
+            correctionState: "none",
+            safeToUse: false,
+            safety: "blocked",
+            safetyReasons: ["blocked in current context"],
+          },
+        },
+      ],
+      filters: [],
+      budget: { chars: 4096, used: 100 },
+      namespace: "work",
+    },
+    {
+      schemaVersion: 1,
+      decision: "refuse",
+      confidence: 0.2,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: ["missing xray provenance"],
+      factors: [],
+      retrievedMemoryCount: 1,
+      usableMemoryCount: 0,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 0,
+      safeToAct: false,
+    },
+  );
+
+  assert.match(result.safeRecallPreview, /Unverified recall preview/);
+  assert.match(result.safeRecallPreview, /unverified work detail/);
+  assert.equal(result.memories[0]?.preview, "unverified work detail");
+  assert.equal(result.memories[0]?.safety, "requires-review");
+  assert.match(result.memories[0]?.safetyReasons[0] ?? "", /provenance was missing/);
+});
+
 test("ChatGPT Apps inspector rejects malformed currentContextScopes before service dispatch", async () => {
   const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
   const server = new EngramMcpServer(fakeService(capture));

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -618,6 +618,121 @@ test("ChatGPT Apps inspector matches X-ray provenance by path before duplicate i
   assert.equal(result.memories[1]?.preview, "safe work detail");
 });
 
+test("ChatGPT Apps inspector redacts ambiguous same-id memories when any unmatched X-ray row is blocked", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "blocked private detail\nsafe work detail",
+    count: 2,
+    memoryIds: ["mem-shared", "mem-shared"],
+    results: [
+      {
+        id: "mem-shared",
+        path: "private/stale-mem-shared.md",
+        category: "preference",
+        status: "active",
+        tags: [],
+        preview: "blocked private detail",
+      },
+      {
+        id: "mem-shared",
+        path: "work/mem-shared.md",
+        category: "preference",
+        status: "active",
+        tags: [],
+        preview: "safe work detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work", allowUnverifiedPreview: true },
+    recall,
+    {
+      schemaVersion: "1",
+      query: "show preferences",
+      snapshotId: "snap-ambiguous-blocked-same-id",
+      capturedAt: 1_779_000_000_000,
+      tierExplain: null,
+      results: [
+        {
+          memoryId: "mem-shared",
+          path: "private/mem-shared.md",
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.9 },
+          admittedBy: ["test"],
+          provenance: {
+            source: "conversation",
+            scope: "namespace:private",
+            userContextScopes: ["work"],
+            retrievalReason: "test",
+            confidence: 0.9,
+            stale: false,
+            corrected: false,
+            correctionState: "none",
+            safeToUse: false,
+            safety: "blocked",
+            safetyReasons: ["blocked in current context"],
+          },
+        },
+        {
+          memoryId: "mem-shared",
+          path: "work/mem-shared.md",
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.8 },
+          admittedBy: ["test"],
+          provenance: {
+            source: "conversation",
+            scope: "namespace:work",
+            userContextScopes: ["work"],
+            retrievalReason: "test",
+            confidence: 0.8,
+            stale: false,
+            corrected: false,
+            correctionState: "none",
+            safeToUse: true,
+            safety: "safe",
+            safetyReasons: [],
+          },
+        },
+      ],
+      filters: [],
+      budget: { chars: 4096, used: 100 },
+      namespace: "work",
+    },
+    {
+      schemaVersion: 1,
+      decision: "ask",
+      confidence: 0.5,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: [],
+      factors: [],
+      retrievedMemoryCount: 2,
+      usableMemoryCount: 1,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 1,
+      safeToAct: false,
+    },
+  );
+
+  assert.match(result.safeRecallPreview, /1 retrieved memory is blocked/);
+  assert.doesNotMatch(result.safeRecallPreview, /blocked private detail/);
+  assert.equal(
+    result.memories[0]?.preview,
+    "Preview withheld: this memory is blocked in the current context.",
+  );
+  assert.equal(result.memories[0]?.safety, "blocked");
+  assert.match(result.memories[0]?.safetyReasons[0] ?? "", /unmatched X-ray row/);
+  assert.equal(result.memories[1]?.preview, "safe work detail");
+});
+
 test("ChatGPT Apps inspector falls back to unique memory id when X-ray path is stale", () => {
   const recall: EngramAccessRecallResponse = {
     query: "show preferences",

--- a/tests/access-mcp-chatgpt-app.test.ts
+++ b/tests/access-mcp-chatgpt-app.test.ts
@@ -9,6 +9,7 @@ import {
   REMNIC_CHATGPT_MEMORY_INSPECTOR_WIDGET_URI,
   type RemnicChatGptMemoryInspectorResult,
 } from "../src/mcp-memory-inspector-app.js";
+import type { RecallXrayResult } from "../src/recall-xray.js";
 import { EngramMcpServer } from "../src/access-mcp.js";
 import type {
   EngramAccessRecallResponse,
@@ -38,6 +39,7 @@ function fakeService(capture: Capture): EngramAccessService {
             path: "preferences/2026-05-01/update-style.md",
             category: "preference",
             status: "active",
+            tags: [],
             preview: "Prefers concise, implementation-focused updates.",
           },
         ],
@@ -61,6 +63,7 @@ function fakeService(capture: Capture): EngramAccessService {
             path: "preferences/2026-05-01/update-style.md",
             category: "preference",
             status: "active",
+            tags: [],
             preview: "Prefers concise, implementation-focused updates.",
           },
         ],
@@ -165,11 +168,17 @@ test("ChatGPT Apps inspector advertises app-compatible tool metadata and aliases
   ) as {
     title?: string;
     annotations?: Record<string, unknown>;
+    inputSchema?: { properties?: Record<string, unknown> };
     outputSchema?: { properties?: Record<string, unknown> };
     _meta?: Record<string, unknown>;
   };
   assert.equal(descriptor.title, "Show Remnic Memory Inspector");
   assert.deepEqual(descriptor.outputSchema?.properties?.sessionKey, { type: "string" });
+  assert.deepEqual(descriptor.inputSchema?.properties?.allowUnverifiedPreview, {
+    type: "boolean",
+    description:
+      "If true, the inspector may show recalled preview text when X-ray provenance is missing or unavailable. Explicitly blocked memories remain redacted.",
+  });
   assert.deepEqual(descriptor.annotations, {
     readOnlyHint: true,
     destructiveHint: false,
@@ -346,9 +355,10 @@ test("ChatGPT Apps inspector withholds preview when blocked memory is beyond vis
     path: `memories/mem-${index + 1}.md`,
     category: "preference",
     status: "active",
+    tags: [],
     preview: index === 8 ? "blocked private detail" : `safe preview ${index + 1}`,
   }));
-  const xrayResults = recallResults.map((memory, index) => ({
+  const xrayResults: RecallXrayResult[] = recallResults.map((memory, index) => ({
     memoryId: memory.id,
     path: memory.path,
     servedBy: "hybrid" as const,
@@ -431,6 +441,7 @@ test("ChatGPT Apps inspector redacts blocked visible memory card previews", () =
         path: "memories/mem-blocked.md",
         category: "preference",
         status: "active",
+        tags: [],
         preview: "blocked private detail",
       },
     ],
@@ -511,6 +522,7 @@ test("ChatGPT Apps inspector matches X-ray provenance by path before duplicate i
         path: "private/mem-shared.md",
         category: "preference",
         status: "active",
+        tags: [],
         preview: "blocked private detail",
       },
       {
@@ -518,6 +530,7 @@ test("ChatGPT Apps inspector matches X-ray provenance by path before duplicate i
         path: "work/mem-shared.md",
         category: "preference",
         status: "active",
+        tags: [],
         preview: "safe work detail",
       },
     ],
@@ -605,6 +618,88 @@ test("ChatGPT Apps inspector matches X-ray provenance by path before duplicate i
   assert.equal(result.memories[1]?.preview, "safe work detail");
 });
 
+test("ChatGPT Apps inspector falls back to unique memory id when X-ray path is stale", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "safe work detail",
+    count: 1,
+    memoryIds: ["mem-safe"],
+    results: [
+      {
+        id: "mem-safe",
+        path: "legacy/work/mem-safe.md",
+        category: "preference",
+        status: "active",
+        tags: [],
+        preview: "safe work detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work" },
+    recall,
+    {
+      schemaVersion: "1",
+      query: "show preferences",
+      snapshotId: "snap-stale-path-unique-id",
+      capturedAt: 1_779_000_000_000,
+      tierExplain: null,
+      results: [
+        {
+          memoryId: "mem-safe",
+          path: "work/mem-safe.md",
+          servedBy: "hybrid",
+          scoreDecomposition: { final: 0.8 },
+          admittedBy: ["test"],
+          provenance: {
+            source: "conversation",
+            scope: "namespace:work",
+            userContextScopes: ["work"],
+            retrievalReason: "test",
+            confidence: 0.8,
+            stale: false,
+            corrected: false,
+            correctionState: "none",
+            safeToUse: true,
+            safety: "safe",
+            safetyReasons: [],
+          },
+        },
+      ],
+      filters: [],
+      budget: { chars: 4096, used: 100 },
+      namespace: "work",
+    },
+    {
+      schemaVersion: 1,
+      decision: "draft",
+      confidence: 0.8,
+      risk: "medium",
+      contextReadiness: "sufficient",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: [],
+      factors: [],
+      retrievedMemoryCount: 1,
+      usableMemoryCount: 1,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 0,
+      safeToAct: false,
+    },
+  );
+
+  assert.equal(result.safeRecallPreview, "safe work detail");
+  assert.equal(result.memories[0]?.preview, "safe work detail");
+  assert.equal(result.memories[0]?.source, "conversation");
+  assert.equal(result.memories[0]?.safety, "safe");
+});
+
 test("ChatGPT Apps inspector pluralizes blocked memory preview messages", () => {
   const recall: EngramAccessRecallResponse = {
     query: "show preferences",
@@ -618,6 +713,7 @@ test("ChatGPT Apps inspector pluralizes blocked memory preview messages", () => 
         path: "memories/mem-blocked-1.md",
         category: "preference",
         status: "active",
+        tags: [],
         preview: "blocked first detail",
       },
       {
@@ -625,6 +721,7 @@ test("ChatGPT Apps inspector pluralizes blocked memory preview messages", () => 
         path: "memories/mem-blocked-2.md",
         category: "preference",
         status: "active",
+        tags: [],
         preview: "blocked second detail",
       },
     ],
@@ -632,7 +729,7 @@ test("ChatGPT Apps inspector pluralizes blocked memory preview messages", () => 
     sourcesUsed: ["memories"],
     disclosure: "chunk",
   };
-  const blockedXrayResults = recall.results.map((summary) => ({
+  const blockedXrayResults: RecallXrayResult[] = recall.results.map((summary) => ({
     memoryId: summary.id,
     path: summary.path ?? "",
     servedBy: "hybrid" as const,
@@ -703,6 +800,7 @@ test("ChatGPT Apps inspector withholds previews when X-ray provenance is unavail
         path: "memories/mem-unverified.md",
         category: "preference",
         status: "active",
+        tags: [],
         preview: "unverified memory detail",
       },
     ],
@@ -766,6 +864,7 @@ test("ChatGPT Apps inspector treats missing per-memory provenance as unsafe", ()
         path: "memories/mem-unverified.md",
         category: "preference",
         status: "active",
+        tags: [],
         preview: "unverified memory detail",
       },
     ],
@@ -834,6 +933,86 @@ test("ChatGPT Apps inspector treats missing per-memory provenance as unsafe", ()
   assert.doesNotMatch(result.memories[0]?.preview ?? "", /unverified memory detail/);
 });
 
+test("ChatGPT Apps inspector can show unverified previews when explicitly requested", () => {
+  const recall: EngramAccessRecallResponse = {
+    query: "show preferences",
+    namespace: "work",
+    context: "unverified memory detail",
+    count: 1,
+    memoryIds: ["mem-unverified"],
+    results: [
+      {
+        id: "mem-unverified",
+        path: "memories/mem-unverified.md",
+        category: "preference",
+        status: "active",
+        tags: [],
+        preview: "unverified memory detail",
+      },
+    ],
+    fallbackUsed: false,
+    sourcesUsed: ["memories"],
+    disclosure: "chunk",
+  };
+  const xray = {
+    schemaVersion: "1" as const,
+    query: "show preferences",
+    snapshotId: "snap-missing-provenance-allowed",
+    capturedAt: 1_779_000_000_000,
+    tierExplain: null,
+    results: [
+      {
+        memoryId: "mem-unverified",
+        path: "memories/mem-unverified.md",
+        servedBy: "hybrid" as const,
+        scoreDecomposition: { final: 0.9 },
+        admittedBy: ["test"],
+      },
+    ],
+    filters: [],
+    budget: { chars: 4096, used: 100 },
+    namespace: "work",
+  };
+  const actionRequest = buildChatGptMemoryInspectorActionRequest(
+    { query: "show preferences", namespace: "work", allowUnverifiedPreview: true },
+    recall,
+    xray,
+  );
+  const result = buildChatGptMemoryInspectorResult(
+    { query: "show preferences", namespace: "work", allowUnverifiedPreview: true },
+    recall,
+    xray,
+    {
+      schemaVersion: 1,
+      decision: "refuse",
+      confidence: 0.2,
+      risk: "medium",
+      contextReadiness: "partial",
+      attentionPolicy: "interruption_budgeting",
+      principle: "A good agent should spend the user's attention carefully.",
+      reasons: [],
+      blockers: ["missing xray provenance"],
+      factors: [],
+      retrievedMemoryCount: 1,
+      usableMemoryCount: 0,
+      staleMemoryCount: 0,
+      correctedMemoryCount: 0,
+      scopeMismatchCount: 0,
+      safeToAct: false,
+    },
+  );
+
+  assert.equal(actionRequest.contextReadiness, "partial");
+  assert.equal(actionRequest.retrievedMemories?.[0]?.safeToUse, false);
+  assert.equal(actionRequest.retrievedMemories?.[0]?.safety, "blocked");
+  assert.match(result.safeRecallPreview, /Unverified recall preview/);
+  assert.match(result.safeRecallPreview, /unverified memory detail/);
+  assert.equal(result.memories[0]?.preview, "unverified memory detail");
+  assert.equal(result.memories[0]?.safeToUse, false);
+  assert.equal(result.memories[0]?.safety, "requires-review");
+  assert.match(result.memories[0]?.safetyReasons[0] ?? "", /provenance was missing/);
+});
+
 test("ChatGPT Apps inspector rejects malformed currentContextScopes before service dispatch", async () => {
   const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
   const server = new EngramMcpServer(fakeService(capture));
@@ -850,6 +1029,25 @@ test("ChatGPT Apps inspector rejects malformed currentContextScopes before servi
     },
   });
   assert.match(resultText(response), /currentContextScopes must be an array of strings/);
+  assert.deepEqual(capture, { recalls: [], xrays: [], actionRequests: [] });
+});
+
+test("ChatGPT Apps inspector rejects malformed allowUnverifiedPreview before service dispatch", async () => {
+  const capture: Capture = { recalls: [], xrays: [], actionRequests: [] };
+  const server = new EngramMcpServer(fakeService(capture));
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: REMNIC_CHATGPT_MEMORY_INSPECTOR_TOOL,
+      arguments: {
+        query: "q",
+        allowUnverifiedPreview: "true",
+      },
+    },
+  });
+  assert.match(resultText(response), /allowUnverifiedPreview must be a boolean/);
   assert.deepEqual(capture, { recalls: [], xrays: [], actionRequests: [] });
 });
 


### PR DESCRIPTION
## Summary
- add `allowUnverifiedPreview` to the ChatGPT memory inspector MCP tool
- keep default preview withholding for missing/unavailable X-ray provenance
- still redact explicitly blocked memories even when unverified previews are allowed
- match X-ray rows by exact path first, then by unique memory id only when unique on both recall and X-ray sides

## Verification
- `NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=remnic-source" pnpm exec tsx --test tests/access-mcp-chatgpt-app.test.ts`
- `pnpm exec tsc --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --types node tests/access-mcp-chatgpt-app.test.ts`
- `npm run preflight:quick` (fails at existing repo-wide `scripts/check-test-types.mjs` baseline; modified `tests/access-mcp-chatgpt-app.test.ts` is no longer in the failure list after local fixture fixes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what memory preview text the inspector exposes and how recall rows join X-ray provenance—safety-sensitive behavior even though blocked content stays redacted and the new preview mode is opt-in.
> 
> **Overview**
> Adds **`allowUnverifiedPreview`** to the ChatGPT memory inspector MCP tool so local audits can surface recall text when Recall X-ray provenance is missing or unavailable. **Default behavior is unchanged**: previews stay withheld unless the flag is explicitly `true`, and memories X-ray marks **blocked** remain redacted either way.
> 
> Inspector result building now treats unverified rows as **`requires-review`** when previews are allowed (instead of always **`blocked`**), and adjusts **`safeRecallPreview`** to either withhold or show an “Unverified recall preview” with truncated context.
> 
> **X-ray ↔ recall matching** is tightened: match by exact **path** first, then by **memory id** only when that id is unique on both recall and X-ray sides. Duplicate ids no longer get a loose id match; if an unmatched X-ray row for the same id is blocked, recall rows with that id are treated as blocked. Stale recall paths can still align via unique-id fallback when path match fails.
> 
> MCP wiring validates the new boolean, documents it in **`docs/chatgpt-apps-demo.md`**, and extends **`access-mcp-chatgpt-app.test.ts`** (plus typecheck baseline cleanup for that file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92823ef65056f8dc03f7c4f154f0c7786f72a0af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->