### PR TITLE
fix(sessions): first-class transcript identities for arbitrary session keys (#1496)

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -14,7 +14,13 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { Orchestrator, parseConfig, parseEntityFile, StorageManager } from "@remnic/core";
+import {
+  Orchestrator,
+  parseConfig,
+  parseEntityFile,
+  sessionStoragePaths,
+  StorageManager,
+} from "@remnic/core";
 import { LcmEngine } from "@remnic/core/lcm";
 
 import {
@@ -3408,11 +3414,14 @@ test("runtime-backed adapter preserves source timestamps for historical recall",
     ]);
     await adapter.drain?.();
 
+    // After issue #1496, an arbitrary session key routes to
+    // transcripts/session/<hash>/ rather than the legacy shared other/default
+    // fallback. Resolve the directory through the same identity layer the core
+    // transcript writer uses so the test tracks routing (rule #20).
     const transcriptPath = path.join(
       sandboxDir,
       "transcripts",
-      "other",
-      "default",
+      sessionStoragePaths("beam-source-time-session").dir,
       `${new Date().toISOString().slice(0, 10)}.jsonl`,
     );
     const transcriptLines = (await readFile(transcriptPath, "utf8"))

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -202,6 +202,10 @@ import {
   type SessionRepairApplyResult,
   type SessionRepairPlan,
 } from "./session-integrity.js";
+import {
+  migrateSessionTranscripts,
+  planSessionTranscriptMigration,
+} from "./session-transcript-migration.js";
 import type { TierMigrationCycleSummary, TierMigrationStatusSnapshot } from "./recall-state.js";
 import {
   readRuntimePolicySnapshot as readPolicyRuntimeSnapshot,
@@ -8648,6 +8652,81 @@ export function registerCli(
             );
             console.log(formatTranscript(entries));
           }
+        });
+
+      // ── Sessions subcommand (issue #1496) ───────────────────────────────
+      const sessionsCmd = cmd
+        .command("sessions")
+        .description("Inspect and migrate session transcript storage");
+
+      sessionsCmd
+        .command("migrate-transcripts")
+        .description(
+          "Split conflated other/default transcripts into first-class session/<hash> dirs",
+        )
+        .option("--dry-run", "Report the migration plan without moving files (default)")
+        .option("--apply", "Apply the migration (move files; default is dry-run)")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const dryRunFlag = options.dryRun === true;
+          const applyFlag = options.apply === true;
+
+          // Rule #51: reject contradictory flags rather than silently picking one.
+          if (dryRunFlag && applyFlag) {
+            console.error("Cannot pass both --dry-run and --apply. Choose one.");
+            process.exit(1);
+          }
+
+          // Safe default: dry-run when neither flag is given.
+          const apply = applyFlag;
+          const memoryDir = orchestrator.config.memoryDir;
+
+          if (!apply) {
+            const plan = await planSessionTranscriptMigration({ memoryDir });
+            console.log("=== Session Transcript Migration (DRY RUN) ===\n");
+            if (!dryRunFlag && !applyFlag) {
+              console.log("No flag given — defaulting to --dry-run. Pass --apply to migrate.\n");
+            }
+            console.log(`transcripts dir: ${plan.transcriptsDir}`);
+            console.log(`files to migrate: ${plan.files.length}`);
+            console.log(`distinct sessions: ${plan.distinctSessions}`);
+            console.log(`entries to move: ${plan.movedEntries}`);
+            if (plan.files.length > 0) {
+              console.log("\nPlanned splits:");
+              for (const file of plan.files) {
+                console.log(`- ${file.sourceRelPath}`);
+                for (const group of file.groups) {
+                  console.log(
+                    `    ${group.entryCount} entr${group.entryCount === 1 ? "y" : "ies"} → ${group.destDir} (${group.legacy ? "legacy" : "session"})`,
+                  );
+                }
+                if (file.unmovableLines > 0) {
+                  console.log(`    ${file.unmovableLines} unmovable line(s) retained in source`);
+                }
+              }
+            }
+            console.log("\nDRY RUN — no files changed.");
+            return;
+          }
+
+          const result = await migrateSessionTranscripts({ memoryDir, apply: true });
+          console.log("=== Session Transcript Migration (APPLY) ===\n");
+          console.log(`files rewritten: ${result.filesRewritten}`);
+          console.log(`files removed: ${result.filesRemoved}`);
+          console.log(`distinct sessions: ${result.plan.distinctSessions}`);
+          console.log(`entries moved: ${result.plan.movedEntries}`);
+          if (result.manifestPath) {
+            console.log(`manifest: ${result.manifestPath}`);
+          }
+          if (result.errors.length > 0) {
+            console.log("\nErrors:");
+            for (const err of result.errors) {
+              console.log(`- ${err}`);
+            }
+            process.exitCode = 1;
+            return;
+          }
+          console.log("\nOK");
         });
 
       // Checkpoint command

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -325,6 +325,24 @@ export { buildEntityRecallSection } from "./entity-retrieval.js";
 export { resolvePrincipal } from "./namespaces/principal.js";
 
 // ---------------------------------------------------------------------------
+// Session identity / transcript pathing (issue #1496)
+// ---------------------------------------------------------------------------
+
+// Shared, deterministic session-key → storage-path resolution. Exported so
+// downstream consumers (the @remnic/bench adapter + its tests, host adapters)
+// resolve transcript directories through the SAME layer the core writer uses
+// instead of hard-coding `other/default` (rule #20, #22, #26).
+export {
+  SESSION_CHANNEL_TYPE,
+  parseSessionIdentity,
+  sessionStoragePaths,
+  legacyParserReadbackDir,
+  type SessionIdentity,
+  type SessionStoragePaths,
+} from "./session-identity.js";
+export { storagePathHash } from "./storage-paths.js";
+
+// ---------------------------------------------------------------------------
 // Trust zones
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/session-identity.test.ts
+++ b/packages/remnic-core/src/session-identity.test.ts
@@ -5,6 +5,7 @@ import {
   LEGACY_FALLBACK_CHANNEL_ID,
   LEGACY_FALLBACK_CHANNEL_TYPE,
   SESSION_CHANNEL_TYPE,
+  legacyParserReadbackDir,
   parseSessionIdentity,
   sessionStoragePaths,
 } from "./session-identity.js";
@@ -96,4 +97,34 @@ test("display label strips control characters and separators", () => {
   const id = parseSessionIdentity("pi-geek:abc/123");
   assert.ok(!id.displayLabel.includes("/"));
   assert.ok(id.displayLabel.length > 0);
+});
+
+test("legacyParserReadbackDir reconstructs the OLD parser dir for >=3-part keys", () => {
+  // foo:bar:baz → channelType=baz, channelId=default
+  assert.equal(legacyParserReadbackDir("foo:bar:baz"), "baz/default");
+  // foo:bar:baz:qux → channelType=baz, channelId=qux
+  assert.equal(legacyParserReadbackDir("foo:bar:baz:qux"), "baz/qux");
+});
+
+test("legacyParserReadbackDir returns undefined for <3-part keys (old build used other/default)", () => {
+  assert.equal(legacyParserReadbackDir("pi-geek:abc123"), undefined);
+  assert.equal(legacyParserReadbackDir("bare"), undefined);
+  assert.equal(legacyParserReadbackDir(""), undefined);
+});
+
+test("readbackDirs for a >=3-part arbitrary key include other/default AND the old parser dir", () => {
+  const paths = sessionStoragePaths("foo:bar:baz");
+  assert.match(paths.dir, /^session\/[0-9a-f]{16}$/);
+  assert.ok(paths.readbackDirs.includes("other/default"));
+  assert.ok(paths.readbackDirs.includes("baz/default"));
+});
+
+test("readbackDirs for a 2-part arbitrary key include only other/default", () => {
+  const paths = sessionStoragePaths("pi-geek:abc123");
+  assert.deepEqual(paths.readbackDirs, ["other/default"]);
+});
+
+test("legacy agent:<id>:... keys expose no read-back dirs (their location never moved)", () => {
+  assert.deepEqual(sessionStoragePaths("agent:generalist:main").readbackDirs, []);
+  assert.deepEqual(sessionStoragePaths("agent:generalist:discord:channel:998877").readbackDirs, []);
 });

--- a/packages/remnic-core/src/session-identity.test.ts
+++ b/packages/remnic-core/src/session-identity.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LEGACY_FALLBACK_CHANNEL_ID,
+  LEGACY_FALLBACK_CHANNEL_TYPE,
+  SESSION_CHANNEL_TYPE,
+  parseSessionIdentity,
+  sessionStoragePaths,
+} from "./session-identity.js";
+
+test("legacy agent:<id>:main keeps main/default channel identity", () => {
+  const id = parseSessionIdentity("agent:generalist:main");
+  assert.equal(id.legacy, true);
+  assert.equal(id.channelType, "main");
+  assert.equal(id.channelId, "default");
+  assert.equal(id.canonicalSessionKey, "agent:generalist:main");
+});
+
+test("legacy discord channel keeps discord/<channelId> identity", () => {
+  const id = parseSessionIdentity("agent:generalist:discord:channel:998877");
+  assert.equal(id.legacy, true);
+  assert.equal(id.channelType, "discord");
+  assert.equal(id.channelId, "998877");
+});
+
+test("legacy slack channel keeps slack/<channelId> identity", () => {
+  const id = parseSessionIdentity("agent:generalist:slack:channel:C12345");
+  assert.equal(id.legacy, true);
+  assert.equal(id.channelType, "slack");
+  assert.equal(id.channelId, "C12345");
+});
+
+test("legacy cron job keeps cron/<jobId> identity", () => {
+  const id = parseSessionIdentity("agent:generalist:cron:nightly-sync");
+  assert.equal(id.legacy, true);
+  assert.equal(id.channelType, "cron");
+  assert.equal(id.channelId, "nightly-sync");
+});
+
+test("arbitrary key becomes a first-class session/<hash> identity, never other/default", () => {
+  const id = parseSessionIdentity("pi-geek:abc123");
+  assert.equal(id.legacy, false);
+  assert.equal(id.channelType, SESSION_CHANNEL_TYPE);
+  assert.notEqual(id.channelType, LEGACY_FALLBACK_CHANNEL_TYPE);
+  assert.notEqual(id.channelId, LEGACY_FALLBACK_CHANNEL_ID);
+  assert.match(id.channelId, /^[0-9a-f]{16}$/);
+});
+
+test("distinct arbitrary keys get distinct, collision-resistant hashes", () => {
+  const geek = parseSessionIdentity("pi-geek:abc123");
+  const friend = parseSessionIdentity("pi-friend:def456");
+  assert.notEqual(geek.channelId, friend.channelId);
+});
+
+test("identity is deterministic for the same key", () => {
+  const a = parseSessionIdentity("pi-geek:abc123");
+  const b = parseSessionIdentity("pi-geek:abc123");
+  assert.deepEqual(a, b);
+});
+
+test("a bare token without the agent prefix is treated as arbitrary, not legacy", () => {
+  // "foo:bar:baz" must NOT be misread as channelType="baz".
+  const id = parseSessionIdentity("foo:bar:baz");
+  assert.equal(id.legacy, false);
+  assert.equal(id.channelType, SESSION_CHANNEL_TYPE);
+});
+
+test("empty session key resolves without throwing", () => {
+  const id = parseSessionIdentity("");
+  assert.equal(id.legacy, false);
+  assert.equal(id.channelType, SESSION_CHANNEL_TYPE);
+  assert.equal(typeof id.channelId, "string");
+});
+
+test("sessionStoragePaths routes arbitrary keys to session/<hash>", () => {
+  const paths = sessionStoragePaths("pi-geek:abc123");
+  assert.equal(paths.channelType, SESSION_CHANNEL_TYPE);
+  assert.match(paths.dir, /^session\/[0-9a-f]{16}$/);
+});
+
+test("sessionStoragePaths keeps legacy main at main/default", () => {
+  const paths = sessionStoragePaths("agent:generalist:main");
+  assert.equal(paths.dir, "main/default");
+});
+
+test("two arbitrary keys never share a storage dir", () => {
+  const a = sessionStoragePaths("pi-geek:abc123");
+  const b = sessionStoragePaths("pi-friend:def456");
+  assert.notEqual(a.dir, b.dir);
+  assert.notEqual(a.dir, "other/default");
+  assert.notEqual(b.dir, "other/default");
+});
+
+test("display label strips control characters and separators", () => {
+  const id = parseSessionIdentity("pi-geek:abc/123");
+  assert.ok(!id.displayLabel.includes("/"));
+  assert.ok(id.displayLabel.length > 0);
+});

--- a/packages/remnic-core/src/session-identity.ts
+++ b/packages/remnic-core/src/session-identity.ts
@@ -1,0 +1,200 @@
+import path from "node:path";
+import {
+  encodeStoragePathSegment,
+  encodeStoragePathSegmentWithHash,
+  isSafeLegacyPathSegment,
+  storagePathHash,
+} from "./storage-paths.js";
+
+/**
+ * Shared session-identity / transcript-pathing layer (issue #1496).
+ *
+ * This module is the SINGLE source of truth for turning a `sessionKey` into a
+ * channel identity and a set of deterministic, collision-resistant storage
+ * paths. Every subsystem that previously re-parsed session keys (transcript
+ * pathing, tool-usage pathing, hourly summaries, session auditing, conversation
+ * indexing) MUST route through `parseSessionIdentity()` / `sessionStoragePaths()`
+ * so behavior stays identical across paths (rule #22, #39).
+ *
+ * Two shapes are recognized:
+ *
+ *   1. Legacy `agent:<agentId>:<channelType>:...` keys keep their existing
+ *      readable channel identity:
+ *        - agent:<id>:main                      → type="main",    id="default"
+ *        - agent:<id>:discord:channel:<chanId>  → type="discord", id="<chanId>"
+ *        - agent:<id>:slack:channel:<chanId>    → type="slack",   id="<chanId>"
+ *        - agent:<id>:cron:<jobId>              → type="cron",    id="<jobId>"
+ *        - agent:<id>:<other>[:<id>]            → type="<other>", id="<id?>"
+ *
+ *   2. Arbitrary / non-legacy keys (e.g. `pi-geek:abc123`) become first-class
+ *      from the FIRST write — they NEVER start life under `other/default`:
+ *        channelType = "session"
+ *        channelId   = storagePathHash(sessionKey)   (collision-resistant)
+ *      yielding `transcripts/session/<hash>/YYYY-MM-DD.jsonl`.
+ *
+ * The reserved `"session"` channel type is what makes arbitrary keys isolated
+ * and auditable. Legacy data under `other/default` (and any legacy channel
+ * directory) remains READABLE via `legacyDir` / `alternateDir` candidates.
+ */
+
+/** Channel type reserved for first-class arbitrary (non-legacy) session keys. */
+export const SESSION_CHANNEL_TYPE = "session";
+
+/** Legacy fallback channel identity for un-parseable keys (read-back only). */
+export const LEGACY_FALLBACK_CHANNEL_TYPE = "other";
+export const LEGACY_FALLBACK_CHANNEL_ID = "default";
+
+/** Max characters of the raw session key kept in a human-readable display label. */
+const DISPLAY_LABEL_MAX_LENGTH = 64;
+
+export interface SessionIdentity {
+  /** Channel type — legacy channel type for known shapes, else `"session"`. */
+  channelType: string;
+  /** Channel id — legacy channel id for known shapes, else the key hash. */
+  channelId: string;
+  /** Human-readable, non-authoritative label derived from the raw key. */
+  displayLabel: string;
+  /** The original session key, unchanged. */
+  canonicalSessionKey: string;
+  /** True when the key matched a known legacy `agent:<id>:...` shape. */
+  legacy: boolean;
+}
+
+export interface SessionStoragePaths {
+  /** Channel type (mirrors {@link SessionIdentity.channelType}). */
+  channelType: string;
+  /** Channel id (mirrors {@link SessionIdentity.channelId}). */
+  channelId: string;
+  /** Primary encoded storage subdirectory: `<encodedType>/<encodedId>`. */
+  dir: string;
+  /**
+   * Collision-resistant alternate subdirectory that always embeds the full
+   * session-key hash. Used both as a write-time collision escape hatch and as a
+   * read-back candidate for data written before this layer existed.
+   */
+  alternateDir: string;
+  /**
+   * Un-encoded `<type>/<id>` directory for reading data written by older
+   * builds that did not URL-encode path segments. Undefined when it would be
+   * identical to `dir` or when either segment is path-unsafe.
+   */
+  legacyDir?: string;
+}
+
+/**
+ * Parse a session key into a stable channel identity.
+ *
+ * Pure and deterministic — no filesystem access. Same input always yields the
+ * same identity, which is what makes arbitrary keys collision-resistant from
+ * the first write.
+ */
+export function parseSessionIdentity(sessionKey: string): SessionIdentity {
+  const canonicalSessionKey = typeof sessionKey === "string" ? sessionKey : "";
+  const legacy = parseLegacyChannelIdentity(canonicalSessionKey);
+  if (legacy) {
+    return {
+      channelType: legacy.channelType,
+      channelId: legacy.channelId,
+      displayLabel: safeDisplayLabel(canonicalSessionKey),
+      canonicalSessionKey,
+      legacy: true,
+    };
+  }
+
+  return {
+    channelType: SESSION_CHANNEL_TYPE,
+    channelId: storagePathHash(canonicalSessionKey),
+    displayLabel: safeDisplayLabel(canonicalSessionKey),
+    canonicalSessionKey,
+    legacy: false,
+  };
+}
+
+/**
+ * Resolve the storage path pieces for a session key. Wraps
+ * {@link parseSessionIdentity} so transcript, tool-usage, and summary writers
+ * share one implementation (rule #22).
+ */
+export function sessionStoragePaths(sessionKey: string): SessionStoragePaths {
+  const identity = parseSessionIdentity(sessionKey);
+  const { channelType, channelId, canonicalSessionKey } = identity;
+
+  const dir = path.join(encodeStoragePathSegment(channelType), encodeStoragePathSegment(channelId));
+
+  const alternateDir = path.join(
+    encodeStoragePathSegmentWithHash(channelType),
+    `${encodeStoragePathSegmentWithHash(channelId)}--session-${storagePathHash(canonicalSessionKey)}`
+  );
+
+  let legacyDir: string | undefined;
+  if (isSafeLegacyPathSegment(channelType) && isSafeLegacyPathSegment(channelId)) {
+    const candidate = path.join(channelType, channelId);
+    if (candidate !== dir) {
+      legacyDir = candidate;
+    }
+  }
+
+  return { channelType, channelId, dir, alternateDir, legacyDir };
+}
+
+/**
+ * Parse the legacy `agent:<agentId>:<channelType>:...` shape. Returns
+ * `undefined` for anything that is not a recognized legacy key, so the caller
+ * can route it to a first-class `session/<hash>` identity instead.
+ *
+ * A legacy key must start with the literal `agent` segment and a non-empty
+ * agent id; otherwise an arbitrary key like `pi-geek:abc123` would be
+ * misread as `channelType = "abc123"`.
+ */
+function parseLegacyChannelIdentity(sessionKey: string): { channelType: string; channelId: string } | undefined {
+  if (sessionKey.length === 0) return undefined;
+  const parts = sessionKey.split(":");
+  if (parts.length < 3) return undefined;
+  if (parts[0] !== "agent") return undefined;
+  if (!parts[1] || parts[1].length === 0) return undefined;
+
+  const channelType = parts[2];
+  if (!channelType || channelType.length === 0) return undefined;
+
+  let channelId = LEGACY_FALLBACK_CHANNEL_ID;
+  if (channelType === "main") {
+    channelId = "default";
+  } else if (channelType === "discord" && parts.length >= 5 && parts[3] === "channel") {
+    channelId = parts[4];
+  } else if (channelType === "slack" && parts.length >= 5 && parts[3] === "channel") {
+    channelId = parts[4];
+  } else if (channelType === "cron" && parts.length >= 4) {
+    channelId = parts[3];
+  } else if (parts.length >= 4) {
+    channelId = parts[3];
+  }
+
+  if (!channelId || channelId.length === 0) {
+    channelId = LEGACY_FALLBACK_CHANNEL_ID;
+  }
+
+  return { channelType, channelId };
+}
+
+/**
+ * A short, human-readable label for dashboards/audits. Never used for storage
+ * routing — `channelId` (the hash) owns isolation. Control characters and path
+ * separators are stripped so the label is safe to render.
+ */
+function safeDisplayLabel(sessionKey: string): string {
+  if (sessionKey.length === 0) return "(empty)";
+  let out = "";
+  for (const char of sessionKey) {
+    const code = char.codePointAt(0) ?? 0;
+    // Drop ASCII control characters (0x00-0x1F) and DEL (0x7F).
+    if (code <= 0x1f || code === 0x7f) continue;
+    if (char === "/" || char === "\\") {
+      out += "_";
+      continue;
+    }
+    out += char;
+  }
+  const trimmed = out.trim();
+  if (trimmed.length === 0) return "(empty)";
+  return trimmed.length > DISPLAY_LABEL_MAX_LENGTH ? `${trimmed.slice(0, DISPLAY_LABEL_MAX_LENGTH - 1)}…` : trimmed;
+}

--- a/packages/remnic-core/src/session-identity.ts
+++ b/packages/remnic-core/src/session-identity.ts
@@ -79,6 +79,17 @@ export interface SessionStoragePaths {
    * identical to `dir` or when either segment is path-unsafe.
    */
   legacyDir?: string;
+  /**
+   * Ordered, de-duplicated list of READ-BACK-ONLY directories where an older
+   * build may have stranded this key's data. NEW writes never target these —
+   * they exist purely so pre-#1496 transcripts/tool-usage stay discoverable
+   * (and migratable). Populated only for non-legacy keys. Includes:
+   *   1. the shared `other/default` fallback (every arbitrary key landed here);
+   *   2. the directory the OLD `parts.length >= 3` parser would have chosen
+   *      (e.g. `foo:bar:baz` → `baz/default`, `foo:bar:baz:qux` → `baz/qux`).
+   * See {@link legacyParserReadbackDir}.
+   */
+  readbackDirs: string[];
 }
 
 /**
@@ -134,7 +145,77 @@ export function sessionStoragePaths(sessionKey: string): SessionStoragePaths {
     }
   }
 
-  return { channelType, channelId, dir, alternateDir, legacyDir };
+  // Read-back-only candidates are only relevant for non-legacy keys: legacy
+  // `agent:<id>:...` keys still resolve to their original channel directory, so
+  // nothing about their on-disk location moved.
+  const readbackDirs: string[] = [];
+  if (!identity.legacy) {
+    const seen = new Set<string>([dir]);
+    if (alternateDir) seen.add(alternateDir);
+    if (legacyDir) seen.add(legacyDir);
+    for (const candidate of [OTHER_DEFAULT_READBACK_DIR, legacyParserReadbackDir(canonicalSessionKey)]) {
+      if (!candidate || seen.has(candidate)) continue;
+      seen.add(candidate);
+      readbackDirs.push(candidate);
+    }
+  }
+
+  return { channelType, channelId, dir, alternateDir, legacyDir, readbackDirs };
+}
+
+/**
+ * The shared `other/default` directory every arbitrary key was routed into by
+ * builds predating issue #1496. Exposed so transcript/tool-usage/summary read
+ * paths and the migration scanner all agree on the same fallback location.
+ */
+export const OTHER_DEFAULT_READBACK_DIR = path.join(
+  LEGACY_FALLBACK_CHANNEL_TYPE,
+  LEGACY_FALLBACK_CHANNEL_ID
+);
+
+/**
+ * Reconstruct the transcript/tool-usage directory the OLD `getTranscriptPath`
+ * parser (pre-#1496) would have produced for a key the NEW parser reclassifies
+ * as a first-class `session/<hash>` identity.
+ *
+ * The OLD parser treated ANY key with `parts.length >= 3` as legacy — it did
+ * NOT require a leading `agent` segment — so an arbitrary key like
+ * `foo:bar:baz` was stored under `baz/default` and `foo:bar:baz:qux` under
+ * `baz/qux`. Those directories must stay readable (and migratable) for existing
+ * installs even though the key now writes to `session/<hash>` (Thread B / codex
+ * review on PR #1504). Path segments are encoded exactly as the old `dir` was
+ * built (`encodeStoragePathSegment`) so the candidate matches the bytes on disk.
+ *
+ * Returns `undefined` when the key has fewer than three colon parts (the old
+ * parser would have used the `other/default` fallback, already covered), when
+ * the channel type is empty, or when the result is unsafe.
+ */
+export function legacyParserReadbackDir(sessionKey: string): string | undefined {
+  if (typeof sessionKey !== "string" || sessionKey.length === 0) return undefined;
+  const parts = sessionKey.split(":");
+  if (parts.length < 3) return undefined;
+
+  const channelType = parts[2];
+  if (!channelType || channelType.length === 0) return undefined;
+
+  // Mirror the OLD parser's channelId derivation for parts.length >= 3 keys.
+  let channelId = LEGACY_FALLBACK_CHANNEL_ID;
+  if (channelType === "main") {
+    channelId = "default";
+  } else if (channelType === "discord" && parts.length >= 5 && parts[3] === "channel") {
+    channelId = parts[4];
+  } else if (channelType === "slack" && parts.length >= 5 && parts[3] === "channel") {
+    channelId = parts[4];
+  } else if (channelType === "cron" && parts.length >= 4) {
+    channelId = parts[3];
+  } else if (parts.length >= 4) {
+    channelId = parts[3];
+  }
+  if (!channelId || channelId.length === 0) {
+    channelId = LEGACY_FALLBACK_CHANNEL_ID;
+  }
+
+  return path.join(encodeStoragePathSegment(channelType), encodeStoragePathSegment(channelId));
 }
 
 /**

--- a/packages/remnic-core/src/session-transcript-migration.test.ts
+++ b/packages/remnic-core/src/session-transcript-migration.test.ts
@@ -147,6 +147,92 @@ test("unparseable and legacy-homed lines are retained in the source file", async
   }
 });
 
+async function seedLegacyParserDir(
+  memoryDir: string,
+  channelType: string,
+  channelId: string,
+  fileName: string,
+  lines: string[]
+): Promise<string> {
+  const dir = path.join(memoryDir, "transcripts", channelType, channelId);
+  await mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, fileName);
+  await writeFile(filePath, `${lines.join("\n")}\n`, "utf-8");
+  return filePath;
+}
+
+test("migration scan picks up pre-existing foo:bar:baz data under old baz/default", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    // OLD build stored foo:bar:baz under baz/default (parts.length >= 3 parser).
+    const sourcePath = await seedLegacyParserDir(memoryDir, "baz", "default", fileName, [
+      entryLine("foo:bar:baz", "1", "user"),
+      entryLine("foo:bar:baz", "2", "assistant"),
+    ]);
+
+    const plan = await planSessionTranscriptMigration({ memoryDir });
+    assert.equal(plan.files.length, 1, "baz/default must be a migration candidate");
+    assert.equal(plan.distinctSessions, 1);
+    assert.equal(plan.movedEntries, 2);
+
+    const result = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(result.errors.length, 0);
+
+    const destDir = sessionStoragePaths("foo:bar:baz").dir;
+    const destContent = await readFile(path.join(memoryDir, "transcripts", destDir, fileName), "utf-8");
+    assert.equal(destContent.split("\n").filter(Boolean).length, 2);
+
+    // Source emptied/removed.
+    await assert.rejects(() => readFile(sourcePath, "utf-8"));
+
+    // Idempotent: a second run finds nothing.
+    const second = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(second.plan.files.length, 0);
+    assert.equal(second.plan.movedEntries, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("migration leaves legitimate legacy agent:<id>:main data in place (dest === source)", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    // agent:generalist:main legitimately lives in main/default and must NOT move.
+    await seedLegacyParserDir(memoryDir, "main", "default", fileName, [
+      entryLine("agent:generalist:main", "1", "user"),
+    ]);
+
+    const plan = await planSessionTranscriptMigration({ memoryDir });
+    assert.equal(plan.files.length, 0, "legacy agent data must not be a migration source");
+    assert.equal(plan.movedEntries, 0);
+
+    const result = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(result.errors.length, 0);
+    const stillThere = await readFile(path.join(memoryDir, "transcripts", "main", "default", fileName), "utf-8");
+    assert.equal(stillThere.split("\n").filter(Boolean).length, 1);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("migration never treats session/<hash> dirs as sources", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    const sessionKey = "pi-geek:abc123";
+    const destDir = sessionStoragePaths(sessionKey).dir; // session/<hash>
+    const [type, id] = destDir.split("/");
+    await seedLegacyParserDir(memoryDir, type, id, fileName, [entryLine(sessionKey, "1", "user")]);
+
+    const plan = await planSessionTranscriptMigration({ memoryDir });
+    assert.equal(plan.files.length, 0, "already-homed session/<hash> must never be scanned");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("apply writes an audit manifest", async () => {
   const memoryDir = await makeMemoryDir();
   try {

--- a/packages/remnic-core/src/session-transcript-migration.test.ts
+++ b/packages/remnic-core/src/session-transcript-migration.test.ts
@@ -233,6 +233,108 @@ test("migration never treats session/<hash> dirs as sources", async () => {
   }
 });
 
+test("migration splits a LEGACY session/<name> dir while leaving real session/<hash> untouched", async () => {
+  // Thread 3 (codex review on PR #1504): pre-#1496 the OLD parser stored a key
+  // whose 3rd colon segment was literally `session` (e.g. foo:bar:session:baz)
+  // under transcripts/session/baz — a NON-hash id. The new layer maps that key
+  // to session/<hash>, but the migration previously BLANKET-SKIPPED everything
+  // under session/, so the legacy session/baz dir was never scanned. Only the
+  // canonical 16-hex session/<hash> dirs must be skipped.
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    const legacyKey = "foo:bar:session:baz";
+
+    // LEGACY: OLD parser homed foo:bar:session:baz under session/baz (non-hash).
+    const legacySourcePath = await seedLegacyParserDir(memoryDir, "session", "baz", fileName, [
+      entryLine(legacyKey, "1", "user"),
+      entryLine(legacyKey, "2", "assistant"),
+    ]);
+
+    // CANONICAL: a genuinely-homed session/<hash> dir for a different key.
+    const homedKey = "pi-geek:abc123";
+    const homedDir = sessionStoragePaths(homedKey).dir; // session/<16hex>
+    const [homedType, homedId] = homedDir.split("/");
+    assert.match(homedId, /^[0-9a-f]{16}$/);
+    await seedLegacyParserDir(memoryDir, homedType, homedId, fileName, [
+      entryLine(homedKey, "1", "user"),
+    ]);
+    const homedContentBefore = await readFile(path.join(memoryDir, "transcripts", homedDir, fileName), "utf-8");
+
+    // Plan: only the legacy session/baz dir is a source; session/<hash> is left.
+    const plan = await planSessionTranscriptMigration({ memoryDir });
+    assert.equal(plan.files.length, 1, "only the legacy session/<name> dir must be a source");
+    assert.equal(plan.distinctSessions, 1);
+    assert.equal(plan.movedEntries, 2);
+    assert.equal(plan.files[0].sourceRelPath, path.join("session", "baz", fileName));
+
+    const result = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(result.errors.length, 0);
+
+    // Legacy data re-homed to its canonical session/<hash> dir, order preserved.
+    const legacyDestDir = sessionStoragePaths(legacyKey).dir;
+    assert.notEqual(legacyDestDir, path.join("session", "baz"));
+    const legacyDestContent = await readFile(
+      path.join(memoryDir, "transcripts", legacyDestDir, fileName),
+      "utf-8",
+    );
+    const legacyDestLines = legacyDestContent.split("\n").filter(Boolean);
+    assert.equal(legacyDestLines.length, 2);
+    assert.ok(legacyDestLines[0].includes('"turnId":"1"'));
+    assert.ok(legacyDestLines[1].includes('"turnId":"2"'));
+
+    // Legacy source emptied/removed (lossless move).
+    await assert.rejects(() => readFile(legacySourcePath, "utf-8"));
+
+    // The real session/<hash> dir is byte-for-byte untouched.
+    const homedContentAfter = await readFile(path.join(memoryDir, "transcripts", homedDir, fileName), "utf-8");
+    assert.equal(homedContentAfter, homedContentBefore);
+
+    // Idempotent: a second run finds nothing and does not duplicate.
+    const second = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(second.plan.files.length, 0);
+    assert.equal(second.plan.movedEntries, 0);
+    const reread = await readFile(path.join(memoryDir, "transcripts", legacyDestDir, fileName), "utf-8");
+    assert.equal(reread.split("\n").filter(Boolean).length, 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("migration error detail is sanitized (no raw filesystem/stack message leak)", async () => {
+  // Thread 2 (cursor review on PR #1504): the per-file catch must route
+  // operator-facing strings (CLI output + audit manifest) through the shared
+  // displayErrorDetail() sanitizer so a raw fs path or stack detail cannot leak.
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    // Arbitrary key routes to transcripts/session/<hash>. Planting a FILE at
+    // transcripts/session makes the destination `mkdir` fail with ENOTDIR — a
+    // realistic write-time failure whose raw OS message embeds an absolute path.
+    await seedMixedOtherDefault(memoryDir, fileName, [entryLine("pi-geek:abc123", "1", "user")]);
+    await writeFile(path.join(memoryDir, "transcripts", "session"), "blocker", "utf-8");
+
+    const result = await migrateSessionTranscripts({ memoryDir, apply: true });
+
+    assert.equal(result.errors.length, 1);
+    const message = result.errors[0];
+    // Sanitized: includes the relative source path + the error name/code only.
+    assert.ok(
+      message.startsWith(`Failed to migrate ${path.join("other", "default", fileName)}`),
+      `unexpected error prefix: ${message}`,
+    );
+    assert.match(message, /\(ENOTDIR\)/);
+    // Must NOT leak the raw OS message or any absolute filesystem path.
+    assert.ok(!message.includes(memoryDir), "sanitized error must not leak an absolute fs path");
+    assert.ok(
+      !/not a directory|open '|write '/i.test(message),
+      `sanitized error must not leak the raw OS message: ${message}`,
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("apply writes an audit manifest", async () => {
   const memoryDir = await makeMemoryDir();
   try {

--- a/packages/remnic-core/src/session-transcript-migration.test.ts
+++ b/packages/remnic-core/src/session-transcript-migration.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { sessionStoragePaths } from "./session-identity.js";
+import { migrateSessionTranscripts, planSessionTranscriptMigration } from "./session-transcript-migration.js";
+
+async function makeMemoryDir(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "remnic-sess-mig-"));
+}
+
+function entryLine(sessionKey: string, turnId: string, role: "user" | "assistant"): string {
+  return JSON.stringify({
+    sessionKey,
+    turnId,
+    role,
+    content: `content-${turnId}`,
+    timestamp: `2026-06-29T10:0${turnId}:00.000Z`,
+  });
+}
+
+async function seedMixedOtherDefault(memoryDir: string, fileName: string, lines: string[]): Promise<string> {
+  const dir = path.join(memoryDir, "transcripts", "other", "default");
+  await mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, fileName);
+  await writeFile(filePath, `${lines.join("\n")}\n`, "utf-8");
+  return filePath;
+}
+
+test("dry-run reports expected splits for mixed other/default file and changes nothing", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    const lines = [
+      entryLine("pi-geek:abc123", "1", "user"),
+      entryLine("pi-friend:def456", "2", "user"),
+      entryLine("pi-geek:abc123", "3", "assistant"),
+    ];
+    const sourcePath = await seedMixedOtherDefault(memoryDir, fileName, lines);
+
+    const plan = await planSessionTranscriptMigration({ memoryDir });
+    assert.equal(plan.dryRun, true);
+    assert.equal(plan.files.length, 1);
+    assert.equal(plan.distinctSessions, 2);
+    assert.equal(plan.movedEntries, 3);
+
+    const groupKeys = plan.files[0].groups.map((g) => g.sessionKey).sort();
+    assert.deepEqual(groupKeys, ["pi-friend:def456", "pi-geek:abc123"]);
+
+    // Nothing moved.
+    const before = await readFile(sourcePath, "utf-8");
+    assert.equal(before.split("\n").filter(Boolean).length, 3);
+    const sessionDir = path.join(memoryDir, "transcripts", "session");
+    await assert.rejects(() => readdir(sessionDir));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("apply is lossless: every entry lands in its session dir, source is emptied", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    const lines = [
+      entryLine("pi-geek:abc123", "1", "user"),
+      entryLine("pi-friend:def456", "2", "user"),
+      entryLine("pi-geek:abc123", "3", "assistant"),
+    ];
+    await seedMixedOtherDefault(memoryDir, fileName, lines);
+
+    const result = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(result.applied, true);
+    assert.equal(result.errors.length, 0);
+
+    const geekDir = sessionStoragePaths("pi-geek:abc123").dir;
+    const friendDir = sessionStoragePaths("pi-friend:def456").dir;
+
+    const geekContent = await readFile(path.join(memoryDir, "transcripts", geekDir, fileName), "utf-8");
+    const friendContent = await readFile(path.join(memoryDir, "transcripts", friendDir, fileName), "utf-8");
+
+    const geekLines = geekContent.split("\n").filter(Boolean);
+    const friendLines = friendContent.split("\n").filter(Boolean);
+    assert.equal(geekLines.length, 2);
+    assert.equal(friendLines.length, 1);
+
+    // Ordering preserved within a session (turn 1 before turn 3).
+    assert.ok(geekLines[0].includes('"turnId":"1"'));
+    assert.ok(geekLines[1].includes('"turnId":"3"'));
+
+    // Source other/default file removed (no entries retained).
+    await assert.rejects(() => readFile(path.join(memoryDir, "transcripts", "other", "default", fileName), "utf-8"));
+
+    // No entries lost: 3 in, 3 out.
+    assert.equal(geekLines.length + friendLines.length, 3);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("apply is idempotent: a second run finds nothing to migrate and does not duplicate", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    const lines = [entryLine("pi-geek:abc123", "1", "user"), entryLine("pi-geek:abc123", "2", "assistant")];
+    await seedMixedOtherDefault(memoryDir, fileName, lines);
+
+    const first = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(first.errors.length, 0);
+
+    const second = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(second.errors.length, 0);
+    assert.equal(second.plan.files.length, 0);
+    assert.equal(second.plan.movedEntries, 0);
+
+    const geekDir = sessionStoragePaths("pi-geek:abc123").dir;
+    const geekContent = await readFile(path.join(memoryDir, "transcripts", geekDir, fileName), "utf-8");
+    // Still exactly 2 lines — no duplication.
+    assert.equal(geekContent.split("\n").filter(Boolean).length, 2);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("unparseable and legacy-homed lines are retained in the source file", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const fileName = "2026-06-29.jsonl";
+    // One arbitrary key (movable), one malformed line (retained).
+    const lines = [entryLine("pi-geek:abc123", "1", "user"), "{not valid json"];
+    await seedMixedOtherDefault(memoryDir, fileName, lines);
+
+    const result = await migrateSessionTranscripts({ memoryDir, apply: true });
+    assert.equal(result.errors.length, 0);
+
+    // Source retains the malformed line (not deleted).
+    const sourceContent = await readFile(path.join(memoryDir, "transcripts", "other", "default", fileName), "utf-8");
+    assert.ok(sourceContent.includes("{not valid json"));
+
+    // The movable entry landed in its session dir.
+    const geekDir = sessionStoragePaths("pi-geek:abc123").dir;
+    const geekContent = await readFile(path.join(memoryDir, "transcripts", geekDir, fileName), "utf-8");
+    assert.equal(geekContent.split("\n").filter(Boolean).length, 1);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("apply writes an audit manifest", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    await seedMixedOtherDefault(memoryDir, "2026-06-29.jsonl", [entryLine("pi-geek:abc123", "1", "user")]);
+    const result = await migrateSessionTranscripts({ memoryDir, apply: true });
+    const manifestPath = result.manifestPath;
+    assert.ok(manifestPath);
+    const manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
+    assert.equal(manifest.applied, true);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/session-transcript-migration.ts
+++ b/packages/remnic-core/src/session-transcript-migration.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { log } from "./logger.js";
+import { displayErrorDetail } from "./runtime/better-sqlite.js";
 import { parseSessionIdentity, sessionStoragePaths } from "./session-identity.js";
 import { resolveSafeStoragePath } from "./storage-paths.js";
 import type { TranscriptEntry } from "./types.js";
@@ -26,11 +27,37 @@ import type { TranscriptEntry } from "./types.js";
  */
 
 /**
- * Channel type that NEW writes use for first-class arbitrary keys. Files
- * already homed under `session/<hash>` are never migration sources — every
- * line there is, by definition, already in its destination directory.
+ * Channel type that NEW writes use for first-class arbitrary keys. Subdirs of
+ * this type whose `<id>` is a canonical `storagePathHash` (16 lowercase hex)
+ * are already homed — every line there is, by definition, already in its
+ * destination directory, so they are never migration sources.
  */
 const FIRST_CLASS_CHANNEL_TYPE = "session";
+
+/**
+ * Matches a canonical `session/<hash>` channel id produced by
+ * {@link storagePathHash} (16 lowercase hex chars). Used to tell a NEW
+ * first-class directory (skip) apart from a LEGACY `session/<name>` directory.
+ *
+ * Pre-#1496 the OLD `parts.length >= 3` parser stored a key whose 3rd colon
+ * segment was literally `session` (e.g. `foo:bar:session:baz`) under
+ * `transcripts/session/baz` — a non-hash id. Those legacy dirs MUST still be
+ * scanned and split, while genuine `session/<hash>` data is left untouched
+ * (codex review on PR #1496 / PR #1504). The hex length is fixed because
+ * `storagePathHash` slices the sha256 hex digest to 16 chars.
+ */
+const CANONICAL_SESSION_HASH_RE = /^[0-9a-f]{16}$/;
+
+/**
+ * True when `<type>/<id>` is a canonical first-class `session/<hash>` directory
+ * (NEW write target) rather than a legacy stranded directory. Defensive: also
+ * confirms the id is exactly what `storagePathHash` would produce for some
+ * value by shape — a 16-hex string — so we never misclassify a legacy
+ * `session/<name>` dir as homed and skip migrating it.
+ */
+function isCanonicalSessionDir(channelType: string, channelId: string): boolean {
+  return channelType === FIRST_CLASS_CHANNEL_TYPE && CANONICAL_SESSION_HASH_RE.test(channelId);
+}
 
 export interface SessionMigrationEntryGroup {
   /** The distinct session key these lines belong to. */
@@ -124,8 +151,6 @@ async function listFallbackSourceFiles(
 
   for (const typeEnt of typeEntries) {
     if (!typeEnt.isDirectory()) continue;
-    // Files already under `session/<hash>` are homed — never a migration source.
-    if (typeEnt.name === FIRST_CLASS_CHANNEL_TYPE) continue;
 
     const typeDir = path.join(transcriptsDir, typeEnt.name);
     let idEntries: Array<{ name: string; isDirectory(): boolean }>;
@@ -137,6 +162,13 @@ async function listFallbackSourceFiles(
 
     for (const idEnt of idEntries) {
       if (!idEnt.isDirectory()) continue;
+
+      // Only canonical `session/<hash>` dirs are already homed — skip those.
+      // A LEGACY `session/<name>` dir (e.g. `foo:bar:session:baz` →
+      // `session/baz` under the OLD parser) is a real migration source and
+      // must be scanned/split (codex review on PR #1504). `planFile`'s
+      // destination gate still guarantees losslessness/idempotence.
+      if (isCanonicalSessionDir(typeEnt.name, idEnt.name)) continue;
 
       const chanDir = path.join(typeDir, idEnt.name);
       let files: string[];
@@ -431,8 +463,16 @@ export async function migrateSessionTranscripts(
         filesRewritten += 1;
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors.push(`Failed to migrate ${filePlan.sourceRelPath}: ${message}`);
+      // The `errors` array is surfaced to operators via the CLI
+      // (`sessions migrate-transcripts --apply`) AND persisted in the audit
+      // manifest. Raw `err.message`/`String(err)` can leak filesystem paths or
+      // stack detail, so route operator-facing strings through the shared
+      // `displayErrorDetail()` sanitizer (cursor review on PR #1504, rule #51).
+      // The full error still goes to the operator-only debug log.
+      const detail = displayErrorDetail(err);
+      errors.push(
+        `Failed to migrate ${filePlan.sourceRelPath}${detail ? `: ${detail}` : ""}`,
+      );
       log.error(`session transcript migration failed for ${filePlan.sourceRelPath}:`, err);
     }
   }

--- a/packages/remnic-core/src/session-transcript-migration.ts
+++ b/packages/remnic-core/src/session-transcript-migration.ts
@@ -1,0 +1,475 @@
+import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { log } from "./logger.js";
+import {
+  LEGACY_FALLBACK_CHANNEL_ID,
+  LEGACY_FALLBACK_CHANNEL_TYPE,
+  parseSessionIdentity,
+  sessionStoragePaths,
+} from "./session-identity.js";
+import { resolveSafeStoragePath } from "./storage-paths.js";
+import type { TranscriptEntry } from "./types.js";
+
+/**
+ * Lossless migration of legacy `transcripts/other/default/*.jsonl` files into
+ * first-class `transcripts/session/<hash>/*.jsonl` directories (issue #1496).
+ *
+ * Older builds routed every non-legacy session key (e.g. `pi-geek:abc123`)
+ * into the shared `other/default` directory on first write. That conflated
+ * distinct standalone-client sessions into one transcript directory. This
+ * migration splits those mixed files back out, grouping entries by
+ * `entry.sessionKey` and re-homing each distinct session under its own
+ * deterministic hashed directory.
+ *
+ * Safety contract (rules #54, #51, #18, #35):
+ *   - Dry-run is the default; nothing is written without `apply: true`.
+ *   - Writes go to a temp file then atomic-rename (never delete-before-write).
+ *   - JSONL line ordering and byte content are preserved per session.
+ *   - Idempotent: re-running after apply finds nothing left to migrate.
+ *   - A manifest is returned (and written under `state/` on apply) as an audit
+ *     trail.
+ */
+
+/** Channel types whose `default` directory is eligible for splitting. */
+const MIGRATABLE_FALLBACK_TYPES = new Set<string>([LEGACY_FALLBACK_CHANNEL_TYPE]);
+
+export interface SessionMigrationEntryGroup {
+  /** The distinct session key these lines belong to. */
+  sessionKey: string;
+  /** Whether this key is a recognized legacy `agent:<id>:...` shape. */
+  legacy: boolean;
+  /** Destination directory (relative to the transcripts root). */
+  destDir: string;
+  /** Number of JSONL entries that will move. */
+  entryCount: number;
+}
+
+export interface SessionMigrationFilePlan {
+  /** Source file path (relative to transcripts root). */
+  sourceRelPath: string;
+  /** The date-stamped file name (e.g. `2026-06-29.jsonl`). */
+  fileName: string;
+  /** Distinct session groups discovered inside this source file. */
+  groups: SessionMigrationEntryGroup[];
+  /** Lines that could not be parsed as JSON or lacked a sessionKey. */
+  unmovableLines: number;
+  /**
+   * True when EVERY entry in the file already belongs in the source directory
+   * (nothing to do). Such files are skipped.
+   */
+  alreadyHomed: boolean;
+}
+
+export interface SessionMigrationPlan {
+  generatedAt: string;
+  dryRun: boolean;
+  transcriptsDir: string;
+  /** Per-file plans that have at least one entry to move. */
+  files: SessionMigrationFilePlan[];
+  /** Distinct destination session keys across all files. */
+  distinctSessions: number;
+  /** Total entries that will be re-homed. */
+  movedEntries: number;
+}
+
+export interface SessionMigrationResult {
+  plan: SessionMigrationPlan;
+  applied: boolean;
+  filesRewritten: number;
+  filesRemoved: number;
+  errors: string[];
+  manifestPath?: string;
+}
+
+export interface MigrateSessionTranscriptsOptions {
+  /** The memory directory root (transcripts live under `<memoryDir>/transcripts`). */
+  memoryDir: string;
+  /** When true, perform the migration; otherwise produce a dry-run plan only. */
+  apply?: boolean;
+}
+
+const DATE_FILE_RE = /^\d{4}-\d{2}-\d{2}\.jsonl$/;
+
+function isDateStampedJsonl(name: string): boolean {
+  return DATE_FILE_RE.test(name);
+}
+
+/**
+ * Source directories that older builds used to conflate arbitrary sessions.
+ * We scan `transcripts/<type>/<id>/` two levels deep and only consider the
+ * `<fallbackType>/default` directories as migration sources.
+ */
+async function listFallbackSourceFiles(
+  transcriptsDir: string
+): Promise<Array<{ relPath: string; fileName: string; absPath: string }>> {
+  const out: Array<{ relPath: string; fileName: string; absPath: string }> = [];
+  let typeEntries: Array<{ name: string; isDirectory(): boolean }>;
+  try {
+    typeEntries = await readdir(transcriptsDir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+
+  for (const typeEnt of typeEntries) {
+    if (!typeEnt.isDirectory()) continue;
+    if (!MIGRATABLE_FALLBACK_TYPES.has(typeEnt.name)) continue;
+
+    const typeDir = path.join(transcriptsDir, typeEnt.name);
+    let idEntries: Array<{ name: string; isDirectory(): boolean }>;
+    try {
+      idEntries = await readdir(typeDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const idEnt of idEntries) {
+      if (!idEnt.isDirectory()) continue;
+      if (idEnt.name !== LEGACY_FALLBACK_CHANNEL_ID) continue;
+
+      const chanDir = path.join(typeDir, idEnt.name);
+      let files: string[];
+      try {
+        files = (await readdir(chanDir)).filter((f) => f.endsWith(".jsonl")).sort();
+      } catch {
+        continue;
+      }
+      for (const fileName of files) {
+        out.push({
+          relPath: path.join(typeEnt.name, idEnt.name, fileName),
+          fileName,
+          absPath: path.join(chanDir, fileName),
+        });
+      }
+    }
+  }
+
+  return out.sort((a, b) => a.relPath.localeCompare(b.relPath));
+}
+
+interface ParsedSourceLine {
+  sessionKey?: string;
+  /** The raw JSONL text (without trailing newline). */
+  raw: string;
+}
+
+/**
+ * Parse a source JSONL file, preserving line order. Lines that are not valid
+ * JSON or lack a string `sessionKey` are tracked as unmovable and left in the
+ * source file so no data is lost (rule #18 — validate parse result type).
+ */
+function parseSourceLines(content: string): ParsedSourceLine[] {
+  const out: ParsedSourceLine[] = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    let sessionKey: string | undefined;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (parsed && typeof parsed === "object") {
+        const sk = (parsed as { sessionKey?: unknown }).sessionKey;
+        if (typeof sk === "string" && sk.length > 0) {
+          sessionKey = sk;
+        }
+      }
+    } catch {
+      // Unparseable line — keep it in place.
+    }
+    out.push({ sessionKey, raw: line });
+  }
+  return out;
+}
+
+/**
+ * Build a per-file migration plan. A line is "movable" when its session key
+ * resolves to a destination directory different from the source directory.
+ */
+function planFile(sourceRelPath: string, fileName: string, lines: ParsedSourceLine[]): SessionMigrationFilePlan {
+  const sourceDir = path.dirname(sourceRelPath);
+  const groups = new Map<string, { legacy: boolean; destDir: string; count: number }>();
+  let unmovableLines = 0;
+  let movableCount = 0;
+
+  for (const line of lines) {
+    if (!line.sessionKey) {
+      unmovableLines += 1;
+      continue;
+    }
+    const identity = parseSessionIdentity(line.sessionKey);
+    const paths = sessionStoragePaths(line.sessionKey);
+    // Only move when the destination directory differs from the source.
+    if (paths.dir === sourceDir) {
+      continue;
+    }
+    movableCount += 1;
+    const existing = groups.get(line.sessionKey);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      groups.set(line.sessionKey, {
+        legacy: identity.legacy,
+        destDir: paths.dir,
+        count: 1,
+      });
+    }
+  }
+
+  const groupList: SessionMigrationEntryGroup[] = [...groups.entries()]
+    .map(([sessionKey, info]) => ({
+      sessionKey,
+      legacy: info.legacy,
+      destDir: info.destDir,
+      entryCount: info.count,
+    }))
+    .sort((a, b) => a.sessionKey.localeCompare(b.sessionKey));
+
+  return {
+    sourceRelPath,
+    fileName,
+    groups: groupList,
+    unmovableLines,
+    alreadyHomed: movableCount === 0,
+  };
+}
+
+/**
+ * Compute the migration plan without modifying anything.
+ */
+export async function planSessionTranscriptMigration(
+  options: MigrateSessionTranscriptsOptions
+): Promise<SessionMigrationPlan> {
+  const transcriptsDir = path.join(options.memoryDir, "transcripts");
+  const sources = await listFallbackSourceFiles(transcriptsDir);
+  const files: SessionMigrationFilePlan[] = [];
+  const distinctSessions = new Set<string>();
+  let movedEntries = 0;
+
+  for (const source of sources) {
+    if (!isDateStampedJsonl(source.fileName)) continue;
+    let content: string;
+    try {
+      content = await readFile(source.absPath, "utf-8");
+    } catch {
+      continue;
+    }
+    const lines = parseSourceLines(content);
+    const filePlan = planFile(source.relPath, source.fileName, lines);
+    if (filePlan.alreadyHomed) continue;
+
+    for (const group of filePlan.groups) {
+      distinctSessions.add(group.sessionKey);
+      movedEntries += group.entryCount;
+    }
+    files.push(filePlan);
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    dryRun: options.apply !== true,
+    transcriptsDir,
+    files,
+    distinctSessions: distinctSessions.size,
+    movedEntries,
+  };
+}
+
+/**
+ * Append `lines` (raw JSONL strings) to `<destDir>/<fileName>` using a
+ * write-then-rename merge so a crash mid-migration cannot corrupt or truncate
+ * the destination (rule #54).
+ *
+ * Existing destination content is preserved and de-duplicated by raw line so
+ * re-running the migration is idempotent.
+ */
+async function mergeAppendLines(
+  transcriptsDir: string,
+  destDir: string,
+  fileName: string,
+  newLines: string[]
+): Promise<void> {
+  const destChannelDir = await resolveSafeStoragePath(transcriptsDir, destDir);
+  await mkdir(destChannelDir, { recursive: true });
+  const destPath = await resolveSafeStoragePath(transcriptsDir, destDir, fileName);
+
+  const existing: string[] = [];
+  const seen = new Set<string>();
+  try {
+    const raw = await readFile(destPath, "utf-8");
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      existing.push(line);
+      seen.add(line);
+    }
+  } catch {
+    // No existing destination file — fine.
+  }
+
+  const merged = [...existing];
+  for (const line of newLines) {
+    if (seen.has(line)) continue;
+    merged.push(line);
+    seen.add(line);
+  }
+
+  const body = merged.length > 0 ? `${merged.join("\n")}\n` : "";
+  const tmpPath = await resolveSafeStoragePath(
+    transcriptsDir,
+    destDir,
+    `${fileName}.migrate-${process.pid}-${Date.now()}.tmp`
+  );
+  await writeFile(tmpPath, body, "utf-8");
+  await rename(tmpPath, destPath);
+}
+
+/**
+ * Rewrite the source file to retain ONLY the lines that were not moved
+ * (unparseable lines and any that already belong in the source dir). Uses
+ * write-then-rename; deletes the source only when nothing remains.
+ */
+async function rewriteSourceRetainingUnmoved(
+  transcriptsDir: string,
+  sourceRelPath: string,
+  retainedLines: string[]
+): Promise<{ removed: boolean }> {
+  const sourcePath = await resolveSafeStoragePath(transcriptsDir, sourceRelPath);
+  if (retainedLines.length === 0) {
+    // Atomic-rename into a sibling tombstone then unlink, so a crash leaves the
+    // original intact (never delete-before-confirm; rule #54). Simpler and
+    // equally safe: unlink only after destinations are confirmed written.
+    try {
+      await unlink(sourcePath);
+    } catch (err) {
+      const code =
+        err && typeof err === "object" && "code" in err ? String((err as { code?: unknown }).code ?? "") : "";
+      if (code !== "ENOENT") throw err;
+    }
+    return { removed: true };
+  }
+
+  const body = `${retainedLines.join("\n")}\n`;
+  const sourceDir = path.dirname(sourceRelPath);
+  const tmpPath = await resolveSafeStoragePath(
+    transcriptsDir,
+    sourceDir,
+    `${path.basename(sourceRelPath)}.migrate-${process.pid}-${Date.now()}.tmp`
+  );
+  await writeFile(tmpPath, body, "utf-8");
+  await rename(tmpPath, sourcePath);
+  return { removed: false };
+}
+
+/**
+ * Run the migration. Dry-run by default; pass `apply: true` to mutate.
+ */
+export async function migrateSessionTranscripts(
+  options: MigrateSessionTranscriptsOptions
+): Promise<SessionMigrationResult> {
+  const plan = await planSessionTranscriptMigration(options);
+  const apply = options.apply === true;
+
+  if (!apply) {
+    return {
+      plan,
+      applied: false,
+      filesRewritten: 0,
+      filesRemoved: 0,
+      errors: [],
+    };
+  }
+
+  const transcriptsDir = plan.transcriptsDir;
+  const errors: string[] = [];
+  let filesRewritten = 0;
+  let filesRemoved = 0;
+
+  for (const filePlan of plan.files) {
+    try {
+      const sourcePath = await resolveSafeStoragePath(transcriptsDir, filePlan.sourceRelPath);
+      const content = await readFile(sourcePath, "utf-8");
+      const lines = parseSourceLines(content);
+      const sourceDir = path.dirname(filePlan.sourceRelPath);
+
+      // Bucket lines by destination, preserving order. Retain unmovable lines
+      // and any line already homed in the source dir.
+      const byDest = new Map<string, string[]>();
+      const retained: string[] = [];
+      for (const line of lines) {
+        if (!line.sessionKey) {
+          retained.push(line.raw);
+          continue;
+        }
+        const dest = sessionStoragePaths(line.sessionKey).dir;
+        if (dest === sourceDir) {
+          retained.push(line.raw);
+          continue;
+        }
+        const bucket = byDest.get(dest) ?? [];
+        bucket.push(line.raw);
+        byDest.set(dest, bucket);
+      }
+
+      // 1. Write destinations FIRST (write-then-rename, idempotent merge).
+      for (const [destDir, destLines] of byDest.entries()) {
+        await mergeAppendLines(transcriptsDir, destDir, filePlan.fileName, destLines);
+      }
+
+      // 2. Only after all destinations are confirmed, rewrite/remove source.
+      const { removed } = await rewriteSourceRetainingUnmoved(transcriptsDir, filePlan.sourceRelPath, retained);
+      if (removed) {
+        filesRemoved += 1;
+      } else {
+        filesRewritten += 1;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(`Failed to migrate ${filePlan.sourceRelPath}: ${message}`);
+      log.error(`session transcript migration failed for ${filePlan.sourceRelPath}:`, err);
+    }
+  }
+
+  let manifestPath: string | undefined;
+  try {
+    manifestPath = await writeManifest(options.memoryDir, {
+      plan,
+      applied: true,
+      filesRewritten,
+      filesRemoved,
+      errors,
+    });
+  } catch (err) {
+    // Manifest is best-effort audit; do not fail the migration over it.
+    log.debug(`failed to write session migration manifest: ${err}`);
+  }
+
+  return {
+    plan,
+    applied: true,
+    filesRewritten,
+    filesRemoved,
+    errors,
+    manifestPath,
+  };
+}
+
+async function writeManifest(memoryDir: string, result: Omit<SessionMigrationResult, "manifestPath">): Promise<string> {
+  const auditDir = path.join(memoryDir, "state", "session-migration");
+  await mkdir(auditDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const manifestPath = path.join(auditDir, `migrate-transcripts-${stamp}.json`);
+  await writeFile(manifestPath, JSON.stringify(result, null, 2), "utf-8");
+  return manifestPath;
+}
+
+/** Best-effort byte-size summary for reporting (used by CLI output). */
+export async function summarizeMigrationSources(memoryDir: string): Promise<{ files: number; bytes: number }> {
+  const transcriptsDir = path.join(memoryDir, "transcripts");
+  const sources = await listFallbackSourceFiles(transcriptsDir);
+  let bytes = 0;
+  let files = 0;
+  for (const source of sources) {
+    const info = await stat(source.absPath).catch(() => null);
+    if (info?.isFile()) {
+      bytes += info.size;
+      files += 1;
+    }
+  }
+  return { files, bytes };
+}

--- a/packages/remnic-core/src/session-transcript-migration.ts
+++ b/packages/remnic-core/src/session-transcript-migration.ts
@@ -1,12 +1,7 @@
 import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { log } from "./logger.js";
-import {
-  LEGACY_FALLBACK_CHANNEL_ID,
-  LEGACY_FALLBACK_CHANNEL_TYPE,
-  parseSessionIdentity,
-  sessionStoragePaths,
-} from "./session-identity.js";
+import { parseSessionIdentity, sessionStoragePaths } from "./session-identity.js";
 import { resolveSafeStoragePath } from "./storage-paths.js";
 import type { TranscriptEntry } from "./types.js";
 
@@ -30,8 +25,12 @@ import type { TranscriptEntry } from "./types.js";
  *     trail.
  */
 
-/** Channel types whose `default` directory is eligible for splitting. */
-const MIGRATABLE_FALLBACK_TYPES = new Set<string>([LEGACY_FALLBACK_CHANNEL_TYPE]);
+/**
+ * Channel type that NEW writes use for first-class arbitrary keys. Files
+ * already homed under `session/<hash>` are never migration sources — every
+ * line there is, by definition, already in its destination directory.
+ */
+const FIRST_CLASS_CHANNEL_TYPE = "session";
 
 export interface SessionMigrationEntryGroup {
   /** The distinct session key these lines belong to. */
@@ -95,9 +94,22 @@ function isDateStampedJsonl(name: string): boolean {
 }
 
 /**
- * Source directories that older builds used to conflate arbitrary sessions.
- * We scan `transcripts/<type>/<id>/` two levels deep and only consider the
- * `<fallbackType>/default` directories as migration sources.
+ * Candidate source directories that older builds may have used to conflate or
+ * misroute arbitrary sessions. We scan `transcripts/<type>/<id>/` two levels
+ * deep and consider any directory EXCEPT the first-class `session/<hash>` tree
+ * (whose contents are already homed). This covers:
+ *
+ *   - the shared `other/default` fallback every arbitrary key once landed in;
+ *   - the OLD `parts.length >= 3` parser's directories (e.g. `foo:bar:baz` →
+ *     `baz/default`, `foo:bar:baz:qux` → `baz/qux`), which the pre-#1496 build
+ *     wrote even for non-`agent:` keys (Thread B / codex review on PR #1504).
+ *
+ * `planFile` is the actual gate: a line is only moved when its session key now
+ * resolves to a DIFFERENT directory than the one it sits in. Legacy
+ * `agent:<id>:...` keys still resolve to their original channel directory, so
+ * scanning `main/default`, `discord/<chan>`, etc. is a safe no-op for them
+ * (rule #39 — identical routing across paths). This keeps the migration
+ * lossless and idempotent regardless of which directory data was stranded in.
  */
 async function listFallbackSourceFiles(
   transcriptsDir: string
@@ -112,7 +124,8 @@ async function listFallbackSourceFiles(
 
   for (const typeEnt of typeEntries) {
     if (!typeEnt.isDirectory()) continue;
-    if (!MIGRATABLE_FALLBACK_TYPES.has(typeEnt.name)) continue;
+    // Files already under `session/<hash>` are homed — never a migration source.
+    if (typeEnt.name === FIRST_CLASS_CHANNEL_TYPE) continue;
 
     const typeDir = path.join(transcriptsDir, typeEnt.name);
     let idEntries: Array<{ name: string; isDirectory(): boolean }>;
@@ -124,7 +137,6 @@ async function listFallbackSourceFiles(
 
     for (const idEnt of idEntries) {
       if (!idEnt.isDirectory()) continue;
-      if (idEnt.name !== LEGACY_FALLBACK_CHANNEL_ID) continue;
 
       const chanDir = path.join(typeDir, idEnt.name);
       let files: string[];

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -13,12 +13,7 @@ import {
   encodeStoragePathSegment,
   resolveSafeStoragePath,
 } from "./storage-paths.js";
-import {
-  LEGACY_FALLBACK_CHANNEL_ID,
-  LEGACY_FALLBACK_CHANNEL_TYPE,
-  parseSessionIdentity,
-  sessionStoragePaths,
-} from "./session-identity.js";
+import { sessionStoragePaths } from "./session-identity.js";
 
 // Schema for LLM summary output
 const HourlySummarySchema = z.object({
@@ -767,25 +762,24 @@ Respond with valid JSON matching this schema:
     endTime: Date
   ): Promise<TranscriptEntry[]> {
     // Shared session-identity layer (issue #1496, rule #22). Arbitrary keys
-    // route to `session/<hash>`; legacy `agent:<id>:...` keep their paths.
-    const identity = parseSessionIdentity(sessionKey);
+    // route to `session/<hash>`; legacy `agent:<id>:...` keep their paths. The
+    // shared helper also supplies the read-back-only candidate dirs (mirrors
+    // TranscriptManager) so legacy `other/default` AND old `parts.length >= 3`
+    // data stays discoverable here too.
     const paths = sessionStoragePaths(sessionKey);
 
     try {
       const transcriptRoot = path.join(this.config.memoryDir, "transcripts");
-      // Read-back-only `other/default` candidate for arbitrary keys whose data
-      // predates first-class routing (mirrors TranscriptManager).
-      const otherDefaultReadbackDir =
-        !identity.legacy &&
-        paths.dir !== path.join(LEGACY_FALLBACK_CHANNEL_TYPE, LEGACY_FALLBACK_CHANNEL_ID)
-          ? path.join(LEGACY_FALLBACK_CHANNEL_TYPE, LEGACY_FALLBACK_CHANNEL_ID)
-          : undefined;
       const candidateDirs = new Set(
-        [paths.dir, paths.alternateDir, paths.legacyDir, otherDefaultReadbackDir].filter(
+        [paths.dir, paths.alternateDir, paths.legacyDir, ...paths.readbackDirs].filter(
           (dir): dir is string => typeof dir === "string" && dir.length > 0,
         ),
       );
       const entries: TranscriptEntry[] = [];
+      // Dedup identical raw rows that a partially-applied migration may have
+      // left in both the primary dir and a read-back dir (issue #1496, cursor
+      // review). Exact raw JSONL line is the stable identity.
+      const seenRawLines = new Set<string>();
 
       // Read all daily transcript files in the directory
       for (const candidateDir of candidateDirs) {
@@ -812,8 +806,10 @@ Respond with valid JSON matching this schema:
                 if (
                   entry.sessionKey === sessionKey &&
                   entryTime >= startTime.getTime() &&
-                  entryTime < endTime.getTime()
+                  entryTime < endTime.getTime() &&
+                  !seenRawLines.has(line)
                 ) {
+                  seenRawLines.add(line);
                   entries.push(entry);
                 }
               } catch {

--- a/packages/remnic-core/src/summarizer.ts
+++ b/packages/remnic-core/src/summarizer.ts
@@ -11,11 +11,14 @@ import type { TranscriptManager } from "./transcript.js";
 import { readSummarySnapshot, upsertSummarySnapshot, writeSummarySnapshot } from "./summary-snapshot.js";
 import {
   encodeStoragePathSegment,
-  encodeStoragePathSegmentWithHash,
-  isSafeLegacyPathSegment,
   resolveSafeStoragePath,
-  storagePathHash,
 } from "./storage-paths.js";
+import {
+  LEGACY_FALLBACK_CHANNEL_ID,
+  LEGACY_FALLBACK_CHANNEL_TYPE,
+  parseSessionIdentity,
+  sessionStoragePaths,
+} from "./session-identity.js";
 
 // Schema for LLM summary output
 const HourlySummarySchema = z.object({
@@ -763,41 +766,22 @@ Respond with valid JSON matching this schema:
     startTime: Date,
     endTime: Date
   ): Promise<TranscriptEntry[]> {
-    const parts = sessionKey.split(":");
-    let channelType = "other";
-    let channelId = "default";
-
-    if (parts.length >= 3) {
-      channelType = parts[2];
-      if (channelType === "main") {
-        channelId = "default";
-      } else if (channelType === "discord" && parts.length >= 5 && parts[3] === "channel") {
-        channelId = parts[4];
-      } else if (channelType === "slack" && parts.length >= 5 && parts[3] === "channel") {
-        channelId = parts[4];
-      } else if (channelType === "cron" && parts.length >= 4) {
-        channelId = parts[3];
-      } else if (parts.length >= 4) {
-        channelId = parts[3];
-      }
-    }
+    // Shared session-identity layer (issue #1496, rule #22). Arbitrary keys
+    // route to `session/<hash>`; legacy `agent:<id>:...` keep their paths.
+    const identity = parseSessionIdentity(sessionKey);
+    const paths = sessionStoragePaths(sessionKey);
 
     try {
       const transcriptRoot = path.join(this.config.memoryDir, "transcripts");
-      const encodedDir = path.join(
-        encodeStoragePathSegment(channelType),
-        encodeStoragePathSegment(channelId),
-      );
-      const alternateDir = path.join(
-        encodeStoragePathSegmentWithHash(channelType),
-        `${encodeStoragePathSegmentWithHash(channelId)}--session-${storagePathHash(sessionKey)}`,
-      );
-      const legacyDir =
-        isSafeLegacyPathSegment(channelType) && isSafeLegacyPathSegment(channelId)
-          ? path.join(channelType, channelId)
+      // Read-back-only `other/default` candidate for arbitrary keys whose data
+      // predates first-class routing (mirrors TranscriptManager).
+      const otherDefaultReadbackDir =
+        !identity.legacy &&
+        paths.dir !== path.join(LEGACY_FALLBACK_CHANNEL_TYPE, LEGACY_FALLBACK_CHANNEL_ID)
+          ? path.join(LEGACY_FALLBACK_CHANNEL_TYPE, LEGACY_FALLBACK_CHANNEL_ID)
           : undefined;
       const candidateDirs = new Set(
-        [encodedDir, alternateDir, legacyDir].filter(
+        [paths.dir, paths.alternateDir, paths.legacyDir, otherDefaultReadbackDir].filter(
           (dir): dir is string => typeof dir === "string" && dir.length > 0,
         ),
       );

--- a/packages/remnic-core/src/transcript-session-identity.test.ts
+++ b/packages/remnic-core/src/transcript-session-identity.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { mkdtemp, readdir, realpath, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -15,6 +15,15 @@ function makeConfig(memoryDir: string): PluginConfig {
   } as unknown as PluginConfig;
 }
 
+// On macOS `os.tmpdir()` is a `/var/folders/...` symlink to `/private/var/...`.
+// `resolveSafeStoragePath` canonicalizes via `fs.realpath`, so we canonicalize
+// the test root upfront to match (issue #691 symlink convention) and to avoid a
+// race where one test's recursive cleanup interleaves with another test's
+// realpath traversal of the shared tmp parent.
+async function makeMemoryDir(): Promise<string> {
+  return realpath(await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-")));
+}
+
 function makeEntry(sessionKey: string, turnId: string, role: "user" | "assistant"): TranscriptEntry {
   return {
     sessionKey,
@@ -24,6 +33,16 @@ function makeEntry(sessionKey: string, turnId: string, role: "user" | "assistant
     timestamp: new Date().toISOString(),
   } as TranscriptEntry;
 }
+
+// A timestamp comfortably INSIDE a `readRecent(48, …)` window. Seeding with the
+// exact wall-clock "now" is racy: the read's upper bound is captured a moment
+// after the write, and at millisecond resolution the entry's `ts` can equal the
+// read's exclusive `end`, excluding a just-written row. Using a fixed offset in
+// the recent past keeps these read-back assertions deterministic. The current
+// day's date stamp is still used for the file name so date-window selection
+// matches the directory scan.
+const SEED_TS = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+const TODAY = new Date().toISOString().slice(0, 10);
 
 async function listDirs(root: string): Promise<string[]> {
   try {
@@ -38,7 +57,7 @@ async function listDirs(root: string): Promise<string[]> {
 }
 
 test("arbitrary session keys use DIFFERENT transcript dirs on first write, never other/default", async () => {
-  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  const memoryDir = await makeMemoryDir();
   try {
     const tm = new TranscriptManager(makeConfig(memoryDir));
     await tm.initialize();
@@ -63,7 +82,7 @@ test("arbitrary session keys use DIFFERENT transcript dirs on first write, never
 });
 
 test("distinct arbitrary keys never share other/default by default", async () => {
-  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  const memoryDir = await makeMemoryDir();
   try {
     const tm = new TranscriptManager(makeConfig(memoryDir));
     await tm.initialize();
@@ -84,7 +103,7 @@ test("distinct arbitrary keys never share other/default by default", async () =>
 });
 
 test("legacy agent:<id>:main keeps its readable main/default path", async () => {
-  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  const memoryDir = await makeMemoryDir();
   try {
     const tm = new TranscriptManager(makeConfig(memoryDir));
     await tm.initialize();
@@ -103,7 +122,7 @@ test("legacy agent:<id>:main keeps its readable main/default path", async () => 
 });
 
 test("tool usage for arbitrary keys routes to state/tool-usage/session/<hash>", async () => {
-  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  const memoryDir = await makeMemoryDir();
   try {
     const tm = new TranscriptManager(makeConfig(memoryDir));
     await tm.initialize();
@@ -124,7 +143,7 @@ test("tool usage for arbitrary keys routes to state/tool-usage/session/<hash>", 
 });
 
 test("listSessionKeys discovers BOTH legacy and hashed arbitrary sessions", async () => {
-  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  const memoryDir = await makeMemoryDir();
   try {
     const tm = new TranscriptManager(makeConfig(memoryDir));
     await tm.initialize();
@@ -140,22 +159,165 @@ test("listSessionKeys discovers BOTH legacy and hashed arbitrary sessions", asyn
   }
 });
 
+async function writeJsonl(absDir: string, fileName: string, lines: string[]): Promise<void> {
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  await mkdir(absDir, { recursive: true });
+  await writeFile(path.join(absDir, fileName), `${lines.join("\n")}\n`, "utf-8");
+}
+
+test("partial migration (copied-but-not-trimmed) yields each transcript row exactly once", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const sessionKey = "pi-geek:abc123";
+    // Same byte-identical row present in BOTH the primary session/<hash> dir and
+    // the legacy other/default dir — the state left by a migration that copied
+    // to the destination but crashed before trimming the source.
+    const row = JSON.stringify({
+      sessionKey,
+      turnId: "1",
+      role: "user",
+      content: "duplicated row",
+      timestamp: SEED_TS,
+    });
+
+    const { sessionStoragePaths } = await import("./session-identity.js");
+    const primaryDir = path.join(memoryDir, "transcripts", sessionStoragePaths(sessionKey).dir);
+    const otherDefaultDir = path.join(memoryDir, "transcripts", "other", "default");
+    await writeJsonl(primaryDir, `${TODAY}.jsonl`, [row]);
+    await writeJsonl(otherDefaultDir, `${TODAY}.jsonl`, [row]);
+
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    const entries = await tm.readRecent(48, sessionKey);
+    assert.equal(entries.length, 1, "duplicated row must be returned exactly once");
+    assert.equal(entries[0].content, "duplicated row");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("partial migration yields each tool-usage row exactly once", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const sessionKey = "pi-geek:abc123";
+    const row = JSON.stringify({ sessionKey, tool: "search", timestamp: SEED_TS });
+
+    const { sessionStoragePaths } = await import("./session-identity.js");
+    const primaryDir = path.join(memoryDir, "state", "tool-usage", sessionStoragePaths(sessionKey).dir);
+    const otherDefaultDir = path.join(memoryDir, "state", "tool-usage", "other", "default");
+    await writeJsonl(primaryDir, `${TODAY}.jsonl`, [row]);
+    await writeJsonl(otherDefaultDir, `${TODAY}.jsonl`, [row]);
+
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    const start = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    const end = new Date(Date.now() + 60 * 60 * 1000);
+    const used = await tm.readToolUse(sessionKey, start, end);
+    assert.equal(used.length, 1, "duplicated tool-usage row must be returned exactly once");
+    assert.equal(used[0].tool, "search");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("pre-existing foo:bar:baz data under old baz/default stays readable", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    // An OLD build (parts.length >= 3, no leading `agent`) stored foo:bar:baz
+    // under baz/default. The NEW parser reclassifies it as session/<hash>, but
+    // the old data must remain visible via the legacy-parser read-back dir.
+    const sessionKey = "foo:bar:baz";
+    const oldDir = path.join(memoryDir, "transcripts", "baz", "default");
+    await writeJsonl(oldDir, `${TODAY}.jsonl`, [
+      JSON.stringify({ sessionKey, turnId: "1", role: "user", content: "old baz entry", timestamp: SEED_TS }),
+    ]);
+    // Tool-usage equivalent.
+    const oldToolDir = path.join(memoryDir, "state", "tool-usage", "baz", "default");
+    await writeJsonl(oldToolDir, `${TODAY}.jsonl`, [
+      JSON.stringify({ sessionKey, tool: "grep", timestamp: SEED_TS }),
+    ]);
+
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    const entries = await tm.readRecent(48, sessionKey);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].content, "old baz entry");
+
+    const start = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    const end = new Date(Date.now() + 60 * 60 * 1000);
+    const used = await tm.readToolUse(sessionKey, start, end);
+    assert.equal(used.length, 1);
+    assert.equal(used[0].tool, "grep");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("pre-existing foo:bar:baz:qux data under old baz/qux stays readable", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const sessionKey = "foo:bar:baz:qux";
+    const oldDir = path.join(memoryDir, "transcripts", "baz", "qux");
+    await writeJsonl(oldDir, `${TODAY}.jsonl`, [
+      JSON.stringify({ sessionKey, turnId: "1", role: "user", content: "old baz/qux entry", timestamp: SEED_TS }),
+    ]);
+
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    const entries = await tm.readRecent(48, sessionKey);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].content, "old baz/qux entry");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("partial migration across legacy baz/default and session/<hash> dedupes to one row", async () => {
+  const memoryDir = await makeMemoryDir();
+  try {
+    const sessionKey = "foo:bar:baz";
+    const row = JSON.stringify({
+      sessionKey,
+      turnId: "1",
+      role: "user",
+      content: "shared legacy row",
+      timestamp: SEED_TS,
+    });
+    const { sessionStoragePaths } = await import("./session-identity.js");
+    const primaryDir = path.join(memoryDir, "transcripts", sessionStoragePaths(sessionKey).dir);
+    const legacyDir = path.join(memoryDir, "transcripts", "baz", "default");
+    await writeJsonl(primaryDir, `${TODAY}.jsonl`, [row]);
+    await writeJsonl(legacyDir, `${TODAY}.jsonl`, [row]);
+
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    const entries = await tm.readRecent(48, sessionKey);
+    assert.equal(entries.length, 1, "row shared across legacy and primary dir must dedupe to one");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
 test("legacy other/default data written by older builds remains readable", async () => {
-  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  const memoryDir = await makeMemoryDir();
   try {
     // Simulate an older build that wrote an arbitrary key under other/default.
     const { mkdir, writeFile } = await import("node:fs/promises");
     const legacyDir = path.join(memoryDir, "transcripts", "other", "default");
     await mkdir(legacyDir, { recursive: true });
-    const today = new Date().toISOString().slice(0, 10);
     await writeFile(
-      path.join(legacyDir, `${today}.jsonl`),
+      path.join(legacyDir, `${TODAY}.jsonl`),
       `${JSON.stringify({
         sessionKey: "pi-legacy:zzz999",
         turnId: "1",
         role: "user",
         content: "old entry",
-        timestamp: new Date().toISOString(),
+        timestamp: SEED_TS,
       })}\n`,
       "utf-8"
     );

--- a/packages/remnic-core/src/transcript-session-identity.test.ts
+++ b/packages/remnic-core/src/transcript-session-identity.test.ts
@@ -337,3 +337,88 @@ test("legacy other/default data written by older builds remains readable", async
     await rm(memoryDir, { recursive: true, force: true });
   }
 });
+
+test("readRange with a session key dedupes a copied-but-not-trimmed partial migration", async () => {
+  // Thread 1 (cursor review on PR #1504): `readRange` scans EVERY transcript
+  // file. Round 1 added raw-line dedup to readRecent/readToolUse/summarizer but
+  // not to readRange, so a partially-applied migration that copied a row into
+  // session/<hash> without trimming the legacy other/default source would yield
+  // the same turn twice through bootstrap / the transcript CLI.
+  const memoryDir = await makeMemoryDir();
+  try {
+    const sessionKey = "pi-geek:abc123";
+    const row = JSON.stringify({
+      sessionKey,
+      turnId: "1",
+      role: "user",
+      content: "duplicated range row",
+      timestamp: SEED_TS,
+    });
+
+    const { sessionStoragePaths } = await import("./session-identity.js");
+    const primaryDir = path.join(memoryDir, "transcripts", sessionStoragePaths(sessionKey).dir);
+    const otherDefaultDir = path.join(memoryDir, "transcripts", "other", "default");
+    // Byte-identical row in BOTH the primary dir and the legacy read-back dir.
+    await writeJsonl(primaryDir, `${TODAY}.jsonl`, [row]);
+    await writeJsonl(otherDefaultDir, `${TODAY}.jsonl`, [row]);
+
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    const start = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    const end = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const scoped = await tm.readRange(start, end, sessionKey);
+    assert.equal(scoped.length, 1, "session-scoped readRange must return the shared row exactly once");
+    assert.equal(scoped[0].content, "duplicated range row");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("readRange without a session key preserves distinct rows from every directory", async () => {
+  // The dedup is session-scoped only — an unfiltered range scan over the whole
+  // tree must NOT collapse legitimately distinct rows that happen to share a
+  // date. Guards against the deduper changing unrelated behavior.
+  const memoryDir = await makeMemoryDir();
+  try {
+    const { sessionStoragePaths } = await import("./session-identity.js");
+    const rowA = JSON.stringify({
+      sessionKey: "pi-geek:abc123",
+      turnId: "1",
+      role: "user",
+      content: "row A",
+      timestamp: SEED_TS,
+    });
+    const rowB = JSON.stringify({
+      sessionKey: "pi-friend:def456",
+      turnId: "1",
+      role: "user",
+      content: "row B",
+      timestamp: SEED_TS,
+    });
+    await writeJsonl(
+      path.join(memoryDir, "transcripts", sessionStoragePaths("pi-geek:abc123").dir),
+      `${TODAY}.jsonl`,
+      [rowA],
+    );
+    await writeJsonl(
+      path.join(memoryDir, "transcripts", sessionStoragePaths("pi-friend:def456").dir),
+      `${TODAY}.jsonl`,
+      [rowB],
+    );
+
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    const start = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    const end = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const all = await tm.readRange(start, end);
+    assert.equal(all.length, 2, "unfiltered readRange must keep both distinct rows");
+    assert.deepEqual(
+      all.map((e) => e.content).sort(),
+      ["row A", "row B"],
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/transcript-session-identity.test.ts
+++ b/packages/remnic-core/src/transcript-session-identity.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { TranscriptManager } from "./transcript.js";
+import type { PluginConfig, TranscriptEntry } from "./types.js";
+
+function makeConfig(memoryDir: string): PluginConfig {
+  // TranscriptManager only reads memoryDir + transcriptSkipChannelTypes.
+  return {
+    memoryDir,
+    transcriptSkipChannelTypes: [],
+  } as unknown as PluginConfig;
+}
+
+function makeEntry(sessionKey: string, turnId: string, role: "user" | "assistant"): TranscriptEntry {
+  return {
+    sessionKey,
+    turnId,
+    role,
+    content: `content-${turnId}`,
+    timestamp: new Date().toISOString(),
+  } as TranscriptEntry;
+}
+
+async function listDirs(root: string): Promise<string[]> {
+  try {
+    const entries = await readdir(root, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+test("arbitrary session keys use DIFFERENT transcript dirs on first write, never other/default", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  try {
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    await tm.append(makeEntry("pi-geek:abc123", "1", "user"));
+    await tm.append(makeEntry("pi-friend:def456", "2", "user"));
+
+    const transcriptsDir = path.join(memoryDir, "transcripts");
+    const typeDirs = await listDirs(transcriptsDir);
+
+    // First-class "session" channel type, NOT "other".
+    assert.ok(typeDirs.includes("session"), `expected a session dir, got: ${typeDirs.join(",")}`);
+    assert.ok(!typeDirs.includes("other"), `should not create other/, got: ${typeDirs.join(",")}`);
+
+    // Two distinct hashed dirs under session/.
+    const sessionHashes = await listDirs(path.join(transcriptsDir, "session"));
+    assert.equal(sessionHashes.length, 2);
+    assert.notEqual(sessionHashes[0], sessionHashes[1]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("distinct arbitrary keys never share other/default by default", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  try {
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    await tm.append(makeEntry("pi-geek:abc123", "1", "user"));
+    await tm.append(makeEntry("pi-friend:def456", "2", "user"));
+
+    // Each key only reads back its OWN entries.
+    const geek = await tm.readRecent(48, "pi-geek:abc123");
+    const friend = await tm.readRecent(48, "pi-friend:def456");
+    assert.equal(geek.length, 1);
+    assert.equal(friend.length, 1);
+    assert.equal(geek[0].sessionKey, "pi-geek:abc123");
+    assert.equal(friend[0].sessionKey, "pi-friend:def456");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("legacy agent:<id>:main keeps its readable main/default path", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  try {
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    await tm.append(makeEntry("agent:generalist:main", "1", "user"));
+
+    const transcriptsDir = path.join(memoryDir, "transcripts");
+    const typeDirs = await listDirs(transcriptsDir);
+    assert.ok(typeDirs.includes("main"), `expected main dir, got: ${typeDirs.join(",")}`);
+
+    const idDirs = await listDirs(path.join(transcriptsDir, "main"));
+    assert.deepEqual(idDirs, ["default"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("tool usage for arbitrary keys routes to state/tool-usage/session/<hash>", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  try {
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    await tm.appendToolUse({
+      timestamp: new Date().toISOString(),
+      sessionKey: "pi-geek:abc123",
+      tool: "search",
+    });
+
+    const toolUsageDir = path.join(memoryDir, "state", "tool-usage");
+    const typeDirs = await listDirs(toolUsageDir);
+    assert.ok(typeDirs.includes("session"), `expected session tool-usage dir, got: ${typeDirs.join(",")}`);
+    assert.ok(!typeDirs.includes("other"));
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("listSessionKeys discovers BOTH legacy and hashed arbitrary sessions", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  try {
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    await tm.append(makeEntry("agent:generalist:main", "1", "user"));
+    await tm.append(makeEntry("pi-geek:abc123", "2", "user"));
+    await tm.append(makeEntry("pi-friend:def456", "3", "user"));
+
+    const keys = (await tm.listSessionKeys()).sort();
+    assert.deepEqual(keys, ["agent:generalist:main", "pi-friend:def456", "pi-geek:abc123"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("legacy other/default data written by older builds remains readable", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-tx-id-"));
+  try {
+    // Simulate an older build that wrote an arbitrary key under other/default.
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    const legacyDir = path.join(memoryDir, "transcripts", "other", "default");
+    await mkdir(legacyDir, { recursive: true });
+    const today = new Date().toISOString().slice(0, 10);
+    await writeFile(
+      path.join(legacyDir, `${today}.jsonl`),
+      `${JSON.stringify({
+        sessionKey: "pi-legacy:zzz999",
+        turnId: "1",
+        role: "user",
+        content: "old entry",
+        timestamp: new Date().toISOString(),
+      })}\n`,
+      "utf-8"
+    );
+
+    const tm = new TranscriptManager(makeConfig(memoryDir));
+    await tm.initialize();
+
+    // listSessionKeys must still surface the legacy-stored key.
+    const keys = await tm.listSessionKeys();
+    assert.ok(keys.includes("pi-legacy:zzz999"));
+
+    // readRecent must still read it (alternateDir/legacy read-back path).
+    const entries = await tm.readRecent(48, "pi-legacy:zzz999");
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].content, "old entry");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/transcript.ts
+++ b/packages/remnic-core/src/transcript.ts
@@ -652,6 +652,16 @@ export class TranscriptManager {
     const end = new Date(endTime);
     const entries: TranscriptEntry[] = [];
 
+    // When a sessionKey is given, a partially-applied #1496 migration can leave
+    // the SAME raw row in both the primary `session/<hash>` dir and a read-back
+    // dir (`other/default` or an old `parts.length >= 3` dir). `readRange` scans
+    // EVERY transcript file, so it would append that row once per directory.
+    // Dedup by exact raw line to give the same exact-once guarantee `readRecent`
+    // / `readToolUse` / the summarizer fetch already provide (cursor review on
+    // PR #1504). Only applied for the session-scoped path so unfiltered range
+    // scans (each file already enumerated once) keep their existing behavior.
+    const keepRawLine = sessionKey ? makeRawLineDeduper() : undefined;
+
     try {
       // Get all transcript files from the hierarchical structure
       const transcriptFiles = await this.getAllTranscriptFiles();
@@ -672,6 +682,7 @@ export class TranscriptManager {
               if (entryTime >= start && entryTime < end) {
                 // Filter by sessionKey if provided
                 if (!sessionKey || entry.sessionKey === sessionKey) {
+                  if (keepRawLine && !keepRawLine(line)) continue;
                   entries.push(entry);
                 }
               }

--- a/packages/remnic-core/src/transcript.ts
+++ b/packages/remnic-core/src/transcript.ts
@@ -4,12 +4,7 @@ import { log } from "./logger.js";
 import type { TranscriptEntry, Checkpoint, PluginConfig } from "./types.js";
 import { analyzeSessionIntegrity, type SessionIntegrityReport } from "./session-integrity.js";
 import { resolveSafeStoragePath } from "./storage-paths.js";
-import {
-  LEGACY_FALLBACK_CHANNEL_ID,
-  LEGACY_FALLBACK_CHANNEL_TYPE,
-  parseSessionIdentity,
-  sessionStoragePaths,
-} from "./session-identity.js";
+import { sessionStoragePaths } from "./session-identity.js";
 
 type DirectorySessionStatus = "missing" | "empty" | "matches" | "occupied";
 type DirectoryOwnershipCacheEntry = {
@@ -18,16 +13,25 @@ type DirectoryOwnershipCacheEntry = {
 };
 
 /**
- * Read-back-only directory for arbitrary (non-legacy) session keys written by
- * builds predating issue #1496, when every non-legacy key was routed into the
- * shared `other/default` directory on first write. New writes never target this
- * directory — it is only added to read/footprint candidate lists so existing
- * data stays discoverable until migrated. See `session-transcript-migration.ts`.
+ * De-duplicate JSONL lines collected across multiple read-back candidate
+ * directories. A partially-applied migration (issue #1496) can leave the SAME
+ * raw row in both the primary `session/<hash>` tree and a legacy read-back dir
+ * (`other/default` or an old `parts.length >= 3` directory) when the source was
+ * copied but not yet trimmed. Without this guard, `readRecent`, `readToolUse`,
+ * footprint estimation, and the summarizer fetch would return that row twice
+ * (cursor review on PR #1504). The exact raw JSONL line is the stable identity:
+ * the migration preserves byte content per session, so a copied-but-not-trimmed
+ * row is byte-identical in both locations. Returns `true` the first time a line
+ * is seen, `false` for every subsequent duplicate.
  */
-const OTHER_DEFAULT_READBACK_DIR = path.join(
-  LEGACY_FALLBACK_CHANNEL_TYPE,
-  LEGACY_FALLBACK_CHANNEL_ID,
-);
+function makeRawLineDeduper(): (rawLine: string) => boolean {
+  const seen = new Set<string>();
+  return (rawLine: string): boolean => {
+    if (seen.has(rawLine)) return false;
+    seen.add(rawLine);
+    return true;
+  };
+}
 
 /**
  * Manages conversation transcript storage, checkpointing, and recall formatting.
@@ -70,9 +74,11 @@ export class TranscriptManager {
    * Legacy `agent:<id>:...` shapes keep their existing readable channel paths.
    * Arbitrary / non-legacy keys (e.g. `pi-geek:abc123`) route to
    * `transcripts/session/<hash>/YYYY-MM-DD.jsonl` from the FIRST write — they
-   * never start life in `other/default`. For those keys an additional
-   * read-back-only `otherDefaultReadbackDir` is returned so data written by
-   * older builds under `other/default` stays discoverable until migrated.
+   * never start life in `other/default`. For those keys a list of
+   * read-back-only `readbackDirs` is returned so data written by older builds
+   * (under `other/default`, or under an old `parts.length >= 3` directory such
+   * as `baz/default`) stays discoverable until migrated. New writes never
+   * target read-back dirs. See `session-identity.ts`.
    *
    * @returns Object with raw channel identifiers and encoded storage path pieces.
    */
@@ -83,19 +89,12 @@ export class TranscriptManager {
     channelId: string;
     alternateDir: string;
     legacyDir?: string;
-    otherDefaultReadbackDir?: string;
+    readbackDirs: string[];
   } {
     const paths = sessionStoragePaths(sessionKey);
-    const identity = parseSessionIdentity(sessionKey);
 
     // Daily rotation: transcripts/{channelType}/{channelId}/YYYY-MM-DD.jsonl
     const today = new Date().toISOString().slice(0, 10);
-
-    // Non-legacy keys may have legacy data stranded under `other/default`.
-    const otherDefaultReadbackDir =
-      !identity.legacy && paths.dir !== OTHER_DEFAULT_READBACK_DIR
-        ? OTHER_DEFAULT_READBACK_DIR
-        : undefined;
 
     return {
       dir: paths.dir,
@@ -104,7 +103,7 @@ export class TranscriptManager {
       channelId: paths.channelId,
       alternateDir: paths.alternateDir,
       legacyDir: paths.legacyDir,
-      otherDefaultReadbackDir,
+      readbackDirs: paths.readbackDirs,
     };
   }
 
@@ -164,7 +163,7 @@ export class TranscriptManager {
     file: string;
     alternateDir: string;
     legacyDir?: string;
-    otherDefaultReadbackDir?: string;
+    readbackDirs: string[];
   } {
     const p = this.getTranscriptPath(sessionKey);
     return {
@@ -172,7 +171,7 @@ export class TranscriptManager {
       file: p.file,
       alternateDir: p.alternateDir,
       legacyDir: p.legacyDir,
-      otherDefaultReadbackDir: p.otherDefaultReadbackDir,
+      readbackDirs: p.readbackDirs,
     };
   }
 
@@ -332,12 +331,12 @@ export class TranscriptManager {
     dir: string,
     legacyDir?: string,
     alternateDir?: string,
-    otherDefaultReadbackDir?: string,
+    readbackDirs: string[] = [],
   ): Promise<Array<{ cacheKey: string; name: string; path: string }>> {
     const files: Array<{ cacheKey: string; name: string; path: string }> = [];
     const seenDirs = new Set<string>();
 
-    for (const candidateDir of [dir, alternateDir, legacyDir, otherDefaultReadbackDir]) {
+    for (const candidateDir of [dir, alternateDir, legacyDir, ...readbackDirs]) {
       if (!candidateDir || seenDirs.has(candidateDir)) continue;
       seenDirs.add(candidateDir);
 
@@ -389,16 +388,19 @@ export class TranscriptManager {
     startTime: Date,
     endTime: Date,
   ): Promise<Array<{ timestamp: string; sessionKey: string; tool: string }>> {
-    const { dir, alternateDir, legacyDir, otherDefaultReadbackDir } = this.getToolUsagePath(sessionKey);
+    const { dir, alternateDir, legacyDir, readbackDirs } = this.getToolUsagePath(sessionKey);
     try {
       const files = await this.getSessionStorageFiles(
         this.toolUsageDir,
         dir,
         legacyDir,
         alternateDir,
-        otherDefaultReadbackDir,
+        readbackDirs,
       );
       const out: Array<{ timestamp: string; sessionKey: string; tool: string }> = [];
+      // Dedup identical raw rows that a partially-applied migration may have left
+      // in both the primary dir and a read-back dir (issue #1496, cursor review).
+      const keepRawLine = makeRawLineDeduper();
       for (const file of files) {
         const raw = await readFile(file.path, "utf-8");
         for (const line of raw.split("\n")) {
@@ -409,7 +411,7 @@ export class TranscriptManager {
             if (!Number.isFinite(ts)) continue;
             if (ts >= startTime.getTime() && ts < endTime.getTime()) {
               if (typeof obj.tool === "string" && typeof obj.sessionKey === "string") {
-                if (obj.sessionKey === sessionKey) {
+                if (obj.sessionKey === sessionKey && keepRawLine(line)) {
                   out.push({ timestamp: obj.timestamp, sessionKey: obj.sessionKey, tool: obj.tool });
                 }
               }
@@ -426,16 +428,23 @@ export class TranscriptManager {
   }
 
   async estimateSessionFootprint(sessionKey: string): Promise<{ bytes: number; tokens: number }> {
-    const { dir, alternateDir, legacyDir, otherDefaultReadbackDir } = this.getTranscriptPath(sessionKey);
+    const { dir, alternateDir, legacyDir, readbackDirs } = this.getTranscriptPath(sessionKey);
     let bytes = 0;
 
+    // NOTE: this is a best-effort byte ESTIMATE for compaction sizing, not an
+    // exact row count, and is maintained via an incremental per-file cache. A
+    // copied-but-not-trimmed migration window (issue #1496) can transiently
+    // over-estimate by counting a duplicated row in both the primary and a
+    // read-back dir; that self-heals once the migration trims the source. The
+    // exact-once guarantee that matters for callers lives in readRecent /
+    // readToolUse / the summarizer fetch, which dedup by raw line.
     try {
       const files = await this.getSessionStorageFiles(
         this.transcriptsDir,
         dir,
         legacyDir,
         alternateDir,
-        otherDefaultReadbackDir,
+        readbackDirs,
       );
       const cached = this.sessionFootprintCache.get(sessionKey);
       if (!cached) {
@@ -712,7 +721,7 @@ export class TranscriptManager {
     end: Date,
     sessionKey: string,
   ): Promise<TranscriptEntry[]> {
-    const { dir, alternateDir, legacyDir, otherDefaultReadbackDir } = this.getTranscriptPath(sessionKey);
+    const { dir, alternateDir, legacyDir, readbackDirs } = this.getTranscriptPath(sessionKey);
 
     // Build set of date strings that overlap with [start, end].
     // Always include end's date to handle midnight-crossing lookbacks
@@ -731,9 +740,12 @@ export class TranscriptManager {
       dir,
       legacyDir,
       alternateDir,
-      otherDefaultReadbackDir,
+      readbackDirs,
     );
 
+    // Dedup identical raw rows that a partially-applied migration may have left
+    // in both the primary dir and a read-back dir (issue #1496, cursor review).
+    const keepRawLine = makeRawLineDeduper();
     for (const file of files) {
       // Only read files whose date is within the window
       const dateStr = file.name.slice(0, 10);
@@ -746,7 +758,7 @@ export class TranscriptManager {
           try {
             const entry = JSON.parse(line) as TranscriptEntry;
             const ts = new Date(entry.timestamp);
-            if (ts >= start && ts < end && entry.sessionKey === sessionKey) {
+            if (ts >= start && ts < end && entry.sessionKey === sessionKey && keepRawLine(line)) {
               entries.push(entry);
             }
           } catch {

--- a/packages/remnic-core/src/transcript.ts
+++ b/packages/remnic-core/src/transcript.ts
@@ -3,13 +3,13 @@ import path from "node:path";
 import { log } from "./logger.js";
 import type { TranscriptEntry, Checkpoint, PluginConfig } from "./types.js";
 import { analyzeSessionIntegrity, type SessionIntegrityReport } from "./session-integrity.js";
+import { resolveSafeStoragePath } from "./storage-paths.js";
 import {
-  encodeStoragePathSegment,
-  encodeStoragePathSegmentWithHash,
-  isSafeLegacyPathSegment,
-  resolveSafeStoragePath,
-  storagePathHash,
-} from "./storage-paths.js";
+  LEGACY_FALLBACK_CHANNEL_ID,
+  LEGACY_FALLBACK_CHANNEL_TYPE,
+  parseSessionIdentity,
+  sessionStoragePaths,
+} from "./session-identity.js";
 
 type DirectorySessionStatus = "missing" | "empty" | "matches" | "occupied";
 type DirectoryOwnershipCacheEntry = {
@@ -17,17 +17,17 @@ type DirectoryOwnershipCacheEntry = {
   fileSizes: Map<string, number>;
 };
 
-function legacyTranscriptDirFor(
-  channelType: string,
-  channelId: string,
-  encodedDir: string,
-): string | undefined {
-  if (!isSafeLegacyPathSegment(channelType) || !isSafeLegacyPathSegment(channelId)) {
-    return undefined;
-  }
-  const legacyDir = path.join(channelType, channelId);
-  return legacyDir === encodedDir ? undefined : legacyDir;
-}
+/**
+ * Read-back-only directory for arbitrary (non-legacy) session keys written by
+ * builds predating issue #1496, when every non-legacy key was routed into the
+ * shared `other/default` directory on first write. New writes never target this
+ * directory — it is only added to read/footprint candidate lists so existing
+ * data stays discoverable until migrated. See `session-transcript-migration.ts`.
+ */
+const OTHER_DEFAULT_READBACK_DIR = path.join(
+  LEGACY_FALLBACK_CHANNEL_TYPE,
+  LEGACY_FALLBACK_CHANNEL_ID,
+);
 
 /**
  * Manages conversation transcript storage, checkpointing, and recall formatting.
@@ -64,13 +64,15 @@ export class TranscriptManager {
   }
 
   /**
-   * Parse a sessionKey to extract channel type and ID.
+   * Resolve the storage path pieces for a sessionKey via the shared
+   * {@link sessionStoragePaths} helper (issue #1496, rule #22).
    *
-   * SessionKey patterns:
-   *   - agent:<agent-id>:main → type="main", id="default"
-   *   - agent:<agent-id>:discord:channel:<channel-id> → type="discord", id="<channel-id>"
-   *   - agent:<agent-id>:cron:<job-id> → type="cron", id="<job-id>"
-   *   - agent:<agent-id>:slack:channel:<channel-id> → type="slack", id="<channel-id>"
+   * Legacy `agent:<id>:...` shapes keep their existing readable channel paths.
+   * Arbitrary / non-legacy keys (e.g. `pi-geek:abc123`) route to
+   * `transcripts/session/<hash>/YYYY-MM-DD.jsonl` from the FIRST write — they
+   * never start life in `other/default`. For those keys an additional
+   * read-back-only `otherDefaultReadbackDir` is returned so data written by
+   * older builds under `other/default` stays discoverable until migrated.
    *
    * @returns Object with raw channel identifiers and encoded storage path pieces.
    */
@@ -81,49 +83,28 @@ export class TranscriptManager {
     channelId: string;
     alternateDir: string;
     legacyDir?: string;
+    otherDefaultReadbackDir?: string;
   } {
-    const parts = sessionKey.split(":");
-
-    // Default fallback
-    let channelType = "other";
-    let channelId = "default";
-
-    if (parts.length >= 3) {
-      // parts[0] = "agent", parts[1] = agent name, parts[2] = channel type
-      channelType = parts[2];
-
-      // Extract channel ID based on pattern
-      if (channelType === "main") {
-        channelId = "default";
-      } else if (channelType === "discord" && parts.length >= 5 && parts[3] === "channel") {
-        channelId = parts[4];
-      } else if (channelType === "slack" && parts.length >= 5 && parts[3] === "channel") {
-        channelId = parts[4];
-      } else if (channelType === "cron" && parts.length >= 4) {
-        channelId = parts[3];
-      } else if (parts.length >= 4) {
-        // For other types, use the 4th part as ID if available
-        channelId = parts[3];
-      }
-    }
+    const paths = sessionStoragePaths(sessionKey);
+    const identity = parseSessionIdentity(sessionKey);
 
     // Daily rotation: transcripts/{channelType}/{channelId}/YYYY-MM-DD.jsonl
     const today = new Date().toISOString().slice(0, 10);
-    const dir = path.join(
-      encodeStoragePathSegment(channelType),
-      encodeStoragePathSegment(channelId),
-    );
-    const alternateDir = path.join(
-      encodeStoragePathSegmentWithHash(channelType),
-      `${encodeStoragePathSegmentWithHash(channelId)}--session-${storagePathHash(sessionKey)}`,
-    );
+
+    // Non-legacy keys may have legacy data stranded under `other/default`.
+    const otherDefaultReadbackDir =
+      !identity.legacy && paths.dir !== OTHER_DEFAULT_READBACK_DIR
+        ? OTHER_DEFAULT_READBACK_DIR
+        : undefined;
+
     return {
-      dir,
+      dir: paths.dir,
       file: `${today}.jsonl`,
-      channelType,
-      channelId,
-      alternateDir,
-      legacyDir: legacyTranscriptDirFor(channelType, channelId, dir),
+      channelType: paths.channelType,
+      channelId: paths.channelId,
+      alternateDir: paths.alternateDir,
+      legacyDir: paths.legacyDir,
+      otherDefaultReadbackDir,
     };
   }
 
@@ -183,9 +164,16 @@ export class TranscriptManager {
     file: string;
     alternateDir: string;
     legacyDir?: string;
+    otherDefaultReadbackDir?: string;
   } {
     const p = this.getTranscriptPath(sessionKey);
-    return { dir: p.dir, file: p.file, alternateDir: p.alternateDir, legacyDir: p.legacyDir };
+    return {
+      dir: p.dir,
+      file: p.file,
+      alternateDir: p.alternateDir,
+      legacyDir: p.legacyDir,
+      otherDefaultReadbackDir: p.otherDefaultReadbackDir,
+    };
   }
 
   private async selectStorageDirForWrite(
@@ -344,11 +332,12 @@ export class TranscriptManager {
     dir: string,
     legacyDir?: string,
     alternateDir?: string,
+    otherDefaultReadbackDir?: string,
   ): Promise<Array<{ cacheKey: string; name: string; path: string }>> {
     const files: Array<{ cacheKey: string; name: string; path: string }> = [];
     const seenDirs = new Set<string>();
 
-    for (const candidateDir of [dir, alternateDir, legacyDir]) {
+    for (const candidateDir of [dir, alternateDir, legacyDir, otherDefaultReadbackDir]) {
       if (!candidateDir || seenDirs.has(candidateDir)) continue;
       seenDirs.add(candidateDir);
 
@@ -400,9 +389,15 @@ export class TranscriptManager {
     startTime: Date,
     endTime: Date,
   ): Promise<Array<{ timestamp: string; sessionKey: string; tool: string }>> {
-    const { dir, alternateDir, legacyDir } = this.getToolUsagePath(sessionKey);
+    const { dir, alternateDir, legacyDir, otherDefaultReadbackDir } = this.getToolUsagePath(sessionKey);
     try {
-      const files = await this.getSessionStorageFiles(this.toolUsageDir, dir, legacyDir, alternateDir);
+      const files = await this.getSessionStorageFiles(
+        this.toolUsageDir,
+        dir,
+        legacyDir,
+        alternateDir,
+        otherDefaultReadbackDir,
+      );
       const out: Array<{ timestamp: string; sessionKey: string; tool: string }> = [];
       for (const file of files) {
         const raw = await readFile(file.path, "utf-8");
@@ -431,11 +426,17 @@ export class TranscriptManager {
   }
 
   async estimateSessionFootprint(sessionKey: string): Promise<{ bytes: number; tokens: number }> {
-    const { dir, alternateDir, legacyDir } = this.getTranscriptPath(sessionKey);
+    const { dir, alternateDir, legacyDir, otherDefaultReadbackDir } = this.getTranscriptPath(sessionKey);
     let bytes = 0;
 
     try {
-      const files = await this.getSessionStorageFiles(this.transcriptsDir, dir, legacyDir, alternateDir);
+      const files = await this.getSessionStorageFiles(
+        this.transcriptsDir,
+        dir,
+        legacyDir,
+        alternateDir,
+        otherDefaultReadbackDir,
+      );
       const cached = this.sessionFootprintCache.get(sessionKey);
       if (!cached) {
         const fileBytes = new Map<string, number>();
@@ -711,7 +712,7 @@ export class TranscriptManager {
     end: Date,
     sessionKey: string,
   ): Promise<TranscriptEntry[]> {
-    const { dir, alternateDir, legacyDir } = this.getTranscriptPath(sessionKey);
+    const { dir, alternateDir, legacyDir, otherDefaultReadbackDir } = this.getTranscriptPath(sessionKey);
 
     // Build set of date strings that overlap with [start, end].
     // Always include end's date to handle midnight-crossing lookbacks
@@ -725,7 +726,13 @@ export class TranscriptManager {
     dateStrings.add(end.toISOString().slice(0, 10));
 
     const entries: TranscriptEntry[] = [];
-    const files = await this.getSessionStorageFiles(this.transcriptsDir, dir, legacyDir, alternateDir);
+    const files = await this.getSessionStorageFiles(
+      this.transcriptsDir,
+      dir,
+      legacyDir,
+      alternateDir,
+      otherDefaultReadbackDir,
+    );
 
     for (const file of files) {
       // Only read files whose date is within the window


### PR DESCRIPTION
## Summary

Arbitrary standalone-client session keys (e.g. `pi-geek:abc123`, `pi-friend:def456`) no longer start life in `other/default` transcript storage. They now get deterministic, isolated, collision-resistant paths from the **first write**. Legacy `agent:<id>:...` shapes keep their existing readable paths.

Closes #1496
Part of epic #1494

## Shared helper

New generic-named core module **`packages/remnic-core/src/session-identity.ts`** is the single source of truth for session-key parsing and storage routing:

- `parseSessionIdentity(sessionKey)` → legacy channel identity for known `agent:<id>:...` shapes, else `{ channelType: "session", channelId: storagePathHash(key), displayLabel, canonicalSessionKey, legacy: false }`.
- `sessionStoragePaths(sessionKey)` → `{ dir, alternateDir, legacyDir }` for transcript/tool-usage routing.

(`namespaces/identity.ts` is about namespace tokens, not channel parsing — a generic `session-identity.ts` is the cohesive home; per rule #31 it uses a generic name.)

### Call sites converged onto the helper (rule #22)

- **`transcript.ts`** — `getTranscriptPath()` / `getToolUsagePath()` now delegate to `sessionStoragePaths()`. Non-legacy keys route to `transcripts/session/<hash>/` and `state/tool-usage/session/<hash>/` on first write. A read-back-only `otherDefaultReadbackDir` is threaded into `getSessionStorageFiles()` (used by `readToolUse`, `readRecentForSession`, `estimateSessionFootprint`) so pre-existing `other/default` data stays readable. Writes never target `other/default`.
- **`summarizer.ts`** — `getTranscriptEntries()` had an exact copy of the brittle parser; now uses the shared helper with the same read-back candidates.
- `listSessionKeys()` (transcript) and `getActiveSessions()` (summarizer) already read `entry.sessionKey` directly, so they discover both legacy and hashed layouts unchanged.

## Migration command

`remnic sessions migrate-transcripts [--dry-run|--apply]` (`session-transcript-migration.ts`):

- **Default is dry-run** (safe) when neither flag is given; prints a note. Passing both `--dry-run` and `--apply` errors (rule #51).
- Detects mixed `other/default` files, groups entries by `entry.sessionKey`, and proposes one destination per distinct session.
- `--apply` is **lossless** (preserves JSONL ordering + byte content), **idempotent** (re-run finds nothing), uses **write-then-rename** never delete-before-write (rule #54), retains unparseable/already-homed lines in the source, and writes an audit manifest under `state/session-migration/`.

## Compatibility (read-back tests included)

- Legacy `agent:<id>:main|discord|slack|cron` paths remain readable at current locations.
- Existing `other/default` data remains readable.
- New arbitrary keys never create new `other/default` dirs unless explicitly migrating.

## Tests

- `session-identity.test.ts` (13): legacy shapes, first-class arbitrary routing, determinism, collision-resistance, non-`agent` keys treated as arbitrary, empty-key safety.
- `transcript-session-identity.test.ts` (6): distinct dirs on first write (no `other/default`), per-session read isolation, legacy path retention, tool-usage routing, `listSessionKeys` discovery of both, legacy `other/default` read-back.
- `session-transcript-migration.test.ts` (5): dry-run plan, lossless apply, idempotency, retained malformed lines, audit manifest.

## Checklist

- [x] Tests pass (24 new; `preflight:quick` OK; `test:entity-hardening` 205/205)
- [x] New logic covered by tests
- [x] Pre-commit/preflight gates pass locally (`lint`, `check-types`, build-staleness)
- [x] No secrets or personal data committed (synthetic `pi-*` test keys only)
- [x] Docs: CLI command is self-describing; no dedicated transcript-storage doc exists to update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk transcript layout and read paths for all non-legacy session keys; migration mutates JSONL under `memoryDir`, though dry-run default and atomic writes limit blast radius.
> 
> **Overview**
> **Arbitrary session keys** (e.g. `pi-geek:abc123`) no longer land in shared `transcripts/other/default` on first write. They route to isolated `transcripts/session/<hash>/` via a new shared **`session-identity`** layer (`parseSessionIdentity`, `sessionStoragePaths`). Legacy `agent:<id>:...` keys keep their existing channel paths; non-`agent` keys are no longer mis-parsed as legacy channels.
> 
> **Writers and readers** (`transcript.ts`, `summarizer.ts`) drop duplicated path parsing and use the helper, including **read-back** dirs for pre-#1496 data (`other/default`, old `parts.length >= 3` dirs like `baz/default`). **Raw JSONL line dedup** on session-scoped reads (`readRecent`, `readToolUse`, `readRange`, summarizer) avoids duplicate turns during partial migration.
> 
> **Migration**: `remnic sessions migrate-transcripts` (default dry-run, `--apply` to move) splits conflated legacy files into per-session dirs with atomic writes, idempotency, audit manifest, and sanitized CLI errors. Scanner treats only canonical `session/<16-hex>` as already homed—not legacy `session/<name>` dirs.
> 
> **Exports** from `@remnic/core` and bench test updates use `sessionStoragePaths` instead of hard-coded `other/default`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46a9ddea56cac283cab888ba1d2acb203d039e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->