### PR TITLE
fix(recall): scan all memory category dirs in QMD filesystem fallback (#1497)

### DIFF
--- a/packages/remnic-core/src/storage-fallback-category-dirs.test.ts
+++ b/packages/remnic-core/src/storage-fallback-category-dirs.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Issue #1497 — Recall: scan all memory category directories when the QMD
+ * filesystem fallback reads from disk.
+ *
+ * The filesystem fallback recall path (orchestrator `recent_scan`) calls
+ * `StorageManager.readAllMemories()` per namespace, which scans the disk via
+ * `collectActiveMemoryPaths()`. The old implementation only scanned four
+ * directories (facts, procedures, reasoning-traces, corrections), so on-disk
+ * memories in any other category directory (preferences, decisions, moments,
+ * commitments, principles, rules, skills, relationships, questions) were
+ * silently missed when QMD was unavailable.
+ *
+ * These tests seed `.md` memory files directly into the on-disk category
+ * directories (the way an external seed, a migration, or a future routing
+ * change would leave them) and assert the disk-scan recall returns them.
+ *
+ * They FAIL on the old four-directory behavior and PASS once
+ * `collectActiveMemoryPaths()` iterates the shared `ALL_CATEGORY_DIRS`.
+ */
+
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { StorageManager } from "./storage.js";
+import { ALL_CATEGORY_DIRS, CATEGORY_DIR_MAP } from "./utils/category-dir.js";
+
+/** Build a minimal-but-valid memory markdown file body. */
+function memoryFile(id: string, category: string, content: string): string {
+  const now = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `category: ${category}`,
+    `created: ${now}`,
+    `updated: ${now}`,
+    "source: test",
+    "confidence: 0.9",
+    'tags: ["synthetic"]',
+    "---",
+    "",
+    content,
+    "",
+  ].join("\n");
+}
+
+async function seedMemory(
+  baseDir: string,
+  categoryDir: string,
+  id: string,
+  category: string,
+  content: string,
+  options: { nested?: boolean } = {},
+): Promise<void> {
+  const dir = options.nested
+    ? path.join(baseDir, categoryDir, "2026-06-29")
+    : path.join(baseDir, categoryDir);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, `${id}.md`), memoryFile(id, category, content), "utf-8");
+}
+
+async function makeStorage(prefix = "engram-1497-"): Promise<{
+  storage: StorageManager;
+  baseDir: string;
+  cleanup: () => Promise<void>;
+}> {
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const storage = new StorageManager(baseDir);
+  await storage.ensureDirectories();
+  StorageManager.clearAllStaticCaches();
+  storage.invalidateAllMemoriesCacheForDir();
+  return {
+    storage,
+    baseDir,
+    cleanup: async () => {
+      StorageManager.clearAllStaticCaches();
+      await rm(baseDir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Singular-category-key -> {dir, category-frontmatter-value} for every entry the
+ * issue enumerates. `question` has no `MemoryCategory` enum member, so its
+ * frontmatter `category` field is written as "question" (the scan is
+ * directory-based, not category-based, so any valid memory file is returned).
+ */
+const CATEGORY_CASES: ReadonlyArray<{ key: string; dir: string }> = [
+  { key: "fact", dir: "facts" },
+  ...Object.entries(CATEGORY_DIR_MAP).map(([key, dir]) => ({ key, dir })),
+];
+
+test("collectActiveMemoryPaths source-of-truth: every ALL_CATEGORY_DIRS entry is covered", () => {
+  // Guards against the dir list drifting away from the shared source of truth.
+  const expected = new Set(ALL_CATEGORY_DIRS);
+  const covered = new Set(CATEGORY_CASES.map((c) => c.dir));
+  assert.deepEqual(
+    [...covered].sort(),
+    [...expected].sort(),
+    "test cases must cover exactly ALL_CATEGORY_DIRS",
+  );
+});
+
+test("fallback disk recall returns a memory from EVERY category directory", async () => {
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    for (const { key, dir } of CATEGORY_CASES) {
+      await seedMemory(
+        baseDir,
+        dir,
+        `mem-${key}`,
+        key,
+        `Synthetic ${key} memory content for issue 1497.`,
+      );
+    }
+
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+
+    for (const { key, dir } of CATEGORY_CASES) {
+      assert.ok(
+        foundIds.has(`mem-${key}`),
+        `expected fallback recall to find memory in "${dir}/" (category "${key}"), ` +
+          `got ids: ${[...foundIds].join(", ")}`,
+      );
+    }
+    // Exactly one per category directory — no over-counting / double scan.
+    assert.equal(memories.length, CATEGORY_CASES.length);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("fallback disk recall scans nested date subdirectories under category dirs", async () => {
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    // Place files in nested YYYY-MM-DD subdirs for a representative spread of
+    // categories, including ones outside the legacy four-dir scan.
+    await seedMemory(baseDir, "preferences", "nested-pref", "preference", "Nested pref.", {
+      nested: true,
+    });
+    await seedMemory(baseDir, "decisions", "nested-dec", "decision", "Nested decision.", {
+      nested: true,
+    });
+    await seedMemory(baseDir, "facts", "nested-fact", "fact", "Nested fact.", {
+      nested: true,
+    });
+
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+
+    assert.ok(foundIds.has("nested-pref"), "nested preference not found");
+    assert.ok(foundIds.has("nested-dec"), "nested decision not found");
+    assert.ok(foundIds.has("nested-fact"), "nested fact not found");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("missing category directories are ignored without throwing", async () => {
+  // Construct a storage WITHOUT calling ensureDirectories(): none of the
+  // category dirs exist on disk. The scan must not throw and must return [].
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-missing-"));
+  const storage = new StorageManager(baseDir);
+  StorageManager.clearAllStaticCaches();
+  storage.invalidateAllMemoriesCacheForDir();
+  try {
+    const memories = await storage.readAllMemories();
+    assert.deepEqual(memories, []);
+
+    // Now create exactly one non-legacy dir and confirm partial presence works.
+    await seedMemory(baseDir, "rules", "only-rule", "rule", "Only a rule exists.");
+    storage.invalidateAllMemoriesCacheForDir();
+    const after = await storage.readAllMemories();
+    assert.equal(after.length, 1);
+    assert.equal(after[0]?.frontmatter.id, "only-rule");
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("non-memory markdown in category dirs is ignored safely (no crash)", async () => {
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    // A valid memory plus several garbage markdown files in category dirs.
+    await seedMemory(baseDir, "skills", "good-skill", "skill", "A valid skill memory.");
+
+    await mkdir(path.join(baseDir, "principles"), { recursive: true });
+    // No frontmatter at all.
+    await writeFile(
+      path.join(baseDir, "principles", "README.md"),
+      "# Just a heading\n\nNo frontmatter here.\n",
+      "utf-8",
+    );
+    // Broken / truncated frontmatter.
+    await writeFile(
+      path.join(baseDir, "principles", "broken.md"),
+      "---\nid: broken\n(no closing delimiter)\n",
+      "utf-8",
+    );
+    // Empty file.
+    await writeFile(path.join(baseDir, "principles", "empty.md"), "", "utf-8");
+
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+    assert.ok(foundIds.has("good-skill"), "valid skill memory should be returned");
+    assert.ok(!foundIds.has("broken"), "broken markdown must not be parsed as a memory");
+    assert.equal(memories.length, 1, "only the one valid memory should be returned");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("filesystem fallback is namespace-aware across more than one namespace", async () => {
+  // Each namespace is a distinct StorageManager baseDir (mirrors how the
+  // orchestrator's readAllMemoriesForNamespaces routes per namespace). The fix
+  // lives in collectActiveMemoryPaths(), so it must work for ALL baseDirs.
+  const nsA = await makeStorage("engram-1497-nsA-");
+  const nsB = await makeStorage("engram-1497-nsB-");
+  try {
+    // Seed non-legacy category dirs in each namespace.
+    await seedMemory(nsA.baseDir, "relationships", "rel-a", "relationship", "NS A relationship.");
+    await seedMemory(nsA.baseDir, "commitments", "com-a", "commitment", "NS A commitment.");
+    await seedMemory(nsB.baseDir, "moments", "mom-b", "moment", "NS B moment.");
+    await seedMemory(nsB.baseDir, "questions", "q-b", "question", "NS B question.");
+
+    const a = new Set((await nsA.storage.readAllMemories()).map((m) => m.frontmatter.id));
+    const b = new Set((await nsB.storage.readAllMemories()).map((m) => m.frontmatter.id));
+
+    assert.ok(a.has("rel-a") && a.has("com-a"), "namespace A must surface its memories");
+    assert.ok(b.has("mom-b") && b.has("q-b"), "namespace B must surface its memories");
+    // No cross-namespace bleed.
+    assert.ok(!a.has("mom-b") && !a.has("q-b"), "namespace A must not read namespace B");
+    assert.ok(!b.has("rel-a") && !b.has("com-a"), "namespace B must not read namespace A");
+  } finally {
+    await nsA.cleanup();
+    await nsB.cleanup();
+  }
+});
+
+test("non-category content dirs are deliberately EXCLUDED from fallback recall", async () => {
+  // Explicit decision (issue #1497): entities/, state/, artifacts/, identity/,
+  // config/ and profile.md are NOT standard frontmatter-backed memory files and
+  // are intentionally excluded from the category-dir scan. Files placed there
+  // must NOT appear in readAllMemories() — they have dedicated read paths.
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    // A real memory so the corpus is non-empty.
+    await seedMemory(baseDir, "facts", "real-fact", "fact", "A genuine fact.");
+
+    // Drop markdown that *looks* like a memory into the excluded dirs.
+    for (const excluded of ["entities", "state", "artifacts", "identity", "config"]) {
+      await mkdir(path.join(baseDir, excluded), { recursive: true });
+      await writeFile(
+        path.join(baseDir, excluded, "looks-like-memory.md"),
+        memoryFile(`excluded-${excluded}`, "fact", `Should not be recalled (${excluded}).`),
+        "utf-8",
+      );
+    }
+    // profile.md at the root is also excluded.
+    await writeFile(
+      path.join(baseDir, "profile.md"),
+      memoryFile("excluded-profile", "fact", "Profile should not be recalled."),
+      "utf-8",
+    );
+
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+
+    assert.ok(foundIds.has("real-fact"), "the genuine fact must still be recalled");
+    for (const excluded of ["entities", "state", "artifacts", "identity", "config"]) {
+      assert.ok(
+        !foundIds.has(`excluded-${excluded}`),
+        `${excluded}/ must be excluded from fallback recall`,
+      );
+    }
+    assert.ok(!foundIds.has("excluded-profile"), "profile.md must be excluded from fallback recall");
+    assert.equal(memories.length, 1, "only the one in-category memory should be returned");
+  } finally {
+    await cleanup();
+  }
+});
+
+/**
+ * QMD-DISABLED config path.
+ *
+ * A full end-to-end orchestrator recall with QMD disabled requires a large
+ * fixture (gateway API stubs, config, search-collection wiring) that the core
+ * Node test runner does not bootstrap here. The orchestrator's QMD-unavailable
+ * recall fallback (`recent_scan`) routes through
+ * `readAllMemoriesForNamespaces(ns)` -> `StorageManager.readAllMemories()` ->
+ * `collectActiveMemoryPaths()` (see orchestrator.ts readAllMemoriesForNamespaces
+ * and the recent-memory-read step). We therefore exercise that exact collector
+ * directly with a config object that explicitly disables QMD, proving the disk
+ * scan a QMD-disabled deployment relies on returns every category.
+ */
+test("QMD-disabled deployment: disk-scan collector returns all categories", async () => {
+  const baseDir = await mkdtemp(path.join(os.tmpdir(), "engram-1497-qmd-off-"));
+  // entitySchemas is the only other constructor arg; QMD is never constructed by
+  // StorageManager — the fallback recall path is pure filesystem. This models a
+  // deployment configured with `qmdEnabled: false` (no QMD process at all).
+  const qmdDisabledConfig = { qmdEnabled: false } as const;
+  assert.equal(qmdDisabledConfig.qmdEnabled, false);
+
+  const storage = new StorageManager(baseDir);
+  await storage.ensureDirectories();
+  StorageManager.clearAllStaticCaches();
+  storage.invalidateAllMemoriesCacheForDir();
+  try {
+    for (const { key, dir } of CATEGORY_CASES) {
+      await seedMemory(baseDir, dir, `qmdoff-${key}`, key, `QMD-off ${key} memory.`);
+    }
+    storage.invalidateAllMemoriesCacheForDir();
+
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+    for (const { key, dir } of CATEGORY_CASES) {
+      assert.ok(
+        foundIds.has(`qmdoff-${key}`),
+        `QMD-disabled fallback must read "${dir}/" (category "${key}")`,
+      );
+    }
+  } finally {
+    StorageManager.clearAllStaticCaches();
+    await rm(baseDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/storage-fallback-category-dirs.test.ts
+++ b/packages/remnic-core/src/storage-fallback-category-dirs.test.ts
@@ -6,16 +6,24 @@
  * `StorageManager.readAllMemories()` per namespace, which scans the disk via
  * `collectActiveMemoryPaths()`. The old implementation only scanned four
  * directories (facts, procedures, reasoning-traces, corrections), so on-disk
- * memories in any other category directory (preferences, decisions, moments,
- * commitments, principles, rules, skills, relationships, questions) were
- * silently missed when QMD was unavailable.
+ * memories in any other recall category directory (preferences, decisions,
+ * moments, commitments, principles, rules, skills, relationships) were silently
+ * missed when QMD was unavailable.
  *
  * These tests seed `.md` memory files directly into the on-disk category
  * directories (the way an external seed, a migration, or a future routing
  * change would leave them) and assert the disk-scan recall returns them.
  *
  * They FAIL on the old four-directory behavior and PASS once
- * `collectActiveMemoryPaths()` iterates the shared `ALL_CATEGORY_DIRS`.
+ * `collectActiveMemoryPaths()` iterates the shared `RECALL_FALLBACK_DIRS`.
+ *
+ * PR #1503 review (chatgpt-codex-connector, cursor): `questions/` is NOT a
+ * recall memory dir. It holds operational question-QUEUE items written by
+ * `writeQuestion()` and surfaced only through the dedicated, disabled-by-default
+ * `injectQuestions` pipeline stage. The QMD primary recall corpus excludes them,
+ * so the fallback must exclude them too (corpus parity; CLAUDE.md rule #39).
+ * `RECALL_FALLBACK_DIRS` = `ALL_CATEGORY_DIRS` minus `RECALL_NON_MEMORY_DIRS`
+ * (currently just `questions`).
  */
 
 import assert from "node:assert/strict";
@@ -25,7 +33,11 @@ import path from "node:path";
 import test from "node:test";
 
 import { StorageManager } from "./storage.js";
-import { ALL_CATEGORY_DIRS, CATEGORY_DIR_MAP } from "./utils/category-dir.js";
+import {
+  CATEGORY_DIR_MAP,
+  RECALL_FALLBACK_DIRS,
+  RECALL_NON_MEMORY_DIRS,
+} from "./utils/category-dir.js";
 
 /** Build a minimal-but-valid memory markdown file body. */
 function memoryFile(id: string, category: string, content: string): string {
@@ -82,24 +94,28 @@ async function makeStorage(prefix = "engram-1497-"): Promise<{
 }
 
 /**
- * Singular-category-key -> {dir, category-frontmatter-value} for every entry the
- * issue enumerates. `question` has no `MemoryCategory` enum member, so its
- * frontmatter `category` field is written as "question" (the scan is
- * directory-based, not category-based, so any valid memory file is returned).
+ * Singular-category-key -> {dir} for every RECALL category dir the fallback
+ * scan must cover. This is `ALL_CATEGORY_DIRS` minus `RECALL_NON_MEMORY_DIRS`
+ * (the `questions/` queue dir is intentionally absent — see the file header).
  */
 const CATEGORY_CASES: ReadonlyArray<{ key: string; dir: string }> = [
   { key: "fact", dir: "facts" },
   ...Object.entries(CATEGORY_DIR_MAP).map(([key, dir]) => ({ key, dir })),
-];
+].filter(({ dir }) => !RECALL_NON_MEMORY_DIRS.has(dir));
 
-test("collectActiveMemoryPaths source-of-truth: every ALL_CATEGORY_DIRS entry is covered", () => {
+test("collectActiveMemoryPaths source-of-truth: every RECALL_FALLBACK_DIRS entry is covered", () => {
   // Guards against the dir list drifting away from the shared source of truth.
-  const expected = new Set(ALL_CATEGORY_DIRS);
+  const expected = new Set(RECALL_FALLBACK_DIRS);
   const covered = new Set(CATEGORY_CASES.map((c) => c.dir));
   assert.deepEqual(
     [...covered].sort(),
     [...expected].sort(),
-    "test cases must cover exactly ALL_CATEGORY_DIRS",
+    "test cases must cover exactly RECALL_FALLBACK_DIRS",
+  );
+  // questions/ must NOT be a recall fallback dir.
+  assert.ok(
+    !expected.has("questions"),
+    "questions/ is a queue dir and must be excluded from recall fallback",
   );
 });
 
@@ -225,15 +241,14 @@ test("filesystem fallback is namespace-aware across more than one namespace", as
     await seedMemory(nsA.baseDir, "relationships", "rel-a", "relationship", "NS A relationship.");
     await seedMemory(nsA.baseDir, "commitments", "com-a", "commitment", "NS A commitment.");
     await seedMemory(nsB.baseDir, "moments", "mom-b", "moment", "NS B moment.");
-    await seedMemory(nsB.baseDir, "questions", "q-b", "question", "NS B question.");
 
     const a = new Set((await nsA.storage.readAllMemories()).map((m) => m.frontmatter.id));
     const b = new Set((await nsB.storage.readAllMemories()).map((m) => m.frontmatter.id));
 
     assert.ok(a.has("rel-a") && a.has("com-a"), "namespace A must surface its memories");
-    assert.ok(b.has("mom-b") && b.has("q-b"), "namespace B must surface its memories");
+    assert.ok(b.has("mom-b"), "namespace B must surface its memories");
     // No cross-namespace bleed.
-    assert.ok(!a.has("mom-b") && !a.has("q-b"), "namespace A must not read namespace B");
+    assert.ok(!a.has("mom-b"), "namespace A must not read namespace B");
     assert.ok(!b.has("rel-a") && !b.has("com-a"), "namespace B must not read namespace A");
   } finally {
     await nsA.cleanup();
@@ -279,6 +294,50 @@ test("non-category content dirs are deliberately EXCLUDED from fallback recall",
     }
     assert.ok(!foundIds.has("excluded-profile"), "profile.md must be excluded from fallback recall");
     assert.equal(memories.length, 1, "only the one in-category memory should be returned");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("question-queue items written by writeQuestion() do NOT leak into fallback recall", async () => {
+  // PR #1503 review (chatgpt-codex-connector P2 + cursor): scanning questions/
+  // via the category-dir list pulled writeQuestion() queue items
+  // (priority/resolved frontmatter) into recall. They are NOT recall memories —
+  // they are surfaced only via readQuestions() + the disabled-by-default
+  // injectQuestions pipeline. The QMD primary corpus excludes them; the
+  // filesystem fallback must too (CLAUDE.md rule #39 corpus parity).
+  //
+  // This test uses the REAL writeQuestion() path (not a synthetic memory file)
+  // so it exercises exactly the frontmatter shape the reviewers flagged. It
+  // FAILS on the buggy ALL_CATEGORY_DIRS scan and PASSES after the
+  // RECALL_FALLBACK_DIRS fix.
+  const { storage, baseDir, cleanup } = await makeStorage();
+  try {
+    // A genuine recall memory so the corpus is non-empty.
+    await seedMemory(baseDir, "facts", "real-fact", "fact", "A genuine fact.");
+
+    // Real operational question-queue items (frontmatter { id, created,
+    // priority, resolved }, body `<question>\n\n**Context:** ...`).
+    const qId1 = await storage.writeQuestion("What is the user's timezone?", "ctx1", 0.9);
+    const qId2 = await storage.writeQuestion("Does the user prefer dark mode?", "ctx2", 0.5);
+
+    // Queue items remain readable via the dedicated queue surface.
+    const queue = await storage.readQuestions();
+    const queueIds = new Set(queue.map((q) => q.id));
+    assert.ok(queueIds.has(qId1) && queueIds.has(qId2), "readQuestions() must still return the queue");
+
+    // ...but they must NOT appear in the recall corpus.
+    storage.invalidateAllMemoriesCacheForDir();
+    const memories = await storage.readAllMemories();
+    const foundIds = new Set(memories.map((m) => m.frontmatter.id));
+    assert.ok(foundIds.has("real-fact"), "the genuine fact must still be recalled");
+    assert.ok(!foundIds.has(qId1), "question-queue item #1 must NOT leak into recall");
+    assert.ok(!foundIds.has(qId2), "question-queue item #2 must NOT leak into recall");
+    assert.equal(
+      memories.length,
+      1,
+      "only the genuine fact should be recalled (no question-queue leakage)",
+    );
   } finally {
     await cleanup();
   }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { log } from "./logger.js";
 import { isErrnoCode } from "./utils/errno.js";
-import { ALL_CATEGORY_DIRS } from "./utils/category-dir.js";
+import { RECALL_FALLBACK_DIRS } from "./utils/category-dir.js";
 import { getCachedEntities, invalidateCachedEntities, setCachedEntities } from "./memory-cache.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
@@ -4016,31 +4016,35 @@ export class StorageManager {
     // (facts/procedures/reasoning-traces/corrections). Issue #1497: the QMD
     // filesystem-fallback recall path (orchestrator `recent_scan` ->
     // readAllMemoriesForNamespaces -> readAllMemories -> here) must read every
-    // category dir so on-disk memories in preferences/decisions/moments/
-    // commitments/principles/rules/skills/relationships/questions are not
-    // missed when QMD is disabled, missing, or unhealthy. ALL_CATEGORY_DIRS is
-    // the single source of truth shared with ensureDirectories() and the write
-    // routing in utils/category-dir.ts.
+    // recall category dir so on-disk memories in preferences/decisions/moments/
+    // commitments/principles/rules/skills/relationships are not missed when QMD
+    // is disabled, missing, or unhealthy. RECALL_FALLBACK_DIRS is the single
+    // source of truth derived from ALL_CATEGORY_DIRS (shared with
+    // ensureDirectories() and the write routing in utils/category-dir.ts).
     //
     // These paths resolve identically to the legacy this.factsDir /
     // this.correctionsDir / this.proceduresDir / this.reasoningTracesDir
     // getters (all `path.join(this.baseDir, <dir>)`), so the scan stays
     // namespace-aware: this.baseDir is per-namespace, set by the storage router.
     //
-    // Deliberately EXCLUDED (issue #1497): the non-category content dirs that
-    // ensureDirectories() also creates — entities/, state/, artifacts/,
-    // identity/, config/ — plus the root profile.md. These are not
-    // standard frontmatter-backed memory files and have their own dedicated
-    // read paths (readEntities, artifact readers, identity anchors, profile
-    // injection). Including them here would surface non-memory content in
-    // recall. The exclusion is asserted by a test in
-    // storage-fallback-category-dirs.test.ts. (`questions/` IS a recall
-    // category dir and is included via ALL_CATEGORY_DIRS.)
+    // Deliberately EXCLUDED (issue #1497 + PR #1503 review): the non-category
+    // content dirs that ensureDirectories() also creates — entities/, state/,
+    // artifacts/, identity/, config/ — plus the root profile.md, AND the
+    // questions/ queue dir. questions/ holds operational question-QUEUE items
+    // written by writeQuestion() (frontmatter `{ id, created, priority,
+    // resolved }`), read only via readQuestions() and surfaced through the
+    // dedicated, disabled-by-default `injectQuestions` recall-pipeline stage —
+    // never as standard recall memories. The QMD primary recall corpus does not
+    // include them, so the fallback must not either (corpus parity; CLAUDE.md
+    // rule #39). Were questions/ scanned here, parseFrontmatter() would accept
+    // those files (they have a `---` frontmatter block) and leak queue items
+    // into recall. None of these excluded dirs are in RECALL_FALLBACK_DIRS; the
+    // exclusion is asserted by tests in storage-fallback-category-dirs.test.ts.
     //
     // collectPaths() already ignores missing dirs (try/catch) and the parser
     // returns null for non-memory markdown, so unrelated files never crash the
     // scan.
-    for (const dir of ALL_CATEGORY_DIRS) {
+    for (const dir of RECALL_FALLBACK_DIRS) {
       await collectPaths(path.join(this.baseDir, dir));
     }
     return filePaths;

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import path from "node:path";
 import { log } from "./logger.js";
 import { isErrnoCode } from "./utils/errno.js";
+import { ALL_CATEGORY_DIRS } from "./utils/category-dir.js";
 import { getCachedEntities, invalidateCachedEntities, setCachedEntities } from "./memory-cache.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
@@ -4011,10 +4012,37 @@ export class StorageManager {
       }
     };
 
-    await collectPaths(this.factsDir);
-    await collectPaths(this.proceduresDir);
-    await collectPaths(this.reasoningTracesDir);
-    await collectPaths(this.correctionsDir);
+    // Scan EVERY supported memory category directory, not just the legacy four
+    // (facts/procedures/reasoning-traces/corrections). Issue #1497: the QMD
+    // filesystem-fallback recall path (orchestrator `recent_scan` ->
+    // readAllMemoriesForNamespaces -> readAllMemories -> here) must read every
+    // category dir so on-disk memories in preferences/decisions/moments/
+    // commitments/principles/rules/skills/relationships/questions are not
+    // missed when QMD is disabled, missing, or unhealthy. ALL_CATEGORY_DIRS is
+    // the single source of truth shared with ensureDirectories() and the write
+    // routing in utils/category-dir.ts.
+    //
+    // These paths resolve identically to the legacy this.factsDir /
+    // this.correctionsDir / this.proceduresDir / this.reasoningTracesDir
+    // getters (all `path.join(this.baseDir, <dir>)`), so the scan stays
+    // namespace-aware: this.baseDir is per-namespace, set by the storage router.
+    //
+    // Deliberately EXCLUDED (issue #1497): the non-category content dirs that
+    // ensureDirectories() also creates — entities/, state/, artifacts/,
+    // identity/, config/ — plus the root profile.md. These are not
+    // standard frontmatter-backed memory files and have their own dedicated
+    // read paths (readEntities, artifact readers, identity anchors, profile
+    // injection). Including them here would surface non-memory content in
+    // recall. The exclusion is asserted by a test in
+    // storage-fallback-category-dirs.test.ts. (`questions/` IS a recall
+    // category dir and is included via ALL_CATEGORY_DIRS.)
+    //
+    // collectPaths() already ignores missing dirs (try/catch) and the parser
+    // returns null for non-memory markdown, so unrelated files never crash the
+    // scan.
+    for (const dir of ALL_CATEGORY_DIRS) {
+      await collectPaths(path.join(this.baseDir, dir));
+    }
     return filePaths;
   }
 

--- a/packages/remnic-core/src/utils/category-dir.ts
+++ b/packages/remnic-core/src/utils/category-dir.ts
@@ -28,6 +28,32 @@ export const ALL_CATEGORY_DIRS: string[] = [
   ...Object.values(CATEGORY_DIR_MAP),
 ];
 
+/**
+ * Category directories whose files are NOT part of the recall memory corpus.
+ *
+ * `questions/` holds operational question-QUEUE items written by
+ * `StorageManager.writeQuestion()` (frontmatter `{ id, created, priority,
+ * resolved }`, body `<question>\n\n**Context:** ...`). They are read only via
+ * `readQuestions()` and surfaced through the dedicated, disabled-by-default
+ * `injectQuestions` recall-pipeline stage (`{"id":"questions","enabled":false}`)
+ * — never as standard frontmatter-backed recall memories. The QMD primary
+ * recall path treats them the same way (they are not part of the `memories`
+ * corpus), so the filesystem fallback must not pull them into recall either.
+ */
+export const RECALL_NON_MEMORY_DIRS: ReadonlySet<string> = new Set(["questions"]);
+
+/**
+ * Category directories the filesystem-fallback recall scan should read.
+ *
+ * This is `ALL_CATEGORY_DIRS` minus the non-memory queue dirs in
+ * `RECALL_NON_MEMORY_DIRS`. It is the single source of truth for the corpus the
+ * QMD-unavailable fallback (`StorageManager.collectActiveMemoryPaths()`) treats
+ * as recall memories — kept in parity with the QMD primary recall corpus.
+ */
+export const RECALL_FALLBACK_DIRS: string[] = ALL_CATEGORY_DIRS.filter(
+  (dir) => !RECALL_NON_MEMORY_DIRS.has(dir),
+);
+
 /** All category keys (singular form) — used when iterating categories and calling getCategoryDir. */
 export const ALL_CATEGORY_KEYS: string[] = [
   "fact",


### PR DESCRIPTION
## Summary

Fixes the QMD filesystem-fallback recall so it reads **all** supported memory category directories, not only the legacy four (`facts`, `procedures`, `reasoning-traces`, `corrections`). When QMD is disabled, missing, unavailable, or unhealthy, recall falls back to a disk scan; previously that scan silently skipped `preferences`, `decisions`, `moments`, `commitments`, `principles`, `rules`, `skills`, `relationships`, and `questions`, so valid on-disk memories in those directories were missed.

Closes #1497
Part of epic #1494

## What changed and why

- `packages/remnic-core/src/storage.ts` → `StorageManager.collectActiveMemoryPaths()` now iterates the shared `ALL_CATEGORY_DIRS` from `utils/category-dir.ts` (joined to `this.baseDir`) instead of a hard-coded 4-directory list. This is the single collector behind `readAllMemories()` → `_readAllMemoriesFromDisk()`, which the orchestrator's QMD-unavailable `recent_scan` fallback reaches via `readAllMemoriesForNamespaces(ns)`.
- The new paths resolve **identically** to the legacy `factsDir` / `correctionsDir` / `proceduresDir` / `reasoningTracesDir` getters (all `path.join(this.baseDir, <dir>)`), so behavior for the existing four dirs is unchanged and the fallback stays **namespace-aware** — `this.baseDir` is per-namespace, set by the storage router, and each namespace gets its own `StorageManager`.
- `ALL_CATEGORY_DIRS` entries are all distinct, so no directory is scanned twice.
- The existing `collectPaths()` try/catch (missing dirs ignored) and the null-returning frontmatter parser (non-memory markdown ignored) are preserved.

### Explicit decision on non-category content dirs

`ensureDirectories()` also creates `entities/`, `state/`, `artifacts/`, `identity/`, `config/`, plus the root `profile.md`. These are **deliberately excluded** from the fallback scan — they are not standard frontmatter-backed memory files and have their own dedicated read paths (entity readers, artifact readers, identity anchors, profile injection). Surfacing them in recall would inject non-memory content. The exclusion is documented in a code comment **and** asserted by a test. (`questions/` IS a recall category dir and is included via `ALL_CATEGORY_DIRS`.)

## Test coverage

New: `packages/remnic-core/src/storage-fallback-category-dirs.test.ts` (8 tests). All seed `.md` files directly into on-disk category dirs (simulating external seed / migration / future routing) and assert the disk-scan recall returns them:

- source-of-truth guard: test cases cover exactly `ALL_CATEGORY_DIRS`;
- a memory from **every** category dir (fact, correction, question, preference, decision, moment, commitment, principle, rule, skill, relationship, procedure, reasoning_trace) is recalled;
- nested `YYYY-MM-DD` date subdirs under category dirs are scanned;
- missing directories ignored without throwing;
- non-memory markdown (no frontmatter / broken / empty) ignored safely (no crash);
- namespace fallback reading more than one namespace, with no cross-namespace bleed;
- non-category content dirs (`entities/`, `state/`, `artifacts/`, `identity/`, `config/`, `profile.md`) deliberately excluded;
- QMD-disabled config path: drives the exact collector the QMD-disabled fallback relies on (with a documented note on why a full end-to-end orchestrator QMD-off fixture is impractical in the core Node test runner).

These tests **fail on the old four-directory behavior** (6/8 failed pre-fix) and **pass after the fix** (8/8).

## Gate results

- `pnpm --filter @remnic/core build` — pass (tsc + all package check-types clean)
- New tests — 8/8 pass
- Related disk-scan tests (temporal-supersession, source-attribution, memory-worth-frontmatter) — 140/140 pass
- `npm run test:entity-hardening` — 205/205 pass
- `npm run preflight:quick` — pass (exit 0)

## Checklist

- [x] All tests pass
- [x] New logic covered by tests
- [x] Pre-commit/preflight gates pass locally
- [x] No secrets or personal data committed
- [x] Docs/comments updated as needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the QMD-unavailable recall path (`readAllMemories` / `recent_scan`), but behavior is narrowed to a shared dir list with corpus parity and broad test coverage.
> 
> **Overview**
> When QMD is unavailable, disk fallback recall no longer drops on-disk memories outside the legacy four folders (`facts`, `procedures`, `reasoning-traces`, `corrections`). **`collectActiveMemoryPaths()`** now walks **`RECALL_FALLBACK_DIRS`** (all recall category dirs under each namespace `baseDir`) instead of a fixed four-dir list.
> 
> **`category-dir.ts`** adds **`RECALL_NON_MEMORY_DIRS`** (`questions/`) and **`RECALL_FALLBACK_DIRS`** (`ALL_CATEGORY_DIRS` minus that set) so the fallback matches the QMD recall corpus and does **not** pull **`writeQuestion()`** queue items into **`readAllMemories()`**.
> 
> New **`storage-fallback-category-dirs.test.ts`** covers every fallback category dir, nested date subdirs, missing dirs, bad markdown, multi-namespace isolation, excluded non-memory dirs, and question-queue non-leakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d123aa87817e1959efee7c286c9595f3fdf26856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->