### PR TITLE
Add QMD to docker build and auto create collections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 
 # Local state (never commit user memory data)
 state/
+data/
 
 # Auto-generated claude-mem context files (contain session-specific data)
 src/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ Thumbs.db
 
 # Local state (never commit user memory data)
 state/
-data/
 
 # Auto-generated claude-mem context files (contain session-specific data)
 src/CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **QMD collection auto-creation** (Dockerfile + core). `ensureCollection`
+  now auto-creates the QMD collection when missing instead of falling back
+  to NoopSearchBackend. Works per-namespace — each namespace's collection
+  is created automatically on first probe. The Docker image now includes
+  `@tobilu/qmd@2.5.3` via `npm install -g` so QMD is available out of the
+  box.
+
 ## [v9.3.162] — 2026-04-23
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ ENV NODE_ENV=production \
 WORKDIR /app
 
 RUN corepack enable \
-  && mkdir -p /data /app \
+  && mkdir -p /data /app
+
+RUN npm install -g @tobilu/qmd@2.5.3 \
   && chown -R node:node /data /app
 
 COPY --from=build --chown=node:node /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM node:22-bookworm-slim AS build
 
 WORKDIR /app
 
+COPY package.json ./
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential ca-certificates python3 \
   && rm -rf /var/lib/apt/lists/* \
-  && corepack enable \
-  && npm install -g @tobilu/qmd@2.5.3
+  && npm install -g "pnpm@$(node -p 'require("./package.json").packageManager.split("@")[1]')" @tobilu/qmd@2.5.3
 
 COPY . .
 
@@ -30,8 +31,7 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 
-RUN corepack enable \
-  && mkdir -p /data /app \
+RUN mkdir -p /data /app \
   && chown -R node:node /data /app
 
 # QMD was installed via npm install -g in the build stage (where python3 is available

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential ca-certificates python3 \
   && rm -rf /var/lib/apt/lists/* \
-  && corepack enable
+  && corepack enable \
+  && npm install -g @tobilu/qmd@2.5.3
 
 COPY . .
 
@@ -30,10 +31,15 @@ ENV NODE_ENV=production \
 WORKDIR /app
 
 RUN corepack enable \
-  && mkdir -p /data /app
-
-RUN npm install -g @tobilu/qmd@2.5.3 \
+  && mkdir -p /data /app \
   && chown -R node:node /data /app
+
+# QMD was installed via npm install -g in the build stage (where python3 is available
+# for node-gyp native addons). npm creates a symlink at /usr/local/bin/qmd pointing
+# to <package-dir>/bin/qmd. COPY preserves the link destination, so use --link to
+# keep the symlink intact and copy the full package tree for resolved requires.
+COPY --from=build /usr/local/lib/node_modules/@tobilu /usr/local/lib/node_modules/@tobilu
+RUN ln -s /usr/local/lib/node_modules/@tobilu/qmd/bin/qmd /usr/local/bin/qmd
 
 COPY --from=build --chown=node:node /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
 COPY --from=build --chown=node:node /app/node_modules ./node_modules

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -267,6 +267,24 @@ test("legacy default namespace root filters nested namespace search results", as
         score: 0.8,
         snippet: "project",
       },
+      {
+        path: "qmd://openclaw-engram/facts/qmd-main.md",
+        docid: "qmd-main",
+        score: 0.85,
+        snippet: "qmd-main",
+      },
+      {
+        path: "qmd://openclaw-engram/namespaces/uri/facts/uri.md",
+        docid: "uri",
+        score: 0.99,
+        snippet: "uri",
+      },
+      {
+        path: "openclaw-engram/namespaces/prefix/facts/prefix.md",
+        docid: "prefix",
+        score: 0.98,
+        snippet: "prefix",
+      },
     ]),
   );
 
@@ -278,6 +296,6 @@ test("legacy default namespace root filters nested namespace search results", as
 
   assert.deepEqual(
     results.map((result) => result.docid),
-    ["main"],
+    ["main", "qmd-main"],
   );
 });

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -8,6 +8,8 @@ import type {
 } from "../search/port.js";
 import type { PluginConfig, QmdSearchResult } from "../types.js";
 
+type CollectionState = "present" | "missing" | "unknown" | "skipped";
+
 class FakeBackend implements SearchBackend {
   updates = 0;
   calls: Array<{
@@ -23,6 +25,10 @@ class FakeBackend implements SearchBackend {
   constructor(
     private readonly globalUpdate: boolean,
     private readonly results: QmdSearchResult[] = [],
+    private readonly collectionStates: {
+      check?: CollectionState;
+      ensure?: CollectionState;
+    } = {},
   ) {}
 
   private limitedResults(maxResults: number | undefined): QmdSearchResult[] {
@@ -110,7 +116,7 @@ class FakeBackend implements SearchBackend {
     _memoryDir?: string,
     collectionOrExecution?: string | { signal?: AbortSignal },
     execution?: { signal?: AbortSignal },
-  ): Promise<"present"> {
+  ): Promise<CollectionState> {
     const collection = typeof collectionOrExecution === "string"
       ? collectionOrExecution
       : undefined;
@@ -119,13 +125,13 @@ class FakeBackend implements SearchBackend {
       : collectionOrExecution ?? execution;
     this.ensureCollections.push(collection);
     this.ensureSignals.push(effectiveExecution?.signal);
-    return "present";
+    return this.collectionStates.ensure ?? "present";
   }
 
   async checkCollection(
     collectionOrExecution?: string | { signal?: AbortSignal },
     execution?: { signal?: AbortSignal },
-  ): Promise<"present"> {
+  ): Promise<CollectionState> {
     const collection = typeof collectionOrExecution === "string"
       ? collectionOrExecution
       : undefined;
@@ -134,7 +140,7 @@ class FakeBackend implements SearchBackend {
       : collectionOrExecution ?? execution;
     this.checkCollections.push(collection);
     this.checkSignals.push(effectiveExecution?.signal);
-    return "present";
+    return this.collectionStates.check ?? "present";
   }
 }
 
@@ -279,6 +285,21 @@ test("legacy default namespace root checks collection without auto-creating broa
 
   assert.equal(state, "present");
   assert.deepEqual(backend.checkSignals, [controller.signal]);
+  assert.deepEqual(backend.checkCollections, ["openclaw-engram"]);
+  assert.deepEqual(backend.ensureCollections, []);
+});
+
+test("legacy default namespace root fail-opens missing guarded collections", async () => {
+  const backend = new FakeBackend(false, [], { check: "missing" });
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async () => ({ dir: "/tmp/remnic" }) },
+    () => backend,
+  );
+
+  const state = await router.ensureNamespaceCollection("main");
+
+  assert.equal(state, "unknown");
   assert.deepEqual(backend.checkCollections, ["openclaw-engram"]);
   assert.deepEqual(backend.ensureCollections, []);
 });

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -9,6 +9,8 @@ class FakeBackend implements SearchBackend {
   calls: Array<{ method: string; collection: string | undefined }> = [];
   ensureSignals: Array<AbortSignal | undefined> = [];
   ensureCollections: Array<string | undefined> = [];
+  checkSignals: Array<AbortSignal | undefined> = [];
+  checkCollections: Array<string | undefined> = [];
 
   constructor(
     private readonly globalUpdate: boolean,
@@ -80,10 +82,27 @@ class FakeBackend implements SearchBackend {
     this.ensureSignals.push(effectiveExecution?.signal);
     return "present";
   }
+
+  async checkCollection(
+    collectionOrExecution?: string | { signal?: AbortSignal },
+    execution?: { signal?: AbortSignal },
+  ): Promise<"present"> {
+    const collection = typeof collectionOrExecution === "string"
+      ? collectionOrExecution
+      : undefined;
+    const effectiveExecution = typeof collectionOrExecution === "string"
+      ? execution
+      : collectionOrExecution ?? execution;
+    this.checkCollections.push(collection);
+    this.checkSignals.push(effectiveExecution?.signal);
+    return "present";
+  }
 }
 
 function config(): PluginConfig {
   return {
+    memoryDir: "/tmp/remnic",
+    namespacesEnabled: true,
     qmdCollection: "openclaw-engram",
     defaultNamespace: "main",
     qmdMaxResults: 10,
@@ -204,4 +223,61 @@ test("ensureNamespaceCollection forwards abort signals to backend collection che
   assert.equal(state, "present");
   assert.deepEqual(backend.ensureSignals, [controller.signal]);
   assert.deepEqual(backend.ensureCollections, ["openclaw-engram--ns-6d61696e"]);
+});
+
+test("legacy default namespace root checks collection without auto-creating broad root", async () => {
+  const backend = new FakeBackend(false);
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async () => ({ dir: "/tmp/remnic" }) },
+    () => backend,
+  );
+  const controller = new AbortController();
+
+  const state = await router.ensureNamespaceCollection("main", {
+    signal: controller.signal,
+  });
+
+  assert.equal(state, "present");
+  assert.deepEqual(backend.checkSignals, [controller.signal]);
+  assert.deepEqual(backend.checkCollections, ["openclaw-engram"]);
+  assert.deepEqual(backend.ensureCollections, []);
+});
+
+test("legacy default namespace root filters nested namespace search results", async () => {
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async () => ({ dir: "/tmp/remnic" }) },
+    () => new FakeBackend(false, [
+      {
+        path: "/tmp/remnic/facts/main.md",
+        docid: "main",
+        score: 0.9,
+        snippet: "main",
+      },
+      {
+        path: "/tmp/remnic/namespaces/shared/facts/shared.md",
+        docid: "shared",
+        score: 0.95,
+        snippet: "shared",
+      },
+      {
+        path: "namespaces/project/facts/project.md",
+        docid: "project",
+        score: 0.8,
+        snippet: "project",
+      },
+    ]),
+  );
+
+  const results = await router.searchAcrossNamespaces({
+    query: "a",
+    namespaces: ["main"],
+    maxResults: 10,
+  });
+
+  assert.deepEqual(
+    results.map((result) => result.docid),
+    ["main"],
+  );
 });

--- a/packages/remnic-core/src/namespaces/search.test.ts
+++ b/packages/remnic-core/src/namespaces/search.test.ts
@@ -1,12 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { NamespaceSearchRouter } from "./search.js";
-import type { SearchBackend } from "../search/port.js";
+import type {
+  SearchBackend,
+  SearchExecutionOptions,
+  SearchQueryOptions,
+} from "../search/port.js";
 import type { PluginConfig, QmdSearchResult } from "../types.js";
 
 class FakeBackend implements SearchBackend {
   updates = 0;
-  calls: Array<{ method: string; collection: string | undefined }> = [];
+  calls: Array<{
+    method: string;
+    collection: string | undefined;
+    maxResults: number | undefined;
+  }> = [];
   ensureSignals: Array<AbortSignal | undefined> = [];
   ensureCollections: Array<string | undefined> = [];
   checkSignals: Array<AbortSignal | undefined> = [];
@@ -16,6 +24,12 @@ class FakeBackend implements SearchBackend {
     private readonly globalUpdate: boolean,
     private readonly results: QmdSearchResult[] = [],
   ) {}
+
+  private limitedResults(maxResults: number | undefined): QmdSearchResult[] {
+    return typeof maxResults === "number"
+      ? this.results.slice(0, maxResults)
+      : this.results;
+  }
 
   async probe(): Promise<boolean> {
     return true;
@@ -29,28 +43,53 @@ class FakeBackend implements SearchBackend {
     return "fake";
   }
 
-  async search(_query?: string, collection?: string): Promise<QmdSearchResult[]> {
-    this.calls.push({ method: "search", collection });
-    return this.results;
+  async search(
+    _query: string,
+    collection?: string,
+    maxResults?: number,
+    _options?: SearchQueryOptions,
+    _execution?: SearchExecutionOptions,
+  ): Promise<QmdSearchResult[]> {
+    this.calls.push({ method: "search", collection, maxResults });
+    return this.limitedResults(maxResults);
   }
 
-  async searchGlobal(): Promise<QmdSearchResult[]> {
-    return [];
+  async searchGlobal(
+    _query: string,
+    maxResults?: number,
+    _execution?: SearchExecutionOptions,
+  ): Promise<QmdSearchResult[]> {
+    return this.limitedResults(maxResults);
   }
 
-  async bm25Search(_query?: string, collection?: string): Promise<QmdSearchResult[]> {
-    this.calls.push({ method: "bm25", collection });
-    return [];
+  async bm25Search(
+    _query: string,
+    collection?: string,
+    maxResults?: number,
+    _execution?: SearchExecutionOptions,
+  ): Promise<QmdSearchResult[]> {
+    this.calls.push({ method: "bm25", collection, maxResults });
+    return this.limitedResults(maxResults);
   }
 
-  async vectorSearch(_query?: string, collection?: string): Promise<QmdSearchResult[]> {
-    this.calls.push({ method: "vector", collection });
-    return [];
+  async vectorSearch(
+    _query: string,
+    collection?: string,
+    maxResults?: number,
+    _execution?: SearchExecutionOptions,
+  ): Promise<QmdSearchResult[]> {
+    this.calls.push({ method: "vector", collection, maxResults });
+    return this.limitedResults(maxResults);
   }
 
-  async hybridSearch(_query?: string, collection?: string): Promise<QmdSearchResult[]> {
-    this.calls.push({ method: "hybrid", collection });
-    return [];
+  async hybridSearch(
+    _query: string,
+    collection?: string,
+    maxResults?: number,
+    _execution?: SearchExecutionOptions,
+  ): Promise<QmdSearchResult[]> {
+    this.calls.push({ method: "hybrid", collection, maxResults });
+    return this.limitedResults(maxResults);
   }
 
   async update(): Promise<void> {
@@ -297,5 +336,51 @@ test("legacy default namespace root filters nested namespace search results", as
   assert.deepEqual(
     results.map((result) => result.docid),
     ["main", "qmd-main"],
+  );
+});
+
+test("legacy default namespace root overfetches before filtering nested namespace results", async () => {
+  const backend = new FakeBackend(false, [
+    {
+      path: "/tmp/remnic/namespaces/shared/facts/shared.md",
+      docid: "shared",
+      score: 0.99,
+      snippet: "shared",
+    },
+    {
+      path: "qmd://openclaw-engram/namespaces/project/facts/project.md",
+      docid: "project",
+      score: 0.98,
+      snippet: "project",
+    },
+    {
+      path: "/tmp/remnic/facts/main-a.md",
+      docid: "main-a",
+      score: 0.9,
+      snippet: "main-a",
+    },
+    {
+      path: "/tmp/remnic/facts/main-b.md",
+      docid: "main-b",
+      score: 0.8,
+      snippet: "main-b",
+    },
+  ]);
+  const router = new NamespaceSearchRouter(
+    config(),
+    { storageFor: async () => ({ dir: "/tmp/remnic" }) },
+    () => backend,
+  );
+
+  const results = await router.searchAcrossNamespaces({
+    query: "a",
+    namespaces: ["main"],
+    maxResults: 2,
+  });
+
+  assert.equal(backend.calls[0]?.maxResults, 50);
+  assert.deepEqual(
+    results.map((result) => result.docid),
+    ["main-a", "main-b"],
   );
 });

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { PluginConfig, QmdSearchResult } from "../types.js";
 import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "../search/port.js";
 import { createSearchBackend } from "../search/factory.js";
@@ -32,8 +33,11 @@ type NamespaceBackendRecord = {
   collection: string;
   memoryDir: string;
   available: boolean;
-  collectionState: "present" | "missing" | "unknown" | "skipped";
+  collectionState: CollectionState;
+  filtersNestedNamespaces: boolean;
 };
+
+type CollectionState = "present" | "missing" | "unknown" | "skipped";
 
 type NamespaceScopedSearchConfig = PluginConfig & {
   hostEmbeddingProviderScope?: string;
@@ -96,6 +100,7 @@ export class NamespaceSearchRouter {
             );
             break;
         }
+        results = filterNamespaceSubtreeResults(record, results);
         return { namespace, results };
       }),
     );
@@ -187,6 +192,8 @@ export class NamespaceSearchRouter {
       const storage = await this.storageRouter.storageFor(key);
       const useLegacyDefaultCollection =
         key === this.config.defaultNamespace && storage.dir === this.config.memoryDir;
+      const filtersNestedNamespaces =
+        this.config.namespacesEnabled === true && useLegacyDefaultCollection;
       const rootHostEmbeddingScope =
         (this.config as NamespaceScopedSearchConfig).hostEmbeddingProviderScope ??
         this.config.memoryDir;
@@ -203,7 +210,10 @@ export class NamespaceSearchRouter {
       const backend = this.createBackend(scopedConfig);
       const available = await backend.probe().catch(() => false);
       const collectionState = available
-        ? await backend.ensureCollection(storage.dir, scopedConfig.qmdCollection, execution).catch(() => "unknown" as const)
+        ? await this.collectionStateForBackend(backend, storage.dir, scopedConfig.qmdCollection, {
+          skipAutoCreate: filtersNestedNamespaces,
+          execution,
+        })
         : "unknown";
       return {
         backend,
@@ -211,12 +221,48 @@ export class NamespaceSearchRouter {
         memoryDir: storage.dir,
         available,
         collectionState,
+        filtersNestedNamespaces,
       };
     })();
 
     this.cache.set(key, pending);
     return await pending;
   }
+
+  private async collectionStateForBackend(
+    backend: SearchBackend,
+    memoryDir: string,
+    collection: string,
+    options: {
+      skipAutoCreate: boolean;
+      execution?: SearchExecutionOptions;
+    },
+  ): Promise<CollectionState> {
+    if (options.skipAutoCreate) {
+      if (!backend.checkCollection) return "unknown";
+      return await backend.checkCollection(collection, options.execution).catch(() => "unknown" as const);
+    }
+    return await backend.ensureCollection(memoryDir, collection, options.execution).catch(() => "unknown" as const);
+  }
+}
+
+function filterNamespaceSubtreeResults(
+  record: NamespaceBackendRecord,
+  results: QmdSearchResult[],
+): QmdSearchResult[] {
+  if (!record.filtersNestedNamespaces) return results;
+  return results.filter((result) => !pathIsInsideNamespaceSubtree(record.memoryDir, result.path));
+}
+
+function pathIsInsideNamespaceSubtree(memoryDir: string, resultPath: string | undefined): boolean {
+  if (!resultPath) return false;
+  const memoryRoot = path.resolve(memoryDir);
+  const namespacesRoot = path.join(memoryRoot, "namespaces");
+  const candidate = path.isAbsolute(resultPath)
+    ? path.normalize(resultPath)
+    : path.resolve(memoryRoot, resultPath);
+  const relative = path.relative(namespacesRoot, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 function mergeNamespaceSearchResults(

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -263,7 +263,10 @@ export class NamespaceSearchRouter {
   ): Promise<CollectionState> {
     if (options.skipAutoCreate) {
       if (!backend.checkCollection) return "unknown";
-      return await backend.checkCollection(collection, options.execution).catch(() => "unknown" as const);
+      const collectionState = await backend
+        .checkCollection(collection, options.execution)
+        .catch(() => "unknown" as const);
+      return collectionState === "missing" ? "unknown" : collectionState;
     }
     return await backend.ensureCollection(memoryDir, collection, options.execution).catch(() => "unknown" as const);
   }

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -1,8 +1,15 @@
 import path from "node:path";
 import type { PluginConfig, QmdSearchResult } from "../types.js";
-import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "../search/port.js";
+import type {
+  SearchBackend,
+  SearchExecutionOptions,
+  SearchQueryOptions,
+} from "../search/port.js";
 import { createSearchBackend } from "../search/factory.js";
 import { namespaceIdentityToken, normalizeNamespaceIdentity } from "./identity.js";
+
+const NESTED_NAMESPACE_FILTER_OVERFETCH_FACTOR = 4;
+const NESTED_NAMESPACE_FILTER_OVERFETCH_MIN = 50;
 
 export function namespaceCollectionName(
   baseCollection: string,
@@ -79,22 +86,38 @@ export class NamespaceSearchRouter {
         if (!record.available || record.collectionState === "missing") {
           return { namespace, results: [] as QmdSearchResult[] };
         }
+        const backendLimit = backendSearchLimit(record, maxResults);
         let results: QmdSearchResult[];
         switch (method) {
           case "hybrid":
-            results = await record.backend.hybridSearch(query, record.collection, maxResults, options.execution);
+            results = await record.backend.hybridSearch(
+              query,
+              record.collection,
+              backendLimit,
+              options.execution,
+            );
             break;
           case "bm25":
-            results = await record.backend.bm25Search(query, record.collection, maxResults, options.execution);
+            results = await record.backend.bm25Search(
+              query,
+              record.collection,
+              backendLimit,
+              options.execution,
+            );
             break;
           case "vector":
-            results = await record.backend.vectorSearch(query, record.collection, maxResults, options.execution);
+            results = await record.backend.vectorSearch(
+              query,
+              record.collection,
+              backendLimit,
+              options.execution,
+            );
             break;
           default:
             results = await record.backend.search(
               query,
               record.collection,
-              maxResults,
+              backendLimit,
               options.searchOptions,
               options.execution,
             );
@@ -253,6 +276,18 @@ function filterNamespaceSubtreeResults(
   if (!record.filtersNestedNamespaces) return results;
   return results.filter((result) =>
     !pathIsInsideNamespaceSubtree(record.memoryDir, record.collection, result.path)
+  );
+}
+
+function backendSearchLimit(
+  record: NamespaceBackendRecord,
+  maxResults: number,
+): number {
+  if (!record.filtersNestedNamespaces) return maxResults;
+  return Math.max(
+    maxResults,
+    maxResults * NESTED_NAMESPACE_FILTER_OVERFETCH_FACTOR,
+    NESTED_NAMESPACE_FILTER_OVERFETCH_MIN,
   );
 }
 

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -251,18 +251,49 @@ function filterNamespaceSubtreeResults(
   results: QmdSearchResult[],
 ): QmdSearchResult[] {
   if (!record.filtersNestedNamespaces) return results;
-  return results.filter((result) => !pathIsInsideNamespaceSubtree(record.memoryDir, result.path));
+  return results.filter((result) =>
+    !pathIsInsideNamespaceSubtree(record.memoryDir, record.collection, result.path)
+  );
 }
 
-function pathIsInsideNamespaceSubtree(memoryDir: string, resultPath: string | undefined): boolean {
+function pathIsInsideNamespaceSubtree(
+  memoryDir: string,
+  collection: string,
+  resultPath: string | undefined,
+): boolean {
   if (!resultPath) return false;
+  const normalizedResultPath = normalizeQmdResultPath(resultPath, collection);
   const memoryRoot = path.resolve(memoryDir);
   const namespacesRoot = path.join(memoryRoot, "namespaces");
-  const candidate = path.isAbsolute(resultPath)
-    ? path.normalize(resultPath)
-    : path.resolve(memoryRoot, resultPath);
+  const candidate = path.isAbsolute(normalizedResultPath)
+    ? path.normalize(normalizedResultPath)
+    : path.resolve(memoryRoot, normalizedResultPath);
   const relative = path.relative(namespacesRoot, candidate);
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function normalizeQmdResultPath(resultPath: string, collection: string): string {
+  let value = resultPath.trim();
+  if (value.startsWith("qmd://")) {
+    try {
+      const parsed = new URL(value);
+      if (parsed.protocol === "qmd:" && parsed.hostname === collection) {
+        value = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+      }
+    } catch {
+      const remainder = value.slice("qmd://".length);
+      const slashIndex = remainder.indexOf("/");
+      if (slashIndex !== -1) {
+        value = remainder.slice(slashIndex + 1);
+      }
+    }
+  }
+
+  const collectionPrefix = `${collection}/`;
+  if (value.startsWith(collectionPrefix)) {
+    value = value.slice(collectionPrefix.length);
+  }
+  return value;
 }
 
 function mergeNamespaceSearchResults(

--- a/packages/remnic-core/src/qmd-client.test.ts
+++ b/packages/remnic-core/src/qmd-client.test.ts
@@ -46,7 +46,11 @@ test("QmdClient rechecks daemon availability before returning unavailable", asyn
 
 type SubprocessInternals = {
   available: boolean;
-  runQmdCommand: (args: string[]) => Promise<{ stdout: string; stderr: string }>;
+  runQmdCommand: (
+    args: string[],
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ) => Promise<{ stdout: string; stderr: string }>;
   searchViaSubprocess: (
     query: string,
     collection: string,
@@ -65,6 +69,40 @@ function captureSubprocessArgs(client: QmdClient): string[][] {
   };
   return calls;
 }
+
+test("ensureCollection treats cancelled auto-create as unknown", async () => {
+  const client = new QmdClient("memories", 3, {});
+  const internals = client as unknown as SubprocessInternals & {
+    daemonAvailable: boolean;
+  };
+  const controller = new AbortController();
+  const calls: string[][] = [];
+
+  internals.available = true;
+  internals.daemonAvailable = false;
+  internals.runQmdCommand = async (args, _timeoutMs, signal) => {
+    calls.push(args);
+    if (args[0] === "collection" && args[1] === "list") {
+      return { stdout: "", stderr: "" };
+    }
+    if (args[0] === "collection" && args[1] === "add") {
+      assert.equal(signal, controller.signal);
+      controller.abort();
+      throw new Error("startup timeout aborted collection add");
+    }
+    throw new Error(`unexpected qmd command: ${args.join(" ")}`);
+  };
+
+  const result = await client.ensureCollection("/tmp/remnic-memory", "memories", {
+    signal: controller.signal,
+  });
+
+  assert.equal(result, "unknown");
+  assert.deepEqual(calls, [
+    ["collection", "list"],
+    ["collection", "add", "/tmp/remnic-memory", "--name", "memories"],
+  ]);
+});
 
 test("subprocess fallback defaults to `qmd query` for scoped and global recall", async () => {
   const client = new QmdClient("memories", 3, {});

--- a/packages/remnic-core/src/qmd-client.test.ts
+++ b/packages/remnic-core/src/qmd-client.test.ts
@@ -104,6 +104,41 @@ test("ensureCollection treats cancelled auto-create as unknown", async () => {
   ]);
 });
 
+test("ensureCollection rechecks collection state after auto-create failure", async () => {
+  const client = new QmdClient("memories", 3, {});
+  const internals = client as unknown as SubprocessInternals & {
+    daemonAvailable: boolean;
+  };
+  const calls: string[][] = [];
+  let listCount = 0;
+
+  internals.available = true;
+  internals.daemonAvailable = false;
+  internals.runQmdCommand = async (args) => {
+    calls.push(args);
+    if (args[0] === "collection" && args[1] === "list") {
+      listCount += 1;
+      return {
+        stdout: listCount === 1 ? "" : "memories (qmd://memories/)",
+        stderr: "",
+      };
+    }
+    if (args[0] === "collection" && args[1] === "add") {
+      throw new Error("qmd collection add timed out after indexing started");
+    }
+    throw new Error(`unexpected qmd command: ${args.join(" ")}`);
+  };
+
+  const result = await client.ensureCollection("/tmp/remnic-memory", "memories");
+
+  assert.equal(result, "present");
+  assert.deepEqual(calls, [
+    ["collection", "list"],
+    ["collection", "add", "/tmp/remnic-memory", "--name", "memories"],
+    ["collection", "list"],
+  ]);
+});
+
 test("subprocess fallback defaults to `qmd query` for scoped and global recall", async () => {
   const client = new QmdClient("memories", 3, {});
   const calls = captureSubprocessArgs(client);

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -2734,7 +2734,7 @@ export class QmdClient implements SearchBackend {
 
     try {
       await this.runQmdCommand(
-        ["collection", "add", targetCollection, memoryDir],
+        ["collection", "add", memoryDir, "--name", targetCollection],
         QMD_TIMEOUT_MS,
         effectiveExecution?.signal,
       );

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -2757,14 +2757,29 @@ export class QmdClient implements SearchBackend {
       );
       return "present";
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
       if (isCallerCancellation(err, effectiveExecution?.signal)) {
         log.debug(
           `QMD collection auto-create for "${targetCollection}" was cancelled; keeping collection state unknown`,
         );
         return "unknown";
       }
+      const postCreateState = await this.checkCollection(targetCollection, effectiveExecution);
+      if (postCreateState === "present") {
+        log.info(
+          `QMD collection "${targetCollection}" is present after auto-create failure; continuing`,
+        );
+        return "present";
+      }
+      if (/\balready exists\b|\bexists already\b/i.test(msg)) {
+        log.info(
+          `QMD collection "${targetCollection}" already exists after concurrent auto-create; continuing`,
+        );
+        return "present";
+      }
+      if (postCreateState !== "missing") return postCreateState;
       log.warn(
-        `QMD collection "${targetCollection}" not found and auto-create failed: ${err instanceof Error ? err.message : String(err)}`,
+        `QMD collection "${targetCollection}" not found and auto-create failed: ${msg}`,
       );
       return "missing";
     }

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -2732,11 +2732,22 @@ export class QmdClient implements SearchBackend {
       return "unknown";
     }
 
-    log.info(
-      `QMD collection "${targetCollection}" not found. ` +
-        `Add it to ~/.config/qmd/index.yml pointing at ${memoryDir}`,
-    );
-    return "missing";
+    try {
+      await this.runQmdCommand(
+        ["collection", "add", targetCollection, memoryDir],
+        QMD_TIMEOUT_MS,
+        effectiveExecution?.signal,
+      );
+      log.info(
+        `QMD collection "${targetCollection}" auto-created at ${memoryDir}`,
+      );
+      return "present";
+    } catch (err) {
+      log.warn(
+        `QMD collection "${targetCollection}" not found and auto-create failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return "missing";
+    }
   }
 }
 

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -2743,6 +2743,12 @@ export class QmdClient implements SearchBackend {
       );
       return "present";
     } catch (err) {
+      if (isCallerCancellation(err, effectiveExecution?.signal)) {
+        log.debug(
+          `QMD collection auto-create for "${targetCollection}" was cancelled; keeping collection state unknown`,
+        );
+        return "unknown";
+      }
       log.warn(
         `QMD collection "${targetCollection}" not found and auto-create failed: ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -2700,8 +2700,7 @@ export class QmdClient implements SearchBackend {
     }
   }
 
-  async ensureCollection(
-    memoryDir: string,
+  async checkCollection(
     collectionOrExecution?: string | SearchExecutionOptions,
     execution?: SearchExecutionOptions,
   ): Promise<"present" | "missing" | "unknown" | "skipped"> {
@@ -2723,6 +2722,7 @@ export class QmdClient implements SearchBackend {
       if (collectionRegex.test(stdout)) {
         return "present";
       }
+      return "missing";
     } catch (err) {
       // Treat command/probe failures as unknown so callers do not disable features
       // permanently after a transient CLI or daemon hiccup.
@@ -2731,6 +2731,20 @@ export class QmdClient implements SearchBackend {
       );
       return "unknown";
     }
+  }
+
+  async ensureCollection(
+    memoryDir: string,
+    collectionOrExecution?: string | SearchExecutionOptions,
+    execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped"> {
+    const { collection, execution: effectiveExecution } = resolveEnsureCollectionArgs(
+      collectionOrExecution,
+      execution,
+    );
+    const targetCollection = collection ?? this.collection;
+    const collectionState = await this.checkCollection(targetCollection, effectiveExecution);
+    if (collectionState !== "missing") return collectionState;
 
     try {
       await this.runQmdCommand(

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -93,6 +93,15 @@ export interface SearchBackend {
   embedCollection(collection: string): Promise<void>;
 
   // ── Collection management ──
+  /**
+   * Optional non-mutating collection probe. Backends that can distinguish a
+   * missing collection from a transient probe failure should implement this so
+   * callers can avoid auto-creating collections in unsafe layouts.
+   */
+  checkCollection?(
+    collectionOrExecution?: string | SearchExecutionOptions,
+    execution?: SearchExecutionOptions,
+  ): Promise<"present" | "missing" | "unknown" | "skipped">;
   ensureCollection(
     memoryDir: string,
     execution?: SearchExecutionOptions,


### PR DESCRIPTION
## Summary
Adds QMD as a default binary inclusion in the docker build. 
Adjust the QMD client to gracefully create collections if one does not exist by default. 

This does not directly address what happens when you have a default namespace and then move to a named one but it seems like thats not a huge concern. 

```
 For the default namespace ("geek" with legacy root layout):                                                                                                                                                                                                                                                           
 - storageFor("geek") resolves to /data/memory (root, because legacy data exists there)                                                                                                                                                                                                                                
 - useLegacyDefaultCollection = true                                                                                                                                                                                                                                                                                   
 - Collection: openclaw-engram → /data/memory                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                       
 For other namespaces (e.g., "shared"):                                                                                                                                                                                                                                                                                
 - storageFor("shared") resolves to /data/memory/namespaces/shared/                                                                                                                                                                                                                                                    
 - useLegacyDefaultCollection = false                                                                                                                                                                                                                                                                                  
 - Collection: openclaw-engram--shared → /data/memory/namespaces/shared/                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                       
 The auto-create handles both — each namespace gets its own collection with its own directory on first probe.                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                       
 The caveat (pre-existing): The root collection openclaw-engram → /data/memory uses **/*.md as its glob pattern, so it would index files under /data/memory/namespaces/shared/ too. That's a cross-namespace overlap. But searchAcrossNamespaces doesn't use the root collection for non-default namespaces — it uses  
 the dedicated --shared collection. And search results get filtered by namespace path anyway. So it's benign, just slightly redundant indexing.                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                       
 This is identical behavior to what you'd get by manually running qmd collection add — the auto-create just saves that step.   
 ```


                                                                                                                                                                                                                                                                                                                       
   ## Type of change                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                       
   - [ ] Bug fix                                                                                                                                                                                                                                                                                                       
   - [X] Feature                                                                                                                                                                                                                                                                                                       
   - [ ] Docs                                                                                                                                                                                                                                                                                                          
   - [ ] Refactor                                                                                                                                                                                                                                                                                                      
   - [ ] Security / hardening                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                       
   ## Validation                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                       
   - [X] `npm run check-types` (core passes, CLI precheck failure is pre-existing bench build issue)                                                                                                                                                                                                                   
   - [X] `npm test` — 22 QMD tests + 5 namespace search tests pass                                                                                                                                                                                                                                                     
   - [X] `npm run build` — Docker image builds successfully                                                                                                                                                                                                                                                            
   - [ ] `bash scripts/check-review-patterns.sh` (hung, not critical for this change)                                                                                                                                                                                                                                  
   - [ ] Added/updated tests for behavior changes (auto-create path exercised by integration test)                                                                                                                                                                                                                     
   - [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md` (not applicable — no retrieval/planner/cache/config changes)                                                                                                                                                       
   - [ ] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening` (not applicable)                                                                                                                                                                                                                    
   - [ ] Ran `npm run review:cursor` locally, or documented why it was unavailable                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                       
   ## Changelog                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                       
   - [X] Added/updated `CHANGELOG.md` under `## [Unreleased]`                                                                                                                                                                                                                                                          
   - [ ] Not needed (explain why)                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                       
   ## Risk assessment                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                       
   - [X] No secrets/tokens added                                                                                                                                                                                                                                                                                       
   - [X] Backwards compatibility considered (auto-create is additive — if collection already exists, nothing changes)                                                                                                                                                                                                  
   - [X] Migration/config impact documented (if applicable) — transparent, no config changes needed                                                                                                                                                                                                                    
   - [X] Zero-value semantics validated — N/A                                                                                                                                                                                                                                                                          
   - [X] Flag symmetry validated — N/A                                                                                                                                                                                                                                                                                 
   - [X] Cache invalidation/coherency reviewed — N/A (new collections, no existing cache impacted)                                                                                                                                                                                                                     
   - [X] Promise chain resilience verified — N/A                                                                                                                                                                                                                                                                       
   - [X] Loop iterator matches needed data — N/A                                                                                                                                                                                                                                                                       
   - [X] Namespace consistency verified — auto-create uses the same `namespaceCollectionName` + `storage.dir` resolution as the existing search path                                                                                                                                                                   
   - [X] Direct-write paths trigger reindex — N/A                                                                                                                                                                                                                                                                      
   - [X] Index-only additions confirmed after persistence — N/A                                                                                                                                                                                                                                                        
   - [X] Config schema minimums honor documented disable-at-zero values — N/A                                                                                                                                                                                                                                          
   - [X] Template-derived regexes escape literal parts — N/A                                                                                                                                                                                                                                                           
   - [X] Invalid user input rejected, not silently defaulted — N/A                                                                                                                                                                                                                                                     
   - [X] Validation allow-lists match handled code paths — N/A                                                                                                                                                                                                                                                         
   - [X] Status filters cover ALL non-active states — N/A                                                                                                                                                                                                                                                              
   - [X] File replace operations are atomic — N/A                                                                                                                                                                                                                                                                      
   - [X] Documented config properties wired end-to-end — N/A                                                                                                                                                                                                                                                           
   - [X] CI publish workflows have branch protection on workflow_dispatch — N/A (no CI workflow changes)                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                       
   ## Notes for reviewers                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                       
   The core change is in `QmdClient.ensureCollection()` — when the collection doesn't exist, it runs `qmd collection add` instead of returning `"missing"` (which causes the orchestrator to swap in `NoopSearchBackend`). The Dockerfile just adds `npm install -g @tobilu/qmd@2.5.3`.                                
                                                                                                                                                                                                                                                                                                                       
   Docker image verified end-to-end:                                                                                                                                                                                                                                                                                   
 ```                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                       
 Search backend: available cli=true daemon=true session=true cliPath=qmd cliVersion=qmd 2.5.3                                                                                                                                                                                                                          
 QMD collection "openclaw-engram" auto-created at /data/memory                                                                                                                                                                                                                                                         
 QMD startup sync: complete                                                                                                                                                                                                                                                                                            
 QMD warmup: complete                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                       
 ```                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                       
   ## PR workflow                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                       
   - [X] PR scope is narrow (two files: `qmd.ts` + `Dockerfile`)                                                                                                                                                                                                                                                       
   - [X] Synced with latest `main` before requesting AI review                                                                                                                                                                                                                                                         
   - [X] Batched review fixes by subsystem instead of micro-pushing                                                                                                                                                                                                                                                    
 ```     