### PR TITLE
fix(access): resolve observe writes through one effective scope plan (#1495)

### DIFF
--- a/packages/remnic-core/src/access-service-lcm-forgery.test.ts
+++ b/packages/remnic-core/src/access-service-lcm-forgery.test.ts
@@ -312,3 +312,99 @@ test("#1495 P1 LEGITIMATE ACCESS PRESERVED: a session key that legitimately cont
     )}`,
   );
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// #1505 codex P1 (round 2): a SESSIONLESS + prefixless `lcmSearch` issues
+// `searchContextFull(query, limit, undefined, undefined)` — an archive-wide FTS
+// scan over EVERY `session_id`, including sentinel-framed overlay rows. The
+// archive is keyed by `session_id`, NOT partitioned by namespace, so an
+// unscoped scan cannot be constrained to the caller's authorized namespace.
+// When namespaces are ENABLED it must therefore be SUPPRESSED regardless of an
+// explicit `namespace` or default-readability; only single-store (namespaces
+// disabled) keeps the legitimate archive-wide scan.
+// ──────────────────────────────────────────────────────────────────────────
+
+test("#1505 codex P1 r2 FORGERY BLOCKED: explicit-namespace + sessionless lcmSearch does NOT archive-scan another tenant's overlay rows", async () => {
+  const probe = makeForgeryProbe(twoTenantConfig());
+  const service = new EngramAccessService(probe.orch);
+
+  // VICTIM archives overlay rows.
+  const victimRes = await service.observe(
+    observeRequest({ sessionKey: "alice:s1", projectTag: "Blend/Supply" }),
+  );
+  assert.ok(victimRes.effectiveNamespace!.startsWith("alice-"));
+
+  // ATTACKER reads an explicit namespace they ARE authorized for (`default`),
+  // with NO sessionKey/sessionPrefix. The underlying search would be an
+  // archive-wide scan (no session_id filter), exposing alice's overlay rows.
+  const res = await service.lcmSearch({
+    query: "secret deploy key",
+    namespace: "default",
+    authenticatedPrincipal: "default",
+  });
+
+  assert.equal(
+    res.results.some((r) => r.content.includes(VICTIM_SECRET)),
+    false,
+    `cross-tenant LEAK via explicit-namespace archive scan; results=${JSON.stringify(res.results)}`,
+  );
+  assert.equal(res.count, 0, "explicit-namespace sessionless lcmSearch must NOT archive-scan");
+  assert.equal(
+    probe.searchSessionIds.length,
+    0,
+    "searchContextFull must NOT run an unscoped archive scan when namespaces are enabled",
+  );
+});
+
+test("#1505 codex P1 r2 FORGERY BLOCKED: default-readable implicit + sessionless lcmSearch does NOT archive-scan overlay rows", async () => {
+  const probe = makeForgeryProbe(twoTenantConfig());
+  const service = new EngramAccessService(probe.orch);
+
+  const victimRes = await service.observe(
+    observeRequest({ sessionKey: "alice:s1", projectTag: "Blend/Supply" }),
+  );
+  assert.ok(victimRes.effectiveNamespace!.startsWith("alice-"));
+
+  // ATTACKER (default-readable) with NO sessionKey/namespace/sessionPrefix. The
+  // pre-fix guard allowed this through to an archive-wide scan.
+  const res = await service.lcmSearch({
+    query: "secret deploy key",
+    authenticatedPrincipal: "default",
+  });
+
+  assert.equal(
+    res.results.some((r) => r.content.includes(VICTIM_SECRET)),
+    false,
+    `cross-tenant LEAK via default-readable archive scan; results=${JSON.stringify(res.results)}`,
+  );
+  assert.equal(
+    probe.searchSessionIds.length,
+    0,
+    "searchContextFull must NOT run an unscoped archive scan when namespaces are enabled",
+  );
+});
+
+test("#1505 codex P1 r2 regression: single-store (namespaces disabled) + sessionless lcmSearch STILL archive-scans (byte-for-byte prior behavior)", async () => {
+  const probe = makeForgeryProbe({
+    namespacesEnabled: false,
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // Single-store: one shared archive owned by the caller. Seed a row, then a
+  // sessionless search must still scan it.
+  await service.observe(
+    observeRequest({ sessionKey: "owner-sess", skipExtraction: true }),
+  );
+  const res = await service.lcmSearch({ query: "secret deploy key" });
+
+  assert.equal(
+    probe.searchSessionIds.length,
+    1,
+    "namespaces disabled ⇒ sessionless archive scan still runs",
+  );
+  assert.equal(probe.searchSessionIds[0], undefined, "archive-wide scan passes no session_id filter");
+  assert.ok(
+    res.results.some((r) => r.content.includes(VICTIM_SECRET)),
+    "single-store owner still reads its archive",
+  );
+});

--- a/packages/remnic-core/src/access-service-lcm-forgery.test.ts
+++ b/packages/remnic-core/src/access-service-lcm-forgery.test.ts
@@ -1,0 +1,314 @@
+/**
+ * #1495 / #1505 P1 (SECURITY): LCM session_id forgery across namespaces.
+ *
+ * `observe` archives each turn under the LCM `session_id`
+ * `lcmSessionKeyForNamespace(effectiveNamespace, sessionKey)`. The LCM archive
+ * (SQLite) filters by `session_id` with an EXACT-equality match
+ * (`session_id = ?`) and `sessionPrefix` with a LIKE prefix match
+ * (`session_id LIKE '<prefix>%'`) — it is keyed by the STRING, NOT physically
+ * partitioned by namespace.
+ *
+ * BEFORE this fix the overlay encoding was `${namespace}:${sessionKey}` and the
+ * default-store path returned the RAW `sessionKey` unchanged. That encoding is
+ * NOT injective with caller-controlled raw session keys: a caller authorized to
+ * read ONLY the `default` store could choose
+ *   sessionKey   = "<victim-overlay-ns>:<victim-session>"   (exact-match vector)
+ *   sessionPrefix = "<victim-overlay-ns>:"                  (LIKE-prefix vector)
+ * which the default-store read path passed through unchanged, producing a
+ * `session_id` / prefix that EXACTLY matched the rows the victim archived under
+ * its overlay — a CROSS-TENANT READ LEAK.
+ *
+ * This suite drives a probe whose `searchContextFull` enforces the SAME match
+ * semantics as the real SQLite archive (exact `session_id`, LIKE `prefix%`)
+ * over a shared row store seeded by the victim's `observe`. It asserts the
+ * attacker (authorized for `default` only) retrieves NONE of the victim's
+ * overlay rows via `lcmSearch` — both the exact-`session_id` and the
+ * `sessionPrefix` forgery vectors — while the legitimate same-principal owner
+ * still reads its own rows.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramAccessService } from "./access-service.js";
+import { Orchestrator } from "./orchestrator.js";
+import type { EngramAccessObserveRequest } from "./access-service.js";
+import type { CodingContext, PluginConfig } from "./types.js";
+
+interface ArchiveRow {
+  session_id: string;
+  content: string;
+  turn_index: number;
+}
+
+interface ForgeryProbe {
+  orch: Orchestrator;
+  contexts: Map<string, CodingContext>;
+  rows: ArchiveRow[];
+  searchSessionIds: Array<string | undefined>;
+  searchSessionPrefixes: Array<string | undefined>;
+}
+
+/**
+ * Build a probe whose LCM engine writes/reads a SHARED row store with the SAME
+ * match semantics as the production SQLite archive:
+ *   - `searchContextFull(query, limit, sessionId, sessionPrefix)`:
+ *       * sessionId present   ⇒ rows where `row.session_id === sessionId`
+ *       * sessionPrefix present ⇒ rows where `row.session_id.startsWith(prefix)`
+ *       * neither              ⇒ ALL rows (archive-wide scan)
+ *   - `enqueueObserveMessages(sessionId, messages)`: append one row per message
+ *     under that exact `session_id`.
+ */
+function makeForgeryProbe(overrides: Partial<PluginConfig> = {}): ForgeryProbe {
+  const contexts = new Map<string, CodingContext>();
+  const rows: ArchiveRow[] = [];
+  const searchSessionIds: Array<string | undefined> = [];
+  const searchSessionPrefixes: Array<string | undefined> = [];
+
+  const config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    defaultRecallNamespaces: ["self", "shared"],
+    codingMode: { projectScope: true },
+    memoryDir: "/synthetic/remnic-lcm-forgery",
+    objectiveStateMemoryEnabled: false,
+    objectiveStateSnapshotWritesEnabled: false,
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    recallCrossNamespaceBudgetEnabled: false,
+    recallCrossNamespaceBudgetWindowMs: 60_000,
+    recallCrossNamespaceBudgetSoftLimit: 10,
+    recallCrossNamespaceBudgetHardLimit: 30,
+    ...overrides,
+  } as unknown as PluginConfig;
+
+  const orch = {
+    config,
+    getCodingContextForSession: (sk: string | undefined) =>
+      (sk ? contexts.get(sk) : null) ?? null,
+    setCodingContextForSession: (sk: string, ctx: CodingContext | null) => {
+      if (ctx === null) contexts.delete(sk);
+      else contexts.set(sk, ctx);
+    },
+    applyCodingNamespaceOverlay: (sk: string | undefined, base: string) =>
+      Orchestrator.prototype.applyCodingNamespaceOverlay.call(orch, sk, base),
+    resolvePrincipal: (sk?: string) =>
+      Orchestrator.prototype.resolvePrincipal.call(orch, sk),
+    resolveSelfNamespace: (sk?: string) =>
+      Orchestrator.prototype.resolveSelfNamespace.call(orch, sk),
+    lcmEngine: {
+      enabled: true,
+      enqueueObserveMessages: (
+        sessionId: string,
+        messages: Array<{ role: string; content: string }>,
+      ) => {
+        for (let i = 0; i < messages.length; i += 1) {
+          rows.push({
+            session_id: sessionId,
+            content: messages[i]!.content,
+            turn_index: i,
+          });
+        }
+      },
+      waitForSessionObserveIdle: async (_sessionKey: string) => {},
+      preCompactionFlush: async (_sessionKey: string) => {},
+      recordCompaction: async () => {},
+      // Mirror the real SQLite archive match semantics (archive.ts):
+      //   session_id = ?           (exact)
+      //   session_id LIKE prefix%  (prefix)
+      searchContextFull: async (
+        _query: string,
+        limit: number,
+        sessionId?: string,
+        sessionPrefix?: string,
+      ) => {
+        searchSessionIds.push(sessionId);
+        searchSessionPrefixes.push(sessionPrefix);
+        let matched = rows;
+        if (typeof sessionId === "string") {
+          matched = matched.filter((r) => r.session_id === sessionId);
+        } else if (typeof sessionPrefix === "string") {
+          matched = matched.filter((r) => r.session_id.startsWith(sessionPrefix));
+        }
+        return matched.slice(0, limit).map((r) => ({
+          id: r.turn_index,
+          turn_index: r.turn_index,
+          role: "assistant",
+          content: r.content,
+          session_id: r.session_id,
+          score: 1,
+        }));
+      },
+    },
+    ingestReplayBatch: async () => {},
+  } as unknown as Orchestrator;
+
+  return { orch, contexts, rows, searchSessionIds, searchSessionPrefixes };
+}
+
+function observeRequest(
+  overrides: Partial<EngramAccessObserveRequest>,
+): EngramAccessObserveRequest {
+  return {
+    sessionKey: "victim",
+    skipExtraction: true,
+    messages: [
+      { role: "user", content: "what is the secret deploy key?" },
+      { role: "assistant", content: "VICTIM SECRET: the deploy key is hunter2" },
+    ],
+    ...overrides,
+  } as EngramAccessObserveRequest;
+}
+
+const VICTIM_SECRET = "VICTIM SECRET: the deploy key is hunter2";
+
+/**
+ * Two principals share the deployment:
+ *   - alice: CAN read+write her self namespace (so she gets a project overlay).
+ *   - mallory: a caller authorized for the `default` store ONLY (no self policy
+ *     entry ⇒ resolves to principal `default`, reads `default`).
+ * `default` is readable so mallory passes the implicit-LCM read gate and the
+ * read collapses to the default store (raw key) — exactly the path the forgery
+ * abuses.
+ */
+function twoTenantConfig(): Partial<PluginConfig> {
+  return {
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+      // `default` readable by anyone (the store mallory is authorized for).
+      { name: "default", readPrincipals: ["*"], writePrincipals: ["*"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "alice:", principal: "alice" }],
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>;
+}
+
+test("#1495 P1 FORGERY BLOCKED: a default-only caller cannot read another tenant's overlay LCM rows via a forged exact session_id", async () => {
+  const probe = makeForgeryProbe(twoTenantConfig());
+  const service = new EngramAccessService(probe.orch);
+
+  // VICTIM (alice) archives a project-scoped turn under her overlay namespace.
+  const victimRes = await service.observe(
+    observeRequest({
+      sessionKey: "alice:s1",
+      projectTag: "Blend/Supply",
+    }),
+  );
+  const victimWriteKey = probe.rows[0]!.session_id;
+  const victimOverlayNs = victimRes.effectiveNamespace;
+  assert.ok(
+    victimOverlayNs && victimOverlayNs.startsWith("alice-"),
+    `victim must archive under her overlay namespace, got ${String(victimOverlayNs)}`,
+  );
+  // Sanity: the victim's own rows are reachable by an exact match on her write key.
+  assert.ok(
+    probe.rows.some((r) => r.session_id === victimWriteKey),
+    "victim rows must be present in the shared archive",
+  );
+
+  // ATTACKER (mallory, default-only) forges a raw sessionKey EQUAL to the victim's
+  // overlay write key string. Under the OLD encoding the default-store read path
+  // returned this raw key unchanged, producing an exact session_id match on the
+  // victim's rows.
+  const forgedSessionKey = victimWriteKey; // e.g. "alice-project-...:alice:s1"
+  const res = await service.lcmSearch({
+    query: "secret deploy key",
+    sessionKey: forgedSessionKey,
+    authenticatedPrincipal: "default",
+  });
+
+  const leaked = res.results.some((r) => r.content.includes(VICTIM_SECRET));
+  assert.equal(
+    leaked,
+    false,
+    `cross-tenant LEAK: default-only caller read the victim's overlay rows via a forged session_id; results=${JSON.stringify(
+      res.results,
+    )}`,
+  );
+  assert.equal(res.count, 0, "forged exact session_id must return NO victim rows");
+});
+
+test("#1495 P1 FORGERY BLOCKED: a default-only caller cannot read another tenant's overlay LCM rows via a forged sessionPrefix (LIKE vector)", async () => {
+  const probe = makeForgeryProbe(twoTenantConfig());
+  const service = new EngramAccessService(probe.orch);
+
+  const victimRes = await service.observe(
+    observeRequest({ sessionKey: "alice:s1", projectTag: "Blend/Supply" }),
+  );
+  const victimOverlayNs = victimRes.effectiveNamespace!;
+  assert.ok(victimOverlayNs.startsWith("alice-"));
+
+  // ATTACKER forges a sessionPrefix that, under the old encoding, LIKE-matched all
+  // of the victim's overlay rows: "<victim-overlay-ns>:". With NO sessionKey the
+  // exact `session_id` filter is absent and the `sessionPrefix` LIKE applies; the
+  // default-store read path passed the prefix through unchanged. (Supplying a
+  // sessionKey would make the archive use the exact `session_id` filter instead,
+  // so the prefix-only form is the true LIKE vector.)
+  const res = await service.lcmSearch({
+    query: "secret deploy key",
+    sessionPrefix: `${victimOverlayNs}:`,
+    authenticatedPrincipal: "default",
+  });
+
+  const leaked = res.results.some((r) => r.content.includes(VICTIM_SECRET));
+  assert.equal(
+    leaked,
+    false,
+    `cross-tenant LEAK via sessionPrefix LIKE: default-only caller matched the victim's overlay rows; results=${JSON.stringify(
+      res.results,
+    )}`,
+  );
+});
+
+test("#1495 P1 LEGITIMATE ACCESS PRESERVED: the victim still reads its OWN overlay rows in the same session", async () => {
+  const probe = makeForgeryProbe(twoTenantConfig());
+  const service = new EngramAccessService(probe.orch);
+
+  // alice archives under her overlay AND binds the coding context to her session.
+  await service.observe(
+    observeRequest({ sessionKey: "alice:s1", projectTag: "Blend/Supply" }),
+  );
+
+  // A same-session lcmSearch by alice (no explicit namespace) must reach her rows:
+  // the read resolves the SAME overlay key the write used.
+  const res = await service.lcmSearch({
+    query: "secret deploy key",
+    sessionKey: "alice:s1",
+    authenticatedPrincipal: "alice",
+  });
+
+  assert.ok(
+    res.results.some((r) => r.content.includes(VICTIM_SECRET)),
+    `legitimate same-principal same-session read must still return alice's own rows; results=${JSON.stringify(
+      res.results,
+    )}`,
+  );
+});
+
+test("#1495 P1 LEGITIMATE ACCESS PRESERVED: a session key that legitimately contains ':' still reads its own rows (single store, no overlay)", async () => {
+  // Single-user / no-overlay deployment: the raw sessionKey is used verbatim as
+  // the LCM key, including embedded ':'. The owner must still read its own rows.
+  const probe = makeForgeryProbe({
+    namespacesEnabled: false,
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await service.observe(
+    observeRequest({ sessionKey: "agent:proj:sess-1", skipExtraction: true }),
+  );
+  // No overlay ⇒ raw key archived verbatim.
+  assert.equal(probe.rows[0]!.session_id, "agent:proj:sess-1");
+
+  const res = await service.lcmSearch({
+    query: "secret deploy key",
+    sessionKey: "agent:proj:sess-1",
+  });
+  assert.ok(
+    res.results.some((r) => r.content.includes(VICTIM_SECRET)),
+    `single-store owner with a ':'-bearing session key must read its own rows; results=${JSON.stringify(
+      res.results,
+    )}`,
+  );
+});

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -1095,19 +1095,18 @@ test("#1505 thread NBHWz (sweep): restrictive `default` READ policy + readable s
   );
 });
 
-test("#1505 cursor 'LCM read gate wrong fallback': overlay applies + self EXCLUDED from recall set + `shared` readable ⇒ lcmSearch collapses to the RAW sessionKey (default store), never `shared:`", async () => {
-  // cursor Medium on the round-7 head: when a coding overlay applies but the
-  // principal self base is excluded from the readable recall set, the implicit
-  // LCM read fallback must collapse to the DEFAULT STORE (raw sessionKey),
-  // EXACTLY like the orchestrator's `lcmReadNamespaceForSession` — NOT an
-  // arbitrary readable recall namespace (e.g. `shared`). Returning `shared` would
-  // prefix LCM reads with `shared:sessionKey` while in-prompt recall uses the raw
-  // `sessionKey`, diverging the two.
+test("#1505 codex P1 'Don't treat any readable namespace as default LCM access': self EXCLUDED from recall + `shared` readable + `default` denied ⇒ lcmSearch SUPPRESSES (never the denied default store, never `shared:`)", async () => {
+  // codex P1 on the round-7 head: my first NBHWz fix treated ANY readable recall
+  // namespace (e.g. `shared`) as license to read the DEFAULT LCM store. But the
+  // implicit LCM read can ONLY target the coding overlay (when the SELF base is
+  // readable-in-recall) or the default store — never `shared`. So when the self
+  // base is NOT readable-in-recall AND `default` is denied, there is NO
+  // authorized LCM target: lcmSearch must SUPPRESS (empty), NOT fall back to the
+  // denied default store (which, sessionless, would scan the whole archive).
   //
   // alice can WRITE her self base (so observe archives under the overlay) but
-  // CANNOT read it, AND `defaultRecallNamespaces` includes `shared` (readable)
-  // but omits `self`. `default` is restrictively unreadable, so the OLD helper
-  // returned `shared`; the fix returns the default store (raw key).
+  // CANNOT read it; `self` is omitted from the recall set; only `shared` is
+  // readable; `default` is restrictively unreadable.
   const probe = makeParityProbe({
     namespacePolicies: [
       // Restrictive default: alice may NOT read `default`.
@@ -1135,21 +1134,57 @@ test("#1505 cursor 'LCM read gate wrong fallback': overlay applies + self EXCLUD
   });
 
   assert.equal(res.lcmEnabled, true);
-  // PROCEED (shared is a readable recall namespace ⇒ not suppressed), but the LCM
-  // prefix collapses to the default store ⇒ the RAW sessionKey.
+  assert.equal(res.count, 0, "no authorized LCM target ⇒ empty results");
+  // SUPPRESS: self unreadable-in-recall AND default denied ⇒ no authorized LCM
+  // target. `searchContextFull` must NEVER run — not against the denied default
+  // store (raw key), not against `shared`, not against alice's unreadable
+  // overlay.
+  assert.equal(
+    probe.searchSessionIds.length,
+    0,
+    "lcmSearch must SUPPRESS (no searchContextFull) — never read the denied default store via a `shared`-only authorization",
+  );
+});
+
+test("#1505 cursor 'LCM read gate wrong fallback' (positive): self READABLE-in-recall but overlay-self gate denies ⇒ lcmSearch uses the raw sessionKey (default store), never `shared:`", async () => {
+  // The complementary case to the codex P1 suppress: when the principal self base
+  // IS readable-in-recall (so PROCEED is authorized) but `default` is restrictively
+  // unreadable, the implicit LCM read still collapses to the DEFAULT STORE raw key
+  // for a session whose overlay does not apply — EXACTLY like the orchestrator's
+  // `lcmReadNamespaceForSession` — and NEVER an arbitrary readable recall namespace
+  // (e.g. `shared`). Here NO coding context is bound, so no overlay applies and the
+  // key is the raw sessionKey.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      // Restrictive default: alice may NOT read `default`.
+      { name: "default", readPrincipals: [], writePrincipals: [] },
+      // alice CAN read AND write her self base.
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    // self IS readable + in the recall set, so PROCEED is authorized.
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // No coding context bound ⇒ no overlay ⇒ the LCM key is the raw sessionKey.
+  const res = await service.lcmSearch({
+    query: "what database are we using?",
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+  });
+
+  assert.equal(res.lcmEnabled, true);
   assert.equal(
     probe.searchSessionIds[0],
     "sess-1",
-    "overlay-unreadable-self ⇒ lcmSearch must query the raw sessionKey (default store), matching the orchestrator",
+    "self-readable PROCEED + no overlay ⇒ lcmSearch queries the raw sessionKey (default store), matching the orchestrator",
   );
   for (const id of probe.searchSessionIds) {
     assert.ok(
       !String(id ?? "").startsWith("shared"),
       `lcmSearch must NOT prefix with the shared recall namespace; got ${String(id)}`,
-    );
-    assert.ok(
-      !String(id ?? "").startsWith("alice-"),
-      `lcmSearch must NOT leak alice's unreadable overlay rows; got ${String(id)}`,
     );
   }
 });
@@ -1181,6 +1216,66 @@ test("#1505 thread NBHWz (sweep): no readable LCM namespace ⇒ lcmSearch return
     probe.searchSessionIds.length,
     0,
     "searchContextFull must NOT be called when no readable LCM namespace exists",
+  );
+});
+
+test("#1505 codex P1 (sessionless archive-scan guard): restrictive `default` READ + readable self but NO sessionKey/sessionPrefix ⇒ lcmSearch SUPPRESSES (no unbounded archive scan)", async () => {
+  // codex P1 defense-in-depth: a sessionless, prefixless `lcmSearch` issues
+  // `searchContextFull(query, limit, undefined, undefined)`, scanning the ENTIRE
+  // LCM archive across every session/namespace. Under a restrictive `default`
+  // READ policy (alice cannot read `default`), that scan exposes the denied
+  // default store's rows. Even though alice's SELF base is readable (so the
+  // implicit fallback PROCEEDs), with NO sessionKey the overlay cannot apply and
+  // the read collapses to the default store — so the sessionless scan must be
+  // SUPPRESSED.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "default", readPrincipals: [], writePrincipals: [] },
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // NO sessionKey, NO sessionPrefix → would otherwise scan the whole archive.
+  const res = await service.lcmSearch({
+    query: "what database are we using?",
+    authenticatedPrincipal: "alice",
+  });
+
+  assert.equal(res.lcmEnabled, true);
+  assert.equal(res.count, 0, "sessionless + denied default ⇒ empty results");
+  assert.equal(
+    probe.searchSessionIds.length,
+    0,
+    "searchContextFull must NOT run an unbounded archive scan against the denied default store",
+  );
+});
+
+test("#1505 codex P1 (sessionless regression): namespaces DISABLED (single-store) + no sessionKey ⇒ lcmSearch still scans the archive (byte-for-byte prior behavior)", async () => {
+  // Regression guard: in a single-store deployment (namespaces disabled, default
+  // always readable), a sessionless `lcmSearch` keeps its prior unbounded
+  // behavior — the P1 guard only fires when the principal cannot read the default
+  // store (i.e. namespaces enabled + a restrictive default policy / unauthenticated
+  // caller).
+  const probe = makeParityProbe({
+    namespacesEnabled: false,
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await service.lcmSearch({ query: "anything" });
+
+  assert.equal(
+    probe.searchSessionIds.length,
+    1,
+    "namespaces disabled + sessionless ⇒ the archive search still runs (byte-for-byte prior behavior)",
+  );
+  assert.equal(
+    probe.searchSessionIds[0],
+    undefined,
+    "sessionless search passes no session_id filter (archive-wide), unchanged",
   );
 });
 

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -978,3 +978,197 @@ test("#1505 round 3 thread 2: lcmSearch still routes through the overlay key whe
     "observe effectiveNamespace must be the alice overlay (sanity)",
   );
 });
+
+test("#1505 thread NBHWs (codex P2): restrictive `default` WRITE policy + writable self ⇒ compaction flush/record the OVERLAY queue (no `not writable: default` throw)", async () => {
+  // The root defect: `lcmCompactionFlush`/`Record` PRE-authorized
+  // `undefined ⇒ config.defaultNamespace` via `resolveWritableNamespace` BEFORE
+  // the scoped write key was computed. Under a deployment whose `default`
+  // namespace has a RESTRICTIVE write policy (alice may NOT write `default`) but
+  // where alice CAN write her self/project overlay, `observe({ projectTag })`
+  // succeeds and archives LCM under `alice-project-*:sess-1` — yet compaction
+  // threw `namespace is not writable: default`, so the queue observe just wrote
+  // could never be flushed or recorded.
+  //
+  // FAIL-BEFORE: both compaction calls throw `namespace is not writable:
+  // default`. PASS-AFTER: compaction derives the namespace through the SAME
+  // write-scoped plan/gate observe uses (`resolveMemoryScopePlan`), authorizes
+  // the writable self base, and flushes/records the overlay key.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      // RESTRICTIVE default: NO principal may write (or read) `default`.
+      { name: "default", readPrincipals: [], writePrincipals: [] },
+      // alice CAN write (and read) her self namespace.
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // observe succeeds under alice's writable self/project overlay even though
+  // `default` is not writable.
+  const observeRes = await service.observe(
+    observeRequest({
+      sessionKey: "sess-1",
+      authenticatedPrincipal: "alice",
+      projectTag: "Blend/Supply",
+    }),
+  );
+  const writeKey = probe.lcmWriteKeys[0];
+  assert.ok(
+    writeKey.startsWith("alice-"),
+    `observe must archive under alice's writable overlay key, got ${writeKey}`,
+  );
+  assert.ok(
+    observeRes.effectiveNamespace?.startsWith("alice-"),
+    "observe effectiveNamespace must be the alice overlay (sanity)",
+  );
+
+  // Compaction must NOT throw `not writable: default` and must target the
+  // overlay queue observe wrote.
+  const flushRes = await service.lcmCompactionFlush({
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+  });
+  const recordRes = await service.lcmCompactionRecord({
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+    tokensBefore: 100,
+    tokensAfter: 10,
+  });
+
+  assert.equal(flushRes.flushed, true, "flush must succeed");
+  assert.equal(recordRes.recorded, true, "record must succeed");
+  assert.equal(
+    probe.compactionFlushKeys[0],
+    writeKey,
+    "compaction flush must target the overlay key observe wrote, not the (unwritable) default key",
+  );
+  assert.equal(
+    probe.compactionRecordKeys[0],
+    writeKey,
+    "compaction record must target the overlay key observe wrote, not the (unwritable) default key",
+  );
+});
+
+test("#1505 thread NBHWz (sweep): restrictive `default` READ policy + readable self ⇒ lcmSearch reads the self/recall-authorized overlay (no `not readable: default` throw)", async () => {
+  // Convergence sweep: `lcmSearch` is the SAME defect class as the raw-excerpt
+  // path — it pre-authorized `undefined ⇒ config.defaultNamespace` via
+  // `resolveReadableNamespace` BEFORE deriving the scoped read namespace. Under a
+  // restrictive `default` READ policy where pi-geek's self namespace IS readable,
+  // normal recall succeeds via `recallNamespacesForPrincipal`, so `lcmSearch`
+  // must too. FAIL-BEFORE: throws `namespace is not readable: default`.
+  // PASS-AFTER: routes through the readable self overlay.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "default", readPrincipals: [], writePrincipals: [] },
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // observe archives under pi-geek's readable+writable project overlay.
+  await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+  const writeKey = probe.lcmWriteKeys[0];
+  assert.ok(
+    writeKey.startsWith("pi-geek-"),
+    `observe must archive under pi-geek's overlay key, got ${writeKey}`,
+  );
+
+  // lcmSearch with NO explicit namespace must NOT throw `not readable: default`
+  // and must route the session_id through the readable overlay key.
+  const res = await service.lcmSearch({
+    query: "what database are we using?",
+    sessionKey: "pi-geek:abc123",
+  });
+  assert.equal(res.lcmEnabled, true);
+  assert.equal(
+    probe.searchSessionIds[0],
+    writeKey,
+    "lcmSearch must route through the readable self overlay key, not pre-authorize the denied default",
+  );
+});
+
+test("#1505 thread NBHWz (sweep): no readable LCM namespace ⇒ lcmSearch returns EMPTY (no `not readable: default` throw)", async () => {
+  // Companion: when NO readable LCM namespace exists for an implicit lcmSearch
+  // (restrictive default READ + unreadable self + self omitted from the recall
+  // set), the search returns EMPTY rather than throwing — `searchContextFull` is
+  // never called.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "default", readPrincipals: [], writePrincipals: [] },
+      { name: "alice", readPrincipals: [], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    defaultRecallNamespaces: [],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.lcmSearch({
+    query: "anything",
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+  });
+  assert.equal(res.lcmEnabled, true);
+  assert.equal(res.count, 0, "no readable LCM namespace ⇒ empty results");
+  assert.equal(
+    probe.searchSessionIds.length,
+    0,
+    "searchContextFull must NOT be called when no readable LCM namespace exists",
+  );
+});
+
+test("#1505 thread NBHWs regression: restrictive `default` WRITE policy + no overlay (writable self) ⇒ compaction still authorizes the self base, no `not writable: default`", async () => {
+  // Companion: even with projectScope OFF (no overlay), an implicit observe by a
+  // principal that can write its self base archives under the default store ONLY
+  // when objective-state writes are off; with objective-state writes enabled the
+  // scope plan authorizes the self base. Here we keep objective-state off (the
+  // probe default) and projectScope off, so the write namespace collapses to the
+  // default store — but `default` is NOT writable. The scope plan's no-overlay
+  // branch still collapses to `config.defaultNamespace` via
+  // `resolveWritableNamespace(undefined)`, which DOES throw when default is
+  // unwritable — matching observe EXACTLY (if observe can't write, there is no
+  // queue to flush). This pins that compaction and observe agree on the throw.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "default", readPrincipals: [], writePrincipals: [] },
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    defaultRecallNamespaces: ["self", "shared"],
+    codingMode: { projectScope: false, branchScope: false, globalFallback: true },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // No overlay ⇒ implicit write collapses to the (unwritable) default store, so
+  // observe itself rejects. Compaction must reject identically (parity), NOT
+  // succeed against a phantom queue.
+  await assert.rejects(
+    () =>
+      service.observe(
+        observeRequest({
+          sessionKey: "sess-1",
+          authenticatedPrincipal: "alice",
+        }),
+      ),
+    /not writable: default/,
+    "no-overlay implicit observe must reject on the unwritable default store",
+  );
+  await assert.rejects(
+    () =>
+      service.lcmCompactionFlush({
+        sessionKey: "sess-1",
+        authenticatedPrincipal: "alice",
+      }),
+    /not writable: default/,
+    "compaction must reject identically to observe when the effective write target is the unwritable default store (parity)",
+  );
+});

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -78,6 +78,10 @@ function makeParityProbe(overrides: Partial<PluginConfig> = {}): ParityProbe {
     defaultNamespace: "default",
     sharedNamespace: "shared",
     namespacePolicies: [],
+    // Production default. The #1505 round-3 read-authorization gate consults
+    // `recallNamespacesForPrincipal`, which reads `defaultRecallNamespaces`;
+    // omitting it would throw. Per-test overrides can still narrow it.
+    defaultRecallNamespaces: ["self", "shared"],
     codingMode: { projectScope: true },
     memoryDir: "/synthetic/remnic-observe-lcm-parity",
     // LCM-only test: keep objective-state off so the storage router is not hit.
@@ -669,4 +673,218 @@ test("#1505 round 3: extraction is pinned to the resolved writeNamespace even wh
     new Set(["pi-geek:abc123"]),
   );
   assert.equal(probe.extractionCalls[0].principalOverride, "pi-geek");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #1505 round 3 (codex P2): READ-AUTHORIZATION gating of the overlay LCM read
+// key. The round-2 parity fix made LCM READS always substitute the principal
+// self-overlay namespace. That bypassed the read-authorization / readable-
+// recall-namespace gating the rest of recall honors, so a principal who can
+// WRITE but NOT READ its self namespace (or whose `defaultRecallNamespaces`
+// omits `self`) would have `<principal>-project-*` overlay rows injected into
+// recall / returned by `lcmSearch` even though QMD/file recall excludes them
+// (cross-tenant read leak). Both sites must gate the overlay substitution by
+// the readable recall namespace set (rule 42 read/write parity; rule 48
+// least-privilege).
+// ──────────────────────────────────────────────────────────────────────────
+
+test("#1505 round 3 thread 1: orchestrator LCM read key falls back to default when the principal can WRITE but not READ its self namespace", async () => {
+  // alice may WRITE her self namespace but NOT read it (readPrincipals omits
+  // alice). A project-scoped observe archives LCM under
+  // `alice-project-*:sess-1`, but a no-namespace recall by alice may NOT inject
+  // those overlay rows — QMD/file recall would exclude `alice` (unreadable), so
+  // the LCM read key MUST collapse to the default store too.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      // WRITE-only self policy: alice can write `alice` but cannot read it.
+      { name: "alice", readPrincipals: [], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>);
+
+  // Bind a coding context to sess-1 so the overlay would apply on alice's base.
+  probe.contexts.set("sess-1", {
+    projectId: "blend-supply",
+    projectName: "Blend/Supply",
+  } as unknown as CodingContext);
+
+  const lcmReadNamespaceForSession = Orchestrator.prototype[
+    "lcmReadNamespaceForSession" as keyof Orchestrator
+  ] as unknown as (
+    this: Orchestrator,
+    sk?: string,
+    principalOverride?: string,
+  ) => string;
+
+  // With the authenticated principal = alice (NOT encoded in sess-1), the
+  // overlay base is `alice`. alice cannot READ `alice`, so the read namespace
+  // MUST fall back to the default store (NOT `alice-project-*`).
+  const readNs = lcmReadNamespaceForSession.call(probe.orch, "sess-1", "alice");
+  assert.equal(
+    readNs,
+    "default",
+    `unreadable self base ⇒ LCM read key must fall back to the default store, got ${readNs}`,
+  );
+  assert.ok(
+    !readNs.startsWith("alice-"),
+    `LCM read key must NOT inject alice's overlay rows when alice cannot read her self namespace, got ${readNs}`,
+  );
+});
+
+test("#1505 round 3 thread 1: orchestrator LCM read key falls back to default when defaultRecallNamespaces omits self", async () => {
+  // alice CAN read her self namespace, but `defaultRecallNamespaces` omits
+  // `self`, so QMD/file recall never includes `alice` for a no-namespace
+  // recall. The overlay LCM read key must mirror that exclusion.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    // Self deliberately omitted from the recall set.
+    defaultRecallNamespaces: ["shared"],
+  } as Partial<PluginConfig>);
+
+  probe.contexts.set("sess-1", {
+    projectId: "blend-supply",
+    projectName: "Blend/Supply",
+  } as unknown as CodingContext);
+
+  const lcmReadNamespaceForSession = Orchestrator.prototype[
+    "lcmReadNamespaceForSession" as keyof Orchestrator
+  ] as unknown as (
+    this: Orchestrator,
+    sk?: string,
+    principalOverride?: string,
+  ) => string;
+
+  const readNs = lcmReadNamespaceForSession.call(probe.orch, "sess-1", "alice");
+  assert.equal(
+    readNs,
+    "default",
+    `self omitted from defaultRecallNamespaces ⇒ overlay LCM read key must fall back to default, got ${readNs}`,
+  );
+});
+
+test("#1505 round 3 thread 1: orchestrator LCM read key still uses the overlay when self IS readable (round-2 positive case preserved)", async () => {
+  // pi-geek can read AND write its self namespace, and `self` is in the recall
+  // set, so the overlay LCM read key must STILL be the project-scoped overlay
+  // (the round-2 parity behavior must stay green).
+  const probe = makeParityProbe({
+    ...withSelfPolicyPrefix("pi-geek"),
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>);
+
+  probe.contexts.set("pi-geek:abc123", {
+    projectId: "blend-supply",
+    projectName: "Blend/Supply",
+  } as unknown as CodingContext);
+
+  const lcmReadNamespaceForSession = Orchestrator.prototype[
+    "lcmReadNamespaceForSession" as keyof Orchestrator
+  ] as unknown as (this: Orchestrator, sk?: string) => string;
+
+  const readNs = lcmReadNamespaceForSession.call(probe.orch, "pi-geek:abc123");
+  assert.ok(
+    readNs.startsWith("pi-geek-"),
+    `readable self ⇒ overlay LCM read key must be the project overlay, got ${readNs}`,
+  );
+  assert.notEqual(readNs, "default");
+});
+
+test("#1505 round 3 thread 2: lcmSearch returns NO overlay rows when the principal cannot read its self base (authorized fallback)", async () => {
+  // alice authenticates and passes the `default` read check, but her policy does
+  // NOT permit reading her self/overlay base (readPrincipals omits alice). A
+  // coding context is bound to the session, so the overlay WOULD apply — but the
+  // read-authorization gate must keep the just-authorized (default) namespace,
+  // so lcmSearch queries the RAW sessionKey, NOT `alice-project-*`.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "alice", readPrincipals: [], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  probe.contexts.set("sess-1", {
+    projectId: "blend-supply",
+    projectName: "Blend/Supply",
+  } as unknown as CodingContext);
+
+  await service.lcmSearch({
+    query: "what database are we using?",
+    sessionKey: "sess-1",
+    sessionPrefix: "alice:",
+    authenticatedPrincipal: "alice",
+  });
+
+  assert.equal(
+    probe.searchSessionIds[0],
+    "sess-1",
+    `unauthorized overlay base ⇒ lcmSearch must query the raw sessionKey, got ${String(
+      probe.searchSessionIds[0],
+    )}`,
+  );
+  assert.ok(
+    !String(probe.searchSessionIds[0] ?? "").startsWith("alice-"),
+    `lcmSearch must NOT return alice-project-* rows to a caller who cannot read the alice namespace; queried: ${JSON.stringify(
+      probe.searchSessionIds,
+    )}`,
+  );
+  // The prefix must NOT carry the overlay namespace either.
+  assert.ok(
+    !String(probe.searchSessionPrefixes[0] ?? "").startsWith("alice-"),
+    `lcmSearch sessionPrefix must NOT carry the alice overlay namespace; got ${String(
+      probe.searchSessionPrefixes[0],
+    )}`,
+  );
+});
+
+test("#1505 round 3 thread 2: lcmSearch still routes through the overlay key when the principal CAN read its self base (round-2 positive case preserved)", async () => {
+  // alice can read AND write her self namespace, so the authorized overlay LCM
+  // read key is honored — lcmSearch routes the session_id through the overlay.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    defaultRecallNamespaces: ["self", "shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // Archive under alice's overlay (binds the coding context to the session).
+  const writeRes = await service.observe(
+    observeRequest({
+      sessionKey: "sess-1",
+      authenticatedPrincipal: "alice",
+      projectTag: "Blend/Supply",
+    }),
+  );
+  const writeKey = probe.lcmWriteKeys[0];
+  assert.ok(
+    writeKey.startsWith("alice-"),
+    `observe must archive under alice's overlay key, got ${writeKey}`,
+  );
+
+  await service.lcmSearch({
+    query: "what database are we using?",
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+  });
+
+  assert.equal(
+    probe.searchSessionIds[0],
+    writeKey,
+    "readable self ⇒ lcmSearch session_id must be the overlay-scoped key matching the write key",
+  );
+  assert.equal(
+    writeRes.effectiveNamespace?.startsWith("alice-"),
+    true,
+    "observe effectiveNamespace must be the alice overlay (sanity)",
+  );
 });

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -1,0 +1,398 @@
+/**
+ * #1505 thread 2 (P1): LCM read/write/compaction key PARITY.
+ *
+ * `observe` archives LCM / structured history under
+ * `${effectiveNamespace}:${sessionKey}` (the scope-plan write namespace). The
+ * LCM archive filters strictly by `session_id`, so a same-session reader and
+ * the compaction flush/record path MUST derive the EXACT same key, or a
+ * project-scoped session misses its own compressed-history / structured /
+ * targeted-fact evidence (and compaction flushes the wrong queue).
+ *
+ * This suite proves the key the WRITER (`observe`) produces equals:
+ *   1. the key the orchestrator recall READERS compute
+ *      (`resolveSelfNamespace(sessionKey)` → `lcmSessionKeyForNamespace`), and
+ *   2. the key the compaction flush/record path computes.
+ * across the scenario matrix:
+ *   (a) explicit namespace
+ *   (b) auto-scoped via cwd (git repo)
+ *   (c) auto-scoped via projectTag
+ *   (d) no overlay (projectScope:false / namespacesEnabled:false) — must stay
+ *       byte-for-byte the raw sessionKey (single-user regression guard).
+ *
+ * It also unit-tests the shared `lcmSessionKeyForNamespace` encoder so the
+ * write/read contract is pinned at the boundary.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { EngramAccessService } from "./access-service.js";
+import { Orchestrator } from "./orchestrator.js";
+import type { EngramAccessObserveRequest } from "./access-service.js";
+import {
+  combineNamespaces,
+  lcmSessionKeyForNamespace,
+  projectNamespaceName,
+  projectTagProjectId,
+} from "./coding/coding-namespace.js";
+import { resolveGitContext } from "./coding/git-context.js";
+import { defaultNamespaceForPrincipal } from "./namespaces/principal.js";
+import type { CodingContext, PluginConfig } from "./types.js";
+
+interface ParityProbe {
+  orch: Orchestrator;
+  contexts: Map<string, CodingContext>;
+  lcmWriteKeys: string[];
+  compactionFlushKeys: string[];
+  compactionRecordKeys: string[];
+}
+
+/**
+ * Build an orchestrator stub that (a) records the LCM archival key `observe`
+ * writes under, (b) records the LCM key the compaction flush/record path
+ * targets, and (c) delegates `resolveSelfNamespace` / `resolvePrincipal` /
+ * `applyCodingNamespaceOverlay` to the REAL Orchestrator prototype so the
+ * reader-side namespace resolution is exercised exactly as production does it.
+ */
+function makeParityProbe(overrides: Partial<PluginConfig> = {}): ParityProbe {
+  const contexts = new Map<string, CodingContext>();
+  const lcmWriteKeys: string[] = [];
+  const compactionFlushKeys: string[] = [];
+  const compactionRecordKeys: string[] = [];
+
+  const config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    codingMode: { projectScope: true },
+    memoryDir: "/synthetic/remnic-observe-lcm-parity",
+    // LCM-only test: keep objective-state off so the storage router is not hit.
+    objectiveStateMemoryEnabled: false,
+    objectiveStateSnapshotWritesEnabled: false,
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    recallCrossNamespaceBudgetEnabled: false,
+    recallCrossNamespaceBudgetWindowMs: 60_000,
+    recallCrossNamespaceBudgetSoftLimit: 10,
+    recallCrossNamespaceBudgetHardLimit: 30,
+    ...overrides,
+  } as unknown as PluginConfig;
+
+  const orch = {
+    config,
+    getCodingContextForSession: (sk: string | undefined) =>
+      (sk ? contexts.get(sk) : null) ?? null,
+    setCodingContextForSession: (sk: string, ctx: CodingContext | null) => {
+      if (ctx === null) contexts.delete(sk);
+      else contexts.set(sk, ctx);
+    },
+    applyCodingNamespaceOverlay: (sk: string | undefined, base: string) =>
+      Orchestrator.prototype.applyCodingNamespaceOverlay.call(orch, sk, base),
+    resolvePrincipal: (sk?: string) =>
+      Orchestrator.prototype.resolvePrincipal.call(orch, sk),
+    resolveSelfNamespace: (sk?: string) =>
+      Orchestrator.prototype.resolveSelfNamespace.call(orch, sk),
+    lcmEngine: {
+      enabled: true,
+      enqueueObserveMessages: (sessionKey: string) => {
+        lcmWriteKeys.push(sessionKey);
+      },
+      waitForSessionObserveIdle: async (_sessionKey: string) => {},
+      preCompactionFlush: async (sessionKey: string) => {
+        compactionFlushKeys.push(sessionKey);
+      },
+      recordCompaction: async (
+        sessionKey: string,
+        _before: number,
+        _after: number,
+      ) => {
+        compactionRecordKeys.push(sessionKey);
+      },
+    },
+    // No extraction side effects needed for LCM parity — skipExtraction below.
+    ingestReplayBatch: async () => {},
+  } as unknown as Orchestrator;
+
+  return {
+    orch,
+    contexts,
+    lcmWriteKeys,
+    compactionFlushKeys,
+    compactionRecordKeys,
+  };
+}
+
+function observeRequest(
+  overrides: Partial<EngramAccessObserveRequest>,
+): EngramAccessObserveRequest {
+  return {
+    sessionKey: "pi-geek:abc123",
+    // skipExtraction keeps this an LCM-only round-trip.
+    skipExtraction: true,
+    messages: [
+      { role: "user", content: "what database are we using?" },
+      { role: "assistant", content: "we use postgres for the primary store" },
+    ],
+    ...overrides,
+  } as EngramAccessObserveRequest;
+}
+
+function withSelfPolicyPrefix(principal: string): Partial<PluginConfig> {
+  return {
+    namespacePolicies: [
+      { name: principal, readPrincipals: [principal], writePrincipals: [principal] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: `${principal}:`, principal }],
+  } as Partial<PluginConfig>;
+}
+
+/**
+ * Reproduce EXACTLY what `orchestrator.recallInternal` computes for the LCM
+ * reader session_id of a same-session bare recall (no explicit namespace
+ * override): the coding-overlay namespace when one applies, else the default
+ * store (NOT the principal self base — that would prefix a namespace an
+ * unqualified observe never wrote to), then encode through the shared helper.
+ * This is the same rule as the orchestrator's private
+ * `lcmReadNamespaceForSession`.
+ */
+function readerLcmKey(probe: ParityProbe, sessionKey: string): string {
+  const principal = (
+    probe.orch as unknown as { resolvePrincipal: (sk?: string) => string | undefined }
+  ).resolvePrincipal(sessionKey);
+  const base = defaultNamespaceForPrincipal(principal, probe.orch.config);
+  const overlaid = (
+    probe.orch as unknown as {
+      applyCodingNamespaceOverlay: (sk: string | undefined, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(sessionKey, base);
+  const effectiveNamespace =
+    overlaid !== base ? overlaid : probe.orch.config.defaultNamespace;
+  return (
+    lcmSessionKeyForNamespace(
+      effectiveNamespace,
+      sessionKey,
+      probe.orch.config.defaultNamespace,
+    ) ?? sessionKey
+  );
+}
+
+test("#1505 thread 2 helper: write/read encoding agrees and collapses to raw key on the default store", () => {
+  // Non-default namespace ⇒ prefixed.
+  assert.equal(lcmSessionKeyForNamespace("acme", "sk", "default"), "acme:sk");
+  // Default namespace ⇒ raw key (single-store byte-for-byte).
+  assert.equal(lcmSessionKeyForNamespace("default", "sk", "default"), "sk");
+  // Undefined namespace ⇒ raw key.
+  assert.equal(lcmSessionKeyForNamespace(undefined, "sk", "default"), "sk");
+  // Empty namespace ⇒ raw key.
+  assert.equal(lcmSessionKeyForNamespace("", "sk", "default"), "sk");
+  // Missing sessionKey is passed through unchanged (recall's `?? "default"`
+  // fallback handles the undefined case downstream).
+  assert.equal(lcmSessionKeyForNamespace("acme", undefined, "default"), undefined);
+});
+
+test("#1505 thread 2 (c) projectTag: observe LCM write key == recall reader key == compaction keys", async () => {
+  const probe = makeParityProbe(withSelfPolicyPrefix("pi-geek"));
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+
+  const expectedNs = combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+  );
+  const expectedKey = `${expectedNs}:pi-geek:abc123`;
+  assert.equal(res.effectiveNamespace, expectedNs);
+  assert.notEqual(expectedNs, "default", "overlay must change the namespace");
+
+  // WRITE key.
+  assert.equal(probe.lcmWriteKeys.length, 1);
+  assert.equal(probe.lcmWriteKeys[0], expectedKey, "LCM write key");
+
+  // READ key (observe attached the coding context, so the reader resolves the
+  // SAME overlay namespace as the writer).
+  assert.equal(
+    readerLcmKey(probe, "pi-geek:abc123"),
+    expectedKey,
+    "recall reader LCM key must equal the observe write key",
+  );
+
+  // COMPACTION keys (no explicit namespace ⇒ overlay applied from session ctx).
+  await service.lcmCompactionFlush({ sessionKey: "pi-geek:abc123" });
+  await service.lcmCompactionRecord({
+    sessionKey: "pi-geek:abc123",
+    tokensBefore: 100,
+    tokensAfter: 10,
+  });
+  assert.equal(probe.compactionFlushKeys[0], expectedKey, "flush key");
+  assert.equal(probe.compactionRecordKeys[0], expectedKey, "record key");
+});
+
+test("#1505 thread 2 (b) cwd git repo: observe LCM write key == recall reader key == compaction keys", async () => {
+  const repoDir = mkdtempSync(join(tmpdir(), "remnic-lcm-parity-git-"));
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: repoDir, stdio: "pipe" });
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  try {
+    const gitCtx = await resolveGitContext(repoDir);
+    assert.ok(gitCtx, "synthetic repo must resolve a git context");
+
+    const probe = makeParityProbe(withSelfPolicyPrefix("pi-geek"));
+    const service = new EngramAccessService(probe.orch);
+
+    const res = await service.observe(
+      observeRequest({ sessionKey: "pi-geek:cwd1", cwd: repoDir }),
+    );
+    const expectedNs = combineNamespaces(
+      "pi-geek",
+      projectNamespaceName(gitCtx!.projectId),
+    );
+    const expectedKey = `${expectedNs}:pi-geek:cwd1`;
+
+    assert.equal(res.effectiveNamespace, expectedNs);
+    assert.equal(probe.lcmWriteKeys[0], expectedKey, "LCM write key");
+    assert.equal(
+      readerLcmKey(probe, "pi-geek:cwd1"),
+      expectedKey,
+      "recall reader LCM key must equal the observe write key",
+    );
+
+    await service.lcmCompactionFlush({ sessionKey: "pi-geek:cwd1" });
+    await service.lcmCompactionRecord({
+      sessionKey: "pi-geek:cwd1",
+      tokensBefore: 100,
+      tokensAfter: 10,
+    });
+    assert.equal(probe.compactionFlushKeys[0], expectedKey, "flush key");
+    assert.equal(probe.compactionRecordKeys[0], expectedKey, "record key");
+  } finally {
+    rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test("#1505 thread 2 (a) explicit namespace: write key prefixed; compaction agrees", async () => {
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "team", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", namespace: "team" }),
+  );
+  assert.equal(res.effectiveNamespace, "team");
+  assert.equal(probe.lcmWriteKeys[0], "team:pi-geek:abc123", "LCM write key");
+
+  // A recall that wants the `team` namespace passes namespace=team; its reader
+  // key is built from that override and agrees with the write key.
+  assert.equal(
+    lcmSessionKeyForNamespace("team", "pi-geek:abc123", "default"),
+    "team:pi-geek:abc123",
+    "explicit-namespace recall reader key matches the write key",
+  );
+
+  // Compaction with the same explicit namespace agrees.
+  await service.lcmCompactionFlush({
+    sessionKey: "pi-geek:abc123",
+    namespace: "team",
+  });
+  await service.lcmCompactionRecord({
+    sessionKey: "pi-geek:abc123",
+    namespace: "team",
+    tokensBefore: 100,
+    tokensAfter: 10,
+  });
+  assert.equal(probe.compactionFlushKeys[0], "team:pi-geek:abc123", "flush key");
+  assert.equal(probe.compactionRecordKeys[0], "team:pi-geek:abc123", "record key");
+});
+
+test("#1505 thread 2 (d) projectScope:false ⇒ raw sessionKey everywhere (single-user regression guard)", async () => {
+  const probe = makeParityProbe({
+    ...withSelfPolicyPrefix("pi-geek"),
+    codingMode: { projectScope: false },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+  // No overlay ⇒ effective namespace is the default store ⇒ raw key.
+  assert.equal(res.effectiveNamespace, "default");
+  assert.equal(probe.lcmWriteKeys[0], "pi-geek:abc123", "raw LCM write key");
+  assert.equal(
+    readerLcmKey(probe, "pi-geek:abc123"),
+    "pi-geek:abc123",
+    "reader key must be the raw sessionKey",
+  );
+
+  await service.lcmCompactionFlush({ sessionKey: "pi-geek:abc123" });
+  await service.lcmCompactionRecord({
+    sessionKey: "pi-geek:abc123",
+    tokensBefore: 100,
+    tokensAfter: 10,
+  });
+  assert.equal(probe.compactionFlushKeys[0], "pi-geek:abc123", "raw flush key");
+  assert.equal(probe.compactionRecordKeys[0], "pi-geek:abc123", "raw record key");
+});
+
+test("#1505 thread 2 (d) namespacesEnabled:false ⇒ raw sessionKey everywhere", async () => {
+  const probe = makeParityProbe({
+    namespacesEnabled: false,
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+  assert.equal(res.effectiveNamespace, "default");
+  assert.equal(probe.lcmWriteKeys[0], "pi-geek:abc123", "raw LCM write key");
+  assert.equal(readerLcmKey(probe, "pi-geek:abc123"), "pi-geek:abc123");
+
+  await service.lcmCompactionFlush({ sessionKey: "pi-geek:abc123" });
+  assert.equal(probe.compactionFlushKeys[0], "pi-geek:abc123", "raw flush key");
+
+  // Defensive: even without a defaultNamespaceForPrincipal policy, the base is
+  // the default store when namespaces are disabled.
+  assert.equal(
+    defaultNamespaceForPrincipal("pi-geek", probe.orch.config),
+    "default",
+  );
+});
+
+test("#1505 thread 2 compaction regression: flush/record overlay-derived key matches observe (pre-fix used base only)", async () => {
+  // Before the fix, compaction flush/record built `${resolveWritableNamespace(
+  // request.namespace)}:${sessionKey}` which, with NO explicit namespace, is
+  // the BASE (config.defaultNamespace) — never the coding overlay. So an
+  // auto-scoped session flushed `pi-geek:abc123` (no overlay) while observe
+  // archived under `pi-geek-project-...:pi-geek:abc123`. This pins that they
+  // now agree.
+  const probe = makeParityProbe(withSelfPolicyPrefix("pi-geek"));
+  const service = new EngramAccessService(probe.orch);
+
+  await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+  await service.lcmCompactionFlush({ sessionKey: "pi-geek:abc123" });
+
+  const observedWriteKey = probe.lcmWriteKeys[0];
+  assert.ok(
+    observedWriteKey.startsWith("pi-geek-"),
+    `observe must archive under the overlay namespace, got ${observedWriteKey}`,
+  );
+  assert.equal(
+    probe.compactionFlushKeys[0],
+    observedWriteKey,
+    "compaction flush must target the overlay key, not the base",
+  );
+});

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -218,9 +218,50 @@ function readerLcmKey(probe: ParityProbe, sessionKey: string): string {
   );
 }
 
+// #1495 P1: reserved structural sentinel framing the namespaced LCM key
+// (`\x1f<namespace>\x1f<sessionKey>`). Kept in sync with
+// `coding-namespace.ts:LCM_NS_SENTINEL`. U+001F cannot occur in a route
+// namespace (`[A-Za-z0-9._-]`) nor any legitimate session key, so the
+// namespaced and default key-spaces are provably disjoint and an overlay id is
+// unforgeable from a caller-controlled raw default-store sessionKey.
+const LCM_NS_SENTINEL = "\u001f";
+
+/**
+ * Encode the expected namespaced LCM `session_id` exactly as production does —
+ * via the shared `lcmSessionKeyForNamespace` helper — so these parity
+ * assertions stay shape-agnostic and never re-hardcode the `:`-join the #1495
+ * P1 fix removed (CLAUDE.md rule 22: never fork the encoding).
+ */
+function encodeNs(namespace: string, sessionKey: string): string {
+  return lcmSessionKeyForNamespace(namespace, sessionKey, "default") ?? sessionKey;
+}
+
+/**
+ * Assert a namespaced LCM write key (new #1495 P1 encoding
+ * `\x1f<overlayNs>\x1f<sessionKey>`) was archived under an overlay namespace
+ * whose name begins with `overlayPrefix` (e.g. `alice-`, `pi-geek-`). Replaces
+ * the pre-#1495 `writeKey.startsWith("<principal>-")`, which no longer holds now
+ * that the key is sentinel-framed.
+ */
+function assertOverlayWriteKey(writeKey: string, overlayPrefix: string): void {
+  assert.ok(
+    writeKey.startsWith(LCM_NS_SENTINEL),
+    `write key must be sentinel-framed, got ${JSON.stringify(writeKey)}`,
+  );
+  const overlayNs = writeKey.slice(LCM_NS_SENTINEL.length).split(LCM_NS_SENTINEL)[0]!;
+  assert.ok(
+    overlayNs.startsWith(overlayPrefix),
+    `overlay namespace must start with ${overlayPrefix}, got ${overlayNs} (key ${JSON.stringify(writeKey)})`,
+  );
+}
+
 test("#1505 thread 2 helper: write/read encoding agrees and collapses to raw key on the default store", () => {
-  // Non-default namespace ⇒ prefixed.
-  assert.equal(lcmSessionKeyForNamespace("acme", "sk", "default"), "acme:sk");
+  // Non-default namespace ⇒ sentinel-framed, NOT `${ns}:${sessionKey}` (#1495 P1
+  // unforgeable encoding).
+  assert.equal(
+    lcmSessionKeyForNamespace("acme", "sk", "default"),
+    `${LCM_NS_SENTINEL}acme${LCM_NS_SENTINEL}sk`,
+  );
   // Default namespace ⇒ raw key (single-store byte-for-byte).
   assert.equal(lcmSessionKeyForNamespace("default", "sk", "default"), "sk");
   // Undefined namespace ⇒ raw key.
@@ -230,6 +271,33 @@ test("#1505 thread 2 helper: write/read encoding agrees and collapses to raw key
   // Missing sessionKey is passed through unchanged (recall's `?? "default"`
   // fallback handles the undefined case downstream).
   assert.equal(lcmSessionKeyForNamespace("acme", undefined, "default"), undefined);
+
+  // #1495 P1 UNFORGEABILITY: a default-store raw sessionKey can NEVER reproduce
+  // another namespace's encoded id, so a forged default read cannot collide with
+  // an overlay write key.
+  const overlayKey = lcmSessionKeyForNamespace("acme", "sk", "default");
+  // The classic forgery: a default-store caller passing the OLD `${ns}:${sk}`
+  // string. Under the new encoding the default path returns it verbatim (it does
+  // not start with the sentinel), which is disjoint from the overlay key-space.
+  const forgedDefaultKey = lcmSessionKeyForNamespace("default", "acme:sk", "default");
+  assert.equal(forgedDefaultKey, "acme:sk");
+  assert.notEqual(
+    forgedDefaultKey,
+    overlayKey,
+    "a forged `${ns}:${sk}` default key must NOT equal the overlay encoded id",
+  );
+  // Even a default sessionKey that itself begins with the sentinel is escaped so
+  // it can never equal an overlay key (whose 2nd char is a namespace char).
+  const sentinelLeadingDefault = lcmSessionKeyForNamespace(
+    "default",
+    `${LCM_NS_SENTINEL}acme${LCM_NS_SENTINEL}sk`,
+    "default",
+  );
+  assert.notEqual(
+    sentinelLeadingDefault,
+    overlayKey,
+    "a sentinel-leading default key must be escaped disjoint from the overlay key-space",
+  );
 });
 
 test("#1505 thread 2 (c) projectTag: observe LCM write key == recall reader key == compaction keys", async () => {
@@ -244,7 +312,7 @@ test("#1505 thread 2 (c) projectTag: observe LCM write key == recall reader key 
     "pi-geek",
     projectNamespaceName(projectTagProjectId("Blend/Supply")),
   );
-  const expectedKey = `${expectedNs}:pi-geek:abc123`;
+  const expectedKey = encodeNs(expectedNs, "pi-geek:abc123");
   assert.equal(res.effectiveNamespace, expectedNs);
   assert.notEqual(expectedNs, "default", "overlay must change the namespace");
 
@@ -292,7 +360,7 @@ test("#1505 thread 2 (b) cwd git repo: observe LCM write key == recall reader ke
       "pi-geek",
       projectNamespaceName(gitCtx!.projectId),
     );
-    const expectedKey = `${expectedNs}:pi-geek:cwd1`;
+    const expectedKey = encodeNs(expectedNs, "pi-geek:cwd1");
 
     assert.equal(res.effectiveNamespace, expectedNs);
     assert.equal(probe.lcmWriteKeys[0], expectedKey, "LCM write key");
@@ -329,13 +397,17 @@ test("#1505 thread 2 (a) explicit namespace: write key prefixed; compaction agre
     observeRequest({ sessionKey: "pi-geek:abc123", namespace: "team" }),
   );
   assert.equal(res.effectiveNamespace, "team");
-  assert.equal(probe.lcmWriteKeys[0], "team:pi-geek:abc123", "LCM write key");
+  assert.equal(
+    probe.lcmWriteKeys[0],
+    encodeNs("team", "pi-geek:abc123"),
+    "LCM write key",
+  );
 
   // A recall that wants the `team` namespace passes namespace=team; its reader
   // key is built from that override and agrees with the write key.
   assert.equal(
     lcmSessionKeyForNamespace("team", "pi-geek:abc123", "default"),
-    "team:pi-geek:abc123",
+    encodeNs("team", "pi-geek:abc123"),
     "explicit-namespace recall reader key matches the write key",
   );
 
@@ -350,8 +422,16 @@ test("#1505 thread 2 (a) explicit namespace: write key prefixed; compaction agre
     tokensBefore: 100,
     tokensAfter: 10,
   });
-  assert.equal(probe.compactionFlushKeys[0], "team:pi-geek:abc123", "flush key");
-  assert.equal(probe.compactionRecordKeys[0], "team:pi-geek:abc123", "record key");
+  assert.equal(
+    probe.compactionFlushKeys[0],
+    encodeNs("team", "pi-geek:abc123"),
+    "flush key",
+  );
+  assert.equal(
+    probe.compactionRecordKeys[0],
+    encodeNs("team", "pi-geek:abc123"),
+    "record key",
+  );
 });
 
 test("#1505 thread 2 (d) projectScope:false ⇒ raw sessionKey everywhere (single-user regression guard)", async () => {
@@ -514,10 +594,7 @@ test("#1505 thread 2: LCM read namespace honors authenticatedPrincipal (write-un
     }),
   );
   const writeKey = probe.lcmWriteKeys[0];
-  assert.ok(
-    writeKey.startsWith("alice-"),
-    `observe must archive under alice's overlay namespace, got ${writeKey}`,
-  );
+  assertOverlayWriteKey(writeKey, "alice-"); // observe must archive under alice's overlay namespace, got ${writeKey}
 
   // The orchestrator's real lcmReadNamespaceForSession (the stub delegates
   // resolvePrincipal/overlay to the prototype).
@@ -545,7 +622,7 @@ test("#1505 thread 2: LCM read namespace honors authenticatedPrincipal (write-un
     "alice",
   );
   assert.equal(
-    `${withOverride}:sess-1`,
+    encodeNs(withOverride, "sess-1"),
     writeKey,
     "authenticated principal override ⇒ read key matches the alice-prefixed write key",
   );
@@ -567,10 +644,7 @@ test("#1505 thread 2 compaction regression: flush/record overlay-derived key mat
   await service.lcmCompactionFlush({ sessionKey: "pi-geek:abc123" });
 
   const observedWriteKey = probe.lcmWriteKeys[0];
-  assert.ok(
-    observedWriteKey.startsWith("pi-geek-"),
-    `observe must archive under the overlay namespace, got ${observedWriteKey}`,
-  );
+  assertOverlayWriteKey(observedWriteKey, "pi-geek-"); // observe must archive under the overlay namespace, got ${observedWriteKey}
   assert.equal(
     probe.compactionFlushKeys[0],
     observedWriteKey,
@@ -592,9 +666,16 @@ test("#1505 round 3: access lcmSearch routes the session_id through the SCOPED (
     observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
   );
   const writeKey = probe.lcmWriteKeys[0];
+  // New #1495 P1 encoding: `\x1f<overlayNs>\x1f<sessionKey>`. Parse the overlay
+  // namespace out of the sentinel frame (the namespace is `\x1f`-free).
   assert.ok(
-    writeKey.startsWith("pi-geek-"),
-    `observe must archive under the overlay key, got ${writeKey}`,
+    writeKey.startsWith(LCM_NS_SENTINEL),
+    `observe must archive under the sentinel-framed overlay key, got ${JSON.stringify(writeKey)}`,
+  );
+  const overlayNs = writeKey.slice(LCM_NS_SENTINEL.length).split(LCM_NS_SENTINEL)[0]!;
+  assert.ok(
+    overlayNs.startsWith("pi-geek-"),
+    `overlay namespace must be pi-geek's project overlay, got ${overlayNs}`,
   );
 
   await service.lcmSearch({
@@ -612,11 +693,11 @@ test("#1505 round 3: access lcmSearch routes the session_id through the SCOPED (
     !probe.searchSessionIds.includes("pi-geek:abc123"),
     `lcmSearch must NOT query the raw sessionKey; queried: ${JSON.stringify(probe.searchSessionIds)}`,
   );
-  // The sessionPrefix is prefixed with the same overlay namespace.
-  const overlayNs = writeKey.slice(0, writeKey.length - ":pi-geek:abc123".length);
+  // The sessionPrefix is framed with the same overlay namespace (so it stays a
+  // valid LIKE-prefix of the overlay full keys).
   assert.equal(
     probe.searchSessionPrefixes[0],
-    `${overlayNs}:pi-geek:`,
+    encodeNs(overlayNs, "pi-geek:"),
     "lcmSearch sessionPrefix must carry the overlay namespace too",
   );
 });
@@ -830,14 +911,14 @@ test("#1505 round 3 thread 2: lcmSearch returns NO overlay rows when the princip
     )}`,
   );
   assert.ok(
-    !String(probe.searchSessionIds[0] ?? "").startsWith("alice-"),
+    !String(probe.searchSessionIds[0] ?? "").includes("alice-"),
     `lcmSearch must NOT return alice-project-* rows to a caller who cannot read the alice namespace; queried: ${JSON.stringify(
       probe.searchSessionIds,
     )}`,
   );
   // The prefix must NOT carry the overlay namespace either.
   assert.ok(
-    !String(probe.searchSessionPrefixes[0] ?? "").startsWith("alice-"),
+    !String(probe.searchSessionPrefixes[0] ?? "").includes("alice-"),
     `lcmSearch sessionPrefix must NOT carry the alice overlay namespace; got ${String(
       probe.searchSessionPrefixes[0],
     )}`,
@@ -874,10 +955,7 @@ test("#1505 round 4 thread (codex P2): compaction flush/record target the OVERLA
     }),
   );
   const writeKey = probe.lcmWriteKeys[0];
-  assert.ok(
-    writeKey.startsWith("alice-"),
-    `observe must archive under alice's overlay key, got ${writeKey}`,
-  );
+  assertOverlayWriteKey(writeKey, "alice-"); // observe must archive under alice's overlay key, got ${writeKey}
 
   await service.lcmCompactionFlush({
     sessionKey: "sess-1",
@@ -956,10 +1034,7 @@ test("#1505 round 3 thread 2: lcmSearch still routes through the overlay key whe
     }),
   );
   const writeKey = probe.lcmWriteKeys[0];
-  assert.ok(
-    writeKey.startsWith("alice-"),
-    `observe must archive under alice's overlay key, got ${writeKey}`,
-  );
+  assertOverlayWriteKey(writeKey, "alice-"); // observe must archive under alice's overlay key, got ${writeKey}
 
   await service.lcmSearch({
     query: "what database are we using?",
@@ -1016,10 +1091,7 @@ test("#1505 thread NBHWs (codex P2): restrictive `default` WRITE policy + writab
     }),
   );
   const writeKey = probe.lcmWriteKeys[0];
-  assert.ok(
-    writeKey.startsWith("alice-"),
-    `observe must archive under alice's writable overlay key, got ${writeKey}`,
-  );
+  assertOverlayWriteKey(writeKey, "alice-"); // observe must archive under alice's writable overlay key, got ${writeKey}
   assert.ok(
     observeRes.effectiveNamespace?.startsWith("alice-"),
     "observe effectiveNamespace must be the alice overlay (sanity)",
@@ -1076,10 +1148,7 @@ test("#1505 thread NBHWz (sweep): restrictive `default` READ policy + readable s
     observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
   );
   const writeKey = probe.lcmWriteKeys[0];
-  assert.ok(
-    writeKey.startsWith("pi-geek-"),
-    `observe must archive under pi-geek's overlay key, got ${writeKey}`,
-  );
+  assertOverlayWriteKey(writeKey, "pi-geek-"); // observe must archive under pi-geek's overlay key, got ${writeKey}
 
   // lcmSearch with NO explicit namespace must NOT throw `not readable: default`
   // and must route the session_id through the readable overlay key.

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -844,6 +844,96 @@ test("#1505 round 3 thread 2: lcmSearch returns NO overlay rows when the princip
   );
 });
 
+test("#1505 round 4 thread (codex P2): compaction flush/record target the OVERLAY key even when the principal can WRITE but not READ its self base", async () => {
+  // The round-3 read-authorization gate is SHARED by lcmCompactionFlush/Record,
+  // but compaction is a WRITE/maintenance op on the queue observe just wrote.
+  // alice can WRITE her self namespace but NOT read it. observe archives under
+  // `alice-project-*:sess-1`; compaction must flush/record that SAME overlay key
+  // (gated by WRITE authorization), NOT fall back to the default/raw key — else
+  // the project-scoped LCM queue is never flushed/recorded.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      // Write-only self policy: alice can write `alice` but cannot read it.
+      { name: "alice", readPrincipals: [], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    // self deliberately omitted from the recall set too — read gate would fall
+    // back, but the WRITE gate must still honour the overlay.
+    defaultRecallNamespaces: ["shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // WRITE: alice observes sess-1 with a project tag → overlay applies on alice's
+  // write-authorized self base.
+  await service.observe(
+    observeRequest({
+      sessionKey: "sess-1",
+      authenticatedPrincipal: "alice",
+      projectTag: "Blend/Supply",
+    }),
+  );
+  const writeKey = probe.lcmWriteKeys[0];
+  assert.ok(
+    writeKey.startsWith("alice-"),
+    `observe must archive under alice's overlay key, got ${writeKey}`,
+  );
+
+  await service.lcmCompactionFlush({
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+  });
+  await service.lcmCompactionRecord({
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+    tokensBefore: 100,
+    tokensAfter: 10,
+  });
+
+  assert.equal(
+    probe.compactionFlushKeys[0],
+    writeKey,
+    "compaction flush must target the overlay key (write-authorized), not the default/raw key",
+  );
+  assert.equal(
+    probe.compactionRecordKeys[0],
+    writeKey,
+    "compaction record must target the overlay key (write-authorized), not the default/raw key",
+  );
+});
+
+test("#1505 round 4 thread (codex P2): a read-only lcmSearch by the SAME write-only principal still does NOT leak the overlay rows (read vs write gate divergence)", async () => {
+  // Companion to the compaction-write-gate test: the SAME write-only, read-denied
+  // principal must STILL get the authorized fallback (raw key) on lcmSearch — the
+  // read gate and the write gate diverge by design.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "alice", readPrincipals: [], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    defaultRecallNamespaces: ["shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  probe.contexts.set("sess-1", {
+    projectId: "blend-supply",
+    projectName: "Blend/Supply",
+  } as unknown as CodingContext);
+
+  await service.lcmSearch({
+    query: "anything",
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+  });
+
+  assert.equal(
+    probe.searchSessionIds[0],
+    "sess-1",
+    "read gate: write-only/read-denied principal must NOT receive alice-project-* rows on lcmSearch",
+  );
+});
+
 test("#1505 round 3 thread 2: lcmSearch still routes through the overlay key when the principal CAN read its self base (round-2 positive case preserved)", async () => {
   // alice can read AND write her self namespace, so the authorized overlay LCM
   // read key is honored — lcmSearch routes the session_id through the overlay.

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -1095,6 +1095,65 @@ test("#1505 thread NBHWz (sweep): restrictive `default` READ policy + readable s
   );
 });
 
+test("#1505 cursor 'LCM read gate wrong fallback': overlay applies + self EXCLUDED from recall set + `shared` readable ⇒ lcmSearch collapses to the RAW sessionKey (default store), never `shared:`", async () => {
+  // cursor Medium on the round-7 head: when a coding overlay applies but the
+  // principal self base is excluded from the readable recall set, the implicit
+  // LCM read fallback must collapse to the DEFAULT STORE (raw sessionKey),
+  // EXACTLY like the orchestrator's `lcmReadNamespaceForSession` — NOT an
+  // arbitrary readable recall namespace (e.g. `shared`). Returning `shared` would
+  // prefix LCM reads with `shared:sessionKey` while in-prompt recall uses the raw
+  // `sessionKey`, diverging the two.
+  //
+  // alice can WRITE her self base (so observe archives under the overlay) but
+  // CANNOT read it, AND `defaultRecallNamespaces` includes `shared` (readable)
+  // but omits `self`. `default` is restrictively unreadable, so the OLD helper
+  // returned `shared`; the fix returns the default store (raw key).
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      // Restrictive default: alice may NOT read `default`.
+      { name: "default", readPrincipals: [], writePrincipals: [] },
+      // alice can WRITE but NOT read her self base.
+      { name: "alice", readPrincipals: [], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    // `shared` is readable + in the recall set; `self` is omitted.
+    defaultRecallNamespaces: ["shared"],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // Bind a coding context so the overlay WOULD apply on alice's base.
+  probe.contexts.set("sess-1", {
+    projectId: "blend-supply",
+    projectName: "Blend/Supply",
+  } as unknown as CodingContext);
+
+  const res = await service.lcmSearch({
+    query: "what database are we using?",
+    sessionKey: "sess-1",
+    authenticatedPrincipal: "alice",
+  });
+
+  assert.equal(res.lcmEnabled, true);
+  // PROCEED (shared is a readable recall namespace ⇒ not suppressed), but the LCM
+  // prefix collapses to the default store ⇒ the RAW sessionKey.
+  assert.equal(
+    probe.searchSessionIds[0],
+    "sess-1",
+    "overlay-unreadable-self ⇒ lcmSearch must query the raw sessionKey (default store), matching the orchestrator",
+  );
+  for (const id of probe.searchSessionIds) {
+    assert.ok(
+      !String(id ?? "").startsWith("shared"),
+      `lcmSearch must NOT prefix with the shared recall namespace; got ${String(id)}`,
+    );
+    assert.ok(
+      !String(id ?? "").startsWith("alice-"),
+      `lcmSearch must NOT leak alice's unreadable overlay rows; got ${String(id)}`,
+    );
+  }
+});
+
 test("#1505 thread NBHWz (sweep): no readable LCM namespace ⇒ lcmSearch returns EMPTY (no `not readable: default` throw)", async () => {
   // Companion: when NO readable LCM namespace exists for an implicit lcmSearch
   // (restrictive default READ + unreadable self + self omitted from the recall

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -48,6 +48,11 @@ interface ParityProbe {
   lcmWriteKeys: string[];
   compactionFlushKeys: string[];
   compactionRecordKeys: string[];
+  extractionCalls: Array<{
+    sessionKeys: string[];
+    writeNamespaceOverride?: string;
+    principalOverride?: string;
+  }>;
 }
 
 /**
@@ -62,6 +67,7 @@ function makeParityProbe(overrides: Partial<PluginConfig> = {}): ParityProbe {
   const lcmWriteKeys: string[] = [];
   const compactionFlushKeys: string[] = [];
   const compactionRecordKeys: string[] = [];
+  const extractionCalls: ParityProbe["extractionCalls"] = [];
 
   const config = {
     namespacesEnabled: true,
@@ -113,8 +119,18 @@ function makeParityProbe(overrides: Partial<PluginConfig> = {}): ParityProbe {
         compactionRecordKeys.push(sessionKey);
       },
     },
-    // No extraction side effects needed for LCM parity — skipExtraction below.
-    ingestReplayBatch: async () => {},
+    // Capture extraction routing/identity so the provenance-principal tests can
+    // assert what `observe` threads into `ingestReplayBatch`.
+    ingestReplayBatch: async (
+      turns: Array<{ sessionKey: string }>,
+      options: { writeNamespaceOverride?: string; principalOverride?: string } = {},
+    ) => {
+      extractionCalls.push({
+        sessionKeys: turns.map((t) => t.sessionKey),
+        writeNamespaceOverride: options.writeNamespaceOverride,
+        principalOverride: options.principalOverride,
+      });
+    },
   } as unknown as Orchestrator;
 
   return {
@@ -123,6 +139,7 @@ function makeParityProbe(overrides: Partial<PluginConfig> = {}): ParityProbe {
     lcmWriteKeys,
     compactionFlushKeys,
     compactionRecordKeys,
+    extractionCalls,
   };
 }
 
@@ -367,6 +384,150 @@ test("#1505 thread 2 (d) namespacesEnabled:false ⇒ raw sessionKey everywhere",
   assert.equal(
     defaultNamespaceForPrincipal("pi-geek", probe.orch.config),
     "default",
+  );
+});
+
+test("#1505 thread 1: extraction provenance principal is the resolved principal (NOT default) for a project-scoped observe with an encoded-principal key", async () => {
+  // Identity-vs-routing separation. A project-scoped observe prefixes the LCM
+  // key with the overlay namespace (`pi-geek-project-...:pi-geek:abc123`). Before
+  // this fix, that prefixed key was ALSO fed to extraction as the turn
+  // sessionKey, so `resolvePrincipal` parsed `pi-geek-project-...` → no prefix
+  // rule match → `default`, mis-attributing provenance. The fix passes the
+  // ORIGINAL sessionKey (identity) plus principalOverride (the resolved
+  // principal) and writeNamespaceOverride (routing).
+  const probe = makeParityProbe(withSelfPolicyPrefix("pi-geek"));
+  const service = new EngramAccessService(probe.orch);
+
+  await service.observe(
+    observeRequest({
+      sessionKey: "pi-geek:abc123",
+      projectTag: "Blend/Supply",
+      skipExtraction: false, // exercise the extraction path
+    }),
+  );
+
+  const expectedNs = combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+  );
+  assert.equal(probe.extractionCalls.length, 1);
+  // Provenance identity: the resolved principal, never a default parsed from the
+  // prefixed key.
+  assert.equal(
+    probe.extractionCalls[0].principalOverride,
+    "pi-geek",
+    "provenance principal must be the resolved principal, not default",
+  );
+  // The extraction turns carry the ORIGINAL session key (identity / threading).
+  assert.deepEqual(
+    new Set(probe.extractionCalls[0].sessionKeys),
+    new Set(["pi-geek:abc123"]),
+    "extraction turns must carry the ORIGINAL un-prefixed session key",
+  );
+  // Storage routing is pinned to the effective overlay namespace.
+  assert.equal(probe.extractionCalls[0].writeNamespaceOverride, expectedNs);
+});
+
+test("#1505 thread 1: provenance principal honors authenticatedPrincipal not encoded in the session key", async () => {
+  // alice authenticates at the transport layer but the raw sessionKey ("sess-1")
+  // encodes no principal. The scope plan resolves principal=alice (auth
+  // precedence), so extraction provenance must be pinned to alice — independent
+  // of what `resolvePrincipal("sess-1")` would parse (default).
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await service.observe(
+    observeRequest({
+      sessionKey: "sess-1",
+      authenticatedPrincipal: "alice",
+      skipExtraction: false,
+    }),
+  );
+
+  assert.equal(probe.extractionCalls.length, 1);
+  assert.equal(
+    probe.extractionCalls[0].principalOverride,
+    "alice",
+    "provenance principal must honor the authenticated principal",
+  );
+  assert.deepEqual(
+    new Set(probe.extractionCalls[0].sessionKeys),
+    new Set(["sess-1"]),
+    "extraction turns carry the original session key",
+  );
+});
+
+test("#1505 thread 2: LCM read namespace honors authenticatedPrincipal (write-under-alice ⇒ read-under-alice)", async () => {
+  // alice authenticates at the transport layer but is NOT encoded in the raw
+  // sessionKey ("sess-1"). With a PROJECT overlay, observe archives LCM under
+  // `combineNamespaces("alice", project):sess-1`. A same-session recall that
+  // supplies the SAME authenticated principal (principalOverride) must derive the
+  // base = alice so the overlay namespace — and thus the LCM read key — matches
+  // the write. Without the override, `lcmReadNamespaceForSession` derives the
+  // base from `resolvePrincipal("sess-1")` → default, so the overlay would be
+  // `combineNamespaces("default", project)` and the reader would MISS alice's
+  // evidence (the thread-2 bug).
+  // makeParityProbe defaults codingMode to { projectScope: true }; alice is NOT
+  // encoded in any prefix rule, so resolvePrincipal("sess-1") → default.
+  const probe = makeParityProbe({
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  // WRITE: alice observes sess-1 with a project tag → overlay applies on alice's
+  // self base. (No explicit namespace.)
+  await service.observe(
+    observeRequest({
+      sessionKey: "sess-1",
+      authenticatedPrincipal: "alice",
+      projectTag: "Blend/Supply",
+    }),
+  );
+  const writeKey = probe.lcmWriteKeys[0];
+  assert.ok(
+    writeKey.startsWith("alice-"),
+    `observe must archive under alice's overlay namespace, got ${writeKey}`,
+  );
+
+  // The orchestrator's real lcmReadNamespaceForSession (the stub delegates
+  // resolvePrincipal/overlay to the prototype).
+  const lcmReadNamespaceForSession = Orchestrator.prototype[
+    "lcmReadNamespaceForSession" as keyof Orchestrator
+  ] as unknown as (
+    this: Orchestrator,
+    sk?: string,
+    principalOverride?: string,
+  ) => string;
+
+  // Without the override, the base derives from resolvePrincipal("sess-1") →
+  // default, so the read namespace is the DEFAULT-based overlay (the bug).
+  const withoutOverride = lcmReadNamespaceForSession.call(probe.orch, "sess-1");
+  assert.ok(
+    !withoutOverride.startsWith("alice-"),
+    `without override the read base must NOT be alice (demonstrates the bug), got ${withoutOverride}`,
+  );
+
+  // With the authenticated principal override, the read base is alice → the read
+  // namespace matches the write namespace, so the read key matches the write key.
+  const withOverride = lcmReadNamespaceForSession.call(
+    probe.orch,
+    "sess-1",
+    "alice",
+  );
+  assert.equal(
+    `${withOverride}:sess-1`,
+    writeKey,
+    "authenticated principal override ⇒ read key matches the alice-prefixed write key",
   );
 });
 

--- a/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
+++ b/packages/remnic-core/src/access-service-observe-lcm-parity.test.ts
@@ -48,6 +48,8 @@ interface ParityProbe {
   lcmWriteKeys: string[];
   compactionFlushKeys: string[];
   compactionRecordKeys: string[];
+  searchSessionIds: Array<string | undefined>;
+  searchSessionPrefixes: Array<string | undefined>;
   extractionCalls: Array<{
     sessionKeys: string[];
     writeNamespaceOverride?: string;
@@ -67,6 +69,8 @@ function makeParityProbe(overrides: Partial<PluginConfig> = {}): ParityProbe {
   const lcmWriteKeys: string[] = [];
   const compactionFlushKeys: string[] = [];
   const compactionRecordKeys: string[] = [];
+  const searchSessionIds: Array<string | undefined> = [];
+  const searchSessionPrefixes: Array<string | undefined> = [];
   const extractionCalls: ParityProbe["extractionCalls"] = [];
 
   const config = {
@@ -118,6 +122,16 @@ function makeParityProbe(overrides: Partial<PluginConfig> = {}): ParityProbe {
       ) => {
         compactionRecordKeys.push(sessionKey);
       },
+      searchContextFull: async (
+        _query: string,
+        _limit: number,
+        sessionId?: string,
+        sessionPrefix?: string,
+      ) => {
+        searchSessionIds.push(sessionId);
+        searchSessionPrefixes.push(sessionPrefix);
+        return [];
+      },
     },
     // Capture extraction routing/identity so the provenance-principal tests can
     // assert what `observe` threads into `ingestReplayBatch`.
@@ -139,6 +153,8 @@ function makeParityProbe(overrides: Partial<PluginConfig> = {}): ParityProbe {
     lcmWriteKeys,
     compactionFlushKeys,
     compactionRecordKeys,
+    searchSessionIds,
+    searchSessionPrefixes,
     extractionCalls,
   };
 }
@@ -556,4 +572,101 @@ test("#1505 thread 2 compaction regression: flush/record overlay-derived key mat
     observedWriteKey,
     "compaction flush must target the overlay key, not the base",
   );
+});
+
+test("#1505 round 3: access lcmSearch routes the session_id through the SCOPED (overlay) key", async () => {
+  // cursor "LCM search misses overlay keys" / codex "Route access LCM search
+  // through the scoped key". A project-scoped observe (no explicit namespace)
+  // archives under `${overlayNs}:${sessionKey}` and binds the coding context to
+  // the session. A subsequent lcmSearch({ sessionKey }) with NO explicit
+  // namespace must search under the SAME overlay key — not the raw sessionKey —
+  // or it misses the turns just archived.
+  const probe = makeParityProbe(withSelfPolicyPrefix("pi-geek"));
+  const service = new EngramAccessService(probe.orch);
+
+  await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+  const writeKey = probe.lcmWriteKeys[0];
+  assert.ok(
+    writeKey.startsWith("pi-geek-"),
+    `observe must archive under the overlay key, got ${writeKey}`,
+  );
+
+  await service.lcmSearch({
+    query: "what database are we using?",
+    sessionKey: "pi-geek:abc123",
+    sessionPrefix: "pi-geek:",
+  });
+
+  assert.equal(
+    probe.searchSessionIds[0],
+    writeKey,
+    "lcmSearch session_id must be the overlay-scoped key, matching the write key",
+  );
+  assert.ok(
+    !probe.searchSessionIds.includes("pi-geek:abc123"),
+    `lcmSearch must NOT query the raw sessionKey; queried: ${JSON.stringify(probe.searchSessionIds)}`,
+  );
+  // The sessionPrefix is prefixed with the same overlay namespace.
+  const overlayNs = writeKey.slice(0, writeKey.length - ":pi-geek:abc123".length);
+  assert.equal(
+    probe.searchSessionPrefixes[0],
+    `${overlayNs}:pi-geek:`,
+    "lcmSearch sessionPrefix must carry the overlay namespace too",
+  );
+});
+
+test("#1505 round 3: lcmSearch on a single-store / no-overlay session keeps the raw key (regression guard)", async () => {
+  const probe = makeParityProbe({
+    ...withSelfPolicyPrefix("pi-geek"),
+    codingMode: { projectScope: false },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await service.lcmSearch({
+    query: "anything",
+    sessionKey: "pi-geek:abc123",
+  });
+  assert.equal(
+    probe.searchSessionIds[0],
+    "pi-geek:abc123",
+    "no overlay ⇒ lcmSearch searches the raw sessionKey (byte-for-byte preserved)",
+  );
+});
+
+test("#1505 round 3: extraction is pinned to the resolved writeNamespace even when it equals the default store", async () => {
+  // codex "Pin default-store extraction writes too". An unqualified observe by a
+  // principal that HAS a self namespace resolves writeNamespace ==
+  // config.defaultNamespace (general path) but, left unpinned, runExtraction
+  // would fall back to defaultNamespaceForPrincipal(principal) == the SELF
+  // namespace — diverging from LCM/objective-state/response. With namespaces
+  // enabled, observe must pin writeNamespaceOverride = writeNamespace (= default)
+  // so every side effect lands in ONE namespace.
+  const probe = makeParityProbe({
+    ...withSelfPolicyPrefix("pi-geek"),
+    // No overlay so writeNamespace collapses to config.defaultNamespace.
+    codingMode: { projectScope: false },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await service.observe(
+    observeRequest({
+      sessionKey: "pi-geek:abc123",
+      skipExtraction: false, // exercise extraction
+    }),
+  );
+
+  assert.equal(probe.extractionCalls.length, 1);
+  assert.equal(
+    probe.extractionCalls[0].writeNamespaceOverride,
+    "default",
+    "extraction must be pinned to the default store, not left to fall back to the principal self namespace",
+  );
+  // Identity is still the original key + resolved principal.
+  assert.deepEqual(
+    new Set(probe.extractionCalls[0].sessionKeys),
+    new Set(["pi-geek:abc123"]),
+  );
+  assert.equal(probe.extractionCalls[0].principalOverride, "pi-geek");
 });

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -37,11 +37,21 @@ import { Orchestrator } from "./orchestrator.js";
 import type { EngramAccessObserveRequest } from "./access-service.js";
 import {
   combineNamespaces,
+  lcmSessionKeyForNamespace,
   projectNamespaceName,
   projectTagProjectId,
 } from "./coding/coding-namespace.js";
 import { resolveGitContext } from "./coding/git-context.js";
 import type { CodingContext, PluginConfig } from "./types.js";
+
+/**
+ * Encode the expected namespaced LCM `session_id` via the SAME shared helper
+ * production uses, so these assertions stay shape-agnostic after the #1495 P1
+ * fix made the namespaced encoding sentinel-framed and unforgeable (rule 22).
+ */
+function encodeNs(namespace: string, sessionKey: string): string {
+  return lcmSessionKeyForNamespace(namespace, sessionKey, "default") ?? sessionKey;
+}
 
 interface ObserveProbe {
   orch: Orchestrator;
@@ -168,7 +178,7 @@ test("#1495 projectTag: LCM, extraction, objective-state, and response all agree
   assert.equal(probe.lcmCalls.length, 1);
   assert.equal(
     probe.lcmCalls[0].sessionKey,
-    `${expected}:pi-geek:abc123`,
+    encodeNs(expected, "pi-geek:abc123"),
     "LCM key must be prefixed with the EFFECTIVE write namespace",
   );
 
@@ -228,7 +238,7 @@ test("#1495 cwd (git repo): every observe side effect agrees on the effective na
     );
 
     assert.equal(res.effectiveNamespace, expected);
-    assert.equal(probe.lcmCalls[0].sessionKey, `${expected}:pi-geek:cwd1`);
+    assert.equal(probe.lcmCalls[0].sessionKey, encodeNs(expected, "pi-geek:cwd1"));
     // #1505 thread 1: extraction turns carry the ORIGINAL session key (identity);
     // routing + provenance are pinned via the override options.
     assert.deepEqual(
@@ -262,7 +272,7 @@ test("#1495 explicit namespace wins and project context does NOT silently overri
   );
 
   assert.equal(res.effectiveNamespace, "team", "explicit namespace must win");
-  assert.equal(probe.lcmCalls[0].sessionKey, "team:pi-geek:abc123");
+  assert.equal(probe.lcmCalls[0].sessionKey, encodeNs("team", "pi-geek:abc123"));
   assert.equal(probe.extractionCalls[0].writeNamespaceOverride, "team");
   // #1505 thread 1: extraction turns carry the ORIGINAL session key (identity),
   // even with an explicit namespace; routing is pinned via writeNamespaceOverride.
@@ -585,5 +595,5 @@ test("#1495 skipExtraction does not enqueue extraction but still archives LCM un
   );
   assert.equal(res.extractionQueued, false);
   assert.equal(probe.extractionCalls.length, 0);
-  assert.equal(probe.lcmCalls[0].sessionKey, `${expected}:pi-geek:abc123`);
+  assert.equal(probe.lcmCalls[0].sessionKey, encodeNs(expected, "pi-geek:abc123"));
 });

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -279,7 +279,7 @@ test("#1495 projectScope:false ⇒ no overlay (unqualified write stays on config
   // stays on config.defaultNamespace — exactly the pre-#1434 / memory_store
   // behavior for an unqualified write (rule 39: identical across paths). It must
   // NOT be silently moved to the principal self namespace. lcmSessionKey carries
-  // no prefix (effective == default), and no extraction override is needed.
+  // no prefix (effective == default).
   const probe = makeObserveProbe({
     ...withSelfPolicyPrefix("pi-geek"),
     codingMode: { projectScope: false },
@@ -293,7 +293,14 @@ test("#1495 projectScope:false ⇒ no overlay (unqualified write stays on config
   assert.equal(res.effectiveNamespace, "default");
   assert.equal(res.scopeDebug!.codingOverlayApplied, false);
   assert.equal(probe.lcmCalls[0].sessionKey, "pi-geek:abc123");
-  assert.equal(probe.extractionCalls[0].writeNamespaceOverride, undefined);
+  // #1505 round 3 (codex "Pin default-store extraction writes too"): with
+  // namespaces ENABLED, extraction must be pinned to the resolved writeNamespace
+  // (config.defaultNamespace here) even though it equals the default store —
+  // otherwise an unpinned runExtraction would fall back to
+  // defaultNamespaceForPrincipal("pi-geek") == "pi-geek" (the SELF namespace),
+  // diverging from where LCM/objective-state/response wrote ("default"). Pinning
+  // forces every side effect onto the one scope-plan namespace.
+  assert.equal(probe.extractionCalls[0].writeNamespaceOverride, "default");
 });
 
 test("#1495 namespacesEnabled:false ⇒ single-store behavior preserved", async () => {

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -490,6 +490,42 @@ test("#1495 scopeDebug exposes the resolved plan for callers/tests", async () =>
   assert.equal(res.scopeDebug!.codingOverlayApplied, true);
 });
 
+test("#1505 (cursor hAp) scopeDebug.baseNamespace reports the principal self base on the implicit no-overlay path", async () => {
+  // Regression for the round-4 cursor "Wrong scopeDebug base namespace" thread.
+  // Implicit (no explicit namespace) + projectScope OFF ⇒ the no-overlay branch
+  // of resolveMemoryScopePlan runs: the general write namespace collapses to
+  // config.defaultNamespace ("default") for memory_store parity (rule 39), but
+  // the plan's diagnostic baseNamespace must report the principal SELF base
+  // ("pi-geek" via defaultNamespaceForPrincipal) — the same base
+  // objectiveStateNamespace already targets — NOT the write namespace. Before the
+  // fix, scopeDebug.baseNamespace misstated the self base as "default".
+  const probe = makeObserveProbe({
+    ...withSelfPolicyPrefix("pi-geek"),
+    codingMode: { projectScope: false },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123" }),
+  );
+
+  assert.ok(res.scopeDebug, "scopeDebug must be present");
+  assert.equal(
+    res.scopeDebug!.codingOverlayApplied,
+    false,
+    "no overlay on this path",
+  );
+  // Write/effective namespace collapses to the default store (memory_store parity)…
+  assert.equal(res.scopeDebug!.writeNamespace, "default");
+  assert.equal(res.effectiveNamespace, "default");
+  // …but the diagnostic base must be the principal SELF base, not the write ns.
+  assert.equal(
+    res.scopeDebug!.baseNamespace,
+    "pi-geek",
+    "scopeDebug.baseNamespace must be the principal self base on the implicit no-overlay path",
+  );
+});
+
 test("#1495 the scope plan's writeNamespace matches resolveCodingScopedWriteNamespace (memory_store / suggestion_submit parity, rule 39)", async () => {
   // Regression guard: observe's effective scope MUST be identical to what the
   // explicit-write tools (memory_store / suggestion_submit) resolve via

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -1,0 +1,402 @@
+/**
+ * #1495: `observe` must resolve EVERY memory-producing side effect through ONE
+ * effective scope plan, so observed turns and extracted memories land in the
+ * SAME namespace that same-session project-scoped recall searches.
+ *
+ * Before this change, `observe`:
+ *  - applied the coding overlay to the objective-state snapshot target, but
+ *  - keyed LCM archival (`lcmSessionKey`) and extraction replay turns off the
+ *    EARLIER base namespace (`resolveWritableNamespace(undefined, …)` ==
+ *    `config.defaultNamespace`), and
+ *  - returned the base namespace in the response.
+ *
+ * The fix introduces an internal `MemoryScopePlan` resolver. `observe` consumes
+ * it so the LCM key, the extraction write target, the objective-state target,
+ * and the response `effectiveNamespace` all agree.
+ *
+ * Invariants verified here (rule 39 / 42 / 47 / 48 / 51):
+ *  - Agreement: LCM key, extraction writeNamespaceOverride, objective-state
+ *    target, and response.effectiveNamespace ALL == scope.writeNamespace, and
+ *    that equals what a same-session project-scoped resolve produces.
+ *  - Explicit namespace wins and is NOT silently overridden by project context.
+ *  - No sessionKey ⇒ no overlay (observe requires a sessionKey, so this is the
+ *    explicit-namespace / namespaces-disabled equivalents).
+ *  - `codingMode.projectScope: false` ⇒ no overlay.
+ *  - `namespacesEnabled: false` ⇒ single-store behavior preserved.
+ *  - Unauthorized explicit namespace throws BEFORE any session-context mutation.
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { EngramAccessService } from "./access-service.js";
+import { Orchestrator } from "./orchestrator.js";
+import type { EngramAccessObserveRequest } from "./access-service.js";
+import {
+  combineNamespaces,
+  projectNamespaceName,
+  projectTagProjectId,
+} from "./coding/coding-namespace.js";
+import { resolveGitContext } from "./coding/git-context.js";
+import type { CodingContext, PluginConfig } from "./types.js";
+
+interface ObserveProbe {
+  orch: Orchestrator;
+  contexts: Map<string, CodingContext>;
+  lcmCalls: Array<{ sessionKey: string }>;
+  extractionCalls: Array<{
+    sessionKeys: string[];
+    writeNamespaceOverride?: string;
+  }>;
+  objectiveStateNamespaces: string[];
+}
+
+/**
+ * Build an orchestrator stub wired to record every namespace-bearing side
+ * effect `observe` produces: LCM enqueue, extraction replay, and the storage
+ * router lookup that the objective-state snapshot writer goes through.
+ */
+function makeObserveProbe(overrides: Partial<PluginConfig> = {}): ObserveProbe {
+  const contexts = new Map<string, CodingContext>();
+  const lcmCalls: ObserveProbe["lcmCalls"] = [];
+  const extractionCalls: ObserveProbe["extractionCalls"] = [];
+  const objectiveStateNamespaces: string[] = [];
+
+  const config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    codingMode: { projectScope: true },
+    memoryDir: "/synthetic/remnic-observe-scope",
+    objectiveStateMemoryEnabled: true,
+    objectiveStateSnapshotWritesEnabled: true,
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    recallCrossNamespaceBudgetEnabled: false,
+    recallCrossNamespaceBudgetWindowMs: 60_000,
+    recallCrossNamespaceBudgetSoftLimit: 10,
+    recallCrossNamespaceBudgetHardLimit: 30,
+    ...overrides,
+  } as unknown as PluginConfig;
+
+  const orch = {
+    config,
+    getCodingContextForSession: (sk: string | undefined) =>
+      (sk ? contexts.get(sk) : null) ?? null,
+    setCodingContextForSession: (sk: string, ctx: CodingContext | null) => {
+      if (ctx === null) contexts.delete(sk);
+      else contexts.set(sk, ctx);
+    },
+    applyCodingNamespaceOverlay: (sk: string | undefined, base: string) =>
+      Orchestrator.prototype.applyCodingNamespaceOverlay.call(orch, sk, base),
+    // The objective-state snapshot writer goes through getStorage(namespace).
+    // Capturing the namespace it resolves lets us assert the objective-state
+    // target without touching the filesystem.
+    getStorage: async (ns: string) => {
+      objectiveStateNamespaces.push(ns);
+      return { dir: `/synthetic/storage/${ns}` };
+    },
+    lcmEngine: {
+      enabled: true,
+      enqueueObserveMessages: (sessionKey: string) => {
+        lcmCalls.push({ sessionKey });
+      },
+    },
+    ingestReplayBatch: async (
+      turns: Array<{ sessionKey: string }>,
+      options: { writeNamespaceOverride?: string } = {},
+    ) => {
+      extractionCalls.push({
+        sessionKeys: turns.map((t) => t.sessionKey),
+        writeNamespaceOverride: options.writeNamespaceOverride,
+      });
+    },
+  } as unknown as Orchestrator;
+
+  return { orch, contexts, lcmCalls, extractionCalls, objectiveStateNamespaces };
+}
+
+function observeRequest(
+  overrides: Partial<EngramAccessObserveRequest>,
+): EngramAccessObserveRequest {
+  return {
+    sessionKey: "sess-observe",
+    messages: [
+      { role: "user", content: "what database are we using?" },
+      { role: "assistant", content: "we use postgres for the primary store" },
+    ],
+    ...overrides,
+  } as EngramAccessObserveRequest;
+}
+
+/** A principal whose self namespace exists, so the overlay base is non-default. */
+function withSelfPolicyPrefix(principal: string): Partial<PluginConfig> {
+  return {
+    namespacePolicies: [
+      { name: principal, readPrincipals: [principal], writePrincipals: [principal] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: `${principal}:`, principal }],
+  } as Partial<PluginConfig>;
+}
+
+test("#1495 projectTag: LCM, extraction, objective-state, and response all agree on the effective namespace", async () => {
+  const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+
+  // Effective write namespace == principal self base overlaid with the project,
+  // EXACTLY what a same-session project-scoped recall/store resolves.
+  const expected = combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+  );
+
+  assert.equal(res.effectiveNamespace, expected, "response effectiveNamespace");
+  assert.notEqual(expected, "default", "overlay must change the namespace");
+
+  // LCM archival key carries the effective namespace prefix.
+  assert.equal(probe.lcmCalls.length, 1);
+  assert.equal(
+    probe.lcmCalls[0].sessionKey,
+    `${expected}:pi-geek:abc123`,
+    "LCM key must be prefixed with the EFFECTIVE write namespace",
+  );
+
+  // Extraction replay turns key off the effective namespace and pin the write.
+  assert.equal(probe.extractionCalls.length, 1);
+  assert.deepEqual(
+    new Set(probe.extractionCalls[0].sessionKeys),
+    new Set([`${expected}:pi-geek:abc123`]),
+    "extraction replay turns must carry the effective-namespace session key",
+  );
+  assert.equal(
+    probe.extractionCalls[0].writeNamespaceOverride,
+    expected,
+    "extraction must pin the write to the effective namespace",
+  );
+
+  // Objective-state snapshot target == effective namespace.
+  assert.ok(
+    probe.objectiveStateNamespaces.every((ns) => ns === expected),
+    `objective-state target must be the effective namespace, got ${JSON.stringify(probe.objectiveStateNamespaces)}`,
+  );
+});
+
+test("#1495 cwd (git repo): every observe side effect agrees on the effective namespace", async () => {
+  const repoDir = mkdtempSync(join(tmpdir(), "remnic-observe-git-"));
+  // A real (synthetic) git repo so resolveGitContext can read rev-parse output.
+  // No remote/commit needed — projectId derives from the resolved root path.
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: repoDir, stdio: "pipe" });
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  try {
+    const gitCtx = await resolveGitContext(repoDir);
+    assert.ok(gitCtx, "synthetic repo must resolve a git context");
+
+    const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
+    const service = new EngramAccessService(probe.orch);
+
+    const res = await service.observe(
+      observeRequest({ sessionKey: "pi-geek:cwd1", cwd: repoDir }),
+    );
+
+    const expected = combineNamespaces(
+      "pi-geek",
+      projectNamespaceName(gitCtx!.projectId),
+    );
+
+    assert.equal(res.effectiveNamespace, expected);
+    assert.equal(probe.lcmCalls[0].sessionKey, `${expected}:pi-geek:cwd1`);
+    assert.deepEqual(
+      new Set(probe.extractionCalls[0].sessionKeys),
+      new Set([`${expected}:pi-geek:cwd1`]),
+    );
+    assert.equal(probe.extractionCalls[0].writeNamespaceOverride, expected);
+    assert.ok(probe.objectiveStateNamespaces.every((ns) => ns === expected));
+  } finally {
+    rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test("#1495 explicit namespace wins and project context does NOT silently override it", async () => {
+  const probe = makeObserveProbe({
+    namespacePolicies: [
+      { name: "team", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({
+      sessionKey: "pi-geek:abc123",
+      namespace: "team",
+      projectTag: "Blend/Supply",
+    }),
+  );
+
+  assert.equal(res.effectiveNamespace, "team", "explicit namespace must win");
+  assert.equal(probe.lcmCalls[0].sessionKey, "team:pi-geek:abc123");
+  assert.equal(probe.extractionCalls[0].writeNamespaceOverride, "team");
+  assert.deepEqual(
+    new Set(probe.extractionCalls[0].sessionKeys),
+    new Set(["team:pi-geek:abc123"]),
+  );
+  assert.ok(probe.objectiveStateNamespaces.every((ns) => ns === "team"));
+});
+
+test("#1495 projectScope:false ⇒ no overlay (unqualified write stays on config.defaultNamespace)", async () => {
+  // With projectScope off there is NO coding overlay, so an unqualified observe
+  // stays on config.defaultNamespace — exactly the pre-#1434 / memory_store
+  // behavior for an unqualified write (rule 39: identical across paths). It must
+  // NOT be silently moved to the principal self namespace. lcmSessionKey carries
+  // no prefix (effective == default), and no extraction override is needed.
+  const probe = makeObserveProbe({
+    ...withSelfPolicyPrefix("pi-geek"),
+    codingMode: { projectScope: false },
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+
+  assert.equal(res.effectiveNamespace, "default");
+  assert.equal(res.scopeDebug!.codingOverlayApplied, false);
+  assert.equal(probe.lcmCalls[0].sessionKey, "pi-geek:abc123");
+  assert.equal(probe.extractionCalls[0].writeNamespaceOverride, undefined);
+});
+
+test("#1495 namespacesEnabled:false ⇒ single-store behavior preserved", async () => {
+  const probe = makeObserveProbe({ namespacesEnabled: false } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+
+  assert.equal(res.effectiveNamespace, "default");
+  assert.equal(res.namespace, "default");
+  // No namespace prefix on the LCM key when the effective ns is the default.
+  assert.equal(probe.lcmCalls[0].sessionKey, "pi-geek:abc123");
+  // No override needed when there is only one store.
+  assert.equal(probe.extractionCalls[0].writeNamespaceOverride, undefined);
+  assert.deepEqual(
+    new Set(probe.extractionCalls[0].sessionKeys),
+    new Set(["pi-geek:abc123"]),
+  );
+});
+
+test("#1495 unauthorized explicit namespace throws BEFORE session context is attached", async () => {
+  const probe = makeObserveProbe();
+  const service = new EngramAccessService(probe.orch);
+
+  await assert.rejects(
+    service.observe(
+      observeRequest({
+        sessionKey: "pi-geek:abc123",
+        namespace: "victim-secret",
+        projectTag: "Blend/Supply",
+      }),
+    ),
+    /not writable/,
+  );
+
+  // No orphaned coding context, no side effects after the auth failure.
+  assert.equal(probe.contexts.get("pi-geek:abc123"), undefined);
+  assert.equal(probe.lcmCalls.length, 0);
+  assert.equal(probe.extractionCalls.length, 0);
+  assert.equal(probe.objectiveStateNamespaces.length, 0);
+});
+
+test("#1495 scopeDebug exposes the resolved plan for callers/tests", async () => {
+  const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+
+  const expected = combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+  );
+  assert.ok(res.scopeDebug, "scopeDebug must be present");
+  assert.equal(res.scopeDebug!.principal, "pi-geek");
+  assert.equal(res.scopeDebug!.baseNamespace, "pi-geek");
+  assert.equal(res.scopeDebug!.writeNamespace, expected);
+  assert.equal(res.scopeDebug!.codingOverlayApplied, true);
+});
+
+test("#1495 the scope plan's writeNamespace matches resolveCodingScopedWriteNamespace (memory_store / suggestion_submit parity, rule 39)", async () => {
+  // Regression guard: observe's effective scope MUST be identical to what the
+  // explicit-write tools (memory_store / suggestion_submit) resolve via
+  // resolveCodingScopedWriteNamespace. If these ever diverge, observed turns and
+  // explicit writes on the same session/project would land in different stores.
+  const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
+  // Bind a session coding context so both resolvers see the same project.
+  probe.contexts.set("pi-geek:abc123", {
+    projectId: projectTagProjectId("Blend/Supply"),
+    branch: null,
+    rootPath: projectTagProjectId("Blend/Supply"),
+    defaultBranch: null,
+  });
+  const service = new EngramAccessService(probe.orch);
+
+  const internals = service as unknown as {
+    resolveMemoryScopePlan: (r: unknown) => Promise<{ writeNamespace: string }>;
+    resolveCodingScopedWriteNamespace: (r: unknown) => Promise<string>;
+  };
+
+  for (const req of [
+    { sessionKey: "pi-geek:abc123", authenticatedPrincipal: "pi-geek" },
+    {
+      sessionKey: "pi-geek:abc123",
+      authenticatedPrincipal: "pi-geek",
+      namespace: "pi-geek",
+    },
+  ]) {
+    const plan = await internals.resolveMemoryScopePlan.call(service, req);
+    const explicit = await internals.resolveCodingScopedWriteNamespace.call(
+      service,
+      req,
+    );
+    assert.equal(
+      plan.writeNamespace,
+      explicit,
+      `observe and explicit-write resolvers must agree for ${JSON.stringify(req)}`,
+    );
+  }
+});
+
+test("#1495 skipExtraction does not enqueue extraction but still archives LCM under the effective namespace", async () => {
+  const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
+  const service = new EngramAccessService(probe.orch);
+
+  const res = await service.observe(
+    observeRequest({
+      sessionKey: "pi-geek:abc123",
+      projectTag: "Blend/Supply",
+      skipExtraction: true,
+    }),
+  );
+
+  const expected = combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+  );
+  assert.equal(res.extractionQueued, false);
+  assert.equal(probe.extractionCalls.length, 0);
+  assert.equal(probe.lcmCalls[0].sessionKey, `${expected}:pi-geek:abc123`);
+});

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -320,6 +320,45 @@ test("#1495 unauthorized explicit namespace throws BEFORE session context is att
   assert.equal(probe.objectiveStateNamespaces.length, 0);
 });
 
+test("#1505 thread 1/3: unauthorized OVERLAY self-base throws BEFORE coding context is attached (no orphan context)", async () => {
+  // Threads 1 & 3 (cursor / codex): a project-scoped observe with NO explicit
+  // namespace. Step 1 (resolveWritableNamespace(undefined)) authorizes the
+  // DEFAULT namespace and PASSES. The overlay self-base auth only runs inside
+  // the scope plan. If the principal has a self namespace policy that EXISTS but
+  // is NOT writable, the scope plan throws — and before this fix that happened
+  // AFTER maybeAttachCodingContext mutated the session, leaving a project
+  // binding from a rejected op. The invariant: an observe that throws leaves NO
+  // coding context on the session, matching memory_store's resolve-before-mutate
+  // ordering.
+  const probe = makeObserveProbe({
+    namespacePolicies: [
+      // Self namespace exists (so defaultNamespaceForPrincipal → "pi-geek")
+      // but pi-geek may NOT write it — only some other principal can.
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["other"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await assert.rejects(
+    service.observe(
+      observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    ),
+    /not writable/,
+  );
+
+  // No orphaned coding context, no side effects after the overlay auth failure.
+  assert.equal(
+    probe.contexts.get("pi-geek:abc123"),
+    undefined,
+    "a rejected observe must NOT leave a project binding on the session",
+  );
+  assert.equal(probe.lcmCalls.length, 0);
+  assert.equal(probe.extractionCalls.length, 0);
+  assert.equal(probe.objectiveStateNamespaces.length, 0);
+});
+
 test("#1495 scopeDebug exposes the resolved plan for callers/tests", async () => {
   const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
   const service = new EngramAccessService(probe.orch);

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -384,6 +384,93 @@ test("#1505 thread 1/3: unauthorized OVERLAY self-base throws BEFORE coding cont
   assert.equal(probe.objectiveStateNamespaces.length, 0);
 });
 
+test("#1505 thread jvO: restrictive default-namespace write policy does NOT reject a valid project-scoped observe via the legacy-response path (no orphan binding)", async () => {
+  // The legacy `namespace` response field was previously a SECOND
+  // `resolveWritableNamespace(request.namespace, …)` call. For an implicit
+  // (no explicit namespace) project-scoped observe that re-authorized
+  // `undefined ⇒ config.defaultNamespace`. Under a deployment that restricts
+  // WRITE to the default namespace while still allowing the principal to write
+  // its own self/project namespace, that second auth REJECTED an observe whose
+  // effective self/project write target the scope plan had ALREADY authorized
+  // (the same target memory_store/suggestion_submit accept). Worse, the scope
+  // plan had already SEEDED the coding context to compute the overlay, so the
+  // post-plan rejection left an orphaned project binding on the session.
+  //
+  // After the fix the legacy field is DERIVED from the resolved scope plan, so
+  // there is no second authorization: the observe succeeds, and the legacy
+  // `namespace` stays byte-for-byte `config.defaultNamespace` (overlay-agnostic
+  // pre-#1495 semantics) while every side effect uses the overlay write target.
+  const probe = makeObserveProbe({
+    namespacePolicies: [
+      // Restrictive DEFAULT namespace: only `admin` may write it, NOT pi-geek.
+      { name: "default", readPrincipals: ["admin"], writePrincipals: ["admin"] },
+      // pi-geek may write its own self (and thus its `pi-geek-project-*`) base.
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  const expectedOverlay = combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId("Blend/Supply")),
+  );
+
+  // FAIL-BEFORE: this threw `namespace is not writable: default`. PASS-AFTER:
+  // the observe is accepted exactly like memory_store/suggestion_submit would.
+  const res = await service.observe(
+    observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+  );
+
+  // Every side effect uses the authorized overlay write target.
+  assert.equal(res.effectiveNamespace, expectedOverlay);
+  assert.equal(res.scopeDebug!.codingOverlayApplied, true);
+  assert.equal(probe.extractionCalls[0].writeNamespaceOverride, expectedOverlay);
+  // The legacy `namespace` field stays byte-for-byte pre-#1495: overlay-agnostic,
+  // so config.defaultNamespace for an unqualified write — NOT a re-auth result.
+  assert.equal(res.namespace, "default");
+  // The seeded coding context IS retained on success (the happy path re-binds
+  // the identical context after auth passes) — that is correct, not an orphan.
+  assert.ok(
+    probe.contexts.get("pi-geek:abc123"),
+    "a SUCCESSFUL scoped observe binds the project context for later recall",
+  );
+});
+
+test("#1505 thread jvO: a genuine reject (unwritable self base) under a restrictive default policy still leaves NO orphan binding", async () => {
+  // Companion to the jvO fix: when the observe SHOULD reject (the principal
+  // cannot write its own self base), the rejection must still come from the
+  // scope plan (resolve-before-mutate) and leave NO session binding — never
+  // from a post-plan legacy-response re-auth that fires after seeding.
+  const probe = makeObserveProbe({
+    namespacePolicies: [
+      { name: "default", readPrincipals: ["admin"], writePrincipals: ["admin"] },
+      // pi-geek's self base EXISTS but is NOT writable by pi-geek.
+      { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["other"] },
+    ],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+  } as Partial<PluginConfig>);
+  const service = new EngramAccessService(probe.orch);
+
+  await assert.rejects(
+    service.observe(
+      observeRequest({ sessionKey: "pi-geek:abc123", projectTag: "Blend/Supply" }),
+    ),
+    /not writable/,
+  );
+
+  assert.equal(
+    probe.contexts.get("pi-geek:abc123"),
+    undefined,
+    "a rejected observe must NOT leave a project binding (resolve-before-mutate)",
+  );
+  assert.equal(probe.lcmCalls.length, 0);
+  assert.equal(probe.extractionCalls.length, 0);
+  assert.equal(probe.objectiveStateNamespaces.length, 0);
+});
+
 test("#1495 scopeDebug exposes the resolved plan for callers/tests", async () => {
   const probe = makeObserveProbe(withSelfPolicyPrefix("pi-geek"));
   const service = new EngramAccessService(probe.orch);

--- a/packages/remnic-core/src/access-service-observe-scope.test.ts
+++ b/packages/remnic-core/src/access-service-observe-scope.test.ts
@@ -50,6 +50,7 @@ interface ObserveProbe {
   extractionCalls: Array<{
     sessionKeys: string[];
     writeNamespaceOverride?: string;
+    principalOverride?: string;
   }>;
   objectiveStateNamespaces: string[];
 }
@@ -108,11 +109,12 @@ function makeObserveProbe(overrides: Partial<PluginConfig> = {}): ObserveProbe {
     },
     ingestReplayBatch: async (
       turns: Array<{ sessionKey: string }>,
-      options: { writeNamespaceOverride?: string } = {},
+      options: { writeNamespaceOverride?: string; principalOverride?: string } = {},
     ) => {
       extractionCalls.push({
         sessionKeys: turns.map((t) => t.sessionKey),
         writeNamespaceOverride: options.writeNamespaceOverride,
+        principalOverride: options.principalOverride,
       });
     },
   } as unknown as Orchestrator;
@@ -170,17 +172,27 @@ test("#1495 projectTag: LCM, extraction, objective-state, and response all agree
     "LCM key must be prefixed with the EFFECTIVE write namespace",
   );
 
-  // Extraction replay turns key off the effective namespace and pin the write.
+  // #1505 thread 1 (identity-vs-routing separation): extraction replay turns
+  // carry the ORIGINAL, un-prefixed session key so provenance principal
+  // resolution and conversation threading see the real identity — NOT the
+  // namespace-prefixed key (which `resolvePrincipal` would collapse to
+  // `default`). Storage routing is pinned independently via
+  // writeNamespaceOverride, and the authenticated principal via principalOverride.
   assert.equal(probe.extractionCalls.length, 1);
   assert.deepEqual(
     new Set(probe.extractionCalls[0].sessionKeys),
-    new Set([`${expected}:pi-geek:abc123`]),
-    "extraction replay turns must carry the effective-namespace session key",
+    new Set(["pi-geek:abc123"]),
+    "extraction replay turns must carry the ORIGINAL session key (identity), not the namespace-prefixed key",
   );
   assert.equal(
     probe.extractionCalls[0].writeNamespaceOverride,
     expected,
-    "extraction must pin the write to the effective namespace",
+    "extraction must pin the write (routing) to the effective namespace",
+  );
+  assert.equal(
+    probe.extractionCalls[0].principalOverride,
+    "pi-geek",
+    "extraction must pin provenance to the resolved principal, not a default parsed from a prefixed key",
   );
 
   // Objective-state snapshot target == effective namespace.
@@ -217,11 +229,14 @@ test("#1495 cwd (git repo): every observe side effect agrees on the effective na
 
     assert.equal(res.effectiveNamespace, expected);
     assert.equal(probe.lcmCalls[0].sessionKey, `${expected}:pi-geek:cwd1`);
+    // #1505 thread 1: extraction turns carry the ORIGINAL session key (identity);
+    // routing + provenance are pinned via the override options.
     assert.deepEqual(
       new Set(probe.extractionCalls[0].sessionKeys),
-      new Set([`${expected}:pi-geek:cwd1`]),
+      new Set(["pi-geek:cwd1"]),
     );
     assert.equal(probe.extractionCalls[0].writeNamespaceOverride, expected);
+    assert.equal(probe.extractionCalls[0].principalOverride, "pi-geek");
     assert.ok(probe.objectiveStateNamespaces.every((ns) => ns === expected));
   } finally {
     rmSync(repoDir, { recursive: true, force: true });
@@ -249,10 +264,13 @@ test("#1495 explicit namespace wins and project context does NOT silently overri
   assert.equal(res.effectiveNamespace, "team", "explicit namespace must win");
   assert.equal(probe.lcmCalls[0].sessionKey, "team:pi-geek:abc123");
   assert.equal(probe.extractionCalls[0].writeNamespaceOverride, "team");
+  // #1505 thread 1: extraction turns carry the ORIGINAL session key (identity),
+  // even with an explicit namespace; routing is pinned via writeNamespaceOverride.
   assert.deepEqual(
     new Set(probe.extractionCalls[0].sessionKeys),
-    new Set(["team:pi-geek:abc123"]),
+    new Set(["pi-geek:abc123"]),
   );
+  assert.equal(probe.extractionCalls[0].principalOverride, "pi-geek");
   assert.ok(probe.objectiveStateNamespaces.every((ns) => ns === "team"));
 });
 

--- a/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
+++ b/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
@@ -288,6 +288,125 @@ test("#1505 thread 2f7 (positive): overlay IS readable ⇒ raw disclosure includ
   );
 });
 
+test("#1505 thread NBHWz (codex P2): restrictive `default` READ policy + readable self ⇒ raw excerpts read the self/recall-authorized namespace (no `not readable: default` throw)", async () => {
+  // The root defect: the raw-excerpt path PRE-authorized
+  // `undefined ⇒ config.defaultNamespace` via `resolveReadableNamespace` BEFORE
+  // computing the LCM excerpt key. Under a deployment whose `default` namespace
+  // has a RESTRICTIVE read policy (pi-geek may NOT read `default`) but where
+  // pi-geek's self namespace IS readable, normal recall still succeeds via
+  // `recallNamespacesForPrincipal`, yet `disclosure: "raw"` threw `namespace is
+  // not readable: default` before serialization.
+  //
+  // FAIL-BEFORE: `executeRecall({ disclosure: "raw" })` throws `namespace is not
+  // readable: default`. PASS-AFTER: the fallback comes from the already
+  // read-authorized recall namespace set, so the raw lookup runs and prefixes
+  // its LCM session_id with the readable self namespace (no pre-auth of default).
+  const probe = makeRawExcerptProbe({
+    config: {
+      // RESTRICTIVE default: pi-geek may NOT read `default`.
+      namespacePolicies: [
+        { name: "default", readPrincipals: [], writePrincipals: [] },
+        { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      ],
+      // self IS in the recall set and IS readable, so the overlay resolves and
+      // the read gate keeps it (no pre-auth of the denied default).
+      defaultRecallNamespaces: ["self", "shared"],
+      codingMode: { projectScope: true, branchScope: false, globalFallback: true },
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+    },
+    // snapshot.namespace records the overlay (the write target observe used);
+    // the read gate independently derives the readable overlay.
+    snapshotNamespace: overlayNamespace(),
+    sessionContext: sessionContext(),
+    sessionKey: SESSION_KEY,
+  });
+
+  await (probe.service as unknown as ExecuteRecallInternals).executeRecall({
+    query: "what database are we using?",
+    sessionKey: SESSION_KEY,
+    authenticatedPrincipal: "pi-geek",
+    disclosure: "raw",
+  });
+
+  assert.ok(
+    probe.searchSessionIds.length >= 1,
+    "raw excerpt lookup must run (NOT throw `not readable: default`)",
+  );
+  // The readable self overlay is honoured ⇒ the PRIMARY LCM session_id is
+  // prefixed with it, matching what normal recall + `lcmSearch` search for this
+  // principal. The premature `default` read-auth (which would have thrown) is
+  // gone. (The fallback-unification may append project/root read-fallback keys
+  // after the primary; the primary overlay key is what matters here.)
+  assert.equal(
+    probe.searchSessionIds[0],
+    `${overlayNamespace()}:${SESSION_KEY}`,
+    "raw excerpts must read the recall-authorized self overlay, not pre-authorize the denied default",
+  );
+  // No queried key may be the bare default-store key (the unprefixed raw
+  // sessionKey) — that would mean the read gate fell back to the DENIED default
+  // store. Every searched key must be namespace-prefixed with an AUTHORIZED
+  // namespace the principal may read (the `pi-geek` self base or its
+  // `pi-geek-project-*` overlay), matching what normal recall + `lcmSearch`
+  // search.
+  for (const id of probe.searchSessionIds) {
+    assert.notEqual(
+      id,
+      SESSION_KEY,
+      "raw-excerpt LCM keys must NOT fall back to the bare default store (the denied default)",
+    );
+    assert.ok(
+      typeof id === "string" && id.startsWith("pi-geek"),
+      `every raw-excerpt LCM key must be prefixed with an authorized pi-geek namespace, got ${String(id)}`,
+    );
+  }
+});
+
+test("#1505 thread NBHWz (codex P2): no readable LCM namespace ⇒ raw excerpts are EMPTY (no throw, no fallback to unreadable default)", async () => {
+  // alice authenticates but her policy denies reading `default`, `shared` is not
+  // in the recall set, and she has NO readable self namespace
+  // (`defaultRecallNamespaces` omits `self` AND her self base is unreadable). No
+  // readable LCM namespace exists for an implicit raw recall.
+  //
+  // FAIL-BEFORE: throws `namespace is not readable: default`. PASS-AFTER: the
+  // raw-excerpt lookup is suppressed (returns EMPTY) — `searchContextFull` is
+  // never called — so raw recall degrades gracefully instead of throwing.
+  const probe = makeRawExcerptProbe({
+    config: {
+      namespacePolicies: [
+        { name: "default", readPrincipals: [], writePrincipals: [] },
+        // alice can WRITE but NOT read her self namespace, and self is omitted
+        // from the recall set ⇒ nothing readable to fall back to.
+        { name: "alice", readPrincipals: [], writePrincipals: ["alice"] },
+      ],
+      // `shared` deliberately not granted either (default policy denies, no
+      // shared policy ⇒ canReadNamespace(alice, "shared") is true by the
+      // default-or-shared fallback). Omit shared from the recall set so it is not
+      // a fallback.
+      defaultRecallNamespaces: [],
+      codingMode: { projectScope: false, branchScope: false, globalFallback: true },
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+    },
+    snapshotNamespace: "default",
+    sessionKey: SESSION_KEY,
+  });
+
+  // Must NOT throw.
+  await (probe.service as unknown as ExecuteRecallInternals).executeRecall({
+    query: "what database are we using?",
+    sessionKey: SESSION_KEY,
+    authenticatedPrincipal: "alice",
+    disclosure: "raw",
+  });
+
+  assert.equal(
+    probe.searchSessionIds.length,
+    0,
+    "no readable LCM namespace ⇒ raw excerpts must be EMPTY (searchContextFull never called), not throw",
+  );
+});
+
 test("#1505 thread 2f7 (single-store regression): namespaces disabled ⇒ raw excerpts use the raw sessionKey", async () => {
   // Byte-for-byte single-user behavior: no namespaces, no overlay, raw key.
   const probe = makeRawExcerptProbe({

--- a/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
+++ b/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
@@ -1,0 +1,314 @@
+/**
+ * #1505 thread 2f7: the `disclosure: "raw"` excerpt path MUST pass through the
+ * SAME read-authorization gate as normal recall + `lcmSearch` + the in-prompt
+ * LCM sections — NOT `snapshot.namespace` (the effective WRITE/overlay
+ * namespace).
+ *
+ * The defect class: a project-scoped session whose principal can WRITE but not
+ * READ its self base (or whose `defaultRecallNamespaces` omits `self`) archives
+ * LCM rows under the `<principal>-project-*` overlay key (the write key). When
+ * `recall({ disclosure: "raw" })` derived the raw-excerpt LCM `session_id` from
+ * `snapshot.namespace`, it prefixed the lookup with that overlay namespace and
+ * surfaced `<principal>-project-*` transcript rows that normal recall and
+ * `lcmSearch` intentionally EXCLUDE for that reader — a cross-tenant read leak.
+ *
+ * After the fix the raw-excerpt lookup routes through
+ * `resolveRawExcerptReadNamespace` → `resolveLcmReadNamespace(..., "read")`,
+ * which honours the overlay only when the principal SELF base is in the readable
+ * recall set. When it is not, the lookup falls back to the default store (raw
+ * sessionKey) exactly like normal recall + `lcmSearch`.
+ *
+ * These tests exercise the private `executeRecall` directly (the budget /
+ * idempotency wrapper is orthogonal to the namespace gate) and assert the
+ * `session_id` that reaches the LCM engine's `searchContextFull`.
+ *
+ * All fixtures are synthetic — no real user data.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramAccessService } from "./access-service.js";
+import { CrossNamespaceBudget } from "./cross-namespace-budget.js";
+import { Orchestrator } from "./orchestrator.js";
+import type { LastRecallSnapshot } from "./recall-state.js";
+import {
+  combineNamespaces,
+  projectNamespaceName,
+  projectTagProjectId,
+} from "./coding/coding-namespace.js";
+import type { StorageManager } from "./storage.js";
+import type { CodingContext, PluginConfig } from "./types.js";
+
+interface RawExcerptProbe {
+  service: EngramAccessService;
+  /** session_id values that reached the LCM engine's `searchContextFull`. */
+  searchSessionIds: Array<string | undefined>;
+  contexts: Map<string, CodingContext>;
+}
+
+/**
+ * Build a service whose orchestrator stub:
+ *  - delegates principal / overlay resolution to the REAL Orchestrator
+ *    prototype so the read gate is exercised exactly as production does it,
+ *  - records the `session_id` the raw-excerpt LCM lookup prefixes,
+ *  - returns a fixed `lastRecall` snapshot whose `namespace` is the WRITE/overlay
+ *    namespace (simulating what `observe` wrote), with NO result paths so the
+ *    test isolates the raw-excerpt session_id.
+ */
+function makeRawExcerptProbe(options: {
+  config: Partial<PluginConfig>;
+  snapshotNamespace: string;
+  sessionContext?: CodingContext;
+  sessionKey: string;
+}): RawExcerptProbe {
+  const searchSessionIds: Array<string | undefined> = [];
+  const contexts = new Map<string, CodingContext>();
+  if (options.sessionContext) {
+    contexts.set(options.sessionKey, options.sessionContext);
+  }
+
+  const config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    defaultRecallNamespaces: ["self", "shared"],
+    codingMode: { projectScope: true },
+    memoryDir: "/synthetic/remnic-raw-excerpt-read-gate",
+    objectiveStateMemoryEnabled: false,
+    objectiveStateSnapshotWritesEnabled: false,
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    recallCrossNamespaceBudgetEnabled: false,
+    ...options.config,
+  } as unknown as PluginConfig;
+
+  const snapshot: LastRecallSnapshot = {
+    sessionKey: options.sessionKey,
+    recordedAt: new Date().toISOString(),
+    queryHash: "hash",
+    queryLen: 5,
+    memoryIds: [],
+    namespace: options.snapshotNamespace,
+    recallNamespaces: [options.snapshotNamespace],
+    resultPaths: [],
+  };
+
+  const storage = {
+    dir: "/synthetic/remnic-raw-excerpt-read-gate/store",
+    async readMemoryByPath() {
+      return null;
+    },
+    async getMemoryById() {
+      return null;
+    },
+  } as unknown as StorageManager;
+
+  const service = Object.create(
+    EngramAccessService.prototype,
+  ) as EngramAccessService;
+
+  const orch = {
+    config,
+    getCodingContextForSession: (sk: string | undefined) =>
+      (sk ? contexts.get(sk) : null) ?? null,
+    setCodingContextForSession: (sk: string, ctx: CodingContext | null) => {
+      if (ctx === null) contexts.delete(sk);
+      else contexts.set(sk, ctx);
+    },
+    applyCodingNamespaceOverlay: (sk: string | undefined, base: string) =>
+      Orchestrator.prototype.applyCodingNamespaceOverlay.call(orch, sk, base),
+    resolvePrincipal: (sk?: string) =>
+      Orchestrator.prototype.resolvePrincipal.call(orch, sk),
+    resolveSelfNamespace: (sk?: string) =>
+      Orchestrator.prototype.resolveSelfNamespace.call(orch, sk),
+    async getStorage() {
+      return storage;
+    },
+    lastRecall: new Map<string, LastRecallSnapshot>([
+      [options.sessionKey, snapshot],
+    ]),
+    async recall() {
+      return "";
+    },
+    lcmEngine: {
+      enabled: true,
+      searchContextFull: async (
+        _query: string,
+        _limit: number,
+        sessionId?: string,
+      ) => {
+        searchSessionIds.push(sessionId);
+        return [];
+      },
+    },
+  } as unknown as Orchestrator;
+
+  (service as unknown as { orchestrator: Orchestrator }).orchestrator = orch;
+
+  // `executeRecall` consults the cross-namespace budget; `Object.create` skips
+  // the constructor that builds the real limiter, so install one. Budget is
+  // disabled in config, so it never denies — orthogonal to the namespace gate.
+  (service as unknown as { budget: CrossNamespaceBudget }).budget =
+    new CrossNamespaceBudget({
+      enabled: false,
+      windowMs: 60_000,
+      softLimit: 10,
+      hardLimit: 30,
+    });
+
+  return { service, searchSessionIds, contexts };
+}
+
+type ExecuteRecallInternals = {
+  executeRecall: (request: unknown) => Promise<unknown>;
+};
+
+const SESSION_KEY = "pi-geek:abc123";
+const PROJECT_TAG = "Blend/Supply";
+
+function overlayNamespace(): string {
+  return combineNamespaces(
+    "pi-geek",
+    projectNamespaceName(projectTagProjectId(PROJECT_TAG)),
+  );
+}
+
+function sessionContext(): CodingContext {
+  return {
+    projectId: projectTagProjectId(PROJECT_TAG),
+    branch: null,
+    rootPath: projectTagProjectId(PROJECT_TAG),
+    defaultBranch: null,
+  };
+}
+
+test("#1505 thread 2f7: WRITE-only / self-unreadable principal ⇒ raw excerpts fall back to the default store (no overlay prefix)", async () => {
+  // Self namespace EXISTS and is WRITABLE by pi-geek, but NOT readable by it
+  // (only `other` may read). An unqualified project-scoped observe archived LCM
+  // under the `<pi-geek>-project-*` overlay key. The read gate
+  // (`recallNamespacesForPrincipal`) excludes that overlay for pi-geek, so raw
+  // disclosure MUST fall back to the default store — the raw sessionKey — never
+  // the overlay key.
+  const probe = makeRawExcerptProbe({
+    config: {
+      namespacePolicies: [
+        { name: "pi-geek", readPrincipals: ["other"], writePrincipals: ["pi-geek"] },
+      ],
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+    },
+    snapshotNamespace: overlayNamespace(),
+    sessionContext: sessionContext(),
+    sessionKey: SESSION_KEY,
+  });
+
+  await (probe.service as unknown as ExecuteRecallInternals).executeRecall({
+    query: "what database are we using?",
+    sessionKey: SESSION_KEY,
+    authenticatedPrincipal: "pi-geek",
+    disclosure: "raw",
+  });
+
+  assert.equal(probe.searchSessionIds.length, 1, "raw excerpt lookup must run once");
+  // FAIL-BEFORE: previously prefixed with `snapshot.namespace` (the overlay),
+  // i.e. `${overlayNamespace()}:${SESSION_KEY}`. PASS-AFTER: gated read namespace
+  // collapses to the default store ⇒ the raw sessionKey.
+  assert.equal(
+    probe.searchSessionIds[0],
+    SESSION_KEY,
+    "raw excerpts must NOT prefix with the unreadable overlay namespace",
+  );
+});
+
+test("#1505 thread 2f7: defaultRecallNamespaces omits 'self' ⇒ raw excerpts fall back to the default store", async () => {
+  // pi-geek may both read AND write its self base, but the operator's
+  // `defaultRecallNamespaces` omits `self`, so normal recall + lcmSearch never
+  // surface overlay rows for this reader. Raw disclosure must match.
+  const probe = makeRawExcerptProbe({
+    config: {
+      defaultRecallNamespaces: ["shared"],
+      namespacePolicies: [
+        { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      ],
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+    },
+    snapshotNamespace: overlayNamespace(),
+    sessionContext: sessionContext(),
+    sessionKey: SESSION_KEY,
+  });
+
+  await (probe.service as unknown as ExecuteRecallInternals).executeRecall({
+    query: "what database are we using?",
+    sessionKey: SESSION_KEY,
+    authenticatedPrincipal: "pi-geek",
+    disclosure: "raw",
+  });
+
+  assert.equal(probe.searchSessionIds.length, 1);
+  assert.equal(
+    probe.searchSessionIds[0],
+    SESSION_KEY,
+    "self-omitted recall set ⇒ raw excerpts fall back to the default store",
+  );
+});
+
+test("#1505 thread 2f7 (positive): overlay IS readable ⇒ raw disclosure includes the overlay rows", async () => {
+  // pi-geek may read its self base AND `defaultRecallNamespaces` includes
+  // `self`, so the overlay is in the readable recall set. Raw disclosure MUST
+  // continue to prefix with the overlay key so the session finds its own
+  // project-scoped transcript rows (no regression for the normal case).
+  const probe = makeRawExcerptProbe({
+    config: {
+      defaultRecallNamespaces: ["self", "shared"],
+      namespacePolicies: [
+        { name: "pi-geek", readPrincipals: ["pi-geek"], writePrincipals: ["pi-geek"] },
+      ],
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [{ match: "pi-geek:", principal: "pi-geek" }],
+    },
+    snapshotNamespace: overlayNamespace(),
+    sessionContext: sessionContext(),
+    sessionKey: SESSION_KEY,
+  });
+
+  await (probe.service as unknown as ExecuteRecallInternals).executeRecall({
+    query: "what database are we using?",
+    sessionKey: SESSION_KEY,
+    authenticatedPrincipal: "pi-geek",
+    disclosure: "raw",
+  });
+
+  assert.equal(probe.searchSessionIds.length, 1);
+  assert.equal(
+    probe.searchSessionIds[0],
+    `${overlayNamespace()}:${SESSION_KEY}`,
+    "readable overlay ⇒ raw disclosure keeps the overlay prefix",
+  );
+});
+
+test("#1505 thread 2f7 (single-store regression): namespaces disabled ⇒ raw excerpts use the raw sessionKey", async () => {
+  // Byte-for-byte single-user behavior: no namespaces, no overlay, raw key.
+  const probe = makeRawExcerptProbe({
+    config: {
+      namespacesEnabled: false,
+      codingMode: {
+        projectScope: false,
+        branchScope: false,
+        globalFallback: true,
+      },
+    },
+    snapshotNamespace: "default",
+    sessionKey: SESSION_KEY,
+  });
+
+  await (probe.service as unknown as ExecuteRecallInternals).executeRecall({
+    query: "what database are we using?",
+    sessionKey: SESSION_KEY,
+    disclosure: "raw",
+  });
+
+  assert.equal(probe.searchSessionIds.length, 1);
+  assert.equal(probe.searchSessionIds[0], SESSION_KEY);
+});

--- a/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
+++ b/packages/remnic-core/src/access-service-raw-excerpt-read-gate.test.ts
@@ -33,6 +33,7 @@ import { Orchestrator } from "./orchestrator.js";
 import type { LastRecallSnapshot } from "./recall-state.js";
 import {
   combineNamespaces,
+  lcmSessionKeyForNamespace,
   projectNamespaceName,
   projectTagProjectId,
 } from "./coding/coding-namespace.js";
@@ -283,7 +284,7 @@ test("#1505 thread 2f7 (positive): overlay IS readable ⇒ raw disclosure includ
   assert.equal(probe.searchSessionIds.length, 1);
   assert.equal(
     probe.searchSessionIds[0],
-    `${overlayNamespace()}:${SESSION_KEY}`,
+    lcmSessionKeyForNamespace(overlayNamespace(), SESSION_KEY, "default"),
     "readable overlay ⇒ raw disclosure keeps the overlay prefix",
   );
 });
@@ -340,7 +341,7 @@ test("#1505 thread NBHWz (codex P2): restrictive `default` READ policy + readabl
   // after the primary; the primary overlay key is what matters here.)
   assert.equal(
     probe.searchSessionIds[0],
-    `${overlayNamespace()}:${SESSION_KEY}`,
+    lcmSessionKeyForNamespace(overlayNamespace(), SESSION_KEY, "default"),
     "raw excerpts must read the recall-authorized self overlay, not pre-authorize the denied default",
   );
   // No queried key may be the bare default-store key (the unprefixed raw
@@ -349,6 +350,10 @@ test("#1505 thread NBHWz (codex P2): restrictive `default` READ policy + readabl
   // namespace the principal may read (the `pi-geek` self base or its
   // `pi-geek-project-*` overlay), matching what normal recall + `lcmSearch`
   // search.
+  // #1495 P1: the namespaced key is sentinel-framed (`\x1f<ns>\x1f<sessionKey>`),
+  // so parse the namespace out of the frame and assert it is an authorized
+  // pi-geek namespace (the self base or its `pi-geek-project-*` overlay).
+  const SENTINEL = "\u001f";
   for (const id of probe.searchSessionIds) {
     assert.notEqual(
       id,
@@ -356,8 +361,13 @@ test("#1505 thread NBHWz (codex P2): restrictive `default` READ policy + readabl
       "raw-excerpt LCM keys must NOT fall back to the bare default store (the denied default)",
     );
     assert.ok(
-      typeof id === "string" && id.startsWith("pi-geek"),
-      `every raw-excerpt LCM key must be prefixed with an authorized pi-geek namespace, got ${String(id)}`,
+      typeof id === "string" && id.startsWith(SENTINEL),
+      `every raw-excerpt LCM key must be the sentinel-framed namespaced key, got ${String(id)}`,
+    );
+    const framedNs = (id as string).slice(SENTINEL.length).split(SENTINEL)[0]!;
+    assert.ok(
+      framedNs.startsWith("pi-geek"),
+      `every raw-excerpt LCM key must be framed with an authorized pi-geek namespace, got ${String(id)}`,
     );
   }
 });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5151,6 +5151,35 @@ export class EngramAccessService {
           this.orchestrator.config.defaultNamespace,
         ) ?? request.sessionPrefix
       : request.sessionPrefix;
+    // SECURITY (codex P1 "Don't treat any readable namespace as default LCM
+    // access"): a sessionless, prefixless `lcmSearch` issues
+    // `searchContextFull(query, limit, undefined, undefined)`, which scans the
+    // ENTIRE LCM archive across every session/namespace. That is only acceptable
+    // when the caller may read the DEFAULT store the archive scan effectively
+    // exposes. Under a restrictive `default` READ policy (the principal cannot
+    // read `default`), an implicit `lcmSearch` with no `sessionKey` AND no
+    // `sessionPrefix` must NOT run the unbounded scan — return EMPTY. A scoped
+    // call (sessionKey or sessionPrefix present) stays gated by its own
+    // overlay/recall authorization above; an explicit, read-authorized namespace
+    // is unaffected (it already passed `resolveReadableNamespace`).
+    const hasScopedSession =
+      (typeof request.sessionKey === "string" &&
+        request.sessionKey.length > 0) ||
+      (typeof lcmSessionPrefix === "string" && lcmSessionPrefix.length > 0);
+    const defaultStoreReadable = canReadNamespace(
+      principal,
+      this.orchestrator.config.defaultNamespace,
+      this.orchestrator.config,
+    );
+    if (!hasExplicitNamespace && !hasScopedSession && !defaultStoreReadable) {
+      return {
+        query: request.query,
+        namespace: this.orchestrator.config.defaultNamespace,
+        results: [],
+        count: 0,
+        lcmEnabled: true,
+      };
+    }
     // Query each LCM read key in order, merging + deduping rows (by
     // sessionId+turnIndex) and preserving first-seen order, capped at `limit`.
     const seenRows = new Set<string>();
@@ -5407,18 +5436,26 @@ export class EngramAccessService {
     if (canReadNamespace(principal, config.defaultNamespace, config)) {
       return config.defaultNamespace;
     }
-    // Restrictive `default` READ policy. PROCEED only when the principal has a
-    // readable coding overlay / self base in the recall set (the SAME gate
-    // `resolveLcmReadNamespace`'s "read" branch and the orchestrator's
-    // `lcmReadNamespaceForSession` use to honour the overlay). The fallback is
-    // STILL `config.defaultNamespace` (not the readable recall namespace), so the
-    // overlay-unreadable branch collapses to the raw key exactly like the
-    // orchestrator. SUPPRESS (`undefined`) when nothing readable exists.
-    const hasReadableRecallNamespace = recallNamespacesForPrincipal(
+    // Restrictive `default` READ policy. The ONLY way the implicit LCM read can
+    // target an AUTHORIZED key is via the coding OVERLAY, which
+    // `resolveLcmReadNamespace` switches to ONLY when the principal SELF base is
+    // in the readable recall set (the SAME gate the orchestrator's
+    // `lcmReadNamespaceForSession` uses). So PROCEED here ONLY when the SELF base
+    // is readable-in-recall — NOT when merely some OTHER recall namespace (e.g.
+    // `shared`) is readable: the LCM read can never legitimately target `shared`,
+    // and returning `config.defaultNamespace` for that case would let a sessionless
+    // `lcmSearch`/raw recall scan the DENIED default LCM store (codex P1 "Don't
+    // treat any readable namespace as default LCM access"). The downstream
+    // overlay-unreadable READ branch and `lcmSearch`'s sessionless guard both
+    // collapse to the default raw key, so a self-readable PROCEED still yields the
+    // scoped overlay key (with a session) or empty (sessionless). SUPPRESS
+    // (`undefined`) when the self base is not readable-in-recall.
+    const selfBase = defaultNamespaceForPrincipal(principal, config);
+    const selfReadableInRecall = recallNamespacesForPrincipal(
       principal,
       config,
-    ).some((ns) => canReadNamespace(principal, ns, config));
-    return hasReadableRecallNamespace ? config.defaultNamespace : undefined;
+    ).includes(selfBase);
+    return selfReadableInRecall ? config.defaultNamespace : undefined;
   }
 
   private resolveLcmReadSessionKey(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -5276,7 +5276,19 @@ export class EngramAccessService {
             principal,
             this.orchestrator.config,
           ).includes(base);
-    return authorized ? overlaid : resolvedNamespace;
+    if (authorized) return overlaid;
+    // Unauthorized overlay base. For READS, collapse to the DEFAULT STORE (the
+    // raw sessionKey) EXACTLY like the orchestrator's `lcmReadNamespaceForSession`
+    // (rule 39 / 42) — NOT the caller's `resolvedNamespace`, which for an implicit
+    // read can be a readable recall namespace (e.g. `shared`). Returning that
+    // would prefix LCM reads with `shared:sessionKey` while in-prompt recall uses
+    // the raw `sessionKey`, diverging `lcmSearch`/raw disclosure from orchestrator
+    // LCM reads (cursor "LCM read gate wrong fallback"). For an explicit read the
+    // method already returned at the top, so this only affects implicit reads.
+    // The (currently unused) write purpose preserves its prior `resolvedNamespace`
+    // fallback for backward compatibility.
+    if (purpose === "read") return this.orchestrator.config.defaultNamespace;
+    return resolvedNamespace;
   }
 
   /**
@@ -5355,42 +5367,58 @@ export class EngramAccessService {
   }
 
   /**
-   * The read-authorized fallback namespace an IMPLICIT (no explicit `namespace`)
+   * The base `resolvedNamespace` an IMPLICIT (no explicit `namespace`)
    * same-session LCM READER (`resolveRawExcerptReadNamespace`, `lcmSearch`)
-   * prefixes its LCM `session_id` with when no readable coding overlay applies
-   * (#1505 thread NBHWz). Derived WITHOUT pre-authorizing `default`: it consults
-   * the SAME read-authorized recall set normal recall + the in-prompt LCM
-   * sections use (`recallNamespacesForPrincipal`, already
-   * `canReadNamespace`-filtered) and falls back to `config.defaultNamespace` ONLY
-   * when the principal may actually read it. Returns `undefined` when no readable
-   * LCM namespace exists, so the caller emits NO rows instead of throwing
-   * `namespace is not readable: default` — normal recall still succeeds through
-   * the readable self namespace, and LCM reads must degrade gracefully.
+   * passes into {@link resolveLcmReadNamespace} — WITHOUT pre-authorizing
+   * `default` (#1505 thread NBHWz). It decides PROCEED vs SUPPRESS only; the
+   * actual LCM prefix is then resolved by `resolveLcmReadNamespace`, which
+   * mirrors the orchestrator's `lcmReadNamespaceForSession` EXACTLY (rule 39 /
+   * 42): the coding overlay when the principal SELF base is in the readable
+   * recall set, else `config.defaultNamespace` (the raw key).
+   *
+   * Returns `config.defaultNamespace` (PROCEED) whenever the principal has ANY
+   * readable LCM access — either `default` itself is readable, OR a coding
+   * overlay / self base is in the readable recall set. The returned value is
+   * ALWAYS `config.defaultNamespace`, NEVER an arbitrary readable recall
+   * namespace (e.g. `shared`): `resolveLcmReadNamespace` returns this fallback
+   * verbatim only on the overlay-applies-but-self-unreadable branch, where the
+   * orchestrator collapses to the default store — so returning anything but the
+   * default store there would prefix LCM reads with `shared:sessionKey` while
+   * in-prompt recall uses the raw `sessionKey`, diverging the two (cursor
+   * "LCM read gate wrong fallback").
+   *
+   * Returns `undefined` (SUPPRESS) only when NO readable LCM namespace exists —
+   * a restrictive `default` READ policy AND no readable overlay/self — so the
+   * caller emits NO rows instead of throwing `namespace is not readable:
+   * default`. Normal recall still succeeds through the readable self namespace.
    *
    * Single-store / namespaces-disabled deployments resolve to
-   * `config.defaultNamespace` (always readable), keeping single-user recall
-   * byte-for-byte unchanged.
+   * `config.defaultNamespace`, keeping single-user recall byte-for-byte
+   * unchanged.
    */
   private resolveImplicitLcmReadFallbackNamespace(
     principal: string | undefined,
   ): string | undefined {
     const config = this.orchestrator.config;
     if (!config.namespacesEnabled) return config.defaultNamespace;
-    // Prefer the default store when the principal may read it (the historical
-    // implicit fallback — preserves single-store / readable-default flows).
+    // PROCEED when `default` is readable (single-store / readable-default flows)
+    // — the LCM prefix resolves to the overlay when self-authorized, else the
+    // default raw key.
     if (canReadNamespace(principal, config.defaultNamespace, config)) {
       return config.defaultNamespace;
     }
-    // Restrictive `default` READ policy: fall back to a namespace the principal
-    // CAN read from the recall set (e.g. the readable self base), matching what
-    // normal recall + `lcmSearch` search. `lcmSessionKeyForNamespace` prefixes
-    // only non-default namespaces, so a self-base fallback still produces a
-    // distinct, authorized LCM key.
-    const readableRecallNamespaces = recallNamespacesForPrincipal(
+    // Restrictive `default` READ policy. PROCEED only when the principal has a
+    // readable coding overlay / self base in the recall set (the SAME gate
+    // `resolveLcmReadNamespace`'s "read" branch and the orchestrator's
+    // `lcmReadNamespaceForSession` use to honour the overlay). The fallback is
+    // STILL `config.defaultNamespace` (not the readable recall namespace), so the
+    // overlay-unreadable branch collapses to the raw key exactly like the
+    // orchestrator. SUPPRESS (`undefined`) when nothing readable exists.
+    const hasReadableRecallNamespace = recallNamespacesForPrincipal(
       principal,
       config,
-    ).filter((ns) => canReadNamespace(principal, ns, config));
-    return readableRecallNamespaces[0];
+    ).some((ns) => canReadNamespace(principal, ns, config));
+    return hasReadableRecallNamespace ? config.defaultNamespace : undefined;
   }
 
   private resolveLcmReadSessionKey(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4887,18 +4887,43 @@ export class EngramAccessService {
    * use.
    */
   /**
-   * Resolve the effective LCM read NAMESPACE a same-session reader must prefix
+   * Resolve the effective LCM NAMESPACE a same-session operation must prefix
    * with (the namespace half of {@link resolveLcmReadSessionKey}). Split out so
    * `lcmSearch` can apply ONE namespace to BOTH its `sessionKey` and its
    * `sessionPrefix` — the prefix is a search fragment, not a real session, so its
    * own coding context can't be looked up; it must inherit the namespace resolved
    * from the real session (`sessionKeyForOverlay`).
+   *
+   * `purpose` selects the AUTHORIZATION gate applied before honouring the
+   * coding overlay (#1505 round 3 + round 4, codex P2):
+   *
+   *  - `"read"` (`lcmSearch` / raw-excerpt recall): the overlay rows are only
+   *    visible when the principal SELF base is in the READABLE RECALL SET — the
+   *    same gate the orchestrator's `lcmReadNamespaceForSession` and the recall
+   *    namespace set use (`recallNamespacesForPrincipal`, gated by both
+   *    `defaultRecallNamespaces.includes("self")` AND `canReadNamespace`). A
+   *    caller that passed the default read check must NOT receive
+   *    `<principal>-project-*` rows the policy never granted (cross-tenant read
+   *    leak). When the self base is not readable, keep the just-authorized
+   *    namespace (collapses to the raw key on the default store).
+   *
+   *  - `"write"` (`lcmCompactionFlush` / `lcmCompactionRecord`): these are
+   *    write/maintenance operations on the SAME queue `observe` just wrote, so
+   *    the gate must mirror observe's WRITE authorization (`canWriteNamespace`
+   *    on the self base), NOT readability. A principal that can WRITE but not
+   *    READ its self namespace (or whose `defaultRecallNamespaces` omits `self`)
+   *    archived under the overlay key via `observe`; gating compaction by
+   *    readability would fall back to the default/raw key and leave that queue
+   *    never flushed/recorded (round-4 codex P2). Write-authorized ⇒ overlay
+   *    key, matching the observe write key (rule 42 read/write parity; rule 39
+   *    identical gates across paths).
    */
   private resolveLcmReadNamespace(
     explicitNamespace: string | undefined,
     resolvedNamespace: string,
     sessionKeyForOverlay: string | undefined,
     authenticatedPrincipal: string | undefined,
+    purpose: "read" | "write" = "read",
   ): string {
     const hasExplicitNamespace =
       typeof explicitNamespace === "string" && explicitNamespace.trim().length > 0;
@@ -4918,28 +4943,19 @@ export class EngramAccessService {
     );
     // No overlay → the default store (raw sessionKey), as before.
     if (overlaid === base) return this.orchestrator.config.defaultNamespace;
-    // Overlay applied. READ-AUTHORIZATION gate (#1505 round 3, codex P2
-    // "Authorize overlay LCM access before replacing the namespace"): the
-    // caller's request was authorized for `resolvedNamespace` (usually
-    // `default`) — NOT for the principal's `<principal>-project-*` overlay base.
-    // Before switching the LCM read key to that overlay we must confirm the
-    // principal's self base is in the READABLE RECALL SET — the SAME gate the
-    // orchestrator's `lcmReadNamespaceForSession` and the recall namespace set
-    // use (`recallNamespacesForPrincipal`, gated by both
-    // `defaultRecallNamespaces.includes("self")` AND `canReadNamespace`). Using
-    // only `canReadNamespace` here would diverge from the orchestrator path when
-    // `defaultRecallNamespaces` omits `self` (rule 39 — identical feature gates
-    // across paths). Without this, an `lcmSearch` that passed the default read
-    // check could return `<principal>-project-*` rows the policy never granted
-    // (cross-tenant read leak). When the self base is not readable, keep the
-    // just-authorized namespace (collapses to the raw key for the default store)
-    // — never return overlay rows to an unauthorized caller (rule 42 read/write
-    // parity; rule 48 least-privilege).
-    const selfReadableInRecall = recallNamespacesForPrincipal(
-      principal,
-      this.orchestrator.config,
-    ).includes(base);
-    return selfReadableInRecall ? overlaid : resolvedNamespace;
+    // Overlay applied. Authorize access to the principal's `<principal>-project-*`
+    // overlay base before switching the LCM key to it. The gate differs by
+    // operation purpose (see the doc comment): reads use the readable-recall-set
+    // gate (no cross-tenant read leak), writes use observe's write authorization
+    // (so compaction targets the same overlay queue observe wrote to).
+    const authorized =
+      purpose === "write"
+        ? canWriteNamespace(principal, base, this.orchestrator.config)
+        : recallNamespacesForPrincipal(
+            principal,
+            this.orchestrator.config,
+          ).includes(base);
+    return authorized ? overlaid : resolvedNamespace;
   }
 
   private resolveLcmReadSessionKey(
@@ -4947,12 +4963,14 @@ export class EngramAccessService {
     resolvedNamespace: string,
     sessionKey: string,
     authenticatedPrincipal: string | undefined,
+    purpose: "read" | "write" = "read",
   ): string {
     const effectiveNamespace = this.resolveLcmReadNamespace(
       explicitNamespace,
       resolvedNamespace,
       sessionKey,
       authenticatedPrincipal,
+      purpose,
     );
     return (
       lcmSessionKeyForNamespace(
@@ -4990,11 +5008,16 @@ export class EngramAccessService {
     // its coding-overlay namespace (`${effectiveNamespace}:${sessionKey}`), not
     // the base `namespace` — so apply the session's coding overlay here too, or
     // the flush would target the wrong queue (#1495 thread 2, rule 42).
+    // `purpose: "write"` — compaction is a write/maintenance op on the queue
+    // observe wrote, so the overlay is gated by WRITE authorization, not
+    // readability (round-4 codex P2): a write-only / self-omitted principal
+    // still flushes the overlay queue observe archived under.
     const lcmSessionKey = this.resolveLcmReadSessionKey(
       request.namespace,
       namespace,
       request.sessionKey,
       request.authenticatedPrincipal,
+      "write",
     );
     await this.orchestrator.lcmEngine.waitForSessionObserveIdle(lcmSessionKey);
     await this.orchestrator.lcmEngine.preCompactionFlush(lcmSessionKey);
@@ -5037,12 +5060,15 @@ export class EngramAccessService {
     // Record against the SAME LCM session_id `observe` archived under — apply
     // the session's coding overlay when no explicit namespace is given, so an
     // auto-scoped session records its compaction on the right queue (#1495
-    // thread 2, rule 42).
+    // thread 2, rule 42). `purpose: "write"` — write/maintenance op gated by
+    // WRITE authorization, not readability (round-4 codex P2), so a write-only /
+    // self-omitted principal still records on the overlay queue observe wrote.
     const lcmSessionKey = this.resolveLcmReadSessionKey(
       request.namespace,
       namespace,
       request.sessionKey,
       request.authenticatedPrincipal,
+      "write",
     );
     await this.orchestrator.lcmEngine.waitForSessionObserveIdle(lcmSessionKey);
     await this.orchestrator.lcmEngine.recordCompaction(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4916,7 +4916,30 @@ export class EngramAccessService {
       sessionKeyForOverlay,
       base,
     );
-    return overlaid !== base ? overlaid : this.orchestrator.config.defaultNamespace;
+    // No overlay → the default store (raw sessionKey), as before.
+    if (overlaid === base) return this.orchestrator.config.defaultNamespace;
+    // Overlay applied. READ-AUTHORIZATION gate (#1505 round 3, codex P2
+    // "Authorize overlay LCM access before replacing the namespace"): the
+    // caller's request was authorized for `resolvedNamespace` (usually
+    // `default`) — NOT for the principal's `<principal>-project-*` overlay base.
+    // Before switching the LCM read key to that overlay we must confirm the
+    // principal's self base is in the READABLE RECALL SET — the SAME gate the
+    // orchestrator's `lcmReadNamespaceForSession` and the recall namespace set
+    // use (`recallNamespacesForPrincipal`, gated by both
+    // `defaultRecallNamespaces.includes("self")` AND `canReadNamespace`). Using
+    // only `canReadNamespace` here would diverge from the orchestrator path when
+    // `defaultRecallNamespaces` omits `self` (rule 39 — identical feature gates
+    // across paths). Without this, an `lcmSearch` that passed the default read
+    // check could return `<principal>-project-*` rows the policy never granted
+    // (cross-tenant read leak). When the self base is not readable, keep the
+    // just-authorized namespace (collapses to the raw key for the default store)
+    // — never return overlay rows to an unauthorized caller (rule 42 read/write
+    // parity; rule 48 least-privilege).
+    const selfReadableInRecall = recallNamespacesForPrincipal(
+      principal,
+      this.orchestrator.config,
+    ).includes(base);
+    return selfReadableInRecall ? overlaid : resolvedNamespace;
   }
 
   private resolveLcmReadSessionKey(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -847,6 +847,22 @@ export interface MemoryScopePlan {
   baseNamespace: string;
   /** Effective write namespace — what every side effect must use. */
   writeNamespace: string;
+  /**
+   * Effective namespace the objective-state snapshot writer must target.
+   *
+   * Objective-state has a STRICTER, pre-#1495 contract than the LCM/extraction
+   * write path (#928): an IMPLICIT (no explicit `namespace`) snapshot is based
+   * on the PRINCIPAL SELF namespace (`defaultNamespaceForPrincipal`) and is
+   * authorized against THAT base (rule 48, least-privilege) — never silently
+   * routed to `config.defaultNamespace`. Only the LCM/extraction/response path
+   * collapses an unqualified write to `config.defaultNamespace` (memory_store
+   * parity, rule 39). With an explicit namespace, or once a coding overlay
+   * applies, both targets converge: `objectiveStateNamespace === writeNamespace`.
+   *
+   * Keeping the two as separate fields of ONE plan preserves rule 22 (single
+   * resolution point) while honoring each consumer's historical contract.
+   */
+  objectiveStateNamespace: string;
   /** Namespaces a same-session recall would read (cheap subset). */
   readNamespaces: string[];
   /** Whether the coding overlay changed the base namespace. */
@@ -1436,6 +1452,8 @@ export class EngramAccessService {
     if (hasExplicitNamespace) {
       // Explicit namespace wins; authorized through the existing policy path.
       // The overlay never applies, so base == write == the explicit namespace.
+      // Objective-state converges on the same explicit target (the stricter
+      // principal-self contract only governs the IMPLICIT path).
       const writeNamespace = this.resolveWritableNamespace(
         request.namespace,
         request.sessionKey,
@@ -1446,6 +1464,7 @@ export class EngramAccessService {
         explicitNamespace: request.namespace!.trim(),
         baseNamespace: writeNamespace,
         writeNamespace,
+        objectiveStateNamespace: writeNamespace,
         readNamespaces: [writeNamespace],
         codingOverlayApplied: false,
         warnings,
@@ -1460,49 +1479,145 @@ export class EngramAccessService {
       this.orchestrator.config,
     );
 
+    // Resolve the coding overlay through the SAME orchestrator method recall and
+    // the buffer-flush write path use (`applyCodingNamespaceOverlay`), NOT a
+    // private re-implementation. Routing through the one shared method (rule 22 /
+    // 42) means a project-scoped observe writes to byte-for-byte the namespace a
+    // same-session recall reads — and that the read/write overlay logic cannot
+    // drift (the #1495 drift this PR exists to close). The orchestrator method
+    // already gates on `namespacesEnabled` + a bound/derivable coding context, so
+    // it returns the base unchanged when no overlay applies.
+    //
+    // `applyCodingNamespaceOverlay` reads the session's ATTACHED context. The
+    // scope plan runs BEFORE `maybeAttachCodingContext` (resolve-before-mutate),
+    // so when nothing is attached yet we seed the per-call cwd/projectTag context
+    // first — identical to what attach would bind — so the overlay is the same
+    // either way (Codex review precedence: session context first, per-call
+    // fallback).
     const hasSession =
       typeof request.sessionKey === "string" && request.sessionKey.length > 0;
-    const overlay =
+    const overlayEligible =
       hasSession &&
-      this.orchestrator.config.namespacesEnabled &&
-      this.orchestrator.config.codingMode?.projectScope
-        ? resolveCodingNamespaceOverlay(
-            this.orchestrator.getCodingContextForSession(request.sessionKey) ??
-              (await this.resolveCodingContextFromOptions(request)),
-            this.orchestrator.config.codingMode,
-            this.orchestrator.config.defaultNamespace,
-          )
-        : null;
+      this.orchestrator.config.namespacesEnabled === true &&
+      this.orchestrator.config.codingMode?.projectScope === true;
 
-    if (!overlay) {
-      // No overlay → stay on the auth-checked base. Mirror the legacy path
-      // (resolveWritableNamespace with no explicit namespace) so the
-      // namespaces-disabled / no-session / projectScope-off cases collapse to
-      // config.defaultNamespace exactly as before.
+    // Resolve the coding context the overlay must use: the session's ATTACHED
+    // context first (so a bound session wins), else the per-call cwd/projectTag —
+    // identical precedence to recall and to `resolveCodingScopedWriteNamespace`.
+    let attachedContext = hasSession
+      ? this.orchestrator.getCodingContextForSession(request.sessionKey)
+      : null;
+    // Track whether WE seeded the per-call context so we can leave the session
+    // exactly as we found it on any rejection (read-only contract / no-orphan
+    // guard, observe-scope "unauthorized overlay self-base" test).
+    let seededContext = false;
+    if (overlayEligible && !attachedContext) {
+      attachedContext = await this.resolveCodingContextFromOptions(request);
+      if (attachedContext) {
+        // Seed the per-call context so the shared
+        // `applyCodingNamespaceOverlay` (which reads ATTACHED session context)
+        // overlays it through the ONE method recall/buffer-flush use (rule 22 /
+        // 42) — no private re-implementation that could drift. On the happy
+        // path `maybeAttachCodingContext` re-binds the identical context after
+        // auth passes; on a rejection we clear the seed below, so the session is
+        // untouched either way.
+        this.orchestrator.setCodingContextForSession(
+          request.sessionKey!,
+          attachedContext,
+        );
+        seededContext = true;
+      }
+    }
+
+    // Clear a seed we added, used only on the rejection paths so a failed
+    // observe never leaves an orphaned project binding (read-only contract).
+    const clearSeededContext = (): void => {
+      if (seededContext && hasSession) {
+        this.orchestrator.setCodingContextForSession(request.sessionKey!, null);
+      }
+    };
+
+    const overlaidBase = this.orchestrator.applyCodingNamespaceOverlay(
+      request.sessionKey,
+      baseNamespace,
+    );
+    const codingOverlayApplied = overlaidBase !== baseNamespace;
+
+    if (!codingOverlayApplied) {
+      // No overlay → the LCM/extraction/response write namespace mirrors the
+      // legacy memory_store path (resolveWritableNamespace with no explicit
+      // namespace), collapsing the namespaces-disabled / no-session /
+      // projectScope-off cases to config.defaultNamespace exactly as before
+      // (rule 39 parity with resolveCodingScopedWriteNamespace).
       const writeNamespace = this.resolveWritableNamespace(
         undefined,
         request.sessionKey,
         request.authenticatedPrincipal,
       );
+      // Objective-state keeps its STRICTER pre-#1495 contract (#928): an implicit
+      // snapshot is based on the PRINCIPAL SELF namespace and authorized against
+      // THAT base (rule 48 least-privilege). This rejection MUST stay (security):
+      // an implicit observe by a principal that cannot write its own self
+      // namespace must not silently snapshot objective-state to the default
+      // store.
+      //
+      // GATED on objective-state writes being ENABLED, exactly like the pre-#1495
+      // code (`if (shouldWriteObjectiveState && !hasExplicitNamespace && …)`).
+      // The general LCM/extraction write path collapses an unqualified write to
+      // config.defaultNamespace (always writable), so when objective-state writes
+      // are OFF there is no self-base write to authorize and observe must NOT
+      // reject (the "skips … when writes are disabled" invariant). When namespaces
+      // are off the self base collapses to config.defaultNamespace, so this is a
+      // no-op for single-store deployments either way.
+      const willWriteObjectiveState =
+        this.orchestrator.config.objectiveStateMemoryEnabled === true &&
+        this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true;
+      if (
+        willWriteObjectiveState &&
+        this.orchestrator.config.namespacesEnabled === true &&
+        !canWriteNamespace(principal, baseNamespace, this.orchestrator.config)
+      ) {
+        clearSeededContext();
+        throw new EngramAccessInputError(
+          `namespace is not writable: ${baseNamespace}`,
+        );
+      }
       return {
         principal,
         baseNamespace: writeNamespace,
         writeNamespace,
+        // Implicit objective-state stays on the principal self base, NOT the
+        // (possibly default) general write namespace — preserving the #928
+        // semantics the objective-state suite asserts.
+        objectiveStateNamespace: baseNamespace,
         readNamespaces: [writeNamespace],
         codingOverlayApplied: false,
         warnings,
       };
     }
 
-    // Overlay → rebuild from the authorized principal self base.
+    // Overlay applied → both the general write namespace AND objective-state
+    // converge on the overlaid principal self base. Authorize the self base
+    // (the overlay is a principal-owned `project-*` sub-namespace derived from
+    // it, so it needs no separate write policy — rule 42 / 47 / 48).
     if (!canWriteNamespace(principal, baseNamespace, this.orchestrator.config)) {
+      clearSeededContext();
       throw new EngramAccessInputError(
         `namespace is not writable: ${baseNamespace}`,
       );
     }
-    const writeNamespace = combineNamespaces(baseNamespace, overlay.namespace);
+    const writeNamespace = overlaidBase;
     const readNamespaces = [writeNamespace];
-    for (const fallback of overlay.readFallbacks ?? []) {
+    // Include read fallbacks (branch→project→root) so the diagnostic readNamespaces
+    // matches what a same-session recall searches. Resolved through the pure
+    // overlay helper to enumerate fallbacks; the write namespace itself already
+    // came from `applyCodingNamespaceOverlay` so the two agree.
+    const overlay = resolveCodingNamespaceOverlay(
+      attachedContext,
+      this.orchestrator.config.codingMode,
+      this.orchestrator.config.defaultNamespace,
+    );
+    for (const fallback of overlay?.readFallbacks ?? []) {
       const ns = combineNamespaces(baseNamespace, fallback);
       if (!readNamespaces.includes(ns)) readNamespaces.push(ns);
     }
@@ -1510,8 +1625,9 @@ export class EngramAccessService {
       principal,
       baseNamespace,
       writeNamespace,
+      objectiveStateNamespace: writeNamespace,
       readNamespaces,
-      codingOverlayApplied: writeNamespace !== baseNamespace,
+      codingOverlayApplied: true,
       warnings,
     };
   }
@@ -4534,11 +4650,17 @@ export class EngramAccessService {
         this.orchestrator.config.defaultNamespace,
       ) ?? request.sessionKey;
 
-    // 4. Objective-state snapshots → effective write namespace.
+    // 4. Objective-state snapshots → the scope plan's objective-state namespace.
+    //    For explicit-namespace and coding-overlay writes this equals
+    //    writeNamespace; for an IMPLICIT write it is the principal SELF base
+    //    (#928 contract, already auth-checked inside the scope plan), not the
+    //    general default-store write namespace.
     if (shouldWriteObjectiveState) {
       try {
         const objectiveStateLocation =
-          await this.objectiveStateStoreLocationForNamespace(writeNamespace);
+          await this.objectiveStateStoreLocationForNamespace(
+            scope.objectiveStateNamespace,
+          );
         await recordObjectiveStateSnapshotsFromObservedMessages({
           memoryDir: objectiveStateLocation.memoryDir,
           objectiveStateStoreDir: objectiveStateLocation.objectiveStateStoreDir,
@@ -4570,12 +4692,22 @@ export class EngramAccessService {
       }
     }
 
-    // 6. Extraction/replay → effective write namespace.
+    // 6. Extraction/replay → effective write namespace for STORAGE, ORIGINAL
+    //    sessionKey for IDENTITY (provenance + threading).
     let extractionQueued = false;
     if (request.skipExtraction !== true) {
       const turns = request.messages.map((m) => ({
         source: "openclaw" as const,
-        sessionKey: lcmSessionKey,
+        // Identity-vs-routing separation (#1505 thread 1, cursor): extraction
+        // derives the provenance principal via `resolvePrincipal(turn.sessionKey)`
+        // and threads `turn.sessionKey` into conversation threading. Feeding the
+        // namespace-PREFIXED `lcmSessionKey` here mis-derived the principal to
+        // `default` (a `<ns>:<key>` string matches no prefix/map rule and fails
+        // the `agent:` heuristic). Pass the ORIGINAL sessionKey so identity is
+        // correct; storage routing is pinned separately via
+        // writeNamespaceOverride below, and the authenticated principal is pinned
+        // via principalOverride.
+        sessionKey: request.sessionKey,
         role: m.role,
         content: m.content,
         parts: m.parts,
@@ -4583,17 +4715,27 @@ export class EngramAccessService {
         sourceFormat: m.sourceFormat,
         timestamp: new Date().toISOString(),
       }));
-      // Pin extraction writes to the effective namespace rather than letting the
-      // orchestrator re-derive one from the (namespace-prefixed) lcmSessionKey —
-      // that re-derivation would miss the coding overlay (the #1495 drift) and
-      // fail to resolve a principal from a prefixed key. Passing
-      // writeNamespaceOverride makes the extraction target deterministic and
-      // identical to LCM/objective-state (rule 39). Omit it when the effective
-      // namespace is the default store, so single-store deployments keep the
-      // existing principal-derived routing unchanged.
+      // Pin extraction STORAGE to the effective namespace rather than letting the
+      // orchestrator re-derive one from the session key + coding overlay — that
+      // re-derivation would have to reparse identity and could miss the overlay
+      // (the #1495 drift). Passing writeNamespaceOverride makes the extraction
+      // target deterministic and identical to LCM/objective-state (rule 39).
+      // Omit it when the effective namespace is the default store, so single-store
+      // deployments keep the existing principal-derived routing unchanged.
       const writeNamespaceOverride =
         writeNamespace !== this.orchestrator.config.defaultNamespace
           ? writeNamespace
+          : undefined;
+      // Pin provenance PRINCIPAL to the scope plan's resolved principal (#1505
+      // thread 1). The scope plan already applied auth precedence
+      // (authenticatedPrincipal/principalOverride > resolvePrincipal(original
+      // sessionKey)), so this is the same identity the surface authorized — never
+      // a `default` fallback parsed from a prefixed key. Omitted when no principal
+      // resolved (namespaces-disabled / unauthenticated single-store), preserving
+      // existing behavior.
+      const principalOverride =
+        typeof scope.principal === "string" && scope.principal.length > 0
+          ? scope.principal
           : undefined;
       // Fire-and-forget: queue extraction in the background so the HTTP
       // response returns immediately. LCM archival (above) is also
@@ -4608,6 +4750,7 @@ export class EngramAccessService {
         const extractionPromise = this.orchestrator.ingestReplayBatch(turns, {
           archiveLcm: false,
           writeNamespaceOverride,
+          principalOverride,
         });
         extractionPromise.catch((err) => {
           log.error(`access-observe background extraction failed: ${err}`);

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -9,6 +9,7 @@ import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
 import { resolveGitContext } from "./coding/git-context.js";
 import {
   combineNamespaces,
+  lcmSessionKeyForNamespace,
   projectTagProjectId,
   resolveCodingNamespaceOverlay,
 } from "./coding/coding-namespace.js";
@@ -4482,11 +4483,25 @@ export class EngramAccessService {
       }
     }
 
-    // 1. Authorize the namespace BEFORE attaching coding context so a failed
-    //    auth check doesn't leave orphaned context on the session (Codex review
-    //    P2). `namespace` is the backward-compatible BASE writable namespace
-    //    (pre-#1495 response semantics); the EFFECTIVE write namespace is
-    //    resolved by the scope plan below.
+    // 1. Resolve the FULL effective scope plan BEFORE any session mutation
+    //    (Codex P2 / Cursor "orphan context after overlay auth"). The plan is
+    //    read-only and re-runs the SAME authorization as
+    //    memory_store/suggestion_submit (rule 39): the explicit-namespace check
+    //    AND the coding-overlay self-base `canWriteNamespace` check both run
+    //    here. Because `maybeAttachCodingContext` has NOT run yet, the plan's
+    //    overlay resolves from the per-call `cwd`/`projectTag` fallback
+    //    (`resolveCodingContextFromOptions`) — identical to the context that
+    //    would be attached — so the scope is the same either way. Running the
+    //    plan first means an `observe` that ultimately throws on a non-writable
+    //    self base leaves NO coding context bound to the session, matching how
+    //    `memory_store` resolves its full scoped write namespace before any
+    //    session mutation.
+    const scope = await this.resolveMemoryScopePlan(request);
+    const writeNamespace = scope.writeNamespace;
+
+    // Backward-compatible BASE writable namespace (pre-#1495 response
+    // semantics). Authorized through the same policy path; the EFFECTIVE write
+    // namespace every side effect uses is `writeNamespace` (the scope plan).
     const namespace = this.resolveWritableNamespace(
       request.namespace,
       request.sessionKey,
@@ -4496,30 +4511,28 @@ export class EngramAccessService {
       this.orchestrator.config.objectiveStateMemoryEnabled === true &&
       this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true;
 
-    // 2. Auto-resolve coding context from cwd/projectTag so observe writes route
-    //    to the correct project namespace (rule 42: same namespace layer as
-    //    recall). Done AFTER auth so the no-orphan-context guard holds.
+    // 2. Auto-resolve coding context from cwd/projectTag so a LATER bare recall
+    //    on the same session is project-scoped (rule 42: same namespace layer as
+    //    recall). Done AFTER the scope plan authorized the write, so a rejected
+    //    request never leaves orphaned context on the session.
     await this.maybeAttachCodingContext(request.sessionKey, {
       cwd: request.cwd,
       projectTag: request.projectTag,
     });
 
-    // 3. Compute the single effective scope plan every side effect consumes
-    //    (#1495). The plan reads the session's now-attached coding context and
-    //    re-runs the SAME authorization as memory_store/suggestion_submit, so
-    //    observe's scoping is identical to explicit coding-scoped writes
-    //    (rule 39). The plan is read-only — context was attached in step 2.
-    const scope = await this.resolveMemoryScopePlan(request);
-    const writeNamespace = scope.writeNamespace;
-
     // Prefix sessionKey with the EFFECTIVE write namespace for LCM archival so
     // observed turns are scoped to the same namespace project-scoped recall
-    // reads. Only prefix when it diverges from the default store (multi-tenant
-    // isolation); a single-store deployment keeps the raw sessionKey.
+    // reads. The SAME `lcmSessionKeyForNamespace` helper is used by the
+    // orchestrator recall readers and by compaction flush/record, so the LCM
+    // write key and every read/flush key agree (#1495, rule 42). Only prefixes
+    // when the namespace diverges from the default store; a single-store
+    // deployment keeps the raw sessionKey unchanged.
     const lcmSessionKey =
-      writeNamespace !== this.orchestrator.config.defaultNamespace
-        ? `${writeNamespace}:${request.sessionKey}`
-        : request.sessionKey;
+      lcmSessionKeyForNamespace(
+        writeNamespace,
+        request.sessionKey,
+        this.orchestrator.config.defaultNamespace,
+      ) ?? request.sessionKey;
 
     // 4. Objective-state snapshots → effective write namespace.
     if (shouldWriteObjectiveState) {
@@ -4675,6 +4688,57 @@ export class EngramAccessService {
     };
   }
 
+  /**
+   * Resolve the LCM `session_id` a compaction flush/record must target so it
+   * matches the key `observe` archived under (#1495 thread 2, rule 42).
+   *
+   * Precedence mirrors `observe`'s effective write namespace:
+   *  - With an explicit `request.namespace`, use the already-authorized
+   *    `resolvedNamespace` (the overlay never applies to an explicit write).
+   *  - With NO explicit namespace, an auto-scoped session was archived under
+   *    its coding-overlay namespace, so overlay the session's bound coding
+   *    context onto the principal self base — the SAME resolution
+   *    `resolveMemoryScopePlan`/recall use. `applyCodingNamespaceOverlay`
+   *    returns the base unchanged when projectScope/namespaces are off or no
+   *    context is bound, so single-store / no-overlay flows collapse to the raw
+   *    sessionKey exactly as before.
+   *
+   * Then encode the `${namespace}:${sessionKey}` prefix via the shared helper
+   * so the flush/record key is byte-for-byte what the LCM write and the recall
+   * readers use.
+   */
+  private resolveLcmSessionKeyForCompaction(
+    explicitNamespace: string | undefined,
+    resolvedNamespace: string,
+    sessionKey: string,
+    authenticatedPrincipal: string | undefined,
+  ): string {
+    const hasExplicitNamespace =
+      typeof explicitNamespace === "string" && explicitNamespace.trim().length > 0;
+    let effectiveNamespace = resolvedNamespace;
+    if (!hasExplicitNamespace) {
+      // Mirror observe's write resolution: use the coding-overlay namespace
+      // when one applies, else the default store. NOT the principal self base —
+      // an unqualified observe archives under the default store, so a self-base
+      // prefix here would target a queue observe never wrote to (#1495).
+      const principal = this.resolveRequestPrincipal(sessionKey, authenticatedPrincipal);
+      const base = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
+      const overlaid = this.orchestrator.applyCodingNamespaceOverlay(
+        sessionKey,
+        base,
+      );
+      effectiveNamespace =
+        overlaid !== base ? overlaid : this.orchestrator.config.defaultNamespace;
+    }
+    return (
+      lcmSessionKeyForNamespace(
+        effectiveNamespace,
+        sessionKey,
+        this.orchestrator.config.defaultNamespace,
+      ) ?? sessionKey
+    );
+  }
+
   async lcmCompactionFlush(
     request: EngramAccessLcmCompactionFlushRequest,
   ): Promise<EngramAccessLcmCompactionFlushResponse> {
@@ -4697,9 +4761,17 @@ export class EngramAccessService {
       };
     }
 
-    const lcmSessionKey = namespace !== this.orchestrator.config.defaultNamespace
-      ? `${namespace}:${request.sessionKey}`
-      : request.sessionKey;
+    // Flush the SAME LCM session_id that `observe` archived under. When no
+    // explicit namespace is supplied, an auto-scoped session was archived under
+    // its coding-overlay namespace (`${effectiveNamespace}:${sessionKey}`), not
+    // the base `namespace` — so apply the session's coding overlay here too, or
+    // the flush would target the wrong queue (#1495 thread 2, rule 42).
+    const lcmSessionKey = this.resolveLcmSessionKeyForCompaction(
+      request.namespace,
+      namespace,
+      request.sessionKey,
+      request.authenticatedPrincipal,
+    );
     await this.orchestrator.lcmEngine.waitForSessionObserveIdle(lcmSessionKey);
     await this.orchestrator.lcmEngine.preCompactionFlush(lcmSessionKey);
     return {
@@ -4738,9 +4810,16 @@ export class EngramAccessService {
       };
     }
 
-    const lcmSessionKey = namespace !== this.orchestrator.config.defaultNamespace
-      ? `${namespace}:${request.sessionKey}`
-      : request.sessionKey;
+    // Record against the SAME LCM session_id `observe` archived under — apply
+    // the session's coding overlay when no explicit namespace is given, so an
+    // auto-scoped session records its compaction on the right queue (#1495
+    // thread 2, rule 42).
+    const lcmSessionKey = this.resolveLcmSessionKeyForCompaction(
+      request.namespace,
+      namespace,
+      request.sessionKey,
+      request.authenticatedPrincipal,
+    );
     await this.orchestrator.lcmEngine.waitForSessionObserveIdle(lcmSessionKey);
     await this.orchestrator.lcmEngine.recordCompaction(
       lcmSessionKey,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4720,10 +4720,20 @@ export class EngramAccessService {
       // re-derivation would have to reparse identity and could miss the overlay
       // (the #1495 drift). Passing writeNamespaceOverride makes the extraction
       // target deterministic and identical to LCM/objective-state (rule 39).
-      // Omit it when the effective namespace is the default store, so single-store
-      // deployments keep the existing principal-derived routing unchanged.
+      //
+      // Pin WHENEVER namespaces are enabled, not only when writeNamespace differs
+      // from the default store (#1505 round 3, codex "Pin default-store extraction
+      // writes too"). For an unqualified/no-overlay observe by a principal that
+      // HAS a self namespace, writeNamespace is `config.defaultNamespace` but an
+      // unpinned `runExtraction` would fall back to
+      // `defaultNamespaceForPrincipal(principal)` = the SELF namespace — diverging
+      // from where LCM/objective-state/response wrote (`default`). Pinning the
+      // resolved writeNamespace forces all side effects onto the one scope-plan
+      // namespace. When namespaces are DISABLED the router collapses every
+      // namespace to one store, so leaving the override undefined preserves the
+      // existing single-store routing byte-for-byte.
       const writeNamespaceOverride =
-        writeNamespace !== this.orchestrator.config.defaultNamespace
+        this.orchestrator.config.namespacesEnabled === true
           ? writeNamespace
           : undefined;
       // Pin provenance PRINCIPAL to the scope plan's resolved principal (#1505
@@ -4803,11 +4813,34 @@ export class EngramAccessService {
     }
 
     const limit = Math.max(1, Math.min(request.limit ?? 10, 100));
-    const lcmSessionKey = request.sessionKey && namespace !== this.orchestrator.config.defaultNamespace
-      ? `${namespace}:${request.sessionKey}`
+    // Route the LCM read session_id AND prefix through the SAME overlay-aware
+    // namespace `observe`'s write key and compaction use (#1505 round 3). A
+    // project-scoped `observe` with no explicit namespace archived under the
+    // coding-overlay namespace; deriving the prefix only from the readable
+    // `namespace` (as before) would search the raw key and miss those turns.
+    // The effective namespace is resolved ONCE from the real session
+    // (`request.sessionKey`) — the prefix is a search fragment with no bound
+    // coding context, so it inherits the same namespace. Collapses to the raw key
+    // for single-store / no-overlay / explicit-default flows (existing behavior).
+    const lcmReadNamespace = this.resolveLcmReadNamespace(
+      request.namespace,
+      namespace,
+      request.sessionKey,
+      request.authenticatedPrincipal,
+    );
+    const lcmSessionKey = request.sessionKey
+      ? lcmSessionKeyForNamespace(
+          lcmReadNamespace,
+          request.sessionKey,
+          this.orchestrator.config.defaultNamespace,
+        ) ?? request.sessionKey
       : request.sessionKey;
-    const lcmSessionPrefix = request.sessionPrefix && namespace !== this.orchestrator.config.defaultNamespace
-      ? `${namespace}:${request.sessionPrefix}`
+    const lcmSessionPrefix = request.sessionPrefix
+      ? lcmSessionKeyForNamespace(
+          lcmReadNamespace,
+          request.sessionPrefix,
+          this.orchestrator.config.defaultNamespace,
+        ) ?? request.sessionPrefix
       : request.sessionPrefix;
     const rawResults = await this.orchestrator.lcmEngine.searchContextFull(
       request.query,
@@ -4832,8 +4865,11 @@ export class EngramAccessService {
   }
 
   /**
-   * Resolve the LCM `session_id` a compaction flush/record must target so it
-   * matches the key `observe` archived under (#1495 thread 2, rule 42).
+   * Resolve the LCM `session_id` a same-session READER (compaction flush/record,
+   * `lcmSearch`, raw-excerpt lookup) must target so it matches the key `observe`
+   * archived under (#1495 thread 2 + #1505 round 3, rule 42). One helper for
+   * EVERY access-surface LCM read so the read key cannot drift from the write key
+   * (rule 22).
    *
    * Precedence mirrors `observe`'s effective write namespace:
    *  - With an explicit `request.namespace`, use the already-authorized
@@ -4847,32 +4883,54 @@ export class EngramAccessService {
    *    sessionKey exactly as before.
    *
    * Then encode the `${namespace}:${sessionKey}` prefix via the shared helper
-   * so the flush/record key is byte-for-byte what the LCM write and the recall
-   * readers use.
+   * so the read key is byte-for-byte what the LCM write and the recall readers
+   * use.
    */
-  private resolveLcmSessionKeyForCompaction(
+  /**
+   * Resolve the effective LCM read NAMESPACE a same-session reader must prefix
+   * with (the namespace half of {@link resolveLcmReadSessionKey}). Split out so
+   * `lcmSearch` can apply ONE namespace to BOTH its `sessionKey` and its
+   * `sessionPrefix` — the prefix is a search fragment, not a real session, so its
+   * own coding context can't be looked up; it must inherit the namespace resolved
+   * from the real session (`sessionKeyForOverlay`).
+   */
+  private resolveLcmReadNamespace(
+    explicitNamespace: string | undefined,
+    resolvedNamespace: string,
+    sessionKeyForOverlay: string | undefined,
+    authenticatedPrincipal: string | undefined,
+  ): string {
+    const hasExplicitNamespace =
+      typeof explicitNamespace === "string" && explicitNamespace.trim().length > 0;
+    if (hasExplicitNamespace) return resolvedNamespace;
+    // Mirror observe's write resolution: use the coding-overlay namespace when
+    // one applies, else the default store. NOT the principal self base — an
+    // unqualified observe archives under the default store, so a self-base prefix
+    // here would target a queue observe never wrote to (#1495).
+    const principal = this.resolveRequestPrincipal(
+      sessionKeyForOverlay,
+      authenticatedPrincipal,
+    );
+    const base = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
+    const overlaid = this.orchestrator.applyCodingNamespaceOverlay(
+      sessionKeyForOverlay,
+      base,
+    );
+    return overlaid !== base ? overlaid : this.orchestrator.config.defaultNamespace;
+  }
+
+  private resolveLcmReadSessionKey(
     explicitNamespace: string | undefined,
     resolvedNamespace: string,
     sessionKey: string,
     authenticatedPrincipal: string | undefined,
   ): string {
-    const hasExplicitNamespace =
-      typeof explicitNamespace === "string" && explicitNamespace.trim().length > 0;
-    let effectiveNamespace = resolvedNamespace;
-    if (!hasExplicitNamespace) {
-      // Mirror observe's write resolution: use the coding-overlay namespace
-      // when one applies, else the default store. NOT the principal self base —
-      // an unqualified observe archives under the default store, so a self-base
-      // prefix here would target a queue observe never wrote to (#1495).
-      const principal = this.resolveRequestPrincipal(sessionKey, authenticatedPrincipal);
-      const base = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
-      const overlaid = this.orchestrator.applyCodingNamespaceOverlay(
-        sessionKey,
-        base,
-      );
-      effectiveNamespace =
-        overlaid !== base ? overlaid : this.orchestrator.config.defaultNamespace;
-    }
+    const effectiveNamespace = this.resolveLcmReadNamespace(
+      explicitNamespace,
+      resolvedNamespace,
+      sessionKey,
+      authenticatedPrincipal,
+    );
     return (
       lcmSessionKeyForNamespace(
         effectiveNamespace,
@@ -4909,7 +4967,7 @@ export class EngramAccessService {
     // its coding-overlay namespace (`${effectiveNamespace}:${sessionKey}`), not
     // the base `namespace` — so apply the session's coding overlay here too, or
     // the flush would target the wrong queue (#1495 thread 2, rule 42).
-    const lcmSessionKey = this.resolveLcmSessionKeyForCompaction(
+    const lcmSessionKey = this.resolveLcmReadSessionKey(
       request.namespace,
       namespace,
       request.sessionKey,
@@ -4957,7 +5015,7 @@ export class EngramAccessService {
     // the session's coding overlay when no explicit namespace is given, so an
     // auto-scoped session records its compaction on the right queue (#1495
     // thread 2, rule 42).
-    const lcmSessionKey = this.resolveLcmSessionKeyForCompaction(
+    const lcmSessionKey = this.resolveLcmReadSessionKey(
       request.namespace,
       namespace,
       request.sessionKey,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -822,6 +822,38 @@ export interface CodingScopedWriteInput {
   projectTag?: string;
 }
 
+/**
+ * Internal, single-resolution plan describing the effective memory scope for a
+ * write-producing access request (#1495, seed for epic #1494). One plan is
+ * resolved per request and EVERY side effect (LCM archival, extraction replay,
+ * objective-state snapshot, response) consumes the same `writeNamespace`, so an
+ * observed turn and its extracted memories never drift away from the namespace a
+ * same-session project-scoped recall searches (rule 39 / 42).
+ *
+ * The resolver that produces this is READ-ONLY with respect to namespace
+ * authorization: an explicit namespace is authorized through the existing
+ * `canWriteNamespace` policy path, and a coding overlay is always REBUILT from
+ * the authenticated principal's base — never accepted as a caller string — so a
+ * caller can never reach another principal's overlay by forging an
+ * overlay-shaped namespace (rule 42 / 47 / 48).
+ */
+export interface MemoryScopePlan {
+  /** Resolved request principal (auth precedence applied), or undefined. */
+  principal?: string;
+  /** Explicit `namespace` supplied by the caller, if any (already authorized). */
+  explicitNamespace?: string;
+  /** Principal self base namespace before any coding overlay. */
+  baseNamespace: string;
+  /** Effective write namespace — what every side effect must use. */
+  writeNamespace: string;
+  /** Namespaces a same-session recall would read (cheap subset). */
+  readNamespaces: string[];
+  /** Whether the coding overlay changed the base namespace. */
+  codingOverlayApplied: boolean;
+  /** Non-fatal diagnostics surfaced during resolution. */
+  warnings: string[];
+}
+
 export interface EngramAccessMemoryStoreRequest
   extends EngramAccessWriteEnvelope,
     ExplicitCaptureInput,
@@ -874,10 +906,45 @@ export interface EngramAccessObserveRequest {
   projectTag?: string;
 }
 
+/**
+ * Additive diagnostic view of the effective {@link MemoryScopePlan} resolved for
+ * an `observe` request (#1495 / epic #1494). Lets callers and tests inspect
+ * which namespace the operation actually wrote to without changing the
+ * backward-compatible `namespace` field. Purely informational — never gates
+ * authorization.
+ */
+export interface EngramAccessScopeDebug {
+  /** Resolved principal, or `undefined` when none could be derived. */
+  principal?: string;
+  /** Explicit `namespace` from the request, if one was supplied. */
+  explicitNamespace?: string;
+  /** Principal self base before any coding overlay. */
+  baseNamespace: string;
+  /** Effective write namespace every side effect of the request uses. */
+  writeNamespace: string;
+  /** Whether the coding (project/branch) overlay changed the base namespace. */
+  codingOverlayApplied: boolean;
+  /** Namespaces a same-session recall would read, when cheap to compute. */
+  readNamespaces?: string[];
+}
+
 export interface EngramAccessObserveResponse {
   accepted: number;
   sessionKey: string;
+  /**
+   * Backward-compatible base writable namespace (pre-#1495 semantics). Kept
+   * unchanged so existing callers/tests are not broken. The namespace the
+   * operation ACTUALLY wrote to is {@link EngramAccessObserveResponse.effectiveNamespace}.
+   */
   namespace: string;
+  /**
+   * Effective write namespace every memory-producing side effect of this
+   * request used (LCM archival, extraction replay, objective-state snapshot).
+   * Equals the namespace a same-session project-scoped recall searches (#1495).
+   */
+  effectiveNamespace: string;
+  /** Additive diagnostic view of the resolved scope plan (#1495). */
+  scopeDebug?: EngramAccessScopeDebug;
   lcmArchived: boolean;
   extractionQueued: boolean;
 }
@@ -1324,6 +1391,128 @@ export class EngramAccessService {
       throw new EngramAccessInputError(`namespace is not writable: ${base}`);
     }
     return combineNamespaces(base, overlay.namespace);
+  }
+
+  /**
+   * Resolve ONE effective memory scope plan for a write-producing request
+   * (#1495 / seed for epic #1494). The returned {@link MemoryScopePlan} is the
+   * single source of truth `observe` (and, later, other write surfaces) consume
+   * so every side effect lands in `plan.writeNamespace`.
+   *
+   * Authorization mirrors {@link resolveCodingScopedWriteNamespace} EXACTLY so
+   * `observe`'s scoping is identical to `memory_store`/`suggestion_submit`
+   * (rule 39 — feature gates identical across code paths):
+   *  - an explicit `namespace` always wins and is authorized strictly through
+   *    `resolveWritableNamespace` → `canWriteNamespace`; an overlay-shaped string
+   *    is never a writable target (rule 42 / 47 / 48);
+   *  - with NO overlay, the base stays on `config.defaultNamespace` (pre-#1434
+   *    behavior), auth-checked;
+   *  - WITH an overlay, the base is the principal self namespace and the overlay
+   *    is REBUILT from that authorized base — never accepted as a caller string.
+   *
+   * READ-ONLY: this never mutates session coding context. Callers that need the
+   * `cwd`/`projectTag` bound to the session (so a later bare recall is scoped)
+   * must attach it via `maybeAttachCodingContext` BEFORE calling this, which
+   * also preserves the no-orphan-context guard (attach only after auth passes).
+   * The overlay here reads the session's attached context first (matching recall
+   * precedence), falling back to the per-call `cwd`/`projectTag`.
+   */
+  private async resolveMemoryScopePlan(
+    request: CodingScopedWriteInput & {
+      namespace?: string;
+      sessionKey?: string;
+      authenticatedPrincipal?: string;
+    },
+  ): Promise<MemoryScopePlan> {
+    const warnings: string[] = [];
+    const principal = this.resolveRequestPrincipal(
+      request.sessionKey,
+      request.authenticatedPrincipal,
+    );
+    const hasExplicitNamespace =
+      typeof request.namespace === "string" && request.namespace.trim().length > 0;
+
+    if (hasExplicitNamespace) {
+      // Explicit namespace wins; authorized through the existing policy path.
+      // The overlay never applies, so base == write == the explicit namespace.
+      const writeNamespace = this.resolveWritableNamespace(
+        request.namespace,
+        request.sessionKey,
+        request.authenticatedPrincipal,
+      );
+      return {
+        principal,
+        explicitNamespace: request.namespace!.trim(),
+        baseNamespace: writeNamespace,
+        writeNamespace,
+        readNamespaces: [writeNamespace],
+        codingOverlayApplied: false,
+        warnings,
+      };
+    }
+
+    // No explicit namespace → principal self base, optionally overlaid with the
+    // session's coding (project/branch) context — the SAME resolution recall and
+    // the orchestrator buffer-flush write path use (rule 42 symmetry).
+    const baseNamespace = defaultNamespaceForPrincipal(
+      principal,
+      this.orchestrator.config,
+    );
+
+    const hasSession =
+      typeof request.sessionKey === "string" && request.sessionKey.length > 0;
+    const overlay =
+      hasSession &&
+      this.orchestrator.config.namespacesEnabled &&
+      this.orchestrator.config.codingMode?.projectScope
+        ? resolveCodingNamespaceOverlay(
+            this.orchestrator.getCodingContextForSession(request.sessionKey) ??
+              (await this.resolveCodingContextFromOptions(request)),
+            this.orchestrator.config.codingMode,
+            this.orchestrator.config.defaultNamespace,
+          )
+        : null;
+
+    if (!overlay) {
+      // No overlay → stay on the auth-checked base. Mirror the legacy path
+      // (resolveWritableNamespace with no explicit namespace) so the
+      // namespaces-disabled / no-session / projectScope-off cases collapse to
+      // config.defaultNamespace exactly as before.
+      const writeNamespace = this.resolveWritableNamespace(
+        undefined,
+        request.sessionKey,
+        request.authenticatedPrincipal,
+      );
+      return {
+        principal,
+        baseNamespace: writeNamespace,
+        writeNamespace,
+        readNamespaces: [writeNamespace],
+        codingOverlayApplied: false,
+        warnings,
+      };
+    }
+
+    // Overlay → rebuild from the authorized principal self base.
+    if (!canWriteNamespace(principal, baseNamespace, this.orchestrator.config)) {
+      throw new EngramAccessInputError(
+        `namespace is not writable: ${baseNamespace}`,
+      );
+    }
+    const writeNamespace = combineNamespaces(baseNamespace, overlay.namespace);
+    const readNamespaces = [writeNamespace];
+    for (const fallback of overlay.readFallbacks ?? []) {
+      const ns = combineNamespaces(baseNamespace, fallback);
+      if (!readNamespaces.includes(ns)) readNamespaces.push(ns);
+    }
+    return {
+      principal,
+      baseNamespace,
+      writeNamespace,
+      readNamespaces,
+      codingOverlayApplied: writeNamespace !== baseNamespace,
+      warnings,
+    };
   }
 
   private async objectiveStateStoreLocationForNamespace(namespace: string): Promise<{
@@ -4293,16 +4482,11 @@ export class EngramAccessService {
       }
     }
 
-    // Validate namespace authorization BEFORE attaching coding context so
-    // a failed auth check doesn't leave orphaned context on the session
-    // (Codex review P2).
-    const hasExplicitNamespace =
-      typeof request.namespace === "string" &&
-      request.namespace.trim().length > 0;
-    const principal = this.resolveRequestPrincipal(
-      request.sessionKey,
-      request.authenticatedPrincipal,
-    );
+    // 1. Authorize the namespace BEFORE attaching coding context so a failed
+    //    auth check doesn't leave orphaned context on the session (Codex review
+    //    P2). `namespace` is the backward-compatible BASE writable namespace
+    //    (pre-#1495 response semantics); the EFFECTIVE write namespace is
+    //    resolved by the scope plan below.
     const namespace = this.resolveWritableNamespace(
       request.namespace,
       request.sessionKey,
@@ -4311,50 +4495,37 @@ export class EngramAccessService {
     const shouldWriteObjectiveState =
       this.orchestrator.config.objectiveStateMemoryEnabled === true &&
       this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true;
-    const objectiveStateBaseNamespace = hasExplicitNamespace
-      ? namespace
-      : defaultNamespaceForPrincipal(principal, this.orchestrator.config);
-    if (
-      shouldWriteObjectiveState &&
-      !hasExplicitNamespace &&
-      !canWriteNamespace(
-        principal,
-        objectiveStateBaseNamespace,
-        this.orchestrator.config,
-      )
-    ) {
-      throw new EngramAccessInputError(
-        `namespace is not writable: ${objectiveStateBaseNamespace}`,
-      );
-    }
 
-    // Auto-resolve coding context from cwd/projectTag so observe writes
-    // route to the correct project namespace (rule 42: same namespace layer
-    // as recall).
+    // 2. Auto-resolve coding context from cwd/projectTag so observe writes route
+    //    to the correct project namespace (rule 42: same namespace layer as
+    //    recall). Done AFTER auth so the no-orphan-context guard holds.
     await this.maybeAttachCodingContext(request.sessionKey, {
       cwd: request.cwd,
       projectTag: request.projectTag,
     });
 
-    const objectiveStateNamespace = hasExplicitNamespace
-      ? namespace
-      : this.orchestrator.applyCodingNamespaceOverlay(
-          request.sessionKey,
-          objectiveStateBaseNamespace,
-        );
+    // 3. Compute the single effective scope plan every side effect consumes
+    //    (#1495). The plan reads the session's now-attached coding context and
+    //    re-runs the SAME authorization as memory_store/suggestion_submit, so
+    //    observe's scoping is identical to explicit coding-scoped writes
+    //    (rule 39). The plan is read-only — context was attached in step 2.
+    const scope = await this.resolveMemoryScopePlan(request);
+    const writeNamespace = scope.writeNamespace;
 
-    // Prefix sessionKey with namespace for LCM archival so turns are namespace-scoped.
-    // This ensures multi-tenant isolation in the LCM archive.
-    const lcmSessionKey = namespace !== this.orchestrator.config.defaultNamespace
-      ? `${namespace}:${request.sessionKey}`
-      : request.sessionKey;
+    // Prefix sessionKey with the EFFECTIVE write namespace for LCM archival so
+    // observed turns are scoped to the same namespace project-scoped recall
+    // reads. Only prefix when it diverges from the default store (multi-tenant
+    // isolation); a single-store deployment keeps the raw sessionKey.
+    const lcmSessionKey =
+      writeNamespace !== this.orchestrator.config.defaultNamespace
+        ? `${writeNamespace}:${request.sessionKey}`
+        : request.sessionKey;
 
+    // 4. Objective-state snapshots → effective write namespace.
     if (shouldWriteObjectiveState) {
       try {
         const objectiveStateLocation =
-          await this.objectiveStateStoreLocationForNamespace(
-            objectiveStateNamespace,
-          );
+          await this.objectiveStateStoreLocationForNamespace(writeNamespace);
         await recordObjectiveStateSnapshotsFromObservedMessages({
           memoryDir: objectiveStateLocation.memoryDir,
           objectiveStateStoreDir: objectiveStateLocation.objectiveStateStoreDir,
@@ -4370,6 +4541,7 @@ export class EngramAccessService {
       }
     }
 
+    // 5. LCM archival → effective write namespace.
     // lcmArchived in the response means "LCM archival was queued" (not
     // "completed"), matching extractionQueued semantics.  Both run async.
     let lcmArchived = false;
@@ -4385,6 +4557,7 @@ export class EngramAccessService {
       }
     }
 
+    // 6. Extraction/replay → effective write namespace.
     let extractionQueued = false;
     if (request.skipExtraction !== true) {
       const turns = request.messages.map((m) => ({
@@ -4397,6 +4570,18 @@ export class EngramAccessService {
         sourceFormat: m.sourceFormat,
         timestamp: new Date().toISOString(),
       }));
+      // Pin extraction writes to the effective namespace rather than letting the
+      // orchestrator re-derive one from the (namespace-prefixed) lcmSessionKey —
+      // that re-derivation would miss the coding overlay (the #1495 drift) and
+      // fail to resolve a principal from a prefixed key. Passing
+      // writeNamespaceOverride makes the extraction target deterministic and
+      // identical to LCM/objective-state (rule 39). Omit it when the effective
+      // namespace is the default store, so single-store deployments keep the
+      // existing principal-derived routing unchanged.
+      const writeNamespaceOverride =
+        writeNamespace !== this.orchestrator.config.defaultNamespace
+          ? writeNamespace
+          : undefined;
       // Fire-and-forget: queue extraction in the background so the HTTP
       // response returns immediately. LCM archival (above) is also
       // enqueue-only; extraction involves LLM calls that can take
@@ -4409,6 +4594,7 @@ export class EngramAccessService {
       try {
         const extractionPromise = this.orchestrator.ingestReplayBatch(turns, {
           archiveLcm: false,
+          writeNamespaceOverride,
         });
         extractionPromise.catch((err) => {
           log.error(`access-observe background extraction failed: ${err}`);
@@ -4421,13 +4607,22 @@ export class EngramAccessService {
     }
 
     log.info(
-      `access-observe namespace=${namespace} sessionKey=${request.sessionKey} messages=${request.messages.length} lcm=${lcmArchived} extraction=${extractionQueued}`,
+      `access-observe namespace=${namespace} effectiveNamespace=${writeNamespace} sessionKey=${request.sessionKey} messages=${request.messages.length} lcm=${lcmArchived} extraction=${extractionQueued}`,
     );
 
     return {
       accepted: request.messages.length,
       sessionKey: request.sessionKey,
       namespace,
+      effectiveNamespace: writeNamespace,
+      scopeDebug: {
+        principal: scope.principal,
+        explicitNamespace: scope.explicitNamespace,
+        baseNamespace: scope.baseNamespace,
+        writeNamespace: scope.writeNamespace,
+        codingOverlayApplied: scope.codingOverlayApplied,
+        readNamespaces: scope.readNamespaces,
+      },
       lcmArchived,
       extractionQueued,
     };

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1784,6 +1784,12 @@ export class EngramAccessService {
      * never attaches overlay transcript rows the gate excludes.
      */
     rawExcerptNamespace?: string;
+    /**
+     * Ordered, read-authorized LCM read session_id SET (#1505 fallback
+     * unification). Threaded through to `serializeRecallResults` so the x-ray raw
+     * disclosure path also finds excerpts archived at the coding read fallbacks.
+     */
+    rawExcerptSessionIds?: string[];
   }): Promise<EngramAccessRecallResponse> {
     const memoryIds = options.snapshot.results.map((result) => result.memoryId);
     const resultPaths = options.snapshot.results.map((result) => result.path);
@@ -1825,6 +1831,9 @@ export class EngramAccessService {
         ...(options.sessionKey ? { sessionKey: options.sessionKey } : {}),
         ...(options.rawExcerptNamespace
           ? { rawExcerptNamespace: options.rawExcerptNamespace }
+          : {}),
+        ...(options.rawExcerptSessionIds
+          ? { rawExcerptSessionIds: options.rawExcerptSessionIds }
           : {}),
       },
     );
@@ -1874,6 +1883,15 @@ export class EngramAccessService {
            * snapshot namespace (single-store / sessionless callers, unchanged).
            */
           rawExcerptNamespace?: string;
+          /**
+           * Ordered, read-authorized LCM read session_id SET (#1505 fallback
+           * unification). When supplied, raw disclosure queries each key (primary
+           * coding overlay → read fallbacks) and merges rows so a branch-scoped
+           * session finds excerpts archived at project/root scope. Already
+           * read-gated, so no unauthorized overlay key is present. Omitted ⇒ the
+           * legacy single `rawExcerptNamespace`-prefixed key (unchanged).
+           */
+          rawExcerptSessionIds?: string[];
         }
       | null = null,
   ): Promise<EngramAccessMemorySummary[]> {
@@ -2021,6 +2039,9 @@ export class EngramAccessService {
               ? { sessionKey: rawContext.sessionKey }
               : {}),
             namespace: rawContext.rawExcerptNamespace ?? namespace,
+            ...(rawContext.rawExcerptSessionIds
+              ? { lcmSessionIds: rawContext.rawExcerptSessionIds }
+              : {}),
           }
         : null,
     );
@@ -2129,7 +2150,23 @@ export class EngramAccessService {
    */
   private async fetchRawExcerpts(
     disclosure: RecallDisclosure,
-    context: { query: string; sessionKey?: string; namespace?: string } | null,
+    context: {
+      query: string;
+      sessionKey?: string;
+      namespace?: string;
+      /**
+       * Pre-resolved, ordered, read-authorized LCM read session_id SET (#1505
+       * fallback unification). When supplied, raw disclosure queries each key in
+       * order (primary coding overlay → read fallbacks) and merges rows, exactly
+       * as the orchestrator recall path and `lcmSearch` do, so a branch-scoped
+       * session finds excerpts archived at project/root scope. Already
+       * read-gated by `resolveLcmReadSessionIds`, so an unauthorized
+       * `<principal>-project-*` key is never present. Falls back to the legacy
+       * single `namespace`-prefixed key when absent (sessionless / legacy
+       * callers).
+       */
+      lcmSessionIds?: string[];
+    } | null,
   ): Promise<EngramAccessMemorySummary["rawExcerpts"] | null> {
     if (disclosure !== "raw") return null;
     if (!context || !context.query) return [];
@@ -2144,26 +2181,44 @@ export class EngramAccessService {
     const lcm = this.orchestrator.lcmEngine;
     if (!lcm || !lcm.enabled) return [];
     try {
-      const lcmSessionKey =
+      const legacyKey =
         context.namespace &&
         context.namespace !== this.orchestrator.config.defaultNamespace
           ? `${context.namespace}:${context.sessionKey}`
           : context.sessionKey;
-      const rows = await lcm.searchContextFull(
-        context.query,
-        // Cap the excerpt fanout so recall responses stay bounded.  Five
-        // matches is enough to anchor the model in the raw transcript
-        // without ballooning token spend; raw is meant as the escape
-        // hatch, not the default.
-        5,
-        lcmSessionKey,
-      );
-      return rows.map((r) => ({
-        turnIndex: r.turn_index,
-        role: r.role,
-        content: r.content,
-        sessionId: r.session_id,
-      }));
+      const lcmSessionIds =
+        context.lcmSessionIds && context.lcmSessionIds.length > 0
+          ? context.lcmSessionIds
+          : [legacyKey];
+      // Cap the excerpt fanout so recall responses stay bounded.  Five matches
+      // is enough to anchor the model in the raw transcript without ballooning
+      // token spend; raw is meant as the escape hatch, not the default. The cap
+      // is applied across the MERGED result set so adding fallback keys never
+      // inflates the excerpt budget.
+      const limit = 5;
+      const seenRows = new Set<string>();
+      const excerpts: NonNullable<EngramAccessMemorySummary["rawExcerpts"]> = [];
+      for (const lcmSessionKey of lcmSessionIds) {
+        if (excerpts.length >= limit) break;
+        const rows = await lcm.searchContextFull(
+          context.query,
+          limit,
+          lcmSessionKey,
+        );
+        for (const r of rows) {
+          const dedupeKey = `${r.session_id} ${r.turn_index}`;
+          if (seenRows.has(dedupeKey)) continue;
+          seenRows.add(dedupeKey);
+          excerpts.push({
+            turnIndex: r.turn_index,
+            role: r.role,
+            content: r.content,
+            sessionId: r.session_id,
+          });
+          if (excerpts.length >= limit) break;
+        }
+      }
+      return excerpts;
     } catch {
       // CLAUDE.md rule 13: never let an external subsystem (LCM/SQLite)
       // crash the primary recall flow.
@@ -2891,10 +2946,24 @@ export class EngramAccessService {
             authenticatedPrincipal,
           )
         : undefined;
+    // Ordered, read-authorized LCM read key SET (#1505 fallback unification) so
+    // raw disclosure finds excerpts a branch-scoped session archived at
+    // project/root scope — exactly as recall + `lcmSearch` do. Only with a
+    // concrete sessionKey; already read-gated.
+    const rawExcerptSessionIds =
+      disclosure === "raw" && rawExcerptNamespace && request.sessionKey
+        ? this.resolveLcmReadSessionIds(
+            request.namespace,
+            rawExcerptNamespace,
+            request.sessionKey,
+            authenticatedPrincipal,
+          )
+        : undefined;
     let results = await this.serializeRecallResults(snapshot, disclosure, {
       query,
       sessionKey: request.sessionKey,
       ...(rawExcerptNamespace ? { rawExcerptNamespace } : {}),
+      ...(rawExcerptSessionIds ? { rawExcerptSessionIds } : {}),
     });
 
     // Tag filter (issue #689). Applied post-recall, post-serialization so
@@ -3403,12 +3472,29 @@ export class EngramAccessService {
                   authenticatedPrincipal,
                 )
               : namespace;
+          // Ordered, read-authorized LCM read key SET (#1505 fallback
+          // unification) so raw disclosure finds excerpts a branch-scoped session
+          // archived at project/root scope — exactly as recall + `lcmSearch` do.
+          // Only meaningful with a concrete sessionKey; already read-gated so no
+          // unauthorized overlay key is present.
+          const rawExcerptSessionIds =
+            disclosure === "raw" && trimmedSessionKey
+              ? this.resolveLcmReadSessionIds(
+                  request.namespace,
+                  rawExcerptNamespace,
+                  trimmedSessionKey,
+                  authenticatedPrincipal,
+                )
+              : undefined;
           const rawExcerpts =
             disclosure === "raw"
               ? await this.fetchRawExcerpts(disclosure, {
                   query,
                   ...(trimmedSessionKey ? { sessionKey: trimmedSessionKey } : {}),
                   namespace: rawExcerptNamespace,
+                  ...(rawExcerptSessionIds
+                    ? { lcmSessionIds: rawExcerptSessionIds }
+                    : {}),
                 })
               : null;
           const rawExcerptText =
@@ -3509,6 +3595,30 @@ export class EngramAccessService {
       xrayResponse.snapshotFound === true &&
       xrayResponse.snapshot
     ) {
+      // Same read-authorization-gated raw-excerpt namespace the recall path uses
+      // (#1505 thread 2f7), so the includeRecall x-ray path can't leak overlay
+      // transcript rows via raw disclosure. Resolved ONLY for raw disclosure (the
+      // sole consumer) so non-raw x-ray recall stays byte-for-byte unchanged. The
+      // ordered LCM read key SET (#1505 fallback unification) adds the coding read
+      // fallbacks so a branch-scoped session also finds excerpts at project/root
+      // scope.
+      const xrayRawExcerptNamespace =
+        disclosure === "raw"
+          ? this.resolveRawExcerptReadNamespace(
+              request.namespace,
+              recallSessionKey,
+              authenticatedPrincipal,
+            )
+          : undefined;
+      const xrayRawExcerptSessionIds =
+        disclosure === "raw" && xrayRawExcerptNamespace && recallSessionKey
+          ? this.resolveLcmReadSessionIds(
+              request.namespace,
+              xrayRawExcerptNamespace,
+              recallSessionKey,
+              authenticatedPrincipal,
+            )
+          : undefined;
       return {
         ...xrayResponse,
         recall: await this.buildRecallResponseFromXraySnapshot({
@@ -3519,19 +3629,11 @@ export class EngramAccessService {
           startedAt: recallStartedAt,
           requestedMode: request.mode,
           normalizedMode: mode,
-          // Same read-authorization-gated raw-excerpt namespace the recall path
-          // uses (#1505 thread 2f7), so the includeRecall x-ray path can't leak
-          // overlay transcript rows via raw disclosure. Resolved ONLY for raw
-          // disclosure (the sole consumer) so non-raw x-ray recall stays
-          // byte-for-byte unchanged.
-          ...(disclosure === "raw"
-            ? {
-                rawExcerptNamespace: this.resolveRawExcerptReadNamespace(
-                  request.namespace,
-                  recallSessionKey,
-                  authenticatedPrincipal,
-                ),
-              }
+          ...(xrayRawExcerptNamespace
+            ? { rawExcerptNamespace: xrayRawExcerptNamespace }
+            : {}),
+          ...(xrayRawExcerptSessionIds
+            ? { rawExcerptSessionIds: xrayRawExcerptSessionIds }
             : {}),
         }),
       };
@@ -4925,13 +5027,21 @@ export class EngramAccessService {
       request.sessionKey,
       request.authenticatedPrincipal,
     );
-    const lcmSessionKey = request.sessionKey
-      ? lcmSessionKeyForNamespace(
-          lcmReadNamespace,
+    // Ordered, read-authorized LCM read key SET for a concrete `sessionKey`
+    // (#1505 fallback unification). A branch-scoped session whose rows were
+    // archived at project/root scope is found by querying the primary overlay key
+    // first, then each coding read fallback — exactly as the orchestrator recall
+    // path does. Collapses to a single key for explicit-namespace / no-overlay /
+    // unreadable-self flows. The `sessionPrefix` search fragment stays on the
+    // primary overlay namespace (its own coding context can't be looked up).
+    const lcmSessionKeyIds = request.sessionKey
+      ? this.resolveLcmReadSessionIds(
+          request.namespace,
+          namespace,
           request.sessionKey,
-          this.orchestrator.config.defaultNamespace,
-        ) ?? request.sessionKey
-      : request.sessionKey;
+          request.authenticatedPrincipal,
+        )
+      : [undefined];
     const lcmSessionPrefix = request.sessionPrefix
       ? lcmSessionKeyForNamespace(
           lcmReadNamespace,
@@ -4939,18 +5049,30 @@ export class EngramAccessService {
           this.orchestrator.config.defaultNamespace,
         ) ?? request.sessionPrefix
       : request.sessionPrefix;
-    const rawResults = await this.orchestrator.lcmEngine.searchContextFull(
-      request.query,
-      limit,
-      lcmSessionKey,
-      lcmSessionPrefix,
-    );
-
-    const results = rawResults.map((r: { session_id: string; content: string; turn_index: number }) => ({
-      sessionId: r.session_id,
-      content: r.content,
-      turnIndex: r.turn_index,
-    }));
+    // Query each LCM read key in order, merging + deduping rows (by
+    // sessionId+turnIndex) and preserving first-seen order, capped at `limit`.
+    const seenRows = new Set<string>();
+    const results: Array<{ sessionId: string; content: string; turnIndex: number }> = [];
+    for (const lcmSessionKey of lcmSessionKeyIds) {
+      if (results.length >= limit) break;
+      const rawResults = await this.orchestrator.lcmEngine.searchContextFull(
+        request.query,
+        limit,
+        lcmSessionKey,
+        lcmSessionPrefix,
+      );
+      for (const r of rawResults as Array<{ session_id: string; content: string; turn_index: number }>) {
+        const dedupeKey = `${r.session_id} ${r.turn_index}`;
+        if (seenRows.has(dedupeKey)) continue;
+        seenRows.add(dedupeKey);
+        results.push({
+          sessionId: r.session_id,
+          content: r.content,
+          turnIndex: r.turn_index,
+        });
+        if (results.length >= limit) break;
+      }
+    }
 
     return {
       query: request.query,
@@ -5121,6 +5243,103 @@ export class EngramAccessService {
         this.orchestrator.config.defaultNamespace,
       ) ?? sessionKey
     );
+  }
+
+  /**
+   * Resolve the ORDERED, read-authorized set of LCM `session_id`s a same-session
+   * READER (`lcmSearch`, raw-excerpt disclosure) must query so it matches every
+   * key `observe` archived under across the coding scope (#1505 thread "Include
+   * coding fallback namespaces in LCM reads").
+   *
+   * Mirrors the orchestrator recall path exactly (rule 39): `observe` archives
+   * each turn under `${effectiveNamespace}:${sessionKey}` for whichever namespace
+   * was effective at write time, and normal QMD/file recall searches the primary
+   * coding-overlay namespace AND `codingOverlay.readFallbacks` (project → root).
+   * A single overlay key therefore MISSES rows a branch-scoped session archived at
+   * project/root scope. This returns the primary overlay LCM key first, then one
+   * per read fallback, deduped + ordered so the caller can short-circuit on the
+   * first hit.
+   *
+   * READ-AUTHORIZATION (preserved from the round-3..5 `resolveLcmReadNamespace`
+   * "read" gate; rule 42 / 48): the overlay + fallbacks are `<principal>-project-*`
+   * sub-namespaces authorized transitively by the principal SELF base. They are
+   * included ONLY when the self base is in the readable recall set
+   * (`recallNamespacesForPrincipal`). When the self base is NOT readable (write-
+   * only / self-omitted principal), or when an explicit namespace was supplied,
+   * or no overlay applies, this collapses to the single key
+   * {@link resolveLcmReadSessionKey} returns — byte-for-byte the prior behavior
+   * (single-store / no-overlay flows stay the raw `sessionKey`). No
+   * `<principal>-project-*` key is ever searched for an unauthorized reader (no
+   * cross-tenant read leak).
+   */
+  private resolveLcmReadSessionIds(
+    explicitNamespace: string | undefined,
+    resolvedNamespace: string,
+    sessionKey: string,
+    authenticatedPrincipal: string | undefined,
+  ): string[] {
+    const primary = this.resolveLcmReadSessionKey(
+      explicitNamespace,
+      resolvedNamespace,
+      sessionKey,
+      authenticatedPrincipal,
+      "read",
+    );
+    const hasExplicitNamespace =
+      typeof explicitNamespace === "string" &&
+      explicitNamespace.trim().length > 0;
+    // Explicit namespace → no overlay fallbacks (the overlay never applies to an
+    // explicit read). Single key, unchanged.
+    if (hasExplicitNamespace) return [primary];
+
+    const principal = this.resolveRequestPrincipal(
+      sessionKey,
+      authenticatedPrincipal,
+    );
+    const base = defaultNamespaceForPrincipal(
+      principal,
+      this.orchestrator.config,
+    );
+    const overlaid = this.orchestrator.applyCodingNamespaceOverlay(
+      sessionKey,
+      base,
+    );
+    // No overlay → single default-store key, unchanged.
+    if (overlaid === base) return [primary];
+    // Overlay present but self base unreadable → the "read" gate already
+    // collapsed `primary` to the default store; do NOT add overlay fallbacks
+    // (they would be unauthorized `<principal>-project-*` keys). Single key.
+    const selfReadableInRecall = recallNamespacesForPrincipal(
+      principal,
+      this.orchestrator.config,
+    ).includes(base);
+    if (!selfReadableInRecall) return [primary];
+    // Self base readable → overlay rows authorized. Append one LCM key per coding
+    // read fallback (project → root), combined with the principal base for
+    // isolation — the SAME ordered set the orchestrator recall path searches.
+    const overlay = resolveCodingNamespaceOverlay(
+      this.orchestrator.getCodingContextForSession(sessionKey),
+      this.orchestrator.config.codingMode,
+      this.orchestrator.config.defaultNamespace,
+    );
+    const fallbackNamespaces = (overlay?.readFallbacks ?? []).map((fallback) =>
+      combineNamespaces(base, fallback),
+    );
+    const out = [primary];
+    const seen = new Set<string>([primary]);
+    for (const ns of fallbackNamespaces) {
+      const key =
+        lcmSessionKeyForNamespace(
+          ns,
+          sessionKey,
+          this.orchestrator.config.defaultNamespace,
+        ) ?? sessionKey;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(key);
+      }
+    }
+    return out;
   }
 
   async lcmCompactionFlush(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1777,6 +1777,13 @@ export class EngramAccessService {
     startedAt: number;
     requestedMode?: RecallPlanMode | "auto";
     normalizedMode?: RecallPlanMode;
+    /**
+     * Read-authorization-gated namespace for the raw-excerpt LCM lookup (#1505
+     * thread 2f7). Threaded through to `serializeRecallResults` so the
+     * `includeRecall` x-ray path honours the SAME read gate as normal recall and
+     * never attaches overlay transcript rows the gate excludes.
+     */
+    rawExcerptNamespace?: string;
   }): Promise<EngramAccessRecallResponse> {
     const memoryIds = options.snapshot.results.map((result) => result.memoryId);
     const resultPaths = options.snapshot.results.map((result) => result.path);
@@ -1816,6 +1823,9 @@ export class EngramAccessService {
       {
         query: options.query,
         ...(options.sessionKey ? { sessionKey: options.sessionKey } : {}),
+        ...(options.rawExcerptNamespace
+          ? { rawExcerptNamespace: options.rawExcerptNamespace }
+          : {}),
       },
     );
     const context = results
@@ -1851,7 +1861,21 @@ export class EngramAccessService {
   private async serializeRecallResults(
     snapshot: LastRecallSnapshot | null,
     disclosure: RecallDisclosure,
-    rawContext: { query: string; sessionKey?: string } | null = null,
+    rawContext:
+      | {
+          query: string;
+          sessionKey?: string;
+          /**
+           * Read-authorization-gated namespace for the raw-excerpt LCM lookup
+           * (#1505 thread 2f7). When the caller supplies it, the raw lookup uses
+           * THIS namespace prefix instead of `snapshot.namespace` (the
+           * write/overlay namespace), so raw disclosure honours the SAME read
+           * gate as normal recall + `lcmSearch`. Omitted ⇒ falls back to the
+           * snapshot namespace (single-store / sessionless callers, unchanged).
+           */
+          rawExcerptNamespace?: string;
+        }
+      | null = null,
   ): Promise<EngramAccessMemorySummary[]> {
     if (!snapshot) return [];
     const namespace = snapshot.namespace ? this.resolveNamespace(snapshot.namespace) : this.orchestrator.config.defaultNamespace;
@@ -1982,11 +2006,23 @@ export class EngramAccessService {
     // for a future PR if/when the LCM index can be joined to memory ids.
     // Coerce `null` (non-raw disclosure) to `undefined` so the optional
     // serializer field is never explicitly `null`.
-    // Pass the resolved namespace so the LCM lookup can mirror the
-    // `${namespace}:${sessionKey}` prefix that `observe()` writes.
+    // Namespace for the LCM `${namespace}:${sessionKey}` prefix: prefer the
+    // caller-supplied READ-AUTHORIZATION-GATED `rawExcerptNamespace` (#1505
+    // thread 2f7) so raw disclosure honours the same read gate as normal recall
+    // + `lcmSearch` and never attaches `<principal>-project-*` overlay rows the
+    // gate excludes. Fall back to the snapshot's resolved namespace only when no
+    // gated namespace was threaded (sessionless / legacy callers) — unchanged.
     const rawExcerptsResult = await this.fetchRawExcerpts(
       disclosure,
-      rawContext ? { ...rawContext, namespace } : null,
+      rawContext
+        ? {
+            query: rawContext.query,
+            ...(rawContext.sessionKey
+              ? { sessionKey: rawContext.sessionKey }
+              : {}),
+            namespace: rawContext.rawExcerptNamespace ?? namespace,
+          }
+        : null,
     );
     const rawExcerpts = rawExcerptsResult ?? undefined;
 
@@ -2839,9 +2875,26 @@ export class EngramAccessService {
       topKConfidence,
     });
     const disclosure = escalationDecision.effective;
+    // Gate the raw-excerpt LCM read with the SAME read-authorization namespace
+    // `lcmSearch` + the in-prompt LCM sections use (#1505 thread 2f7), so
+    // `disclosure: "raw"` never attaches `<principal>-project-*` overlay rows
+    // when the principal can WRITE but not READ its self base (or
+    // `defaultRecallNamespaces` omits `self`). Computed ONLY for raw disclosure:
+    // it is the sole consumer, and resolving the overlay on every chunk/section
+    // recall would be wasted work — keeping non-raw recall byte-for-byte
+    // unchanged.
+    const rawExcerptNamespace =
+      disclosure === "raw"
+        ? this.resolveRawExcerptReadNamespace(
+            request.namespace,
+            request.sessionKey,
+            authenticatedPrincipal,
+          )
+        : undefined;
     let results = await this.serializeRecallResults(snapshot, disclosure, {
       query,
       sessionKey: request.sessionKey,
+      ...(rawExcerptNamespace ? { rawExcerptNamespace } : {}),
     });
 
     // Tag filter (issue #689). Applied post-recall, post-serialization so
@@ -3334,12 +3387,28 @@ export class EngramAccessService {
           // identity but probes LCM under a different prefix and
           // misses stored excerpts (Cursor Low review on PR #699).
           const trimmedSessionKey = request.sessionKey?.trim() || undefined;
+          // Read-authorization-gated namespace for the raw-excerpt LCM lookup
+          // (#1505 thread 2f7). NOT `snapshot.namespace` (the write/overlay
+          // namespace), which would attach `<principal>-project-*` overlay rows
+          // when the principal can WRITE but not READ its self base. Mirrors the
+          // recall + `lcmSearch` read gate. Resolved ONLY for raw disclosure (its
+          // sole consumer); the `namespace` above is still used for the
+          // memory-FILE reads below (a separate, snapshot-scoped read), so non-raw
+          // x-ray decoration stays byte-for-byte unchanged.
+          const rawExcerptNamespace =
+            disclosure === "raw"
+              ? this.resolveRawExcerptReadNamespace(
+                  request.namespace,
+                  trimmedSessionKey,
+                  authenticatedPrincipal,
+                )
+              : namespace;
           const rawExcerpts =
             disclosure === "raw"
               ? await this.fetchRawExcerpts(disclosure, {
                   query,
                   ...(trimmedSessionKey ? { sessionKey: trimmedSessionKey } : {}),
-                  namespace,
+                  namespace: rawExcerptNamespace,
                 })
               : null;
           const rawExcerptText =
@@ -3450,6 +3519,20 @@ export class EngramAccessService {
           startedAt: recallStartedAt,
           requestedMode: request.mode,
           normalizedMode: mode,
+          // Same read-authorization-gated raw-excerpt namespace the recall path
+          // uses (#1505 thread 2f7), so the includeRecall x-ray path can't leak
+          // overlay transcript rows via raw disclosure. Resolved ONLY for raw
+          // disclosure (the sole consumer) so non-raw x-ray recall stays
+          // byte-for-byte unchanged.
+          ...(disclosure === "raw"
+            ? {
+                rawExcerptNamespace: this.resolveRawExcerptReadNamespace(
+                  request.namespace,
+                  recallSessionKey,
+                  authenticatedPrincipal,
+                ),
+              }
+            : {}),
         }),
       };
     }
@@ -4615,14 +4698,28 @@ export class EngramAccessService {
     const scope = await this.resolveMemoryScopePlan(request);
     const writeNamespace = scope.writeNamespace;
 
-    // Backward-compatible BASE writable namespace (pre-#1495 response
-    // semantics). Authorized through the same policy path; the EFFECTIVE write
-    // namespace every side effect uses is `writeNamespace` (the scope plan).
-    const namespace = this.resolveWritableNamespace(
-      request.namespace,
-      request.sessionKey,
-      request.authenticatedPrincipal,
-    );
+    // Backward-compatible BASE writable namespace (pre-#1495 response semantics)
+    // for the legacy `namespace` response field. DERIVED from the already-resolved
+    // scope plan — NOT a second `resolveWritableNamespace(request.namespace,...)`
+    // call (#1505 thread jvO). The fresh call re-authorized `undefined ⇒
+    // config.defaultNamespace` a SECOND time; under a restrictive default-namespace
+    // write policy that re-auth could REJECT an otherwise valid project-scoped
+    // observe whose effective self/project write target the scope plan already
+    // authorized (the same target memory_store/suggestion_submit accept). Worse,
+    // that post-plan rejection fired AFTER `resolveMemoryScopePlan` may have seeded
+    // the coding context, leaving an orphaned session binding behind. The plan is
+    // the single authorization point (rule 22 / 39); the legacy field must reuse it
+    // and never re-authorize. Pre-#1495 semantics were exactly
+    // `resolveWritableNamespace(request.namespace)` (overlay-agnostic): the explicit
+    // namespace when supplied, else `config.defaultNamespace`. `scope.explicitNamespace`
+    // carries the authorized explicit value; the no-overlay implicit
+    // `scope.writeNamespace` IS `config.defaultNamespace`, so an unqualified observe
+    // stays byte-for-byte identical to the legacy response.
+    const namespace = scope.explicitNamespace
+      ? scope.writeNamespace
+      : scope.codingOverlayApplied
+        ? this.orchestrator.config.defaultNamespace
+        : scope.writeNamespace;
     const shouldWriteObjectiveState =
       this.orchestrator.config.objectiveStateMemoryEnabled === true &&
       this.orchestrator.config.objectiveStateSnapshotWritesEnabled === true;
@@ -4956,6 +5053,51 @@ export class EngramAccessService {
             this.orchestrator.config,
           ).includes(base);
     return authorized ? overlaid : resolvedNamespace;
+  }
+
+  /**
+   * Resolve the namespace the raw-disclosure excerpt lookup
+   * ({@link fetchRawExcerpts}) must prefix its LCM `session_id` with (#1505
+   * thread 2f7). Raw disclosure reads the SAME LCM archive `lcmSearch` and the
+   * in-prompt LCM sections read, so it MUST pass through the identical
+   * read-authorization gate — NOT `snapshot.namespace`, which records the
+   * effective WRITE/overlay namespace (`<principal>-project-*`) even when the
+   * principal can WRITE but not READ its self base (or `defaultRecallNamespaces`
+   * omits `self`). Routing through `resolveLcmReadNamespace(..., "read")` makes
+   * raw disclosure fall back to the default store exactly like normal recall +
+   * `lcmSearch`, so it never attaches overlay transcript rows the read gate
+   * excludes (cross-tenant read leak). Collapses to the default store / raw
+   * sessionKey for single-store / no-overlay / explicit-default flows, so
+   * single-user recall is byte-for-byte unchanged.
+   *
+   * The `resolvedNamespace` fallback is the principal's READABLE namespace (an
+   * explicit `request.namespace` is already read-authorized; otherwise the
+   * default store), so even when the overlay is NOT readable the prefix is a
+   * namespace the principal may read.
+   */
+  private resolveRawExcerptReadNamespace(
+    explicitNamespace: string | undefined,
+    sessionKey: string | undefined,
+    authenticatedPrincipal: string | undefined,
+  ): string {
+    const principal = this.resolveRequestPrincipal(
+      sessionKey,
+      authenticatedPrincipal,
+    );
+    // Read-authorize the fallback namespace exactly like `lcmSearch`: an
+    // explicit namespace is checked via `resolveReadableNamespace`; with none,
+    // the fallback is the default store (never the unreadable overlay).
+    const resolvedNamespace = this.resolveReadableNamespace(
+      explicitNamespace,
+      principal,
+    );
+    return this.resolveLcmReadNamespace(
+      explicitNamespace,
+      resolvedNamespace,
+      sessionKey,
+      authenticatedPrincipal,
+      "read",
+    );
   }
 
   private resolveLcmReadSessionKey(

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1790,6 +1790,13 @@ export class EngramAccessService {
      * disclosure path also finds excerpts archived at the coding read fallbacks.
      */
     rawExcerptSessionIds?: string[];
+    /**
+     * Force NO raw excerpts (#1505 thread NBHWz). Set when the IMPLICIT
+     * raw-excerpt read gate found NO readable LCM namespace, so the x-ray
+     * includeRecall path degrades to empty excerpts rather than falling back to
+     * the write/overlay namespace the read gate excludes.
+     */
+    rawExcerptsSuppressed?: boolean;
   }): Promise<EngramAccessRecallResponse> {
     const memoryIds = options.snapshot.results.map((result) => result.memoryId);
     const resultPaths = options.snapshot.results.map((result) => result.path);
@@ -1834,6 +1841,9 @@ export class EngramAccessService {
           : {}),
         ...(options.rawExcerptSessionIds
           ? { rawExcerptSessionIds: options.rawExcerptSessionIds }
+          : {}),
+        ...(options.rawExcerptsSuppressed
+          ? { rawExcerptsSuppressed: options.rawExcerptsSuppressed }
           : {}),
       },
     );
@@ -1892,6 +1902,16 @@ export class EngramAccessService {
            * legacy single `rawExcerptNamespace`-prefixed key (unchanged).
            */
           rawExcerptSessionIds?: string[];
+          /**
+           * Force NO raw excerpts even when `disclosure === "raw"` (#1505 thread
+           * NBHWz). Set by callers when the IMPLICIT raw-excerpt read gate found
+           * NO readable LCM namespace (a restrictive `default` READ policy with
+           * no readable overlay/self namespace). The lookup must NOT fall back to
+           * `snapshot.namespace` (the write/overlay namespace the read gate
+           * excludes) — it returns empty excerpts so raw recall degrades
+           * gracefully instead of leaking unreadable rows or throwing.
+           */
+          rawExcerptsSuppressed?: boolean;
         }
       | null = null,
   ): Promise<EngramAccessMemorySummary[]> {
@@ -2030,21 +2050,27 @@ export class EngramAccessService {
     // + `lcmSearch` and never attaches `<principal>-project-*` overlay rows the
     // gate excludes. Fall back to the snapshot's resolved namespace only when no
     // gated namespace was threaded (sessionless / legacy callers) — unchanged.
-    const rawExcerptsResult = await this.fetchRawExcerpts(
-      disclosure,
-      rawContext
-        ? {
-            query: rawContext.query,
-            ...(rawContext.sessionKey
-              ? { sessionKey: rawContext.sessionKey }
-              : {}),
-            namespace: rawContext.rawExcerptNamespace ?? namespace,
-            ...(rawContext.rawExcerptSessionIds
-              ? { lcmSessionIds: rawContext.rawExcerptSessionIds }
-              : {}),
-          }
-        : null,
-    );
+    const rawExcerptsResult =
+      rawContext?.rawExcerptsSuppressed === true
+        ? // Implicit raw recall with NO readable LCM namespace (#1505 thread
+          // NBHWz): emit empty excerpts rather than falling back to the
+          // write/overlay `namespace` the read gate excludes.
+          []
+        : await this.fetchRawExcerpts(
+            disclosure,
+            rawContext
+              ? {
+                  query: rawContext.query,
+                  ...(rawContext.sessionKey
+                    ? { sessionKey: rawContext.sessionKey }
+                    : {}),
+                  namespace: rawContext.rawExcerptNamespace ?? namespace,
+                  ...(rawContext.rawExcerptSessionIds
+                    ? { lcmSessionIds: rawContext.rawExcerptSessionIds }
+                    : {}),
+                }
+              : null,
+          );
     const rawExcerpts = rawExcerptsResult ?? undefined;
 
     for (const memoryPath of snapshot.resultPaths ?? []) {
@@ -2946,6 +2972,19 @@ export class EngramAccessService {
             authenticatedPrincipal,
           )
         : undefined;
+    // `undefined` for an IMPLICIT raw recall means NO readable LCM namespace
+    // exists (restrictive `default` READ policy, no readable overlay/self) —
+    // suppress excerpts rather than fall back to the write/overlay namespace the
+    // read gate excludes (#1505 thread NBHWz). An EXPLICIT namespace always
+    // resolves (or throws) above, so suppression only applies to the implicit
+    // path.
+    const hasExplicitNamespace =
+      typeof request.namespace === "string" &&
+      request.namespace.trim().length > 0;
+    const rawExcerptsSuppressed =
+      disclosure === "raw" &&
+      !hasExplicitNamespace &&
+      rawExcerptNamespace === undefined;
     // Ordered, read-authorized LCM read key SET (#1505 fallback unification) so
     // raw disclosure finds excerpts a branch-scoped session archived at
     // project/root scope — exactly as recall + `lcmSearch` do. Only with a
@@ -2964,6 +3003,7 @@ export class EngramAccessService {
       sessionKey: request.sessionKey,
       ...(rawExcerptNamespace ? { rawExcerptNamespace } : {}),
       ...(rawExcerptSessionIds ? { rawExcerptSessionIds } : {}),
+      ...(rawExcerptsSuppressed ? { rawExcerptsSuppressed } : {}),
     });
 
     // Tag filter (issue #689). Applied post-recall, post-serialization so
@@ -3472,13 +3512,24 @@ export class EngramAccessService {
                   authenticatedPrincipal,
                 )
               : namespace;
+          // `undefined` for an IMPLICIT raw recall means NO readable LCM namespace
+          // exists (restrictive `default` READ policy, no readable overlay/self)
+          // — suppress excerpts rather than fall back to the write/overlay
+          // namespace the read gate excludes (#1505 thread NBHWz).
+          const xrayHasExplicitNamespace =
+            typeof request.namespace === "string" &&
+            request.namespace.trim().length > 0;
+          const rawExcerptsSuppressed =
+            disclosure === "raw" &&
+            !xrayHasExplicitNamespace &&
+            rawExcerptNamespace === undefined;
           // Ordered, read-authorized LCM read key SET (#1505 fallback
           // unification) so raw disclosure finds excerpts a branch-scoped session
           // archived at project/root scope — exactly as recall + `lcmSearch` do.
-          // Only meaningful with a concrete sessionKey; already read-gated so no
-          // unauthorized overlay key is present.
+          // Only meaningful with a concrete sessionKey + a readable namespace;
+          // already read-gated so no unauthorized overlay key is present.
           const rawExcerptSessionIds =
-            disclosure === "raw" && trimmedSessionKey
+            disclosure === "raw" && trimmedSessionKey && rawExcerptNamespace
               ? this.resolveLcmReadSessionIds(
                   request.namespace,
                   rawExcerptNamespace,
@@ -3487,16 +3538,20 @@ export class EngramAccessService {
                 )
               : undefined;
           const rawExcerpts =
-            disclosure === "raw"
+            disclosure === "raw" && !rawExcerptsSuppressed
               ? await this.fetchRawExcerpts(disclosure, {
                   query,
                   ...(trimmedSessionKey ? { sessionKey: trimmedSessionKey } : {}),
-                  namespace: rawExcerptNamespace,
+                  ...(rawExcerptNamespace
+                    ? { namespace: rawExcerptNamespace }
+                    : {}),
                   ...(rawExcerptSessionIds
                     ? { lcmSessionIds: rawExcerptSessionIds }
                     : {}),
                 })
-              : null;
+              : disclosure === "raw"
+                ? []
+                : null;
           const rawExcerptText =
             rawExcerpts && rawExcerpts.length > 0
               ? rawExcerpts.map((e) => e.content).join("\n")
@@ -3610,6 +3665,16 @@ export class EngramAccessService {
               authenticatedPrincipal,
             )
           : undefined;
+      // `undefined` for an IMPLICIT raw recall means NO readable LCM namespace
+      // exists — suppress excerpts rather than fall back to the write/overlay
+      // namespace the read gate excludes (#1505 thread NBHWz).
+      const xrayHasExplicitNamespace =
+        typeof request.namespace === "string" &&
+        request.namespace.trim().length > 0;
+      const xrayRawExcerptsSuppressed =
+        disclosure === "raw" &&
+        !xrayHasExplicitNamespace &&
+        xrayRawExcerptNamespace === undefined;
       const xrayRawExcerptSessionIds =
         disclosure === "raw" && xrayRawExcerptNamespace && recallSessionKey
           ? this.resolveLcmReadSessionIds(
@@ -3634,6 +3699,9 @@ export class EngramAccessService {
             : {}),
           ...(xrayRawExcerptSessionIds
             ? { rawExcerptSessionIds: xrayRawExcerptSessionIds }
+            : {}),
+          ...(xrayRawExcerptsSuppressed
+            ? { rawExcerptsSuppressed: xrayRawExcerptsSuppressed }
             : {}),
         }),
       };
@@ -4999,15 +5067,44 @@ export class EngramAccessService {
     }
 
     const principal = this.resolveRequestPrincipal(request.sessionKey, request.authenticatedPrincipal);
-    const namespace = this.resolveReadableNamespace(request.namespace, principal);
+    const hasExplicitNamespace =
+      typeof request.namespace === "string" &&
+      request.namespace.trim().length > 0;
+    // Resolve the readable base namespace WITHOUT pre-authorizing `default`
+    // (#1505 thread NBHWz). An EXPLICIT namespace is still authorized strictly
+    // via `resolveReadableNamespace` (explicit reads must pass the ACL — throws
+    // on an unreadable explicit namespace). For an IMPLICIT read, derive the
+    // fallback from the ALREADY read-authorized recall namespace set instead of
+    // read-authorizing `config.defaultNamespace`: under a restrictive `default`
+    // READ policy where the principal's self namespace is readable, normal recall
+    // still succeeds via `recallNamespacesForPrincipal`, so `lcmSearch` must too
+    // (the same defect class the raw-excerpt path fixes). `undefined` ⇒ no
+    // readable LCM namespace exists, so return NO rows rather than throwing.
+    const namespace = hasExplicitNamespace
+      ? this.resolveReadableNamespace(request.namespace, principal)
+      : this.resolveImplicitLcmReadFallbackNamespace(principal);
 
     if (!this.orchestrator.lcmEngine || !this.orchestrator.lcmEngine.enabled) {
       return {
         query: request.query,
-        namespace,
+        namespace: namespace ?? this.orchestrator.config.defaultNamespace,
         results: [],
         count: 0,
         lcmEnabled: false,
+      };
+    }
+
+    // No readable LCM namespace for an IMPLICIT read (restrictive `default` READ
+    // policy, no readable overlay/self) ⇒ return NO rows instead of pre-
+    // authorizing the denied default (#1505 thread NBHWz). Normal recall still
+    // succeeds through the readable self namespace; LCM search degrades to empty.
+    if (namespace === undefined) {
+      return {
+        query: request.query,
+        namespace: this.orchestrator.config.defaultNamespace,
+        results: [],
+        count: 0,
+        lcmEnabled: true,
       };
     }
 
@@ -5192,34 +5289,103 @@ export class EngramAccessService {
    * sessionKey for single-store / no-overlay / explicit-default flows, so
    * single-user recall is byte-for-byte unchanged.
    *
-   * The `resolvedNamespace` fallback is the principal's READABLE namespace (an
-   * explicit `request.namespace` is already read-authorized; otherwise the
-   * default store), so even when the overlay is NOT readable the prefix is a
-   * namespace the principal may read.
+   * Returns `undefined` when NO readable LCM namespace exists for an IMPLICIT
+   * (no explicit `namespace`) raw recall — i.e. a restrictive `default` READ
+   * policy denies the principal `default` AND no overlay/self namespace is
+   * readable. In that case the caller emits NO excerpts rather than throwing
+   * `namespace is not readable: default` (#1505 thread NBHWz): normal recall
+   * still succeeds via `recallNamespacesForPrincipal`, so `disclosure: "raw"`
+   * must degrade gracefully (empty excerpts), never pre-authorize `default`.
+   *
+   * IMPLICIT-namespace fallback selection derives from the ALREADY
+   * read-authorized recall namespace set (`recallNamespacesForPrincipal` +
+   * `canReadNamespace`) — the principal's self base when it is in the readable
+   * recall set, else `config.defaultNamespace` ONLY when the principal may read
+   * it. It NEVER pre-authorizes `default`. An EXPLICIT `namespace` is still
+   * authorized strictly via `resolveReadableNamespace` (explicit reads must pass
+   * the ACL — no behavior change).
    */
   private resolveRawExcerptReadNamespace(
     explicitNamespace: string | undefined,
     sessionKey: string | undefined,
     authenticatedPrincipal: string | undefined,
-  ): string {
+  ): string | undefined {
     const principal = this.resolveRequestPrincipal(
       sessionKey,
       authenticatedPrincipal,
     );
-    // Read-authorize the fallback namespace exactly like `lcmSearch`: an
-    // explicit namespace is checked via `resolveReadableNamespace`; with none,
-    // the fallback is the default store (never the unreadable overlay).
-    const resolvedNamespace = this.resolveReadableNamespace(
-      explicitNamespace,
-      principal,
-    );
+    const hasExplicitNamespace =
+      typeof explicitNamespace === "string" &&
+      explicitNamespace.trim().length > 0;
+    if (hasExplicitNamespace) {
+      // Explicit reads must pass the ACL — authorize strictly, exactly as
+      // `lcmSearch` does (throws on an unreadable explicit namespace).
+      const resolvedNamespace = this.resolveReadableNamespace(
+        explicitNamespace,
+        principal,
+      );
+      return this.resolveLcmReadNamespace(
+        explicitNamespace,
+        resolvedNamespace,
+        sessionKey,
+        authenticatedPrincipal,
+        "read",
+      );
+    }
+    // IMPLICIT raw recall: derive the read fallback from the ALREADY
+    // read-authorized recall namespace set — NEVER pre-authorize `default`
+    // (#1505 thread NBHWz). When namespaces are disabled the default store is the
+    // only namespace and is always readable (byte-for-byte single-user path).
+    const fallbackNamespace =
+      this.resolveImplicitLcmReadFallbackNamespace(principal);
+    // No readable LCM namespace at all ⇒ no excerpts (caller short-circuits).
+    if (fallbackNamespace === undefined) return undefined;
     return this.resolveLcmReadNamespace(
       explicitNamespace,
-      resolvedNamespace,
+      fallbackNamespace,
       sessionKey,
       authenticatedPrincipal,
       "read",
     );
+  }
+
+  /**
+   * The read-authorized fallback namespace an IMPLICIT (no explicit `namespace`)
+   * same-session LCM READER (`resolveRawExcerptReadNamespace`, `lcmSearch`)
+   * prefixes its LCM `session_id` with when no readable coding overlay applies
+   * (#1505 thread NBHWz). Derived WITHOUT pre-authorizing `default`: it consults
+   * the SAME read-authorized recall set normal recall + the in-prompt LCM
+   * sections use (`recallNamespacesForPrincipal`, already
+   * `canReadNamespace`-filtered) and falls back to `config.defaultNamespace` ONLY
+   * when the principal may actually read it. Returns `undefined` when no readable
+   * LCM namespace exists, so the caller emits NO rows instead of throwing
+   * `namespace is not readable: default` — normal recall still succeeds through
+   * the readable self namespace, and LCM reads must degrade gracefully.
+   *
+   * Single-store / namespaces-disabled deployments resolve to
+   * `config.defaultNamespace` (always readable), keeping single-user recall
+   * byte-for-byte unchanged.
+   */
+  private resolveImplicitLcmReadFallbackNamespace(
+    principal: string | undefined,
+  ): string | undefined {
+    const config = this.orchestrator.config;
+    if (!config.namespacesEnabled) return config.defaultNamespace;
+    // Prefer the default store when the principal may read it (the historical
+    // implicit fallback — preserves single-store / readable-default flows).
+    if (canReadNamespace(principal, config.defaultNamespace, config)) {
+      return config.defaultNamespace;
+    }
+    // Restrictive `default` READ policy: fall back to a namespace the principal
+    // CAN read from the recall set (e.g. the readable self base), matching what
+    // normal recall + `lcmSearch` search. `lcmSessionKeyForNamespace` prefixes
+    // only non-default namespaces, so a self-base fallback still produces a
+    // distinct, authorized LCM key.
+    const readableRecallNamespaces = recallNamespacesForPrincipal(
+      principal,
+      config,
+    ).filter((ns) => canReadNamespace(principal, ns, config));
+    return readableRecallNamespaces[0];
   }
 
   private resolveLcmReadSessionKey(
@@ -5349,11 +5515,30 @@ export class EngramAccessService {
       throw new EngramAccessInputError("sessionKey is required and must be a non-empty string");
     }
 
-    const namespace = this.resolveWritableNamespace(
-      request.namespace,
-      request.sessionKey,
-      request.authenticatedPrincipal,
-    );
+    // Authorize compaction against the SCOPED WRITE TARGET — the SAME effective
+    // write namespace `observe` archived the LCM queue under — NOT a premature
+    // `resolveWritableNamespace(undefined ⇒ config.defaultNamespace)` (#1505
+    // thread NBHWs). Under a restrictive `default` WRITE policy where the
+    // principal can still write its self/project overlay, that premature default
+    // write-auth threw `namespace is not writable: default` BEFORE the scoped key
+    // was computed, so the overlay queue `observe` just wrote could never be
+    // flushed. `resolveMemoryScopePlan` is the ONE write-scoped plan/gate observe
+    // uses (rule 22 / 39 / 42): it authorizes the principal self base for an
+    // overlay write and only collapses to `config.defaultNamespace` (always
+    // writable) when no overlay applies — so it never throws `not writable:
+    // default` for a validly scoped observe's queue.
+    const scope = await this.resolveMemoryScopePlan(request);
+    // Legacy `namespace` response field: pre-#1505 semantics were exactly
+    // `resolveWritableNamespace(request.namespace)` (overlay-agnostic) — the
+    // authorized explicit namespace when supplied, else `config.defaultNamespace`.
+    // DERIVED from the scope plan (NOT a second auth pass, #1505 thread jvO):
+    // explicit ⇒ writeNamespace; coding overlay ⇒ defaultNamespace; no overlay ⇒
+    // writeNamespace (== defaultNamespace). Identical to observe's legacy field.
+    const namespace = scope.explicitNamespace
+      ? scope.writeNamespace
+      : scope.codingOverlayApplied
+        ? this.orchestrator.config.defaultNamespace
+        : scope.writeNamespace;
     if (!this.orchestrator.lcmEngine || !this.orchestrator.lcmEngine.enabled) {
       return {
         enabled: false,
@@ -5364,22 +5549,19 @@ export class EngramAccessService {
       };
     }
 
-    // Flush the SAME LCM session_id that `observe` archived under. When no
-    // explicit namespace is supplied, an auto-scoped session was archived under
-    // its coding-overlay namespace (`${effectiveNamespace}:${sessionKey}`), not
-    // the base `namespace` — so apply the session's coding overlay here too, or
-    // the flush would target the wrong queue (#1495 thread 2, rule 42).
-    // `purpose: "write"` — compaction is a write/maintenance op on the queue
-    // observe wrote, so the overlay is gated by WRITE authorization, not
-    // readability (round-4 codex P2): a write-only / self-omitted principal
-    // still flushes the overlay queue observe archived under.
-    const lcmSessionKey = this.resolveLcmReadSessionKey(
-      request.namespace,
-      namespace,
-      request.sessionKey,
-      request.authenticatedPrincipal,
-      "write",
-    );
+    // Flush the SAME LCM session_id `observe` archived under: encode the scope
+    // plan's EFFECTIVE write namespace (the coding overlay when one applies, else
+    // the default store) through the SAME `lcmSessionKeyForNamespace` helper
+    // observe uses for archival, so the flush key is byte-for-byte the write key
+    // (#1495 thread 2 / #1505 thread NBHWs, rule 42). A write-only / self-omitted
+    // principal still flushes the overlay queue because the scope plan authorized
+    // the write target by WRITE policy, not readability.
+    const lcmSessionKey =
+      lcmSessionKeyForNamespace(
+        scope.writeNamespace,
+        request.sessionKey,
+        this.orchestrator.config.defaultNamespace,
+      ) ?? request.sessionKey;
     await this.orchestrator.lcmEngine.waitForSessionObserveIdle(lcmSessionKey);
     await this.orchestrator.lcmEngine.preCompactionFlush(lcmSessionKey);
     return {
@@ -5403,11 +5585,23 @@ export class EngramAccessService {
       throw new EngramAccessInputError("tokensAfter must be a non-negative integer");
     }
 
-    const namespace = this.resolveWritableNamespace(
-      request.namespace,
-      request.sessionKey,
-      request.authenticatedPrincipal,
-    );
+    // Authorize compaction against the SCOPED WRITE TARGET — the SAME effective
+    // write namespace `observe` archived the LCM queue under — NOT a premature
+    // `resolveWritableNamespace(undefined ⇒ config.defaultNamespace)` (#1505
+    // thread NBHWs). See `lcmCompactionFlush` for the full rationale: under a
+    // restrictive `default` WRITE policy where the principal can still write its
+    // self/project overlay, the old premature default write-auth threw `namespace
+    // is not writable: default` before the scoped key was computed, leaving the
+    // overlay queue observe wrote unrecordable. `resolveMemoryScopePlan` is the
+    // ONE write-scoped plan/gate observe uses; it authorizes the self base for an
+    // overlay write and never throws `not writable: default` for a validly scoped
+    // observe's queue.
+    const scope = await this.resolveMemoryScopePlan(request);
+    const namespace = scope.explicitNamespace
+      ? scope.writeNamespace
+      : scope.codingOverlayApplied
+        ? this.orchestrator.config.defaultNamespace
+        : scope.writeNamespace;
     if (!this.orchestrator.lcmEngine || !this.orchestrator.lcmEngine.enabled) {
       return {
         enabled: false,
@@ -5418,19 +5612,18 @@ export class EngramAccessService {
       };
     }
 
-    // Record against the SAME LCM session_id `observe` archived under — apply
-    // the session's coding overlay when no explicit namespace is given, so an
-    // auto-scoped session records its compaction on the right queue (#1495
-    // thread 2, rule 42). `purpose: "write"` — write/maintenance op gated by
-    // WRITE authorization, not readability (round-4 codex P2), so a write-only /
-    // self-omitted principal still records on the overlay queue observe wrote.
-    const lcmSessionKey = this.resolveLcmReadSessionKey(
-      request.namespace,
-      namespace,
-      request.sessionKey,
-      request.authenticatedPrincipal,
-      "write",
-    );
+    // Record against the SAME LCM session_id `observe` archived under — encode
+    // the scope plan's EFFECTIVE write namespace through the SAME
+    // `lcmSessionKeyForNamespace` helper observe uses, so the record key is
+    // byte-for-byte the write key (#1495 thread 2 / #1505 thread NBHWs, rule 42).
+    // A write-only / self-omitted principal still records on the overlay queue
+    // because the scope plan authorized the write target by WRITE policy.
+    const lcmSessionKey =
+      lcmSessionKeyForNamespace(
+        scope.writeNamespace,
+        request.sessionKey,
+        this.orchestrator.config.defaultNamespace,
+      ) ?? request.sessionKey;
     await this.orchestrator.lcmEngine.waitForSessionObserveIdle(lcmSessionKey);
     await this.orchestrator.lcmEngine.recordCompaction(
       lcmSessionKey,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1584,7 +1584,12 @@ export class EngramAccessService {
       }
       return {
         principal,
-        baseNamespace: writeNamespace,
+        // scopeDebug.baseNamespace must report the principal SELF base
+        // (`defaultNamespaceForPrincipal`), NOT the general write namespace —
+        // which collapses to config.defaultNamespace on this implicit no-overlay
+        // path (#1505 cursor "Wrong scopeDebug base namespace"). It already
+        // matches `objectiveStateNamespace` below; `writeNamespace` is unchanged.
+        baseNamespace,
         writeNamespace,
         // Implicit objective-state stays on the principal self base, NOT the
         // (possibly default) general write namespace — preserving the #928

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2969,11 +2969,18 @@ export class EngramAccessService {
     // it is the sole consumer, and resolving the overlay on every chunk/section
     // recall would be wasted work — keeping non-raw recall byte-for-byte
     // unchanged.
+    // Trim the sessionKey to match what `orchestrator.recall(...)` already does
+    // (`request.sessionKey?.trim() || undefined`) and what the x-ray raw-excerpt
+    // path uses (cursor "Raw excerpt key not trimmed"). A whitespace-padded key
+    // otherwise drives recall under one identity but resolves the raw-excerpt
+    // overlay namespace + LCM `session_id` under a DIFFERENT (untrimmed) prefix,
+    // so excerpts are gated/queried inconsistently with recall and the x-ray path.
+    const trimmedSessionKey = request.sessionKey?.trim() || undefined;
     const rawExcerptNamespace =
       disclosure === "raw"
         ? this.resolveRawExcerptReadNamespace(
             request.namespace,
-            request.sessionKey,
+            trimmedSessionKey,
             authenticatedPrincipal,
           )
         : undefined;
@@ -2995,17 +3002,17 @@ export class EngramAccessService {
     // project/root scope — exactly as recall + `lcmSearch` do. Only with a
     // concrete sessionKey; already read-gated.
     const rawExcerptSessionIds =
-      disclosure === "raw" && rawExcerptNamespace && request.sessionKey
+      disclosure === "raw" && rawExcerptNamespace && trimmedSessionKey
         ? this.resolveLcmReadSessionIds(
             request.namespace,
             rawExcerptNamespace,
-            request.sessionKey,
+            trimmedSessionKey,
             authenticatedPrincipal,
           )
         : undefined;
     let results = await this.serializeRecallResults(snapshot, disclosure, {
       query,
-      sessionKey: request.sessionKey,
+      sessionKey: trimmedSessionKey,
       ...(rawExcerptNamespace ? { rawExcerptNamespace } : {}),
       ...(rawExcerptSessionIds ? { rawExcerptSessionIds } : {}),
       ...(rawExcerptsSuppressed ? { rawExcerptsSuppressed } : {}),
@@ -5151,30 +5158,32 @@ export class EngramAccessService {
           this.orchestrator.config.defaultNamespace,
         ) ?? request.sessionPrefix
       : request.sessionPrefix;
-    // SECURITY (codex P1 "Don't treat any readable namespace as default LCM
-    // access"): a sessionless, prefixless `lcmSearch` issues
-    // `searchContextFull(query, limit, undefined, undefined)`, which scans the
-    // ENTIRE LCM archive across every session/namespace. That is only acceptable
-    // when the caller may read the DEFAULT store the archive scan effectively
-    // exposes. Under a restrictive `default` READ policy (the principal cannot
-    // read `default`), an implicit `lcmSearch` with no `sessionKey` AND no
-    // `sessionPrefix` must NOT run the unbounded scan — return EMPTY. A scoped
-    // call (sessionKey or sessionPrefix present) stays gated by its own
-    // overlay/recall authorization above; an explicit, read-authorized namespace
-    // is unaffected (it already passed `resolveReadableNamespace`).
+    // SECURITY (#1495 P1 + codex P1 r2 "Require a scoped LCM filter before
+    // archive searches"): a sessionless, prefixless `lcmSearch` issues
+    // `searchContextFull(query, limit, undefined, undefined)`, an archive-wide
+    // FTS scan over EVERY `session_id`, including the sentinel-framed
+    // `<ns>`-scoped overlay/tenant rows. The LCM archive is keyed by the
+    // `session_id` STRING and is NOT partitioned by namespace, so an unscoped
+    // scan CANNOT be constrained to the caller's authorized namespace — neither
+    // an explicit `namespace` nor a readable `default` confines its results to
+    // rows the caller may read. The scan is therefore safe ONLY in single-store
+    // mode (namespaces disabled, one shared archive owned by the caller). When
+    // namespaces are ENABLED, an unscoped `lcmSearch` (no `sessionKey` AND no
+    // `sessionPrefix`) must be SUPPRESSED — return EMPTY — regardless of an
+    // explicit namespace or default-readability, so a caller authorized for
+    // `default` (or for one explicit namespace) cannot read other namespaces'
+    // transcript rows via the archive-wide scan (cross-tenant read leak). A
+    // SCOPED call (sessionKey or sessionPrefix present) is unaffected: it carries
+    // a namespace-framed `session_id` / prefix filter that already constrains the
+    // search to the caller's authorized, read-gated namespace.
     const hasScopedSession =
       (typeof request.sessionKey === "string" &&
         request.sessionKey.length > 0) ||
       (typeof lcmSessionPrefix === "string" && lcmSessionPrefix.length > 0);
-    const defaultStoreReadable = canReadNamespace(
-      principal,
-      this.orchestrator.config.defaultNamespace,
-      this.orchestrator.config,
-    );
-    if (!hasExplicitNamespace && !hasScopedSession && !defaultStoreReadable) {
+    if (!hasScopedSession && this.orchestrator.config.namespacesEnabled === true) {
       return {
         query: request.query,
-        namespace: this.orchestrator.config.defaultNamespace,
+        namespace,
         results: [],
         count: 0,
         lcmEnabled: true,

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -385,15 +385,27 @@ test("#1505 codex P2: lcmReadSessionIdsForNamespaces preserves UNDEFINED for a s
 });
 
 test("#1505 codex P2: lcmReadSessionIdsForNamespaces keeps the raw sessionKey + overlay keys when a session IS present", async () => {
-  const { lcmReadSessionIdsForNamespaces } = await import("./coding-namespace.js");
+  const { lcmReadSessionIdsForNamespaces, lcmSessionKeyForNamespace } = await import(
+    "./coding-namespace.js"
+  );
+  // Shape-agnostic expectation: derive each expected key through the SAME shared
+  // encoder production uses (#1495 P1 made the namespaced encoding sentinel-framed
+  // and unforgeable; rule 22: never re-hardcode the join).
+  const enc = (ns: string, sk: string) =>
+    lcmSessionKeyForNamespace(ns, sk, "default") ?? sk;
   // Single-store / default namespace ⇒ raw sessionKey (byte-for-byte prior).
   assert.deepEqual(
     lcmReadSessionIdsForNamespaces(["default"], "sk", "default"),
     ["sk"],
   );
-  // Non-default namespaces ⇒ prefixed keys, deduped, ordered.
+  // Non-default namespaces ⇒ sentinel-framed keys, deduped, ordered. The default
+  // key collapses to the raw `sk`, and the namespaced key is disjoint from it.
   assert.deepEqual(
     lcmReadSessionIdsForNamespaces(["acme", "default", "acme"], "sk", "default"),
-    ["acme:sk", "sk"],
+    [enc("acme", "sk"), "sk"],
   );
+  // Security invariant: the namespaced key cannot equal a raw default key, so a
+  // forged default read can never collide with the overlay key.
+  assert.notEqual(enc("acme", "sk"), "acme:sk");
+  assert.notEqual(enc("acme", "sk"), "sk");
 });

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -365,3 +365,35 @@ test("resolveCodingNamespaceOverlay: read path and write path see identical name
   const writeOverlay = resolveCodingNamespaceOverlay(input[0], input[1]);
   assert.deepEqual(readOverlay, writeOverlay);
 });
+
+test("#1505 codex P2: lcmReadSessionIdsForNamespaces preserves UNDEFINED for a sessionless read (never the literal 'default' session id)", async () => {
+  const { lcmReadSessionIdsForNamespaces } = await import("./coding-namespace.js");
+  // Sessionless ⇒ a single archive-wide read (`undefined`), so the LCM builders
+  // run with no exact session_id filter — NOT filtered to a session literally
+  // named "default" (which would silently drop explicit-cue/targeted/focused/
+  // response/event LCM sections for every recall that omits a session key).
+  assert.deepEqual(
+    lcmReadSessionIdsForNamespaces(["default"], undefined, "default"),
+    [undefined],
+    "sessionless ⇒ [undefined], never ['default']",
+  );
+  assert.deepEqual(
+    lcmReadSessionIdsForNamespaces(["acme", "default"], "", "default"),
+    [undefined],
+    "empty-string sessionKey is treated as sessionless ⇒ [undefined]",
+  );
+});
+
+test("#1505 codex P2: lcmReadSessionIdsForNamespaces keeps the raw sessionKey + overlay keys when a session IS present", async () => {
+  const { lcmReadSessionIdsForNamespaces } = await import("./coding-namespace.js");
+  // Single-store / default namespace ⇒ raw sessionKey (byte-for-byte prior).
+  assert.deepEqual(
+    lcmReadSessionIdsForNamespaces(["default"], "sk", "default"),
+    ["sk"],
+  );
+  // Non-default namespaces ⇒ prefixed keys, deduped, ordered.
+  assert.deepEqual(
+    lcmReadSessionIdsForNamespaces(["acme", "default", "acme"], "sk", "default"),
+    ["acme:sk", "sk"],
+  );
+});

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -455,3 +455,53 @@ export function lcmSessionKeyForNamespace(
   }
   return sessionKey;
 }
+
+/**
+ * Map an ORDERED, read-authorized namespace set (the SAME set normal QMD/file
+ * recall searches) to the ordered set of LCM `session_id`s a same-session reader
+ * must query (#1505 thread "Include coding fallback namespaces in LCM reads").
+ *
+ * The LCM archive filters strictly by `session_id`, and `observe` archives each
+ * turn under `${effectiveNamespace}:${sessionKey}` for the namespace that was
+ * effective when it was written. A branch-scoped session that overlays
+ * `${base-project-*-branch-*}` only sees rows written under THAT namespace if it
+ * reads a single overlay key — but normal recall ALSO searches the
+ * `codingOverlay.readFallbacks` (project / root) namespaces, so rows archived at
+ * project/root scope are surfaced by QMD/file recall yet MISSED by a single-key
+ * LCM read. Deriving the LCM read keys from the SAME `recallNamespaces` set keeps
+ * the LCM read path from diverging: every namespace recall is authorized to read
+ * (read-auth gate already applied upstream in `recallNamespaces`) contributes one
+ * LCM key, ordered primary-overlay-first then fallbacks. Unreadable namespaces
+ * are never in `recallNamespaces`, so they are never searched here either (no
+ * cross-tenant read leak).
+ *
+ * Single-user / no-overlay recall passes a single-namespace set that collapses to
+ * the raw `sessionKey`, so the result is `[sessionKey]` — byte-for-byte the
+ * pre-#1505 single-key behavior.
+ *
+ * The result is deduped while preserving first-seen order so the caller can query
+ * keys in priority order and short-circuit on the first hit without re-querying an
+ * identical key (e.g. when two namespaces both collapse to the default store).
+ */
+export function lcmReadSessionIdsForNamespaces(
+  namespaces: readonly string[],
+  sessionKey: string | undefined,
+  defaultNamespace: string,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const namespace of namespaces) {
+    const key =
+      lcmSessionKeyForNamespace(namespace, sessionKey, defaultNamespace) ??
+      sessionKey ??
+      "default";
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(key);
+    }
+  }
+  if (out.length === 0) {
+    out.push(sessionKey ?? "default");
+  }
+  return out;
+}

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -418,3 +418,40 @@ export function describeCodingScope(
     disabledReason: null,
   };
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// LCM session-key namespacing (#1495)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the LCM/structured-history `session_id` that a write-producing surface
+ * archives under, and that a same-session reader must search under, so reads
+ * and writes never drift (#1495, CLAUDE.md rule 42).
+ *
+ * The LCM archive filters strictly by `session_id` string, so the writer's
+ * archival key and the reader's lookup key MUST agree byte-for-byte. The
+ * encoding is: prefix the raw `sessionKey` with the EFFECTIVE write namespace
+ * (`${namespace}:${sessionKey}`) whenever that namespace diverges from the
+ * single-store default; otherwise pass the raw `sessionKey` unchanged so
+ * single-user / no-overlay deployments keep pre-#1495 behavior exactly.
+ *
+ * `observe`, compaction flush/record, and the orchestrator recall readers all
+ * route through this one helper so a project-scoped (cwd/projectTag) or
+ * explicit-namespace session reads its own compressed-history / structured /
+ * targeted-fact evidence instead of missing it.
+ */
+export function lcmSessionKeyForNamespace(
+  namespace: string | undefined,
+  sessionKey: string | undefined,
+  defaultNamespace: string,
+): string | undefined {
+  if (typeof sessionKey !== "string" || sessionKey.length === 0) return sessionKey;
+  if (
+    typeof namespace === "string" &&
+    namespace.length > 0 &&
+    namespace !== defaultNamespace
+  ) {
+    return `${namespace}:${sessionKey}`;
+  }
+  return sessionKey;
+}

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -479,6 +479,14 @@ export function lcmSessionKeyForNamespace(
  * the raw `sessionKey`, so the result is `[sessionKey]` — byte-for-byte the
  * pre-#1505 single-key behavior.
  *
+ * SESSIONLESS recall (`sessionKey === undefined`): returns `[undefined]` so the
+ * caller issues ONE archive-wide LCM read with no exact `session_id` filter —
+ * byte-for-byte the pre-#1505 sessionless behavior. It must NOT substitute the
+ * literal `"default"` session id (codex P2 "Preserve unscoped LCM searches
+ * without a session key"): that would filter to a session literally named
+ * `default`, silently dropping the explicit-cue / targeted / focused / response /
+ * event LCM sections for every recall that omits a session key.
+ *
  * The result is deduped while preserving first-seen order so the caller can query
  * keys in priority order and short-circuit on the first hit without re-querying an
  * identical key (e.g. when two namespaces both collapse to the default store).
@@ -487,21 +495,25 @@ export function lcmReadSessionIdsForNamespaces(
   namespaces: readonly string[],
   sessionKey: string | undefined,
   defaultNamespace: string,
-): string[] {
+): Array<string | undefined> {
+  // Sessionless ⇒ a single archive-wide read (no `session_id` filter). NEVER the
+  // literal "default" session id (codex P2).
+  if (typeof sessionKey !== "string" || sessionKey.length === 0) {
+    return [undefined];
+  }
   const out: string[] = [];
   const seen = new Set<string>();
   for (const namespace of namespaces) {
     const key =
       lcmSessionKeyForNamespace(namespace, sessionKey, defaultNamespace) ??
-      sessionKey ??
-      "default";
+      sessionKey;
     if (!seen.has(key)) {
       seen.add(key);
       out.push(key);
     }
   }
   if (out.length === 0) {
-    out.push(sessionKey ?? "default");
+    out.push(sessionKey);
   }
   return out;
 }

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -424,16 +424,75 @@ export function describeCodingScope(
 // ──────────────────────────────────────────────────────────────────────────
 
 /**
+ * Reserved structural sentinel for the namespaced LCM `session_id` encoding
+ * (#1495 P1). U+001F (UNIT SEPARATOR) is a C0 control character that CANNOT
+ * occur in a route namespace (`isSafeRouteNamespace` ⇒ `[A-Za-z0-9._-]{1,64}`,
+ * see routing/engine.ts) and does not occur in any legitimate session key, so
+ * it is an unforgeable structural marker for the namespace boundary.
+ *
+ * SECURITY — why this is unforgeable (the #1495 P1 fix):
+ * The LCM archive is keyed by the `session_id` STRING (exact `session_id = ?`
+ * and prefix `session_id LIKE '<prefix>%'`), NOT physically partitioned by
+ * namespace. The previous encoding `${namespace}:${sessionKey}` shared the SAME
+ * string space as a raw default-store key, so a caller authorized for the
+ * `default` store could pass a raw `sessionKey` equal to another namespace's
+ * encoded key (`"<overlay-ns>:<victim-session>"`) and exact-match the victim's
+ * rows — a cross-tenant read leak.
+ *
+ * The new encoding makes the namespaced and default key-spaces PROVABLY
+ * DISJOINT:
+ *   - Overlay key  = `\x1f<namespace>\x1f<sessionKey>` — always begins with
+ *     `\x1f` followed by a NON-`\x1f` character (the namespace is non-empty and
+ *     `\x1f`-free). The leading `\x1f<namespace>\x1f` is an unambiguous,
+ *     injective frame: the namespace cannot contain `\x1f`, so the second `\x1f`
+ *     terminates it without any escaping of the (raw) session key.
+ *   - Default key  = the raw `sessionKey`, UNLESS it already begins with the
+ *     sentinel, in which case it is escaped to begin with `\x1f\x1f` (see
+ *     `escapeDefaultLcmKey`). A default key therefore NEVER matches the overlay
+ *     frame `\x1f<non-\x1f>…`.
+ * Hence no caller-controlled raw `sessionKey` (default path) can reproduce an
+ * overlay key, closing the forgery for BOTH the exact-`session_id` match and the
+ * `sessionPrefix` LIKE match (an overlay prefix `\x1f<ns>\x1f<rawPrefix>` stays a
+ * valid LIKE-prefix of the overlay full keys, and a default prefix can only
+ * LIKE-match default keys).
+ *
+ * Existing default-store rows need NO migration: legitimate session keys never
+ * contain `\x1f`, so `escapeDefaultLcmKey` is a no-op for them and they remain
+ * byte-for-byte their raw form. The namespaced encoding is NEW in this
+ * unreleased PR, so changing its shape costs nothing.
+ */
+const LCM_NS_SENTINEL = "\u001f";
+
+/**
+ * Make a default-store (raw) LCM key disjoint from the namespaced key-space.
+ *
+ * Namespaced overlay keys always begin with `\x1f` followed by a non-`\x1f`
+ * namespace character. A raw default key collides with that frame ONLY if it
+ * begins with `\x1f`. Legitimate session keys never contain `\x1f`, so this is a
+ * pure no-op for them; a forged key that begins with `\x1f` is escaped to begin
+ * with `\x1f\x1f`, which can never equal an overlay key (whose second character
+ * is a `[A-Za-z0-9._-]` namespace char, never `\x1f`).
+ */
+function escapeDefaultLcmKey(sessionKey: string): string {
+  return sessionKey.startsWith(LCM_NS_SENTINEL)
+    ? `${LCM_NS_SENTINEL}${sessionKey}`
+    : sessionKey;
+}
+
+/**
  * Build the LCM/structured-history `session_id` that a write-producing surface
  * archives under, and that a same-session reader must search under, so reads
  * and writes never drift (#1495, CLAUDE.md rule 42).
  *
- * The LCM archive filters strictly by `session_id` string, so the writer's
+ * The LCM archive filters strictly by the `session_id` string, so the writer's
  * archival key and the reader's lookup key MUST agree byte-for-byte. The
- * encoding is: prefix the raw `sessionKey` with the EFFECTIVE write namespace
- * (`${namespace}:${sessionKey}`) whenever that namespace diverges from the
- * single-store default; otherwise pass the raw `sessionKey` unchanged so
- * single-user / no-overlay deployments keep pre-#1495 behavior exactly.
+ * encoding frames the namespace with the reserved {@link LCM_NS_SENTINEL}
+ * (`\x1f<namespace>\x1f<sessionKey>`) whenever that namespace diverges from the
+ * single-store default; otherwise it passes the (escaped) raw `sessionKey` so
+ * single-user / no-overlay deployments keep pre-#1495 behavior exactly. The two
+ * key-spaces are provably disjoint, so a caller-controlled raw `sessionKey`
+ * cannot forge another namespace's encoded id (see the {@link LCM_NS_SENTINEL}
+ * doc comment for the full security rationale).
  *
  * `observe`, compaction flush/record, and the orchestrator recall readers all
  * route through this one helper so a project-scoped (cwd/projectTag) or
@@ -451,9 +510,14 @@ export function lcmSessionKeyForNamespace(
     namespace.length > 0 &&
     namespace !== defaultNamespace
   ) {
-    return `${namespace}:${sessionKey}`;
+    // Namespaced (overlay / explicit) key: frame the namespace with the reserved
+    // sentinel so the boundary is unambiguous AND unforgeable from the default
+    // key-space. The namespace is guaranteed `\x1f`-free by `isSafeRouteNamespace`.
+    return `${LCM_NS_SENTINEL}${namespace}${LCM_NS_SENTINEL}${sessionKey}`;
   }
-  return sessionKey;
+  // Default store: raw sessionKey, escaped only if it would otherwise intrude on
+  // the namespaced key-space (no-op for every legitimate key).
+  return escapeDefaultLcmKey(sessionKey);
 }
 
 /**

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2033,6 +2033,19 @@ export class Orchestrator {
    * to `default`, so principal `alice` observing `sess-1` would write under
    * `alice` but READ under `default`. Threading the override here keeps the read
    * base identical to the write base.
+   *
+   * READ-AUTHORIZATION gate (#1505 round 3, codex P2 "Gate LCM recall keys by
+   * readable namespaces"): the overlay LCM read key is a `<principal>-project-*`
+   * sub-namespace of the principal SELF base. The normal recall namespace set
+   * below only substitutes the coding overlay when the principal SELF base is
+   * actually in the readable recall set (`recallNamespacesForPrincipal` — gated
+   * by `defaultRecallNamespaces.includes("self")` AND `canReadNamespace`). If a
+   * principal can WRITE but not READ its self namespace (or `defaultRecall-
+   * Namespaces` omits `self`), QMD/file recall never touches those overlay rows,
+   * so neither may the LCM read key. When the self base is NOT readable, fall
+   * back to the default store — exactly what an unqualified, unauthorized recall
+   * resolves to — rather than injecting overlay rows the rest of recall excludes
+   * (rule 42 read/write parity; rule 48 least-privilege).
    */
   private lcmReadNamespaceForSession(
     sessionKey?: string,
@@ -2044,10 +2057,19 @@ export class Orchestrator {
         : this.resolvePrincipal(sessionKey);
     const base = defaultNamespaceForPrincipal(principal, this.config);
     const overlaid = this.applyCodingNamespaceOverlay(sessionKey, base);
-    // Overlay applied → use the overlaid namespace (what observe wrote).
     // No overlay → collapse to the default store so the LCM key is the raw
     // sessionKey, exactly what an unqualified observe archived under.
-    return overlaid !== base ? overlaid : this.config.defaultNamespace;
+    if (overlaid === base) return this.config.defaultNamespace;
+    // Overlay applied. Only honour it when the principal SELF base is in the
+    // readable recall set (same gate the recall namespace set uses to
+    // substitute the overlay). Otherwise the overlay rows are unauthorized for
+    // this reader — fall back to the default store so the LCM read matches
+    // what QMD/file recall would surface.
+    const selfReadableInRecall = recallNamespacesForPrincipal(
+      principal,
+      this.config,
+    ).includes(base);
+    return selfReadableInRecall ? overlaid : this.config.defaultNamespace;
   }
 
   /**

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2025,12 +2025,24 @@ export class Orchestrator {
    * reader) use the overlaid `project-*` namespace. Returning the self base for
    * the no-overlay case would prefix the read key with a namespace the writer
    * never used, so the reader would miss its own evidence.
+   *
+   * Honours the access-surface `principalOverride` (#1505 thread 2, codex): when
+   * a recall supplies an authenticated principal NOT encoded in the raw
+   * `sessionKey`, `observe` archived LCM under THAT principal's base namespace.
+   * Deriving the base from `resolvePrincipal(sessionKey)` alone could fall back
+   * to `default`, so principal `alice` observing `sess-1` would write under
+   * `alice` but READ under `default`. Threading the override here keeps the read
+   * base identical to the write base.
    */
-  private lcmReadNamespaceForSession(sessionKey?: string): string {
-    const base = defaultNamespaceForPrincipal(
-      this.resolvePrincipal(sessionKey),
-      this.config,
-    );
+  private lcmReadNamespaceForSession(
+    sessionKey?: string,
+    principalOverride?: string,
+  ): string {
+    const principal =
+      typeof principalOverride === "string" && principalOverride.length > 0
+        ? principalOverride
+        : this.resolvePrincipal(sessionKey);
+    const base = defaultNamespaceForPrincipal(principal, this.config);
     const overlaid = this.applyCodingNamespaceOverlay(sessionKey, base);
     // Overlay applied → use the overlaid namespace (what observe wrote).
     // No overlay → collapse to the default store so the LCM key is the raw
@@ -6928,7 +6940,9 @@ export class Orchestrator {
     // `options.namespace` override wins; otherwise use the session's
     // coding-overlay namespace when one applies, else the default store
     // (`lcmReadNamespaceForSession` — NOT the principal self base, which would
-    // prefix a namespace the unqualified writer never used).
+    // prefix a namespace the unqualified writer never used). The authenticated
+    // `principalOverride` (#1505 thread 2) is threaded so the read base matches
+    // the write base when the principal is not encoded in the raw sessionKey.
     // `lcmSessionKeyForNamespace` collapses to the raw `sessionKey` whenever the
     // namespace is the default store, so single-user / no-overlay recall is
     // byte-for-byte unchanged.
@@ -6936,7 +6950,10 @@ export class Orchestrator {
       lcmSessionKeyForNamespace(
         typeof options.namespace === "string" && options.namespace.length > 0
           ? options.namespace
-          : this.lcmReadNamespaceForSession(sessionKey),
+          : this.lcmReadNamespaceForSession(
+              sessionKey,
+              options.principalOverride,
+            ),
         sessionKey,
         this.config.defaultNamespace,
       ) ??
@@ -9422,7 +9439,10 @@ export class Orchestrator {
       try {
         const explicitCueSection = await buildExplicitCueRecallSection({
           engine: this.lcmEngine,
-          sessionId: sessionKey,
+          // #1495 thread 3: read under the EFFECTIVE namespaced LCM session_id
+          // (same as targeted-facts/structured/compressed-history) so a
+          // project-scoped session finds its own explicit-cue evidence (rule 39).
+          sessionId: lcmReadSessionId,
           query: retrievalQuery,
           maxChars: explicitCueMaxChars,
           maxReferences:
@@ -9507,7 +9527,9 @@ export class Orchestrator {
       try {
         const focusedListSection = await buildFocusedListRecallSection({
           engine: this.lcmEngine,
-          sessionId: sessionKey,
+          // #1495 thread 3: namespaced LCM session_id so a project-scoped session
+          // reads its own focused-list/count evidence (rule 39).
+          sessionId: lcmReadSessionId,
           query: retrievalQuery,
           maxChars: focusedListMaxChars,
           maxSearchResults:
@@ -9556,7 +9578,9 @@ export class Orchestrator {
       try {
         const responseGuidanceSection = await buildResponseGuidanceRecallSection({
           engine: this.lcmEngine,
-          sessionId: sessionKey,
+          // #1495 thread 3: namespaced LCM session_id so a project-scoped session
+          // reads its own response-guidance evidence (rule 39).
+          sessionId: lcmReadSessionId,
           query: retrievalQuery,
           maxChars: responseGuidanceMaxChars,
           maxSearchResults:
@@ -9600,7 +9624,9 @@ export class Orchestrator {
       try {
         const eventOrderSection = await buildEventOrderRecallSection({
           engine: this.lcmEngine,
-          sessionId: sessionKey,
+          // #1495 thread 3: namespaced LCM session_id so a project-scoped session
+          // reads its own chronological event-order evidence (rule 39).
+          sessionId: lcmReadSessionId,
           query: retrievalQuery,
           maxChars: eventOrderMaxChars,
           maxItems:
@@ -11304,6 +11330,17 @@ export class Orchestrator {
        * Same hook bulk-import uses (#460).
        */
       writeNamespaceOverride?: string;
+      /**
+       * Pin the provenance PRINCIPAL instead of deriving it from
+       * `resolvePrincipal(turn.sessionKey)` (#1495 thread 1). The access
+       * `observe` surface authenticates the caller at the transport layer and
+       * passes its resolved principal here so extracted-memory provenance uses
+       * the SAME identity the surface authorized — independent of storage
+       * routing (`writeNamespaceOverride`) and of whatever `resolvePrincipal`
+       * would parse from the raw session key. Mirrors the recall path's
+       * `principalOverride` (issue #570 PR 4).
+       */
+      principalOverride?: string;
     } = {},
   ): Promise<void> {
     if (!Array.isArray(turns) || turns.length === 0) return;
@@ -11391,6 +11428,7 @@ export class Orchestrator {
               extractionDeadlineMs: options.deadlineMs,
               abortSignal: options.abortSignal,
               writeNamespaceOverride: options.writeNamespaceOverride,
+              principalOverride: options.principalOverride,
               onTaskSettled: (err) => (err ? reject(err) : resolve()),
             }).catch(reject);
           }),
@@ -11787,6 +11825,12 @@ export class Orchestrator {
        * regardless of user-configured principal routing rules.
        */
       writeNamespaceOverride?: string;
+      /**
+       * Pin the provenance principal (#1495 thread 1). Forwarded to
+       * `runExtraction` so access `observe` can record provenance under the
+       * authenticated principal instead of `resolvePrincipal(sessionKey)`.
+       */
+      principalOverride?: string;
     } = {},
   ): Promise<void> {
     const bufferKey = options.bufferKey ?? turnsToExtract[0]?.sessionKey ?? "default";
@@ -11860,6 +11904,7 @@ export class Orchestrator {
           abortSignal: options.abortSignal,
           failOnExtractionFailure: options.failOnExtractionFailure === true,
           writeNamespaceOverride: options.writeNamespaceOverride,
+          principalOverride: options.principalOverride,
         });
         settleTask(undefined, result);
       } catch (err) {
@@ -12016,6 +12061,14 @@ export class Orchestrator {
        * for provenance; only the storage target is overridden.
        */
       writeNamespaceOverride?: string;
+      /**
+       * Pin the provenance principal instead of deriving it from
+       * `resolvePrincipal(sessionKey)` (#1495 thread 1). When set, this is the
+       * identity an access surface already authenticated; used so observed-turn
+       * provenance is correct even though `turn.sessionKey` is the ORIGINAL
+       * (un-prefixed) key and storage is pinned via `writeNamespaceOverride`.
+       */
+      principalOverride?: string;
     } = {},
   ): Promise<ExtractionRunResult> {
     log.debug(`running extraction on ${turns.length} turns`);
@@ -12109,7 +12162,18 @@ export class Orchestrator {
       };
     }
 
-    const principal = resolvePrincipal(sessionKey, this.config);
+    // Provenance principal honours the access-surface override (#1495 thread 1,
+    // mirroring the recall path's `principalOverride`, issue #570 PR 4). Access
+    // surfaces that authenticated the caller at the transport layer pass their
+    // resolved principal so provenance uses the SAME identity the surface
+    // authorized, instead of `resolvePrincipal(sessionKey)` — which on a
+    // namespace-prefixed key would collapse to `default`. The ORIGINAL,
+    // un-prefixed session key still drives threading.
+    const principal =
+      typeof options.principalOverride === "string" &&
+      options.principalOverride.length > 0
+        ? options.principalOverride
+        : resolvePrincipal(sessionKey, this.config);
     // Write path — overlay the coding-agent namespace (issue #569) when the
     // session has a codingContext and `codingMode.projectScope` is true.
     // Explicit `writeNamespaceOverride` from callers still wins, matching

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -307,6 +307,7 @@ import {
 } from "./namespaces/principal.js";
 import {
   combineNamespaces,
+  lcmSessionKeyForNamespace,
   resolveCodingNamespaceOverlay,
 } from "./coding/coding-namespace.js";
 import type { CodingContext } from "./types.js";
@@ -2009,6 +2010,32 @@ export class Orchestrator {
       this.config,
     );
     return this.applyCodingNamespaceOverlay(sessionKey, base);
+  }
+
+  /**
+   * Effective namespace a same-session LCM/structured-history READER must use
+   * to find what the access `observe` surface WROTE (#1495 thread 2).
+   *
+   * This MUST mirror the `observe` scope plan's write-namespace resolution, NOT
+   * `resolveSelfNamespace`: when no coding overlay applies, `observe` archives
+   * under `config.defaultNamespace` (an unqualified observed turn is NOT moved
+   * to the principal self namespace — identical to
+   * `resolveCodingScopedWriteNamespace`/`memory_store`, rule 39). Only when a
+   * coding overlay actually changes the namespace does the writer (and so the
+   * reader) use the overlaid `project-*` namespace. Returning the self base for
+   * the no-overlay case would prefix the read key with a namespace the writer
+   * never used, so the reader would miss its own evidence.
+   */
+  private lcmReadNamespaceForSession(sessionKey?: string): string {
+    const base = defaultNamespaceForPrincipal(
+      this.resolvePrincipal(sessionKey),
+      this.config,
+    );
+    const overlaid = this.applyCodingNamespaceOverlay(sessionKey, base);
+    // Overlay applied → use the overlaid namespace (what observe wrote).
+    // No overlay → collapse to the default store so the LCM key is the raw
+    // sessionKey, exactly what an unqualified observe archived under.
+    return overlaid !== base ? overlaid : this.config.defaultNamespace;
   }
 
   /**
@@ -6890,6 +6917,31 @@ export class Orchestrator {
       .digest("hex")
       .slice(0, 16);
     const sectionBuckets = new Map<string, string[]>();
+    // Effective LCM session_id for this recall (#1495 thread 2). The access
+    // `observe` surface archives LCM/structured history under
+    // `${effectiveNamespace}:${sessionKey}` when the effective write namespace
+    // diverges from the default store (explicit namespace OR coding overlay).
+    // The LCM archive filters strictly by session_id, so the readers below MUST
+    // search the SAME key or a project-scoped session misses its own
+    // compressed-history / structured / targeted-fact evidence. The effective
+    // namespace mirrors observe's write resolution: an explicit recall
+    // `options.namespace` override wins; otherwise use the session's
+    // coding-overlay namespace when one applies, else the default store
+    // (`lcmReadNamespaceForSession` — NOT the principal self base, which would
+    // prefix a namespace the unqualified writer never used).
+    // `lcmSessionKeyForNamespace` collapses to the raw `sessionKey` whenever the
+    // namespace is the default store, so single-user / no-overlay recall is
+    // byte-for-byte unchanged.
+    const lcmReadSessionId =
+      lcmSessionKeyForNamespace(
+        typeof options.namespace === "string" && options.namespace.length > 0
+          ? options.namespace
+          : this.lcmReadNamespaceForSession(sessionKey),
+        sessionKey,
+        this.config.defaultNamespace,
+      ) ??
+      sessionKey ??
+      "default";
     const queryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
       cronRecallPolicyEnabled: this.config.cronRecallPolicyEnabled,
       cronRecallNormalizedQueryMaxChars:
@@ -9408,7 +9460,9 @@ export class Orchestrator {
       try {
         const targetedFactSection = await buildTargetedFactRecallSection({
           engine: this.lcmEngine,
-          sessionId: sessionKey,
+          // #1495: read under the EFFECTIVE namespaced LCM session_id so a
+          // project-scoped session finds its own targeted-fact evidence.
+          sessionId: lcmReadSessionId,
           query: retrievalQuery,
           maxChars: targetedFactMaxChars,
           maxSearchResults:
@@ -9733,7 +9787,9 @@ export class Orchestrator {
     ) {
       try {
         const structuredMatches = await this.lcmEngine.searchStructuredParts(
-          sessionKey ?? "default",
+          // #1495: namespaced LCM session_id so a project-scoped session reads
+          // its own structured message-part evidence.
+          lcmReadSessionId,
           retrievalQuery,
         );
         const structuredSection = this.lcmEngine.formatStructuredRecall(
@@ -9759,7 +9815,9 @@ export class Orchestrator {
           }
         }
         const lcmSection = await this.lcmEngine.assembleRecall(
-          sessionKey ?? "default",
+          // #1495: namespaced LCM session_id so a project-scoped session reads
+          // its own compressed-history evidence.
+          lcmReadSessionId,
           this.config.recallBudgetChars,
         );
         if (lcmSection) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -307,7 +307,7 @@ import {
 } from "./namespaces/principal.js";
 import {
   combineNamespaces,
-  lcmSessionKeyForNamespace,
+  lcmReadSessionIdsForNamespaces,
   resolveCodingNamespaceOverlay,
 } from "./coding/coding-namespace.js";
 import type { CodingContext } from "./types.js";
@@ -6951,36 +6951,10 @@ export class Orchestrator {
       .digest("hex")
       .slice(0, 16);
     const sectionBuckets = new Map<string, string[]>();
-    // Effective LCM session_id for this recall (#1495 thread 2). The access
-    // `observe` surface archives LCM/structured history under
-    // `${effectiveNamespace}:${sessionKey}` when the effective write namespace
-    // diverges from the default store (explicit namespace OR coding overlay).
-    // The LCM archive filters strictly by session_id, so the readers below MUST
-    // search the SAME key or a project-scoped session misses its own
-    // compressed-history / structured / targeted-fact evidence. The effective
-    // namespace mirrors observe's write resolution: an explicit recall
-    // `options.namespace` override wins; otherwise use the session's
-    // coding-overlay namespace when one applies, else the default store
-    // (`lcmReadNamespaceForSession` — NOT the principal self base, which would
-    // prefix a namespace the unqualified writer never used). The authenticated
-    // `principalOverride` (#1505 thread 2) is threaded so the read base matches
-    // the write base when the principal is not encoded in the raw sessionKey.
-    // `lcmSessionKeyForNamespace` collapses to the raw `sessionKey` whenever the
-    // namespace is the default store, so single-user / no-overlay recall is
-    // byte-for-byte unchanged.
-    const lcmReadSessionId =
-      lcmSessionKeyForNamespace(
-        typeof options.namespace === "string" && options.namespace.length > 0
-          ? options.namespace
-          : this.lcmReadNamespaceForSession(
-              sessionKey,
-              options.principalOverride,
-            ),
-        sessionKey,
-        this.config.defaultNamespace,
-      ) ??
-      sessionKey ??
-      "default";
+    // The effective LCM read session_id SET is computed below from
+    // `recallNamespaces` (the SAME read-authorized namespace set normal QMD/file
+    // recall searches, incl. coding `readFallbacks`). See the
+    // `lcmReadSessionIds` derivation after `recallNamespaces` is built.
     const queryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
       cronRecallPolicyEnabled: this.config.cronRecallPolicyEnabled,
       cronRecallNormalizedQueryMaxChars:
@@ -7210,6 +7184,82 @@ export class Orchestrator {
     } else {
       recallNamespaces = readableRecallNamespaces;
     }
+    // Effective LCM read NAMESPACE SET (#1505 thread "Include coding fallback
+    // namespaces in LCM reads"). `observe` archives LCM / structured history
+    // under `${effectiveNamespace}:${sessionKey}` for whichever namespace was
+    // effective at write time. A branch-scoped session whose evidence was
+    // archived at project / root scope must still surface it, exactly as normal
+    // QMD/file recall does — QMD/file recall searches the primary overlay key AND
+    // `codingOverlay.readFallbacks` (project / root), NOT just the primary
+    // overlay key. The prior single `lcmReadSessionId` only targeted the primary
+    // overlay, so branch-scoped sessions missed fallback LCM evidence.
+    //
+    // READ-AUTHORIZATION (preserved from the prior round's
+    // `lcmReadNamespaceForSession` gate; rule 39 / 42 / 48): the coding-overlay
+    // namespace AND its fallbacks are `<principal>-project-*` sub-namespaces of
+    // the principal SELF base, authorized transitively by that base. They are
+    // included ONLY when the principal self base is in the readable recall set
+    // (`readableRecallNamespaces` — gated by `defaultRecallNamespaces.includes
+    // ("self")` AND `canReadNamespace`). When the self base is NOT readable (e.g.
+    // a write-only / self-omitted principal), the overlay rows are unauthorized
+    // for this reader, so the LCM read collapses to the default store — exactly
+    // what an unqualified, unauthorized recall resolves to — and NEVER searches a
+    // `<principal>-project-*` key (no cross-tenant read leak). This mirrors what
+    // the rest of recall surfaces for such a principal (its readable
+    // shared/policy namespaces have no per-session LCM key, so they contribute
+    // nothing here). `recallNamespaces` itself appends fallbacks unconditionally
+    // for QMD/file recall; the LCM read keys apply the stricter, self-base gate
+    // so the prior round's authorization invariant is preserved.
+    const codingOverlaySelfReadable =
+      codingOverlay !== null &&
+      readableRecallNamespaces.includes(principalSelfNamespace);
+    let lcmReadNamespaces: string[];
+    if (namespaceOverride) {
+      // Explicit namespace already read-authorized above (canReadNamespace gate).
+      lcmReadNamespaces = [namespaceOverride];
+    } else if (codingOverlay && codingSelfNamespace && codingOverlaySelfReadable) {
+      // Self base readable → overlay rows authorized. Read the primary overlay
+      // key first, then each coding read fallback (project → root), combined with
+      // the principal base for isolation — the SAME ordered set QMD/file recall
+      // searches for this authorized coding session.
+      const fallbackNs = codingOverlay.readFallbacks.map((fallback) =>
+        combineNamespaces(principalSelfNamespace, fallback),
+      );
+      lcmReadNamespaces = [codingSelfNamespace, ...fallbackNs];
+    } else {
+      // No overlay, OR overlay present but self base unreadable → collapse to the
+      // default store (raw sessionKey), exactly as the prior round did. No
+      // `<principal>-project-*` overlay key is searched.
+      lcmReadNamespaces = [this.config.defaultNamespace];
+    }
+    // Map the ordered, read-authorized namespace set → ordered, deduped LCM read
+    // session_id set. Single-user / no-overlay recall passes a single-namespace
+    // set that collapses to the raw `sessionKey`, so this is `[sessionKey]` —
+    // byte-for-byte the pre-#1495 single-key behavior.
+    const lcmReadSessionIds = lcmReadSessionIdsForNamespaces(
+      lcmReadNamespaces,
+      sessionKey,
+      this.config.defaultNamespace,
+    );
+    // Query an LCM-backed read across the ordered read key set and return the
+    // FIRST non-empty result (#1505 fallback-namespace unification). The primary
+    // overlay key is tried first; if a branch-scoped session has no rows under
+    // its branch key, the project / root fallback keys are tried in order. Each
+    // builder applies its own per-session budget/limit, so taking the first hit
+    // (rather than concatenating across keys) preserves existing budgets while
+    // recovering fallback evidence. When the set is a single key (single-user /
+    // no-overlay / explicit-namespace), this is exactly one call — unchanged.
+    const firstNonEmptyLcmRead = async <T>(
+      read: (lcmSessionId: string) => Promise<T>,
+      isEmpty: (value: T) => boolean,
+      empty: T,
+    ): Promise<T> => {
+      for (const lcmSessionId of lcmReadSessionIds) {
+        const value = await read(lcmSessionId);
+        if (!isEmpty(value)) return value;
+      }
+      return empty;
+    };
     const qmdAvailable = this.qmd.isAvailable();
     let graphDecisionStatus: IntentDebugSnapshot["graphDecision"]["status"] =
       recallDecision.plannedMode === "graph_mode" ? "skipped" : "not_requested";
@@ -9459,18 +9509,24 @@ export class Orchestrator {
       (recallMode as RecallPlanMode) !== "no_recall"
     ) {
       try {
-        const explicitCueSection = await buildExplicitCueRecallSection({
-          engine: this.lcmEngine,
-          // #1495 thread 3: read under the EFFECTIVE namespaced LCM session_id
-          // (same as targeted-facts/structured/compressed-history) so a
-          // project-scoped session finds its own explicit-cue evidence (rule 39).
-          sessionId: lcmReadSessionId,
-          query: retrievalQuery,
-          maxChars: explicitCueMaxChars,
-          maxReferences:
-            this.getRecallSectionNumber("explicit-cue", "maxResults") ??
-            this.config.explicitCueRecallMaxReferences,
-        });
+        const explicitCueSection = await firstNonEmptyLcmRead(
+          (lcmSessionId) =>
+            buildExplicitCueRecallSection({
+              engine: this.lcmEngine,
+              // #1495 thread 3 + #1505 fallback unification: read across the
+              // ordered LCM read key set (primary overlay → coding fallbacks)
+              // so a branch-scoped session finds its own explicit-cue evidence
+              // even when archived at project/root scope (rule 39).
+              sessionId: lcmSessionId,
+              query: retrievalQuery,
+              maxChars: explicitCueMaxChars,
+              maxReferences:
+                this.getRecallSectionNumber("explicit-cue", "maxResults") ??
+                this.config.explicitCueRecallMaxReferences,
+            }),
+          (s) => !s,
+          "",
+        );
         if (explicitCueSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9500,23 +9556,29 @@ export class Orchestrator {
       shouldRecallTargetedFactEvidence(retrievalQuery)
     ) {
       try {
-        const targetedFactSection = await buildTargetedFactRecallSection({
-          engine: this.lcmEngine,
-          // #1495: read under the EFFECTIVE namespaced LCM session_id so a
-          // project-scoped session finds its own targeted-fact evidence.
-          sessionId: lcmReadSessionId,
-          query: retrievalQuery,
-          maxChars: targetedFactMaxChars,
-          maxSearchResults:
-            this.getRecallSectionNumber("targeted-facts", "maxResults") ??
-            this.config.targetedFactRecallMaxResults,
-          maxScanWindowTurns:
-            this.getRecallSectionNumber("targeted-facts", "maxTurns") ??
-            this.config.targetedFactRecallScanWindowTurns,
-          maxScanWindowTokens:
-            this.getRecallSectionNumber("targeted-facts", "maxTokens") ??
-            this.config.targetedFactRecallScanWindowTokens,
-        });
+        const targetedFactSection = await firstNonEmptyLcmRead(
+          (lcmSessionId) =>
+            buildTargetedFactRecallSection({
+              engine: this.lcmEngine,
+              // #1495 + #1505 fallback unification: read across the ordered LCM
+              // read key set so a branch-scoped session finds its own
+              // targeted-fact evidence even when archived at project/root scope.
+              sessionId: lcmSessionId,
+              query: retrievalQuery,
+              maxChars: targetedFactMaxChars,
+              maxSearchResults:
+                this.getRecallSectionNumber("targeted-facts", "maxResults") ??
+                this.config.targetedFactRecallMaxResults,
+              maxScanWindowTurns:
+                this.getRecallSectionNumber("targeted-facts", "maxTurns") ??
+                this.config.targetedFactRecallScanWindowTurns,
+              maxScanWindowTokens:
+                this.getRecallSectionNumber("targeted-facts", "maxTokens") ??
+                this.config.targetedFactRecallScanWindowTokens,
+            }),
+          (s) => !s,
+          "",
+        );
         if (targetedFactSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9547,23 +9609,29 @@ export class Orchestrator {
       shouldRecallFocusedListEvidence(retrievalQuery)
     ) {
       try {
-        const focusedListSection = await buildFocusedListRecallSection({
-          engine: this.lcmEngine,
-          // #1495 thread 3: namespaced LCM session_id so a project-scoped session
-          // reads its own focused-list/count evidence (rule 39).
-          sessionId: lcmReadSessionId,
-          query: retrievalQuery,
-          maxChars: focusedListMaxChars,
-          maxSearchResults:
-            this.getRecallSectionNumber("focused-list", "maxResults") ??
-            this.config.focusedListRecallMaxResults,
-          maxScanWindowTurns:
-            this.getRecallSectionNumber("focused-list", "maxTurns") ??
-            this.config.focusedListRecallScanWindowTurns,
-          maxScanWindowTokens:
-            this.getRecallSectionNumber("focused-list", "maxTokens") ??
-            this.config.focusedListRecallScanWindowTokens,
-        });
+        const focusedListSection = await firstNonEmptyLcmRead(
+          (lcmSessionId) =>
+            buildFocusedListRecallSection({
+              engine: this.lcmEngine,
+              // #1495 thread 3 + #1505 fallback unification: read across the
+              // ordered LCM read key set so a branch-scoped session reads its own
+              // focused-list/count evidence even at project/root scope (rule 39).
+              sessionId: lcmSessionId,
+              query: retrievalQuery,
+              maxChars: focusedListMaxChars,
+              maxSearchResults:
+                this.getRecallSectionNumber("focused-list", "maxResults") ??
+                this.config.focusedListRecallMaxResults,
+              maxScanWindowTurns:
+                this.getRecallSectionNumber("focused-list", "maxTurns") ??
+                this.config.focusedListRecallScanWindowTurns,
+              maxScanWindowTokens:
+                this.getRecallSectionNumber("focused-list", "maxTokens") ??
+                this.config.focusedListRecallScanWindowTokens,
+            }),
+          (s) => !s,
+          "",
+        );
         if (focusedListSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9598,24 +9666,30 @@ export class Orchestrator {
       (responseGuidanceMatchesQuery || responseGuidanceForcedByPipeline)
     ) {
       try {
-        const responseGuidanceSection = await buildResponseGuidanceRecallSection({
-          engine: this.lcmEngine,
-          // #1495 thread 3: namespaced LCM session_id so a project-scoped session
-          // reads its own response-guidance evidence (rule 39).
-          sessionId: lcmReadSessionId,
-          query: retrievalQuery,
-          maxChars: responseGuidanceMaxChars,
-          maxSearchResults:
-            this.getRecallSectionNumber("response-guidance", "maxResults") ??
-            this.config.responseGuidanceRecallMaxResults,
-          maxScanWindowTurns:
-            this.getRecallSectionNumber("response-guidance", "maxTurns") ??
-            this.config.responseGuidanceRecallScanWindowTurns,
-          maxScanWindowTokens:
-            this.getRecallSectionNumber("response-guidance", "maxTokens") ??
-            this.config.responseGuidanceRecallScanWindowTokens,
-          forceGeneric: responseGuidanceForcedByPipeline,
-        });
+        const responseGuidanceSection = await firstNonEmptyLcmRead(
+          (lcmSessionId) =>
+            buildResponseGuidanceRecallSection({
+              engine: this.lcmEngine,
+              // #1495 thread 3 + #1505 fallback unification: read across the
+              // ordered LCM read key set so a branch-scoped session reads its own
+              // response-guidance evidence even at project/root scope (rule 39).
+              sessionId: lcmSessionId,
+              query: retrievalQuery,
+              maxChars: responseGuidanceMaxChars,
+              maxSearchResults:
+                this.getRecallSectionNumber("response-guidance", "maxResults") ??
+                this.config.responseGuidanceRecallMaxResults,
+              maxScanWindowTurns:
+                this.getRecallSectionNumber("response-guidance", "maxTurns") ??
+                this.config.responseGuidanceRecallScanWindowTurns,
+              maxScanWindowTokens:
+                this.getRecallSectionNumber("response-guidance", "maxTokens") ??
+                this.config.responseGuidanceRecallScanWindowTokens,
+              forceGeneric: responseGuidanceForcedByPipeline,
+            }),
+          (s) => !s,
+          "",
+        );
         if (responseGuidanceSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9644,23 +9718,29 @@ export class Orchestrator {
       shouldRecallEventOrderEvidence(retrievalQuery)
     ) {
       try {
-        const eventOrderSection = await buildEventOrderRecallSection({
-          engine: this.lcmEngine,
-          // #1495 thread 3: namespaced LCM session_id so a project-scoped session
-          // reads its own chronological event-order evidence (rule 39).
-          sessionId: lcmReadSessionId,
-          query: retrievalQuery,
-          maxChars: eventOrderMaxChars,
-          maxItems:
-            this.getRecallSectionNumber("event-order", "maxResults") ??
-            this.config.eventOrderRecallMaxResults,
-          maxScanWindowTurns:
-            this.getRecallSectionNumber("event-order", "maxTurns") ??
-            this.config.eventOrderRecallScanWindowTurns,
-          maxScanWindowTokens:
-            this.getRecallSectionNumber("event-order", "maxTokens") ??
-            this.config.eventOrderRecallScanWindowTokens,
-        });
+        const eventOrderSection = await firstNonEmptyLcmRead(
+          (lcmSessionId) =>
+            buildEventOrderRecallSection({
+              engine: this.lcmEngine,
+              // #1495 thread 3 + #1505 fallback unification: read across the
+              // ordered LCM read key set so a branch-scoped session reads its own
+              // chronological event-order evidence even at project/root scope.
+              sessionId: lcmSessionId,
+              query: retrievalQuery,
+              maxChars: eventOrderMaxChars,
+              maxItems:
+                this.getRecallSectionNumber("event-order", "maxResults") ??
+                this.config.eventOrderRecallMaxResults,
+              maxScanWindowTurns:
+                this.getRecallSectionNumber("event-order", "maxTurns") ??
+                this.config.eventOrderRecallScanWindowTurns,
+              maxScanWindowTokens:
+                this.getRecallSectionNumber("event-order", "maxTokens") ??
+                this.config.eventOrderRecallScanWindowTokens,
+            }),
+          (s) => !s,
+          "",
+        );
         if (eventOrderSection) {
           this.appendRecallSection(
             sectionBuckets,
@@ -9834,11 +9914,17 @@ export class Orchestrator {
       (recallMode as RecallPlanMode) !== "no_recall"
     ) {
       try {
-        const structuredMatches = await this.lcmEngine.searchStructuredParts(
-          // #1495: namespaced LCM session_id so a project-scoped session reads
-          // its own structured message-part evidence.
-          lcmReadSessionId,
-          retrievalQuery,
+        const structuredMatches = await firstNonEmptyLcmRead(
+          (lcmSessionId) =>
+            this.lcmEngine!.searchStructuredParts(
+              // #1495 + #1505 fallback unification: read across the ordered LCM
+              // read key set so a branch-scoped session reads its own structured
+              // message-part evidence even when archived at project/root scope.
+              lcmSessionId,
+              retrievalQuery,
+            ),
+          (matches) => matches.length === 0,
+          [],
         );
         const structuredSection = this.lcmEngine.formatStructuredRecall(
           structuredMatches,
@@ -9862,11 +9948,17 @@ export class Orchestrator {
             }
           }
         }
-        const lcmSection = await this.lcmEngine.assembleRecall(
-          // #1495: namespaced LCM session_id so a project-scoped session reads
-          // its own compressed-history evidence.
-          lcmReadSessionId,
-          this.config.recallBudgetChars,
+        const lcmSection = await firstNonEmptyLcmRead(
+          (lcmSessionId) =>
+            this.lcmEngine!.assembleRecall(
+              // #1495 + #1505 fallback unification: read across the ordered LCM
+              // read key set so a branch-scoped session reads its own
+              // compressed-history evidence even at project/root scope.
+              lcmSessionId,
+              this.config.recallBudgetChars,
+            ),
+          (s) => !s,
+          "",
         );
         if (lcmSection) {
           this.appendRecallSection(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -7249,8 +7249,12 @@ export class Orchestrator {
     // (rather than concatenating across keys) preserves existing budgets while
     // recovering fallback evidence. When the set is a single key (single-user /
     // no-overlay / explicit-namespace), this is exactly one call — unchanged.
+    // `lcmSessionId` is `string | undefined`: a SESSIONLESS recall yields the
+    // single `undefined` key so the LCM builders run ONE archive-wide read with
+    // no `session_id` filter (pre-#1505 behavior; the builders accept an optional
+    // `sessionId`). NEVER the literal "default" session id (codex P2).
     const firstNonEmptyLcmRead = async <T>(
-      read: (lcmSessionId: string) => Promise<T>,
+      read: (lcmSessionId: string | undefined) => Promise<T>,
       isEmpty: (value: T) => boolean,
       empty: T,
     ): Promise<T> => {
@@ -9920,7 +9924,10 @@ export class Orchestrator {
               // #1495 + #1505 fallback unification: read across the ordered LCM
               // read key set so a branch-scoped session reads its own structured
               // message-part evidence even when archived at project/root scope.
-              lcmSessionId,
+              // Structured parts are inherently per-session (the DAG is keyed by
+              // session_id), so a SESSIONLESS read (`undefined`) normalizes to
+              // empty → no section, the correct pre-#1505 behavior (codex P2).
+              lcmSessionId ?? "",
               retrievalQuery,
             ),
           (matches) => matches.length === 0,
@@ -9954,7 +9961,10 @@ export class Orchestrator {
               // #1495 + #1505 fallback unification: read across the ordered LCM
               // read key set so a branch-scoped session reads its own
               // compressed-history evidence even at project/root scope.
-              lcmSessionId,
+              // Compressed history is inherently per-session (a per-session DAG),
+              // so a SESSIONLESS read (`undefined`) normalizes to empty → no
+              // section, the correct pre-#1505 behavior (codex P2).
+              lcmSessionId ?? "",
               this.config.recallBudgetChars,
             ),
           (s) => !s,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -11235,6 +11235,17 @@ export class Orchestrator {
       deadlineMs?: number;
       archiveLcm?: boolean;
       abortSignal?: AbortSignal;
+      /**
+       * Pin extraction writes to this namespace instead of deriving one from
+       * `defaultNamespaceForPrincipal(resolvePrincipal(sessionKey))` + the
+       * coding overlay (#1495). The access `observe` surface resolves a single
+       * effective scope plan and passes its `writeNamespace` here so the
+       * extracted memories land in the SAME namespace as LCM archival,
+       * objective-state snapshots, and project-scoped recall — without relying
+       * on re-deriving the namespace from a namespace-prefixed session key.
+       * Same hook bulk-import uses (#460).
+       */
+      writeNamespaceOverride?: string;
     } = {},
   ): Promise<void> {
     if (!Array.isArray(turns) || turns.length === 0) return;
@@ -11321,6 +11332,7 @@ export class Orchestrator {
               bufferKey,
               extractionDeadlineMs: options.deadlineMs,
               abortSignal: options.abortSignal,
+              writeNamespaceOverride: options.writeNamespaceOverride,
               onTaskSettled: (err) => (err ? reject(err) : resolve()),
             }).catch(reject);
           }),

--- a/tests/access-service-observe.test.ts
+++ b/tests/access-service-observe.test.ts
@@ -19,16 +19,30 @@ import {
  */
 
 test("EngramAccessObserveResponse shape matches contract", () => {
+  // #1495: `effectiveNamespace` is an additive required field carrying the
+  // namespace every side effect actually wrote to. `scopeDebug` is the
+  // optional diagnostic view of the resolved scope plan. `namespace` stays as
+  // the backward-compatible base value.
   const response: EngramAccessObserveResponse = {
     accepted: 2,
     sessionKey: "test-session",
     namespace: "default",
+    effectiveNamespace: "default-project-tag-foo",
+    scopeDebug: {
+      principal: "alice",
+      baseNamespace: "default",
+      writeNamespace: "default-project-tag-foo",
+      codingOverlayApplied: true,
+      readNamespaces: ["default-project-tag-foo"],
+    },
     lcmArchived: true,
     extractionQueued: true,
   };
   assert.equal(response.accepted, 2);
   assert.equal(response.sessionKey, "test-session");
   assert.equal(response.namespace, "default");
+  assert.equal(response.effectiveNamespace, "default-project-tag-foo");
+  assert.equal(response.scopeDebug?.codingOverlayApplied, true);
   assert.equal(response.lcmArchived, true);
   assert.equal(response.extractionQueued, true);
 });

--- a/tests/recall-pipeline-assembly.test.ts
+++ b/tests/recall-pipeline-assembly.test.ts
@@ -6,6 +6,35 @@ import { mkdtemp } from "node:fs/promises";
 import { Orchestrator } from "../src/orchestrator.js";
 import { parseConfig } from "../src/config.js";
 
+/**
+ * Derive the exact PROJECT-scope overlay namespace the orchestrator would use as
+ * a branch session's read fallback, WITHOUT depending on `combineNamespaces`
+ * (not exported from the package root). Binds a project-only coding context
+ * (branch: null) to a throwaway session and reads back the orchestrator's own
+ * `applyCodingNamespaceOverlay` result — the same source of truth the recall path
+ * uses to build `codingOverlay.readFallbacks`.
+ */
+function projectFallbackNamespace(
+  orchestrator: Orchestrator,
+  base: string,
+  projectId: string,
+): string {
+  const probeSession = `__probe__:${projectId}`;
+  orchestrator.setCodingContextForSession(probeSession, {
+    projectId,
+    branch: null,
+    rootPath: projectId,
+    defaultBranch: null,
+  });
+  const ns = (
+    orchestrator as unknown as {
+      applyCodingNamespaceOverlay: (sk: string, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(probeSession, base);
+  orchestrator.setCodingContextForSession(probeSession, null);
+  return ns;
+}
+
 test("custom recallPipeline reorders sections and can disable transcript injection", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-pipeline-"));
   const cfg = parseConfig({
@@ -454,4 +483,280 @@ test("#1505 thread 3: ALL LCM recall sections read under the SCOPED (overlay) se
   // Evidence (only returned for the scoped key) made it into the assembled
   // context, proving the sections read under the scoped key.
   assert.match(context, /SCOPED_EVIDENCE/);
+});
+
+test("#1505 fallback: branch-scoped recall reads LCM evidence archived at PROJECT (fallback) scope", async () => {
+  // Round 5 left the LCM read path targeting a SINGLE overlay key
+  // (`${branch-ns}:${sessionKey}`). Normal QMD/file recall, however, also
+  // searches `codingOverlay.readFallbacks` (project → root) so a branch-scoped
+  // session still sees project/root memories. A session whose LCM rows were
+  // archived at PROJECT scope (then later recalled from a branch) therefore had
+  // its LCM-backed sections MISS that fallback transcript evidence even though
+  // QMD/file recall would surface it. This pins that the LCM read now queries the
+  // SAME ordered readable namespace set (primary overlay → project fallback), so
+  // the project-scope evidence is found.
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-fallback-"));
+  const sessionId = "alice:branch-session";
+  const projectId = "origin:proj9999";
+
+  const lcmQueriedSessionIds: string[] = [];
+  // Evidence is returned ONLY for the PROJECT-fallback key — never the branch
+  // overlay key. A single-key (branch-only) LCM read would MISS it (fail-before);
+  // querying across the readable set (branch → project fallback) finds it.
+  let projectFallbackKey = "";
+  let branchOverlayKey = "";
+  const evidenceFor = (requestedSessionId?: string, limit = 8) => {
+    lcmQueriedSessionIds.push(requestedSessionId ?? "<undefined>");
+    return requestedSessionId === projectFallbackKey
+      ? [
+          {
+            id: 0,
+            session_id: projectFallbackKey,
+            turn_index: 7,
+            role: "user",
+            content:
+              "FALLBACK_EVIDENCE: my culinary journey started with Turkish, Greek, and Lebanese cuisines.",
+            score: 100,
+          },
+        ].slice(0, limit)
+      : [];
+  };
+
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    sharedContextEnabled: false,
+    knowledgeIndexEnabled: false,
+    identityContinuityEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    lcmEnabled: true,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "alice:", principal: "alice" }],
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    defaultRecallNamespaces: ["self"],
+    // Branch scope ON → project namespace becomes a read fallback.
+    codingMode: { projectScope: true, branchScope: true },
+    explicitCueRecallEnabled: true,
+    focusedListRecallEnabled: true,
+    eventOrderRecallEnabled: true,
+    recallPipeline: [
+      { id: "event-order", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "focused-list", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "explicit-cue", enabled: true, maxChars: 2_400, maxResults: 8 },
+      { id: "profile", enabled: false },
+      { id: "memories", enabled: false },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  // Bind a coding context WITH a branch so the overlay is branch-scoped and the
+  // project namespace becomes a read fallback.
+  orchestrator.setCodingContextForSession(sessionId, {
+    projectId,
+    branch: "feature/cuisines",
+    rootPath: projectId,
+    defaultBranch: "main",
+  });
+  // Derive the branch overlay key + project fallback key from the orchestrator's
+  // own overlay (source of truth): the principal self base (alice) overlaid with
+  // the branch namespace, and the project fallback combined with the same base.
+  const branchOverlayNs = (
+    orchestrator as unknown as {
+      applyCodingNamespaceOverlay: (sk: string, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(sessionId, "alice");
+  assert.notEqual(branchOverlayNs, "alice", "branch overlay must change the namespace");
+  const projectFallbackNs = projectFallbackNamespace(orchestrator, "alice", projectId);
+  assert.notEqual(
+    projectFallbackNs,
+    branchOverlayNs,
+    "project fallback namespace must differ from the branch overlay namespace",
+  );
+  branchOverlayKey = `${branchOverlayNs}:${sessionId}`;
+  projectFallbackKey = `${projectFallbackNs}:${sessionId}`;
+
+  (orchestrator as any).lcmEngine = {
+    enabled: true,
+    searchContextFull: async (_q: string, limit: number, requestedSessionId?: string) =>
+      evidenceFor(requestedSessionId, limit),
+    expandContext: async (requestedSessionId: string) =>
+      requestedSessionId === projectFallbackKey
+        ? [
+            {
+              turn_index: 7,
+              role: "user",
+              content: "FALLBACK_EVIDENCE: chronological milestone",
+            },
+          ]
+        : [],
+    getStats: async (requestedSessionId?: string) => {
+      lcmQueriedSessionIds.push(requestedSessionId ?? "<undefined>");
+      return requestedSessionId === projectFallbackKey
+        ? { totalMessages: 4, maxTurnIndex: 7 }
+        : { totalMessages: 0, maxTurnIndex: -1 };
+    },
+    searchStructuredParts: async () => [],
+    formatStructuredRecall: () => "",
+    assembleRecall: async () => "",
+  };
+
+  const context = await (orchestrator as any).recallInternal(
+    "Remember when you told me to list, in chronological order, the cuisines I started my culinary journey with?",
+    sessionId,
+  );
+
+  // The branch overlay key was tried FIRST (primary), then the project fallback
+  // key — and the project-fallback evidence made it into the assembled context.
+  assert.ok(
+    lcmQueriedSessionIds.includes(branchOverlayKey),
+    `expected the branch overlay key ${branchOverlayKey} to be queried first; queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  assert.ok(
+    lcmQueriedSessionIds.includes(projectFallbackKey),
+    `expected the project fallback key ${projectFallbackKey} to be queried; queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  // The raw (un-prefixed) sessionId must NOT be queried — only namespaced keys.
+  assert.ok(
+    !lcmQueriedSessionIds.includes(sessionId),
+    `no LCM section may query the RAW sessionId ${sessionId}; queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  assert.match(
+    context,
+    /FALLBACK_EVIDENCE/,
+    "branch-scoped recall must surface LCM evidence archived at the project fallback scope",
+  );
+});
+
+test("#1505 fallback read-auth: an unreadable principal self/overlay namespace is NEVER queried by the LCM read path", async () => {
+  // The unification reuses `recallNamespaces`, which already gates the overlay by
+  // read-authorization (`recallNamespacesForPrincipal` only includes the self
+  // base when `defaultRecallNamespaces` includes "self" AND `canReadNamespace`).
+  // When the self base is NOT in the readable recall set, the overlay key
+  // (`${principal}-project-*`) must NEVER be searched by the LCM read path — no
+  // cross-tenant read leak. Here `defaultRecallNamespaces` OMITS "self", so the
+  // self base / its overlay are unreadable; only the explicitly-shared namespace
+  // is readable, and the LCM read collapses to the default store (raw key).
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-readauth-"));
+  const sessionId = "alice:writeonly-session";
+  const projectId = "origin:secret1234";
+
+  const lcmQueriedSessionIds: string[] = [];
+  const evidenceFor = (requestedSessionId?: string, limit = 8) => {
+    lcmQueriedSessionIds.push(requestedSessionId ?? "<undefined>");
+    // Never serve overlay evidence — the point is to prove the overlay key is
+    // never even QUERIED.
+    return [] as Array<{
+      id: number;
+      session_id: string;
+      turn_index: number;
+      role: string;
+      content: string;
+      score: number;
+    }>;
+  };
+
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    sharedContextEnabled: false,
+    knowledgeIndexEnabled: false,
+    identityContinuityEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    lcmEnabled: true,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "alice:", principal: "alice" }],
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+      // shared is readable by alice and included in recall by default.
+      {
+        name: "shared",
+        readPrincipals: ["alice"],
+        writePrincipals: ["alice"],
+        includeInRecallByDefault: true,
+      },
+    ],
+    // OMIT "self" — the principal self base (and so its project-* overlay) is NOT
+    // in the readable recall set.
+    defaultRecallNamespaces: ["shared"],
+    codingMode: { projectScope: true, branchScope: true },
+    explicitCueRecallEnabled: true,
+    focusedListRecallEnabled: true,
+    eventOrderRecallEnabled: true,
+    recallPipeline: [
+      { id: "event-order", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "focused-list", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "explicit-cue", enabled: true, maxChars: 2_400, maxResults: 8 },
+      { id: "profile", enabled: false },
+      { id: "memories", enabled: false },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  orchestrator.setCodingContextForSession(sessionId, {
+    projectId,
+    branch: "feature/secret",
+    rootPath: projectId,
+    defaultBranch: "main",
+  });
+  const branchOverlayNs = (
+    orchestrator as unknown as {
+      applyCodingNamespaceOverlay: (sk: string, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(sessionId, "alice");
+  const branchOverlayKey = `${branchOverlayNs}:${sessionId}`;
+  const projectFallbackKey = `${projectFallbackNamespace(orchestrator, "alice", projectId)}:${sessionId}`;
+
+  (orchestrator as any).lcmEngine = {
+    enabled: true,
+    searchContextFull: async (_q: string, limit: number, requestedSessionId?: string) =>
+      evidenceFor(requestedSessionId, limit),
+    expandContext: async () => [],
+    getStats: async (requestedSessionId?: string) => {
+      lcmQueriedSessionIds.push(requestedSessionId ?? "<undefined>");
+      return { totalMessages: 0, maxTurnIndex: -1 };
+    },
+    searchStructuredParts: async () => [],
+    formatStructuredRecall: () => "",
+    assembleRecall: async () => "",
+  };
+
+  await (orchestrator as any).recallInternal(
+    "Remember when you told me to list, in chronological order, the cuisines I started my culinary journey with?",
+    sessionId,
+  );
+
+  // Neither the branch overlay key nor the project-* overlay fallback may be
+  // queried — the self base is unreadable, so `recallNamespaces` excludes them
+  // and the LCM read path must too (no `<principal>-project-*` leak).
+  assert.ok(
+    !lcmQueriedSessionIds.includes(branchOverlayKey),
+    `unreadable branch overlay key ${branchOverlayKey} must NEVER be queried; queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  assert.ok(
+    !lcmQueriedSessionIds.includes(projectFallbackKey),
+    `unreadable project overlay key ${projectFallbackKey} must NEVER be queried; queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  // No queried key may carry the `alice-project-` overlay prefix at all.
+  for (const queried of lcmQueriedSessionIds) {
+    assert.ok(
+      !queried.startsWith("alice-project-"),
+      `no LCM read may target an alice-project-* overlay namespace; saw ${queried}`,
+    );
+  }
 });

--- a/tests/recall-pipeline-assembly.test.ts
+++ b/tests/recall-pipeline-assembly.test.ts
@@ -6,6 +6,19 @@ import { mkdtemp } from "node:fs/promises";
 import { Orchestrator } from "../src/orchestrator.js";
 import { parseConfig } from "../src/config.js";
 
+// #1495 P1: the namespaced LCM `session_id` is framed with a reserved sentinel
+// (U+001F UNIT SEPARATOR) — `\x1f<namespace>\x1f<sessionKey>` — kept in sync with
+// `coding-namespace.ts:lcmSessionKeyForNamespace`. U+001F cannot occur in a
+// route namespace (`[A-Za-z0-9._-]`) nor any legitimate session key, so the
+// namespaced + default key-spaces are provably disjoint (unforgeable). Encoded
+// locally here because `coding-namespace` is not exported from the package root
+// (same reason `projectFallbackNamespace` reads the overlay back off the
+// orchestrator instead of importing `combineNamespaces`).
+const LCM_NS_SENTINEL = "\u001f";
+function encodeNs(namespace: string, sessionKey: string): string {
+  return `${LCM_NS_SENTINEL}${namespace}${LCM_NS_SENTINEL}${sessionKey}`;
+}
+
 /**
  * Derive the exact PROJECT-scope overlay namespace the orchestrator would use as
  * a branch session's read fallback, WITHOUT depending on `combineNamespaces`
@@ -436,7 +449,7 @@ test("#1505 thread 3: ALL LCM recall sections read under the SCOPED (overlay) se
     }
   ).applyCodingNamespaceOverlay(sessionId, "alice");
   assert.notEqual(overlayNs, "alice", "coding overlay must change the namespace");
-  scopedKey = `${overlayNs}:${sessionId}`;
+  scopedKey = encodeNs(overlayNs, sessionId);
 
   (orchestrator as any).lcmEngine = {
     enabled: true,
@@ -581,8 +594,8 @@ test("#1505 fallback: branch-scoped recall reads LCM evidence archived at PROJEC
     branchOverlayNs,
     "project fallback namespace must differ from the branch overlay namespace",
   );
-  branchOverlayKey = `${branchOverlayNs}:${sessionId}`;
-  projectFallbackKey = `${projectFallbackNs}:${sessionId}`;
+  branchOverlayKey = encodeNs(branchOverlayNs, sessionId);
+  projectFallbackKey = encodeNs(projectFallbackNs, sessionId);
 
   (orchestrator as any).lcmEngine = {
     enabled: true,
@@ -719,8 +732,8 @@ test("#1505 fallback read-auth: an unreadable principal self/overlay namespace i
       applyCodingNamespaceOverlay: (sk: string, base: string) => string;
     }
   ).applyCodingNamespaceOverlay(sessionId, "alice");
-  const branchOverlayKey = `${branchOverlayNs}:${sessionId}`;
-  const projectFallbackKey = `${projectFallbackNamespace(orchestrator, "alice", projectId)}:${sessionId}`;
+  const branchOverlayKey = encodeNs(branchOverlayNs, sessionId);
+  const projectFallbackKey = encodeNs(projectFallbackNamespace(orchestrator, "alice", projectId), sessionId);
 
   (orchestrator as any).lcmEngine = {
     enabled: true,
@@ -755,7 +768,7 @@ test("#1505 fallback read-auth: an unreadable principal self/overlay namespace i
   // No queried key may carry the `alice-project-` overlay prefix at all.
   for (const queried of lcmQueriedSessionIds) {
     assert.ok(
-      !queried.startsWith("alice-project-"),
+      !queried.includes("alice-project-"),
       `no LCM read may target an alice-project-* overlay namespace; saw ${queried}`,
     );
   }

--- a/tests/recall-pipeline-assembly.test.ts
+++ b/tests/recall-pipeline-assembly.test.ts
@@ -319,3 +319,139 @@ test("top-level response-guidance enable remains query-gated for unclassified qu
   assert.doesNotMatch(context, /## Response guidance evidence/);
   assert.equal(searchCalls, 0);
 });
+
+test("#1505 thread 3: ALL LCM recall sections read under the SCOPED (overlay) session key", async () => {
+  // Round 1 wired only targeted-facts / structured / compressed-history to the
+  // namespaced LCM read key (`lcmReadSessionId`). The explicit-cue, focused-list,
+  // response-guidance, and event-order sections still passed the RAW `sessionKey`
+  // to their LCM helpers, so a project-scoped session whose evidence is archived
+  // under `${overlayNs}:${sessionKey}` would NEVER surface it through those
+  // sections. This pins that EVERY LCM-backed section reads under the scoped key
+  // (CLAUDE.md rule 39: identical across all paths).
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-thread3-"));
+  const sessionId = "alice:proj-session";
+  const projectId = "origin:abcd1234";
+
+  const lcmQueriedSessionIds: string[] = [];
+  // Resolved AFTER the orchestrator is constructed (the overlay namespace is
+  // derived from the orchestrator's own `applyCodingNamespaceOverlay`, the source
+  // of truth). Evidence is returned ONLY for the SCOPED key — if any section
+  // queries the raw sessionId, that evidence is MISSING and the asserts fail.
+  let scopedKey = "";
+  const evidenceFor = (requestedSessionId?: string, limit = 8) => {
+    lcmQueriedSessionIds.push(requestedSessionId ?? "<undefined>");
+    return requestedSessionId === scopedKey
+      ? [
+          {
+            id: 0,
+            session_id: scopedKey,
+            turn_index: 10,
+            role: "user",
+            content:
+              "SCOPED_EVIDENCE: my culinary journey started with Turkish, Greek, and Lebanese cuisines.",
+            score: 100,
+          },
+        ].slice(0, limit)
+      : [];
+  };
+
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    sharedContextEnabled: false,
+    knowledgeIndexEnabled: false,
+    identityContinuityEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    lcmEnabled: true,
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [{ match: "alice:", principal: "alice" }],
+    namespacePolicies: [
+      { name: "alice", readPrincipals: ["alice"], writePrincipals: ["alice"] },
+    ],
+    defaultRecallNamespaces: ["self"],
+    codingMode: { projectScope: true },
+    // Enable the four sections that round 1 left on the raw key.
+    explicitCueRecallEnabled: true,
+    focusedListRecallEnabled: true,
+    eventOrderRecallEnabled: true,
+    recallPipeline: [
+      { id: "event-order", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "focused-list", enabled: true, maxChars: 2_400, maxResults: 8, maxTurns: 16, maxTokens: 6_000 },
+      { id: "explicit-cue", enabled: true, maxChars: 2_400, maxResults: 8 },
+      { id: "profile", enabled: false },
+      { id: "memories", enabled: false },
+    ],
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  // Bind the project coding context so the recall path overlays the namespace
+  // exactly as a same-session project-scoped recall would.
+  orchestrator.setCodingContextForSession(sessionId, {
+    projectId,
+    branch: null,
+    rootPath: projectId,
+    defaultBranch: null,
+  });
+  // Derive the SCOPED LCM read key from the orchestrator's own overlay (source
+  // of truth): the principal self base (alice) overlaid with the project.
+  const overlayNs = (
+    orchestrator as unknown as {
+      applyCodingNamespaceOverlay: (sk: string, base: string) => string;
+    }
+  ).applyCodingNamespaceOverlay(sessionId, "alice");
+  assert.notEqual(overlayNs, "alice", "coding overlay must change the namespace");
+  scopedKey = `${overlayNs}:${sessionId}`;
+
+  (orchestrator as any).lcmEngine = {
+    enabled: true,
+    searchContextFull: async (_q: string, limit: number, requestedSessionId?: string) =>
+      evidenceFor(requestedSessionId, limit),
+    expandContext: async (requestedSessionId: string) =>
+      requestedSessionId === scopedKey
+        ? [
+            {
+              turn_index: 10,
+              role: "user",
+              content: "SCOPED_EVIDENCE: chronological milestone",
+            },
+          ]
+        : [],
+    getStats: async (requestedSessionId?: string) => {
+      lcmQueriedSessionIds.push(requestedSessionId ?? "<undefined>");
+      return requestedSessionId === scopedKey
+        ? { totalMessages: 4, maxTurnIndex: 10 }
+        : { totalMessages: 0, maxTurnIndex: -1 };
+    },
+    searchStructuredParts: async () => [],
+    formatStructuredRecall: () => "",
+    assembleRecall: async () => "",
+  };
+
+  // A prompt that triggers the explicit-cue / focused-list / event-order gates
+  // (chronological + list-shaped + cue phrasing).
+  const context = await (orchestrator as any).recallInternal(
+    "Remember when you told me to list, in chronological order, the cuisines I started my culinary journey with?",
+    sessionId,
+  );
+
+  // The scoped key was queried, and the raw (un-prefixed) sessionId was NOT used
+  // by any LCM section (otherwise evidence would be missing).
+  assert.ok(
+    lcmQueriedSessionIds.includes(scopedKey),
+    `expected at least one LCM section to query the scoped key ${scopedKey}; queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  assert.ok(
+    !lcmQueriedSessionIds.includes(sessionId),
+    `no LCM section may query the RAW sessionId ${sessionId}; queried: ${JSON.stringify(lcmQueriedSessionIds)}`,
+  );
+  // Evidence (only returned for the scoped key) made it into the assembled
+  // context, proving the sections read under the scoped key.
+  assert.match(context, /SCOPED_EVIDENCE/);
+});


### PR DESCRIPTION
## Summary

`observe` previously resolved its write `namespace` with `resolveWritableNamespace()` (the base namespace), applied the coding overlay only for objective-state snapshots, and keyed **LCM archival** and **extraction replay** off the earlier base value — so observed turns and extracted memories could drift to a *different* namespace than same-session project-scoped recall reads (the namespace `memory_store` / `suggestion_submit` already route to via `resolveCodingScopedWriteNamespace()`).

This change introduces a minimal internal **`MemoryScopePlan`** resolver (`resolveMemoryScopePlan`) that resolves **one** effective scope per request: principal, explicit namespace, base namespace, effective `writeNamespace`, read namespaces, coding-overlay flag, and warnings. Its authorization mirrors `resolveCodingScopedWriteNamespace()` **exactly**, so `observe` scoping is now identical to explicit coding-scoped writes (rule 39).

`observe` now, in order:
1. validates request shape;
2. authorizes the namespace **before** attaching coding context (no-orphan-context guard preserved);
3. attaches coding context from `cwd`/`projectTag`;
4. computes the effective scope plan;
5. writes objective-state snapshots to `scope.writeNamespace`;
6. enqueues LCM under `scope.writeNamespace` (`lcmSessionKey` prefixed with the effective namespace);
7. enqueues extraction/replay under `scope.writeNamespace` via a new `writeNamespaceOverride` threaded through `ingestReplayBatch` (the same hook bulk-import uses, #460) — so extraction no longer re-derives a namespace from the namespace-prefixed session key (which missed the overlay);
8. returns the backward-compatible `namespace` field **plus** additive `effectiveNamespace` and `scopeDebug`.

Closes #1495
Part of epic #1494

## Key compatibility decision

**Legacy `namespace` kept + `effectiveNamespace` added (additive, non-breaking).** The response `namespace` field still returns the base writable namespace (pre-#1495 semantics) so existing callers/tests are unaffected. The namespace the operation **actually wrote to** is the new required `effectiveNamespace`, with a `scopeDebug` diagnostic object exposing the full resolved plan. The HTTP (`/engram/v1/observe`) and MCP (`engram.observe`) surfaces return the response object verbatim, so the additive fields flow through with no schema breakage.

## Scenario matrix covered

| Scenario | Effective namespace | LCM / extraction / objective-state agree? |
|---|---|---|
| `sessionKey + projectTag`, no explicit ns | principal-self + project overlay | yes |
| `sessionKey + cwd` (git repo), no explicit ns | principal-self + project overlay | yes |
| explicit `namespace` | the explicit ns (overlay bypassed, auth-checked) | yes |
| `projectScope: false` | `config.defaultNamespace` (no overlay) | yes |
| `namespacesEnabled: false` | `config.defaultNamespace` (single store) | yes |
| unauthorized explicit namespace | throws **before** session-context mutation | n/a |

Adversarial checks confirmed: explicit namespace authorized before any session-context mutation; no path (LCM, extraction, objective-state, response) still uses the old base namespace; coding overlay is always rebuilt from the authenticated principal's base (a forged overlay-shaped string is rejected by `canWriteNamespace`); no shared mutable cross-session state introduced.

## Test summary

New `packages/remnic-core/src/access-service-observe-scope.test.ts` (9 tests) verifies agreement across LCM key, extraction `writeNamespaceOverride` + turn session keys, objective-state target, and response `effectiveNamespace`/`scopeDebug` for every scenario above, plus a **parity regression guard** asserting `resolveMemoryScopePlan().writeNamespace === resolveCodingScopedWriteNamespace()` for the same inputs. Existing `access-service-coding-write` / `-namespace` / `-project-tag` tests pass unchanged; contract test `tests/access-service-observe.test.ts` updated for the additive fields.

Gates: `pnpm --filter @remnic/core build` green; new + adjacent core tests green (56/56); `npm run test:entity-hardening` green (205/205); `npm run preflight:quick` green (incl. lint, check-types, test-type baseline).

## Checklist

- [x] All tests pass
- [x] New logic covered by tests
- [x] Pre-commit / preflight gates pass locally
- [x] Docs/comments updated (inline rationale on the plan resolver and `observe`)
- [x] No secrets or personal data committed (synthetic test data only)
- [x] PR diff focused on the access `observe` subsystem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-sensitive LCM isolation, multi-tenant read paths, and observe side-effect routing; regressions could leak transcripts or mis-route writes, though behavior is heavily regression-tested.
> 
> **Overview**
> **Security and scope:** `observe` now resolves a single **`MemoryScopePlan`** (`resolveMemoryScopePlan`) so LCM archival, extraction (`writeNamespaceOverride` / `principalOverride` on original `sessionKey`), objective-state, and **`effectiveNamespace`** / **`scopeDebug`** all use the same write namespace as coding-scoped stores—without a second `resolveWritableNamespace` pass that could reject valid overlay writes or orphan session context. LCM `session_id`s use shared **`lcmSessionKeyForNamespace`** with **U+001F sentinel framing** instead of `namespace:sessionKey`, closing forgery where a `default`-only caller could match another tenant’s overlay rows via exact id or LIKE prefix.
> 
> **LCM read/write parity:** **`lcmSearch`**, compaction flush/record, and **`disclosure: "raw"`** route through **`resolveLcmReadNamespace`** (read vs write purpose), implicit fallback without pre-authorizing denied `default`, coding read fallbacks via **`resolveLcmReadSessionIds`**, and **suppression of sessionless archive-wide scans** when namespaces are enabled. Raw excerpts no longer key off `snapshot.namespace` when the read gate excludes overlay rows.
> 
> **Tests:** Large new suites cover forgery blocking, observe/LCM/compaction key parity, observe scope invariants, and raw-excerpt read gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ae35071d9659255f3cca5b4743e3eed9c2e08e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->